### PR TITLE
Server - Add an option to always expose empty groups in GetCapabilities

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -35,6 +35,13 @@ Returns group WMS short name
 Returns group WMS abstract
 %End
 
+    bool groupAlwaysExpose();
+%Docstring
+If the group is always exposed on QGIS Server, even if it's empty.
+
+.. versionadded:: 3.38
+%End
+
 
   public slots:
     void setGroupTitle( const QString &title );
@@ -50,6 +57,13 @@ Sets group WMS short name
     void setGroupAbstract( const QString &abstract );
 %Docstring
 Sets group WMS abstract
+%End
+
+    void setAlwaysExpose( bool alwaysExpose );
+%Docstring
+Set if the group is always exposed on QGIS Server, even if it's empty.
+
+.. versionadded:: 3.38
 %End
 
 

--- a/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -35,6 +35,13 @@ Returns group WMS short name
 Returns group WMS abstract
 %End
 
+    bool groupAlwaysExpose();
+%Docstring
+If the group is always exposed on QGIS Server, even if it's empty.
+
+.. versionadded:: 3.38
+%End
+
 
   public slots:
     void setGroupTitle( const QString &title );
@@ -50,6 +57,13 @@ Sets group WMS short name
     void setGroupAbstract( const QString &abstract );
 %Docstring
 Sets group WMS abstract
+%End
+
+    void setAlwaysExpose( bool alwaysExpose );
+%Docstring
+Set if the group is always exposed on QGIS Server, even if it's empty.
+
+.. versionadded:: 3.38
 %End
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12381,11 +12381,13 @@ void QgisApp::legendGroupSetWmsData()
   dlg->setGroupShortName( currentGroup->customProperty( QStringLiteral( "wmsShortName" ) ).toString() );
   dlg->setGroupTitle( currentGroup->customProperty( QStringLiteral( "wmsTitle" ) ).toString() );
   dlg->setGroupAbstract( currentGroup->customProperty( QStringLiteral( "wmsAbstract" ) ).toString() );
+  dlg->setAlwaysExpose( currentGroup->customProperty( QStringLiteral( "wmsAlwaysExpose" ) ).toBool() );
   if ( dlg->exec() )
   {
     currentGroup->setCustomProperty( QStringLiteral( "wmsShortName" ), dlg->groupShortName() );
     currentGroup->setCustomProperty( QStringLiteral( "wmsTitle" ), dlg->groupTitle() );
     currentGroup->setCustomProperty( QStringLiteral( "wmsAbstract" ), dlg->groupAbstract() );
+    currentGroup->setCustomProperty( QStringLiteral( "wmsAlwaysExpose" ), dlg->groupAlwaysExpose() );
   }
   delete dlg;
 }

--- a/src/gui/qgsgroupwmsdatadialog.cpp
+++ b/src/gui/qgsgroupwmsdatadialog.cpp
@@ -56,3 +56,13 @@ void QgsGroupWmsDataDialog::setGroupAbstract( const QString &abstract )
 {
   mAbstractTextEdit->setPlainText( abstract );
 }
+
+bool QgsGroupWmsDataDialog::groupAlwaysExpose()
+{
+  return mAlwaysExpose->isChecked();
+}
+
+void QgsGroupWmsDataDialog::setAlwaysExpose( bool alwaysExpose )
+{
+  mAlwaysExpose->setChecked( alwaysExpose );
+}

--- a/src/gui/qgsgroupwmsdatadialog.h
+++ b/src/gui/qgsgroupwmsdatadialog.h
@@ -43,6 +43,13 @@ class GUI_EXPORT QgsGroupWmsDataDialog: public QDialog, private Ui::QgsGroupWMSD
     //! Returns group WMS abstract
     QString groupAbstract();
 
+    /**
+     * If the group is always exposed on QGIS Server, even if it's empty.
+     *
+     * \since QGIS 3.38
+     */
+    bool groupAlwaysExpose();
+
 
   public slots:
     //! Sets group WMS title
@@ -53,6 +60,13 @@ class GUI_EXPORT QgsGroupWmsDataDialog: public QDialog, private Ui::QgsGroupWMSD
 
     //! Sets group WMS abstract
     void setGroupAbstract( const QString &abstract );
+
+    /**
+     * Set if the group is always exposed on QGIS Server, even if it's empty.
+     *
+     * \since QGIS 3.38
+     */
+    void setAlwaysExpose( bool alwaysExpose );
 
 
   private:

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1021,7 +1021,7 @@ namespace QgsWms
           handleLayersFromTreeGroup( doc, layerElem, serverIface, project, request, treeGroupChild, wmsLayerInfos, projectSettings );
 
           // Check if child layer elements have been added
-          if ( layerElem.elementsByTagName( QStringLiteral( "Layer" ) ).length() == 0 )
+          if ( layerElem.elementsByTagName( QStringLiteral( "Layer" ) ).length() == 0 && ! treeGroupChild->customProperty( QStringLiteral( "wmsAlwaysExpose" ) ).toBool() )
           {
             continue;
           }

--- a/src/ui/qgsgroupwmsdatadialogbase.ui
+++ b/src/ui/qgsgroupwmsdatadialogbase.ui
@@ -30,11 +30,10 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff/>
-   </iconset>
+    <normaloff>.</normaloff>.</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
@@ -43,10 +42,24 @@
    </item>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="mShortNameLabel">
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="mTitleLineEdit">
+       <property name="placeholderText">
+        <string>The title is for the benefit of humans to identify group layer.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QTextEdit" name="mAbstractTextEdit">
+       <property name="toolTip">
+        <string>The abstract is a descriptive narrative providing more information about the group layer.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="mTitleLabel">
        <property name="text">
-        <string>Short name</string>
+        <string>Title</string>
        </property>
       </widget>
      </item>
@@ -60,17 +73,10 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="mTitleLineEdit">
-       <property name="placeholderText">
-        <string>The title is for the benefit of humans to identify group layer.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="mTitleLabel">
+     <item row="0" column="0">
+      <widget class="QLabel" name="mShortNameLabel">
        <property name="text">
-        <string>Title</string>
+        <string>Short name</string>
        </property>
       </widget>
      </item>
@@ -81,10 +87,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QTextEdit" name="mAbstractTextEdit">
-       <property name="toolTip">
-        <string>The abstract is a descriptive narrative providing more information about the group layer.</string>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="mAlwaysExpose">
+       <property name="text">
+        <string>Always export, even if the group is empty</string>
        </property>
       </widget>
      </item>

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -192,6 +192,11 @@ class QgsServerTestBase(QgisTestCase):
         self.temporary_dir.cleanup()
         super().tearDownClass()
 
+    @classmethod
+    def _query_string(cls, data: dict) -> str:
+        """ Build a query string. """
+        return urllib.parse.urlencode(data)
+
     def strip_version_xmlns(self, text):
         """Order of attributes is random, strip version and xmlns"""
         return text.replace(b'version="1.3.0"', b'').replace(b'xmlns="http://www.opengis.net/ogc"', b'')

--- a/tests/src/python/test_qgsserver_accesscontrol_wms.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wms.py
@@ -62,6 +62,27 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
             str(response).find("<Name>Country</Name>") != -1,
             f"Unexpected Country layer in GetCapabilities\n{response}")
 
+    def test_empty_group_getcapabilities(self):
+        """ Test empty groups in GetCapabilities. """
+        query_string = self._query_string({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetCapabilities"
+        })
+
+        name = "empty group excluded"
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find(f'<Name>{name}</Name>') == -1,
+            f"No '{name}' layer in GetCapabilities\n{response}")
+
+        name = "empty group included"
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find(f'<Name>{name}</Name>') != -1,
+            f"No '{name}' layer in GetCapabilities\n{response}")
+
     def test_wms_getprojectsettings(self):
         query_string = "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),

--- a/tests/testdata/qgis_server_accesscontrol/project_grp.qgs
+++ b/tests/testdata/qgis_server_accesscontrol/project_grp.qgs
@@ -1,64 +1,110 @@
-<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="QGIS Server Hello World" version="3.10.10-A Coruña">
-  <homePath path=""/>
+<qgis projectname="QGIS Server Hello World" saveDateTime="2024-03-04T15:09:39" saveUser="etienne" saveUserFull="Etienne Trimaille" version="3.34.4-Prizren">
+  <homePath path=""></homePath>
   <title>QGIS Server Hello World</title>
-  <autotransaction active="0"/>
-  <evaluateDefaultValues active="0"/>
-  <trust active="0"/>
+  <transaction mode="Disabled"></transaction>
+  <projectFlags set=""></projectFlags>
   <projectCrs>
-    <spatialrefsys>
-      <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-      <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+    <spatialrefsys nativeFormat="Wkt">
+      <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+      <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
       <srsid>3857</srsid>
       <srid>3857</srid>
       <authid>EPSG:3857</authid>
       <description>WGS 84 / Pseudo-Mercator</description>
       <projectionacronym>merc</projectionacronym>
-      <ellipsoidacronym>WGS84</ellipsoidacronym>
+      <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
       <geographicflag>false</geographicflag>
     </spatialrefsys>
   </projectCrs>
+  <elevation-shading-renderer combined-method="0" edl-distance="0.5" edl-distance-unit="0" edl-is-active="1" edl-strength="1000" hillshading-is-active="0" hillshading-is-multidirectional="0" hillshading-z-factor="1" is-active="0" light-altitude="45" light-azimuth="315"></elevation-shading-renderer>
   <layer-tree-group>
-    <customproperties/>
-    <layer-tree-layer name="db_point" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=" id="points20150803121107046" legend_exp="">
-      <customproperties/>
+    <customproperties>
+      <Option></Option>
+    </customproperties>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="points20150803121107046" legend_exp="" legend_split_behavior="0" name="db_point" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;points&quot; (geom)">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-group name="Hello_grp" expanded="1" checked="Qt::Checked">
-      <customproperties/>
-      <layer-tree-layer name="Hello" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="hello20131022151106574" legend_exp="">
-        <customproperties/>
+    <layer-tree-group checked="Qt::Checked" expanded="1" groupLayer="" name="Hello_grp">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
+      <layer-tree-layer checked="Qt::Checked" expanded="1" id="hello20131022151106574" legend_exp="" legend_split_behavior="0" name="Hello" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;hello&quot; (geom)">
+        <customproperties>
+          <Option></Option>
+        </customproperties>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-layer name="Hello_OnOff" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" legend_exp="" legend_split_behavior="0" name="Hello_OnOff" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;hello&quot; (geom)">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer name="Hello_Filter" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" legend_exp="" legend_split_behavior="0" name="Hello_Filter" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;hello&quot; (geom)">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer name="Hello_SubsetString" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_copy20150804164427541" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="Hello_copy20150804164427541" legend_exp="" legend_split_behavior="0" name="Hello_SubsetString" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;hello&quot; (geom)">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer name="Hello_Project_SubsetString" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )" id="Hello_SubsetString_copy20160222085231770" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="Hello_SubsetString_copy20160222085231770" legend_exp="" legend_split_behavior="0" name="Hello_Project_SubsetString" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer name="Hello_Filter_SubsetString" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_Project_SubsetString_copy20160223113949592" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="Hello_Project_SubsetString_copy20160223113949592" legend_exp="" legend_split_behavior="0" name="Hello_Filter_SubsetString" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;hello&quot; (geom)">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer name="dem" expanded="0" providerKey="gdal" checked="Qt::Checked" source="./dem.tif" id="dem20150730091219559" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="0" id="dem20150730091219559" legend_exp="" legend_split_behavior="0" name="dem" patch_size="0,0" providerKey="gdal" source="./dem.tif">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-group name="Country_grp" expanded="1" checked="Qt::Checked">
-      <customproperties/>
-      <layer-tree-layer name="Country" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" id="country20131022151106556" legend_exp="">
-        <customproperties/>
+    <layer-tree-group checked="Qt::Checked" expanded="1" groupLayer="" name="Country_grp">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
+      <layer-tree-layer checked="Qt::Checked" expanded="1" id="country20131022151106556" legend_exp="" legend_split_behavior="0" name="Country" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;country&quot; (geom)">
+        <customproperties>
+          <Option></Option>
+        </customproperties>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-layer name="Country_Labels" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" id="Country_copy20161127151800736" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="Country_copy20161127151800736" legend_exp="" legend_split_behavior="0" name="Country_Labels" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;country&quot; (geom)">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer name="Country_Diagrams" expanded="0" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" id="country20170328164317226" legend_exp="">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="0" id="country20170328164317226" legend_exp="" legend_split_behavior="0" name="Country_Diagrams" patch_size="0,0" providerKey="spatialite" source="dbname='./helloworld.db' table=&quot;country&quot; (geom)">
+      <customproperties>
+        <Option></Option>
+      </customproperties>
     </layer-tree-layer>
+    <layer-tree-group checked="Qt::Checked" expanded="1" groupLayer="" name="empty group excluded">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsAbstract" type="QString" value="This group should be excluded in GetCapabilities"></Option>
+          <Option name="wmsShortName" type="QString" value=""></Option>
+          <Option name="wmsTitle" type="QString" value=""></Option>
+        </Option>
+      </customproperties>
+    </layer-tree-group>
+    <layer-tree-group checked="Qt::Checked" expanded="1" groupLayer="" name="empty group included">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsAlwaysExpose" type="bool" value="true"></Option>
+          <Option name="wmsAbstract" type="QString" value="This group should be included in GetCapabilities"></Option>
+          <Option name="wmsShortName" type="QString" value=""></Option>
+          <Option name="wmsTitle" type="QString" value=""></Option>
+        </Option>
+      </customproperties>
+    </layer-tree-group>
     <custom-order enabled="0">
       <item>points20150803121107046</item>
       <item>hello20131022151106574</item>
@@ -73,22 +119,23 @@
       <item>Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings type="1" mode="3" intersection-snapping="0" enabled="1" unit="1" tolerance="40">
+  <snapping-settings enabled="1" intersection-snapping="0" maxScale="0" minScale="0" mode="3" scaleDependencyMode="0" self-snapping="0" tolerance="40" type="1" unit="1">
     <individual-layer-settings>
-      <layer-setting type="1" units="2" enabled="1" id="Hello_copy20150804164427541" tolerance="0"/>
-      <layer-setting type="1" units="1" enabled="0" id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" tolerance="12"/>
-      <layer-setting type="1" units="1" enabled="1" id="hello20131022151106574" tolerance="40"/>
-      <layer-setting type="1" units="2" enabled="1" id="Country_copy20161127151800736" tolerance="0"/>
-      <layer-setting type="1" units="2" enabled="1" id="Hello_Project_SubsetString_copy20160223113949592" tolerance="0"/>
-      <layer-setting type="1" units="1" enabled="1" id="country20131022151106556" tolerance="40"/>
-      <layer-setting type="1" units="2" enabled="1" id="Hello_SubsetString_copy20160222085231770" tolerance="0"/>
-      <layer-setting type="1" units="1" enabled="0" id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" tolerance="12"/>
-      <layer-setting type="1" units="2" enabled="0" id="country20170328164317226" tolerance="0"/>
-      <layer-setting type="1" units="2" enabled="1" id="points20150803121107046" tolerance="0"/>
+      <layer-setting enabled="0" id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="country20170328164317226" maxScale="0" minScale="0" tolerance="0" type="1" units="2"></layer-setting>
+      <layer-setting enabled="1" id="Hello_copy20150804164427541" maxScale="0" minScale="0" tolerance="0" type="1" units="2"></layer-setting>
+      <layer-setting enabled="1" id="Hello_SubsetString_copy20160222085231770" maxScale="0" minScale="0" tolerance="0" type="1" units="2"></layer-setting>
+      <layer-setting enabled="0" id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="1" id="points20150803121107046" maxScale="0" minScale="0" tolerance="0" type="1" units="2"></layer-setting>
+      <layer-setting enabled="1" id="hello20131022151106574" maxScale="0" minScale="0" tolerance="40" type="1" units="1"></layer-setting>
+      <layer-setting enabled="1" id="Hello_Project_SubsetString_copy20160223113949592" maxScale="0" minScale="0" tolerance="0" type="1" units="2"></layer-setting>
+      <layer-setting enabled="1" id="country20131022151106556" maxScale="0" minScale="0" tolerance="40" type="1" units="1"></layer-setting>
+      <layer-setting enabled="1" id="Country_copy20161127151800736" maxScale="0" minScale="0" tolerance="0" type="1" units="2"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
-  <relations/>
-  <mapcanvas name="theMapCanvas" annotationsVisible="1">
+  <relations></relations>
+  <polymorphicRelations></polymorphicRelations>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
     <units>meters</units>
     <extent>
       <xmin>-20609693.37008669599890709</xmin>
@@ -98,108 +145,301 @@
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
-      <spatialrefsys>
-        <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
         <srsid>3857</srsid>
         <srid>3857</srid>
         <authid>EPSG:3857</authid>
         <description>WGS 84 / Pseudo-Mercator</description>
         <projectionacronym>merc</projectionacronym>
-        <ellipsoidacronym>WGS84</ellipsoidacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </destinationsrs>
     <rendermaptile>0</rendermaptile>
-    <expressionContextScope/>
+    <expressionContextScope></expressionContextScope>
   </mapcanvas>
-  <projectModels/>
+  <StateDataPlotly>
+    <Option type="Map">
+      <Option name="geometry" type="QString" value="AdnQywADAAAAAAe6AAAAGwAADv8AAASvAAAHugAAAEAAAA5uAAAD1gAAAAACAAAAB4AAAAe6AAAAQAAADv8AAASv"></Option>
+      <Option name="state" type="QString" value="AAAA/wAAA+f9AAAABAAAAAAAAAEMAAADx/wCAAAADfwAAACLAAADxwAAAHsBAAAa+gAAAAIBAAAABPsAAAAOAEIAcgBvAHcAcwBlAHIBAAAAAP////8AAAA3AP////sAAAAUAEwAYQB5AGUAcgBPAHIAZABlAHIAAAAAAP////8AAAC6AP////sAAAAMAEwAYQB5AGUAcgBzAQAAAAD/////AAAANwD////7AAAADABMAGUAZwBlAG4AZAEAAAAA/////wAAAAAAAAAA+wAAABAATwB2AGUAcgB2AGkAZQB3AAAAAdcAAADEAAAAEgD////7AAAAIgBDAG8AbwByAGQAaQBuAGEAdABlAEMAYQBwAHQAdQByAGUAAAABfgAAAKAAAAAAAAAAAPsAAAAIAFUAbgBkAG8AAAAB5AAAANwAAAAAAAAAAPsAAAAQAEIAcgBvAHcAcwBlAHIAMgAAAAITAAAArQAAAGIA////+wAAABwARwBQAFMASQBuAGYAbwByAG0AYQB0AGkAbwBuAAAAAbsAAAEFAAAARQD////7AAAAKABkAHcATwBwAGUAbgBsAGEAeQBlAHIAcwBPAHYAZQByAHYAaQBlAHcAAAABZAAAATcAAAAAAAAAAPsAAAAcAHUAbgBkAG8ALwByAGUAZABvACAAZABvAGMAawAAAAAA/////wAAAO4A////+wAAAC4AQQBkAHYAYQBuAGMAZQBkAEQAaQBnAGkAdABpAHoAaQBuAGcAVABvAG8AbABzAAAAAAD/////AAAA5wD////7AAAANABTAHQAYQB0AGkAcwB0AGEAbABTAHUAbQBtAGEAcgB5AEQAbwBjAGsAVwBpAGQAZwBlAHQAAAAAAP////8AAAAAAAAAAPsAAAAmAEIAbwBvAGsAbQBhAHIAawBzAEQAbwBjAGsAVwBpAGQAZwBlAHQAAAAAAP////8AAABgAP////sAAAA4AFMAdABhAHQAaQBzAHQAaQBjAGEAbABTAHUAbQBtAGEAcgB5AEQAbwBjAGsAVwBpAGQAZwBlAHQAAAAAAP////8AAACsAP////sAAAAYAFYAZQByAHQAZQB4AEUAZABpAHQAbwByAAAAA4QAAADNAAAARQD///8AAAABAAACUwAAA8f8AgAAAA37AAAAHgBTAGUAeAB0AGEAbgB0AGUAVABvAG8AbABiAG8AeAAAAABnAAACNAAAAAAAAAAA/AAAAIsAAAPHAAAAqAEAABr6AAAAAQEAAAAC+wAAABgATABhAHkAZQByAFMAdAB5AGwAaQBuAGcBAAAD1gAAASoAAAElAP////sAAAAiAFAAcgBvAGMAZQBzAHMAaQBuAGcAVABvAG8AbABiAG8AeAEAAAAA/////wAAAFkA////+wAAABQARABvAGMAawBXAGkAZABnAGUAdAAAAAAA/////wAAAAAAAAAA+wAAABoAUgBlAHMAdQBsAHQAcwBWAGkAZQB3AGUAcgAAAAAA/////wAAAQcA////+wAAACYASQBkAGUAbgB0AGkAZgB5AFIAZQBzAHUAbAB0AHMARABvAGMAawEAAALGAAABFwAAAAAAAAAA+wAAACIAUQBtAHMAUwBlAHIAdgBpAGMAZQBUAG8AbwBsAGIAbwB4AAAAAGIAAALFAAAAsAD////7AAAAHABEAGEAdABhAFAAbABvAHQAbAB5AEQAbwBjAGsAAAAAAP////8AAAAAAAAAAPsAAAA0AEQAYQB0AGEAUABsAG8AdABsAHkALQBEAGEAdABhAFAAbABvAHQAbAB5AC0ARABvAGMAawAAAALaAAAAVwAAAEUA////+wAAACgAYwBhAGQAYQBzAHQAcgBlAF8AcwBlAGEAcgBjAGgAXwBmAG8AcgBtAAAAAAD/////AAAAUQD////7AAAAEABEAGUAdgBUAG8AbwBsAHMAAAAAAP////8AAABJAP////sAAAAeAHAAZwBtAGUAdABhAGQAYQB0AGEAXwBkAG8AYwBrAAAAAIsAAAPGAAAARAD////7/////wAAAAAA/////wAAAtQA////+wAAACAAdABoAGUAVABpAGwAZQBTAGMAYQBsAGUARABvAGMAawAAAAAA/////wAAAHgA////AAAAAgAABioAAALR/AEAAAAB+wAAACYAVABlAG0AcABvAHIAYQBsACAAQwBvAG4AdAByAG8AbABsAGUAcgAAAAKQAAADNAAAAxwA////AAAAAwAAA9sAAALl/AEAAAAF/AAAARIAAAPbAAAAgQD////6AAAAAAEAAAAH+wAAABQATQBlAHMAcwBhAGcAZQBMAG8AZwEAAAAA/////wAAAIEA////+wAAABwAQQB0AHQAcgBpAGIAdQB0AGUAVABhAGIAbABlAQAAAAD/////AAAAAAAAAAD7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAQAAAAD/////AAAAAAAAAAD7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAAAAAAD/////AAAAAAAAAAD7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAQAAAAD/////AAAAAAAAAAD7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAQAAAAD/////AAAAAAAAAAD7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAQAAAAD/////AAAAAAAAAAD7AAAAJgBVAHMAZQByAEkAbgBwAHUAdABEAG8AYwBrAFcAaQBkAGcAZQB0AgAAAAAAAAAAAAAAyAAAAGT7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAAAAARwAAAYqAAAAAAAAAAD7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAQAAAR0AAAYpAAAAAAAAAAD7AAAAGgBQAHkAdABoAG8AbgBDAG8AbgBzAG8AbABlAQAAAR0AAAYpAAAAAAAAAAAAAAPbAAAA3AAAAAEAAAACAAAAAQAAAAL8AAAADgAAAAAAAAABAAAAGgBtAEwAYQB5AGUAcgBUAG8AbwBsAEIAYQByAgAAADAAAAOWAAAAAAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAAgAAAAAAAAACAAAABAAAABgAbQBGAGkAbABlAFQAbwBvAGwAQgBhAHIBAAAAAP////8AAAAAAAAAAAAAABwAbQBNAGEAcABOAGEAdgBUAG8AbwBsAEIAYQByAQAAANT/////AAAAAAAAAAAAAAAUAEwAYQB5AGUAcgBCAG8AYQByAGQBAAAC/P////8AAAAAAAAAAAAAAB4AYwBhAGQAYQBzAHQAcgBlAFQAbwBvAGwAYgBhAHIBAAADJgAABB8AAAAAAAAAAAAAAAIAAAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAAAAAAAgAAAAAAAAACAAAACQAAACQAbQBBAHQAdAByAGkAYgB1AHQAZQBzAFQAbwBvAGwAQgBhAHIBAAAAAP////8AAAAAAAAAAAAAACIAbQBTAGUAbABlAGMAdABpAG8AbgBUAG8AbwBsAEIAYQByAQAAAT//////AAAAAAAAAAAAAAAyAG0ARABhAHQAYQBTAG8AdQByAGMAZQBNAGEAbgBhAGcAZQByAFQAbwBvAGwAQgBhAHIBAAACA/////8AAAAAAAAAAAAAACAAbQBEAGEAdABhAGIAYQBzAGUAVABvAG8AbABCAGEAcgEAAAL5/////wAAAAAAAAAAAAAAFgBtAFcAZQBiAFQAbwBvAGwAQgBhAHIBAAADI/////8AAAAAAAAAAAAAABwAbQBQAGwAdQBnAGkAbgBUAG8AbwBsAEIAYQByAQAAA7MAAALDAAAAAAAAAAAAAAAYAG0ASABlAGwAcABUAG8AbwBsAEIAYQByAQAABnb/////AAAAAAAAAAAAAAAcAG0AVgBlAGMAdABvAHIAVABvAG8AbABCAGEAcgAAAAak/////wAAAAAAAAAAAAAAIABtAFMAbgBhAHAAcABpAG4AZwBUAG8AbwBsAEIAYQByAQAABqAAAANMAAAAAAAAAAAAAAACAAAAAQAAABwAbQBSAGEAcwB0AGUAcgBUAG8AbwBsAEIAYQByAAAAAAAAAAKwAAAAAAAAAAAAAAACAAAAAwAAACoAbQBTAGgAYQBwAGUARABpAGcAaQB0AGkAegBlAFQAbwBvAGwAQgBhAHIAAAAAAP////8AAAAAAAAAAAAAABgAbQBNAGUAcwBoAFQAbwBvAGwAQgBhAHIAAAAAuP////8AAAAAAAAAAAAAACYAbQBBAG4AbgBvAHQAYQB0AGkAbwBuAHMAVABvAG8AbABCAGEAcgAAAAAA/////wAAAAAAAAAAAAAAAgAAAAUAAAAgAG0ARABpAGcAaQB0AGkAegBlAFQAbwBvAGwAQgBhAHIBAAAAAP////8AAAAAAAAAAAAAABoAbQBMAGEAYgBlAGwAVABvAG8AbABCAGEAcgEAAAHc/////wAAAAAAAAAAAAAAMABtAEEAZAB2AGEAbgBjAGUAZABEAGkAZwBpAHQAaQB6AGUAVABvAG8AbABCAGEAcgEAAAMeAAAC1QAAAAAAAAAAAAAAFgBtAEcAcABzAFQAbwBvAGwAQgBhAHIBAAAF8wAAAnUAAAAAAAAAAAAAABAAUQB1AGkAYwBrAE8AUwBNAQAABw//////AAAAAAAAAAA="></Option>
+    </Option>
+  </StateDataPlotly>
+  <DataPlotly>
+    <Option type="Map">
+      <Option name="dynamic_properties" type="Map">
+        <Option name="name" type="QString" value=""></Option>
+        <Option name="properties"></Option>
+        <Option name="type" type="QString" value="collection"></Option>
+      </Option>
+      <Option name="plot_layout" type="Map">
+        <Option name="additional_info_expression" type="QString" value=""></Option>
+        <Option name="bar_mode" type="QString" value="group"></Option>
+        <Option name="bargaps" type="double" value="0"></Option>
+        <Option name="bins_check" type="bool" value="false"></Option>
+        <Option name="font_title_color" type="QString" value="#000000"></Option>
+        <Option name="font_title_family" type="QString" value="Arial"></Option>
+        <Option name="font_title_size" type="int" value="10"></Option>
+        <Option name="font_xlabel_color" type="QString" value="#000000"></Option>
+        <Option name="font_xlabel_family" type="QString" value="Arial"></Option>
+        <Option name="font_xlabel_size" type="int" value="10"></Option>
+        <Option name="font_xticks_color" type="QString" value="#000000"></Option>
+        <Option name="font_xticks_family" type="QString" value="Arial"></Option>
+        <Option name="font_xticks_size" type="int" value="10"></Option>
+        <Option name="font_ylabel_color" type="QString" value="#000000"></Option>
+        <Option name="font_ylabel_family" type="QString" value="Arial"></Option>
+        <Option name="font_ylabel_size" type="int" value="10"></Option>
+        <Option name="font_yticks_color" type="QString" value="#000000"></Option>
+        <Option name="font_yticks_family" type="QString" value="Arial"></Option>
+        <Option name="font_yticks_size" type="int" value="10"></Option>
+        <Option name="gridcolor" type="QString" value="#bdbfc0"></Option>
+        <Option name="legend" type="bool" value="true"></Option>
+        <Option name="legend_orientation" type="QString" value="v"></Option>
+        <Option name="legend_title" type="invalid"></Option>
+        <Option name="polar" type="Map">
+          <Option name="angularaxis" type="Map">
+            <Option name="direction" type="QString" value="clockwise"></Option>
+          </Option>
+        </Option>
+        <Option name="range_slider" type="Map">
+          <Option name="borderwidth" type="int" value="1"></Option>
+          <Option name="visible" type="bool" value="false"></Option>
+        </Option>
+        <Option name="title" type="QString" value=""></Option>
+        <Option name="x_inv" type="invalid"></Option>
+        <Option name="x_max" type="invalid"></Option>
+        <Option name="x_min" type="invalid"></Option>
+        <Option name="x_title" type="QString" value=""></Option>
+        <Option name="x_type" type="QString" value="linear"></Option>
+        <Option name="xaxis" type="invalid"></Option>
+        <Option name="y_inv" type="invalid"></Option>
+        <Option name="y_max" type="invalid"></Option>
+        <Option name="y_min" type="invalid"></Option>
+        <Option name="y_title" type="QString" value=""></Option>
+        <Option name="y_type" type="QString" value="linear"></Option>
+        <Option name="z_title" type="QString" value=""></Option>
+      </Option>
+      <Option name="plot_properties" type="Map">
+        <Option name="additional_hover_text" type="invalid"></Option>
+        <Option name="bins" type="int" value="10"></Option>
+        <Option name="box_orientation" type="QString" value="v"></Option>
+        <Option name="box_outliers" type="bool" value="false"></Option>
+        <Option name="box_stat" type="bool" value="false"></Option>
+        <Option name="color_scale" type="QString" value="Greys"></Option>
+        <Option name="color_scale_data_defined_in_check" type="bool" value="false"></Option>
+        <Option name="color_scale_data_defined_in_invert_check" type="bool" value="false"></Option>
+        <Option name="cont_type" type="QString" value="fill"></Option>
+        <Option name="contour_type_combo" type="QString" value="Fill"></Option>
+        <Option name="cumulative" type="bool" value="false"></Option>
+        <Option name="custom" type="List">
+          <Option type="QString" value=""></Option>
+        </Option>
+        <Option name="hover_label_position" type="QString" value="auto"></Option>
+        <Option name="hover_label_text" type="invalid"></Option>
+        <Option name="hover_text" type="QString" value="all"></Option>
+        <Option name="in_color" type="QString" value="#8ebad9"></Option>
+        <Option name="invert_color_scale" type="bool" value="false"></Option>
+        <Option name="invert_hist" type="QString" value="increasing"></Option>
+        <Option name="layout_filter_by_atlas" type="bool" value="false"></Option>
+        <Option name="layout_filter_by_map" type="bool" value="false"></Option>
+        <Option name="line_combo" type="QString" value="Solid Line"></Option>
+        <Option name="line_dash" type="QString" value="solid"></Option>
+        <Option name="marker" type="QString" value="markers"></Option>
+        <Option name="marker_size" type="double" value="10"></Option>
+        <Option name="marker_symbol" type="int" value="0"></Option>
+        <Option name="marker_type_combo" type="QString" value="Points"></Option>
+        <Option name="marker_width" type="double" value="1"></Option>
+        <Option name="name" type="QString" value=""></Option>
+        <Option name="normalization" type="QString" value=""></Option>
+        <Option name="opacity" type="double" value="1"></Option>
+        <Option name="out_color" type="QString" value="#1f77b4"></Option>
+        <Option name="pie_hole" type="double" value="0"></Option>
+        <Option name="point_combo" type="QString" value=""></Option>
+        <Option name="selected_features_only" type="bool" value="false"></Option>
+        <Option name="show_colorscale_legend" type="bool" value="false"></Option>
+        <Option name="show_lines" type="bool" value="true"></Option>
+        <Option name="show_lines_check" type="bool" value="true"></Option>
+        <Option name="show_mean_line" type="bool" value="true"></Option>
+        <Option name="violin_box" type="bool" value="true"></Option>
+        <Option name="violin_side" type="QString" value="both"></Option>
+        <Option name="visible_features_only" type="bool" value="false"></Option>
+        <Option name="x_name" type="QString" value=""></Option>
+        <Option name="y_name" type="QString" value=""></Option>
+        <Option name="z_name" type="QString" value=""></Option>
+      </Option>
+      <Option name="plot_type" type="QString" value="scatter"></Option>
+      <Option name="source_layer_id" type="QString" value="Country_copy20161127151800736"></Option>
+    </Option>
+  </DataPlotly>
+  <projectModels></projectModels>
   <legend updateDrawingOrder="true">
-    <legendlayer name="db_point" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="points20150803121107046" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="db_point" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="points20150803121107046" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendgroup name="Hello_grp" checked="Qt::Checked" open="true">
-      <legendlayer name="Hello" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-        <filegroup open="true" hidden="false">
-          <legendlayerfile layerid="hello20131022151106574" visible="1" isInOverview="0"/>
+    <legendgroup checked="Qt::Checked" name="Hello_grp" open="true">
+      <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Hello" open="true" showFeatureCount="0">
+        <filegroup hidden="false" open="true">
+          <legendlayerfile isInOverview="0" layerid="hello20131022151106574" visible="1"></legendlayerfile>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendlayer name="Hello_OnOff" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Hello_OnOff" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="Hello_Filter" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Hello_Filter" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="Hello_SubsetString" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="Hello_copy20150804164427541" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Hello_SubsetString" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="Hello_copy20150804164427541" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="Hello_Project_SubsetString" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="Hello_SubsetString_copy20160222085231770" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Hello_Project_SubsetString" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="Hello_SubsetString_copy20160222085231770" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="Hello_Filter_SubsetString" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="Hello_Project_SubsetString_copy20160223113949592" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Hello_Filter_SubsetString" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="Hello_Project_SubsetString_copy20160223113949592" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="dem" drawingOrder="-1" checked="Qt::Checked" open="false" showFeatureCount="0">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile layerid="dem20150730091219559" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="dem" open="false" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile isInOverview="0" layerid="dem20150730091219559" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendgroup name="Country_grp" checked="Qt::Checked" open="true">
-      <legendlayer name="Country" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-        <filegroup open="true" hidden="false">
-          <legendlayerfile layerid="country20131022151106556" visible="1" isInOverview="0"/>
+    <legendgroup checked="Qt::Checked" name="Country_grp" open="true">
+      <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Country" open="true" showFeatureCount="0">
+        <filegroup hidden="false" open="true">
+          <legendlayerfile isInOverview="0" layerid="country20131022151106556" visible="1"></legendlayerfile>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendlayer name="Country_Labels" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="Country_copy20161127151800736" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Country_Labels" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="Country_copy20161127151800736" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="Country_Diagrams" drawingOrder="-1" checked="Qt::Checked" open="false" showFeatureCount="0">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile layerid="country20170328164317226" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Country_Diagrams" open="false" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile isInOverview="0" layerid="country20170328164317226" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
+    <legendgroup checked="Qt::Checked" name="empty group excluded" open="true"></legendgroup>
+    <legendgroup checked="Qt::Checked" name="empty group included" open="true"></legendgroup>
   </legend>
-  <mapViewDocks/>
+  <mapViewDocks></mapViewDocks>
+  <mapcanvas annotationsVisible="1" name="mAreaCanvas">
+    <units>meters</units>
+    <extent>
+      <xmin>-20609693.37008669599890709</xmin>
+      <ymin>-11045674.50870379433035851</ymin>
+      <xmax>20961935.60850896313786507</xmax>
+      <ymax>19134440.47931583970785141</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <srsid>3857</srsid>
+        <srid>3857</srid>
+        <authid>EPSG:3857</authid>
+        <description>WGS 84 / Pseudo-Mercator</description>
+        <projectionacronym>merc</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope></expressionContextScope>
+  </mapcanvas>
+  <main-annotation-layer autoRefreshMode="Disabled" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="annotation">
+    <id>Annotations_37b28445_c252_406d_8bc3_a48e7213169b</id>
+    <datasource></datasource>
+    <keywordList>
+      <value></value>
+    </keywordList>
+    <layername></layername>
+    <srs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt></wkt>
+        <proj4></proj4>
+        <srsid>0</srsid>
+        <srid>0</srid>
+        <authid></authid>
+        <description></description>
+        <projectionacronym></projectionacronym>
+        <ellipsoidacronym></ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </srs>
+    <resourceMetadata>
+      <identifier></identifier>
+      <parentidentifier></parentidentifier>
+      <language></language>
+      <type></type>
+      <title></title>
+      <abstract></abstract>
+      <links></links>
+      <dates></dates>
+      <fees></fees>
+      <encoding></encoding>
+      <crs>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt></wkt>
+          <proj4></proj4>
+          <srsid>0</srsid>
+          <srid>0</srid>
+          <authid></authid>
+          <description></description>
+          <projectionacronym></projectionacronym>
+          <ellipsoidacronym></ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </crs>
+      <extent></extent>
+    </resourceMetadata>
+    <items></items>
+    <flags>
+      <Identifiable>1</Identifiable>
+      <Removable>1</Removable>
+      <Searchable>1</Searchable>
+      <Private>0</Private>
+    </flags>
+    <customproperties>
+      <Option></Option>
+    </customproperties>
+    <layerOpacity>1</layerOpacity>
+    <blendMode>0</blendMode>
+    <paintEffect></paintEffect>
+  </main-annotation-layer>
   <projectlayers>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-19619892.68012013286352158</xmin>
-        <ymin>-10327100.34232237376272678</ymin>
-        <xmax>19972134.91854240000247955</xmax>
-        <ymax>18415866.31293442100286484</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>Country_copy20161127151800736</id>
-      <datasource>dbname='./helloworld.db' table="country" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="country" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>Country_Labels</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -210,11 +450,12 @@
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -226,292 +467,291 @@
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
         <map-layer-style name="custom">
-          <qgis maximumScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" readOnly="0" simplifyDrawingHints="1" simplifyAlgorithm="0" version="2.99.0-Master" minimumScale="0" simplifyMaxScale="1" simplifyLocal="1">
+          <qgis hasScaleBasedVisibilityFlag="0" maximumScale="1e+08" minimumScale="0" readOnly="0" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" version="2.99.0-Master">
             <edittypes>
               <edittype name="pk" widgetv2type="TextEdit">
-                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
+                <widgetv2config IsMultiline="0" UseHtml="0" fieldEditable="1" labelOnTop="0"></widgetv2config>
               </edittype>
               <edittype name="name" widgetv2type="TextEdit">
-                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
+                <widgetv2config IsMultiline="0" UseHtml="0" fieldEditable="1" labelOnTop="0"></widgetv2config>
               </edittype>
             </edittypes>
-            <renderer-v2 type="singleSymbol" enableorderby="0" symbollevels="0" forceraster="0">
+            <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="singleSymbol">
               <symbols>
-                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
-                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-                    <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-                    <prop v="145,149,158,255" k="color"/>
-                    <prop v="bevel" k="joinstyle"/>
-                    <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-                    <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="157,157,157,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="0.26" k="outline_width"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="solid" k="style"/>
+                <symbol alpha="1" clip_to_extent="1" name="0" type="fill">
+                  <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+                    <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"></prop>
+                    <prop k="color" v="145,149,158,255"></prop>
+                    <prop k="joinstyle" v="bevel"></prop>
+                    <prop k="offset" v="0.80000000000000004,0.80000000000000004"></prop>
+                    <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="157,157,157,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="0.26"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="style" v="solid"></prop>
                   </layer>
-                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-                    <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-                    <prop v="0,0,255,255" k="color"/>
-                    <prop v="bevel" k="joinstyle"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="0,0,0,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="0.26" k="outline_width"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="solid" k="style"/>
+                  <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+                    <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"></prop>
+                    <prop k="color" v="0,0,255,255"></prop>
+                    <prop k="joinstyle" v="bevel"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="0,0,0,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="0.26"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="style" v="solid"></prop>
                   </layer>
                 </symbol>
               </symbols>
-              <rotation/>
-              <sizescale/>
+              <rotation></rotation>
+              <sizescale></sizescale>
             </renderer-v2>
-            <labeling type="simple"/>
+            <labeling type="simple"></labeling>
             <customproperties>
-              <property key="embeddedWidgets/count" value="0"/>
-              <property key="labeling" value="pal"/>
-              <property key="labeling/addDirectionSymbol" value="false"/>
-              <property key="labeling/angleOffset" value="0"/>
-              <property key="labeling/blendMode" value="0"/>
-              <property key="labeling/bufferBlendMode" value="0"/>
-              <property key="labeling/bufferColorA" value="255"/>
-              <property key="labeling/bufferColorB" value="255"/>
-              <property key="labeling/bufferColorG" value="255"/>
-              <property key="labeling/bufferColorR" value="255"/>
-              <property key="labeling/bufferDraw" value="false"/>
-              <property key="labeling/bufferJoinStyle" value="64"/>
-              <property key="labeling/bufferNoFill" value="false"/>
-              <property key="labeling/bufferOpacity" value="1"/>
-              <property key="labeling/bufferSize" value="1"/>
-              <property key="labeling/bufferSizeInMapUnits" value="false"/>
-              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/bufferSizeUnits" value="MM"/>
-              <property key="labeling/bufferTransp" value="0"/>
-              <property key="labeling/centroidInside" value="false"/>
-              <property key="labeling/centroidWhole" value="false"/>
-              <property key="labeling/decimals" value="3"/>
-              <property key="labeling/displayAll" value="false"/>
-              <property key="labeling/dist" value="0"/>
-              <property key="labeling/distInMapUnits" value="false"/>
-              <property key="labeling/distMapUnitMaxScale" value="0"/>
-              <property key="labeling/distMapUnitMinScale" value="0"/>
-              <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/drawLabels" value="true"/>
-              <property key="labeling/enabled" value="true"/>
-              <property key="labeling/fieldName" value="name"/>
-              <property key="labeling/fitInPolygonOnly" value="false"/>
-              <property key="labeling/fontBold" value="false"/>
-              <property key="labeling/fontCapitals" value="0"/>
-              <property key="labeling/fontFamily" value="Sans Serif"/>
-              <property key="labeling/fontItalic" value="true"/>
-              <property key="labeling/fontLetterSpacing" value="0"/>
-              <property key="labeling/fontLimitPixelSize" value="false"/>
-              <property key="labeling/fontMaxPixelSize" value="10000"/>
-              <property key="labeling/fontMinPixelSize" value="3"/>
-              <property key="labeling/fontSize" value="40"/>
-              <property key="labeling/fontSizeInMapUnits" value="false"/>
-              <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/fontSizeUnit" value="Point"/>
-              <property key="labeling/fontStrikeout" value="false"/>
-              <property key="labeling/fontUnderline" value="true"/>
-              <property key="labeling/fontWeight" value="50"/>
-              <property key="labeling/fontWordSpacing" value="0"/>
-              <property key="labeling/formatNumbers" value="false"/>
-              <property key="labeling/isExpression" value="false"/>
-              <property key="labeling/labelOffsetInMapUnits" value="true"/>
-              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/labelPerPart" value="false"/>
-              <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-              <property key="labeling/limitNumLabels" value="false"/>
-              <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-              <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-              <property key="labeling/maxNumLabels" value="2000"/>
-              <property key="labeling/mergeLines" value="false"/>
-              <property key="labeling/minFeatureSize" value="0"/>
-              <property key="labeling/multilineAlign" value="0"/>
-              <property key="labeling/multilineHeight" value="1"/>
-              <property key="labeling/namedStyle" value="Italic"/>
-              <property key="labeling/obstacle" value="true"/>
-              <property key="labeling/obstacleFactor" value="1"/>
-              <property key="labeling/obstacleType" value="0"/>
-              <property key="labeling/offsetType" value="0"/>
-              <property key="labeling/placeDirectionSymbol" value="0"/>
-              <property key="labeling/placement" value="0"/>
-              <property key="labeling/placementFlags" value="0"/>
-              <property key="labeling/plussign" value="false"/>
-              <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-              <property key="labeling/preserveRotation" value="true"/>
-              <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-              <property key="labeling/priority" value="5"/>
-              <property key="labeling/quadOffset" value="4"/>
-              <property key="labeling/repeatDistance" value="0"/>
-              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-              <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/repeatDistanceUnit" value="1"/>
-              <property key="labeling/reverseDirectionSymbol" value="false"/>
-              <property key="labeling/rightDirectionSymbol" value=">"/>
-              <property key="labeling/scaleMax" value="10000000"/>
-              <property key="labeling/scaleMin" value="1"/>
-              <property key="labeling/scaleVisibility" value="false"/>
-              <property key="labeling/shadowBlendMode" value="6"/>
-              <property key="labeling/shadowColorB" value="0"/>
-              <property key="labeling/shadowColorG" value="0"/>
-              <property key="labeling/shadowColorR" value="0"/>
-              <property key="labeling/shadowDraw" value="false"/>
-              <property key="labeling/shadowOffsetAngle" value="135"/>
-              <property key="labeling/shadowOffsetDist" value="1"/>
-              <property key="labeling/shadowOffsetGlobal" value="true"/>
-              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/shadowOffsetUnit" value="MapUnit"/>
-              <property key="labeling/shadowOffsetUnits" value="1"/>
-              <property key="labeling/shadowOpacity" value="0.69999999999999996"/>
-              <property key="labeling/shadowRadius" value="1.5"/>
-              <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-              <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/shadowRadiusUnit" value="MapUnit"/>
-              <property key="labeling/shadowRadiusUnits" value="1"/>
-              <property key="labeling/shadowScale" value="100"/>
-              <property key="labeling/shadowTransparency" value="30"/>
-              <property key="labeling/shadowUnder" value="0"/>
-              <property key="labeling/shapeBlendMode" value="0"/>
-              <property key="labeling/shapeBorderColorA" value="255"/>
-              <property key="labeling/shapeBorderColorB" value="128"/>
-              <property key="labeling/shapeBorderColorG" value="128"/>
-              <property key="labeling/shapeBorderColorR" value="128"/>
-              <property key="labeling/shapeBorderWidth" value="0"/>
-              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/shapeBorderWidthUnit" value="MapUnit"/>
-              <property key="labeling/shapeBorderWidthUnits" value="1"/>
-              <property key="labeling/shapeDraw" value="false"/>
-              <property key="labeling/shapeFillColorA" value="255"/>
-              <property key="labeling/shapeFillColorB" value="255"/>
-              <property key="labeling/shapeFillColorG" value="255"/>
-              <property key="labeling/shapeFillColorR" value="255"/>
-              <property key="labeling/shapeJoinStyle" value="64"/>
-              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/shapeOffsetUnit" value="MapUnit"/>
-              <property key="labeling/shapeOffsetUnits" value="1"/>
-              <property key="labeling/shapeOffsetX" value="0"/>
-              <property key="labeling/shapeOffsetY" value="0"/>
-              <property key="labeling/shapeOpacity" value="1"/>
-              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/shapeRadiiUnit" value="MapUnit"/>
-              <property key="labeling/shapeRadiiUnits" value="1"/>
-              <property key="labeling/shapeRadiiX" value="0"/>
-              <property key="labeling/shapeRadiiY" value="0"/>
-              <property key="labeling/shapeRotation" value="0"/>
-              <property key="labeling/shapeRotationType" value="0"/>
-              <property key="labeling/shapeSVGFile" value=""/>
-              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-              <property key="labeling/shapeSizeType" value="0"/>
-              <property key="labeling/shapeSizeUnit" value="MapUnit"/>
-              <property key="labeling/shapeSizeUnits" value="1"/>
-              <property key="labeling/shapeSizeX" value="0"/>
-              <property key="labeling/shapeSizeY" value="0"/>
-              <property key="labeling/shapeTransparency" value="0"/>
-              <property key="labeling/shapeType" value="0"/>
-              <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-              <property key="labeling/textColorA" value="255"/>
-              <property key="labeling/textColorB" value="1"/>
-              <property key="labeling/textColorG" value="1"/>
-              <property key="labeling/textColorR" value="255"/>
-              <property key="labeling/textOpacity" value="1"/>
-              <property key="labeling/textTransp" value="0"/>
-              <property key="labeling/upsidedownLabels" value="0"/>
-              <property key="labeling/useSubstitutions" value="false"/>
-              <property key="labeling/wrapChar" value=""/>
-              <property key="labeling/xOffset" value="0"/>
-              <property key="labeling/yOffset" value="0"/>
-              <property key="labeling/zIndex" value="0"/>
-              <property key="variableNames"/>
-              <property key="variableValues"/>
+              <property key="embeddedWidgets/count" value="0"></property>
+              <property key="labeling" value="pal"></property>
+              <property key="labeling/addDirectionSymbol" value="false"></property>
+              <property key="labeling/angleOffset" value="0"></property>
+              <property key="labeling/blendMode" value="0"></property>
+              <property key="labeling/bufferBlendMode" value="0"></property>
+              <property key="labeling/bufferColorA" value="255"></property>
+              <property key="labeling/bufferColorB" value="255"></property>
+              <property key="labeling/bufferColorG" value="255"></property>
+              <property key="labeling/bufferColorR" value="255"></property>
+              <property key="labeling/bufferDraw" value="false"></property>
+              <property key="labeling/bufferJoinStyle" value="64"></property>
+              <property key="labeling/bufferNoFill" value="false"></property>
+              <property key="labeling/bufferOpacity" value="1"></property>
+              <property key="labeling/bufferSize" value="1"></property>
+              <property key="labeling/bufferSizeInMapUnits" value="false"></property>
+              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/bufferSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/bufferSizeUnits" value="MM"></property>
+              <property key="labeling/bufferTransp" value="0"></property>
+              <property key="labeling/centroidInside" value="false"></property>
+              <property key="labeling/centroidWhole" value="false"></property>
+              <property key="labeling/decimals" value="3"></property>
+              <property key="labeling/displayAll" value="false"></property>
+              <property key="labeling/dist" value="0"></property>
+              <property key="labeling/distInMapUnits" value="false"></property>
+              <property key="labeling/distMapUnitMaxScale" value="0"></property>
+              <property key="labeling/distMapUnitMinScale" value="0"></property>
+              <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/drawLabels" value="true"></property>
+              <property key="labeling/enabled" value="true"></property>
+              <property key="labeling/fieldName" value="name"></property>
+              <property key="labeling/fitInPolygonOnly" value="false"></property>
+              <property key="labeling/fontBold" value="false"></property>
+              <property key="labeling/fontCapitals" value="0"></property>
+              <property key="labeling/fontFamily" value="Sans Serif"></property>
+              <property key="labeling/fontItalic" value="true"></property>
+              <property key="labeling/fontLetterSpacing" value="0"></property>
+              <property key="labeling/fontLimitPixelSize" value="false"></property>
+              <property key="labeling/fontMaxPixelSize" value="10000"></property>
+              <property key="labeling/fontMinPixelSize" value="3"></property>
+              <property key="labeling/fontSize" value="40"></property>
+              <property key="labeling/fontSizeInMapUnits" value="false"></property>
+              <property key="labeling/fontSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/fontSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/fontSizeUnit" value="Point"></property>
+              <property key="labeling/fontStrikeout" value="false"></property>
+              <property key="labeling/fontUnderline" value="true"></property>
+              <property key="labeling/fontWeight" value="50"></property>
+              <property key="labeling/fontWordSpacing" value="0"></property>
+              <property key="labeling/formatNumbers" value="false"></property>
+              <property key="labeling/isExpression" value="false"></property>
+              <property key="labeling/labelOffsetInMapUnits" value="true"></property>
+              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/labelOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/labelPerPart" value="false"></property>
+              <property key="labeling/leftDirectionSymbol" value="&lt;"></property>
+              <property key="labeling/limitNumLabels" value="false"></property>
+              <property key="labeling/maxCurvedCharAngleIn" value="20"></property>
+              <property key="labeling/maxCurvedCharAngleOut" value="-20"></property>
+              <property key="labeling/maxNumLabels" value="2000"></property>
+              <property key="labeling/mergeLines" value="false"></property>
+              <property key="labeling/minFeatureSize" value="0"></property>
+              <property key="labeling/multilineAlign" value="0"></property>
+              <property key="labeling/multilineHeight" value="1"></property>
+              <property key="labeling/namedStyle" value="Italic"></property>
+              <property key="labeling/obstacle" value="true"></property>
+              <property key="labeling/obstacleFactor" value="1"></property>
+              <property key="labeling/obstacleType" value="0"></property>
+              <property key="labeling/offsetType" value="0"></property>
+              <property key="labeling/placeDirectionSymbol" value="0"></property>
+              <property key="labeling/placement" value="0"></property>
+              <property key="labeling/placementFlags" value="0"></property>
+              <property key="labeling/plussign" value="false"></property>
+              <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"></property>
+              <property key="labeling/preserveRotation" value="true"></property>
+              <property key="labeling/previewBkgrdColor" value="#ffffff"></property>
+              <property key="labeling/priority" value="5"></property>
+              <property key="labeling/quadOffset" value="4"></property>
+              <property key="labeling/repeatDistance" value="0"></property>
+              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"></property>
+              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"></property>
+              <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/repeatDistanceUnit" value="1"></property>
+              <property key="labeling/reverseDirectionSymbol" value="false"></property>
+              <property key="labeling/rightDirectionSymbol" value=">"></property>
+              <property key="labeling/scaleMax" value="10000000"></property>
+              <property key="labeling/scaleMin" value="1"></property>
+              <property key="labeling/scaleVisibility" value="false"></property>
+              <property key="labeling/shadowBlendMode" value="6"></property>
+              <property key="labeling/shadowColorB" value="0"></property>
+              <property key="labeling/shadowColorG" value="0"></property>
+              <property key="labeling/shadowColorR" value="0"></property>
+              <property key="labeling/shadowDraw" value="false"></property>
+              <property key="labeling/shadowOffsetAngle" value="135"></property>
+              <property key="labeling/shadowOffsetDist" value="1"></property>
+              <property key="labeling/shadowOffsetGlobal" value="true"></property>
+              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/shadowOffsetUnit" value="MapUnit"></property>
+              <property key="labeling/shadowOffsetUnits" value="1"></property>
+              <property key="labeling/shadowOpacity" value="0.69999999999999996"></property>
+              <property key="labeling/shadowRadius" value="1.5"></property>
+              <property key="labeling/shadowRadiusAlphaOnly" value="false"></property>
+              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"></property>
+              <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/shadowRadiusUnit" value="MapUnit"></property>
+              <property key="labeling/shadowRadiusUnits" value="1"></property>
+              <property key="labeling/shadowScale" value="100"></property>
+              <property key="labeling/shadowTransparency" value="30"></property>
+              <property key="labeling/shadowUnder" value="0"></property>
+              <property key="labeling/shapeBlendMode" value="0"></property>
+              <property key="labeling/shapeBorderColorA" value="255"></property>
+              <property key="labeling/shapeBorderColorB" value="128"></property>
+              <property key="labeling/shapeBorderColorG" value="128"></property>
+              <property key="labeling/shapeBorderColorR" value="128"></property>
+              <property key="labeling/shapeBorderWidth" value="0"></property>
+              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/shapeBorderWidthUnit" value="MapUnit"></property>
+              <property key="labeling/shapeBorderWidthUnits" value="1"></property>
+              <property key="labeling/shapeDraw" value="false"></property>
+              <property key="labeling/shapeFillColorA" value="255"></property>
+              <property key="labeling/shapeFillColorB" value="255"></property>
+              <property key="labeling/shapeFillColorG" value="255"></property>
+              <property key="labeling/shapeFillColorR" value="255"></property>
+              <property key="labeling/shapeJoinStyle" value="64"></property>
+              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/shapeOffsetUnit" value="MapUnit"></property>
+              <property key="labeling/shapeOffsetUnits" value="1"></property>
+              <property key="labeling/shapeOffsetX" value="0"></property>
+              <property key="labeling/shapeOffsetY" value="0"></property>
+              <property key="labeling/shapeOpacity" value="1"></property>
+              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/shapeRadiiUnit" value="MapUnit"></property>
+              <property key="labeling/shapeRadiiUnits" value="1"></property>
+              <property key="labeling/shapeRadiiX" value="0"></property>
+              <property key="labeling/shapeRadiiY" value="0"></property>
+              <property key="labeling/shapeRotation" value="0"></property>
+              <property key="labeling/shapeRotationType" value="0"></property>
+              <property key="labeling/shapeSVGFile" value=""></property>
+              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"></property>
+              <property key="labeling/shapeSizeType" value="0"></property>
+              <property key="labeling/shapeSizeUnit" value="MapUnit"></property>
+              <property key="labeling/shapeSizeUnits" value="1"></property>
+              <property key="labeling/shapeSizeX" value="0"></property>
+              <property key="labeling/shapeSizeY" value="0"></property>
+              <property key="labeling/shapeTransparency" value="0"></property>
+              <property key="labeling/shapeType" value="0"></property>
+              <property key="labeling/substitutions" value="&lt;substitutions/>"></property>
+              <property key="labeling/textColorA" value="255"></property>
+              <property key="labeling/textColorB" value="1"></property>
+              <property key="labeling/textColorG" value="1"></property>
+              <property key="labeling/textColorR" value="255"></property>
+              <property key="labeling/textOpacity" value="1"></property>
+              <property key="labeling/textTransp" value="0"></property>
+              <property key="labeling/upsidedownLabels" value="0"></property>
+              <property key="labeling/useSubstitutions" value="false"></property>
+              <property key="labeling/wrapChar" value=""></property>
+              <property key="labeling/xOffset" value="0"></property>
+              <property key="labeling/yOffset" value="0"></property>
+              <property key="labeling/zIndex" value="0"></property>
+              <property key="variableNames"></property>
+              <property key="variableValues"></property>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerTransparency>0</layerTransparency>
             <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie" sizeLegend="0">
-              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" angleOffset="1440" sizeScale="0,0,0,0,0,0" lineSizeScale="0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" enabled="0" transparency="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
-                <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-                <attribute color="#000000" label="" field=""/>
+              <DiagramCategory angleOffset="1440" backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" penAlpha="255" penColor="#000000" penWidth="0" scaleBasedVisibility="0" scaleDependency="Area" sizeScale="0,0,0,0,0,0" sizeType="MM" transparency="0" width="15">
+                <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+                <attribute color="#000000" field="" label=""></attribute>
               </DiagramCategory>
-              <symbol type="marker" alpha="1" clip_to_extent="1" name="sizeSymbol">
-                <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="255,0,0,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="circle" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0,0,0,255" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0" k="outline_width"/>
-                  <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="diameter" k="scale_method"/>
-                  <prop v="2" k="size"/>
-                  <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+              <symbol alpha="1" clip_to_extent="1" name="sizeSymbol" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="255,0,0,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,255"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="diameter"></prop>
+                  <prop k="size" v="2"></prop>
+                  <prop k="size_map_unit_scale" v="0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                 </layer>
               </symbol>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" xPosColumn="-1" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showColumn="0" showAll="1" yPosColumn="-1"/>
+            <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" showColumn="0" xPosColumn="-1" yPosColumn="-1" zIndex="0"></DiagramLayerSettings>
             <annotationform>.</annotationform>
             <aliases>
-              <alias name="" field="pk" index="0"/>
-              <alias name="" field="name" index="1"/>
+              <alias field="pk" index="0" name=""></alias>
+              <alias field="name" index="1" name=""></alias>
             </aliases>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <attributeactions>
-              <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+              <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
             </attributeactions>
             <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
               <columns>
-                <column type="field" width="-1" name="pk" hidden="0"/>
-                <column type="field" width="-1" name="name" hidden="0"/>
-                <column type="actions" width="-1" hidden="1"/>
+                <column hidden="0" name="pk" type="field" width="-1"></column>
+                <column hidden="0" name="name" type="field" width="-1"></column>
+                <column hidden="1" type="actions" width="-1"></column>
               </columns>
             </attributetableconfig>
             <editform>.</editform>
-            <editforminit/>
+            <editforminit></editforminit>
             <editforminitcodesource>0</editforminitcodesource>
-            <editforminitfilepath/>
-            <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+            <editforminitfilepath></editforminitfilepath>
+            <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -527,210 +767,455 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
             <featformsuppress>0</featformsuppress>
             <editorlayout>generatedlayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer columnCount="0" visibilityExpression="" name="ttt" showLabel="1" groupBox="0" visibilityExpressionEnabled="0"/>
+              <attributeEditorContainer columnCount="0" groupBox="0" name="ttt" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0"></attributeEditorContainer>
             </attributeEditorForm>
-            <widgets/>
+            <widgets></widgets>
             <conditionalstyles>
-              <rowstyles/>
-              <fieldstyles/>
+              <rowstyles></rowstyles>
+              <fieldstyles></fieldstyles>
             </conditionalstyles>
-            <expressionfields/>
+            <expressionfields></expressionfields>
             <previewExpression>name</previewExpression>
-            <mapTip/>
+            <mapTip></mapTip>
             <layerGeometryType>2</layerGeometryType>
           </qgis>
         </map-layer-style>
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="145,149,158,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="157,157,157,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{4d343b84-e0c1-470f-83fd-d31e82a59cfb}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="125,139,143,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="0,0,255,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{94ee8fea-ac65-4ad4-b446-2a8f7a3325d4}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="125,139,143,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="89,99,102,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{78af51c4-be38-484c-b3ee-59acbc477522}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="125,139,143,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="89,99,102,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{9061a27d-f475-4288-aa41-819878642364}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="145,149,158,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="157,157,157,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{bef5818d-2983-471e-82bf-ada74ed32179}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="0,0,255,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style blendMode="0" fontLetterSpacing="0" fontItalic="0" fontKerning="1" fontSize="9" fontFamily="Sans Serif" fontWeight="50" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" namedStyle="Normal" useSubstitutions="0" fontCapitals="0" textOrientation="horizontal" textColor="0,0,0,255" multilineHeight="1" fontStrikeout="0" isExpression="0" fontUnderline="0" fontSizeUnit="Point" fieldName="name" previewBkgrdColor="255,255,255,255" fontWordSpacing="0">
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSizeUnits="MM" bufferNoFill="0" bufferSize="1" bufferColor="255,255,255,255" bufferBlendMode="0" bufferDraw="0" bufferJoinStyle="64"/>
-            <background shapeBlendMode="0" shapeRotation="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeOffsetX="0" shapeBorderWidth="0" shapeOffsetUnit="MapUnit" shapeRadiiX="0" shapeSizeUnit="MapUnit" shapeType="0" shapeRotationType="0" shapeRadiiY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeOffsetY="0" shapeSVGFile="" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeBorderWidthUnit="MapUnit" shapeSizeY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeRadiiUnit="MapUnit"/>
-            <shadow shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowRadius="1.5" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowRadiusUnit="MapUnit" shadowOpacity="0.7" shadowRadiusAlphaOnly="0" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MapUnit" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowOffsetAngle="135"/>
+          <text-style allowHtml="0" blendMode="0" capitalization="0" fieldName="name" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="9" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" isExpression="0" legendString="Aa" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="Normal" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <families></families>
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="64" bufferNoFill="0" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MapUnit" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MapUnit" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MapUnit" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MapUnit" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+                <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                  <Option type="Map">
+                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="color" type="QString" value="255,255,255,255"></Option>
+                    <Option name="joinstyle" type="QString" value="bevel"></Option>
+                    <Option name="offset" type="QString" value="0,0"></Option>
+                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="offset_unit" type="QString" value="MM"></Option>
+                    <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                    <Option name="outline_style" type="QString" value="no"></Option>
+                    <Option name="outline_width" type="QString" value="0"></Option>
+                    <Option name="outline_width_unit" type="QString" value="MapUnit"></Option>
+                    <Option name="style" type="QString" value="solid"></Option>
+                  </Option>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MapUnit" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MapUnit" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format decimals="3" multilineAlign="0" leftDirectionSymbol="&lt;" placeDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" wrapChar="" plussign="0" addDirectionSymbol="0" autoWrapLength="0" rightDirectionSymbol=">" reverseDirectionSymbol="0"/>
-          <placement centroidInside="0" maxCurvedCharAngleIn="20" repeatDistanceUnits="MM" fitInPolygonOnly="0" layerType="UnknownGeometry" distUnits="MM" offsetUnits="MapUnit" repeatDistance="0" overrunDistanceUnit="MM" rotationAngle="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" geometryGenerator="" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" placementFlags="0" geometryGeneratorEnabled="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" xOffset="0" centroidWhole="0" quadOffset="4" yOffset="0" maxCurvedCharAngleOut="-20" priority="5" geometryGeneratorType="PointGeometry" offsetType="0"/>
-          <rendering fontMaxPixelSize="10000" minFeatureSize="0" zIndex="0" scaleMin="1" maxNumLabels="2000" drawLabels="1" limitNumLabels="0" scaleMax="10000000" fontLimitPixelSize="0" obstacleType="0" mergeLines="0" displayAll="0" obstacleFactor="1" fontMinPixelSize="3" upsidedownLabels="0" labelPerPart="0" obstacle="1" scaleVisibility="0"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="0" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
+          <placement allowDegraded="0" centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" lineAnchorClipping="0" lineAnchorPercent="0.5" lineAnchorTextPoint="CenterOfText" lineAnchorType="0" maxCurvedCharAngleIn="20" maxCurvedCharAngleOut="-20" offsetType="0" offsetUnits="MapUnit" overlapHandling="PreventOverlap" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="0" polygonPlacementFlags="2" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" rotationUnit="AngleDegrees" xOffset="0" yOffset="0"></placement>
+          <rendering drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="10000000" scaleMin="1" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="blendMode" type="int" value="0"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" name="drawToAllParts" value="false"/>
-              <Option type="QString" name="enabled" value="0"/>
-              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; name=&quot;symbol&quot; force_rhr=&quot;0&quot;>&lt;layer class=&quot;SimpleLine&quot; enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
-              <Option type="double" name="minLength" value="0"/>
-              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="minLengthUnit" value="MM"/>
-              <Option type="double" name="offsetFromAnchor" value="0"/>
-              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
-              <Option type="double" name="offsetFromLabel" value="0"/>
-              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol type=&quot;line&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; name=&quot;symbol&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; locked=&quot;0&quot; pass=&quot;0&quot; enabled=&quot;1&quot; id=&quot;{e6324fdc-2dec-407d-9ba0-d9596a9c505e}&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <Option type="Map">
+          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
+          <Option name="variableNames"></Option>
+          <Option name="variableValues"></Option>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{cc86f9c4-2ee1-4130-b7d6-bc3a26c907bb}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
+        <field configurationFlags="NoFlag" name="pk">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="name">
+        <field configurationFlags="NoFlag" name="name">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="name" index="1"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="name" index="1" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="name" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="name" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="name"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="name" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="name"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" width="-1" name="pk" hidden="0"/>
-          <column type="field" width="-1" name="name" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="pk" type="field" width="-1"></column>
+          <column hidden="0" name="name" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -746,41 +1231,44 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="ttt" showLabel="1" groupBox="0" visibilityExpressionEnabled="0"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="ttt" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+        </attributeEditorContainer>
       </attributeEditorForm>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>name</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-14746250.07513097859919071</xmin>
-        <ymin>-112075.42807669920148328</ymin>
-        <xmax>11342200.07719692215323448</xmax>
-        <ymax>10914413.7141284141689539</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>Hello_Project_SubsetString_copy20160223113949592</id>
-      <datasource>dbname='./helloworld.db' table="hello" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="hello" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>Hello_Filter_SubsetString</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -791,11 +1279,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -807,164 +1296,373 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="178,178,178,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="121,121,121,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{6f33f809-e603-4f58-877b-ae8f09f46f31}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="133,182,111,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="230,85,192,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{8e8c2ec9-a966-49e3-858f-4356060961dc}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="133,182,111,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="95,130,79,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{72bdf76b-34f8-4557-b3d6-084994f631fc}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="133,182,111,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="95,130,79,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{93d7c132-1f8e-4409-a980-209afe395c7b}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="178,178,178,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="121,121,121,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{a07a33ee-7cf7-4abe-a567-454d1ae3c404}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="230,85,192,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
       <customproperties>
-        <property key="variableNames" value="_fields_"/>
-        <property key="variableValues" value=""/>
+        <Option type="Map">
+          <Option name="variableNames" type="QString" value="_fields_"></Option>
+          <Option name="variableValues" type="QString" value=""></Option>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{957b0205-372d-4516-836f-4cfd69695c96}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
+        <field configurationFlags="NoFlag" name="pk">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="pkuid">
+        <field configurationFlags="NoFlag" name="pkuid">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="color">
+        <field configurationFlags="NoFlag" name="color">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="pkuid" index="1"/>
-        <alias name="" field="color" index="2"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="pkuid" index="1" name=""></alias>
+        <alias field="color" index="2" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="pkuid" policy="Duplicate"></policy>
+        <policy field="color" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="pkuid" expression=""/>
-        <default applyOnUpdate="0" field="color" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="pkuid"></default>
+        <default applyOnUpdate="0" expression="" field="color"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
-        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="pkuid" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="pkuid" desc="" exp=""/>
-        <constraint field="color" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="pkuid"></constraint>
+        <constraint desc="" exp="" field="color"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" width="-1" name="pk" hidden="0"/>
-          <column type="field" width="-1" name="pkuid" hidden="0"/>
-          <column type="field" width="-1" name="color" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="pk" type="field" width="-1"></column>
+          <column hidden="0" name="pkuid" type="field" width="-1"></column>
+          <column hidden="0" name="color" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -980,32 +1678,48 @@ from PyQt4.QtGui import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="t" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c1" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="1" name="pkuid" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="color" showLabel="1" index="2"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c2" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="2" name="color" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"pkuid"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="-4.65661e-10" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-2465695.66895584994927049</xmin>
-        <ymin>80258.53580146089370828</ymin>
-        <xmax>5037064.00943838991224766</xmax>
-        <ymax>3762589.19456820981577039</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="-4.6566099999999998e-10" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>Hello_SubsetString_copy20160222085231770</id>
       <datasource>dbname='./helloworld.db' table="hello" (geom) sql="pkuid" in ( 7, 8 )</datasource>
       <keywordList>
@@ -1013,15 +1727,15 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>Hello_Project_SubsetString</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1032,11 +1746,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1048,159 +1763,368 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="178,178,178,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="121,121,121,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{fd3cd0a7-540d-45f8-8771-ffb234ef9f58}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="164,113,88,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="230,85,192,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{5f1c0045-a769-4175-9c96-b513f11380e7}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="164,113,88,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="117,81,63,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{97d8532b-c64a-4657-8ccf-8e0b0b41faa7}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="164,113,88,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="117,81,63,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{7ed7605e-4524-4fc7-b4eb-6e178431173e}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="178,178,178,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="121,121,121,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{036fe2e9-7baf-46d7-8c3a-d380d55792bb}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="230,85,192,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
       <customproperties>
-        <property key="variableNames" value="_fields_"/>
-        <property key="variableValues" value=""/>
+        <Option type="Map">
+          <Option name="variableNames" type="QString" value="_fields_"></Option>
+          <Option name="variableValues" type="QString" value=""></Option>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="-4.65661e-10" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="-4.65661e-10" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{7586b167-83a2-49b2-82bb-c3434f454034}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
+        <field configurationFlags="NoFlag" name="pk">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="pkuid">
+        <field configurationFlags="NoFlag" name="pkuid">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="color">
+        <field configurationFlags="NoFlag" name="color">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="pkuid" index="1"/>
-        <alias name="" field="color" index="2"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="pkuid" index="1" name=""></alias>
+        <alias field="color" index="2" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="pkuid" policy="Duplicate"></policy>
+        <policy field="color" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="pkuid" expression=""/>
-        <default applyOnUpdate="0" field="color" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="pkuid"></default>
+        <default applyOnUpdate="0" expression="" field="color"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
-        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="pkuid" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="pkuid" desc="" exp=""/>
-        <constraint field="color" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="pkuid"></constraint>
+        <constraint desc="" exp="" field="color"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-        <columns/>
+        <columns></columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1216,48 +2140,64 @@ from PyQt4.QtGui import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="t" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c1" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="1" name="pkuid" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="color" showLabel="1" index="2"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c2" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="2" name="color" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"pkuid"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-14746250.07513097859919071</xmin>
-        <ymin>-112075.42807669920148328</ymin>
-        <xmax>11342200.07719692215323448</xmax>
-        <ymax>10914413.7141284141689539</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9</id>
-      <datasource>dbname='./helloworld.db' table="hello" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="hello" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>Hello_Filter</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1268,11 +2208,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1284,167 +2225,376 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="178,178,178,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="121,121,121,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{e8b4c57b-bd00-4b6e-a05d-0e857bc7c006}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="213,180,60,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="230,85,192,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{a908ae37-394f-4390-9948-78c2140b408d}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="213,180,60,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="152,129,43,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{1d23e8c9-160f-4748-a1a3-849430331431}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="213,180,60,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="152,129,43,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{2d6b2dd7-411f-492e-9247-5783aa9becc8}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="178,178,178,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="121,121,121,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{d446e0f8-a077-46cd-bcdc-f474b4c2245f}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="230,85,192,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
       <customproperties>
-        <property key="dualview/previewExpressions">
-          <value>"pkuid"</value>
-        </property>
-        <property key="variableNames" value="_fields_"/>
-        <property key="variableValues" value=""/>
+        <Option type="Map">
+          <Option name="dualview/previewExpressions" type="StringList">
+            <Option type="QString" value="&quot;pkuid&quot;"></Option>
+          </Option>
+          <Option name="variableNames" type="QString" value="_fields_"></Option>
+          <Option name="variableValues" type="QString" value=""></Option>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{ac0bfe17-8d23-4561-8a13-277546a1d61e}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
+        <field configurationFlags="NoFlag" name="pk">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="pkuid">
+        <field configurationFlags="NoFlag" name="pkuid">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="color">
+        <field configurationFlags="NoFlag" name="color">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="pkuid" index="1"/>
-        <alias name="" field="color" index="2"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="pkuid" index="1" name=""></alias>
+        <alias field="color" index="2" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="pkuid" policy="Duplicate"></policy>
+        <policy field="color" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="pkuid" expression=""/>
-        <default applyOnUpdate="0" field="color" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="pkuid"></default>
+        <default applyOnUpdate="0" expression="" field="color"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
-        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="pkuid" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="pkuid" desc="" exp=""/>
-        <constraint field="color" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="pkuid"></constraint>
+        <constraint desc="" exp="" field="color"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" width="-1" name="pk" hidden="0"/>
-          <column type="field" width="-1" name="pkuid" hidden="0"/>
-          <column type="field" width="-1" name="color" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="pk" type="field" width="-1"></column>
+          <column hidden="0" name="pkuid" type="field" width="-1"></column>
+          <column hidden="0" name="color" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1460,48 +2610,64 @@ from PyQt4.QtGui import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="t" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c1" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="1" name="pkuid" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="color" showLabel="1" index="2"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c2" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="2" name="color" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"pkuid"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-14746250.07513097859919071</xmin>
-        <ymin>-112075.42807669920148328</ymin>
-        <xmax>11342200.07719692215323448</xmax>
-        <ymax>10914413.7141284141689539</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>Hello_copy20150804164427541</id>
-      <datasource>dbname='./helloworld.db' table="hello" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="hello" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>Hello_SubsetString</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1512,11 +2678,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1528,159 +2695,368 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="178,178,178,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="121,121,121,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{ecb994b2-a670-40bf-8359-a0b55d38b2a4}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="114,155,111,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="230,85,192,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{b65ce0de-4cb0-460a-84c7-842148c7997a}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="114,155,111,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="81,111,79,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{7da4181e-d0af-4875-b9c7-a48494e8da85}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="114,155,111,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="81,111,79,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{68218788-6ad8-4547-a172-c4e09b0df575}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="178,178,178,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="121,121,121,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{b855bc48-1737-4d29-a067-db2eeb55d43b}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="230,85,192,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
       <customproperties>
-        <property key="variableNames" value="_fields_"/>
-        <property key="variableValues" value=""/>
+        <Option type="Map">
+          <Option name="variableNames" type="QString" value="_fields_"></Option>
+          <Option name="variableValues" type="QString" value=""></Option>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{fc27b913-28d5-41da-8cd7-d43c7c3e0fc5}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
+        <field configurationFlags="NoFlag" name="pk">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="pkuid">
+        <field configurationFlags="NoFlag" name="pkuid">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="color">
+        <field configurationFlags="NoFlag" name="color">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="pkuid" index="1"/>
-        <alias name="" field="color" index="2"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="pkuid" index="1" name=""></alias>
+        <alias field="color" index="2" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="pkuid" policy="Duplicate"></policy>
+        <policy field="color" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="pkuid" expression=""/>
-        <default applyOnUpdate="0" field="color" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="pkuid"></default>
+        <default applyOnUpdate="0" expression="" field="color"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
-        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="pkuid" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="pkuid" desc="" exp=""/>
-        <constraint field="color" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="pkuid"></constraint>
+        <constraint desc="" exp="" field="color"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-        <columns/>
+        <columns></columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1696,48 +3072,64 @@ from PyQt4.QtGui import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="t" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c1" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="1" name="pkuid" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="color" showLabel="1" index="2"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c2" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="2" name="color" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"pkuid"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-14746250.07513097859919071</xmin>
-        <ymin>-112075.42807669920148328</ymin>
-        <xmax>11342200.07719692215323448</xmax>
-        <ymax>10914413.7141284141689539</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c</id>
-      <datasource>dbname='./helloworld.db' table="hello" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="hello" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>Hello_OnOff</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1757,11 +3149,12 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1774,7 +3167,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxx="0" maxz="0" crs="" minz="0" maxy="0" miny="0" dimensions="2" minx="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -1784,78 +3177,77 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="défaut">
         <map-layer-style name="default">
-          <qgis maxScale="0" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" readOnly="0" simplifyDrawingHints="1" simplifyAlgorithm="0" version="3.3.0-Master" minScale="1e+08" simplifyMaxScale="1" labelsEnabled="1" simplifyLocal="1">
-            <renderer-v2 type="singleSymbol" enableorderby="0" symbollevels="0" forceraster="0">
+          <qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="1" maxScale="0" minScale="1e+08" readOnly="0" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" version="3.3.0-Master">
+            <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="singleSymbol">
               <symbols>
-                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
-                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-                    <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-                    <prop v="178,178,178,255" k="color"/>
-                    <prop v="bevel" k="joinstyle"/>
-                    <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-                    <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="121,121,121,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="0.26" k="outline_width"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="solid" k="style"/>
+                <symbol alpha="1" clip_to_extent="1" name="0" type="fill">
+                  <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+                    <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="color" v="178,178,178,255"></prop>
+                    <prop k="joinstyle" v="bevel"></prop>
+                    <prop k="offset" v="0.80000000000000004,0.80000000000000004"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="121,121,121,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="0.26"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="style" v="solid"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" name="name" value=""/>
-                        <Option name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
-                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-                    <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-                    <prop v="230,85,192,255" k="color"/>
-                    <prop v="bevel" k="joinstyle"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="0,0,0,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="0.26" k="outline_width"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="solid" k="style"/>
+                  <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+                    <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="color" v="230,85,192,255"></prop>
+                    <prop k="joinstyle" v="bevel"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="0,0,0,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="0.26"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="style" v="solid"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" name="name" value=""/>
-                        <Option name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
                 </symbol>
               </symbols>
-              <rotation/>
-              <sizescale/>
+              <rotation></rotation>
+              <sizescale></sizescale>
             </renderer-v2>
-            <customproperties/>
+            <customproperties></customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerOpacity>1</layerOpacity>
             <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
-                <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-                <attribute color="#000000" label="" field=""/>
+              <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" width="15">
+                <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+                <attribute color="#000000" field="" label=""></attribute>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+            <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
               <properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </properties>
             </DiagramLayerSettings>
@@ -1863,289 +3255,515 @@ def my_form_open(dialog, layer, feature):
               <field name="pk">
                 <editWidget type="">
                   <config>
-                    <Option/>
+                    <Option></Option>
                   </config>
                 </editWidget>
               </field>
               <field name="pkuid">
                 <editWidget type="">
                   <config>
-                    <Option/>
+                    <Option></Option>
                   </config>
                 </editWidget>
               </field>
               <field name="color">
                 <editWidget type="">
                   <config>
-                    <Option/>
+                    <Option></Option>
                   </config>
                 </editWidget>
               </field>
             </fieldConfiguration>
             <aliases>
-              <alias name="" field="pk" index="0"/>
-              <alias name="" field="pkuid" index="1"/>
-              <alias name="" field="color" index="2"/>
+              <alias field="pk" index="0" name=""></alias>
+              <alias field="pkuid" index="1" name=""></alias>
+              <alias field="color" index="2" name=""></alias>
             </aliases>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <defaults>
-              <default applyOnUpdate="0" field="pk" expression=""/>
-              <default applyOnUpdate="0" field="pkuid" expression=""/>
-              <default applyOnUpdate="0" field="color" expression=""/>
+              <default applyOnUpdate="0" expression="" field="pk"></default>
+              <default applyOnUpdate="0" expression="" field="pkuid"></default>
+              <default applyOnUpdate="0" expression="" field="color"></default>
             </defaults>
             <constraints>
-              <constraint constraints="3" notnull_strength="1" exp_strength="0" field="pk" unique_strength="1"/>
-              <constraint constraints="0" notnull_strength="0" exp_strength="0" field="pkuid" unique_strength="0"/>
-              <constraint constraints="0" notnull_strength="0" exp_strength="0" field="color" unique_strength="0"/>
+              <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+              <constraint constraints="0" exp_strength="0" field="pkuid" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
             </constraints>
             <constraintExpressions>
-              <constraint field="pk" desc="" exp=""/>
-              <constraint field="pkuid" desc="" exp=""/>
-              <constraint field="color" desc="" exp=""/>
+              <constraint desc="" exp="" field="pk"></constraint>
+              <constraint desc="" exp="" field="pkuid"></constraint>
+              <constraint desc="" exp="" field="color"></constraint>
             </constraintExpressions>
             <attributeactions>
-              <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+              <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
             </attributeactions>
             <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-              <columns/>
+              <columns></columns>
             </attributetableconfig>
             <editform tolerant="1">/home</editform>
-            <editforminit/>
+            <editforminit></editforminit>
             <editforminitcodesource>0</editforminitcodesource>
-            <editforminitfilepath/>
-            <editforminitcode><![CDATA[]]></editforminitcode>
+            <editforminitfilepath></editforminitfilepath>
+            <editforminitcode></editforminitcode>
             <featformsuppress>0</featformsuppress>
             <editorlayout>generatedlayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-                <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-                  <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+              <attributeEditorContainer columnCount="0" groupBox="0" name="t" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorContainer columnCount="0" groupBox="1" name="c1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                  <attributeEditorField index="1" name="pkuid" showLabel="1"></attributeEditorField>
                 </attributeEditorContainer>
-                <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-                  <attributeEditorField name="color" showLabel="1" index="2"/>
+                <attributeEditorContainer columnCount="0" groupBox="1" name="c2" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                  <attributeEditorField index="2" name="color" showLabel="1"></attributeEditorField>
                 </attributeEditorContainer>
               </attributeEditorContainer>
             </attributeEditorForm>
-            <editable/>
-            <labelOnTop/>
-            <widgets/>
+            <editable></editable>
+            <labelOnTop></labelOnTop>
+            <widgets></widgets>
             <conditionalstyles>
-              <rowstyles/>
-              <fieldstyles/>
+              <rowstyles></rowstyles>
+              <fieldstyles></fieldstyles>
             </conditionalstyles>
-            <expressionfields/>
-            <previewExpression>COALESCE( "pkuid", '&lt;NULL>' )</previewExpression>
-            <mapTip/>
+            <expressionfields></expressionfields>
+            <previewExpression>COALESCE( "pkuid", '&lt;NULL&gt;' )</previewExpression>
+            <mapTip></mapTip>
             <layerGeometryType>2</layerGeometryType>
           </qgis>
         </map-layer-style>
-        <map-layer-style name="défaut"/>
+        <map-layer-style name="défaut"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="178,178,178,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="121,121,121,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{06caab53-1626-4b3c-a237-3cce7438edbc}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="243,166,178,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="230,85,192,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{1ee2baaa-690f-4c4a-8ffb-1111e9933b2c}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="243,166,178,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="174,119,127,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{f1f90884-ff77-466e-b662-ae742dfee12d}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="243,166,178,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="174,119,127,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{1b51237a-163f-49c5-b451-61d1fbf3eea3}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="178,178,178,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="121,121,121,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{9b3d0dbc-913a-41af-9b95-906ce60f9239}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="230,85,192,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
       <customproperties>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <Option type="Map">
+          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
+          <Option name="variableNames"></Option>
+          <Option name="variableValues"></Option>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{b8a64720-a7bd-4636-8092-b50beb30d61a}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="2" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
+        <field configurationFlags="NoFlag" name="pk">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="pkuid">
+        <field configurationFlags="NoFlag" name="pkuid">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="color">
+        <field configurationFlags="NoFlag" name="color">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="pkuid" index="1"/>
-        <alias name="" field="color" index="2"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="pkuid" index="1" name=""></alias>
+        <alias field="color" index="2" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="pkuid" policy="Duplicate"></policy>
+        <policy field="color" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="pkuid" expression=""/>
-        <default applyOnUpdate="0" field="color" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="pkuid"></default>
+        <default applyOnUpdate="0" expression="" field="color"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
-        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="pkuid" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="pkuid" desc="" exp=""/>
-        <constraint field="color" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="pkuid"></constraint>
+        <constraint desc="" exp="" field="color"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" width="-1" name="pk" hidden="0"/>
-          <column type="field" width="-1" name="pkuid" hidden="0"/>
-          <column type="field" width="-1" name="color" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="pk" type="field" width="-1"></column>
+          <column hidden="0" name="pkuid" type="field" width="-1"></column>
+          <column hidden="0" name="color" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
     geom = feature.geometry()
     control = dialog.findChild(QWidget, "MyLineEdit")
 
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="t" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c1" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="1" name="pkuid" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="color" showLabel="1" index="2"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c2" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="2" name="color" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable>
-        <field name="color" editable="1"/>
-        <field name="pk" editable="1"/>
-        <field name="pkuid" editable="1"/>
+        <field editable="1" name="color"></field>
+        <field editable="1" name="pk"></field>
+        <field editable="1" name="pkuid"></field>
       </editable>
       <labelOnTop>
-        <field name="color" labelOnTop="0"/>
-        <field name="pk" labelOnTop="0"/>
-        <field name="pkuid" labelOnTop="0"/>
+        <field labelOnTop="0" name="color"></field>
+        <field labelOnTop="0" name="pk"></field>
+        <field labelOnTop="0" name="pkuid"></field>
       </labelOnTop>
-      <widgets/>
-      <previewExpression>COALESCE( "pkuid", '&lt;NULL>' )</previewExpression>
-      <mapTip></mapTip>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
+      <previewExpression>COALESCE( "pkuid", '&lt;NULL&gt;' )</previewExpression>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="-4.65661e-10" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-19619892.68012013286352158</xmin>
-        <ymin>-10327100.34232237376272678</ymin>
-        <xmax>19972134.91854240000247955</xmax>
-        <ymax>18415866.31293442100286484</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="-4.6566099999999998e-10" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>country20131022151106556</id>
-      <datasource>dbname='./helloworld.db' table="country" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="country" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>Country</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -2156,11 +3774,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -2172,205 +3791,204 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
         <map-layer-style name="origin">
-          <qgis scaleBasedLabelVisibilityFlag="0" maximumScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" maxLabelScale="1e+08" simplifyDrawingHints="1" version="2.9.0-Master" minimumScale="-4.65661e-10" simplifyMaxScale="1" minLabelScale="1" simplifyLocal="1">
+          <qgis hasScaleBasedVisibilityFlag="0" maxLabelScale="1e+08" maximumScale="1e+08" minLabelScale="1" minimumScale="-4.65661e-10" scaleBasedLabelVisibilityFlag="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" version="2.9.0-Master">
             <edittypes>
               <edittype name="pk" widgetv2type="TextEdit">
-                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
+                <widgetv2config IsMultiline="0" UseHtml="0" fieldEditable="1" labelOnTop="0"></widgetv2config>
               </edittype>
               <edittype name="name" widgetv2type="TextEdit">
-                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
+                <widgetv2config IsMultiline="0" UseHtml="0" fieldEditable="1" labelOnTop="0"></widgetv2config>
               </edittype>
             </edittypes>
-            <renderer-v2 type="singleSymbol" symbollevels="0">
+            <renderer-v2 symbollevels="0" type="singleSymbol">
               <symbols>
-                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
-                  <layer class="SimpleFill" pass="0" locked="0">
-                    <prop v="0,0" k="border_width_map_unit_scale"/>
-                    <prop v="186,221,105,255" k="color"/>
-                    <prop v="bevel" k="joinstyle"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="128,152,72,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="0.26" k="outline_width"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="solid" k="style"/>
-                    <effect type="effectStack" enabled="0">
+                <symbol alpha="1" clip_to_extent="1" name="0" type="fill">
+                  <layer class="SimpleFill" locked="0" pass="0">
+                    <prop k="border_width_map_unit_scale" v="0,0"></prop>
+                    <prop k="color" v="186,221,105,255"></prop>
+                    <prop k="joinstyle" v="bevel"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="128,152,72,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="0.26"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="style" v="solid"></prop>
+                    <effect enabled="0" type="effectStack">
                       <effect type="drawSource">
-                        <prop v="0" k="blend_mode"/>
-                        <prop v="2" k="draw_mode"/>
-                        <prop v="1" k="enabled"/>
-                        <prop v="0" k="transparency"/>
+                        <prop k="blend_mode" v="0"></prop>
+                        <prop k="draw_mode" v="2"></prop>
+                        <prop k="enabled" v="1"></prop>
+                        <prop k="transparency" v="0"></prop>
                       </effect>
                     </effect>
                   </layer>
                 </symbol>
               </symbols>
-              <rotation/>
-              <sizescale scalemethod="area"/>
-              <effect type="effectStack" enabled="0">
+              <rotation></rotation>
+              <sizescale scalemethod="area"></sizescale>
+              <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
-                  <prop v="0" k="blend_mode"/>
-                  <prop v="2" k="draw_mode"/>
-                  <prop v="1" k="enabled"/>
-                  <prop v="0" k="transparency"/>
+                  <prop k="blend_mode" v="0"></prop>
+                  <prop k="draw_mode" v="2"></prop>
+                  <prop k="enabled" v="1"></prop>
+                  <prop k="transparency" v="0"></prop>
                 </effect>
               </effect>
             </renderer-v2>
             <customproperties>
-              <property key="labeling" value="pal"/>
-              <property key="labeling/addDirectionSymbol" value="false"/>
-              <property key="labeling/angleOffset" value="0"/>
-              <property key="labeling/blendMode" value="0"/>
-              <property key="labeling/bufferBlendMode" value="0"/>
-              <property key="labeling/bufferColorA" value="255"/>
-              <property key="labeling/bufferColorB" value="255"/>
-              <property key="labeling/bufferColorG" value="255"/>
-              <property key="labeling/bufferColorR" value="255"/>
-              <property key="labeling/bufferDraw" value="false"/>
-              <property key="labeling/bufferJoinStyle" value="64"/>
-              <property key="labeling/bufferNoFill" value="false"/>
-              <property key="labeling/bufferSize" value="1"/>
-              <property key="labeling/bufferSizeInMapUnits" value="false"/>
-              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/bufferTransp" value="0"/>
-              <property key="labeling/centroidInside" value="false"/>
-              <property key="labeling/centroidWhole" value="false"/>
-              <property key="labeling/decimals" value="3"/>
-              <property key="labeling/displayAll" value="false"/>
-              <property key="labeling/dist" value="0"/>
-              <property key="labeling/distInMapUnits" value="false"/>
-              <property key="labeling/distMapUnitMaxScale" value="0"/>
-              <property key="labeling/distMapUnitMinScale" value="0"/>
-              <property key="labeling/enabled" value="false"/>
-              <property key="labeling/fieldName" value=""/>
-              <property key="labeling/fontBold" value="false"/>
-              <property key="labeling/fontCapitals" value="0"/>
-              <property key="labeling/fontFamily" value="Sans Serif"/>
-              <property key="labeling/fontItalic" value="false"/>
-              <property key="labeling/fontLetterSpacing" value="0"/>
-              <property key="labeling/fontLimitPixelSize" value="false"/>
-              <property key="labeling/fontMaxPixelSize" value="10000"/>
-              <property key="labeling/fontMinPixelSize" value="3"/>
-              <property key="labeling/fontSize" value="9"/>
-              <property key="labeling/fontSizeInMapUnits" value="false"/>
-              <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/fontStrikeout" value="false"/>
-              <property key="labeling/fontUnderline" value="false"/>
-              <property key="labeling/fontWeight" value="50"/>
-              <property key="labeling/fontWordSpacing" value="0"/>
-              <property key="labeling/formatNumbers" value="false"/>
-              <property key="labeling/isExpression" value="true"/>
-              <property key="labeling/labelOffsetInMapUnits" value="true"/>
-              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/labelPerPart" value="false"/>
-              <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-              <property key="labeling/limitNumLabels" value="false"/>
-              <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-              <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-              <property key="labeling/maxNumLabels" value="2000"/>
-              <property key="labeling/mergeLines" value="false"/>
-              <property key="labeling/minFeatureSize" value="0"/>
-              <property key="labeling/multilineAlign" value="0"/>
-              <property key="labeling/multilineHeight" value="1"/>
-              <property key="labeling/namedStyle" value="Normal"/>
-              <property key="labeling/obstacle" value="true"/>
-              <property key="labeling/placeDirectionSymbol" value="0"/>
-              <property key="labeling/placement" value="0"/>
-              <property key="labeling/placementFlags" value="0"/>
-              <property key="labeling/plussign" value="false"/>
-              <property key="labeling/preserveRotation" value="true"/>
-              <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-              <property key="labeling/priority" value="5"/>
-              <property key="labeling/quadOffset" value="4"/>
-              <property key="labeling/repeatDistance" value="0"/>
-              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-              <property key="labeling/repeatDistanceUnit" value="1"/>
-              <property key="labeling/reverseDirectionSymbol" value="false"/>
-              <property key="labeling/rightDirectionSymbol" value=">"/>
-              <property key="labeling/scaleMax" value="10000000"/>
-              <property key="labeling/scaleMin" value="1"/>
-              <property key="labeling/scaleVisibility" value="false"/>
-              <property key="labeling/shadowBlendMode" value="6"/>
-              <property key="labeling/shadowColorB" value="0"/>
-              <property key="labeling/shadowColorG" value="0"/>
-              <property key="labeling/shadowColorR" value="0"/>
-              <property key="labeling/shadowDraw" value="false"/>
-              <property key="labeling/shadowOffsetAngle" value="135"/>
-              <property key="labeling/shadowOffsetDist" value="1"/>
-              <property key="labeling/shadowOffsetGlobal" value="true"/>
-              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/shadowOffsetUnits" value="1"/>
-              <property key="labeling/shadowRadius" value="1.5"/>
-              <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-              <property key="labeling/shadowRadiusUnits" value="1"/>
-              <property key="labeling/shadowScale" value="100"/>
-              <property key="labeling/shadowTransparency" value="30"/>
-              <property key="labeling/shadowUnder" value="0"/>
-              <property key="labeling/shapeBlendMode" value="0"/>
-              <property key="labeling/shapeBorderColorA" value="255"/>
-              <property key="labeling/shapeBorderColorB" value="128"/>
-              <property key="labeling/shapeBorderColorG" value="128"/>
-              <property key="labeling/shapeBorderColorR" value="128"/>
-              <property key="labeling/shapeBorderWidth" value="0"/>
-              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeBorderWidthUnits" value="1"/>
-              <property key="labeling/shapeDraw" value="false"/>
-              <property key="labeling/shapeFillColorA" value="255"/>
-              <property key="labeling/shapeFillColorB" value="255"/>
-              <property key="labeling/shapeFillColorG" value="255"/>
-              <property key="labeling/shapeFillColorR" value="255"/>
-              <property key="labeling/shapeJoinStyle" value="64"/>
-              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeOffsetUnits" value="1"/>
-              <property key="labeling/shapeOffsetX" value="0"/>
-              <property key="labeling/shapeOffsetY" value="0"/>
-              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeRadiiUnits" value="1"/>
-              <property key="labeling/shapeRadiiX" value="0"/>
-              <property key="labeling/shapeRadiiY" value="0"/>
-              <property key="labeling/shapeRotation" value="0"/>
-              <property key="labeling/shapeRotationType" value="0"/>
-              <property key="labeling/shapeSVGFile" value=""/>
-              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeSizeType" value="0"/>
-              <property key="labeling/shapeSizeUnits" value="1"/>
-              <property key="labeling/shapeSizeX" value="0"/>
-              <property key="labeling/shapeSizeY" value="0"/>
-              <property key="labeling/shapeTransparency" value="0"/>
-              <property key="labeling/shapeType" value="0"/>
-              <property key="labeling/textColorA" value="255"/>
-              <property key="labeling/textColorB" value="0"/>
-              <property key="labeling/textColorG" value="0"/>
-              <property key="labeling/textColorR" value="0"/>
-              <property key="labeling/textTransp" value="0"/>
-              <property key="labeling/upsidedownLabels" value="0"/>
-              <property key="labeling/wrapChar" value=""/>
-              <property key="labeling/xOffset" value="0"/>
-              <property key="labeling/yOffset" value="0"/>
+              <property key="labeling" value="pal"></property>
+              <property key="labeling/addDirectionSymbol" value="false"></property>
+              <property key="labeling/angleOffset" value="0"></property>
+              <property key="labeling/blendMode" value="0"></property>
+              <property key="labeling/bufferBlendMode" value="0"></property>
+              <property key="labeling/bufferColorA" value="255"></property>
+              <property key="labeling/bufferColorB" value="255"></property>
+              <property key="labeling/bufferColorG" value="255"></property>
+              <property key="labeling/bufferColorR" value="255"></property>
+              <property key="labeling/bufferDraw" value="false"></property>
+              <property key="labeling/bufferJoinStyle" value="64"></property>
+              <property key="labeling/bufferNoFill" value="false"></property>
+              <property key="labeling/bufferSize" value="1"></property>
+              <property key="labeling/bufferSizeInMapUnits" value="false"></property>
+              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/bufferSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/bufferTransp" value="0"></property>
+              <property key="labeling/centroidInside" value="false"></property>
+              <property key="labeling/centroidWhole" value="false"></property>
+              <property key="labeling/decimals" value="3"></property>
+              <property key="labeling/displayAll" value="false"></property>
+              <property key="labeling/dist" value="0"></property>
+              <property key="labeling/distInMapUnits" value="false"></property>
+              <property key="labeling/distMapUnitMaxScale" value="0"></property>
+              <property key="labeling/distMapUnitMinScale" value="0"></property>
+              <property key="labeling/enabled" value="false"></property>
+              <property key="labeling/fieldName" value=""></property>
+              <property key="labeling/fontBold" value="false"></property>
+              <property key="labeling/fontCapitals" value="0"></property>
+              <property key="labeling/fontFamily" value="Sans Serif"></property>
+              <property key="labeling/fontItalic" value="false"></property>
+              <property key="labeling/fontLetterSpacing" value="0"></property>
+              <property key="labeling/fontLimitPixelSize" value="false"></property>
+              <property key="labeling/fontMaxPixelSize" value="10000"></property>
+              <property key="labeling/fontMinPixelSize" value="3"></property>
+              <property key="labeling/fontSize" value="9"></property>
+              <property key="labeling/fontSizeInMapUnits" value="false"></property>
+              <property key="labeling/fontSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/fontSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/fontStrikeout" value="false"></property>
+              <property key="labeling/fontUnderline" value="false"></property>
+              <property key="labeling/fontWeight" value="50"></property>
+              <property key="labeling/fontWordSpacing" value="0"></property>
+              <property key="labeling/formatNumbers" value="false"></property>
+              <property key="labeling/isExpression" value="true"></property>
+              <property key="labeling/labelOffsetInMapUnits" value="true"></property>
+              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/labelOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/labelPerPart" value="false"></property>
+              <property key="labeling/leftDirectionSymbol" value="&lt;"></property>
+              <property key="labeling/limitNumLabels" value="false"></property>
+              <property key="labeling/maxCurvedCharAngleIn" value="20"></property>
+              <property key="labeling/maxCurvedCharAngleOut" value="-20"></property>
+              <property key="labeling/maxNumLabels" value="2000"></property>
+              <property key="labeling/mergeLines" value="false"></property>
+              <property key="labeling/minFeatureSize" value="0"></property>
+              <property key="labeling/multilineAlign" value="0"></property>
+              <property key="labeling/multilineHeight" value="1"></property>
+              <property key="labeling/namedStyle" value="Normal"></property>
+              <property key="labeling/obstacle" value="true"></property>
+              <property key="labeling/placeDirectionSymbol" value="0"></property>
+              <property key="labeling/placement" value="0"></property>
+              <property key="labeling/placementFlags" value="0"></property>
+              <property key="labeling/plussign" value="false"></property>
+              <property key="labeling/preserveRotation" value="true"></property>
+              <property key="labeling/previewBkgrdColor" value="#ffffff"></property>
+              <property key="labeling/priority" value="5"></property>
+              <property key="labeling/quadOffset" value="4"></property>
+              <property key="labeling/repeatDistance" value="0"></property>
+              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"></property>
+              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"></property>
+              <property key="labeling/repeatDistanceUnit" value="1"></property>
+              <property key="labeling/reverseDirectionSymbol" value="false"></property>
+              <property key="labeling/rightDirectionSymbol" value=">"></property>
+              <property key="labeling/scaleMax" value="10000000"></property>
+              <property key="labeling/scaleMin" value="1"></property>
+              <property key="labeling/scaleVisibility" value="false"></property>
+              <property key="labeling/shadowBlendMode" value="6"></property>
+              <property key="labeling/shadowColorB" value="0"></property>
+              <property key="labeling/shadowColorG" value="0"></property>
+              <property key="labeling/shadowColorR" value="0"></property>
+              <property key="labeling/shadowDraw" value="false"></property>
+              <property key="labeling/shadowOffsetAngle" value="135"></property>
+              <property key="labeling/shadowOffsetDist" value="1"></property>
+              <property key="labeling/shadowOffsetGlobal" value="true"></property>
+              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/shadowOffsetUnits" value="1"></property>
+              <property key="labeling/shadowRadius" value="1.5"></property>
+              <property key="labeling/shadowRadiusAlphaOnly" value="false"></property>
+              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"></property>
+              <property key="labeling/shadowRadiusUnits" value="1"></property>
+              <property key="labeling/shadowScale" value="100"></property>
+              <property key="labeling/shadowTransparency" value="30"></property>
+              <property key="labeling/shadowUnder" value="0"></property>
+              <property key="labeling/shapeBlendMode" value="0"></property>
+              <property key="labeling/shapeBorderColorA" value="255"></property>
+              <property key="labeling/shapeBorderColorB" value="128"></property>
+              <property key="labeling/shapeBorderColorG" value="128"></property>
+              <property key="labeling/shapeBorderColorR" value="128"></property>
+              <property key="labeling/shapeBorderWidth" value="0"></property>
+              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeBorderWidthUnits" value="1"></property>
+              <property key="labeling/shapeDraw" value="false"></property>
+              <property key="labeling/shapeFillColorA" value="255"></property>
+              <property key="labeling/shapeFillColorB" value="255"></property>
+              <property key="labeling/shapeFillColorG" value="255"></property>
+              <property key="labeling/shapeFillColorR" value="255"></property>
+              <property key="labeling/shapeJoinStyle" value="64"></property>
+              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeOffsetUnits" value="1"></property>
+              <property key="labeling/shapeOffsetX" value="0"></property>
+              <property key="labeling/shapeOffsetY" value="0"></property>
+              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeRadiiUnits" value="1"></property>
+              <property key="labeling/shapeRadiiX" value="0"></property>
+              <property key="labeling/shapeRadiiY" value="0"></property>
+              <property key="labeling/shapeRotation" value="0"></property>
+              <property key="labeling/shapeRotationType" value="0"></property>
+              <property key="labeling/shapeSVGFile" value=""></property>
+              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeSizeType" value="0"></property>
+              <property key="labeling/shapeSizeUnits" value="1"></property>
+              <property key="labeling/shapeSizeX" value="0"></property>
+              <property key="labeling/shapeSizeY" value="0"></property>
+              <property key="labeling/shapeTransparency" value="0"></property>
+              <property key="labeling/shapeType" value="0"></property>
+              <property key="labeling/textColorA" value="255"></property>
+              <property key="labeling/textColorB" value="0"></property>
+              <property key="labeling/textColorG" value="0"></property>
+              <property key="labeling/textColorR" value="0"></property>
+              <property key="labeling/textTransp" value="0"></property>
+              <property key="labeling/upsidedownLabels" value="0"></property>
+              <property key="labeling/wrapChar" value=""></property>
+              <property key="labeling/xOffset" value="0"></property>
+              <property key="labeling/yOffset" value="0"></property>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
@@ -2378,252 +3996,252 @@ def my_form_open(dialog, layer, feature):
             <displayfield>name</displayfield>
             <label>0</label>
             <labelattributes>
-              <label fieldname="" text="Label"/>
-              <family name="DejaVu Sans" fieldname=""/>
-              <size units="pt" fieldname="" value="12"/>
-              <bold on="0" fieldname=""/>
-              <italic on="0" fieldname=""/>
-              <underline on="0" fieldname=""/>
-              <strikeout on="0" fieldname=""/>
-              <color green="0" red="0" fieldname="" blue="0"/>
-              <x fieldname=""/>
-              <y fieldname=""/>
-              <offset units="pt" yfieldname="" xfieldname="" y="0" x="0"/>
-              <angle auto="0" fieldname="" value="0"/>
-              <alignment fieldname="" value="center"/>
-              <buffercolor green="255" red="255" fieldname="" blue="255"/>
-              <buffersize units="pt" fieldname="" value="1"/>
-              <bufferenabled on="" fieldname=""/>
-              <multilineenabled on="" fieldname=""/>
-              <selectedonly on=""/>
+              <label fieldname="" text="Label"></label>
+              <family fieldname="" name="DejaVu Sans"></family>
+              <size fieldname="" units="pt" value="12"></size>
+              <bold fieldname="" on="0"></bold>
+              <italic fieldname="" on="0"></italic>
+              <underline fieldname="" on="0"></underline>
+              <strikeout fieldname="" on="0"></strikeout>
+              <color blue="0" fieldname="" green="0" red="0"></color>
+              <x fieldname=""></x>
+              <y fieldname=""></y>
+              <offset units="pt" x="0" xfieldname="" y="0" yfieldname=""></offset>
+              <angle auto="0" fieldname="" value="0"></angle>
+              <alignment fieldname="" value="center"></alignment>
+              <buffercolor blue="255" fieldname="" green="255" red="255"></buffercolor>
+              <buffersize fieldname="" units="pt" value="1"></buffersize>
+              <bufferenabled fieldname="" on=""></bufferenabled>
+              <multilineenabled fieldname="" on=""></multilineenabled>
+              <selectedonly on=""></selectedonly>
             </labelattributes>
             <SingleCategoryDiagramRenderer diagramType="Pie">
-              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" angleOffset="1440" minScaleDenominator="-4.65661e-10" height="15" penColor="#000000" sizeType="MM" enabled="0" transparency="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
-                <attribute color="#000000" label="" field=""/>
+              <DiagramCategory angleOffset="1440" backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" height="15" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" minScaleDenominator="-4.65661e-10" minimumSize="0" penAlpha="255" penColor="#000000" penWidth="0" scaleBasedVisibility="0" scaleDependency="Area" sizeType="MM" transparency="0" width="15">
+                <attribute color="#000000" field="" label=""></attribute>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" xPosColumn="-1" linePlacementFlags="10" priority="0" placement="0" dist="0" showAll="1" yPosColumn="-1"/>
-            <editforminit/>
+            <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" xPosColumn="-1" yPosColumn="-1"></DiagramLayerSettings>
+            <editforminit></editforminit>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <attributeEditorForm>
-              <attributeEditorContainer name="ttt"/>
+              <attributeEditorContainer name="ttt"></attributeEditorContainer>
             </attributeEditorForm>
-            <attributeactions/>
+            <attributeactions></attributeactions>
           </qgis>
         </map-layer-style>
         <map-layer-style name="test2">
-          <qgis scaleBasedLabelVisibilityFlag="0" maximumScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" maxLabelScale="1e+08" simplifyDrawingHints="1" version="2.9.0-Master" minimumScale="0" simplifyMaxScale="1" minLabelScale="1" simplifyLocal="1">
+          <qgis hasScaleBasedVisibilityFlag="0" maxLabelScale="1e+08" maximumScale="1e+08" minLabelScale="1" minimumScale="0" scaleBasedLabelVisibilityFlag="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" version="2.9.0-Master">
             <edittypes>
               <edittype name="pk" widgetv2type="TextEdit">
-                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
+                <widgetv2config IsMultiline="0" UseHtml="0" fieldEditable="1" labelOnTop="0"></widgetv2config>
               </edittype>
               <edittype name="name" widgetv2type="TextEdit">
-                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
+                <widgetv2config IsMultiline="0" UseHtml="0" fieldEditable="1" labelOnTop="0"></widgetv2config>
               </edittype>
             </edittypes>
-            <renderer-v2 type="singleSymbol" symbollevels="0">
+            <renderer-v2 symbollevels="0" type="singleSymbol">
               <symbols>
-                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
-                  <layer class="SimpleFill" pass="0" locked="0">
-                    <prop v="0,0" k="border_width_map_unit_scale"/>
-                    <prop v="145,149,158,255" k="color"/>
-                    <prop v="bevel" k="joinstyle"/>
-                    <prop v="0.8,0.8" k="offset"/>
-                    <prop v="0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="157,157,157,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="0.26" k="outline_width"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="solid" k="style"/>
-                    <effect type="effectStack" enabled="0">
+                <symbol alpha="1" clip_to_extent="1" name="0" type="fill">
+                  <layer class="SimpleFill" locked="0" pass="0">
+                    <prop k="border_width_map_unit_scale" v="0,0"></prop>
+                    <prop k="color" v="145,149,158,255"></prop>
+                    <prop k="joinstyle" v="bevel"></prop>
+                    <prop k="offset" v="0.8,0.8"></prop>
+                    <prop k="offset_map_unit_scale" v="0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="157,157,157,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="0.26"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="style" v="solid"></prop>
+                    <effect enabled="0" type="effectStack">
                       <effect type="drawSource">
-                        <prop v="0" k="blend_mode"/>
-                        <prop v="2" k="draw_mode"/>
-                        <prop v="1" k="enabled"/>
-                        <prop v="0" k="transparency"/>
+                        <prop k="blend_mode" v="0"></prop>
+                        <prop k="draw_mode" v="2"></prop>
+                        <prop k="enabled" v="1"></prop>
+                        <prop k="transparency" v="0"></prop>
                       </effect>
                     </effect>
                   </layer>
-                  <layer class="SimpleFill" pass="0" locked="0">
-                    <prop v="0,0" k="border_width_map_unit_scale"/>
-                    <prop v="0,0,255,255" k="color"/>
-                    <prop v="bevel" k="joinstyle"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="0,0,0,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="0.26" k="outline_width"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="solid" k="style"/>
-                    <effect type="effectStack" enabled="0">
+                  <layer class="SimpleFill" locked="0" pass="0">
+                    <prop k="border_width_map_unit_scale" v="0,0"></prop>
+                    <prop k="color" v="0,0,255,255"></prop>
+                    <prop k="joinstyle" v="bevel"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="0,0,0,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="0.26"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="style" v="solid"></prop>
+                    <effect enabled="0" type="effectStack">
                       <effect type="drawSource">
-                        <prop v="0" k="blend_mode"/>
-                        <prop v="2" k="draw_mode"/>
-                        <prop v="1" k="enabled"/>
-                        <prop v="0" k="transparency"/>
+                        <prop k="blend_mode" v="0"></prop>
+                        <prop k="draw_mode" v="2"></prop>
+                        <prop k="enabled" v="1"></prop>
+                        <prop k="transparency" v="0"></prop>
                       </effect>
                     </effect>
                   </layer>
                 </symbol>
               </symbols>
-              <rotation/>
-              <sizescale scalemethod="area"/>
-              <effect type="effectStack" enabled="0">
+              <rotation></rotation>
+              <sizescale scalemethod="area"></sizescale>
+              <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
-                  <prop v="0" k="blend_mode"/>
-                  <prop v="2" k="draw_mode"/>
-                  <prop v="1" k="enabled"/>
-                  <prop v="0" k="transparency"/>
+                  <prop k="blend_mode" v="0"></prop>
+                  <prop k="draw_mode" v="2"></prop>
+                  <prop k="enabled" v="1"></prop>
+                  <prop k="transparency" v="0"></prop>
                 </effect>
               </effect>
             </renderer-v2>
             <customproperties>
-              <property key="labeling" value="pal"/>
-              <property key="labeling/addDirectionSymbol" value="false"/>
-              <property key="labeling/angleOffset" value="0"/>
-              <property key="labeling/blendMode" value="0"/>
-              <property key="labeling/bufferBlendMode" value="0"/>
-              <property key="labeling/bufferColorA" value="255"/>
-              <property key="labeling/bufferColorB" value="255"/>
-              <property key="labeling/bufferColorG" value="255"/>
-              <property key="labeling/bufferColorR" value="255"/>
-              <property key="labeling/bufferDraw" value="false"/>
-              <property key="labeling/bufferJoinStyle" value="64"/>
-              <property key="labeling/bufferNoFill" value="false"/>
-              <property key="labeling/bufferSize" value="1"/>
-              <property key="labeling/bufferSizeInMapUnits" value="false"/>
-              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/bufferTransp" value="0"/>
-              <property key="labeling/centroidInside" value="false"/>
-              <property key="labeling/centroidWhole" value="false"/>
-              <property key="labeling/decimals" value="3"/>
-              <property key="labeling/displayAll" value="false"/>
-              <property key="labeling/dist" value="0"/>
-              <property key="labeling/distInMapUnits" value="false"/>
-              <property key="labeling/distMapUnitMaxScale" value="0"/>
-              <property key="labeling/distMapUnitMinScale" value="0"/>
-              <property key="labeling/enabled" value="false"/>
-              <property key="labeling/fieldName" value=""/>
-              <property key="labeling/fontBold" value="false"/>
-              <property key="labeling/fontCapitals" value="0"/>
-              <property key="labeling/fontFamily" value="Sans Serif"/>
-              <property key="labeling/fontItalic" value="false"/>
-              <property key="labeling/fontLetterSpacing" value="0"/>
-              <property key="labeling/fontLimitPixelSize" value="false"/>
-              <property key="labeling/fontMaxPixelSize" value="10000"/>
-              <property key="labeling/fontMinPixelSize" value="3"/>
-              <property key="labeling/fontSize" value="9"/>
-              <property key="labeling/fontSizeInMapUnits" value="false"/>
-              <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/fontStrikeout" value="false"/>
-              <property key="labeling/fontUnderline" value="false"/>
-              <property key="labeling/fontWeight" value="50"/>
-              <property key="labeling/fontWordSpacing" value="0"/>
-              <property key="labeling/formatNumbers" value="false"/>
-              <property key="labeling/isExpression" value="true"/>
-              <property key="labeling/labelOffsetInMapUnits" value="true"/>
-              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/labelPerPart" value="false"/>
-              <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-              <property key="labeling/limitNumLabels" value="false"/>
-              <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-              <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-              <property key="labeling/maxNumLabels" value="2000"/>
-              <property key="labeling/mergeLines" value="false"/>
-              <property key="labeling/minFeatureSize" value="0"/>
-              <property key="labeling/multilineAlign" value="0"/>
-              <property key="labeling/multilineHeight" value="1"/>
-              <property key="labeling/namedStyle" value="Normal"/>
-              <property key="labeling/obstacle" value="true"/>
-              <property key="labeling/placeDirectionSymbol" value="0"/>
-              <property key="labeling/placement" value="0"/>
-              <property key="labeling/placementFlags" value="0"/>
-              <property key="labeling/plussign" value="false"/>
-              <property key="labeling/preserveRotation" value="true"/>
-              <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-              <property key="labeling/priority" value="5"/>
-              <property key="labeling/quadOffset" value="4"/>
-              <property key="labeling/repeatDistance" value="0"/>
-              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-              <property key="labeling/repeatDistanceUnit" value="1"/>
-              <property key="labeling/reverseDirectionSymbol" value="false"/>
-              <property key="labeling/rightDirectionSymbol" value=">"/>
-              <property key="labeling/scaleMax" value="10000000"/>
-              <property key="labeling/scaleMin" value="1"/>
-              <property key="labeling/scaleVisibility" value="false"/>
-              <property key="labeling/shadowBlendMode" value="6"/>
-              <property key="labeling/shadowColorB" value="0"/>
-              <property key="labeling/shadowColorG" value="0"/>
-              <property key="labeling/shadowColorR" value="0"/>
-              <property key="labeling/shadowDraw" value="false"/>
-              <property key="labeling/shadowOffsetAngle" value="135"/>
-              <property key="labeling/shadowOffsetDist" value="1"/>
-              <property key="labeling/shadowOffsetGlobal" value="true"/>
-              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/shadowOffsetUnits" value="1"/>
-              <property key="labeling/shadowRadius" value="1.5"/>
-              <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-              <property key="labeling/shadowRadiusUnits" value="1"/>
-              <property key="labeling/shadowScale" value="100"/>
-              <property key="labeling/shadowTransparency" value="30"/>
-              <property key="labeling/shadowUnder" value="0"/>
-              <property key="labeling/shapeBlendMode" value="0"/>
-              <property key="labeling/shapeBorderColorA" value="255"/>
-              <property key="labeling/shapeBorderColorB" value="128"/>
-              <property key="labeling/shapeBorderColorG" value="128"/>
-              <property key="labeling/shapeBorderColorR" value="128"/>
-              <property key="labeling/shapeBorderWidth" value="0"/>
-              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeBorderWidthUnits" value="1"/>
-              <property key="labeling/shapeDraw" value="false"/>
-              <property key="labeling/shapeFillColorA" value="255"/>
-              <property key="labeling/shapeFillColorB" value="255"/>
-              <property key="labeling/shapeFillColorG" value="255"/>
-              <property key="labeling/shapeFillColorR" value="255"/>
-              <property key="labeling/shapeJoinStyle" value="64"/>
-              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeOffsetUnits" value="1"/>
-              <property key="labeling/shapeOffsetX" value="0"/>
-              <property key="labeling/shapeOffsetY" value="0"/>
-              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeRadiiUnits" value="1"/>
-              <property key="labeling/shapeRadiiX" value="0"/>
-              <property key="labeling/shapeRadiiY" value="0"/>
-              <property key="labeling/shapeRotation" value="0"/>
-              <property key="labeling/shapeRotationType" value="0"/>
-              <property key="labeling/shapeSVGFile" value=""/>
-              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-              <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-              <property key="labeling/shapeSizeType" value="0"/>
-              <property key="labeling/shapeSizeUnits" value="1"/>
-              <property key="labeling/shapeSizeX" value="0"/>
-              <property key="labeling/shapeSizeY" value="0"/>
-              <property key="labeling/shapeTransparency" value="0"/>
-              <property key="labeling/shapeType" value="0"/>
-              <property key="labeling/textColorA" value="255"/>
-              <property key="labeling/textColorB" value="0"/>
-              <property key="labeling/textColorG" value="0"/>
-              <property key="labeling/textColorR" value="0"/>
-              <property key="labeling/textTransp" value="0"/>
-              <property key="labeling/upsidedownLabels" value="0"/>
-              <property key="labeling/wrapChar" value=""/>
-              <property key="labeling/xOffset" value="0"/>
-              <property key="labeling/yOffset" value="0"/>
+              <property key="labeling" value="pal"></property>
+              <property key="labeling/addDirectionSymbol" value="false"></property>
+              <property key="labeling/angleOffset" value="0"></property>
+              <property key="labeling/blendMode" value="0"></property>
+              <property key="labeling/bufferBlendMode" value="0"></property>
+              <property key="labeling/bufferColorA" value="255"></property>
+              <property key="labeling/bufferColorB" value="255"></property>
+              <property key="labeling/bufferColorG" value="255"></property>
+              <property key="labeling/bufferColorR" value="255"></property>
+              <property key="labeling/bufferDraw" value="false"></property>
+              <property key="labeling/bufferJoinStyle" value="64"></property>
+              <property key="labeling/bufferNoFill" value="false"></property>
+              <property key="labeling/bufferSize" value="1"></property>
+              <property key="labeling/bufferSizeInMapUnits" value="false"></property>
+              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/bufferSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/bufferTransp" value="0"></property>
+              <property key="labeling/centroidInside" value="false"></property>
+              <property key="labeling/centroidWhole" value="false"></property>
+              <property key="labeling/decimals" value="3"></property>
+              <property key="labeling/displayAll" value="false"></property>
+              <property key="labeling/dist" value="0"></property>
+              <property key="labeling/distInMapUnits" value="false"></property>
+              <property key="labeling/distMapUnitMaxScale" value="0"></property>
+              <property key="labeling/distMapUnitMinScale" value="0"></property>
+              <property key="labeling/enabled" value="false"></property>
+              <property key="labeling/fieldName" value=""></property>
+              <property key="labeling/fontBold" value="false"></property>
+              <property key="labeling/fontCapitals" value="0"></property>
+              <property key="labeling/fontFamily" value="Sans Serif"></property>
+              <property key="labeling/fontItalic" value="false"></property>
+              <property key="labeling/fontLetterSpacing" value="0"></property>
+              <property key="labeling/fontLimitPixelSize" value="false"></property>
+              <property key="labeling/fontMaxPixelSize" value="10000"></property>
+              <property key="labeling/fontMinPixelSize" value="3"></property>
+              <property key="labeling/fontSize" value="9"></property>
+              <property key="labeling/fontSizeInMapUnits" value="false"></property>
+              <property key="labeling/fontSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/fontSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/fontStrikeout" value="false"></property>
+              <property key="labeling/fontUnderline" value="false"></property>
+              <property key="labeling/fontWeight" value="50"></property>
+              <property key="labeling/fontWordSpacing" value="0"></property>
+              <property key="labeling/formatNumbers" value="false"></property>
+              <property key="labeling/isExpression" value="true"></property>
+              <property key="labeling/labelOffsetInMapUnits" value="true"></property>
+              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/labelOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/labelPerPart" value="false"></property>
+              <property key="labeling/leftDirectionSymbol" value="&lt;"></property>
+              <property key="labeling/limitNumLabels" value="false"></property>
+              <property key="labeling/maxCurvedCharAngleIn" value="20"></property>
+              <property key="labeling/maxCurvedCharAngleOut" value="-20"></property>
+              <property key="labeling/maxNumLabels" value="2000"></property>
+              <property key="labeling/mergeLines" value="false"></property>
+              <property key="labeling/minFeatureSize" value="0"></property>
+              <property key="labeling/multilineAlign" value="0"></property>
+              <property key="labeling/multilineHeight" value="1"></property>
+              <property key="labeling/namedStyle" value="Normal"></property>
+              <property key="labeling/obstacle" value="true"></property>
+              <property key="labeling/placeDirectionSymbol" value="0"></property>
+              <property key="labeling/placement" value="0"></property>
+              <property key="labeling/placementFlags" value="0"></property>
+              <property key="labeling/plussign" value="false"></property>
+              <property key="labeling/preserveRotation" value="true"></property>
+              <property key="labeling/previewBkgrdColor" value="#ffffff"></property>
+              <property key="labeling/priority" value="5"></property>
+              <property key="labeling/quadOffset" value="4"></property>
+              <property key="labeling/repeatDistance" value="0"></property>
+              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"></property>
+              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"></property>
+              <property key="labeling/repeatDistanceUnit" value="1"></property>
+              <property key="labeling/reverseDirectionSymbol" value="false"></property>
+              <property key="labeling/rightDirectionSymbol" value=">"></property>
+              <property key="labeling/scaleMax" value="10000000"></property>
+              <property key="labeling/scaleMin" value="1"></property>
+              <property key="labeling/scaleVisibility" value="false"></property>
+              <property key="labeling/shadowBlendMode" value="6"></property>
+              <property key="labeling/shadowColorB" value="0"></property>
+              <property key="labeling/shadowColorG" value="0"></property>
+              <property key="labeling/shadowColorR" value="0"></property>
+              <property key="labeling/shadowDraw" value="false"></property>
+              <property key="labeling/shadowOffsetAngle" value="135"></property>
+              <property key="labeling/shadowOffsetDist" value="1"></property>
+              <property key="labeling/shadowOffsetGlobal" value="true"></property>
+              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/shadowOffsetUnits" value="1"></property>
+              <property key="labeling/shadowRadius" value="1.5"></property>
+              <property key="labeling/shadowRadiusAlphaOnly" value="false"></property>
+              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"></property>
+              <property key="labeling/shadowRadiusUnits" value="1"></property>
+              <property key="labeling/shadowScale" value="100"></property>
+              <property key="labeling/shadowTransparency" value="30"></property>
+              <property key="labeling/shadowUnder" value="0"></property>
+              <property key="labeling/shapeBlendMode" value="0"></property>
+              <property key="labeling/shapeBorderColorA" value="255"></property>
+              <property key="labeling/shapeBorderColorB" value="128"></property>
+              <property key="labeling/shapeBorderColorG" value="128"></property>
+              <property key="labeling/shapeBorderColorR" value="128"></property>
+              <property key="labeling/shapeBorderWidth" value="0"></property>
+              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeBorderWidthUnits" value="1"></property>
+              <property key="labeling/shapeDraw" value="false"></property>
+              <property key="labeling/shapeFillColorA" value="255"></property>
+              <property key="labeling/shapeFillColorB" value="255"></property>
+              <property key="labeling/shapeFillColorG" value="255"></property>
+              <property key="labeling/shapeFillColorR" value="255"></property>
+              <property key="labeling/shapeJoinStyle" value="64"></property>
+              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeOffsetUnits" value="1"></property>
+              <property key="labeling/shapeOffsetX" value="0"></property>
+              <property key="labeling/shapeOffsetY" value="0"></property>
+              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeRadiiUnits" value="1"></property>
+              <property key="labeling/shapeRadiiX" value="0"></property>
+              <property key="labeling/shapeRadiiY" value="0"></property>
+              <property key="labeling/shapeRotation" value="0"></property>
+              <property key="labeling/shapeRotationType" value="0"></property>
+              <property key="labeling/shapeSVGFile" value=""></property>
+              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"></property>
+              <property key="labeling/shapeSizeMapUnitMinScale" value="0"></property>
+              <property key="labeling/shapeSizeType" value="0"></property>
+              <property key="labeling/shapeSizeUnits" value="1"></property>
+              <property key="labeling/shapeSizeX" value="0"></property>
+              <property key="labeling/shapeSizeY" value="0"></property>
+              <property key="labeling/shapeTransparency" value="0"></property>
+              <property key="labeling/shapeType" value="0"></property>
+              <property key="labeling/textColorA" value="255"></property>
+              <property key="labeling/textColorB" value="0"></property>
+              <property key="labeling/textColorG" value="0"></property>
+              <property key="labeling/textColorR" value="0"></property>
+              <property key="labeling/textTransp" value="0"></property>
+              <property key="labeling/upsidedownLabels" value="0"></property>
+              <property key="labeling/wrapChar" value=""></property>
+              <property key="labeling/xOffset" value="0"></property>
+              <property key="labeling/yOffset" value="0"></property>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
@@ -2631,408 +4249,863 @@ def my_form_open(dialog, layer, feature):
             <displayfield>name</displayfield>
             <label>0</label>
             <labelattributes>
-              <label fieldname="" text="Label"/>
-              <family name="DejaVu Sans" fieldname=""/>
-              <size units="pt" fieldname="" value="12"/>
-              <bold on="0" fieldname=""/>
-              <italic on="0" fieldname=""/>
-              <underline on="0" fieldname=""/>
-              <strikeout on="0" fieldname=""/>
-              <color green="0" red="0" fieldname="" blue="0"/>
-              <x fieldname=""/>
-              <y fieldname=""/>
-              <offset units="pt" yfieldname="" xfieldname="" y="0" x="0"/>
-              <angle auto="0" fieldname="" value="0"/>
-              <alignment fieldname="" value="center"/>
-              <buffercolor green="255" red="255" fieldname="" blue="255"/>
-              <buffersize units="pt" fieldname="" value="1"/>
-              <bufferenabled on="" fieldname=""/>
-              <multilineenabled on="" fieldname=""/>
-              <selectedonly on=""/>
+              <label fieldname="" text="Label"></label>
+              <family fieldname="" name="DejaVu Sans"></family>
+              <size fieldname="" units="pt" value="12"></size>
+              <bold fieldname="" on="0"></bold>
+              <italic fieldname="" on="0"></italic>
+              <underline fieldname="" on="0"></underline>
+              <strikeout fieldname="" on="0"></strikeout>
+              <color blue="0" fieldname="" green="0" red="0"></color>
+              <x fieldname=""></x>
+              <y fieldname=""></y>
+              <offset units="pt" x="0" xfieldname="" y="0" yfieldname=""></offset>
+              <angle auto="0" fieldname="" value="0"></angle>
+              <alignment fieldname="" value="center"></alignment>
+              <buffercolor blue="255" fieldname="" green="255" red="255"></buffercolor>
+              <buffersize fieldname="" units="pt" value="1"></buffersize>
+              <bufferenabled fieldname="" on=""></bufferenabled>
+              <multilineenabled fieldname="" on=""></multilineenabled>
+              <selectedonly on=""></selectedonly>
             </labelattributes>
             <SingleCategoryDiagramRenderer diagramType="Pie">
-              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" angleOffset="1440" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" enabled="0" transparency="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
-                <attribute color="#000000" label="" field=""/>
+              <DiagramCategory angleOffset="1440" backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" height="15" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" penAlpha="255" penColor="#000000" penWidth="0" scaleBasedVisibility="0" scaleDependency="Area" sizeType="MM" transparency="0" width="15">
+                <attribute color="#000000" field="" label=""></attribute>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" xPosColumn="-1" linePlacementFlags="10" priority="0" placement="0" dist="0" showAll="1" yPosColumn="-1"/>
-            <editforminit/>
+            <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" xPosColumn="-1" yPosColumn="-1"></DiagramLayerSettings>
+            <editforminit></editforminit>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <attributeEditorForm>
-              <attributeEditorContainer name="ttt"/>
+              <attributeEditorContainer name="ttt"></attributeEditorContainer>
             </attributeEditorForm>
-            <attributeactions/>
+            <attributeactions></attributeactions>
           </qgis>
         </map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="145,149,158,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="157,157,157,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{c09b7f7a-ec41-4055-a6b2-9211e8f1fb8a}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="141,90,153,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="0,0,255,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{eb47e7a6-851d-480c-a1df-5b3cad888548}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="141,90,153,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="101,64,109,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{16287ced-975b-429e-a099-89f35a8a256d}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="141,90,153,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="101,64,109,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{54c3381a-6297-4b68-ac92-015eac31327d}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="145,149,158,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="157,157,157,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{a6b419c5-4247-410d-902e-cb2f6b24b495}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="0,0,255,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style blendMode="0" fontLetterSpacing="0" fontItalic="0" fontKerning="1" fontSize="9" fontFamily="Sans Serif" fontWeight="50" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" namedStyle="Normal" useSubstitutions="0" fontCapitals="0" textOrientation="horizontal" textColor="0,0,0,255" multilineHeight="1" fontStrikeout="0" isExpression="1" fontUnderline="0" fontSizeUnit="Point" fieldName="" previewBkgrdColor="255,255,255,255" fontWordSpacing="0">
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSizeUnits="MM" bufferNoFill="0" bufferSize="1" bufferColor="255,255,255,255" bufferBlendMode="0" bufferDraw="0" bufferJoinStyle="64"/>
-            <background shapeBlendMode="0" shapeRotation="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeOffsetX="0" shapeBorderWidth="0" shapeOffsetUnit="MM" shapeRadiiX="0" shapeSizeUnit="MM" shapeType="0" shapeRotationType="0" shapeRadiiY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeOffsetY="0" shapeSVGFile="" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeRadiiUnit="MM"/>
-            <shadow shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowRadius="1.5" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowRadiusUnit="MM" shadowOpacity="0.7" shadowRadiusAlphaOnly="0" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowOffsetAngle="135"/>
+          <text-style allowHtml="0" blendMode="0" capitalization="0" fieldName="" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="9" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" isExpression="1" legendString="Aa" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="Normal" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <families></families>
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="64" bufferNoFill="0" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+                <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                  <Option type="Map">
+                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="color" type="QString" value="255,255,255,255"></Option>
+                    <Option name="joinstyle" type="QString" value="bevel"></Option>
+                    <Option name="offset" type="QString" value="0,0"></Option>
+                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="offset_unit" type="QString" value="MM"></Option>
+                    <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                    <Option name="outline_style" type="QString" value="no"></Option>
+                    <Option name="outline_width" type="QString" value="0"></Option>
+                    <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                    <Option name="style" type="QString" value="solid"></Option>
+                  </Option>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format decimals="3" multilineAlign="0" leftDirectionSymbol="&lt;" placeDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" wrapChar="" plussign="0" addDirectionSymbol="0" autoWrapLength="0" rightDirectionSymbol=">" reverseDirectionSymbol="0"/>
-          <placement centroidInside="0" maxCurvedCharAngleIn="20" repeatDistanceUnits="MM" fitInPolygonOnly="0" layerType="UnknownGeometry" distUnits="MM" offsetUnits="MapUnit" repeatDistance="0" overrunDistanceUnit="MM" rotationAngle="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" geometryGenerator="" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" placementFlags="0" geometryGeneratorEnabled="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" xOffset="0" centroidWhole="0" quadOffset="4" yOffset="0" maxCurvedCharAngleOut="-20" priority="5" geometryGeneratorType="PointGeometry" offsetType="0"/>
-          <rendering fontMaxPixelSize="10000" minFeatureSize="0" zIndex="0" scaleMin="1" maxNumLabels="2000" drawLabels="1" limitNumLabels="0" scaleMax="10000000" fontLimitPixelSize="0" obstacleType="0" mergeLines="0" displayAll="0" obstacleFactor="1" fontMinPixelSize="3" upsidedownLabels="0" labelPerPart="0" obstacle="1" scaleVisibility="0"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="0" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
+          <placement allowDegraded="0" centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" lineAnchorClipping="0" lineAnchorPercent="0.5" lineAnchorTextPoint="CenterOfText" lineAnchorType="0" maxCurvedCharAngleIn="20" maxCurvedCharAngleOut="-20" offsetType="0" offsetUnits="MapUnit" overlapHandling="PreventOverlap" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="0" polygonPlacementFlags="2" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" rotationUnit="AngleDegrees" xOffset="0" yOffset="0"></placement>
+          <rendering drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="10000000" scaleMin="1" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="blendMode" type="int" value="0"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" name="drawToAllParts" value="false"/>
-              <Option type="QString" name="enabled" value="0"/>
-              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; name=&quot;symbol&quot; force_rhr=&quot;0&quot;>&lt;layer class=&quot;SimpleLine&quot; enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
-              <Option type="double" name="minLength" value="0"/>
-              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="minLengthUnit" value="MM"/>
-              <Option type="double" name="offsetFromAnchor" value="0"/>
-              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
-              <Option type="double" name="offsetFromLabel" value="0"/>
-              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol type=&quot;line&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; name=&quot;symbol&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; locked=&quot;0&quot; pass=&quot;0&quot; enabled=&quot;1&quot; id=&quot;{46f3da81-7eb9-4395-9152-6309723aa9bf}&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
-      <customproperties/>
-      <blendMode>0</blendMode>
-      <featureBlendMode>0</featureBlendMode>
-      <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="-4.65661e-10" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
-        </DiagramCategory>
-      </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
-        <properties>
-          <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
-          </Option>
-        </properties>
-      </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
-      </geometryOptions>
-      <fieldConfiguration>
-        <field name="pk">
-          <editWidget type="">
-            <config>
-              <Option/>
-            </config>
-          </editWidget>
-        </field>
-        <field name="name">
-          <editWidget type="">
-            <config>
-              <Option/>
-            </config>
-          </editWidget>
-        </field>
-      </fieldConfiguration>
-      <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="name" index="1"/>
-      </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
-      <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="name" expression=""/>
-      </defaults>
-      <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
-      </constraints>
-      <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="name" desc="" exp=""/>
-      </constraintExpressions>
-      <expressionfields/>
-      <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
-      </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-        <columns/>
-      </attributetableconfig>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <storedexpressions/>
-      <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
-      <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[]]></editforminitcode>
-      <featformsuppress>0</featformsuppress>
-      <editorlayout>generatedlayout</editorlayout>
-      <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="ttt" showLabel="1" groupBox="0" visibilityExpressionEnabled="0"/>
-      </attributeEditorForm>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
-      <previewExpression>"name"</previewExpression>
-      <mapTip></mapTip>
-    </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-19619892.68012013286352158</xmin>
-        <ymin>-10327100.34232237376272678</ymin>
-        <xmax>19972134.91854240000247955</xmax>
-        <ymax>18415866.31293442100286484</ymax>
-      </extent>
-      <id>country20170328164317226</id>
-      <datasource>dbname='./helloworld.db' table="country" (geom) sql=</datasource>
-      <keywordList>
-        <value></value>
-      </keywordList>
-      <layername>Country_Diagrams</layername>
-      <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
-          <srsid>3857</srsid>
-          <srid>3857</srid>
-          <authid>EPSG:3857</authid>
-          <description>WGS 84 / Pseudo-Mercator</description>
-          <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
-          <geographicflag>false</geographicflag>
-        </spatialrefsys>
-      </srs>
-      <resourceMetadata>
-        <identifier></identifier>
-        <parentidentifier></parentidentifier>
-        <language></language>
-        <type></type>
-        <title></title>
-        <abstract></abstract>
-        <links/>
-        <fees></fees>
-        <encoding></encoding>
-        <crs>
-          <spatialrefsys>
-            <wkt></wkt>
-            <proj4></proj4>
-            <srsid>0</srsid>
-            <srid>0</srid>
-            <authid></authid>
-            <description></description>
-            <projectionacronym></projectionacronym>
-            <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
-          </spatialrefsys>
-        </crs>
-        <extent/>
-      </resourceMetadata>
-      <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
-      <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
-      </map-layer-style-manager>
-      <auxiliaryLayer/>
-      <flags>
-        <Identifiable>1</Identifiable>
-        <Removable>1</Removable>
-        <Searchable>1</Searchable>
-      </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="13,126,136,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
-        </symbols>
-        <rotation/>
-        <sizescale/>
-      </renderer-v2>
       <customproperties>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <Option></Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="inf" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="1" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="Sans Serif,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#6fe20e" label="pk" field="&quot;pk&quot;"/>
-          <attribute color="#38c4c2" label=" length( name )" field=" length( name )"/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="-4.65661e-10" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{0a9cadc6-5624-4cd6-b8cf-49b7bd25d552}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="18" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
-          <editWidget type="TextEdit">
+        <field configurationFlags="NoFlag" name="pk">
+          <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="name">
-          <editWidget type="TextEdit">
+        <field configurationFlags="NoFlag" name="name">
+          <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="name" index="1"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="name" index="1" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="name" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="name" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="name"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="name" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="name"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns></columns>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
+      </conditionalstyles>
+      <storedexpressions></storedexpressions>
+      <editform tolerant="1">../../../../../..</editform>
+      <editforminit></editforminit>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <attributeEditorForm>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="ttt" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+        </attributeEditorContainer>
+      </attributeEditorForm>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
+      <previewExpression>"name"</previewExpression>
+      <mapTip enabled="1"></mapTip>
+    </maplayer>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
+      <id>country20170328164317226</id>
+      <datasource>dbname='./helloworld.db' table="country" (geom)</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>Country_Diagrams</layername>
+      <srs>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <srsid>3857</srsid>
+          <srid>3857</srid>
+          <authid>EPSG:3857</authid>
+          <description>WGS 84 / Pseudo-Mercator</description>
+          <projectionacronym>merc</projectionacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links></links>
+        <dates></dates>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt></wkt>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>true</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent></extent>
+      </resourceMetadata>
+      <provider encoding="UTF-8">spatialite</provider>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"></map-layer-style>
+      </map-layer-style-manager>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+        <Private>0</Private>
+      </flags>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{28adb28c-3de8-4075-9cfe-ee637feeca3f}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="232,113,141,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{8967a67d-ce95-48aa-98f6-e7408320addd}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="232,113,141,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="166,81,101,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{545506b4-df49-428a-8c78-03e4dc206491}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="232,113,141,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="166,81,101,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{2c6b14ca-5066-47af-96d2-e386c651b889}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="13,126,136,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation></rotation>
+        <sizescale></sizescale>
+      </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
+      <customproperties>
+        <Option type="Map">
+          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
+          <Option name="variableNames"></Option>
+          <Option name="variableValues"></Option>
+        </Option>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="1" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="inf" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="Sans Serif,9,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#6fe20e" colorOpacity="1" field="&quot;pk&quot;" label="pk"></attribute>
+          <attribute color="#38c4c2" colorOpacity="1" field=" length( name )" label=" length( name )"></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{41a5dc78-69d8-42ca-9a53-642623f8597c}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
+        <properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
+      </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
+      <fieldConfiguration>
+        <field configurationFlags="NoFlag" name="pk">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="NoFlag" name="name">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="name" index="1" name=""></alias>
+      </aliases>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="name" policy="Duplicate"></policy>
+      </splitPolicies>
+      <defaults>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="name"></default>
+      </defaults>
+      <constraints>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
+      </constraints>
+      <constraintExpressions>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="name"></constraint>
+      </constraintExpressions>
+      <expressionfields></expressionfields>
+      <attributeactions>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" width="-1" name="pk" hidden="0"/>
-          <column type="field" width="-1" name="name" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="pk" type="field" width="-1"></column>
+          <column hidden="0" name="name" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -3048,22 +5121,30 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>name</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer type="raster" refreshOnNotifyMessage="" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" minScale="1e+8" styleCategories="AllStyleCategories">
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="-4.65661e-10" minScale="1e+08" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="raster">
       <extent>
         <xmin>-29.99999999999666755</xmin>
         <ymin>29.99999999999666755</ymin>
         <xmax>0.00000000000333245</xmax>
         <ymax>59.99999999999666755</ymax>
       </extent>
+      <wgs84extent>
+        <xmin>-29.99999999999666755</xmin>
+        <ymin>29.99999999999666755</ymin>
+        <xmax>0.00000000000333245</xmax>
+        <ymax>59.99999999999666755</ymax>
+      </wgs84extent>
       <id>dem20150730091219559</id>
       <datasource>./dem.tif</datasource>
       <keywordList>
@@ -3071,15 +5152,15 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>dem</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]</wkt>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
           <authid>EPSG:4326</authid>
           <description>WGS 84</description>
           <projectionacronym>longlat</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
@@ -3090,13 +5171,14 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
-            <proj4></proj4>
+            <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>0</srsid>
             <srid>0</srid>
             <authid></authid>
@@ -3106,26 +5188,138 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider>gdal</provider>
       <noData>
-        <noDataList useSrcNoData="1" bandNo="1"/>
+        <noDataList bandNo="1" useSrcNoData="1"></noDataList>
       </noData>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
+      <temporal enabled="0" fetchMode="0" mode="0">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation band="1" enabled="0" symbology="Line" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{755cf1cd-085a-4fe3-b7fc-27d8947847ca}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="183,72,75,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{c120932a-e533-46f6-b849-f72e7465f62c}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="183,72,75,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="35,35,35,255"></Option>
+                <Option name="outline_style" type="QString" value="no"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property key="identify/format" value="Value"/>
+        <Option type="Map">
+          <Option name="identify/format" type="QString" value="Value"></Option>
+        </Option>
       </customproperties>
+      <mapTip enabled="1"></mapTip>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""></Option>
+          <Option name="properties"></Option>
+          <Option name="type" type="QString" value="collection"></Option>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
-        <rasterrenderer type="singlebandgray" opacity="1" alphaBand="0" gradient="BlackToWhite" grayBand="1">
-          <rasterTransparency/>
+        <provider>
+          <resampling enabled="false" maxOversampling="2" zoomedInResamplingMethod="nearestNeighbour" zoomedOutResamplingMethod="nearestNeighbour"></resampling>
+        </provider>
+        <rasterrenderer alphaBand="0" gradient="BlackToWhite" grayBand="1" nodataColor="" opacity="1" type="singlebandgray">
+          <rasterTransparency></rasterTransparency>
           <minMaxOrigin>
             <limits>None</limits>
             <extent>WholeRaster</extent>
@@ -3139,36 +5333,44 @@ def my_form_open(dialog, layer, feature):
             <maxValue>1912</maxValue>
             <algorithm>StretchToMinimumMaximum</algorithm>
           </contrastEnhancement>
+          <rampLegendSettings direction="0" maximumLabel="" minimumLabel="" orientation="2" prefix="" suffix="" useContinuousLegend="1">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option name="decimal_separator" type="invalid"></Option>
+                <Option name="decimals" type="int" value="6"></Option>
+                <Option name="rounding_type" type="int" value="0"></Option>
+                <Option name="show_plus" type="bool" value="false"></Option>
+                <Option name="show_thousand_separator" type="bool" value="true"></Option>
+                <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+                <Option name="thousand_separator" type="invalid"></Option>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
         </rasterrenderer>
-        <brightnesscontrast contrast="0" brightness="0"/>
-        <huesaturation colorizeBlue="128" colorizeStrength="100" saturation="0" grayscaleMode="0" colorizeOn="0" colorizeRed="255" colorizeGreen="128"/>
-        <rasterresampler maxOversampling="2"/>
+        <brightnesscontrast brightness="0" contrast="0" gamma="1"></brightnesscontrast>
+        <huesaturation colorizeBlue="128" colorizeGreen="128" colorizeOn="0" colorizeRed="255" colorizeStrength="100" grayscaleMode="0" invertColors="0" saturation="0"></huesaturation>
+        <rasterresampler maxOversampling="2"></rasterresampler>
+        <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
-      <extent>
-        <xmin>-14746250.07513097859919071</xmin>
-        <ymin>-112075.42807669920148328</ymin>
-        <xmax>11342200.07719692215323448</xmax>
-        <ymax>10914413.7141284141689539</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
       <id>hello20131022151106574</id>
-      <datasource>dbname='./helloworld.db' table="hello" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="hello" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>Hello</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -3179,11 +5381,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -3195,197 +5398,422 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="178,178,178,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="121,121,121,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{a66dfab5-beb8-4687-8e08-188ae75ad7bb}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="231,113,72,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="230,85,192,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{4ab0d194-63be-4d23-9a4e-69ab3879209f}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="231,113,72,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="165,81,51,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{343f1a71-4c8b-4e9c-97ff-b349112fb61c}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="231,113,72,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="165,81,51,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{c199c876-cf67-446e-9803-75d79ec696d4}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="178,178,178,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0.80000000000000004,0.80000000000000004"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="121,121,121,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" id="{ed7814d5-c55c-448e-8d9a-15a0dc6fe5bc}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="230,85,192,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
-      <customproperties/>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
+      <customproperties>
+        <Option></Option>
+      </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{6c38ca2a-f77f-4090-a569-30da0c72ddbc}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="pk">
+        <field configurationFlags="NoFlag" name="pk">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="pkuid">
+        <field configurationFlags="NoFlag" name="pkuid">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="color">
+        <field configurationFlags="NoFlag" name="color">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="pk" index="0"/>
-        <alias name="" field="pkuid" index="1"/>
-        <alias name="" field="color" index="2"/>
+        <alias field="pk" index="0" name=""></alias>
+        <alias field="pkuid" index="1" name=""></alias>
+        <alias field="color" index="2" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="pk" policy="Duplicate"></policy>
+        <policy field="pkuid" policy="Duplicate"></policy>
+        <policy field="color" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="pk" expression=""/>
-        <default applyOnUpdate="0" field="pkuid" expression=""/>
-        <default applyOnUpdate="0" field="color" expression=""/>
+        <default applyOnUpdate="0" expression="" field="pk"></default>
+        <default applyOnUpdate="0" expression="" field="pkuid"></default>
+        <default applyOnUpdate="0" expression="" field="color"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
-        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="pk" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="pkuid" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="pk" desc="" exp=""/>
-        <constraint field="pkuid" desc="" exp=""/>
-        <constraint field="color" desc="" exp=""/>
+        <constraint desc="" exp="" field="pk"></constraint>
+        <constraint desc="" exp="" field="pkuid"></constraint>
+        <constraint desc="" exp="" field="color"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-        <columns/>
+        <columns></columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[]]></editforminitcode>
+      <editforminitcode></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+        </labelStyle>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="0" horizontalStretch="0" name="t" showLabel="1" type="Tab" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+          </labelStyle>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c1" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="1" name="pkuid" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-            <attributeEditorField name="color" showLabel="1" index="2"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="0" groupBox="1" horizontalStretch="0" name="c2" showLabel="1" type="GroupBox" verticalStretch="0" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+            </labelStyle>
+            <attributeEditorField horizontalStretch="0" index="2" name="color" showLabel="1" verticalStretch="0">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
+              </labelStyle>
+            </attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
-      <previewExpression>COALESCE( "pkuid", '&lt;NULL>' )</previewExpression>
-      <mapTip></mapTip>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
+      <previewExpression>COALESCE( "pkuid", '&lt;NULL&gt;' )</previewExpression>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="Point" styleCategories="AllStyleCategories" geometry="Point" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="0">
-      <extent>
-        <xmin>1000</xmin>
-        <ymin>2000</ymin>
-        <xmax>1000</xmax>
-        <ymax>2000</ymax>
-      </extent>
+    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Point" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="Point">
       <id>points20150803121107046</id>
-      <datasource>dbname='./helloworld.db' table="points" (geom) sql=</datasource>
+      <datasource>dbname='./helloworld.db' table="points" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>
       <layername>db_point</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -3396,11 +5824,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
+        <dates></dates>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -3412,177 +5841,380 @@ def my_form_open(dialog, layer, feature):
             <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">spatialite</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
-        <symbols>
-          <symbol type="marker" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
-            <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
-              <prop v="0" k="angle"/>
-              <prop v="172,96,98,255" k="color"/>
-              <prop v="1" k="horizontal_anchor_point"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="circle" k="name"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0" k="outline_width"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="diameter" k="scale_method"/>
-              <prop v="2" k="size"/>
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-              <prop v="MM" k="size_unit"/>
-              <prop v="1" k="vertical_anchor_point"/>
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" id="{02a80641-fb6d-4308-9da9-4d2915bf639d}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="152,125,183,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{30866986-ac81-40ac-8876-84bddf368fa7}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="152,125,183,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="109,89,131,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{ac6c4250-2561-4c29-95b1-e3a46a63f37d}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="152,125,183,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="109,89,131,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" id="{08bcdb55-25bd-4aec-af72-742a239e650e}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="172,96,98,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="circle"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="2"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
-      <customproperties/>
+      <selection mode="Default">
+        <selectionColor invalid="1"></selectionColor>
+      </selection>
+      <customproperties>
+        <Option></Option>
+      </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
-          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{d6b77b33-c33f-4ff4-8f6a-8491a8d5f4e9}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="10" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
-        <field name="gid">
+        <field configurationFlags="NoFlag" name="gid">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="name">
+        <field configurationFlags="NoFlag" name="name">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
-        <field name="color">
+        <field configurationFlags="NoFlag" name="color">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="gid" index="0"/>
-        <alias name="" field="name" index="1"/>
-        <alias name="" field="color" index="2"/>
+        <alias field="gid" index="0" name=""></alias>
+        <alias field="name" index="1" name=""></alias>
+        <alias field="color" index="2" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <splitPolicies>
+        <policy field="gid" policy="Duplicate"></policy>
+        <policy field="name" policy="Duplicate"></policy>
+        <policy field="color" policy="Duplicate"></policy>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" field="gid" expression=""/>
-        <default applyOnUpdate="0" field="name" expression=""/>
-        <default applyOnUpdate="0" field="color" expression=""/>
+        <default applyOnUpdate="0" expression="" field="gid"></default>
+        <default applyOnUpdate="0" expression="" field="name"></default>
+        <default applyOnUpdate="0" expression="" field="color"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" notnull_strength="1" field="gid" exp_strength="0" unique_strength="1"/>
-        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
-        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="gid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="color" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="gid" desc="" exp=""/>
-        <constraint field="name" desc="" exp=""/>
-        <constraint field="color" desc="" exp=""/>
+        <constraint desc="" exp="" field="gid"></constraint>
+        <constraint desc="" exp="" field="name"></constraint>
+        <constraint desc="" exp="" field="color"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-        <columns/>
+        <columns></columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../../../..</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[]]></editforminitcode>
+      <editforminitcode></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
-      <editable/>
-      <labelOnTop/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"name"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="points20150803121107046"/>
-    <layer id="hello20131022151106574"/>
-    <layer id="Hello_copy20150804164427541"/>
-    <layer id="Hello_SubsetString_copy20160222085231770"/>
-    <layer id="Hello_Project_SubsetString_copy20160223113949592"/>
-    <layer id="dem20150730091219559"/>
-    <layer id="country20131022151106556"/>
-    <layer id="Country_copy20161127151800736"/>
-    <layer id="country20170328164317226"/>
-    <layer id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c"/>
-    <layer id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9"/>
+    <layer id="points20150803121107046"></layer>
+    <layer id="hello20131022151106574"></layer>
+    <layer id="Hello_copy20150804164427541"></layer>
+    <layer id="Hello_SubsetString_copy20160222085231770"></layer>
+    <layer id="Hello_Project_SubsetString_copy20160223113949592"></layer>
+    <layer id="dem20150730091219559"></layer>
+    <layer id="country20131022151106556"></layer>
+    <layer id="Country_copy20161127151800736"></layer>
+    <layer id="country20170328164317226"></layer>
+    <layer id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c"></layer>
+    <layer id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9"></layer>
   </layerorder>
   <properties>
-    <DefaultStyles>
-      <AlphaInt type="int">255</AlphaInt>
-      <ColorRamp type="QString"></ColorRamp>
-      <Fill type="QString"></Fill>
-      <Line type="QString"></Line>
-      <Marker type="QString"></Marker>
-      <Opacity type="double">1</Opacity>
-      <RandomColors type="bool">true</RandomColors>
-    </DefaultStyles>
+    <DefaultStyles></DefaultStyles>
     <Digitizing>
-      <AvoidIntersectionsList type="QStringList"/>
+      <AvoidIntersectionsList type="QStringList"></AvoidIntersectionsList>
+      <AvoidIntersectionsMode type="int">2</AvoidIntersectionsMode>
       <DefaultSnapTolerance type="double">40</DefaultSnapTolerance>
       <DefaultSnapToleranceUnit type="int">1</DefaultSnapToleranceUnit>
       <DefaultSnapType type="QString">to vertex</DefaultSnapType>
@@ -3618,7 +6250,7 @@ def my_form_open(dialog, layer, feature):
       <SelectionColorRedPart type="int">255</SelectionColorRedPart>
     </Gui>
     <Identify>
-      <disabledLayers type="QStringList"/>
+      <disabledLayers type="QStringList"></disabledLayers>
     </Identify>
     <Legend>
       <filterByMap type="bool">false</filterByMap>
@@ -3635,11 +6267,15 @@ def my_form_open(dialog, layer, feature):
     </Measurement>
     <PAL>
       <CandidatesLine type="int">50</CandidatesLine>
+      <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
       <CandidatesPoint type="int">16</CandidatesPoint>
       <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
+      <DrawLabelMetrics type="bool">false</DrawLabelMetrics>
       <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
       <DrawRectOnly type="bool">false</DrawRectOnly>
       <DrawUnplaced type="bool">false</DrawUnplaced>
+      <PlacementEngineVersion type="int">0</PlacementEngineVersion>
       <SearchMethod type="int">0</SearchMethod>
       <ShowingAllLabels type="bool">false</ShowingAllLabels>
       <ShowingCandidates type="bool">false</ShowingCandidates>
@@ -3670,12 +6306,12 @@ def my_form_open(dialog, layer, feature):
       <showLabel type="int">1</showLabel>
       <timeFrameSize type="int">1</timeFrameSize>
       <timeFrameType type="QString">days</timeFrameType>
-      <timeLayerList type="QStringList"/>
+      <timeLayerList type="QStringList"></timeLayerList>
       <timeLayerManager type="QString"></timeLayerManager>
     </TimeManager>
     <Variables>
-      <variableNames type="QStringList"/>
-      <variableValues type="QStringList"/>
+      <variableNames type="QStringList"></variableNames>
+      <variableValues type="QStringList"></variableValues>
     </Variables>
     <WCSLayers type="QStringList">
       <value>dem20150730091219559</value>
@@ -3740,8 +6376,8 @@ def my_form_open(dialog, layer, feature):
     <WMSOnlineResource type="QString"></WMSOnlineResource>
     <WMSPrecision type="QString">5</WMSPrecision>
     <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSRestrictedLayers type="QStringList"/>
+    <WMSRestrictedComposers type="QStringList"></WMSRestrictedComposers>
+    <WMSRestrictedLayers type="QStringList"></WMSRestrictedLayers>
     <WMSRootName type="QString"></WMSRootName>
     <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
     <WMSServiceAbstract type="QString">Simple test app.</WMSServiceAbstract>
@@ -3751,29 +6387,36 @@ def my_form_open(dialog, layer, feature):
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
     <WMTSGrids>
-      <CRS type="QStringList"/>
-      <Config type="QStringList"/>
+      <CRS type="QStringList"></CRS>
+      <Config type="QStringList"></Config>
     </WMTSGrids>
     <WMTSJpegLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSJpegLayers>
     <WMTSLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSLayers>
     <WMTSMinScale type="int">5000</WMTSMinScale>
     <WMTSPngLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSPngLayers>
     <WMTSUrl type="QString"></WMTSUrl>
   </properties>
-  <visibility-presets/>
-  <transformContext/>
+  <dataDefinedServerProperties>
+    <Option type="Map">
+      <Option name="name" type="QString" value=""></Option>
+      <Option name="properties"></Option>
+      <Option name="type" type="QString" value="collection"></Option>
+    </Option>
+  </dataDefinedServerProperties>
+  <visibility-presets></visibility-presets>
+  <transformContext></transformContext>
   <projectMetadata>
     <identifier></identifier>
     <parentidentifier></parentidentifier>
@@ -3790,583 +6433,1405 @@ def my_form_open(dialog, layer, feature):
       <email></email>
       <role></role>
     </contact>
-    <links/>
+    <links></links>
+    <dates>
+      <date type="Created" value="2000-01-01T00:00:00"></date>
+    </dates>
     <author></author>
     <creation>2000-01-01T00:00:00</creation>
   </projectMetadata>
-  <Annotations/>
+  <Annotations></Annotations>
   <Layouts>
-    <Layout units="mm" name="layoutA4" worldFileMap="" printResolution="300">
-      <Snapper snapToGrid="0" snapToItems="1" tolerance="5" snapToGuides="1"/>
-      <Grid offsetUnits="mm" resUnits="mm" offsetX="0" offsetY="0" resolution="10"/>
+    <Layout name="layoutA4" printResolution="300" units="mm" worldFileMap="">
+      <Snapper snapToGrid="0" snapToGuides="1" snapToItems="1" tolerance="5"></Snapper>
+      <Grid offsetUnits="mm" offsetX="0" offsetY="0" resUnits="mm" resolution="10"></Grid>
       <PageCollection>
-        <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-          <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-            <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-            <prop v="255,255,255,255" k="color"/>
-            <prop v="miter" k="joinstyle"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="no" k="outline_style"/>
-            <prop v="0.26" k="outline_width"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="solid" k="style"/>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleFill" enabled="1" id="{9cbc21ab-4d89-43f4-935d-96ef447c1ade}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="color" type="QString" value="255,255,255,255"></Option>
+              <Option name="joinstyle" type="QString" value="miter"></Option>
+              <Option name="offset" type="QString" value="0,0"></Option>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offset_unit" type="QString" value="MM"></Option>
+              <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+              <Option name="outline_style" type="QString" value="no"></Option>
+              <Option name="outline_width" type="QString" value="0.26"></Option>
+              <Option name="outline_width_unit" type="QString" value="MM"></Option>
+              <Option name="style" type="QString" value="solid"></Option>
+            </Option>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem itemRotation="0" blendMode="0" position="0,0,mm" zValue="0" templateUuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" type="65638" groupUuid="" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="297,210,mm" positionOnPage="0,0,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" background="true">
-          <FrameColor alpha="255" green="0" red="0" blue="0"/>
-          <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+        <LayoutItem background="true" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" opacity="1" outlineWidthM="0.3,mm" position="0,0,mm" positionLock="false" positionOnPage="0,0,mm" referencePoint="0" size="297,210,mm" templateUuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" type="65638" uuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" visibility="1" zValue="0">
+          <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+          <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dataDefinedProperties>
-            <customproperties/>
+            <customproperties>
+              <Option></Option>
+            </customproperties>
           </LayoutObject>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="255,255,255,255" k="color"/>
-              <prop v="miter" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="35,35,35,255" k="outline_color"/>
-              <prop v="no" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{060f1b69-6b5a-46f1-8ac1-94c0a74a8fbc}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="255,255,255,255"></Option>
+                <Option name="joinstyle" type="QString" value="miter"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="35,35,35,255"></Option>
+                <Option name="outline_style" type="QString" value="no"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </LayoutItem>
-        <GuideCollection visible="1"/>
+        <GuideCollection visible="1"></GuideCollection>
       </PageCollection>
-      <LayoutItem itemRotation="0" blendMode="0" position="21.5381,157.547,mm" zValue="4" templateUuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" halign="1" htmlState="0" labelText="QGIS" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="idtextbox" size="120.853,35.0992,mm" positionOnPage="21.5381,157.547,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" background="false" valign="32">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="1" htmlState="0" id="idtextbox" itemRotation="0" labelText="QGIS" marginX="1" marginY="1" opacity="1" outlineWidthM="0.3,mm" position="21.5381,157.547,mm" positionLock="false" positionOnPage="21.5381,157.547,mm" referencePoint="0" size="120.853,35.0992,mm" templateUuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" type="65641" uuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" valign="32" visibility="1" zValue="4">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <LabelFont description="DejaVu Sans,10,-1,5,50,0,0,0,0,0" style=""/>
-        <FontColor alpha="255" green="0" red="0" blue="0"/>
-      </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="21.3911,46,mm" zValue="3" templateUuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="242,104,mm" positionOnPage="21.3911,46,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" mapRotation="0" uuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" background="true">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
-        <LayoutObject>
-          <dataDefinedProperties>
-            <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
-            </Option>
-          </dataDefinedProperties>
-          <customproperties/>
-        </LayoutObject>
-        <Extent ymin="-13032965.18542143888771534" ymax="16020257.03109830431640148" xmax="33978427.73650816082954407" xmin="-33626185.49808585643768311"/>
-        <LayerSet>
-          <Layer provider="spatialite" name="db_point" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=">points20150803121107046</Layer>
-          <Layer provider="spatialite" name="Hello" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">hello20131022151106574</Layer>
-          <Layer provider="spatialite" name="Hello_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_copy20150804164427541</Layer>
-          <Layer provider="spatialite" name="Hello_Project_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )">Hello_SubsetString_copy20160222085231770</Layer>
-          <Layer provider="spatialite" name="Hello_Filter_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_Project_SubsetString_copy20160223113949592</Layer>
-          <Layer provider="gdal" name="dem" source="/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/dem.tif">dem20150730091219559</Layer>
-          <Layer provider="spatialite" name="Country" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20131022151106556</Layer>
-          <Layer provider="spatialite" name="Country_Labels" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">Country_copy20161127151800736</Layer>
-          <Layer provider="spatialite" name="Country_Diagrams" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20170328164317226</Layer>
-        </LayerSet>
-        <ComposerMapGrid annotationExpression="" leftAnnotationDisplay="0" rightAnnotationPosition="1" topAnnotationDisplay="0" rightAnnotationDirection="0" annotationPrecision="3" bottomAnnotationDirection="0" topAnnotationPosition="1" rightAnnotationDisplay="0" leftAnnotationDirection="0" rightFrameDivisions="0" annotationFontColor="0,0,0,255" intervalY="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}" frameAnnotationDistance="1" frameFillColor1="255,255,255,255" offsetY="0" offsetX="0" blendMode="0" unit="0" leftFrameDivisions="0" crossLength="3" topAnnotationDirection="0" bottomFrameDivisions="0" frameFillColor2="0,0,0,255" showAnnotation="0" name="Grid 1" gridFrameMargin="0" gridFrameStyle="0" annotationFormat="0" position="3" minimumIntervalWidth="50" bottomAnnotationDisplay="0" maximumIntervalWidth="100" leftAnnotationPosition="1" gridFrameSideFlags="15" bottomAnnotationPosition="1" gridFramePenColor="0,0,0,255" intervalX="0" topFrameDivisions="0" gridFramePenThickness="0.5" gridStyle="0" gridFrameWidth="2" show="1">
-          <lineStyle>
-            <symbol type="line" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-              <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-                <prop v="square" k="capstyle"/>
-                <prop v="5;2" k="customdash"/>
-                <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-                <prop v="MM" k="customdash_unit"/>
-                <prop v="0" k="draw_inside_polygon"/>
-                <prop v="bevel" k="joinstyle"/>
-                <prop v="0,0,0,255" k="line_color"/>
-                <prop v="solid" k="line_style"/>
-                <prop v="0" k="line_width"/>
-                <prop v="MM" k="line_width_unit"/>
-                <prop v="0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="0" k="ring_filter"/>
-                <prop v="0" k="use_custom_dash"/>
-                <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="DejaVu Sans" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+          <families></families>
+          <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+          <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+          <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="color" type="QString" value="255,255,255,255"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                  <Option name="outline_style" type="QString" value="no"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="style" type="QString" value="solid"></Option>
+                </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </background>
+          <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+          <dd_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dd_properties>
+        </text-style>
+      </LayoutItem>
+      <LayoutItem background="true" blendMode="0" drawCanvasItems="true" excludeFromExports="0" followPreset="false" followPresetName="" frame="false" frameJoinStyle="miter" groupUuid="" id="" isTemporal="0" itemRotation="0" keepLayerSet="false" labelMargin="0,mm" mapFlags="1" mapRotation="0" opacity="1" outlineWidthM="0.3,mm" position="21.3911,46,mm" positionLock="false" positionOnPage="21.3911,46,mm" referencePoint="0" size="242,104,mm" templateUuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" type="65639" uuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" visibility="1" zValue="3">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
+        <LayoutObject>
+          <dataDefinedProperties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dataDefinedProperties>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
+        </LayoutObject>
+        <Extent xmax="33978427.73650816082954407" xmin="-33626185.49808585643768311" ymax="16020257.03109830431640148" ymin="-13032965.18542143888771534"></Extent>
+        <LayerSet>
+          <Layer name="db_point" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom)">points20150803121107046</Layer>
+          <Layer name="Hello" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom)">hello20131022151106574</Layer>
+          <Layer name="Hello_SubsetString" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom)">Hello_copy20150804164427541</Layer>
+          <Layer name="Hello_Project_SubsetString" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )">Hello_SubsetString_copy20160222085231770</Layer>
+          <Layer name="Hello_Filter_SubsetString" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom)">Hello_Project_SubsetString_copy20160223113949592</Layer>
+          <Layer name="dem" provider="gdal" source="/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/dem.tif">dem20150730091219559</Layer>
+          <Layer name="Country" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom)">country20131022151106556</Layer>
+          <Layer name="Country_Labels" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom)">Country_copy20161127151800736</Layer>
+          <Layer name="Country_Diagrams" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom)">country20170328164317226</Layer>
+        </LayerSet>
+        <ComposerMapGrid annotationExpression="" annotationFormat="0" annotationPrecision="3" blendMode="0" bottomAnnotationDirection="0" bottomAnnotationDisplay="0" bottomAnnotationPosition="1" bottomFrameDivisions="0" crossLength="3" frameAnnotationDistance="1" frameFillColor1="255,255,255,255" frameFillColor2="0,0,0,255" gridFrameMargin="0" gridFramePenColor="0,0,0,255" gridFramePenThickness="0.5" gridFrameSideFlags="15" gridFrameStyle="0" gridFrameWidth="2" gridStyle="0" intervalX="0" intervalY="0" leftAnnotationDirection="0" leftAnnotationDisplay="0" leftAnnotationPosition="1" leftFrameDivisions="0" maximumIntervalWidth="100" minimumIntervalWidth="50" name="Grid 1" offsetX="0" offsetY="0" position="3" rightAnnotationDirection="0" rightAnnotationDisplay="0" rightAnnotationPosition="1" rightFrameDivisions="0" rotatedAnnotationsEnabled="0" rotatedAnnotationsLengthMode="0" rotatedAnnotationsMarginToCorner="0" rotatedAnnotationsMinimumAngle="0" rotatedTicksEnabled="0" rotatedTicksLengthMode="0" rotatedTicksMarginToCorner="0" rotatedTicksMinimumAngle="0" show="1" showAnnotation="0" topAnnotationDirection="0" topAnnotationDisplay="0" topAnnotationPosition="1" topFrameDivisions="0" unit="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}">
+          <lineStyle>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{1835befb-1442-4406-82e5-6bed7b00877a}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="0,0,0,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </lineStyle>
           <markerStyle>
-            <symbol type="marker" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-              <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
-                <prop v="0" k="angle"/>
-                <prop v="0,0,0,255" k="color"/>
-                <prop v="1" k="horizontal_anchor_point"/>
-                <prop v="bevel" k="joinstyle"/>
-                <prop v="circle" k="name"/>
-                <prop v="0,0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="0,0,0,255" k="outline_color"/>
-                <prop v="solid" k="outline_style"/>
-                <prop v="0" k="outline_width"/>
-                <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                <prop v="MM" k="outline_width_unit"/>
-                <prop v="area" k="scale_method"/>
-                <prop v="2" k="size"/>
-                <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                <prop v="MM" k="size_unit"/>
-                <prop v="1" k="vertical_anchor_point"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleMarker" enabled="1" id="{3e5cd01b-4f08-4954-bd24-5cd10be5dd04}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="angle" type="QString" value="0"></Option>
+                  <Option name="cap_style" type="QString" value="square"></Option>
+                  <Option name="color" type="QString" value="0,0,0,255"></Option>
+                  <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="name" type="QString" value="circle"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                  <Option name="outline_style" type="QString" value="solid"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="scale_method" type="QString" value="area"></Option>
+                  <Option name="size" type="QString" value="2"></Option>
+                  <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="size_unit" type="QString" value="MM"></Option>
+                  <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+                </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </markerStyle>
-          <annotationFontProperties description=",11,-1,5,50,0,0,0,0,0" style=""/>
+          <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="11" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+            <families></families>
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+                <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                  <Option type="Map">
+                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="color" type="QString" value="255,255,255,255"></Option>
+                    <Option name="joinstyle" type="QString" value="bevel"></Option>
+                    <Option name="offset" type="QString" value="0,0"></Option>
+                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="offset_unit" type="QString" value="MM"></Option>
+                    <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                    <Option name="outline_style" type="QString" value="no"></Option>
+                    <Option name="outline_width" type="QString" value="0"></Option>
+                    <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                    <Option name="style" type="QString" value="solid"></Option>
+                  </Option>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+            <dd_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </dd_properties>
+          </text-style>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dataDefinedProperties>
-            <customproperties/>
+            <customproperties>
+              <Option></Option>
+            </customproperties>
           </LayoutObject>
         </ComposerMapGrid>
-        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
-        <labelBlockingItems/>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"></AtlasMap>
+        <labelBlockingItems></labelBlockingItems>
+        <atlasClippingSettings clippingType="0" enabled="0" forceLabelsInside="0" restrictLayers="0">
+          <layersToClip></layersToClip>
+        </atlasClippingSettings>
+        <itemClippingSettings clipSource="" clippingType="0" enabled="0" forceLabelsInside="0"></itemClippingSettings>
       </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" position="213.302,161.791,mm" zValue="2" templateUuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" halign="1" htmlState="0" labelText="Welcome to our world...." type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="64.3016,11.0626,mm" positionOnPage="213.302,161.791,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" background="false" valign="32">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="1" htmlState="0" id="" itemRotation="0" labelText="Welcome to our world...." marginX="1" marginY="1" opacity="1" outlineWidthM="0.3,mm" position="213.302,161.791,mm" positionLock="false" positionOnPage="213.302,161.791,mm" referencePoint="0" size="64.3016,11.0626,mm" templateUuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" type="65641" uuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" valign="32" visibility="1" zValue="2">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <LabelFont description="DejaVu Sans,12,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor alpha="255" green="0" red="0" blue="0"/>
+        <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="DejaVu Sans" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="12" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="75" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+          <families></families>
+          <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+          <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+          <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="color" type="QString" value="255,255,255,255"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                  <Option name="outline_style" type="QString" value="no"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="style" type="QString" value="solid"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </background>
+          <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+          <dd_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dd_properties>
+        </text-style>
       </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" position="49.9838,9.33411,mm" zValue="1" templateUuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" halign="1" htmlState="0" labelText="QGIS Mapserver" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="215.03,28.0023,mm" positionOnPage="49.9838,9.33411,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" background="false" valign="32">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="1" htmlState="0" id="" itemRotation="0" labelText="QGIS Mapserver" marginX="1" marginY="1" opacity="1" outlineWidthM="0.3,mm" position="49.9838,9.33411,mm" positionLock="false" positionOnPage="49.9838,9.33411,mm" referencePoint="0" size="215.03,28.0023,mm" templateUuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" type="65641" uuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" valign="32" visibility="1" zValue="1">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <LabelFont description="DejaVu Sans,48,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor alpha="255" green="0" red="0" blue="0"/>
+        <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="DejaVu Sans" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="48" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="75" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+          <families></families>
+          <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+          <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+          <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="color" type="QString" value="255,255,255,255"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                  <Option name="outline_style" type="QString" value="no"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="style" type="QString" value="solid"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </background>
+          <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+          <dd_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dd_properties>
+        </text-style>
       </LayoutItem>
-      <customproperties/>
-      <Atlas pageNameExpression="" hideCoverage="0" enabled="0" filterFeatures="0" coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" sortFeatures="0"/>
+      <customproperties>
+        <Option></Option>
+      </customproperties>
+      <Atlas coverageLayer="" enabled="0" filenamePattern="'output_'||@atlas_featurenumber" filterFeatures="0" hideCoverage="0" pageNameExpression="" sortFeatures="0"></Atlas>
     </Layout>
-    <Layout units="mm" name="layoutA4copy" worldFileMap="" printResolution="300">
-      <Snapper snapToGrid="0" snapToItems="1" tolerance="5" snapToGuides="1"/>
-      <Grid offsetUnits="mm" resUnits="mm" offsetX="0" offsetY="0" resolution="10"/>
+    <Layout name="layoutA4copy" printResolution="300" units="mm" worldFileMap="">
+      <Snapper snapToGrid="0" snapToGuides="1" snapToItems="1" tolerance="5"></Snapper>
+      <Grid offsetUnits="mm" offsetX="0" offsetY="0" resUnits="mm" resolution="10"></Grid>
       <PageCollection>
-        <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-          <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-            <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-            <prop v="255,255,255,255" k="color"/>
-            <prop v="miter" k="joinstyle"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="no" k="outline_style"/>
-            <prop v="0.26" k="outline_width"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="solid" k="style"/>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleFill" enabled="1" id="{4e433cc2-6b21-4f66-915b-6c6312c724b7}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="color" type="QString" value="255,255,255,255"></Option>
+              <Option name="joinstyle" type="QString" value="miter"></Option>
+              <Option name="offset" type="QString" value="0,0"></Option>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offset_unit" type="QString" value="MM"></Option>
+              <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+              <Option name="outline_style" type="QString" value="no"></Option>
+              <Option name="outline_width" type="QString" value="0.26"></Option>
+              <Option name="outline_width_unit" type="QString" value="MM"></Option>
+              <Option name="style" type="QString" value="solid"></Option>
+            </Option>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem itemRotation="0" blendMode="0" position="0,0,mm" zValue="0" templateUuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" type="65638" groupUuid="" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="297,210,mm" positionOnPage="0,0,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" background="true">
-          <FrameColor alpha="255" green="0" red="0" blue="0"/>
-          <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+        <LayoutItem background="true" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" opacity="1" outlineWidthM="0.3,mm" position="0,0,mm" positionLock="false" positionOnPage="0,0,mm" referencePoint="0" size="297,210,mm" templateUuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" type="65638" uuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" visibility="1" zValue="0">
+          <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+          <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dataDefinedProperties>
-            <customproperties/>
+            <customproperties>
+              <Option></Option>
+            </customproperties>
           </LayoutObject>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="255,255,255,255" k="color"/>
-              <prop v="miter" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="35,35,35,255" k="outline_color"/>
-              <prop v="no" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{b9e6f5f6-1628-408a-a93c-bb2b386f22e5}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="255,255,255,255"></Option>
+                <Option name="joinstyle" type="QString" value="miter"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="35,35,35,255"></Option>
+                <Option name="outline_style" type="QString" value="no"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </LayoutItem>
-        <GuideCollection visible="1"/>
+        <GuideCollection visible="1"></GuideCollection>
       </PageCollection>
-      <LayoutItem excludeFromExports="0" symbolWidth="7" id="" resizeToContents="1" templateUuid="{3d056e83-9087-450b-81e7-b343a652139d}" map_uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" positionOnPage="147.933,150,mm" fontColor="#000000" groupUuid="" frame="false" wrapChar="" rasterBorderWidth="0" uuid="{3d056e83-9087-450b-81e7-b343a652139d}" wmsLegendHeight="25" size="65.3688,96.2,mm" visibility="1" equalColumnWidth="0" symbolHeight="4" type="65642" columnSpace="2" wmsLegendWidth="50" blendMode="0" frameJoinStyle="miter" title="" lineSpacing="1" positionLock="false" itemRotation="0" rasterBorder="1" outlineWidthM="0.3,mm" background="true" position="147.933,150,mm" referencePoint="0" splitLayer="0" opacity="1" legendFilterByAtlas="0" zValue="5" symbolAlignment="1" columnCount="1" boxSpace="2" titleAlignment="1" rasterBorderColor="0,0,0,255">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="true" blendMode="0" boxSpace="2" columnCount="1" columnSpace="2" equalColumnWidth="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" legendFilterByAtlas="0" map_uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" maxSymbolSize="0" minSymbolSize="0" opacity="1" outlineWidthM="0.3,mm" position="147.933,150,mm" positionLock="false" positionOnPage="147.933,150,mm" rasterBorder="1" rasterBorderColor="0,0,0,255" rasterBorderWidth="0" referencePoint="0" resizeToContents="1" size="65.3688,96.2,mm" splitLayer="0" symbolAlignment="1" symbolHeight="4" symbolWidth="7" templateUuid="{3d056e83-9087-450b-81e7-b343a652139d}" title="" titleAlignment="1" type="65642" uuid="{3d056e83-9087-450b-81e7-b343a652139d}" visibility="1" wmsLegendHeight="25" wmsLegendWidth="50" wrapChar="" zValue="5">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
+        <filterByMaps>
+          <map uuid="{98195e4d-0084-4747-b15b-507220be6d8a}"></map>
+        </filterByMaps>
         <styles>
-          <style name="title" marginBottom="3.5" alignment="1">
-            <styleFont description="Ubuntu,16,-1,5,50,0,0,0,0,0" style=""/>
+          <style alignment="1" indent="0" marginBottom="3.5" name="title">
+            <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="16" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="6.6444479999999997" multilineHeightUnit="MM" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+              <families></families>
+              <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+              <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+              <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                  <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                    <Option type="Map">
+                      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="color" type="QString" value="255,255,255,255"></Option>
+                      <Option name="joinstyle" type="QString" value="bevel"></Option>
+                      <Option name="offset" type="QString" value="0,0"></Option>
+                      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="offset_unit" type="QString" value="MM"></Option>
+                      <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                      <Option name="outline_style" type="QString" value="no"></Option>
+                      <Option name="outline_width" type="QString" value="0"></Option>
+                      <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                      <Option name="style" type="QString" value="solid"></Option>
+                    </Option>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+              </background>
+              <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+              <dd_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </dd_properties>
+            </text-style>
           </style>
-          <style name="group" marginTop="3" alignment="1">
-            <styleFont description="Ubuntu,14,-1,5,50,0,0,0,0,0" style=""/>
+          <style alignment="1" indent="0" marginTop="3" name="group">
+            <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="14" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="5.9388920000000001" multilineHeightUnit="MM" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+              <families></families>
+              <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+              <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+              <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                  <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                    <Option type="Map">
+                      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="color" type="QString" value="255,255,255,255"></Option>
+                      <Option name="joinstyle" type="QString" value="bevel"></Option>
+                      <Option name="offset" type="QString" value="0,0"></Option>
+                      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="offset_unit" type="QString" value="MM"></Option>
+                      <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                      <Option name="outline_style" type="QString" value="no"></Option>
+                      <Option name="outline_width" type="QString" value="0"></Option>
+                      <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                      <Option name="style" type="QString" value="solid"></Option>
+                    </Option>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+              </background>
+              <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+              <dd_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </dd_properties>
+            </text-style>
           </style>
-          <style name="subgroup" marginTop="3" alignment="1">
-            <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""/>
+          <style alignment="1" indent="0" marginTop="3" name="subgroup">
+            <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="12" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="5.2333359999999995" multilineHeightUnit="MM" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+              <families></families>
+              <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+              <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+              <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                  <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                    <Option type="Map">
+                      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="color" type="QString" value="255,255,255,255"></Option>
+                      <Option name="joinstyle" type="QString" value="bevel"></Option>
+                      <Option name="offset" type="QString" value="0,0"></Option>
+                      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="offset_unit" type="QString" value="MM"></Option>
+                      <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                      <Option name="outline_style" type="QString" value="no"></Option>
+                      <Option name="outline_width" type="QString" value="0"></Option>
+                      <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                      <Option name="style" type="QString" value="solid"></Option>
+                    </Option>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+              </background>
+              <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+              <dd_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </dd_properties>
+            </text-style>
           </style>
-          <style name="symbol" marginTop="2.5" alignment="1">
-            <styleFont description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
+          <style alignment="1" indent="0" marginTop="2.5" name="symbol">
+            <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="11" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+              <families></families>
+              <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+              <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+              <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                  <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                    <Option type="Map">
+                      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="color" type="QString" value="255,255,255,255"></Option>
+                      <Option name="joinstyle" type="QString" value="bevel"></Option>
+                      <Option name="offset" type="QString" value="0,0"></Option>
+                      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="offset_unit" type="QString" value="MM"></Option>
+                      <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                      <Option name="outline_style" type="QString" value="no"></Option>
+                      <Option name="outline_width" type="QString" value="0"></Option>
+                      <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                      <Option name="style" type="QString" value="solid"></Option>
+                    </Option>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+              </background>
+              <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+              <dd_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </dd_properties>
+            </text-style>
           </style>
-          <style name="symbolLabel" marginTop="2" marginLeft="2" alignment="1">
-            <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""/>
+          <style alignment="1" indent="0" marginLeft="2" marginTop="2" name="symbolLabel">
+            <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="12" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="5.2333359999999995" multilineHeightUnit="MM" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+              <families></families>
+              <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+              <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+              <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                  <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                    <Option type="Map">
+                      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="color" type="QString" value="255,255,255,255"></Option>
+                      <Option name="joinstyle" type="QString" value="bevel"></Option>
+                      <Option name="offset" type="QString" value="0,0"></Option>
+                      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                      <Option name="offset_unit" type="QString" value="MM"></Option>
+                      <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                      <Option name="outline_style" type="QString" value="no"></Option>
+                      <Option name="outline_width" type="QString" value="0"></Option>
+                      <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                      <Option name="style" type="QString" value="solid"></Option>
+                    </Option>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+              </background>
+              <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+              <dd_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </dd_properties>
+            </text-style>
           </style>
         </styles>
       </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" position="21.5381,157.547,mm" zValue="4" templateUuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" halign="1" htmlState="0" labelText="QGIS" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="idtextbox" size="120.853,35.0992,mm" positionOnPage="21.5381,157.547,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" background="false" valign="32">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="1" htmlState="0" id="idtextbox" itemRotation="0" labelText="QGIS" marginX="1" marginY="1" opacity="1" outlineWidthM="0.3,mm" position="21.5381,157.547,mm" positionLock="false" positionOnPage="21.5381,157.547,mm" referencePoint="0" size="120.853,35.0992,mm" templateUuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" type="65641" uuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" valign="32" visibility="1" zValue="4">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <LabelFont description="DejaVu Sans,10,-1,5,50,0,0,0,0,0" style=""/>
-        <FontColor alpha="255" green="0" red="0" blue="0"/>
-      </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="21.3911,46,mm" zValue="3" templateUuid="{98195e4d-0084-4747-b15b-507220be6d8a}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="242,104,mm" positionOnPage="21.3911,46,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" mapRotation="0" uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" background="true">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
-        <LayoutObject>
-          <dataDefinedProperties>
-            <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
-            </Option>
-          </dataDefinedProperties>
-          <customproperties/>
-        </LayoutObject>
-        <Extent ymin="-13032965.18542143888771534" ymax="16020257.03109830431640148" xmax="33978427.73650816082954407" xmin="-33626185.49808585643768311"/>
-        <LayerSet>
-          <Layer provider="spatialite" name="db_point" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=">points20150803121107046</Layer>
-          <Layer provider="spatialite" name="Hello" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">hello20131022151106574</Layer>
-          <Layer provider="spatialite" name="Hello_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_copy20150804164427541</Layer>
-          <Layer provider="spatialite" name="Hello_Project_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )">Hello_SubsetString_copy20160222085231770</Layer>
-          <Layer provider="spatialite" name="Hello_Filter_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_Project_SubsetString_copy20160223113949592</Layer>
-          <Layer provider="gdal" name="dem" source="/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/dem.tif">dem20150730091219559</Layer>
-          <Layer provider="spatialite" name="Country" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20131022151106556</Layer>
-          <Layer provider="spatialite" name="Country_Labels" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">Country_copy20161127151800736</Layer>
-          <Layer provider="spatialite" name="Country_Diagrams" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20170328164317226</Layer>
-        </LayerSet>
-        <ComposerMapGrid annotationExpression="" leftAnnotationDisplay="0" rightAnnotationPosition="1" topAnnotationDisplay="0" rightAnnotationDirection="0" annotationPrecision="3" bottomAnnotationDirection="0" topAnnotationPosition="1" rightAnnotationDisplay="0" leftAnnotationDirection="0" rightFrameDivisions="0" annotationFontColor="0,0,0,255" intervalY="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}" frameAnnotationDistance="1" frameFillColor1="255,255,255,255" offsetY="0" offsetX="0" blendMode="0" unit="0" leftFrameDivisions="0" crossLength="3" topAnnotationDirection="0" bottomFrameDivisions="0" frameFillColor2="0,0,0,255" showAnnotation="0" name="Grid 1" gridFrameMargin="0" gridFrameStyle="0" annotationFormat="0" position="3" minimumIntervalWidth="50" bottomAnnotationDisplay="0" maximumIntervalWidth="100" leftAnnotationPosition="1" gridFrameSideFlags="15" bottomAnnotationPosition="1" gridFramePenColor="0,0,0,255" intervalX="0" topFrameDivisions="0" gridFramePenThickness="0.5" gridStyle="0" gridFrameWidth="2" show="1">
-          <lineStyle>
-            <symbol type="line" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-              <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-                <prop v="square" k="capstyle"/>
-                <prop v="5;2" k="customdash"/>
-                <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-                <prop v="MM" k="customdash_unit"/>
-                <prop v="0" k="draw_inside_polygon"/>
-                <prop v="bevel" k="joinstyle"/>
-                <prop v="0,0,0,255" k="line_color"/>
-                <prop v="solid" k="line_style"/>
-                <prop v="0" k="line_width"/>
-                <prop v="MM" k="line_width_unit"/>
-                <prop v="0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="0" k="ring_filter"/>
-                <prop v="0" k="use_custom_dash"/>
-                <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="DejaVu Sans" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+          <families></families>
+          <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+          <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+          <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="color" type="QString" value="255,255,255,255"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                  <Option name="outline_style" type="QString" value="no"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="style" type="QString" value="solid"></Option>
+                </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </background>
+          <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+          <dd_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dd_properties>
+        </text-style>
+      </LayoutItem>
+      <LayoutItem background="true" blendMode="0" drawCanvasItems="true" excludeFromExports="0" followPreset="false" followPresetName="" frame="false" frameJoinStyle="miter" groupUuid="" id="" isTemporal="0" itemRotation="0" keepLayerSet="false" labelMargin="0,mm" mapFlags="1" mapRotation="0" opacity="1" outlineWidthM="0.3,mm" position="21.3911,46,mm" positionLock="false" positionOnPage="21.3911,46,mm" referencePoint="0" size="242,104,mm" templateUuid="{98195e4d-0084-4747-b15b-507220be6d8a}" type="65639" uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" visibility="1" zValue="3">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
+        <LayoutObject>
+          <dataDefinedProperties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dataDefinedProperties>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
+        </LayoutObject>
+        <Extent xmax="33978427.73650816082954407" xmin="-33626185.49808585643768311" ymax="16020257.03109830431640148" ymin="-13032965.18542143888771534"></Extent>
+        <LayerSet>
+          <Layer name="db_point" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom)">points20150803121107046</Layer>
+          <Layer name="Hello" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom)">hello20131022151106574</Layer>
+          <Layer name="Hello_SubsetString" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom)">Hello_copy20150804164427541</Layer>
+          <Layer name="Hello_Project_SubsetString" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )">Hello_SubsetString_copy20160222085231770</Layer>
+          <Layer name="Hello_Filter_SubsetString" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom)">Hello_Project_SubsetString_copy20160223113949592</Layer>
+          <Layer name="dem" provider="gdal" source="/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/dem.tif">dem20150730091219559</Layer>
+          <Layer name="Country" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom)">country20131022151106556</Layer>
+          <Layer name="Country_Labels" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom)">Country_copy20161127151800736</Layer>
+          <Layer name="Country_Diagrams" provider="spatialite" source="dbname='/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom)">country20170328164317226</Layer>
+        </LayerSet>
+        <ComposerMapGrid annotationExpression="" annotationFormat="0" annotationPrecision="3" blendMode="0" bottomAnnotationDirection="0" bottomAnnotationDisplay="0" bottomAnnotationPosition="1" bottomFrameDivisions="0" crossLength="3" frameAnnotationDistance="1" frameFillColor1="255,255,255,255" frameFillColor2="0,0,0,255" gridFrameMargin="0" gridFramePenColor="0,0,0,255" gridFramePenThickness="0.5" gridFrameSideFlags="15" gridFrameStyle="0" gridFrameWidth="2" gridStyle="0" intervalX="0" intervalY="0" leftAnnotationDirection="0" leftAnnotationDisplay="0" leftAnnotationPosition="1" leftFrameDivisions="0" maximumIntervalWidth="100" minimumIntervalWidth="50" name="Grid 1" offsetX="0" offsetY="0" position="3" rightAnnotationDirection="0" rightAnnotationDisplay="0" rightAnnotationPosition="1" rightFrameDivisions="0" rotatedAnnotationsEnabled="0" rotatedAnnotationsLengthMode="0" rotatedAnnotationsMarginToCorner="0" rotatedAnnotationsMinimumAngle="0" rotatedTicksEnabled="0" rotatedTicksLengthMode="0" rotatedTicksMarginToCorner="0" rotatedTicksMinimumAngle="0" show="1" showAnnotation="0" topAnnotationDirection="0" topAnnotationDisplay="0" topAnnotationPosition="1" topFrameDivisions="0" unit="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}">
+          <lineStyle>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" enabled="1" id="{950332dd-0f55-40fc-89ed-ea6cbd25eea2}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="0,0,0,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </lineStyle>
           <markerStyle>
-            <symbol type="marker" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-              <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
-                <prop v="0" k="angle"/>
-                <prop v="0,0,0,255" k="color"/>
-                <prop v="1" k="horizontal_anchor_point"/>
-                <prop v="bevel" k="joinstyle"/>
-                <prop v="circle" k="name"/>
-                <prop v="0,0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="0,0,0,255" k="outline_color"/>
-                <prop v="solid" k="outline_style"/>
-                <prop v="0" k="outline_width"/>
-                <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                <prop v="MM" k="outline_width_unit"/>
-                <prop v="area" k="scale_method"/>
-                <prop v="2" k="size"/>
-                <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                <prop v="MM" k="size_unit"/>
-                <prop v="1" k="vertical_anchor_point"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleMarker" enabled="1" id="{2295afdb-3773-4555-85f2-2ef3963af275}" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="angle" type="QString" value="0"></Option>
+                  <Option name="cap_style" type="QString" value="square"></Option>
+                  <Option name="color" type="QString" value="0,0,0,255"></Option>
+                  <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="name" type="QString" value="circle"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+                  <Option name="outline_style" type="QString" value="solid"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="scale_method" type="QString" value="area"></Option>
+                  <Option name="size" type="QString" value="2"></Option>
+                  <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="size_unit" type="QString" value="MM"></Option>
+                  <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+                </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </markerStyle>
-          <annotationFontProperties description=",11,-1,5,50,0,0,0,0,0" style=""/>
+          <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="11" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+            <families></families>
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+                <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                  <Option type="Map">
+                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="color" type="QString" value="255,255,255,255"></Option>
+                    <Option name="joinstyle" type="QString" value="bevel"></Option>
+                    <Option name="offset" type="QString" value="0,0"></Option>
+                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="offset_unit" type="QString" value="MM"></Option>
+                    <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                    <Option name="outline_style" type="QString" value="no"></Option>
+                    <Option name="outline_width" type="QString" value="0"></Option>
+                    <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                    <Option name="style" type="QString" value="solid"></Option>
+                  </Option>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+            <dd_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </dd_properties>
+          </text-style>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dataDefinedProperties>
-            <customproperties/>
+            <customproperties>
+              <Option></Option>
+            </customproperties>
           </LayoutObject>
         </ComposerMapGrid>
-        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
-        <labelBlockingItems/>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"></AtlasMap>
+        <labelBlockingItems></labelBlockingItems>
+        <atlasClippingSettings clippingType="0" enabled="0" forceLabelsInside="0" restrictLayers="0">
+          <layersToClip></layersToClip>
+        </atlasClippingSettings>
+        <itemClippingSettings clipSource="" clippingType="0" enabled="0" forceLabelsInside="0"></itemClippingSettings>
       </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" position="213.302,161.791,mm" zValue="2" templateUuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" halign="1" htmlState="0" labelText="Welcome to our world...." type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="64.3016,11.0626,mm" positionOnPage="213.302,161.791,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" background="false" valign="32">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="1" htmlState="0" id="" itemRotation="0" labelText="Welcome to our world...." marginX="1" marginY="1" opacity="1" outlineWidthM="0.3,mm" position="213.302,161.791,mm" positionLock="false" positionOnPage="213.302,161.791,mm" referencePoint="0" size="64.3016,11.0626,mm" templateUuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" type="65641" uuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" valign="32" visibility="1" zValue="2">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <LabelFont description="DejaVu Sans,12,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor alpha="255" green="0" red="0" blue="0"/>
+        <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="DejaVu Sans" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="12" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="75" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+          <families></families>
+          <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+          <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+          <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="color" type="QString" value="255,255,255,255"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                  <Option name="outline_style" type="QString" value="no"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="style" type="QString" value="solid"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </background>
+          <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+          <dd_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dd_properties>
+        </text-style>
       </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" position="49.9838,9.33411,mm" zValue="1" templateUuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" halign="1" htmlState="0" labelText="QGIS Mapserver" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="215.03,28.0023,mm" positionOnPage="49.9838,9.33411,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" background="false" valign="32">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="1" htmlState="0" id="" itemRotation="0" labelText="QGIS Mapserver" marginX="1" marginY="1" opacity="1" outlineWidthM="0.3,mm" position="49.9838,9.33411,mm" positionLock="false" positionOnPage="49.9838,9.33411,mm" referencePoint="0" size="215.03,28.0023,mm" templateUuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" type="65641" uuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" valign="32" visibility="1" zValue="1">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <LabelFont description="DejaVu Sans,48,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor alpha="255" green="0" red="0" blue="0"/>
+        <text-style allowHtml="0" blendMode="0" capitalization="0" fontFamily="DejaVu Sans" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="48" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="75" fontWordSpacing="0" forcedBold="0" forcedItalic="0" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal">
+          <families></families>
+          <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+          <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+          <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleFill" enabled="1" id="" locked="0" pass="0">
+                <Option type="Map">
+                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="color" type="QString" value="255,255,255,255"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="offset" type="QString" value="0,0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="outline_color" type="QString" value="128,128,128,255"></Option>
+                  <Option name="outline_style" type="QString" value="no"></Option>
+                  <Option name="outline_width" type="QString" value="0"></Option>
+                  <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                  <Option name="style" type="QString" value="solid"></Option>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </background>
+          <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
+          <dd_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </dd_properties>
+        </text-style>
       </LayoutItem>
-      <customproperties/>
-      <Atlas pageNameExpression="" hideCoverage="0" enabled="0" filterFeatures="0" coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" sortFeatures="0"/>
+      <customproperties>
+        <Option></Option>
+      </customproperties>
+      <Atlas coverageLayer="" enabled="0" filenamePattern="'output_'||@atlas_featurenumber" filterFeatures="0" hideCoverage="0" pageNameExpression="" sortFeatures="0"></Atlas>
     </Layout>
-    <Layout units="mm" name="layoutA4twoMaps" worldFileMap="{f254751a-896d-48e8-8eb3-795d74b397c7}" printResolution="300">
-      <Snapper snapToGrid="0" snapToItems="1" tolerance="5" snapToGuides="1"/>
-      <Grid offsetUnits="mm" resUnits="mm" offsetX="0" offsetY="0" resolution="10"/>
+    <Layout name="layoutA4twoMaps" printResolution="300" units="mm" worldFileMap="{f254751a-896d-48e8-8eb3-795d74b397c7}">
+      <Snapper snapToGrid="0" snapToGuides="1" snapToItems="1" tolerance="5"></Snapper>
+      <Grid offsetUnits="mm" offsetX="0" offsetY="0" resUnits="mm" resolution="10"></Grid>
       <PageCollection>
-        <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-          <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-            <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-            <prop v="255,255,255,255" k="color"/>
-            <prop v="miter" k="joinstyle"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="no" k="outline_style"/>
-            <prop v="0.26" k="outline_width"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="solid" k="style"/>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleFill" enabled="1" id="{14fcea5b-907d-462b-bbdb-8b4c16f66853}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="color" type="QString" value="255,255,255,255"></Option>
+              <Option name="joinstyle" type="QString" value="miter"></Option>
+              <Option name="offset" type="QString" value="0,0"></Option>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offset_unit" type="QString" value="MM"></Option>
+              <Option name="outline_color" type="QString" value="0,0,0,255"></Option>
+              <Option name="outline_style" type="QString" value="no"></Option>
+              <Option name="outline_width" type="QString" value="0.26"></Option>
+              <Option name="outline_width_unit" type="QString" value="MM"></Option>
+              <Option name="style" type="QString" value="solid"></Option>
+            </Option>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem itemRotation="0" blendMode="0" position="0,0,mm" zValue="0" templateUuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" type="65638" groupUuid="" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="297,210,mm" positionOnPage="0,0,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" background="true">
-          <FrameColor alpha="255" green="0" red="0" blue="0"/>
-          <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+        <LayoutItem background="true" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" opacity="1" outlineWidthM="0.3,mm" position="0,0,mm" positionLock="false" positionOnPage="0,0,mm" referencePoint="0" size="297,210,mm" templateUuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" type="65638" uuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" visibility="1" zValue="0">
+          <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+          <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dataDefinedProperties>
-            <customproperties/>
+            <customproperties>
+              <Option></Option>
+            </customproperties>
           </LayoutObject>
-          <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
-            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="255,255,255,255" k="color"/>
-              <prop v="miter" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="35,35,35,255" k="outline_color"/>
-              <prop v="no" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" id="{d105d794-a27e-4425-9b16-2d786c11d8c4}" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="255,255,255,255"></Option>
+                <Option name="joinstyle" type="QString" value="miter"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="35,35,35,255"></Option>
+                <Option name="outline_style" type="QString" value="no"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </LayoutItem>
-        <GuideCollection visible="1"/>
+        <GuideCollection visible="1"></GuideCollection>
       </PageCollection>
-      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="158.959,111.439,mm" zValue="2" templateUuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="1,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="88.1003,70.2279,mm" positionOnPage="158.959,111.439,mm" excludeFromExports="0" visibility="1" frame="true" opacity="1" mapRotation="0" uuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" background="true">
-        <FrameColor alpha="255" green="26" red="227" blue="28"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="true" blendMode="0" drawCanvasItems="true" excludeFromExports="0" followPreset="false" followPresetName="" frame="true" frameJoinStyle="miter" groupUuid="" id="" isTemporal="0" itemRotation="0" keepLayerSet="false" labelMargin="0,mm" mapFlags="1" mapRotation="0" opacity="1" outlineWidthM="1,mm" position="158.959,111.439,mm" positionLock="false" positionOnPage="158.959,111.439,mm" referencePoint="0" size="88.1003,70.2279,mm" templateUuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" type="65639" uuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" visibility="1" zValue="2">
+        <FrameColor alpha="255" blue="28" green="26" red="227"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <Extent ymin="-5848927.97872077487409115" ymax="138857.9720494169741869" xmax="19375243.89574331790208817" xmin="11863620.20301065221428871"/>
-        <LayerSet/>
-        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
-        <labelBlockingItems/>
+        <Extent xmax="19375243.89574331790208817" xmin="11863620.20301065221428871" ymax="138857.9720494169741869" ymin="-5848927.97872077487409115"></Extent>
+        <LayerSet></LayerSet>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"></AtlasMap>
+        <labelBlockingItems></labelBlockingItems>
+        <atlasClippingSettings clippingType="0" enabled="0" forceLabelsInside="0" restrictLayers="0">
+          <layersToClip></layersToClip>
+        </atlasClippingSettings>
+        <itemClippingSettings clipSource="" clippingType="0" enabled="0" forceLabelsInside="0"></itemClippingSettings>
       </LayoutItem>
-      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="21.4468,19.5545,mm" zValue="1" templateUuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="1,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="122.583,77.1663,mm" positionOnPage="21.4468,19.5545,mm" excludeFromExports="0" visibility="1" frame="true" opacity="1" mapRotation="0" uuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" background="true">
-        <FrameColor alpha="255" green="0" red="0" blue="0"/>
-        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
+      <LayoutItem background="true" blendMode="0" drawCanvasItems="true" excludeFromExports="0" followPreset="false" followPresetName="" frame="true" frameJoinStyle="miter" groupUuid="" id="" isTemporal="0" itemRotation="0" keepLayerSet="false" labelMargin="0,mm" mapFlags="1" mapRotation="0" opacity="1" outlineWidthM="1,mm" position="21.4468,19.5545,mm" positionLock="false" positionOnPage="21.4468,19.5545,mm" referencePoint="0" size="122.583,77.1663,mm" templateUuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" type="65639" uuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" visibility="1" zValue="1">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties>
+            <Option></Option>
+          </customproperties>
         </LayoutObject>
-        <Extent ymin="3006918.29964823648333549" ymax="7735504.74087103083729744" xmax="3792585.87797374185174704" xmin="-3719037.81475892383605242"/>
-        <LayerSet/>
-        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
-        <labelBlockingItems/>
+        <Extent xmax="3792585.87797374185174704" xmin="-3719037.81475892383605242" ymax="7735504.74087103083729744" ymin="3006918.29964823648333549"></Extent>
+        <LayerSet></LayerSet>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"></AtlasMap>
+        <labelBlockingItems></labelBlockingItems>
+        <atlasClippingSettings clippingType="0" enabled="0" forceLabelsInside="0" restrictLayers="0">
+          <layersToClip></layersToClip>
+        </atlasClippingSettings>
+        <itemClippingSettings clipSource="" clippingType="0" enabled="0" forceLabelsInside="0"></itemClippingSettings>
       </LayoutItem>
       <customproperties>
-        <property key="atlasRasterFormat" value="png"/>
+        <Option type="Map">
+          <Option name="atlasRasterFormat" type="QString" value="png"></Option>
+        </Option>
       </customproperties>
-      <Atlas pageNameExpression="" hideCoverage="0" enabled="0" filterFeatures="0" coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" sortFeatures="0"/>
+      <Atlas coverageLayer="" enabled="0" filenamePattern="'output_'||@atlas_featurenumber" filterFeatures="0" hideCoverage="0" pageNameExpression="" sortFeatures="0"></Atlas>
     </Layout>
   </Layouts>
-  <Bookmarks/>
-  <ProjectViewSettings UseProjectScales="0">
-    <Scales/>
+  <mapViewDocks3D></mapViewDocks3D>
+  <Bookmarks></Bookmarks>
+  <Sensors></Sensors>
+  <ProjectViewSettings UseProjectScales="0" rotation="0">
+    <Scales></Scales>
+    <DefaultViewExtent xmax="68849854.9924132227897644" xmin="-68497612.75399094820022583" ymax="19134440.47931583970785141" ymin="-11045674.50870379433035851">
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <srsid>3857</srsid>
+        <srid>3857</srid>
+        <authid>EPSG:3857</authid>
+        <description>WGS 84 / Pseudo-Mercator</description>
+        <projectionacronym>merc</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </DefaultViewExtent>
   </ProjectViewSettings>
+  <ProjectStyleSettings DefaultSymbolOpacity="1" RandomizeDefaultSymbolColor="1">
+    <databases></databases>
+  </ProjectStyleSettings>
+  <ProjectTimeSettings cumulativeTemporalRange="0" frameRate="1" timeStep="1" timeStepUnit="h"></ProjectTimeSettings>
+  <ElevationProperties>
+    <terrainProvider type="flat">
+      <TerrainProvider offset="0" scale="1"></TerrainProvider>
+    </terrainProvider>
+  </ElevationProperties>
+  <ProjectDisplaySettings CoordinateAxisOrder="Default" CoordinateType="MapCrs">
+    <BearingFormat id="bearing">
+      <Option type="Map">
+        <Option name="decimal_separator" type="invalid"></Option>
+        <Option name="decimals" type="int" value="6"></Option>
+        <Option name="direction_format" type="int" value="0"></Option>
+        <Option name="rounding_type" type="int" value="0"></Option>
+        <Option name="show_plus" type="bool" value="false"></Option>
+        <Option name="show_thousand_separator" type="bool" value="true"></Option>
+        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+        <Option name="thousand_separator" type="invalid"></Option>
+      </Option>
+    </BearingFormat>
+    <GeographicCoordinateFormat id="geographiccoordinate">
+      <Option type="Map">
+        <Option name="angle_format" type="QString" value="DecimalDegrees"></Option>
+        <Option name="decimal_separator" type="invalid"></Option>
+        <Option name="decimals" type="int" value="6"></Option>
+        <Option name="rounding_type" type="int" value="0"></Option>
+        <Option name="show_leading_degree_zeros" type="bool" value="false"></Option>
+        <Option name="show_leading_zeros" type="bool" value="false"></Option>
+        <Option name="show_plus" type="bool" value="false"></Option>
+        <Option name="show_suffix" type="bool" value="false"></Option>
+        <Option name="show_thousand_separator" type="bool" value="true"></Option>
+        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+        <Option name="thousand_separator" type="invalid"></Option>
+      </Option>
+    </GeographicCoordinateFormat>
+    <CoordinateCustomCrs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </CoordinateCustomCrs>
+  </ProjectDisplaySettings>
+  <ProjectGpsSettings autoAddTrackVertices="0" autoCommitFeatures="0" destinationFollowsActiveLayer="1" destinationLayer="">
+    <timeStampFields></timeStampFields>
+  </ProjectGpsSettings>
 </qgis>


### PR DESCRIPTION
Since #51724 empty groups are not exposed in the GetCapabilities.
Some groups can be empty after a server plugin for instance hiding layers.

But for some projects, the GIS client still wants all groups to be fetched from the server. The PR #51724 is a choice but doesn't fit for all needs.

I propose to add a flag if we want the group to be always exposed in the GetCapabilities, even if it's empty.

Can this be backported to the current LTR 3.34 ? (or at least the server part if possible). #51724 is breaking a change for people migrating from 3.28 to the new LTR.

CC @pblottiere @elpaso @rldhont 