### PR TITLE
Fix global QGIS setting key in check validity algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/CheckValidity.py
+++ b/python/plugins/processing/algs/qgis/CheckValidity.py
@@ -44,7 +44,7 @@ from qgis.core import (Qgis,
                        QgsProcessingParameterBoolean)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
-settings_method_key = "/qgis/digitizing/validate_geometries"
+settings_method_key = "/digitizing/validate-geometries"
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
 


### PR DESCRIPTION
## Description

Following changes of QgsSettings keys in https://github.com/qgis/QGIS/pull/51670 the geometry validity processing is not working as expected when method "The one selected in digitizing settings" is selected.

![image](https://github.com/qgis/QGIS/assets/34267385/680d3dbf-0bd3-4a2b-bf90-dcaf085e55d5)

It will always fallback to QGIS internal verification method because the key `/qgis/digitizing/validate_geometries` does not exist any more.

Or does it? Actually it does still exist from previous QGIS versions in old profiles, but is obsolete.



The new key is `/digitizing/validate-geometries` now.
