### PR TITLE
[feature] Value relation autocompleter match contains

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -54,6 +54,13 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
   }
          );
 
+  connect( mUseCompleter, &QCheckBox::stateChanged, this,  [ = ]( int state )
+  {
+    mCompleterMatchFromStart->setEnabled( static_cast<Qt::CheckState>( state ) == Qt::CheckState::Checked );
+  } );
+
+  mCompleterMatchFromStart->setEnabled( mUseCompleter->isChecked() );
+
   connect( mNofColumns, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsEditorConfigWidget::changed );
 
   layerChanged();
@@ -78,6 +85,7 @@ QVariantMap QgsValueRelationConfigDlg::config()
   cfg.insert( QStringLiteral( "OrderByValue" ), mOrderByValue->isChecked() );
   cfg.insert( QStringLiteral( "FilterExpression" ), mFilterExpression->toPlainText() );
   cfg.insert( QStringLiteral( "UseCompleter" ), mUseCompleter->isChecked() );
+  cfg.insert( QStringLiteral( "CompleterMatchFromStart" ), mCompleterMatchFromStart->isChecked() );
 
   return cfg;
 }
@@ -100,6 +108,8 @@ void QgsValueRelationConfigDlg::setConfig( const QVariantMap &config )
   mOrderByValue->setChecked( config.value( QStringLiteral( "OrderByValue" ) ).toBool() );
   mFilterExpression->setPlainText( config.value( QStringLiteral( "FilterExpression" ) ).toString() );
   mUseCompleter->setChecked( config.value( QStringLiteral( "UseCompleter" ) ).toBool() );
+  // Default is true for backwards compatibility
+  mCompleterMatchFromStart->setChecked( config.value( QStringLiteral( "CompleterMatchFromStart" ), true ).toBool() );
 }
 
 void QgsValueRelationConfigDlg::layerChanged()

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -85,7 +85,8 @@ QVariantMap QgsValueRelationConfigDlg::config()
   cfg.insert( QStringLiteral( "OrderByValue" ), mOrderByValue->isChecked() );
   cfg.insert( QStringLiteral( "FilterExpression" ), mFilterExpression->toPlainText() );
   cfg.insert( QStringLiteral( "UseCompleter" ), mUseCompleter->isChecked() );
-  cfg.insert( QStringLiteral( "CompleterMatchFromStart" ), mCompleterMatchFromStart->isChecked() );
+  const Qt::MatchFlags completerMatchFlags { mCompleterMatchFromStart->isChecked() ? Qt::MatchFlag::MatchStartsWith : Qt::MatchFlag::MatchContains };
+  cfg.insert( QStringLiteral( "CompleterMatchFlags" ), static_cast<int>( completerMatchFlags ) );
 
   return cfg;
 }
@@ -108,8 +109,9 @@ void QgsValueRelationConfigDlg::setConfig( const QVariantMap &config )
   mOrderByValue->setChecked( config.value( QStringLiteral( "OrderByValue" ) ).toBool() );
   mFilterExpression->setPlainText( config.value( QStringLiteral( "FilterExpression" ) ).toString() );
   mUseCompleter->setChecked( config.value( QStringLiteral( "UseCompleter" ) ).toBool() );
-  // Default is true for backwards compatibility
-  mCompleterMatchFromStart->setChecked( config.value( QStringLiteral( "CompleterMatchFromStart" ), true ).toBool() );
+  // Default is MatchStartsWith for backwards compatibility
+  const Qt::MatchFlags completerMatchFlags { config.contains( QStringLiteral( "CompleterMatchFlags" ) ) ? static_cast<Qt::MatchFlags>( config.value( QStringLiteral( "CompleterMatchFlags" ), Qt::MatchFlag::MatchStartsWith ).toInt( ) ) :  Qt::MatchFlag::MatchStartsWith };
+  mCompleterMatchFromStart->setChecked( completerMatchFlags.testFlag( Qt::MatchFlag::MatchStartsWith ) );
 }
 
 void QgsValueRelationConfigDlg::layerChanged()

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -560,6 +560,16 @@ void QgsValueRelationWidgetWrapper::populate()
     }
     QStringListModel *m = new QStringListModel( values, mLineEdit );
     QCompleter *completer = new QCompleter( m, mLineEdit );
+    if ( config().value( QStringLiteral( "CompleterMatchFromStart" ), true ).toBool() )
+    {
+      // This is the default, but better explicit than implicit
+      completer->setFilterMode( Qt::MatchFlag::MatchStartsWith );
+
+    }
+    else
+    {
+      completer->setFilterMode( Qt::MatchFlag::MatchContains );
+    }
     completer->setCaseSensitivity( Qt::CaseInsensitive );
     mLineEdit->setCompleter( completer );
   }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -560,15 +560,16 @@ void QgsValueRelationWidgetWrapper::populate()
     }
     QStringListModel *m = new QStringListModel( values, mLineEdit );
     QCompleter *completer = new QCompleter( m, mLineEdit );
-    if ( config().value( QStringLiteral( "CompleterMatchFromStart" ), true ).toBool() )
-    {
-      // This is the default, but better explicit than implicit
-      completer->setFilterMode( Qt::MatchFlag::MatchStartsWith );
 
+    const Qt::MatchFlags completerMatchFlags { config().contains( QStringLiteral( "CompleterMatchFlags" ) ) ? static_cast<Qt::MatchFlags>( config().value( QStringLiteral( "CompleterMatchFlags" ), Qt::MatchFlag::MatchStartsWith ).toInt( ) ) :  Qt::MatchFlag::MatchStartsWith };
+
+    if ( completerMatchFlags.testFlag( Qt::MatchFlag::MatchContains ) )
+    {
+      completer->setFilterMode( Qt::MatchFlag::MatchContains );
     }
     else
     {
-      completer->setFilterMode( Qt::MatchFlag::MatchContains );
+      completer->setFilterMode( Qt::MatchFlag::MatchStartsWith );
     }
     completer->setCaseSensitivity( Qt::CaseInsensitive );
     mLineEdit->setCompleter( completer );

--- a/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
@@ -14,7 +14,26 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
-   <item row="13" column="0" colspan="2">
+   <item row="1" column="1">
+    <widget class="QgsMapLayerComboBox" name="mLayerName"/>
+   </item>
+   <item row="15" column="0" colspan="2">
+    <widget class="QTextEdit" name="mFilterExpression"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Value column</string>
+     </property>
+     <property name="buddy">
+      <cstring>mValueColumn</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QgsFieldComboBox" name="mValueColumn"/>
+   </item>
+   <item row="14" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="label_19">
@@ -32,7 +51,7 @@
         <enum>Qt::RightToLeft</enum>
        </property>
        <property name="icon">
-        <iconset>
+        <iconset resource="../../../images/images.qrc">
          <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
        </property>
       </widget>
@@ -52,38 +71,18 @@
      </item>
     </layout>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_nofColumns">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Number of columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0" colspan="2">
-    <widget class="QTextEdit" name="mFilterExpression"/>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Select layer, key column and value column</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Layer</string>
+      <string>Key column</string>
      </property>
      <property name="buddy">
-      <cstring>mLayerName</cstring>
+      <cstring>mKeyColumn</cstring>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QgsFieldComboBox" name="mValueColumn"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsMapLayerComboBox" name="mLayerName"/>
+   <item row="4" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mDescriptionExpression" native="true"/>
    </item>
    <item row="8" column="0" colspan="2">
     <widget class="QCheckBox" name="mAllowMulti">
@@ -99,43 +98,26 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="0" colspan="2">
-    <widget class="QCheckBox" name="mUseCompleter">
-     <property name="text">
-      <string>Use completer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="mOrderByValue">
-     <property name="text">
-      <string>Order by value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Key column</string>
-     </property>
-     <property name="buddy">
-      <cstring>mKeyColumn</cstring>
-     </property>
-    </widget>
-   </item>
    <item row="9" column="1">
     <widget class="QgsSpinBox" name="mNofColumns"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Layer</string>
+     </property>
+     <property name="buddy">
+      <cstring>mLayerName</cstring>
+     </property>
+    </widget>
    </item>
    <item row="2" column="1">
     <widget class="QgsFieldComboBox" name="mKeyColumn"/>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_7">
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_nofColumns">
      <property name="text">
-      <string>Value column</string>
-     </property>
-     <property name="buddy">
-      <cstring>mValueColumn</cstring>
+      <string>Number of columns</string>
      </property>
     </widget>
    </item>
@@ -146,8 +128,33 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mDescriptionExpression" native="true"/>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Select layer, key column and value column</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="mOrderByValue">
+     <property name="text">
+      <string>Order by value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QCheckBox" name="mCompleterMatchFromStart">
+     <property name="text">
+      <string>Only match from the beginning of the string </string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QCheckBox" name="mUseCompleter">
+     <property name="text">
+      <string>Use completer</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -182,10 +189,11 @@
   <tabstop>mOrderByValue</tabstop>
   <tabstop>mAllowMulti</tabstop>
   <tabstop>mNofColumns</tabstop>
-  <tabstop>mUseCompleter</tabstop>
   <tabstop>mEditExpression</tabstop>
   <tabstop>mFilterExpression</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
the default was to match from the beginning of the string ony.

A checkbox now allows
 to activate the "contains" match
that will match also inside the string.

The old behavior is still the default to keep
backward compatibility.

![immagine](https://github.com/qgis/QGIS/assets/142164/24954185-ad1c-4ba0-bdf9-5acc331f2fdb)
