### PR TITLE
Add elevation range to QgsProjectElevationProperties, expose in project properties

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsprojectelevationproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectelevationproperties.sip.in
@@ -69,11 +69,66 @@ Ownership of ``provider`` is transferred to this object.
 .. seealso:: :py:func:`terrainProvider`
 %End
 
+    QgsDoubleRange elevationRange() const;
+%Docstring
+Returns the project's elevation range, which indicates the upper and lower
+elevation limits associated with the project.
+
+.. note::
+
+   This is a manual, use-set property, and does not necessarily
+   coincide with the elevation ranges for individual layers in the project.
+
+.. seealso:: :py:func:`setElevationRange`
+
+.. seealso:: :py:func:`elevationRangeChanged`
+
+
+.. versionadded:: 3.38
+%End
+
+  public slots:
+
+    void setElevationRange( const QgsDoubleRange &range );
+%Docstring
+Sets the project's elevation ``range``, which indicates the upper and lower
+elevation limits associated with the project.
+
+.. note::
+
+   This is a manual, use-set property, and does not necessarily
+   coincide with the elevation ranges for individual layers in the project.
+
+.. seealso:: :py:func:`elevationRange`
+
+.. seealso:: :py:func:`elevationRangeChanged`
+
+
+.. versionadded:: 3.38
+%End
+
   signals:
 
     void changed();
 %Docstring
 Emitted when the elevation properties change.
+%End
+
+    void elevationRangeChanged( const QgsDoubleRange &range );
+%Docstring
+Emitted when the project's elevation ``is`` changed.
+
+.. note::
+
+   This is a manual, use-set property, and does not necessarily
+   coincide with the elevation ranges for individual layers in the project.
+
+.. seealso:: :py:func:`elevationRange`
+
+.. seealso:: :py:func:`setElevationRange`
+
+
+.. versionadded:: 3.38
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/qgsrange.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrange.sip.in
@@ -186,6 +186,7 @@ Returns ``True`` if the range consists of all possible values.
 
 
 
+
 typedef QgsRange<int> QgsRangeintBase;
 
 class QgsIntRange : QgsRangeintBase
@@ -239,6 +240,7 @@ Returns ``True`` if the range consists of all possible values.
 %End
 
 };
+
 
 
 template <T>

--- a/python/core/auto_generated/project/qgsprojectelevationproperties.sip.in
+++ b/python/core/auto_generated/project/qgsprojectelevationproperties.sip.in
@@ -69,11 +69,66 @@ Ownership of ``provider`` is transferred to this object.
 .. seealso:: :py:func:`terrainProvider`
 %End
 
+    QgsDoubleRange elevationRange() const;
+%Docstring
+Returns the project's elevation range, which indicates the upper and lower
+elevation limits associated with the project.
+
+.. note::
+
+   This is a manual, use-set property, and does not necessarily
+   coincide with the elevation ranges for individual layers in the project.
+
+.. seealso:: :py:func:`setElevationRange`
+
+.. seealso:: :py:func:`elevationRangeChanged`
+
+
+.. versionadded:: 3.38
+%End
+
+  public slots:
+
+    void setElevationRange( const QgsDoubleRange &range );
+%Docstring
+Sets the project's elevation ``range``, which indicates the upper and lower
+elevation limits associated with the project.
+
+.. note::
+
+   This is a manual, use-set property, and does not necessarily
+   coincide with the elevation ranges for individual layers in the project.
+
+.. seealso:: :py:func:`elevationRange`
+
+.. seealso:: :py:func:`elevationRangeChanged`
+
+
+.. versionadded:: 3.38
+%End
+
   signals:
 
     void changed();
 %Docstring
 Emitted when the elevation properties change.
+%End
+
+    void elevationRangeChanged( const QgsDoubleRange &range );
+%Docstring
+Emitted when the project's elevation ``is`` changed.
+
+.. note::
+
+   This is a manual, use-set property, and does not necessarily
+   coincide with the elevation ranges for individual layers in the project.
+
+.. seealso:: :py:func:`elevationRange`
+
+.. seealso:: :py:func:`setElevationRange`
+
+
+.. versionadded:: 3.38
 %End
 
 };

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -186,6 +186,7 @@ Returns ``True`` if the range consists of all possible values.
 
 
 
+
 typedef QgsRange<int> QgsRangeintBase;
 
 class QgsIntRange : QgsRangeintBase
@@ -239,6 +240,7 @@ Returns ``True`` if the range consists of all possible values.
 %End
 
 };
+
 
 
 template <T>

--- a/src/app/project/qgsprojectelevationsettingswidget.cpp
+++ b/src/app/project/qgsprojectelevationsettingswidget.cpp
@@ -184,7 +184,7 @@ bool QgsProjectElevationSettingsWidget::isValid()
 //
 
 QgsProjectElevationSettingsWidgetFactory::QgsProjectElevationSettingsWidgetFactory( QObject *parent )
-  : QgsOptionsWidgetFactory( tr( "Terrain" ), QgsApplication::getThemeIcon( QStringLiteral( "mLayoutItem3DMap.svg" ) ), QStringLiteral( "terrain" ) )
+  : QgsOptionsWidgetFactory( tr( "Elevation" ), QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/elevationscale.svg" ) ), QStringLiteral( "terrain" ) )
 {
   setParent( parent );
 }

--- a/src/app/project/qgsprojectelevationsettingswidget.cpp
+++ b/src/app/project/qgsprojectelevationsettingswidget.cpp
@@ -40,6 +40,8 @@ QgsProjectElevationSettingsWidget::QgsProjectElevationSettingsWidget( QWidget *p
   mComboTerrainType->addItem( tr( "DEM (Raster Layer)" ), QStringLiteral( "raster" ) );
   mComboTerrainType->addItem( tr( "Mesh" ), QStringLiteral( "mesh" ) );
 
+  mStackedWidget->setSizeMode( QgsStackedWidget::SizeMode::CurrentPageOnly );
+
   mStackedWidget->setCurrentWidget( mPageFlat );
   connect( mComboTerrainType, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]
   {

--- a/src/core/project/qgsprojectelevationproperties.h
+++ b/src/core/project/qgsprojectelevationproperties.h
@@ -86,6 +86,36 @@ class CORE_EXPORT QgsProjectElevationProperties : public QObject
      */
     void setTerrainProvider( QgsAbstractTerrainProvider *provider SIP_TRANSFER );
 
+    /**
+     * Returns the project's elevation range, which indicates the upper and lower
+     * elevation limits associated with the project.
+     *
+     * \note This is a manual, use-set property, and does not necessarily
+     * coincide with the elevation ranges for individual layers in the project.
+     *
+     * \see setElevationRange()
+     * \see elevationRangeChanged()
+     *
+     * \since QGIS 3.38
+     */
+    QgsDoubleRange elevationRange() const { return mElevationRange; }
+
+  public slots:
+
+    /**
+     * Sets the project's elevation \a range, which indicates the upper and lower
+     * elevation limits associated with the project.
+     *
+     * \note This is a manual, use-set property, and does not necessarily
+     * coincide with the elevation ranges for individual layers in the project.
+     *
+     * \see elevationRange()
+     * \see elevationRangeChanged()
+     *
+     * \since QGIS 3.38
+     */
+    void setElevationRange( const QgsDoubleRange &range );
+
   signals:
 
     /**
@@ -93,9 +123,23 @@ class CORE_EXPORT QgsProjectElevationProperties : public QObject
      */
     void changed();
 
+    /**
+    * Emitted when the project's elevation \a is changed.
+    *
+     * \note This is a manual, use-set property, and does not necessarily
+     * coincide with the elevation ranges for individual layers in the project.
+     *
+     * \see elevationRange()
+     * \see setElevationRange()
+     *
+     * \since QGIS 3.38
+    */
+    void elevationRangeChanged( const QgsDoubleRange &range );
+
   private:
 
     std::unique_ptr< QgsAbstractTerrainProvider > mTerrainProvider;
+    QgsDoubleRange mElevationRange;
 
 };
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -305,6 +305,8 @@ void QgsApplication::init( QString profileFolder )
 #endif
     qRegisterMetaType<QPainter::CompositionMode>( "QPainter::CompositionMode" );
     qRegisterMetaType<QgsDateTimeRange>( "QgsDateTimeRange" );
+    qRegisterMetaType<QgsDoubleRange>( "QgsDoubleRange" );
+    qRegisterMetaType<QgsIntRange>( "QgsIntRange" );
     qRegisterMetaType<QList<QgsMapLayer *>>( "QList<QgsMapLayer*>" );
     qRegisterMetaType<QMap<QNetworkRequest::Attribute, QVariant>>( "QMap<QNetworkRequest::Attribute,QVariant>" );
     qRegisterMetaType<QMap<QNetworkRequest::KnownHeaders, QVariant>>( "QMap<QNetworkRequest::KnownHeaders,QVariant>" );

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -273,6 +273,8 @@ class CORE_EXPORT QgsDoubleRange : public QgsRange< double >
 
 };
 
+Q_DECLARE_METATYPE( QgsDoubleRange )
+
 
 /**
  * \brief QgsRange which stores a range of integer values.
@@ -343,6 +345,8 @@ class CORE_EXPORT QgsIntRange : public QgsRange< int >
 #endif
 
 };
+
+Q_DECLARE_METATYPE( QgsIntRange )
 
 
 /**

--- a/src/ui/qgsprojectelevationsettingswidgetbase.ui
+++ b/src/ui/qgsprojectelevationsettingswidgetbase.ui
@@ -46,7 +46,7 @@
        <widget class="QComboBox" name="mComboTerrainType"/>
       </item>
       <item row="1" column="0" colspan="2">
-       <widget class="QStackedWidget" name="mStackedWidget">
+       <widget class="QgsStackedWidget" name="mStackedWidget">
         <property name="currentIndex">
          <number>0</number>
         </property>
@@ -80,19 +80,6 @@
              <double>1000000.000000000000000</double>
             </property>
            </widget>
-          </item>
-          <item row="1" column="0">
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
@@ -248,6 +235,12 @@
    <class>QgsMessageBar</class>
    <extends>QWidget</extends>
    <header>qgsmessagebar.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsStackedWidget</class>
+   <extends>QStackedWidget</extends>
+   <header>qgsstackedwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsprojectelevationsettingswidgetbase.ui
+++ b/src/ui/qgsprojectelevationsettingswidgetbase.ui
@@ -220,13 +220,16 @@
       <string notr="true">composeritem</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6" columnstretch="1,2">
-      <item row="0" column="1">
-       <widget class="QgsDoubleSpinBox" name="mElevationLowerSpin">
+      <item row="2" column="1">
+       <widget class="QgsDoubleSpinBox" name="mElevationUpperSpin">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Maximum elevation of interest</string>
         </property>
         <property name="decimals">
          <number>4</number>
@@ -239,7 +242,29 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="1" column="1">
+       <widget class="QgsDoubleSpinBox" name="mElevationLowerSpin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Minimum elevation of interest</string>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="minimum">
+         <double>-9999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="mEndDateTimeLabel_2">
         <property name="text">
          <string>Upper</string>
@@ -249,32 +274,23 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QgsDoubleSpinBox" name="mElevationUpperSpin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="decimals">
-         <number>4</number>
-        </property>
-        <property name="minimum">
-         <double>-9999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>9999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="mStartDateTimeLabel_2">
         <property name="text">
          <string>Lower</string>
         </property>
         <property name="wordWrap">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>When set, these heights define the upper and lower elevation limits for the area of interest in this project.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/ui/qgsprojectelevationsettingswidgetbase.ui
+++ b/src/ui/qgsprojectelevationsettingswidgetbase.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Project Elevation Settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,1">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -203,6 +203,85 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="mElevationRangeCheckBox">
+     <property name="title">
+      <string>Elevation Range</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="syncGroup" stdset="0">
+      <string notr="true">composeritem</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6" columnstretch="1,2">
+      <item row="0" column="1">
+       <widget class="QgsDoubleSpinBox" name="mElevationLowerSpin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="minimum">
+         <double>-9999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mEndDateTimeLabel_2">
+        <property name="text">
+         <string>Upper</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsDoubleSpinBox" name="mElevationUpperSpin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="minimum">
+         <double>-9999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mStartDateTimeLabel_2">
+        <property name="text">
+         <string>Lower</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QVBoxLayout" name="mElevationShadingSettingsLayout"/>
    </item>
    <item>
@@ -244,6 +323,18 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mComboTerrainType</tabstop>
+  <tabstop>mFlatHeightSpinBox</tabstop>
+  <tabstop>mDemOffsetSpinBox</tabstop>
+  <tabstop>mComboDemLayer</tabstop>
+  <tabstop>mDemScaleSpinBox</tabstop>
+  <tabstop>mMeshOffsetSpinBox</tabstop>
+  <tabstop>mComboMeshLayer</tabstop>
+  <tabstop>mMeshScaleSpinBox</tabstop>
+  <tabstop>mElevationLowerSpin</tabstop>
+  <tabstop>mElevationUpperSpin</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/tests/src/python/test_qgsprojectelevationproperties.py
+++ b/tests/src/python/test_qgsprojectelevationproperties.py
@@ -13,6 +13,7 @@ import os
 
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtXml import QDomDocument
+from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsFlatTerrainProvider,
     QgsMeshTerrainProvider,
@@ -21,6 +22,7 @@ from qgis.core import (
     QgsRasterDemTerrainProvider,
     QgsRasterLayer,
     QgsReadWriteContext,
+    QgsDoubleRange,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -35,6 +37,7 @@ class TestQgsProjectElevationProperties(QgisTestCase):
     def testBasic(self):
         props = QgsProjectElevationProperties(None)
         self.assertIsInstance(props.terrainProvider(), QgsFlatTerrainProvider)
+        self.assertTrue(props.elevationRange().isInfinite())
 
         provider = QgsRasterDemTerrainProvider()
         provider.setOffset(5)
@@ -42,6 +45,16 @@ class TestQgsProjectElevationProperties(QgisTestCase):
         props.setTerrainProvider(provider)
 
         self.assertIsInstance(props.terrainProvider(), QgsRasterDemTerrainProvider)
+
+        range_changed_spy = QSignalSpy(props.elevationRangeChanged)
+        props.setElevationRange(QgsDoubleRange(34.2, 78.6))
+        self.assertEqual(props.elevationRange(), QgsDoubleRange(34.2, 78.6))
+        self.assertEqual(len(range_changed_spy), 1)
+        self.assertEqual(range_changed_spy[-1][0], QgsDoubleRange(34.2, 78.6))
+
+        # no signal if not changed
+        props.setElevationRange(QgsDoubleRange(34.2, 78.6))
+        self.assertEqual(len(range_changed_spy), 1)
 
         doc = QDomDocument("testdoc")
         elem = props.writeXml(doc, QgsReadWriteContext())
@@ -51,6 +64,7 @@ class TestQgsProjectElevationProperties(QgisTestCase):
         self.assertIsInstance(props2.terrainProvider(), QgsRasterDemTerrainProvider)
         self.assertEqual(props2.terrainProvider().offset(), 5)
         self.assertEqual(props2.terrainProvider().scale(), 3)
+        self.assertEqual(props2.elevationRange(), QgsDoubleRange(34.2, 78.6))
 
         mesh_provider = QgsMeshTerrainProvider()
         mesh_provider.setOffset(2)


### PR DESCRIPTION
This setting allows users to specify the upper and lower elevation limits associated with the project. (I.e. its an equivalent to the temporal range setting for projects)

This can be specified through the Project Properties, Elevation tab (which I've also renamed from "Terrain" in the PR, to better match the wording used elsewhere in QGIS for similar settings)

![image](https://github.com/qgis/QGIS/assets/1829991/3652fc7e-427d-49b6-8a50-3fed738b0610)

Refs https://github.com/qgis/QGIS-Enhancement-Proposals/issues/201