### PR TITLE
pre filter the number of file to check for spellchecker

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -163,6 +163,14 @@ jobs:
         id: changed_files
         with:
           separator: ' '
+          files_ignore: |
+            **/*.sip.in
+            **/*.png
+            **/*.svg
+            **/*.tif*
+            **/*.gpkg
+            **/*.qgz
+            **/*.qgs
       - name: Spell Test
         run: ./scripts/spell_check/check_spelling.sh -r "${{ steps.changed_files.outputs.all_changed_files }}"
 


### PR DESCRIPTION
This PR provides file exclusions to prefilter the number of file to be passed to the spellchecker. 

This avoids this message in the CI: `line 1: ./scripts/spell_check/check_spelling.sh: Argument list too long` as for [this job](https://github.com/qgis/QGIS/actions/runs/8174729685/job/22350185770)