### PR TITLE
qgsphongmaterialwidget: Fix diffusecoefficientwidget visibility

### DIFF
--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -72,6 +72,7 @@ void QgsPhongMaterialWidget::setTechnique( QgsMaterialSettingsRenderingTechnique
     {
       lblDiffuse->setVisible( true );
       btnDiffuse->setVisible( true );
+      mDiffuseCoefficientWidget->setVisible( true );
       mAmbientDataDefinedButton->setVisible( false );
       mDiffuseDataDefinedButton->setVisible( false );
       mSpecularDataDefinedButton->setVisible( false );
@@ -82,6 +83,7 @@ void QgsPhongMaterialWidget::setTechnique( QgsMaterialSettingsRenderingTechnique
     {
       lblDiffuse->setVisible( false );
       btnDiffuse->setVisible( false );
+      mDiffuseCoefficientWidget->setVisible( false );
       mAmbientDataDefinedButton->setVisible( false );
       mDiffuseDataDefinedButton->setVisible( false );
       mSpecularDataDefinedButton->setVisible( false );
@@ -92,6 +94,7 @@ void QgsPhongMaterialWidget::setTechnique( QgsMaterialSettingsRenderingTechnique
     {
       lblDiffuse->setVisible( true );
       btnDiffuse->setVisible( true );
+      mDiffuseCoefficientWidget->setVisible( true );
       mAmbientDataDefinedButton->setVisible( true );
       mDiffuseDataDefinedButton->setVisible( true );
       mSpecularDataDefinedButton->setVisible( true );


### PR DESCRIPTION
## Description

In the textured case, the diffuse parameters have no effect. Therefore, `mDiffuseCoefficientWidget` needs to be hidden.

Closes: https://github.com/qgis/QGIS/issues/56750
