### PR TITLE
[processing] Use correct ellipsoid for network analysis tools

### DIFF
--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -167,6 +167,12 @@ class AlgorithmsTest:
         # ignore user setting for invalid geometry handling
         context = QgsProcessingContext()
         context.setProject(QgsProject.instance())
+        if 'ellipsoid' in defs:
+            # depending on the project settings, we can't always rely
+            # on QgsProject.ellipsoid() returning the same ellipsoid as was
+            # specified in the test definition. So just force ensure that the
+            # context's ellipsoid is the desired one
+            context.setEllipsoid(defs['ellipsoid'])
 
         if 'skipInvalid' in defs and defs['skipInvalid']:
             context.setInvalidGeometryCheck(QgsFeatureRequest.InvalidGeometryCheck.GeometrySkipInvalid)

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
@@ -1823,6 +1823,7 @@ tests:
 
   - algorithm: native:shortestpathpointtopoint
     name: Shortest path (point to point, shortest route)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 5.0
@@ -1853,6 +1854,7 @@ tests:
 
   - algorithm: native:shortestpathpointtopoint
     name: Shortest path (point to point, fastest route)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 5.0
@@ -1884,6 +1886,7 @@ tests:
 
   - algorithm: native:shortestpathlayertopoint
     name: Shortest path layer to point
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 5.0
@@ -1914,6 +1917,7 @@ tests:
 
   - algorithm: native:shortestpathpointtolayer
     name: Shortest path point to layer
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 5.0
@@ -1944,6 +1948,7 @@ tests:
 
   - algorithm: native:serviceareafrompoint
     name: Service area from point (shortest, nodes)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0
@@ -1975,6 +1980,7 @@ tests:
 
   - algorithm: native:serviceareafrompoint
     name: Service area from point (shortest, nodes, bounds)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0
@@ -2001,6 +2007,7 @@ tests:
 
   - algorithm: native:serviceareafrompoint
     name: Service area from point (shortest, lines)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0
@@ -2032,6 +2039,7 @@ tests:
 
   - algorithm: native:serviceareafrompoint
     name: Service area from point (fastest, old parameter)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0
@@ -2066,6 +2074,7 @@ tests:
 
   - algorithm: native:serviceareafrompoint
     name: Service area from point (fastest, new parameter)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0
@@ -2100,6 +2109,7 @@ tests:
 
   - algorithm: native:serviceareafromlayer
     name: Service area from layer (shortest, nodes)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0
@@ -2135,6 +2145,7 @@ tests:
 
   - algorithm: native:serviceareafromlayer
     name: Service area from layer (shortest, nodes, boundary)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0
@@ -2162,6 +2173,7 @@ tests:
 
   - algorithm: native:serviceareafromlayer
     name: Service area from layer (shortest, lines)
+    ellipsoid: WGS84
     params:
       DEFAULT_DIRECTION: 2
       DEFAULT_SPEED: 50.0

--- a/src/analysis/processing/qgsalgorithmnetworkanalysisbase.cpp
+++ b/src/analysis/processing/qgsalgorithmnetworkanalysisbase.cpp
@@ -133,7 +133,7 @@ void QgsNetworkAnalysisAlgorithmBase::loadCommonParams( const QVariantMap &param
     mDirector->addStrategy( new QgsNetworkDistanceStrategy() );
   }
 
-  mBuilder = std::make_unique< QgsGraphBuilder >( mNetwork->sourceCrs(), true, tolerance );
+  mBuilder = std::make_unique< QgsGraphBuilder >( mNetwork->sourceCrs(), true, tolerance, context.ellipsoid() );
 }
 
 void QgsNetworkAnalysisAlgorithmBase::loadPoints( QgsFeatureSource *source, QVector< QgsPointXY > &points, QHash< int, QgsAttributes > &attributes, QgsProcessingContext &context, QgsProcessingFeedback *feedback )


### PR DESCRIPTION
Use the processing context's ellipsoid instead of a hardcoded WGS84 ellipsoid for distance calculations during network analysis, so that the lengths used will exactly match other measurement tools used on the same features in the same project.

Refs https://github.com/qgis/QGIS/pull/56427#issuecomment-1984823541