### PR TITLE
[api] Add method to retrieve vertical CRS from QgsCoordinateReferenceSystem

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1076,6 +1076,17 @@ May return an invalid CRS if the geographic CRS could not be determined.
 .. versionadded:: 3.24
 %End
 
+    QgsCoordinateReferenceSystem verticalCrs() const;
+%Docstring
+Returns the vertical CRS associated with this CRS object.
+
+In the case of a compound CRS, this method will return just the vertical CRS component.
+
+An invalid CRS will be returned if the object does not contain a vertical component.
+
+.. versionadded:: 3.38
+%End
+
     QString geographicCrsAuthId() const;
 %Docstring
 Returns auth id of related geographic CRS

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1076,6 +1076,17 @@ May return an invalid CRS if the geographic CRS could not be determined.
 .. versionadded:: 3.24
 %End
 
+    QgsCoordinateReferenceSystem verticalCrs() const;
+%Docstring
+Returns the vertical CRS associated with this CRS object.
+
+In the case of a compound CRS, this method will return just the vertical CRS component.
+
+An invalid CRS will be returned if the object does not contain a vertical component.
+
+.. versionadded:: 3.38
+%End
+
     QString geographicCrsAuthId() const;
 %Docstring
 Returns auth id of related geographic CRS

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2975,9 +2975,9 @@ QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::verticalCrs() const
     case Qgis::CrsType::Bound:
     case Qgis::CrsType::Other:
     case Qgis::CrsType::DerivedProjected:
+    case Qgis::CrsType::Geographic3d:
       return QgsCoordinateReferenceSystem();
 
-    case Qgis::CrsType::Geographic3d:
     case Qgis::CrsType::Vertical:
       return *this;
 

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2961,6 +2961,39 @@ QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::toGeographicCrs() con
   }
 }
 
+QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::verticalCrs() const
+{
+  switch ( type() )
+  {
+    case Qgis::CrsType::Unknown:
+    case Qgis::CrsType::Geodetic:
+    case Qgis::CrsType::Geocentric:
+    case Qgis::CrsType::Geographic2d:
+    case Qgis::CrsType::Projected:
+    case Qgis::CrsType::Temporal:
+    case Qgis::CrsType::Engineering:
+    case Qgis::CrsType::Bound:
+    case Qgis::CrsType::Other:
+    case Qgis::CrsType::DerivedProjected:
+      return QgsCoordinateReferenceSystem();
+
+    case Qgis::CrsType::Geographic3d:
+    case Qgis::CrsType::Vertical:
+      return *this;
+
+    case Qgis::CrsType::Compound:
+      break;
+  }
+
+  if ( PJ *obj = d->threadLocalProjObject() )
+  {
+    QgsProjUtils::proj_pj_unique_ptr vertCrs = QgsProjUtils::crsToVerticalCrs( obj );
+    if ( vertCrs )
+      return QgsCoordinateReferenceSystem::fromProjObject( vertCrs.get() );
+  }
+  return QgsCoordinateReferenceSystem();
+}
+
 QString QgsCoordinateReferenceSystem::geographicCrsAuthId() const
 {
   if ( isGeographic() )

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -981,6 +981,17 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     QgsCoordinateReferenceSystem toGeographicCrs() const;
 
+    /**
+     * Returns the vertical CRS associated with this CRS object.
+     *
+     * In the case of a compound CRS, this method will return just the vertical CRS component.
+     *
+     * An invalid CRS will be returned if the object does not contain a vertical component.
+     *
+     * \since QGIS 3.38
+     */
+    QgsCoordinateReferenceSystem verticalCrs() const;
+
     //! Returns auth id of related geographic CRS
     QString geographicCrsAuthId() const;
 

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -217,6 +217,38 @@ QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToHorizontalCrs( const PJ *crs
 #endif
 }
 
+QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToVerticalCrs( const PJ *crs )
+{
+  if ( !crs )
+    return nullptr;
+
+  PJ_CONTEXT *context = QgsProjContext::get();
+  switch ( proj_get_type( crs ) )
+  {
+    case PJ_TYPE_COMPOUND_CRS:
+    {
+      int i = 0;
+      QgsProjUtils::proj_pj_unique_ptr res( proj_crs_get_sub_crs( context, crs, i ) );
+      while ( res && ( proj_get_type( res.get() ) != PJ_TYPE_VERTICAL_CRS ) )
+      {
+        i++;
+        res.reset( proj_crs_get_sub_crs( context, crs, i ) );
+      }
+      return res;
+    }
+
+    case PJ_TYPE_VERTICAL_CRS:
+      return QgsProjUtils::proj_pj_unique_ptr( proj_clone( context, crs ) );
+
+    // maybe other types to handle??
+
+    default:
+      return nullptr;
+  }
+
+  BUILTIN_UNREACHABLE
+}
+
 QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::unboundCrs( const PJ *crs )
 {
   if ( !crs )

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -169,8 +169,22 @@ class CORE_EXPORT QgsProjUtils
      * from it.
      *
      * If \a crs does not contain a horizontal CRS (i.e. it is a vertical CRS) NULLPTR will be returned.
+     *
+     * \see crsToVerticalCrs()
      */
     static proj_pj_unique_ptr crsToHorizontalCrs( const PJ *crs );
+
+    /**
+     * Given a PROJ crs (which may be a compound or bound crs, or some other type), extract the vertical crs
+     * from it.
+     *
+     * If \a crs does not contain a vertical CRS (i.e. it is a horizontal CRS) NULLPTR will be returned.
+     *
+     * \see crsToHorizontalCrs()
+     *
+     * \since QGIS 3.38
+     */
+    static proj_pj_unique_ptr crsToVerticalCrs( const PJ *crs );
 
     /**
      * Given a PROJ crs (which may be a compound or bound crs, or some other type), ensure that it is not

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -175,7 +175,7 @@ class CORE_EXPORT QgsProjUtils
     static proj_pj_unique_ptr crsToHorizontalCrs( const PJ *crs );
 
     /**
-     * Given a PROJ crs (which may be a compound or bound crs, or some other type), extract the vertical crs
+     * Given a PROJ crs (which may be a compound crs, or some other type), extract the vertical crs
      * from it.
      *
      * If \a crs does not contain a vertical CRS (i.e. it is a horizontal CRS) NULLPTR will be returned.

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -49,6 +49,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void projectedCrs();
     void geocentricCrs();
     void geographic3d();
+    void toVertical();
     void coordinateEpoch();
     void saveAsUserCrs();
     void createFromId();
@@ -313,6 +314,20 @@ void TestQgsCoordinateReferenceSystem::geographic3d()
   crs.createFromString( QStringLiteral( "EPSG:4979" ) );
   QVERIFY( crs.isValid() );
   QCOMPARE( crs.type(), Qgis::CrsType::Geographic3d );
+}
+
+void TestQgsCoordinateReferenceSystem::toVertical()
+{
+  // invalid
+  QVERIFY( !QgsCoordinateReferenceSystem().verticalCrs().isValid() );
+  // horizontal only
+  QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ).verticalCrs().isValid() );
+  // compound
+  QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ).verticalCrs().authid(), QStringLiteral( "EPSG:5703" ) );
+  // already vertical
+  QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ).verticalCrs().authid(), QStringLiteral( "EPSG:5703" ) );
+  // geographic 3d
+  QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4979" ) ).verticalCrs().authid(), QStringLiteral( "EPSG:4979" ) );
 }
 
 void TestQgsCoordinateReferenceSystem::coordinateEpoch()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -327,7 +327,7 @@ void TestQgsCoordinateReferenceSystem::toVertical()
   // already vertical
   QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ).verticalCrs().authid(), QStringLiteral( "EPSG:5703" ) );
   // geographic 3d
-  QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4979" ) ).verticalCrs().authid(), QStringLiteral( "EPSG:4979" ) );
+  QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4979" ) ).verticalCrs().isValid() );
 }
 
 void TestQgsCoordinateReferenceSystem::coordinateEpoch()


### PR DESCRIPTION
Returns the vertical CRS associated with this CRS object.

- In the case of a compound CRS, this method will return just the vertical CRS component.
- An invalid CRS will be returned if the object does not contain a vertical component.
