### PR TITLE
[core] Fix QgsMapSettingsUtils::worldFileParameters function not taking device pixel ratio into account

### DIFF
--- a/src/core/qgsmapsettingsutils.cpp
+++ b/src/core/qgsmapsettingsutils.cpp
@@ -93,11 +93,11 @@ void QgsMapSettingsUtils::worldFileParameters( const QgsMapSettings &mapSettings
 
   // scaling matrix
   double s[6];
-  s[0] = ms.mapUnitsPerPixel();
+  s[0] = ms.mapUnitsPerPixel() / ms.devicePixelRatio();
   s[1] = 0;
   s[2] = xOrigin;
   s[3] = 0;
-  s[4] = -ms.mapUnitsPerPixel();
+  s[4] = -ms.mapUnitsPerPixel() / ms.devicePixelRatio();
   s[5] = yOrigin;
 
   // rotation matrix

--- a/tests/src/core/testqgsmapsettingsutils.cpp
+++ b/tests/src/core/testqgsmapsettingsutils.cpp
@@ -66,6 +66,16 @@ void TestQgsMapSettingsUtils::createWorldFileContent()
 
   mMapSettings.setRotation( 145 );
   QCOMPARE( QgsMapSettingsUtils::worldFileContent( mMapSettings ), QString( "-0.81915204428899191\r\n0.57357643635104594\r\n0.57357643635104594\r\n0.81915204428899191\r\n0.5\r\n0.49999999999999994\r\n" ) );
+
+  mMapSettings.setRotation( 0 );
+  mMapSettings.setDevicePixelRatio( 2.0 );
+  QgsMapSettingsUtils::worldFileParameters( mMapSettings, a, b, c, d, e, f );
+  QCOMPARE( a, 0.5 );
+  QCOMPARE( b, 0.0 );
+  QCOMPARE( c, 0.5 );
+  QCOMPARE( d, 0.0 );
+  QCOMPARE( e, -0.5 );
+  QCOMPARE( f, 0.5 );
 }
 
 void TestQgsMapSettingsUtils::containsAdvancedEffects()


### PR DESCRIPTION
## Description

Without this fix, saving  map [canvas] to image creates badly georeferenced datasets :/ I wish I had caught this one a two weeks ago :/