### PR TITLE
qgsfeaturelistcombobox: Reset the combobox when the search is cleared

### DIFF
--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -62,6 +62,7 @@ QgsFeatureListComboBox::QgsFeatureListComboBox( QWidget *parent )
   setModel( mModel );
 
   connect( mLineEdit, &QgsFilterLineEdit::textEdited, this, &QgsFeatureListComboBox::onCurrentTextChanged );
+  connect( mLineEdit, &QgsFilterLineEdit::cleared, this, &QgsFeatureListComboBox::onFilterLineEditCleared );
 
   connect( mModel, &QgsFeatureFilterModel::currentFeatureChanged, this, &QgsFeatureListComboBox::currentFeatureChanged );
 
@@ -104,6 +105,13 @@ void QgsFeatureListComboBox::onCurrentTextChanged( const QString &text )
   mIsCurrentlyEdited = true;
   mPopupRequested = true;
   mModel->setFilterValue( text );
+}
+
+void QgsFeatureListComboBox::onFilterLineEditCleared()
+{
+  // Reset the combobox when the search is cleared
+  const QString clearedValue = allowNull() ? mLineEdit->nullValue() : mLineEdit->defaultValue();
+  mModel->setFilterValue( clearedValue );
 }
 
 void QgsFeatureListComboBox::onFilterUpdateCompleted()

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -253,6 +253,7 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
 
   private slots:
     void onCurrentTextChanged( const QString &text );
+    void onFilterLineEditCleared();
     void onFilterUpdateCompleted();
     void onLoadingChanged();
     void onItemSelected( const QModelIndex &index );


### PR DESCRIPTION
## Description

After a search in a QgsFeatureListComboBox the result are correctly displayed in the combobox. However, after clicking on the clear button of the `QgsFilterLineEdit`, the search result is still displayed in the combo box.

This issue is fixed by resetting the model when the `QgsFilterLineEdit` is cleared.

Closes: https://github.com/qgis/QGIS/issues/56773
