### PR TITLE
[Bugfix] Server GetPrint set HTML content of QgsLayoutItemHtml and not only URL

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -937,7 +937,7 @@ namespace QgsWms
       QgsLayoutFrame *htmlFrame = html->frame( 0 );
       bool ok = false;
       const QString htmlId = htmlFrame->id();
-      const QString url = mWmsParameters.layoutParameter( htmlId, ok );
+      const QString htmlValue = mWmsParameters.layoutParameter( htmlId, ok );
 
       if ( !ok )
       {
@@ -947,15 +947,22 @@ namespace QgsWms
 
       //remove exported Htmls referenced in the request
       //but with empty string
-      if ( url.isEmpty() )
+      if ( htmlValue.isEmpty() )
       {
         c->removeMultiFrame( html );
         delete html;
         continue;
       }
 
-      QUrl newUrl( url );
-      html->setUrl( newUrl );
+      if ( html->contentMode() == QgsLayoutItemHtml::Url )
+      {
+        QUrl newUrl( htmlValue );
+        html->setUrl( newUrl );
+      }
+      else if ( html->contentMode() == QgsLayoutItemHtml::ManualHtml )
+      {
+        html->setHtml( htmlValue );
+      }
       html->update();
     }
 


### PR DESCRIPTION
Since QGIS 3.32, when QGIS and QGIS Server loading Project with old HTML-enabled label items, it was automatically into html items. https://github.com/qgis/QGIS/pull/53192

QGIS Server GetPrint request provides the ability to update label and html items, but for html items, it only accept URL.

QGIS Server was not taken into account the html item content mode, so the automotically migrate old HTML-enabled label items into html items can no longer be modifiable. They were only clear if the value provided is not an URL.

Funded by 3Liz