### PR TITLE
Serial port sensor's data frame delimiter

### DIFF
--- a/python/PyQt6/core/auto_generated/sensor/qgsiodevicesensor.sip.in
+++ b/python/PyQt6/core/auto_generated/sensor/qgsiodevicesensor.sip.in
@@ -246,7 +246,7 @@ Sets the baudrate of the serial port the sensor connects to.
     QByteArray delimiter() const;
 %Docstring
 Returns the current delimiter used to separate data frames. If empty,
-each serial port data updates will be considered a data frame.
+each serial port data update will be considered a data frame.
 
 .. versionadded:: 3.38
 %End
@@ -254,7 +254,7 @@ each serial port data updates will be considered a data frame.
     void setDelimiter( const QByteArray &delimiter );
 %Docstring
 Sets the delimiter used to identify data frames out of the data received
-from the serial port. If empty, each serial port data updates will be
+from the serial port. If empty, each serial port data update will be
 considered a data frame.
 
 :param delimiter: Character used to identify data frames

--- a/python/PyQt6/core/auto_generated/sensor/qgsiodevicesensor.sip.in
+++ b/python/PyQt6/core/auto_generated/sensor/qgsiodevicesensor.sip.in
@@ -243,6 +243,25 @@ Sets the baudrate of the serial port the sensor connects to.
 .. versionadded:: 3.36
 %End
 
+    QByteArray delimiter() const;
+%Docstring
+Returns the current delimiter used to separate data frames. If empty,
+each serial port data updates will be considered a data frame.
+
+.. versionadded:: 3.38
+%End
+
+    void setDelimiter( const QByteArray &delimiter );
+%Docstring
+Sets the delimiter used to identify data frames out of the data received
+from the serial port. If empty, each serial port data updates will be
+considered a data frame.
+
+:param delimiter: Character used to identify data frames
+
+.. versionadded:: 3.38
+%End
+
     virtual bool writePropertiesToElement( QDomElement &element, QDomDocument &document ) const;
 
     virtual bool readPropertiesFromElement( const QDomElement &element, const QDomDocument &document );
@@ -253,6 +272,11 @@ Sets the baudrate of the serial port the sensor connects to.
     virtual void handleConnect();
 
     virtual void handleDisconnect();
+
+
+  protected slots:
+
+    virtual void parseData();
 
 
 };

--- a/python/core/auto_generated/sensor/qgsiodevicesensor.sip.in
+++ b/python/core/auto_generated/sensor/qgsiodevicesensor.sip.in
@@ -246,7 +246,7 @@ Sets the baudrate of the serial port the sensor connects to.
     QByteArray delimiter() const;
 %Docstring
 Returns the current delimiter used to separate data frames. If empty,
-each serial port data updates will be considered a data frame.
+each serial port data update will be considered a data frame.
 
 .. versionadded:: 3.38
 %End
@@ -254,7 +254,7 @@ each serial port data updates will be considered a data frame.
     void setDelimiter( const QByteArray &delimiter );
 %Docstring
 Sets the delimiter used to identify data frames out of the data received
-from the serial port. If empty, each serial port data updates will be
+from the serial port. If empty, each serial port data update will be
 considered a data frame.
 
 :param delimiter: Character used to identify data frames

--- a/python/core/auto_generated/sensor/qgsiodevicesensor.sip.in
+++ b/python/core/auto_generated/sensor/qgsiodevicesensor.sip.in
@@ -243,6 +243,25 @@ Sets the baudrate of the serial port the sensor connects to.
 .. versionadded:: 3.36
 %End
 
+    QByteArray delimiter() const;
+%Docstring
+Returns the current delimiter used to separate data frames. If empty,
+each serial port data updates will be considered a data frame.
+
+.. versionadded:: 3.38
+%End
+
+    void setDelimiter( const QByteArray &delimiter );
+%Docstring
+Sets the delimiter used to identify data frames out of the data received
+from the serial port. If empty, each serial port data updates will be
+considered a data frame.
+
+:param delimiter: Character used to identify data frames
+
+.. versionadded:: 3.38
+%End
+
     virtual bool writePropertiesToElement( QDomElement &element, QDomDocument &document ) const;
 
     virtual bool readPropertiesFromElement( const QDomElement &element, const QDomDocument &document );
@@ -253,6 +272,11 @@ Sets the baudrate of the serial port the sensor connects to.
     virtual void handleConnect();
 
     virtual void handleDisconnect();
+
+
+  protected slots:
+
+    virtual void parseData();
 
 
 };

--- a/src/core/sensor/qgsiodevicesensor.cpp
+++ b/src/core/sensor/qgsiodevicesensor.cpp
@@ -366,11 +366,62 @@ void QgsSerialPortSensor::setBaudRate( const QSerialPort::BaudRate &baudRate )
   mBaudRate = baudRate;
 }
 
+QByteArray QgsSerialPortSensor::delimiter() const
+{
+  return mDelimiter;
+}
+
+void QgsSerialPortSensor::setDelimiter( const QByteArray &delimiter )
+{
+  if ( mDelimiter == delimiter )
+    return;
+
+  mDelimiter = delimiter;
+}
+
+
+void QgsSerialPortSensor::parseData()
+{
+  if ( !mDelimiter.isEmpty() )
+  {
+    if ( mFirstDelimiterHit )
+    {
+      mDataBuffer += mSerialPort->readAll();
+      const qsizetype lastIndex = mDataBuffer.lastIndexOf( mDelimiter );
+      if ( lastIndex > -1 )
+      {
+        QgsAbstractSensor::SensorData data;
+        data.lastValue = mDataBuffer.mid( 0, lastIndex );
+        mDataBuffer = mDataBuffer.mid( lastIndex + mDelimiter.size() );
+        data.lastTimestamp = QDateTime::currentDateTime();
+        setData( data );
+      }
+    }
+    else
+    {
+      QByteArray data = mSerialPort->readAll();
+      const qsizetype lastIndex = data.lastIndexOf( mDelimiter );
+      if ( lastIndex > -1 )
+      {
+        mFirstDelimiterHit = true;
+        mDataBuffer = data.mid( lastIndex + mDelimiter.size() );
+      }
+    }
+  }
+  else
+  {
+    QgsAbstractSensor::SensorData data;
+    data.lastValue = mSerialPort->readAll();
+    data.lastTimestamp = QDateTime::currentDateTime();
+    setData( data );
+  }
+}
 
 void QgsSerialPortSensor::handleConnect()
 {
   mSerialPort->setPortName( mPortName );
   mSerialPort->setBaudRate( mBaudRate );
+  mFirstDelimiterHit = false;
 
   if ( mSerialPort->open( QIODevice::ReadOnly ) )
   {
@@ -417,6 +468,7 @@ bool QgsSerialPortSensor::writePropertiesToElement( QDomElement &element, QDomDo
 {
   element.setAttribute( QStringLiteral( "portName" ), mPortName );
   element.setAttribute( QStringLiteral( "baudRate" ), static_cast<int>( mBaudRate ) );
+  element.setAttribute( QStringLiteral( "delimiter" ), QString( mDelimiter ) );
   return true;
 }
 
@@ -424,6 +476,7 @@ bool QgsSerialPortSensor::readPropertiesFromElement( const QDomElement &element,
 {
   mPortName = element.attribute( QStringLiteral( "portName" ) );
   mBaudRate = static_cast< QSerialPort::BaudRate >( element.attribute( QStringLiteral( "baudRate" ) ).toInt() );
+  mDelimiter = element.attribute( QStringLiteral( "delimiter" ) ).toLocal8Bit();
   return true;
 }
 #endif

--- a/src/core/sensor/qgsiodevicesensor.cpp
+++ b/src/core/sensor/qgsiodevicesensor.cpp
@@ -387,7 +387,7 @@ void QgsSerialPortSensor::parseData()
     if ( mFirstDelimiterHit )
     {
       mDataBuffer += mSerialPort->readAll();
-      const qsizetype lastIndex = mDataBuffer.lastIndexOf( mDelimiter );
+      const auto lastIndex = mDataBuffer.lastIndexOf( mDelimiter );
       if ( lastIndex > -1 )
       {
         QgsAbstractSensor::SensorData data;

--- a/src/core/sensor/qgsiodevicesensor.cpp
+++ b/src/core/sensor/qgsiodevicesensor.cpp
@@ -400,7 +400,7 @@ void QgsSerialPortSensor::parseData()
     else
     {
       QByteArray data = mSerialPort->readAll();
-      const qsizetype lastIndex = data.lastIndexOf( mDelimiter );
+      const auto lastIndex = data.lastIndexOf( mDelimiter );
       if ( lastIndex > -1 )
       {
         mFirstDelimiterHit = true;

--- a/src/core/sensor/qgsiodevicesensor.h
+++ b/src/core/sensor/qgsiodevicesensor.h
@@ -311,7 +311,7 @@ class CORE_EXPORT QgsSerialPortSensor : public QgsIODeviceSensor
     QSerialPort *mSerialPort = nullptr;
 
     QString mPortName;
-    QSerialPort::BaudRate mBaudRate;
+    QSerialPort::BaudRate mBaudRate = QSerialPort::Baud9600;
     QByteArray mDelimiter;
     bool mFirstDelimiterHit = false;
     QByteArray mDataBuffer;

--- a/src/core/sensor/qgsiodevicesensor.h
+++ b/src/core/sensor/qgsiodevicesensor.h
@@ -276,14 +276,14 @@ class CORE_EXPORT QgsSerialPortSensor : public QgsIODeviceSensor
 
     /**
      * Returns the current delimiter used to separate data frames. If empty,
-     * each serial port data updates will be considered a data frame.
+     * each serial port data update will be considered a data frame.
      * \since QGIS 3.38
      */
     QByteArray delimiter() const;
 
     /**
      * Sets the delimiter used to identify data frames out of the data received
-     * from the serial port. If empty, each serial port data updates will be
+     * from the serial port. If empty, each serial port data update will be
      * considered a data frame.
      * \param delimiter Character used to identify data frames
      * \since QGIS 3.38

--- a/src/core/sensor/qgsiodevicesensor.h
+++ b/src/core/sensor/qgsiodevicesensor.h
@@ -274,6 +274,22 @@ class CORE_EXPORT QgsSerialPortSensor : public QgsIODeviceSensor
      */
     void setBaudRate( const QSerialPort::BaudRate &baudRate );
 
+    /**
+     * Returns the current delimiter used to separate data frames. If empty,
+     * each serial port data updates will be considered a data frame.
+     * \since QGIS 3.38
+     */
+    QByteArray delimiter() const;
+
+    /**
+     * Sets the delimiter used to identify data frames out of the data received
+     * from the serial port. If empty, each serial port data updates will be
+     * considered a data frame.
+     * \param delimiter Character used to identify data frames
+     * \since QGIS 3.38
+     */
+    void setDelimiter( const QByteArray &delimiter );
+
     bool writePropertiesToElement( QDomElement &element, QDomDocument &document ) const override;
     bool readPropertiesFromElement( const QDomElement &element, const QDomDocument &document ) override;
 
@@ -281,6 +297,10 @@ class CORE_EXPORT QgsSerialPortSensor : public QgsIODeviceSensor
 
     void handleConnect() override;
     void handleDisconnect() override;
+
+  protected slots:
+
+    void parseData() override;
 
   private slots:
 
@@ -291,8 +311,10 @@ class CORE_EXPORT QgsSerialPortSensor : public QgsIODeviceSensor
     QSerialPort *mSerialPort = nullptr;
 
     QString mPortName;
-
     QSerialPort::BaudRate mBaudRate;
+    QByteArray mDelimiter;
+    bool mFirstDelimiterHit = false;
+    QByteArray mDataBuffer;
 
 };
 SIP_END

--- a/src/gui/sensor/qgssensorwidget.cpp
+++ b/src/gui/sensor/qgssensorwidget.cpp
@@ -157,9 +157,9 @@ QgsSerialPortSensorWidget::QgsSerialPortSensorWidget( QWidget *parent )
   mBaudRateComboBox->addItem( QStringLiteral( "115200 baud" ), static_cast<int>( QSerialPort::Baud115200 ) );
   mBaudRateComboBox->setCurrentIndex( 3 );
 
-  mDataFrameDelimiterComboBox->addItem( tr( "No delimiter" ), QString() );
-  mDataFrameDelimiterComboBox->addItem( tr( "New line" ), QString( "\n" ) );
-  mDataFrameDelimiterComboBox->addItem( tr( "Custom character" ), QString() );
+  mDataFrameDelimiterComboBox->addItem( tr( "No Delimiter" ), QString() );
+  mDataFrameDelimiterComboBox->addItem( tr( "New Line" ), QString( "\n" ) );
+  mDataFrameDelimiterComboBox->addItem( tr( "Custom Character" ), QString() );
 
   updateSerialPortDetails();
 

--- a/src/gui/sensor/qgssensorwidget.cpp
+++ b/src/gui/sensor/qgssensorwidget.cpp
@@ -163,7 +163,7 @@ QgsSerialPortSensorWidget::QgsSerialPortSensorWidget( QWidget *parent )
 
   updateSerialPortDetails();
 
-  connect( mSerialPortComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [ = ]()
+  connect( mSerialPortComboBox, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentTextChanged ), this, [ = ]()
   {
     updateSerialPortDetails();
     emit changed();
@@ -198,7 +198,7 @@ QgsSerialPortSensorWidget::QgsSerialPortSensorWidget( QWidget *parent )
 QgsAbstractSensor *QgsSerialPortSensorWidget::createSensor()
 {
   QgsSerialPortSensor *s = new QgsSerialPortSensor();
-  s->setPortName( mSerialPortComboBox->currentData().toString() );
+  s->setPortName( mSerialPortComboBox->findText( mSerialPortComboBox->currentText() ) != -1 ? mSerialPortComboBox->currentData().toString() : mSerialPortComboBox->currentText() );
   s->setBaudRate( static_cast< QSerialPort::BaudRate >( mBaudRateComboBox->currentData().toInt() ) );
   const QString delimiter = mDataFrameDelimiterComboBox->currentIndex() == mDataFrameDelimiterComboBox->count() - 1 ? mDataFrameDelimiterLineEdit->text() : mDataFrameDelimiterComboBox->currentData().toString();
   s->setDelimiter( delimiter.toLocal8Bit() );
@@ -211,7 +211,7 @@ bool QgsSerialPortSensorWidget::updateSensor( QgsAbstractSensor *sensor )
   if ( !s )
     return false;
 
-  s->setPortName( mSerialPortComboBox->currentData().toString() );
+  s->setPortName( mSerialPortComboBox->findText( mSerialPortComboBox->currentText() ) != -1 ? mSerialPortComboBox->currentData().toString() : mSerialPortComboBox->currentText() );
   s->setBaudRate( static_cast< QSerialPort::BaudRate >( mBaudRateComboBox->currentData().toInt() ) );
   const QString delimiter = mDataFrameDelimiterComboBox->currentIndex() == mDataFrameDelimiterComboBox->count() - 1 ? mDataFrameDelimiterLineEdit->text() : mDataFrameDelimiterComboBox->currentData().toString();
   s->setDelimiter( delimiter.toLocal8Bit() );
@@ -270,12 +270,12 @@ bool QgsSerialPortSensorWidget::setSensor( QgsAbstractSensor *sensor )
 
 void QgsSerialPortSensorWidget::updateSerialPortDetails()
 {
-  if ( mSerialPortComboBox->currentIndex() < 0 )
+  if ( mSerialPortComboBox->currentText().isEmpty() )
   {
     return;
   }
 
-  const QString &currentPortName = mSerialPortComboBox->currentData().toString();
+  const QString &currentPortName = mSerialPortComboBox->findText( mSerialPortComboBox->currentText() ) != -1 ? mSerialPortComboBox->currentData().toString() : mSerialPortComboBox->currentText();
   bool serialPortFound = false;
   for ( const QSerialPortInfo &info : QSerialPortInfo::availablePorts() )
   {
@@ -295,6 +295,10 @@ void QgsSerialPortSensorWidget::updateSerialPortDetails()
   {
     mSerialPortDetails->setText( QStringLiteral( "%1:\n- %2: %3" ).arg( tr( "Serial port details" ),
                                  tr( "Port name" ), currentPortName ) );
+  }
+  else
+  {
+    mSerialPortDetails->setText( QString() );
   }
 }
 #endif

--- a/src/ui/sensor/widget_serialportsensor.ui
+++ b/src/ui/sensor/widget_serialportsensor.ui
@@ -41,6 +41,9 @@
      <property name="toolTip">
       <string>Choose a serial port for the connection</string>
      </property>
+     <property name="editable">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/ui/sensor/widget_serialportsensor.ui
+++ b/src/ui/sensor/widget_serialportsensor.ui
@@ -96,7 +96,7 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>Choose a character acting as data frame delimiter</string>
+        <string>Choose a character to act as the data frame delimiter</string>
        </property>    
       </widget>
      </item>

--- a/src/ui/sensor/widget_serialportsensor.ui
+++ b/src/ui/sensor/widget_serialportsensor.ui
@@ -64,6 +64,55 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="mDataFrameDelimiterLabel">
+     <property name="text">
+      <string>Data frame delimiter</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="dataFrameDelimiterLayout">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QComboBox" name="mDataFrameDelimiterComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Choose a character acting as data frame delimiter</string>
+       </property>    
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="mDataFrameDelimiterLineEdit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>       
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QLabel" name="mSerialPortDetails">
      <property name="enabled">
       <bool>false</bool>

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -373,6 +373,10 @@ ADD_PYTHON_TEST(PyQgsVtpk test_qgsvtpk.py)
 if (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)
 
+  if (WITH_QTSERIALPORT)
+    ADD_PYTHON_TEST(PyQgsSerialPortSensor test_qgsserialportsensor.py)
+  endif()
+
   # Add optional tests which depend on certain cmake options
   if (WITH_SERVER)
     ADD_PYTHON_TEST(PyQgsPalLabelingServer test_qgspallabeling_server.py)

--- a/tests/src/python/test_qgsserialportsensor.py
+++ b/tests/src/python/test_qgsserialportsensor.py
@@ -1,0 +1,102 @@
+"""QGIS Unit tests for QgsSerialPortSensor.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = '(C) 2023 by Mathieu Pellerin'
+__date__ = '19/03/2023'
+__copyright__ = 'Copyright 2023, The QGIS Project'
+
+import os
+import posix
+
+from qgis.PyQt.QtCore import QCoreApplication, QEvent, QLocale, QTemporaryDir, QIODevice, QBuffer, QByteArray
+from qgis.PyQt.QtTest import QSignalSpy
+from qgis.PyQt.QtXml import QDomDocument
+from PyQt5.QtSerialPort import *
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsProject,
+    QgsSerialPortSensor,
+    QgsSensorManager
+)
+import unittest
+from qgis.testing import start_app, QgisTestCase
+
+from utilities import unitTestDataPath
+
+start_app()
+TEST_DATA_DIR = unitTestDataPath()
+
+
+class TestQgsSerialPortSensor(QgisTestCase):
+
+    manager = None
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        super().setUpClass()
+        QCoreApplication.setOrganizationName("QGIS_Test")
+        QCoreApplication.setOrganizationDomain("QGIS_TestQgsSerialPortSensor.com")
+        QCoreApplication.setApplicationName("QGIS_TestQgsSerialPortSensor")
+        QLocale.setDefault(QLocale(QLocale.Language.English))
+        start_app()
+
+        cls.manager = QgsProject.instance().sensorManager()
+
+    def setUp(self):
+        """Run before each test."""
+        pass
+
+    def tearDown(self):
+        """Run after each test."""
+        pass
+
+    def testSerialPortSensor(self):
+        fd1, fd2 = posix.openpty()
+        fd_file = os.fdopen(fd1, "wb")
+
+        serial_port_sensor = QgsSerialPortSensor()
+        serial_port_sensor.setName('serial port sensor')
+        serial_port_sensor.setPortName(os.ttyname(fd2))
+        serial_port_sensor.setBaudRate(QSerialPort.Baud9600)
+        serial_port_sensor.setDelimiter(b'\n')
+
+        serial_port_sensor_id = serial_port_sensor.id()
+
+        self.manager.addSensor(serial_port_sensor)
+
+        sensor_spy = QSignalSpy(serial_port_sensor.dataChanged)
+        manager_spy = QSignalSpy(self.manager.sensorDataCaptured)
+
+        serial_port_sensor.connectSensor()
+        self.assertEqual(serial_port_sensor.status(), Qgis.DeviceConnectionStatus.Connected)
+
+        QCoreApplication.processEvents()
+        fd_file.write(b'test 1\nfull ')
+        fd_file.flush()
+        QCoreApplication.processEvents()
+
+        # No signal should be fired as the delimiter must be captured at least once to insure a full data frame
+        self.assertEqual(len(sensor_spy), 0)
+        self.assertEqual(len(manager_spy), 0)
+
+        QCoreApplication.processEvents()
+        fd_file.write(b'test 2\n')
+        fd_file.flush()
+        QCoreApplication.processEvents()
+
+        self.assertEqual(len(sensor_spy), 1)
+        self.assertEqual(len(manager_spy), 1)
+        self.assertEqual(serial_port_sensor.data().lastValue, QByteArray(b'full test 2'))
+        self.assertEqual(self.manager.sensorData('serial port sensor').lastValue, b'full test 2')
+
+        self.manager.removeSensor(serial_port_sensor_id)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/src/python/test_qgsserialportsensor.py
+++ b/tests/src/python/test_qgsserialportsensor.py
@@ -15,7 +15,6 @@ import posix
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, QLocale, QTemporaryDir, QIODevice, QBuffer, QByteArray
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument
-from PyQt5.QtSerialPort import *
 from qgis.core import (
     Qgis,
     QgsApplication,
@@ -63,7 +62,6 @@ class TestQgsSerialPortSensor(QgisTestCase):
         serial_port_sensor = QgsSerialPortSensor()
         serial_port_sensor.setName('serial port sensor')
         serial_port_sensor.setPortName(os.ttyname(fd2))
-        serial_port_sensor.setBaudRate(QSerialPort.Baud9600)
         serial_port_sensor.setDelimiter(b'\n')
 
         serial_port_sensor_id = serial_port_sensor.id()


### PR DESCRIPTION
## Description

This PR implements this enhancement request (https://github.com/qgis/QGIS/issues/56275) by adding a new data frame delimiter functionality to the serial port sensor:

![image](https://github.com/qgis/QGIS/assets/1728657/5d3ef9b8-f684-4a64-8989-ff84b6c2af60)

In case multiple data frames are found in the last chunk of data pushed by the serial port, this implementation will only return all data frames. Users can then use an expression to further split the returned sensor last data value into individual frames (e.g. string_to_array).

@jtornero , this enhancement was something I needed on my end too, and had some free time. So here it is :)