### PR TITLE
[api] Add QgsCoordinateReferenceSystem method to create a compound CRS

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -323,6 +323,17 @@ Creates a CRS from a specified QGIS SRS ID.
 .. seealso:: :py:func:`validSrsIds`
 %End
 
+    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs );
+%Docstring
+Given a horizontal and vertical CRS, attempts to create a compound CRS
+from them.
+
+Returns an invalid CRS if the inputs are not suitable for a compound CRS,
+or the compound CRS could not be created for the combination.
+
+.. versionadded:: 3.38
+%End
+
 
 
  bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated/;

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -323,6 +323,17 @@ Creates a CRS from a specified QGIS SRS ID.
 .. seealso:: :py:func:`validSrsIds`
 %End
 
+    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs );
+%Docstring
+Given a horizontal and vertical CRS, attempts to create a compound CRS
+from them.
+
+Returns an invalid CRS if the inputs are not suitable for a compound CRS,
+or the compound CRS could not be created for the combination.
+
+.. versionadded:: 3.38
+%End
+
 
 
  bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated/;

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -241,6 +241,19 @@ QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::fromSrsId( long srsId
   return crs;
 }
 
+QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs )
+{
+  PJ *horizontalObj = horizontalCrs.projObject();
+  PJ *verticalObj = verticalCrs.projObject();
+  if ( horizontalObj && verticalObj )
+  {
+    QgsProjUtils::proj_pj_unique_ptr compoundCrs = QgsProjUtils::createCompoundCrs( horizontalObj, verticalObj );
+    if ( compoundCrs )
+      return QgsCoordinateReferenceSystem::fromProjObject( compoundCrs.get() );
+  }
+  return QgsCoordinateReferenceSystem();
+}
+
 QgsCoordinateReferenceSystem::~QgsCoordinateReferenceSystem() //NOLINT
 {
 }

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -337,6 +337,17 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     */
     static QgsCoordinateReferenceSystem fromSrsId( long srsId );
 
+    /**
+     * Given a horizontal and vertical CRS, attempts to create a compound CRS
+     * from them.
+     *
+     * Returns an invalid CRS if the inputs are not suitable for a compound CRS,
+     * or the compound CRS could not be created for the combination.
+     *
+     * \since QGIS 3.38
+     */
+    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs );
+
     // Misc helper functions -----------------------
 
     // TODO QGIS 4: remove type and always use EPSG code, rename to createFromEpsg

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -24,6 +24,7 @@
 #include <QDate>
 
 #include <proj.h>
+#include <proj_experimental.h>
 
 #if defined(USE_THREAD_LOCAL) && !defined(Q_OS_WIN)
 thread_local QgsProjContext QgsProjContext::sProjContext;
@@ -289,6 +290,18 @@ QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToDatumEnsemble( const PJ *crs
 #else
   throw QgsNotSupportedException( QObject::tr( "Calculating datum ensembles requires a QGIS build based on PROJ 8.0 or later" ) );
 #endif
+}
+
+QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::createCompoundCrs( const PJ *horizontalCrs, const PJ *verticalCrs )
+{
+  if ( !horizontalCrs || !verticalCrs )
+    return nullptr;
+
+  // const cast here is for compatibility with proj < 9.5
+  return QgsProjUtils::proj_pj_unique_ptr( proj_create_compound_crs( QgsProjContext::get(),
+         nullptr,
+         const_cast< PJ *>( horizontalCrs ),
+         const_cast< PJ * >( verticalCrs ) ) );
 }
 
 bool QgsProjUtils::identifyCrs( const PJ *crs, QString &authName, QString &authCode, IdentifyFlags flags )

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -208,6 +208,13 @@ class CORE_EXPORT QgsProjUtils
     static proj_pj_unique_ptr crsToDatumEnsemble( const PJ *crs );
 
     /**
+     * Given a PROJ horizontal and vertical CRS, attempt to create a compound CRS from them.
+     *
+     * \since QGIS 3.38
+     */
+    static proj_pj_unique_ptr createCompoundCrs( const PJ *horizontalCrs, const PJ *verticalCrs );
+
+    /**
      * Attempts to identify a \a crs, matching it to a known authority and code within
      * an acceptable level of tolerance.
      *

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -51,6 +51,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void geographic3d();
     void toVertical();
     void coordinateEpoch();
+    void createCompound();
     void saveAsUserCrs();
     void createFromId();
     void fromEpsgId();
@@ -347,6 +348,27 @@ void TestQgsCoordinateReferenceSystem::coordinateEpoch()
   QCOMPARE( crs2.coordinateEpoch(), 2021.3 );
   QVERIFY( crs.projObject() );
   QVERIFY( crs2.projObject() );
+}
+
+void TestQgsCoordinateReferenceSystem::createCompound()
+{
+  //horizontal invalid / vertical invalid
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem() ).isValid() );
+  // horizontal valid / vertical invalid
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem() ).isValid() );
+  // horizontal invalid / vertical valid
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ) ).isValid() );
+  // horizontal valid / vertical valid
+  const QgsCoordinateReferenceSystem compound = QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ) );
+  QVERIFY( compound.isValid() );
+  QCOMPARE( compound.description(), QStringLiteral( "unnamed" ) );
+  QCOMPARE( compound.type(), Qgis::CrsType::Compound );
+  // horizontal / vertical flipped
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ) ).isValid() );
+  // horizontal valid / not vertical
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3113" ) ) ).isValid() );
+  // horizontal already a compound
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ) ).isValid() );
 }
 
 void TestQgsCoordinateReferenceSystem::createFromId()


### PR DESCRIPTION
Allows creation of a compound CRS object from a horizontal + vertical pair