### PR TITLE
Fix tooltip for QgsProjectionSelectionWidget when set to no-crs option

### DIFF
--- a/src/gui/proj/qgsprojectionselectionwidget.cpp
+++ b/src/gui/proj/qgsprojectionselectionwidget.cpp
@@ -470,6 +470,7 @@ void QgsProjectionSelectionWidget::setOptionVisible( const QgsProjectionSelectio
     case QgsProjectionSelectionWidget::CurrentCrs:
     {
       mModel->setOption( option, visible );
+      updateTooltip();
       return;
     }
     case QgsProjectionSelectionWidget::RecentCrs:
@@ -488,6 +489,7 @@ void QgsProjectionSelectionWidget::setOptionVisible( const QgsProjectionSelectio
         if ( !mModel->combinedModel()->currentCrs().isValid() )
           whileBlocking( mCrsComboBox )->setCurrentIndex( 0 );
       }
+      updateTooltip();
 
       return;
     }


### PR DESCRIPTION
This was incorrectly showing the tooltip for the first valid crs in the list