### PR TITLE
Add vertical crs option for projects

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -310,15 +310,23 @@ Returns the project's native coordinate reference system.
 .. seealso:: :py:func:`verticalCrs`
 
 .. seealso:: :py:func:`ellipsoid`
+
+.. seealso:: :py:func:`crsChanged`
 %End
 
     void setCrs( const QgsCoordinateReferenceSystem &crs, bool adjustEllipsoid = false );
 %Docstring
 Sets the project's native coordinate reference system.
-If ``adjustEllipsoid`` is set to ``True``, the ellpsoid of this project will be set to
+
+If ``adjustEllipsoid`` is set to ``True``, the ellipsoid of this project will be set to
 the ellipsoid imposed by the CRS.
 
+Changing the CRS will trigger a :py:func:`~QgsProject.crsChanged` signal. Additionally, if ``crs`` is a compound
+CRS, then the :py:func:`~QgsProject.verticalCrsChanged` signal will also be emitted.
+
 .. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`crsChanged`
 
 .. seealso:: :py:func:`setVerticalCrs`
 
@@ -332,15 +340,19 @@ Returns a proj string representing the project's ellipsoid setting, e.g., "WGS84
 .. seealso:: :py:func:`setEllipsoid`
 
 .. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`verticalCrs`
 %End
 
     void setEllipsoid( const QString &ellipsoid );
 %Docstring
-Sets the project's ellipsoid from a proj string representation, e.g., "WGS84".
+Sets the project's ``ellipsoid`` from a proj string representation, e.g., "WGS84".
 
 .. seealso:: :py:func:`ellipsoid`
 
 .. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`setVerticalCrs`
 %End
 
     QgsCoordinateReferenceSystem verticalCrs() const;
@@ -363,6 +375,8 @@ The returned CRS will be invalid if the project has no vertical CRS.
     bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage /Out/ = 0 );
 %Docstring
 Sets the project's vertical coordinate reference system.
+
+The :py:func:`~QgsProject.verticalCrsChanged` signal will be raised if the vertical CRS is changed.
 
 .. note::
 
@@ -1769,14 +1783,28 @@ Emitted whenever the expression variables stored in the project have been change
 %Docstring
 Emitted when the CRS of the project has changed.
 
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setCrs`
+
 .. seealso:: :py:func:`verticalCrsChanged`
+
+.. seealso:: :py:func:`ellipsoidChanged`
 %End
 
     void verticalCrsChanged();
 %Docstring
-Emitted when the CRS of the project has changed.
+Emitted when the vertical CRS of the project has changed.
+
+This signal will be emitted whenever the vertical CRS of the project is changed, either
+as a direct result of a call to :py:func:`~QgsProject.setVerticalCrs` or when :py:func:`~QgsProject.setCrs` is called with a compound
+CRS.
 
 .. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`setVerticalCrs`
 
 .. seealso:: :py:func:`verticalCrs`
 

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -360,7 +360,7 @@ The returned CRS will be invalid if the project has no vertical CRS.
 .. versionadded:: 3.38
 %End
 
-    void setVerticalCrs( const QgsCoordinateReferenceSystem &crs );
+    bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage /Out/ = 0 );
 %Docstring
 Sets the project's vertical coordinate reference system.
 
@@ -369,6 +369,13 @@ Sets the project's vertical coordinate reference system.
    If the project :py:func:`~QgsProject.crs` is a compound CRS, then the CRS returned for
    :py:func:`~QgsProject.verticalCrs` will be the vertical component of :py:func:`~QgsProject.crs`. Otherwise it will be the value
    explicitly set by this call.
+
+:param crs: the vertical CRS
+
+
+:return: - ``True`` if vertical CRS was successfully set
+         - errorMessage: will be set to a descriptive message if the vertical CRS could not be set
+
 
 .. seealso:: :py:func:`verticalCrs`
 

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -307,6 +307,8 @@ Returns the project's native coordinate reference system.
 
 .. seealso:: :py:func:`setCrs`
 
+.. seealso:: :py:func:`verticalCrs`
+
 .. seealso:: :py:func:`ellipsoid`
 %End
 
@@ -317,6 +319,8 @@ If ``adjustEllipsoid`` is set to ``True``, the ellpsoid of this project will be 
 the ellipsoid imposed by the CRS.
 
 .. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setVerticalCrs`
 
 .. seealso:: :py:func:`setEllipsoid`
 %End
@@ -339,6 +343,40 @@ Sets the project's ellipsoid from a proj string representation, e.g., "WGS84".
 .. seealso:: :py:func:`setCrs`
 %End
 
+    QgsCoordinateReferenceSystem verticalCrs() const;
+%Docstring
+Returns the project's vertical coordinate reference system.
+
+If the project :py:func:`~QgsProject.crs` is a compound CRS, then the CRS returned will
+be the vertical component of :py:func:`~QgsProject.crs`. Otherwise it will be the value
+explicitly set by a call to :py:func:`~QgsProject.setVerticalCrs`.
+
+The returned CRS will be invalid if the project has no vertical CRS.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setVerticalCrs`
+
+.. versionadded:: 3.38
+%End
+
+    void setVerticalCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the project's vertical coordinate reference system.
+
+.. note::
+
+   If the project :py:func:`~QgsProject.crs` is a compound CRS, then the CRS returned for
+   :py:func:`~QgsProject.verticalCrs` will be the vertical component of :py:func:`~QgsProject.crs`. Otherwise it will be the value
+   explicitly set by this call.
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`setCrs`
+
+
+.. versionadded:: 3.38
+%End
 
     QgsCoordinateTransformContext transformContext() const;
 %Docstring
@@ -1723,6 +1761,19 @@ Emitted whenever the expression variables stored in the project have been change
     void crsChanged();
 %Docstring
 Emitted when the CRS of the project has changed.
+
+.. seealso:: :py:func:`verticalCrsChanged`
+%End
+
+    void verticalCrsChanged();
+%Docstring
+Emitted when the CRS of the project has changed.
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. versionadded:: 3.38
 %End
 
     void ellipsoidChanged( const QString &ellipsoid );

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -310,15 +310,23 @@ Returns the project's native coordinate reference system.
 .. seealso:: :py:func:`verticalCrs`
 
 .. seealso:: :py:func:`ellipsoid`
+
+.. seealso:: :py:func:`crsChanged`
 %End
 
     void setCrs( const QgsCoordinateReferenceSystem &crs, bool adjustEllipsoid = false );
 %Docstring
 Sets the project's native coordinate reference system.
-If ``adjustEllipsoid`` is set to ``True``, the ellpsoid of this project will be set to
+
+If ``adjustEllipsoid`` is set to ``True``, the ellipsoid of this project will be set to
 the ellipsoid imposed by the CRS.
 
+Changing the CRS will trigger a :py:func:`~QgsProject.crsChanged` signal. Additionally, if ``crs`` is a compound
+CRS, then the :py:func:`~QgsProject.verticalCrsChanged` signal will also be emitted.
+
 .. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`crsChanged`
 
 .. seealso:: :py:func:`setVerticalCrs`
 
@@ -332,15 +340,19 @@ Returns a proj string representing the project's ellipsoid setting, e.g., "WGS84
 .. seealso:: :py:func:`setEllipsoid`
 
 .. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`verticalCrs`
 %End
 
     void setEllipsoid( const QString &ellipsoid );
 %Docstring
-Sets the project's ellipsoid from a proj string representation, e.g., "WGS84".
+Sets the project's ``ellipsoid`` from a proj string representation, e.g., "WGS84".
 
 .. seealso:: :py:func:`ellipsoid`
 
 .. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`setVerticalCrs`
 %End
 
     QgsCoordinateReferenceSystem verticalCrs() const;
@@ -363,6 +375,8 @@ The returned CRS will be invalid if the project has no vertical CRS.
     bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage /Out/ = 0 );
 %Docstring
 Sets the project's vertical coordinate reference system.
+
+The :py:func:`~QgsProject.verticalCrsChanged` signal will be raised if the vertical CRS is changed.
 
 .. note::
 
@@ -1769,14 +1783,28 @@ Emitted whenever the expression variables stored in the project have been change
 %Docstring
 Emitted when the CRS of the project has changed.
 
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setCrs`
+
 .. seealso:: :py:func:`verticalCrsChanged`
+
+.. seealso:: :py:func:`ellipsoidChanged`
 %End
 
     void verticalCrsChanged();
 %Docstring
-Emitted when the CRS of the project has changed.
+Emitted when the vertical CRS of the project has changed.
+
+This signal will be emitted whenever the vertical CRS of the project is changed, either
+as a direct result of a call to :py:func:`~QgsProject.setVerticalCrs` or when :py:func:`~QgsProject.setCrs` is called with a compound
+CRS.
 
 .. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`setVerticalCrs`
 
 .. seealso:: :py:func:`verticalCrs`
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -360,7 +360,7 @@ The returned CRS will be invalid if the project has no vertical CRS.
 .. versionadded:: 3.38
 %End
 
-    void setVerticalCrs( const QgsCoordinateReferenceSystem &crs );
+    bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage /Out/ = 0 );
 %Docstring
 Sets the project's vertical coordinate reference system.
 
@@ -369,6 +369,13 @@ Sets the project's vertical coordinate reference system.
    If the project :py:func:`~QgsProject.crs` is a compound CRS, then the CRS returned for
    :py:func:`~QgsProject.verticalCrs` will be the vertical component of :py:func:`~QgsProject.crs`. Otherwise it will be the value
    explicitly set by this call.
+
+:param crs: the vertical CRS
+
+
+:return: - ``True`` if vertical CRS was successfully set
+         - errorMessage: will be set to a descriptive message if the vertical CRS could not be set
+
 
 .. seealso:: :py:func:`verticalCrs`
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -307,6 +307,8 @@ Returns the project's native coordinate reference system.
 
 .. seealso:: :py:func:`setCrs`
 
+.. seealso:: :py:func:`verticalCrs`
+
 .. seealso:: :py:func:`ellipsoid`
 %End
 
@@ -317,6 +319,8 @@ If ``adjustEllipsoid`` is set to ``True``, the ellpsoid of this project will be 
 the ellipsoid imposed by the CRS.
 
 .. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setVerticalCrs`
 
 .. seealso:: :py:func:`setEllipsoid`
 %End
@@ -339,6 +343,40 @@ Sets the project's ellipsoid from a proj string representation, e.g., "WGS84".
 .. seealso:: :py:func:`setCrs`
 %End
 
+    QgsCoordinateReferenceSystem verticalCrs() const;
+%Docstring
+Returns the project's vertical coordinate reference system.
+
+If the project :py:func:`~QgsProject.crs` is a compound CRS, then the CRS returned will
+be the vertical component of :py:func:`~QgsProject.crs`. Otherwise it will be the value
+explicitly set by a call to :py:func:`~QgsProject.setVerticalCrs`.
+
+The returned CRS will be invalid if the project has no vertical CRS.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setVerticalCrs`
+
+.. versionadded:: 3.38
+%End
+
+    void setVerticalCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the project's vertical coordinate reference system.
+
+.. note::
+
+   If the project :py:func:`~QgsProject.crs` is a compound CRS, then the CRS returned for
+   :py:func:`~QgsProject.verticalCrs` will be the vertical component of :py:func:`~QgsProject.crs`. Otherwise it will be the value
+   explicitly set by this call.
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`setCrs`
+
+
+.. versionadded:: 3.38
+%End
 
     QgsCoordinateTransformContext transformContext() const;
 %Docstring
@@ -1723,6 +1761,19 @@ Emitted whenever the expression variables stored in the project have been change
     void crsChanged();
 %Docstring
 Emitted when the CRS of the project has changed.
+
+.. seealso:: :py:func:`verticalCrsChanged`
+%End
+
+    void verticalCrsChanged();
+%Docstring
+Emitted when the CRS of the project has changed.
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. versionadded:: 3.38
 %End
 
     void ellipsoidChanged( const QString &ellipsoid );

--- a/src/app/project/qgsprojectelevationsettingswidget.h
+++ b/src/app/project/qgsprojectelevationsettingswidget.h
@@ -22,6 +22,7 @@
 
 class QgsVectorLayer;
 class QgsElevationShadingRendererSettingsWidget;
+class QgsProjectionSelectionWidget;
 
 class QgsProjectElevationSettingsWidget : public QgsOptionsPageWidget, private Ui::QgsProjectElevationSettingsWidgetBase
 {
@@ -36,10 +37,12 @@ class QgsProjectElevationSettingsWidget : public QgsOptionsPageWidget, private U
 
   private slots:
 
+    void updateVerticalCrsOptions();
     bool validate();
 
   private:
     QgsElevationShadingRendererSettingsWidget *mElevationShadingSettingsWidget = nullptr;
+    QgsProjectionSelectionWidget *mVerticalCrsWidget = nullptr;
 
 };
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -733,7 +733,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "project_filename" ), QCoreApplication::translate( "variable_help", "Filename of current project." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_basename" ), QCoreApplication::translate( "variable_help", "Base name of current project's filename (without path and extension)." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_home" ), QCoreApplication::translate( "variable_help", "Home path of current project." ) );
-  sVariableHelpTexts()->insert( QStringLiteral( "project_crs" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of project (e.g., 'EPSG:4326')." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "project_crs" ), QCoreApplication::translate( "variable_help", "Identifier for the coordinate reference system of project (e.g., 'EPSG:4326')." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of project (full definition)." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_units" ), QCoreApplication::translate( "variable_help", "Unit of the project's CRS." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_crs_description" ), QCoreApplication::translate( "variable_help", "Name of the coordinate reference system of the project." ) );
@@ -741,6 +741,12 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "project_crs_ellipsoid" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of the coordinate reference system of the project." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_crs_proj4" ), QCoreApplication::translate( "variable_help", "Proj4 definition of the coordinate reference system of the project." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_crs_wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system of the project." ) );
+
+  sVariableHelpTexts()->insert( QStringLiteral( "project_vertical_crs" ), QCoreApplication::translate( "variable_help", "Identifier for the vertical coordinate reference system of the project (e.g., 'EPSG:5703')." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "project_vertical_crs_definition" ), QCoreApplication::translate( "variable_help", "Vertical coordinate reference system of project (full definition)." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "project_vertical_crs_description" ), QCoreApplication::translate( "variable_help", "Name of the vertical coordinate reference system of the project." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "project_vertical_crs_wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the vertical coordinate reference system of the project." ) );
+
   sVariableHelpTexts()->insert( QStringLiteral( "project_author" ), QCoreApplication::translate( "variable_help", "Project author, taken from project metadata." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_abstract" ), QCoreApplication::translate( "variable_help", "Project abstract, taken from project metadata." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_creation_date" ), QCoreApplication::translate( "variable_help", "Project creation date, taken from project metadata." ) );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -2700,17 +2700,25 @@ QgsExpressionContextScope *QgsProject::createExpressionContextScope() const
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_basename" ), projectBasename, true, true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_home" ), QDir::toNativeSeparators( homePath() ), true, true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_last_saved" ), mSaveDateTime.isNull() ? QVariant() : QVariant( mSaveDateTime ), true, true ) );
+
   const QgsCoordinateReferenceSystem projectCrs = crs();
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs" ), projectCrs.authid(), true, true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_definition" ), projectCrs.toProj(), true, true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_description" ), projectCrs.description(), true, true ) );
-  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_ellipsoid" ), ellipsoid(), true, true ) );
-  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "_project_transform_context" ), QVariant::fromValue<QgsCoordinateTransformContext>( transformContext() ), true, true ) );
-  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_units" ), QgsUnitTypes::toString( projectCrs.mapUnits() ), true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_acronym" ), projectCrs.projectionAcronym(), true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_ellipsoid" ), projectCrs.ellipsoidAcronym(), true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_proj4" ), projectCrs.toProj(), true ) );
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_wkt" ), projectCrs.toWkt( Qgis::CrsWktVariant::Preferred ), true ) );
+
+  const QgsCoordinateReferenceSystem projectVerticalCrs = QgsProject::verticalCrs();
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_vertical_crs" ), projectVerticalCrs.authid(), true, true ) );
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_vertical_crs_definition" ), projectVerticalCrs.toProj(), true, true ) );
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_vertical_crs_description" ), projectVerticalCrs.description(), true, true ) );
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_vertical_crs_wkt" ), projectVerticalCrs.toWkt( Qgis::CrsWktVariant::Preferred ), true ) );
+
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_ellipsoid" ), ellipsoid(), true, true ) );
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "_project_transform_context" ), QVariant::fromValue<QgsCoordinateTransformContext>( transformContext() ), true, true ) );
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_units" ), QgsUnitTypes::toString( projectCrs.mapUnits() ), true ) );
 
   // metadata
   mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_author" ), metadata().author(), true, true ) );

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -370,6 +370,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Returns the project's native coordinate reference system.
      * \see setCrs()
+     * \see verticalCrs()
      * \see ellipsoid()
      */
     QgsCoordinateReferenceSystem crs() const;
@@ -380,6 +381,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * the ellipsoid imposed by the CRS.
      *
      * \see crs()
+     * \see setVerticalCrs()
      * \see setEllipsoid()
      */
     void setCrs( const QgsCoordinateReferenceSystem &crs, bool adjustEllipsoid = false );
@@ -398,6 +400,35 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     void setEllipsoid( const QString &ellipsoid );
 
+    /**
+     * Returns the project's vertical coordinate reference system.
+     *
+     * If the project crs() is a compound CRS, then the CRS returned will
+     * be the vertical component of crs(). Otherwise it will be the value
+     * explicitly set by a call to setVerticalCrs().
+     *
+     * The returned CRS will be invalid if the project has no vertical CRS.
+     *
+     * \see crs()
+     * \see setVerticalCrs()
+     *
+     * \since QGIS 3.38
+     */
+    QgsCoordinateReferenceSystem verticalCrs() const;
+
+    /**
+     * Sets the project's vertical coordinate reference system.
+     *
+     * \note If the project crs() is a compound CRS, then the CRS returned for
+     * verticalCrs() will be the vertical component of crs(). Otherwise it will be the value
+     * explicitly set by this call.
+     *
+     * \see verticalCrs()
+     * \see setCrs()
+     *
+     * \since QGIS 3.38
+     */
+    void setVerticalCrs( const QgsCoordinateReferenceSystem &crs );
 
     /**
      * Returns a copy of the project's coordinate transform context, which stores various
@@ -1772,8 +1803,19 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Emitted when the CRS of the project has changed.
      *
+     * \see verticalCrsChanged()
      */
     void crsChanged();
+
+    /**
+     * Emitted when the CRS of the project has changed.
+     *
+     * \see crsChanged()
+     * \see verticalCrs()
+     *
+     * \since QGIS 3.38
+     */
+    void verticalCrsChanged();
 
     /**
      * Emitted when the project \a ellipsoid is changed.
@@ -2334,6 +2376,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     Qgis::ProjectFlags mFlags;
     QgsCoordinateReferenceSystem mCrs;
+    QgsCoordinateReferenceSystem mVerticalCrs;
     bool mDirty = false;                 // project has been modified since it has been read or saved
     int mDirtyBlockCount = 0;
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -423,12 +423,17 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * verticalCrs() will be the vertical component of crs(). Otherwise it will be the value
      * explicitly set by this call.
      *
+     * \param crs the vertical CRS
+     * \param errorMessage will be set to a descriptive message if the vertical CRS could not be set
+     *
+     * \returns TRUE if vertical CRS was successfully set
+     *
      * \see verticalCrs()
      * \see setCrs()
      *
      * \since QGIS 3.38
      */
-    void setVerticalCrs( const QgsCoordinateReferenceSystem &crs );
+    bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage SIP_OUT = nullptr );
 
     /**
      * Returns a copy of the project's coordinate transform context, which stores various

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -369,18 +369,25 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     /**
      * Returns the project's native coordinate reference system.
+     *
      * \see setCrs()
      * \see verticalCrs()
      * \see ellipsoid()
+     * \see crsChanged()
      */
     QgsCoordinateReferenceSystem crs() const;
 
     /**
      * Sets the project's native coordinate reference system.
-     * If \a adjustEllipsoid is set to TRUE, the ellpsoid of this project will be set to
+     *
+     * If \a adjustEllipsoid is set to TRUE, the ellipsoid of this project will be set to
      * the ellipsoid imposed by the CRS.
      *
+     * Changing the CRS will trigger a crsChanged() signal. Additionally, if \a crs is a compound
+     * CRS, then the verticalCrsChanged() signal will also be emitted.
+     *
      * \see crs()
+     * \see crsChanged()
      * \see setVerticalCrs()
      * \see setEllipsoid()
      */
@@ -388,15 +395,19 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     /**
      * Returns a proj string representing the project's ellipsoid setting, e.g., "WGS84".
+     *
      * \see setEllipsoid()
      * \see crs()
+     * \see verticalCrs()
      */
     QString ellipsoid() const;
 
     /**
-     * Sets the project's ellipsoid from a proj string representation, e.g., "WGS84".
+     * Sets the project's \a ellipsoid from a proj string representation, e.g., "WGS84".
+     *
      * \see ellipsoid()
      * \see setCrs()
+     * \see setVerticalCrs()
      */
     void setEllipsoid( const QString &ellipsoid );
 
@@ -418,6 +429,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     /**
      * Sets the project's vertical coordinate reference system.
+     *
+     * The verticalCrsChanged() signal will be raised if the vertical CRS is changed.
      *
      * \note If the project crs() is a compound CRS, then the CRS returned for
      * verticalCrs() will be the vertical component of crs(). Otherwise it will be the value
@@ -1808,14 +1821,23 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Emitted when the CRS of the project has changed.
      *
+     * \see crs()
+     * \see setCrs()
      * \see verticalCrsChanged()
+     * \see ellipsoidChanged()
      */
     void crsChanged();
 
     /**
-     * Emitted when the CRS of the project has changed.
+     * Emitted when the vertical CRS of the project has changed.
+     *
+     * This signal will be emitted whenever the vertical CRS of the project is changed, either
+     * as a direct result of a call to setVerticalCrs() or when setCrs() is called with a compound
+     * CRS.
      *
      * \see crsChanged()
+     * \see setCrs()
+     * \see setVerticalCrs()
      * \see verticalCrs()
      *
      * \since QGIS 3.38

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -2394,6 +2394,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     mutable std::unique_ptr< QgsExpressionContextScope > mProjectScope;
 
+    bool mBlockChangeSignalsDuringClear = false;
     int mBlockSnappingUpdates = 0;
 
     QgsElevationShadingRenderer mElevationShadingRenderer;

--- a/src/ui/qgsprojectelevationsettingswidgetbase.ui
+++ b/src/ui/qgsprojectelevationsettingswidgetbase.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Project Elevation Settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,1">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -28,6 +28,141 @@
    </property>
    <item>
     <widget class="QgsMessageBar" name="mMessageBar" native="true"/>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Vertical Reference System</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QgsStackedWidget" name="mVerticalCrsStackedWidget">
+        <widget class="QWidget" name="mCrsPageDisabled">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="mCrsDisabledLabel">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="mCrsPageEnabled"/>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="mElevationRangeCheckBox">
+     <property name="title">
+      <string>Elevation Range</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="syncGroup" stdset="0">
+      <string notr="true">composeritem</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6" columnstretch="1,2">
+      <item row="2" column="1">
+       <widget class="QgsDoubleSpinBox" name="mElevationUpperSpin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Maximum elevation of interest</string>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="minimum">
+         <double>-9999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsDoubleSpinBox" name="mElevationLowerSpin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Minimum elevation of interest</string>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="minimum">
+         <double>-9999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="mEndDateTimeLabel_2">
+        <property name="text">
+         <string>Upper</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mStartDateTimeLabel_2">
+        <property name="text">
+         <string>Lower</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>When set, these heights define the upper and lower elevation limits for the area of interest in this project.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox">
@@ -197,101 +332,6 @@
           </item>
          </layout>
         </widget>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="mElevationRangeCheckBox">
-     <property name="title">
-      <string>Elevation Range</string>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <property name="collapsed" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="syncGroup" stdset="0">
-      <string notr="true">composeritem</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_6" columnstretch="1,2">
-      <item row="2" column="1">
-       <widget class="QgsDoubleSpinBox" name="mElevationUpperSpin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Maximum elevation of interest</string>
-        </property>
-        <property name="decimals">
-         <number>4</number>
-        </property>
-        <property name="minimum">
-         <double>-9999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>9999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsDoubleSpinBox" name="mElevationLowerSpin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Minimum elevation of interest</string>
-        </property>
-        <property name="decimals">
-         <number>4</number>
-        </property>
-        <property name="minimum">
-         <double>-9999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>9999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="mEndDateTimeLabel_2">
-        <property name="text">
-         <string>Upper</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="mStartDateTimeLabel_2">
-        <property name="text">
-         <string>Lower</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>When set, these heights define the upper and lower elevation limits for the area of interest in this project.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
        </widget>
       </item>
      </layout>

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -171,6 +171,16 @@ class TestQgsProject(QgisTestCase):
         project.setVerticalCrs(QgsCoordinateReferenceSystem('EPSG:5703'))
         self.assertEqual(len(spy), 1)
 
+        # check that project vertical crs variables are set in expression context
+        project_scope = project.createExpressionContextScope()
+        self.assertEqual(project_scope.variable('project_vertical_crs'), 'EPSG:5703')
+        self.assertIn('vunits=m',
+                      project_scope.variable('project_vertical_crs_definition'), '')
+        self.assertEqual(
+            project_scope.variable('project_vertical_crs_description'), 'NAVD88 height')
+        self.assertIn('VERTCRS',
+                      project_scope.variable('project_vertical_crs_wkt'), '')
+
         # check that vertical crs is saved/restored
         # Tests whether the home paths of a GPKG stored project returns the GPKG folder.
         with TemporaryDirectory() as d:

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -179,12 +179,10 @@ class TestQgsProject(QgisTestCase):
             spy2 = QSignalSpy(project2.verticalCrsChanged)
             project2.read(os.path.join(d, 'test_vertcrs.qgs'))
             self.assertEqual(project2.verticalCrs().authid(), 'EPSG:5703')
-            # todo -- should be 1!
-            self.assertEqual(len(spy2), 2)
+            self.assertEqual(len(spy2), 1)
             project2.read(os.path.join(d, 'test_vertcrs.qgs'))
             self.assertEqual(project2.verticalCrs().authid(), 'EPSG:5703')
-            # todo -- should STILL be 1!
-            self.assertEqual(len(spy2), 4)
+            self.assertEqual(len(spy2), 1)
 
         project.clear()
         self.assertEqual(len(spy), 2)


### PR DESCRIPTION
(refs https://github.com/qgis/QGIS-Enhancement-Proposals/issues/267)

If the project CRS is a compound CRS, then the vertical CRS for the project will be the vertical component of the main project CRS. Otherwise it will be the value explicitly set by the user. 

Users can specify the vertical crs through the Project Properties, Elevation tab:

Eg. when the project CRS is set to a compound crs, the user will see:

![image](https://github.com/qgis/QGIS/assets/1829991/7e5b6ff5-459e-4c1d-8c24-96814576fef6)

When the project CRS is a horizontal CRS, then the user can select a specific vertical CRS for their project:

![image](https://github.com/qgis/QGIS/assets/1829991/07747530-2608-4317-aba6-518aa7facf58)

Currently, this is a "metadata" type property only, and has no impact on rendering or handling of features. (It IS exposed through new `@project_vertical_crs_xxx` variables, though)
