### PR TITLE
Fix QgsSymbol::drawPreviewIcon (fix incorrect preview symbol opacity)

### DIFF
--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -943,7 +943,7 @@ void QgsSymbol::drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext
   const bool prevForceVector = context->forceVectorOutput();
   context->setForceVectorOutput( true );
 
-  const double opacity = expressionContext ? dataDefinedProperties().valueAsDouble( QgsSymbol::Property::Opacity, *expressionContext, mOpacity ) : mOpacity;
+  const double opacity = expressionContext ? dataDefinedProperties().valueAsDouble( QgsSymbol::Property::Opacity, *expressionContext, mOpacity * 100 ) * 0.01 : mOpacity;
 
   QgsSymbolRenderContext symbolContext( *context, Qgis::RenderUnit::Unknown, opacity, false, mRenderHints, nullptr );
   symbolContext.setSelected( selected );


### PR DESCRIPTION
## Description

This PR fixes the incorrect opacity of the preview symbol and various related `"QColor::setAlphaF": invalid value` Qt warning messages (in debug builds) when the Data Defined Override with a valid value is set for the Opacity parameter in the layer symbology by transforming the "Opacity" value calculated by the Data Defined Override expression from the [0-100] range to the [0-1] range.

P.S. after fixing this issue I also noticed that valueAsDouble returns the calculated value, instead of the default value, even if it is outside the 0-100 range declared for QgsSymbol::Property::Opacity (QgsPropertyDefinition::Opacity). Is it normal? If yes, then I think a check should be made to ensure the opacity symbol render context property is not set to the calculated value if it is outside the 0-1 range in QgsSymbol, QgsFillSymbol, QgsLineSymbol and QgsMarkerSymbol in order to avoid a bunch of `"QColor::setAlphaF": invalid value` errors and avoid rendering slowdown.
~~EDIT: I've added a commit to also address such issue.~~

Before:

https://github.com/qgis/QGIS/assets/16253859/b3d82a26-f320-457c-8f27-abb304cc78fa

After:

https://github.com/qgis/QGIS/assets/16253859/96c193a5-4284-435e-8756-5e4345d330fc


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
