### PR TITLE
[postgres] Get rid of 'nextval(NULL)' in default value clauses

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1390,7 +1390,7 @@ bool QgsPostgresProvider::loadFields()
                              .arg( quotedValue( mQuery ) )
                              .arg( quotedValue( fieldName ) );
       QgsPostgresResult seqResult( connectionRO()->PQexec( seqSql ) );
-      if ( seqResult.PQntuples() == 1 && !QgsVariantUtils::isNull( seqResult.PQgetvalue( 0, 0 ) ) )
+      if ( seqResult.PQntuples() == 1 && !seqResult.PQgetisnull( 0, 0 ) )
       {
         defValMap[tableoid][attnum] = QStringLiteral( "nextval(%1)" ).arg( quotedValue( seqResult.PQgetvalue( 0, 0 ) ) );
       }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1390,7 +1390,7 @@ bool QgsPostgresProvider::loadFields()
                              .arg( quotedValue( mQuery ) )
                              .arg( quotedValue( fieldName ) );
       QgsPostgresResult seqResult( connectionRO()->PQexec( seqSql ) );
-      if ( seqResult.PQntuples() == 1 )
+      if ( seqResult.PQntuples() == 1 && !QgsVariantUtils::isNull( seqResult.PQgetvalue( 0, 0 ) ) )
       {
         defValMap[tableoid][attnum] = QStringLiteral( "nextval(%1)" ).arg( quotedValue( seqResult.PQgetvalue( 0, 0 ) ) );
       }

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2707,6 +2707,40 @@ class TestPyQgsPostgresProvider(QgisTestCase, ProviderTestCase):
         self.assertEqual(feature.attribute(4), 123)
         self.assertEqual(feature.attribute(5), 'My default')
 
+    def testNoDefaultValueClauseForPKWithNoDefaultValue(self):
+        """Test issue GH #54058"""
+
+        self.execSQLCommand(
+            'ALTER TABLE IF EXISTS qgis_test."gh_54058" DROP CONSTRAINT IF EXISTS pk_gh_54058;')
+        self.execSQLCommand(
+            'DROP TABLE IF EXISTS qgis_test."gh_54058" CASCADE;')
+        self.execSQLCommand(
+            'CREATE TABLE qgis_test."gh_54058" ( "T_Id" integer NOT NULL, name text );')
+        self.execSQLCommand(
+            'ALTER TABLE qgis_test."gh_54058" ADD CONSTRAINT pk_gh_54058 PRIMARY KEY ("T_Id");')
+
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'id\' table="qgis_test"."gh_54058" () sql=', 'gh_54058', 'postgres')
+        self.assertTrue(vl.isValid())
+
+        dp = vl.dataProvider()
+        self.assertEqual(dp.defaultValueClause(0), '')  # Not nextVal(NULL) anymore!
+
+    def testNoDefaultValueClauseForUniqueNotNullFieldWithNoDefaultValue(self):
+        """Test issue GH #54058b"""
+
+        self.execSQLCommand(
+            'DROP TABLE IF EXISTS qgis_test."gh_54058b" CASCADE;')
+        self.execSQLCommand(
+            'CREATE TABLE qgis_test."gh_54058b" ( "T_Id" integer NOT NULL, name varchar(8) UNIQUE, codigo integer NOT NULL UNIQUE);')
+
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'id\' table="qgis_test"."gh_54058b" () sql=', 'gh_54058b', 'postgres')
+        self.assertTrue(vl.isValid())
+
+        dp = vl.dataProvider()
+        self.assertEqual(dp.defaultValueClause(0), '')  # The issue didn't occur here
+        self.assertEqual(dp.defaultValueClause(1), '')  # The issue didn't occur here
+        self.assertEqual(dp.defaultValueClause(2), '')  # Not nextVal(NULL) anymore!
+
     def testEncodeDecodeUri(self):
         """Test PG encode/decode URI"""
 


### PR DESCRIPTION
AKA, avoid setting `nextval()` clause if no default sequence was found.

Fix #54058 

----------------
cc @elpaso 