### PR TITLE
Fix splitting when snapping to segment is used

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -710,6 +710,17 @@ these error conditions.  (Or maybe we add another method to this
 object to help make the distinction?)
 %End
 
+    bool addTopologicalPoint( const QgsPoint &point, double snappingTolerance = 1e-7, double segmentSearchEpsilon = 1e-12 );
+%Docstring
+Adds a vertex to the segment which intersect ``point`` but don't
+already have a vertex there. Closest segment is identified using ``segmentSearchEpsilon``.
+If a vertex already exists within ``snappingTolearnceDistance``, no additional vertex is inserted.
+
+:return: ``True`` if point was added, ``False`` otherwise
+
+.. versionadded:: 3.38
+%End
+
     bool moveVertex( double x, double y, int atVertex );
 %Docstring
 Moves the vertex at the given position number

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -710,6 +710,17 @@ these error conditions.  (Or maybe we add another method to this
 object to help make the distinction?)
 %End
 
+    bool addTopologicalPoint( const QgsPoint &point, double snappingTolerance = 1e-7, double segmentSearchEpsilon = 1e-12 );
+%Docstring
+Adds a vertex to the segment which intersect ``point`` but don't
+already have a vertex there. Closest segment is identified using ``segmentSearchEpsilon``.
+If a vertex already exists within ``snappingTolearnceDistance``, no additional vertex is inserted.
+
+:return: ``True`` if point was added, ``False`` otherwise
+
+.. versionadded:: 3.38
+%End
+
     bool moveVertex( double x, double y, int atVertex );
 %Docstring
 Moves the vertex at the given position number

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -789,6 +789,15 @@ class CORE_EXPORT QgsGeometry
     bool insertVertex( const QgsPoint &point, int beforeVertex );
 
     /**
+     * Adds a vertex to the segment which intersect \a point but don't
+     * already have a vertex there. Closest segment is identified using \a segmentSearchEpsilon.
+     * If a vertex already exists within \a snappingTolearnceDistance, no additional vertex is inserted.
+     * \returns TRUE if point was added, FALSE otherwise
+     * \since QGIS 3.38
+     */
+    bool addTopologicalPoint( const QgsPoint &point, double snappingTolerance = 1e-7, double segmentSearchEpsilon = 1e-12 );
+
+    /**
      * Moves the vertex at the given position number
      * and item (first number is index 0)
      * to the given coordinates.


### PR DESCRIPTION
## Description
Splitting would very often fail when using _snap to segment_ due to numerical stability.

With the proposed solution, we attempt to add the split line's points as _topological points_ to the geometry before attempting the split, making sure that there are vertices at all the locations where _snap to segment_ was used.

Fixes #29270

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
