### PR TITLE
[api] Add handling for compound crs in a few more places

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1087,6 +1087,19 @@ May return an invalid CRS if the geographic CRS could not be determined.
 .. versionadded:: 3.24
 %End
 
+    QgsCoordinateReferenceSystem horizontalCrs() const;
+%Docstring
+Returns the horizontal CRS associated with this CRS object.
+
+In the case of a compound CRS, this method will return just the horizontal CRS component.
+
+An invalid CRS will be returned if the object does not contain a horizontal component.
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. versionadded:: 3.38
+%End
+
     QgsCoordinateReferenceSystem verticalCrs() const;
 %Docstring
 Returns the vertical CRS associated with this CRS object.
@@ -1094,6 +1107,8 @@ Returns the vertical CRS associated with this CRS object.
 In the case of a compound CRS, this method will return just the vertical CRS component.
 
 An invalid CRS will be returned if the object does not contain a vertical component.
+
+.. seealso:: :py:func:`horizontalCrs`
 
 .. versionadded:: 3.38
 %End

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1087,6 +1087,19 @@ May return an invalid CRS if the geographic CRS could not be determined.
 .. versionadded:: 3.24
 %End
 
+    QgsCoordinateReferenceSystem horizontalCrs() const;
+%Docstring
+Returns the horizontal CRS associated with this CRS object.
+
+In the case of a compound CRS, this method will return just the horizontal CRS component.
+
+An invalid CRS will be returned if the object does not contain a horizontal component.
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. versionadded:: 3.38
+%End
+
     QgsCoordinateReferenceSystem verticalCrs() const;
 %Docstring
 Returns the vertical CRS associated with this CRS object.
@@ -1094,6 +1107,8 @@ Returns the vertical CRS associated with this CRS object.
 In the case of a compound CRS, this method will return just the vertical CRS component.
 
 An invalid CRS will be returned if the object does not contain a vertical component.
+
+.. seealso:: :py:func:`horizontalCrs`
 
 .. versionadded:: 3.38
 %End

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2330,7 +2330,13 @@ bool testIsGeographic( PJ *crs )
 {
   PJ_CONTEXT *pjContext = QgsProjContext::get();
   bool isGeographic = false;
-  QgsProjUtils::proj_pj_unique_ptr coordinateSystem( proj_crs_get_coordinate_system( pjContext, crs ) );
+
+  // check horizontal CRS units
+  QgsProjUtils::proj_pj_unique_ptr horizontalCrs( QgsProjUtils::crsToHorizontalCrs( crs ) );
+  if ( !horizontalCrs )
+    return false;
+
+  QgsProjUtils::proj_pj_unique_ptr coordinateSystem( proj_crs_get_coordinate_system( pjContext, horizontalCrs.get() ) );
   if ( coordinateSystem )
   {
     const int axisCount = proj_cs_get_axis_count( pjContext, coordinateSystem.get() );

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2974,6 +2974,39 @@ QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::toGeographicCrs() con
   }
 }
 
+QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::horizontalCrs() const
+{
+  switch ( type() )
+  {
+    case Qgis::CrsType::Unknown:
+    case Qgis::CrsType::Geodetic:
+    case Qgis::CrsType::Geocentric:
+    case Qgis::CrsType::Geographic2d:
+    case Qgis::CrsType::Projected:
+    case Qgis::CrsType::Temporal:
+    case Qgis::CrsType::Engineering:
+    case Qgis::CrsType::Bound:
+    case Qgis::CrsType::Other:
+    case Qgis::CrsType::DerivedProjected:
+    case Qgis::CrsType::Geographic3d:
+      return *this;
+
+    case Qgis::CrsType::Vertical:
+      return QgsCoordinateReferenceSystem();
+
+    case Qgis::CrsType::Compound:
+      break;
+  }
+
+  if ( PJ *obj = d->threadLocalProjObject() )
+  {
+    QgsProjUtils::proj_pj_unique_ptr hozCrs = QgsProjUtils::crsToHorizontalCrs( obj );
+    if ( hozCrs )
+      return QgsCoordinateReferenceSystem::fromProjObject( hozCrs.get() );
+  }
+  return QgsCoordinateReferenceSystem();
+}
+
 QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::verticalCrs() const
 {
   switch ( type() )

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -993,12 +993,25 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     QgsCoordinateReferenceSystem toGeographicCrs() const;
 
     /**
+     * Returns the horizontal CRS associated with this CRS object.
+     *
+     * In the case of a compound CRS, this method will return just the horizontal CRS component.
+     *
+     * An invalid CRS will be returned if the object does not contain a horizontal component.
+     *
+     * \see verticalCrs()
+     * \since QGIS 3.38
+     */
+    QgsCoordinateReferenceSystem horizontalCrs() const;
+
+    /**
      * Returns the vertical CRS associated with this CRS object.
      *
      * In the case of a compound CRS, this method will return just the vertical CRS component.
      *
      * An invalid CRS will be returned if the object does not contain a vertical component.
      *
+     * \see horizontalCrs()
      * \since QGIS 3.38
      */
     QgsCoordinateReferenceSystem verticalCrs() const;

--- a/src/core/proj/qgscoordinatereferencesystemutils.cpp
+++ b/src/core/proj/qgscoordinatereferencesystemutils.cpp
@@ -19,7 +19,12 @@
 
 Qgis::CoordinateOrder QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( const QgsCoordinateReferenceSystem &crs )
 {
-  const QList< Qgis::CrsAxisDirection > axisList = crs.axisOrdering();
+  // crs may be a compound crs, so get just the horizontal component first
+  const QgsCoordinateReferenceSystem horizontalCrs = crs.horizontalCrs();
+  if ( !horizontalCrs.isValid() )
+    return Qgis::CoordinateOrder::XY;
+
+  const QList< Qgis::CrsAxisDirection > axisList = horizontalCrs.axisOrdering();
   if ( axisList.size() < 2 )
     return Qgis::CoordinateOrder::XY;
 

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -300,6 +300,13 @@ void TestQgsCoordinateReferenceSystem::verticalCrs()
   QVERIFY( crs.isValid() );
 
   QCOMPARE( crs.type(), Qgis::CrsType::Vertical );
+  QCOMPARE( crs.mapUnits(), Qgis::DistanceUnit::Meters );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:6358" ) );
+  QVERIFY( crs.isValid() );
+
+  QCOMPARE( crs.type(), Qgis::CrsType::Vertical );
+  QCOMPARE( crs.mapUnits(), Qgis::DistanceUnit::Feet );
 }
 
 void TestQgsCoordinateReferenceSystem::projectedCrs()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -49,6 +49,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void projectedCrs();
     void geocentricCrs();
     void geographic3d();
+    void toHorizontal();
     void toVertical();
     void coordinateEpoch();
     void createCompound();
@@ -315,6 +316,20 @@ void TestQgsCoordinateReferenceSystem::geographic3d()
   crs.createFromString( QStringLiteral( "EPSG:4979" ) );
   QVERIFY( crs.isValid() );
   QCOMPARE( crs.type(), Qgis::CrsType::Geographic3d );
+}
+
+void TestQgsCoordinateReferenceSystem::toHorizontal()
+{
+  // invalid
+  QVERIFY( !QgsCoordinateReferenceSystem().horizontalCrs().isValid() );
+  // vertical only
+  QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ).horizontalCrs().isValid() );
+  // compound
+  QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ).horizontalCrs().authid(), QStringLiteral( "EPSG:4759" ) );
+  // already horizontal
+  QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ).horizontalCrs().authid(), QStringLiteral( "EPSG:3111" ) );
+  // geographic 3d
+  QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4979" ) ).horizontalCrs().authid(), QStringLiteral( "EPSG:4979" ) );
 }
 
 void TestQgsCoordinateReferenceSystem::toVertical()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -280,6 +280,14 @@ void TestQgsCoordinateReferenceSystem::compoundCrs()
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) );
   QVERIFY( crs.isValid() );
   QCOMPARE( crs.type(), Qgis::CrsType::Compound );
+  QVERIFY( crs.isGeographic() );
+  QCOMPARE( crs.mapUnits(), Qgis::DistanceUnit::Degrees );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:9388" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.type(), Qgis::CrsType::Compound );
+  QVERIFY( !crs.isGeographic() );
+  QCOMPARE( crs.mapUnits(), Qgis::DistanceUnit::Meters );
 }
 
 void TestQgsCoordinateReferenceSystem::verticalCrs()

--- a/tests/src/python/test_qgscoordinatereferencesystemutils.py
+++ b/tests/src/python/test_qgscoordinatereferencesystemutils.py
@@ -30,6 +30,16 @@ class TestQgsCoordinateReferenceSystemUtils(QgisTestCase):
         self.assertEqual(QgsCoordinateReferenceSystemUtils.defaultCoordinateOrderForCrs(QgsCoordinateReferenceSystem()), Qgis.CoordinateOrder.XY)
         self.assertEqual(QgsCoordinateReferenceSystemUtils.defaultCoordinateOrderForCrs(QgsCoordinateReferenceSystem('EPSG:3111')), Qgis.CoordinateOrder.XY)
         self.assertEqual(QgsCoordinateReferenceSystemUtils.defaultCoordinateOrderForCrs(QgsCoordinateReferenceSystem('EPSG:4326')), Qgis.CoordinateOrder.YX)
+        # compound crs
+        self.assertEqual(
+            QgsCoordinateReferenceSystemUtils.defaultCoordinateOrderForCrs(
+                QgsCoordinateReferenceSystem('EPSG:5500')),
+            Qgis.CoordinateOrder.YX)
+        # vertical crs, should be no error here and just return the default
+        self.assertEqual(
+            QgsCoordinateReferenceSystemUtils.defaultCoordinateOrderForCrs(
+                QgsCoordinateReferenceSystem('EPSG:5703')),
+            Qgis.CoordinateOrder.XY)
 
     def test_axis_direction_to_abbreviation(self):
         """


### PR DESCRIPTION
Notably this avoids a lot of console warnings "proj_crs_get_coordinate_system: Object is not a SingleCRS"