### PR TITLE
Ensure that canvas z range is respected when identifying raster layers

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsidentifycontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsidentifycontext.sip.in
@@ -50,6 +50,27 @@ Returns the datetime range to be used with the identify action.
 Returns ``True`` if the temporal range setting is enabled.
 %End
 
+    QgsDoubleRange zRange() const;
+%Docstring
+Returns the range of z-values to identify within, or an infinite range if no filtering by
+z should be applied.
+
+.. seealso:: :py:func:`setZRange`
+
+.. versionadded:: 3.38
+%End
+
+    void setZRange( const QgsDoubleRange &range );
+%Docstring
+Sets the ``range`` of z-values to identify within.
+
+Set to an infinite range if no filtering by z should be applied.
+
+.. seealso:: :py:func:`zRange`
+
+.. versionadded:: 3.38
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterlayerelevationproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterlayerelevationproperties.sip.in
@@ -75,6 +75,15 @@ Sets the ``band`` number from which the elevation should be taken.
 .. seealso:: :py:func:`bandNumber`
 %End
 
+    double elevationForPixelValue( int band, double pixelValue ) const;
+%Docstring
+Returns the elevation corresponding to a raw pixel value from the specified ``band``.
+
+Returns NaN if the pixel value does not correspond to an elevation value.
+
+.. versionadded:: 3.38
+%End
+
     QgsLineSymbol *profileLineSymbol() const;
 %Docstring
 Returns the line symbol used to render the raster profile in elevation profile plots.

--- a/python/core/auto_generated/qgsidentifycontext.sip.in
+++ b/python/core/auto_generated/qgsidentifycontext.sip.in
@@ -50,6 +50,27 @@ Returns the datetime range to be used with the identify action.
 Returns ``True`` if the temporal range setting is enabled.
 %End
 
+    QgsDoubleRange zRange() const;
+%Docstring
+Returns the range of z-values to identify within, or an infinite range if no filtering by
+z should be applied.
+
+.. seealso:: :py:func:`setZRange`
+
+.. versionadded:: 3.38
+%End
+
+    void setZRange( const QgsDoubleRange &range );
+%Docstring
+Sets the ``range`` of z-values to identify within.
+
+Set to an infinite range if no filtering by z should be applied.
+
+.. seealso:: :py:func:`zRange`
+
+.. versionadded:: 3.38
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/raster/qgsrasterlayerelevationproperties.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayerelevationproperties.sip.in
@@ -75,6 +75,15 @@ Sets the ``band`` number from which the elevation should be taken.
 .. seealso:: :py:func:`bandNumber`
 %End
 
+    double elevationForPixelValue( int band, double pixelValue ) const;
+%Docstring
+Returns the elevation corresponding to a raw pixel value from the specified ``band``.
+
+Returns NaN if the pixel value does not correspond to an elevation value.
+
+.. versionadded:: 3.38
+%End
+
     QgsLineSymbol *profileLineSymbol() const;
 %Docstring
 Returns the line symbol used to render the raster profile in elevation profile plots.

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -132,6 +132,7 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
   QgsIdentifyContext identifyContext;
   if ( mCanvas->mapSettings().isTemporal() )
     identifyContext.setTemporalRange( mCanvas->temporalRange() );
+  identifyContext.setZRange( mCanvas->zRange() );
   const QList<IdentifyResult> results = QgsMapToolIdentify::identify( geometry, mode, layerList, AllLayers, identifyContext );
 
   disconnect( this, &QgsMapToolIdentifyAction::identifyMessage, QgisApp::instance(), &QgisApp::showStatusMessage );

--- a/src/core/qgsidentifycontext.cpp
+++ b/src/core/qgsidentifycontext.cpp
@@ -30,3 +30,13 @@ bool QgsIdentifyContext::isTemporal() const
 {
   return mTemporalRange.begin().isValid() || mTemporalRange.end().isValid();
 }
+
+QgsDoubleRange QgsIdentifyContext::zRange() const
+{
+  return mZRange;
+}
+
+void QgsIdentifyContext::setZRange( const QgsDoubleRange &range )
+{
+  mZRange = range;
+}

--- a/src/core/qgsidentifycontext.h
+++ b/src/core/qgsidentifycontext.h
@@ -56,9 +56,29 @@ class CORE_EXPORT QgsIdentifyContext
     */
     bool isTemporal() const;
 
+    /**
+     * Returns the range of z-values to identify within, or an infinite range if no filtering by
+     * z should be applied.
+     *
+     * \see setZRange()
+     * \since QGIS 3.38
+     */
+    QgsDoubleRange zRange() const;
+
+    /**
+     * Sets the \a range of z-values to identify within.
+     *
+     * Set to an infinite range if no filtering by z should be applied.
+     *
+     * \see zRange()
+     * \since QGIS 3.38
+     */
+    void setZRange( const QgsDoubleRange &range );
+
   private:
 
     QgsDateTimeRange mTemporalRange;
+    QgsDoubleRange mZRange;
 
 };
 

--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -150,6 +150,17 @@ void QgsRasterLayerElevationProperties::setBandNumber( int band )
   emit profileGenerationPropertyChanged();
 }
 
+double QgsRasterLayerElevationProperties::elevationForPixelValue( int band, double pixelValue ) const
+{
+  if ( !mEnabled )
+    return std::numeric_limits< double >::quiet_NaN();
+
+  if ( band != mBandNumber )
+    return std::numeric_limits< double >::quiet_NaN();
+
+  return pixelValue * mZScale + mZOffset;
+}
+
 QgsLineSymbol *QgsRasterLayerElevationProperties::profileLineSymbol() const
 {
   return mProfileLineSymbol.get();

--- a/src/core/raster/qgsrasterlayerelevationproperties.h
+++ b/src/core/raster/qgsrasterlayerelevationproperties.h
@@ -84,6 +84,15 @@ class CORE_EXPORT QgsRasterLayerElevationProperties : public QgsMapLayerElevatio
     void setBandNumber( int band );
 
     /**
+     * Returns the elevation corresponding to a raw pixel value from the specified \a band.
+     *
+     * Returns NaN if the pixel value does not correspond to an elevation value.
+     *
+     * \since QGIS 3.38
+     */
+    double elevationForPixelValue( int band, double pixelValue ) const;
+
+    /**
      * Returns the line symbol used to render the raster profile in elevation profile plots.
      *
      * \see setProfileLineSymbol()

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -531,11 +531,18 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
 
 bool QgsMapToolIdentify::identifyPointCloudLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsPointCloudLayer *layer, const QgsGeometry &geometry, const QgsIdentifyContext &identifyContext )
 {
-  Q_UNUSED( identifyContext )
+  if ( !identifyContext.zRange().isInfinite() )
+  {
+    if ( !layer->elevationProperties()->isVisibleInZRange( identifyContext.zRange() ) )
+      return false;
+  }
+
   QgsPointCloudRenderer *renderer = layer->renderer();
 
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mCanvas->mapSettings() );
   context.setCoordinateTransform( QgsCoordinateTransform( layer->crs(), mCanvas->mapSettings().destinationCrs(), mCanvas->mapSettings().transformContext() ) );
+  if ( !identifyContext.zRange().isInfinite() )
+    context.setZRange( identifyContext.zRange() );
 
   const double searchRadiusMapUnits = mOverrideCanvasSearchRadius < 0 ? searchRadiusMU( mCanvas ) : mOverrideCanvasSearchRadius;
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -213,30 +213,51 @@ bool QgsMapToolIdentify::identifyLayer( QList<IdentifyResult> *results, QgsMapLa
 
 bool QgsMapToolIdentify::identifyLayer( QList<IdentifyResult> *results, QgsMapLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType, const QgsIdentifyContext &identifyContext )
 {
-  if ( layer->type() == Qgis::LayerType::Raster && layerType.testFlag( RasterLayer ) )
+  switch ( layer->type() )
   {
-    return identifyRasterLayer( results, qobject_cast<QgsRasterLayer *>( layer ), geometry, viewExtent, mapUnitsPerPixel, identifyContext );
+    case Qgis::LayerType::Vector:
+      if ( layerType.testFlag( VectorLayer ) )
+      {
+        return identifyVectorLayer( results, qobject_cast<QgsVectorLayer *>( layer ), geometry, identifyContext );
+      }
+      break;
+
+    case Qgis::LayerType::Raster:
+      if ( layerType.testFlag( RasterLayer ) )
+      {
+        return identifyRasterLayer( results, qobject_cast<QgsRasterLayer *>( layer ), geometry, viewExtent, mapUnitsPerPixel, identifyContext );
+      }
+      break;
+
+    case Qgis::LayerType::Mesh:
+      if ( layerType.testFlag( MeshLayer ) )
+      {
+        return identifyMeshLayer( results, qobject_cast<QgsMeshLayer *>( layer ), geometry, identifyContext );
+      }
+      break;
+
+    case Qgis::LayerType::VectorTile:
+      if ( layerType.testFlag( VectorTileLayer ) )
+      {
+        return identifyVectorTileLayer( results, qobject_cast<QgsVectorTileLayer *>( layer ), geometry, identifyContext );
+      }
+      break;
+
+    case Qgis::LayerType::PointCloud:
+      if ( layerType.testFlag( PointCloudLayer ) )
+      {
+        return identifyPointCloudLayer( results, qobject_cast<QgsPointCloudLayer *>( layer ), geometry, identifyContext );
+      }
+      break;
+
+    // not supported
+    case Qgis::LayerType::Plugin:
+    case Qgis::LayerType::Annotation:
+    case Qgis::LayerType::Group:
+    case Qgis::LayerType::TiledScene:
+      break;
   }
-  else if ( layer->type() == Qgis::LayerType::Vector && layerType.testFlag( VectorLayer ) )
-  {
-    return identifyVectorLayer( results, qobject_cast<QgsVectorLayer *>( layer ), geometry, identifyContext );
-  }
-  else if ( layer->type() == Qgis::LayerType::Mesh && layerType.testFlag( MeshLayer ) )
-  {
-    return identifyMeshLayer( results, qobject_cast<QgsMeshLayer *>( layer ), geometry, identifyContext );
-  }
-  else if ( layer->type() == Qgis::LayerType::VectorTile && layerType.testFlag( VectorTileLayer ) )
-  {
-    return identifyVectorTileLayer( results, qobject_cast<QgsVectorTileLayer *>( layer ), geometry, identifyContext );
-  }
-  else if ( layer->type() == Qgis::LayerType::PointCloud && layerType.testFlag( PointCloudLayer ) )
-  {
-    return identifyPointCloudLayer( results, qobject_cast<QgsPointCloudLayer *>( layer ), geometry, identifyContext );
-  }
-  else
-  {
-    return false;
-  }
+  return false;
 }
 
 bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point, const QgsIdentifyContext &identifyContext )

--- a/tests/src/python/test_qgsrasterlayerelevationproperties.py
+++ b/tests/src/python/test_qgsrasterlayerelevationproperties.py
@@ -10,6 +10,7 @@ __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
+import math
 
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
@@ -120,6 +121,28 @@ class TestQgsRasterLayerElevationProperties(QgisTestCase):
         layer.setName('i am a aster satellite layer')
         self.assertTrue(
             QgsRasterLayerElevationProperties.layerLooksLikeDem(layer))
+
+    def test_elevation_for_pixel_value(self):
+        """
+        Test transforming pixel values to elevations
+        """
+        props = QgsRasterLayerElevationProperties(None)
+        self.assertTrue(math.isnan(props.elevationForPixelValue(band=1, pixelValue=3)))
+        props.setEnabled(True)
+        self.assertEqual(props.elevationForPixelValue(band=1, pixelValue=3),
+                         3)
+
+        # check that band number is respected
+        props.setBandNumber(2)
+        self.assertTrue(math.isnan(props.elevationForPixelValue(band=1, pixelValue=3)))
+        self.assertEqual(props.elevationForPixelValue(band=2, pixelValue=3),
+                         3)
+
+        # check that offset/scale is respected
+        props.setZOffset(0.5)
+        props.setZScale(2)
+        self.assertEqual(props.elevationForPixelValue(band=2, pixelValue=3),
+                         6.5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This was already handled for point cloud layers, but I've made the API more generic and made sure it works for elevation enabled raster layer filtering too.