### PR TITLE
Fix merge features with hidden fields

### DIFF
--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -171,6 +171,9 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
     if ( setup.type() == QLatin1String( "Hidden" ) || setup.type() == QLatin1String( "Immutable" ) )
     {
       mHiddenAttributes.insert( idx );
+    }
+    if ( setup.type() == QLatin1String( "Immutable" ) )
+    {
       continue;
     }
 
@@ -182,12 +185,17 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
     mTableWidget->setHorizontalHeaderItem( col, item );
 
     QComboBox *cb = createMergeComboBox( mFields.at( idx ).type(), col );
-    if ( ! mVectorLayer->dataProvider()->pkAttributeIndexes().contains( mFields.fieldOriginIndex( idx ) ) &&
-         mFields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
+    if ( ( ! mVectorLayer->dataProvider()->pkAttributeIndexes().contains( mFields.fieldOriginIndex( idx ) ) &&
+           mFields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique ) || mHiddenAttributes.contains( idx ) )
     {
       cb->setCurrentIndex( cb->findData( "skip" ) );
     }
     mTableWidget->setCellWidget( 0, col, cb );
+
+    if ( mHiddenAttributes.contains( idx ) )
+    {
+      mTableWidget->setColumnHidden( idx, col );
+    }
 
     col++;
   }
@@ -768,13 +776,6 @@ QgsAttributes QgsMergeAttributesDialog::mergedAttributes() const
   QgsAttributes results( mFields.count() );
   for ( int fieldIdx = 0; fieldIdx < mFields.count(); ++fieldIdx )
   {
-    if ( mHiddenAttributes.contains( fieldIdx ) )
-    {
-      //hidden attribute, set to default value
-      results[fieldIdx] = QVariant();
-      continue;
-    }
-
     QComboBox *comboBox = qobject_cast<QComboBox *>( mTableWidget->cellWidget( 0, widgetIndex ) );
     if ( !comboBox )
       continue;

--- a/tests/src/app/testqgsmergeattributesdialog.cpp
+++ b/tests/src/app/testqgsmergeattributesdialog.cpp
@@ -150,6 +150,74 @@ class TestQgsMergeattributesDialog : public QgsTest
       QVERIFY( !dialog.mergedAttributes().at( 0 ).isValid() );
       QCOMPARE( dialog.mergedAttributes().at( 1 ), 22 );
     }
+
+    void testWithHiddenField()
+    {
+      // Create test layer
+      QgsVectorFileWriter::SaveVectorOptions options;
+      QgsVectorLayer ml( "LineString", "test", "memory" );
+      QVERIFY( ml.isValid() );
+
+      QgsField notHiddenField( QStringLiteral( "not_hidden" ), QVariant::Int );
+      QgsField hiddenField( QStringLiteral( "hidden" ), QVariant::Int );
+      // hide the field
+      ml.setEditorWidgetSetup( 1, QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() ) );
+      QVERIFY( ml.dataProvider()->addAttributes( { notHiddenField, hiddenField } ) );
+      ml.updateFields();
+
+      // Create features
+      QgsFeature f1( ml.fields(), 1 );
+      f1.setAttributes( QVector<QVariant>() << 1 << 2 );
+      f1.setGeometry( QgsGeometry::fromWkt( "LINESTRING(0 0, 10 0)" ) );
+      QVERIFY( ml.dataProvider()->addFeature( f1 ) );
+      QCOMPARE( ml.featureCount(), 1 );
+
+      QgsFeature f2( ml.fields(), 2 );
+      f2.setAttributes( QVector<QVariant>() << 3 << 4 );
+      f2.setGeometry( QgsGeometry::fromWkt( "LINESTRING(10 0, 15 0)" ) );
+      QVERIFY( ml.dataProvider()->addFeature( f2 ) );
+      QCOMPARE( ml.featureCount(), 2 );
+
+      // Merge the attributes together
+      QgsMergeAttributesDialog dialog( QgsFeatureList() << f1 << f2, &ml, mQgisApp->mapCanvas() );
+      QVERIFY( QMetaObject::invokeMethod( &dialog, "mFromLargestPushButton_clicked" ) );
+      QCOMPARE( dialog.mergedAttributes(), QgsAttributes() << 1 << 2 );
+    }
+
+    void testWithHiddenFieldDefaultsToEmpty()
+    {
+      // Create test layer
+      QgsVectorFileWriter::SaveVectorOptions options;
+      QgsVectorLayer ml( "LineString", "test", "memory" );
+      QVERIFY( ml.isValid() );
+
+      QgsField notHiddenField( QStringLiteral( "not_hidden" ), QVariant::Int );
+      QgsField hiddenField( QStringLiteral( "hidden" ), QVariant::Int );
+      QVERIFY( ml.dataProvider()->addAttributes( { notHiddenField, hiddenField } ) );
+      ml.updateFields();
+
+      // hide the field
+      ml.setEditorWidgetSetup( 1, QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() ) );
+
+
+      // Create features
+      QgsFeature f1( ml.fields(), 1 );
+      f1.setAttributes( QVector<QVariant>() << 1 << 2 );
+      f1.setGeometry( QgsGeometry::fromWkt( "LINESTRING(0 0, 10 0)" ) );
+      QVERIFY( ml.dataProvider()->addFeature( f1 ) );
+      QCOMPARE( ml.featureCount(), 1 );
+
+      QgsFeature f2( ml.fields(), 2 );
+      f2.setAttributes( QVector<QVariant>() << 3 << 4 );
+      f2.setGeometry( QgsGeometry::fromWkt( "LINESTRING(10 0, 15 0)" ) );
+      QVERIFY( ml.dataProvider()->addFeature( f2 ) );
+      QCOMPARE( ml.featureCount(), 2 );
+
+      // Merge the attributes together
+      QgsMergeAttributesDialog dialog( QgsFeatureList() << f1 << f2, &ml, mQgisApp->mapCanvas() );
+      // QVariant gets turned into default value while saving the layer
+      QCOMPARE( dialog.mergedAttributes(), QgsAttributes() << 1 << QVariant() );
+    }
 };
 
 QGSTEST_MAIN( TestQgsMergeattributesDialog )


### PR DESCRIPTION
## Description

Merge selected features tool won't merge correctly hidden attribute values. With this PR the tool will use for hidden fields the default value defined for field, or the value from the selected feature, if any is selected. 

Fixes #28253 
Backport needed for 3.34 and 3.36
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
