### PR TITLE
Browser: avoid calling slow functions on disconnected drives

### DIFF
--- a/src/core/browser/qgsdirectoryitem.cpp
+++ b/src/core/browser/qgsdirectoryitem.cpp
@@ -58,6 +58,10 @@ void QgsDirectoryItem::init( const QString &dirName )
 
   QgsSettings settings;
 
+  const QFileInfo fi { mDirPath };
+  mIsDir = fi.isDir();
+  mIsSymLink = fi.isSymLink();
+
   mMonitoring = monitoringForPath( mDirPath );
   switch ( mMonitoring )
   {
@@ -164,8 +168,7 @@ QIcon QgsDirectoryItem::icon()
     return QgsDataItem::icon();
 
   // symbolic link? use link icon
-  const QFileInfo fi( mDirPath );
-  if ( fi.isDir() && fi.isSymLink() )
+  if ( mIsDir && mIsSymLink )
   {
     return mIconColor.isValid()
            ? QgsApplication::getThemeIcon( QStringLiteral( "/mIconFolderLinkParams.svg" ), mIconColor, mIconColor.darker() )

--- a/src/core/browser/qgsdirectoryitem.h
+++ b/src/core/browser/qgsdirectoryitem.h
@@ -216,6 +216,9 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
     QDateTime mLastScan;
     QColor mIconColor;
 
+    bool mIsDir = false;
+    bool mIsSymLink = false;
+
     friend class TestQgsDataItem;
 };
 


### PR DESCRIPTION
This is an attempt to fix browser slowness when network drives becomes unavailable.

Some QDir/QFileInfo call may become slow when called on disconneced drives on windows, by calling them in the init method (which is called by a separate thread and when the drive is more likely to be available) the risk to call them when they can become slow is drastically reduced.

Whether this will help to reduce the browser slowness on all network drives scenarios it is hard to tell but it won't certainly hurt.

See: #51710

Funded by: QGIS user group Germany (QGIS Anwendergruppe Deutschland e.V.)