### PR TITLE
 [processing] Avoid non-spatial vector layers in DXF Export alg

### DIFF
--- a/src/core/processing/qgsprocessingparameterdxflayers.cpp
+++ b/src/core/processing/qgsprocessingparameterdxflayers.cpp
@@ -38,7 +38,7 @@ bool QgsProcessingParameterDxfLayers::checkValueIsAcceptable( const QVariant &in
     return mFlags & Qgis::ProcessingParameterFlag::Optional;
 
   QgsMapLayer *mapLayer = nullptr;
-  QgsVectorLayer *vectorLayer = qobject_cast< QgsVectorLayer * >( qvariant_cast<QObject *>( input ) );
+  QgsVectorLayer *vectorLayer = input.value<QgsVectorLayer *>();
   if ( vectorLayer )
   {
     return vectorLayer->isSpatial();
@@ -63,7 +63,7 @@ bool QgsProcessingParameterDxfLayers::checkValueIsAcceptable( const QVariant &in
     const QVariantList layerList = input.toList();
     for ( const QVariant &variantLayer : layerList )
     {
-      vectorLayer = qobject_cast< QgsVectorLayer * >( qvariant_cast<QObject *>( variantLayer ) );
+      vectorLayer = input.value<QgsVectorLayer *>();
       if ( vectorLayer )
       {
         if ( vectorLayer->isSpatial() )

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -93,7 +93,7 @@ QgsProcessingDxfLayersPanelWidget::QgsProcessingDxfLayersPanelWidget(
     seenVectorLayers.insert( layer.layer() );
   }
 
-  const QList<QgsVectorLayer *> options = QgsProcessingUtils::compatibleVectorLayers( project, QList< int >() );
+  const QList<QgsVectorLayer *> options = QgsProcessingUtils::compatibleVectorLayers( project, QList< int >() << static_cast<int>( Qgis::ProcessingSourceType::VectorAnyGeometry ) );
   for ( const QgsVectorLayer *layer : options )
   {
     if ( seenVectorLayers.contains( layer ) )


### PR DESCRIPTION


DXF export functionality doesn't accept non-spatial layers. However, this is the scenario nowadays:

  + DXF Export app dialog does not even show non-spatial layers, which is good!
  + DXF processing algorithm:
     + Shows non-spatial layers and allows users to configure them as valid inputs.
     + Fails at exporting non-spatial layers throwing a "DXF export failed, the extent could not be determined" error message.

To improve the DXF export algorithm behavior, this PR makes non-spatial layers non-acceptable input values for the DXF Export alg. As a result, users won't even have those layers listed in the algorithm dialog, which is cleaner, and in the case of big projects, highly desirable.

Some tests were added as well.

-----
Funded by the [QGIS user group Switzerland](https://qgis.ch/).