### PR TITLE
Browser: fix slow behavior with network drives on windows

### DIFF
--- a/src/core/browser/qgsdirectoryitem.cpp
+++ b/src/core/browser/qgsdirectoryitem.cpp
@@ -454,7 +454,9 @@ bool QgsDirectoryItem::pathShouldByMonitoredByDefault( const QString &path )
 
   // else if we know that the path is on a slow device, we don't monitor by default
   // as this can be very expensive and slow down QGIS
-  if ( QgsFileUtils::pathIsSlowDevice( path ) )
+  // Add trailing slash or windows API functions like GetDriveTypeW won't identify
+  // UNC network drives correctly
+  if ( QgsFileUtils::pathIsSlowDevice( path.endsWith( '/' ) ? path : path + '/' ) )
     return false;
 
   // paths are monitored by default if no explicit setting is in place, and the user hasn't


### PR DESCRIPTION
This fixes UNC paths not identified as network paths.

By ensuring that a trailing slash for directories is passed
down to the identify function.


It should help with #51710 to not monitor (by default) changes on network drives

Funded by QGIS user group Germany: (QGIS Anwendergruppe Deutschland e.V.)