### PR TITLE
Make avoid overlap work with more digitizing tools (fixes #50433)

### DIFF
--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -247,16 +247,13 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           {
             const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( vlayer, id, geom, ignoreFeatures );
 
-            if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType )
+            if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || geom.isEmpty() )
             {
-              emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::MessageLevel::Warning );
-              vlayer->destroyEditCommand();
-              return;
-            }
+              QString errorMessage = ( geom.isEmpty() ) ?
+                                     tr( "Resulting geometry would be empty" ) :
+                                     tr( "An error was reported during intersection removal" );
 
-            if ( geom.isEmpty() )
-            {
-              emit messageEmitted( tr( "Resulting geometry would be empty" ), Qgis::MessageLevel::Warning );
+              emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
               vlayer->destroyEditCommand();
               return;
             }

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -222,7 +222,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         QgsAvoidIntersectionsOperation avoidIntersections;
         connect( &avoidIntersections, &QgsAvoidIntersectionsOperation::messageEmitted, this, &QgsMapTool::messageEmitted );
 
-        // when removing intersections ignore all features being moved
+        // when removing intersections don't check for intersections with selected features
         QSet<QgsFeatureId> ignoreFeatureIds;
         for ( const auto &feat : mMovedFeatures )
         {

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -223,14 +223,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         connect( &avoidIntersections, &QgsAvoidIntersectionsOperation::messageEmitted, this, &QgsMapTool::messageEmitted );
 
         // when removing intersections don't check for intersections with selected features
-        QSet<QgsFeatureId> ignoreFeatureIds;
-        for ( const auto &feat : mMovedFeatures )
-        {
-          ignoreFeatureIds.insert( feat );
-        }
-
-        QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures;
-        ignoreFeatures.insert( vlayer, ignoreFeatureIds );
+        const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures {{ vlayer, mMovedFeatures }};
 
         while ( fi.nextFeature( f ) )
         {
@@ -249,9 +242,9 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 
             if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || geom.isEmpty() )
             {
-              QString errorMessage = ( geom.isEmpty() ) ?
-                                     tr( "Resulting geometry would be empty" ) :
-                                     tr( "An error was reported during intersection removal" );
+              const QString errorMessage = ( geom.isEmpty() ) ?
+                                           tr( "The feature cannot be moved because the resulting geometry would be empty" ) :
+                                           tr( "An error was reported during intersection removal" );
 
               emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
               vlayer->destroyEditCommand();

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -351,7 +351,11 @@ void QgsMapToolOffsetCurve::applyOffset( double offset, Qt::KeyboardModifiers mo
 
   connect( &avoidIntersections, &QgsAvoidIntersectionsOperation::messageEmitted, this, &QgsMapTool::messageEmitted );
 
-  const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures = {{ destLayer, {mModifiedFeature} }};
+  const QSet<QgsFeatureId> ignoredFeatures = ( QgsProject::instance()->avoidIntersectionsMode() != Qgis::AvoidIntersectionsMode::AllowIntersections && ( modifiers & Qt::ControlModifier ) ) ?
+      QSet<QgsFeatureId>() :
+      QSet<QgsFeatureId>( {mModifiedFeature} );
+
+  const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures = {{ destLayer, {ignoredFeatures} }};
 
   const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( destLayer, mModifiedFeature, mModifiedGeometry, ignoreFeatures );
 

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -363,8 +363,7 @@ void QgsMapToolOffsetCurve::applyOffset( double offset, Qt::KeyboardModifiers mo
 
     emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
     destLayer->destroyEditCommand();
-    deleteRubberBandAndGeometry();
-    deleteUserInputWidget();
+    cancel();
     return;
   }
 

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -356,18 +356,13 @@ void QgsMapToolOffsetCurve::applyOffset( double offset, Qt::KeyboardModifiers mo
 
   const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( destLayer, mModifiedFeature, mModifiedGeometry, ignoreFeatures );
 
-  if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType )
+  if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || mModifiedGeometry.isEmpty() )
   {
-    emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::MessageLevel::Warning );
-    destLayer->destroyEditCommand();
-    deleteRubberBandAndGeometry();
-    deleteUserInputWidget();
-    return;
-  }
+    QString errorMessage = ( mModifiedGeometry.isEmpty() ) ?
+                           tr( "Resulting geometry would be empty" ) :
+                           tr( "An error was reported during intersection removal" );
 
-  if ( mModifiedGeometry.isEmpty() )
-  {
-    emit messageEmitted( tr( "Resulting geometry would be empty" ), Qgis::MessageLevel::Warning );
+    emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
     destLayer->destroyEditCommand();
     deleteRubberBandAndGeometry();
     deleteUserInputWidget();

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -351,7 +351,7 @@ void QgsMapToolOffsetCurve::applyOffset( double offset, Qt::KeyboardModifiers mo
 
   connect( &avoidIntersections, &QgsAvoidIntersectionsOperation::messageEmitted, this, &QgsMapTool::messageEmitted );
 
-  const QSet<QgsFeatureId> ignoredFeatures = ( QgsProject::instance()->avoidIntersectionsMode() != Qgis::AvoidIntersectionsMode::AllowIntersections && ( modifiers & Qt::ControlModifier ) ) ?
+  const QSet<QgsFeatureId> ignoredFeatures = ( modifiers & Qt::ControlModifier ) ?
       QSet<QgsFeatureId>() :
       QSet<QgsFeatureId>( {mModifiedFeature} );
 

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -351,16 +351,15 @@ void QgsMapToolOffsetCurve::applyOffset( double offset, Qt::KeyboardModifiers mo
 
   connect( &avoidIntersections, &QgsAvoidIntersectionsOperation::messageEmitted, this, &QgsMapTool::messageEmitted );
 
-  QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures;
-  ignoreFeatures.insert( destLayer, QSet<QgsFeatureId> { mModifiedFeature } );
+  const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures = {{ destLayer, {mModifiedFeature} }};
 
   const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( destLayer, mModifiedFeature, mModifiedGeometry, ignoreFeatures );
 
   if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || mModifiedGeometry.isEmpty() )
   {
-    QString errorMessage = ( mModifiedGeometry.isEmpty() ) ?
-                           tr( "Resulting geometry would be empty" ) :
-                           tr( "An error was reported during intersection removal" );
+    const QString errorMessage = ( mModifiedGeometry.isEmpty() ) ?
+                                 tr( "The feature cannot be modified because the resulting geometry would be empty" ) :
+                                 tr( "An error was reported during intersection removal" );
 
     emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
     destLayer->destroyEditCommand();

--- a/src/app/qgsmaptoolrotatefeature.cpp
+++ b/src/app/qgsmaptoolrotatefeature.cpp
@@ -429,7 +429,6 @@ void QgsMapToolRotateFeature::applyRotation( double rotation )
   QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures;
   ignoreFeatures.insert( vlayer, ignoreFeatureIds );
 
-
   while ( fi.nextFeature( f ) )
   {
     const QgsFeatureId id = f.id();
@@ -440,7 +439,7 @@ void QgsMapToolRotateFeature::applyRotation( double rotation )
     {
       const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( vlayer, id, geom, ignoreFeatures );
 
-      if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType)
+      if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType )
       {
         emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::MessageLevel::Warning );
         vlayer->destroyEditCommand();

--- a/src/app/qgsmaptoolrotatefeature.cpp
+++ b/src/app/qgsmaptoolrotatefeature.cpp
@@ -439,18 +439,13 @@ void QgsMapToolRotateFeature::applyRotation( double rotation )
     {
       const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( vlayer, id, geom, ignoreFeatures );
 
-      if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType )
+      if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || geom.isEmpty() )
       {
-        emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::MessageLevel::Warning );
-        vlayer->destroyEditCommand();
-        deleteRotationWidget();
-        deleteRubberband();
-        return;
-      }
+        QString errorMessage = ( geom.isEmpty() ) ?
+                               tr( "Resulting geometry would be empty" ) :
+                               tr( "An error was reported during intersection removal" );
 
-      if ( geom.isEmpty() )
-      {
-        emit messageEmitted( tr( "Resulting geometry would be empty" ), Qgis::MessageLevel::Warning );
+        emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
         vlayer->destroyEditCommand();
         deleteRotationWidget();
         deleteRubberband();

--- a/src/app/qgsmaptoolrotatefeature.cpp
+++ b/src/app/qgsmaptoolrotatefeature.cpp
@@ -420,14 +420,7 @@ void QgsMapToolRotateFeature::applyRotation( double rotation )
   connect( &avoidIntersections, &QgsAvoidIntersectionsOperation::messageEmitted, this, &QgsMapTool::messageEmitted );
 
   // when removing intersections don't check for intersections with selected features
-  QSet<QgsFeatureId> ignoreFeatureIds;
-  for ( const auto &feat : mRotatedFeatures )
-  {
-    ignoreFeatureIds.insert( feat );
-  }
-
-  QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures;
-  ignoreFeatures.insert( vlayer, ignoreFeatureIds );
+  const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures {{vlayer, mRotatedFeatures}};
 
   while ( fi.nextFeature( f ) )
   {
@@ -441,9 +434,9 @@ void QgsMapToolRotateFeature::applyRotation( double rotation )
 
       if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || geom.isEmpty() )
       {
-        QString errorMessage = ( geom.isEmpty() ) ?
-                               tr( "Resulting geometry would be empty" ) :
-                               tr( "An error was reported during intersection removal" );
+        const QString errorMessage = ( geom.isEmpty() ) ?
+                                     tr( "The feature cannot be rotated because the resulting geometry would be empty" ) :
+                                     tr( "An error was reported during intersection removal" );
 
         emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
         vlayer->destroyEditCommand();

--- a/src/app/qgsmaptoolscalefeature.cpp
+++ b/src/app/qgsmaptoolscalefeature.cpp
@@ -398,18 +398,13 @@ void QgsMapToolScaleFeature::applyScaling( double scale )
     {
       const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( vlayer, id, geom, ignoreFeatures );
 
-      if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType )
+      if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || geom.isEmpty() )
       {
-        emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::MessageLevel::Warning );
-        vlayer->destroyEditCommand();
-        deleteScalingWidget();
-        deleteRubberband();
-        return;
-      }
+        QString errorMessage = ( geom.isEmpty() ) ?
+                               tr( "Resulting geometry would be empty" ) :
+                               tr( "An error was reported during intersection removal" );
 
-      if ( geom.isEmpty() )
-      {
-        emit messageEmitted( tr( "Resulting geometry would be empty" ), Qgis::MessageLevel::Warning );
+        emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
         vlayer->destroyEditCommand();
         deleteScalingWidget();
         deleteRubberband();

--- a/src/app/qgsmaptoolscalefeature.cpp
+++ b/src/app/qgsmaptoolscalefeature.cpp
@@ -374,14 +374,7 @@ void QgsMapToolScaleFeature::applyScaling( double scale )
   connect( &avoidIntersections, &QgsAvoidIntersectionsOperation::messageEmitted, this, &QgsMapTool::messageEmitted );
 
   // when removing intersections don't check for intersections with selected features
-  QSet<QgsFeatureId> ignoreFeatureIds;
-  for ( const auto &f : mScaledFeatures )
-  {
-    ignoreFeatureIds.insert( f );
-  }
-
-  QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures;
-  ignoreFeatures.insert( vlayer, ignoreFeatureIds );
+  const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures {{vlayer, mScaledFeatures}};
 
   while ( fi.nextFeature( feat ) )
   {
@@ -400,9 +393,9 @@ void QgsMapToolScaleFeature::applyScaling( double scale )
 
       if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || geom.isEmpty() )
       {
-        QString errorMessage = ( geom.isEmpty() ) ?
-                               tr( "Resulting geometry would be empty" ) :
-                               tr( "An error was reported during intersection removal" );
+        const QString errorMessage = ( geom.isEmpty() ) ?
+                                     tr( "The feature cannot be scaled because the resulting geometry would be empty" ) :
+                                     tr( "An error was reported during intersection removal" );
 
         emit messageEmitted( errorMessage, Qgis::MessageLevel::Warning );
         vlayer->destroyEditCommand();

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TESTS
   testqgsmaptoolregularpolygon.cpp
   testqgsmaptoolsplitparts.cpp
   testqgsmaptoolsplitfeatures.cpp
+  testqgsmaptooloffsetcurve.cpp
   testqgsmeasuretool.cpp
   testqgsmeasurebearingtool.cpp
   testqgsvertexeditor.cpp

--- a/tests/src/app/testqgsmaptoolmovefeature.cpp
+++ b/tests/src/app/testqgsmaptoolmovefeature.cpp
@@ -167,7 +167,7 @@ void TestQgsMapToolMoveFeature::testTopologicalMoveFeature()
 void TestQgsMapToolMoveFeature::testAvoidIntersectionAndTopoEdit()
 {
   const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
-  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()-> avoidIntersectionsMode() );
+  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
 
   QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
   QgsProject::instance()->setTopologicalEditing( true );

--- a/tests/src/app/testqgsmaptoolmovefeature.cpp
+++ b/tests/src/app/testqgsmaptoolmovefeature.cpp
@@ -175,7 +175,7 @@ void TestQgsMapToolMoveFeature::testAvoidIntersectionAndTopoEdit()
   TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
 
   utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
-  utils.mouseClick( 2.5F, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 2.5, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt1 = "Polygon ((1.5 1, 2 1, 2 0, 1.5 0, 1.5 1))";
   QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt(), wkt1 );

--- a/tests/src/app/testqgsmaptoolmovefeature.cpp
+++ b/tests/src/app/testqgsmaptoolmovefeature.cpp
@@ -46,6 +46,7 @@ class TestQgsMapToolMoveFeature: public QObject
 
     void testMoveFeature();
     void testTopologicalMoveFeature();
+    void testAvoidIntersectionAndTopoEdit();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -161,6 +162,30 @@ void TestQgsMapToolMoveFeature::testTopologicalMoveFeature()
   mLayerBase->undoStack()->undo();
 
   QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+}
+
+void TestQgsMapToolMoveFeature::testAvoidIntersectionAndTopoEdit()
+{
+  const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()-> avoidIntersectionsMode() );
+
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
+  QgsProject::instance()->setTopologicalEditing( true );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 2.5F, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt1 = "Polygon ((1.5 1, 2 1, 2 0, 1.5 0, 1.5 1))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt(), wkt1 );
+  const QString wkt2 = "Polygon ((2 0, 2 1, 2 5, 3 5, 3 0, 2 0))";
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt(), wkt2 );
+
+  mLayerBase->undoStack()->undo();
+
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+  QgsProject::instance()->setAvoidIntersectionsMode( mode );
 }
 
 QGSTEST_MAIN( TestQgsMapToolMoveFeature )

--- a/tests/src/app/testqgsmaptooloffsetcurve.cpp
+++ b/tests/src/app/testqgsmaptooloffsetcurve.cpp
@@ -1,0 +1,245 @@
+/***************************************************************************
+     testqgsmaptooloffsetcurve.cpp
+     --------------------------------
+    Date                 : March 2024
+    Copyright            : (C) 2024 by Juho Ervasti
+    Email                : juho dot ervasti at gispo dot fi
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgisapp.h"
+#include "qgsgeometry.h"
+#include "qgsmapcanvas.h"
+#include "qgssettingsregistrycore.h"
+#include "qgssettingsentryenumflag.h"
+#include "qgsmaptooloffsetcurve.h"
+#include "qgsvectorlayer.h"
+#include "testqgsmaptoolutils.h"
+
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the offset curve tool
+ */
+class TestQgsMapToolOffsetCurve: public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsMapToolOffsetCurve();
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+
+    void testOffsetCurveDefault();
+    void testOffsetCurveJoinStyle();
+    void testAvoidIntersectionAndTopoEdit();
+
+  private:
+    QgisApp *mQgisApp = nullptr;
+    QgsMapCanvas *mCanvas = nullptr;
+    QgsMapToolOffsetCurve *mOffsetCurveTool = nullptr;
+    QgsVectorLayer *mLayerBase = nullptr;
+};
+
+TestQgsMapToolOffsetCurve::TestQgsMapToolOffsetCurve() = default;
+
+
+//runs before all tests
+void TestQgsMapToolOffsetCurve::initTestCase()
+{
+  qDebug() << "TestQgsMapToolOffsetCurve::initTestCase()";
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  // Set up the QSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  mQgisApp = new QgisApp();
+
+  mCanvas = new QgsMapCanvas();
+
+  mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
+
+  mCanvas->setFrameStyle( QFrame::NoFrame );
+  mCanvas->resize( 512, 512 );
+  mCanvas->setExtent( QgsRectangle( 0, 0, 8, 8 ) );
+  mCanvas->show(); // to make the canvas resize
+  mCanvas->hide();
+
+  // make testing layers
+  mLayerBase = new QgsVectorLayer( QStringLiteral( "Polygon?crs=EPSG:3946" ), QStringLiteral( "baselayer" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerBase->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerBase );
+
+  mLayerBase->startEditing();
+  const QString wkt1 = QStringLiteral( "Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))" );
+  QgsFeature f1;
+  f1.setGeometry( QgsGeometry::fromWkt( wkt1 ) );
+  const QString wkt2 = QStringLiteral( "Polygon ((2 0, 2 5, 3 5, 3 0, 2 0))" );
+  QgsFeature f2;
+  f2.setGeometry( QgsGeometry::fromWkt( wkt2 ) );
+
+  QgsFeatureList flist;
+  flist << f1 << f2;
+  mLayerBase->dataProvider()->addFeatures( flist );
+  QCOMPARE( mLayerBase->featureCount(), 2L );
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt(), wkt1 );
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt(), wkt2 );
+
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerBase );
+  mCanvas->setCurrentLayer( mLayerBase );
+
+  // create the tool
+  mOffsetCurveTool = new QgsMapToolOffsetCurve( mCanvas );
+  mCanvas->setMapTool( mOffsetCurveTool );
+
+  QCOMPARE( mCanvas->mapSettings().outputSize(), QSize( 512, 512 ) );
+  QCOMPARE( mCanvas->mapSettings().visibleExtent(), QgsRectangle( 0, 0, 8, 8 ) );
+
+  // set default offset settings to ensure consistency
+
+  const Qgis::JoinStyle joinStyle = Qgis::JoinStyle::Round;
+  const int quadSegments = 8;
+  const double miterLimit = 5.0;
+  const Qgis::EndCapStyle capStyle = Qgis::EndCapStyle::Round;
+
+  QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->setValue( joinStyle );
+  QgsSettingsRegistryCore::settingsDigitizingOffsetQuadSeg->setValue( quadSegments );
+  QgsSettingsRegistryCore::settingsDigitizingOffsetMiterLimit->setValue( miterLimit );
+  QgsSettingsRegistryCore::settingsDigitizingOffsetCapStyle->setValue( capStyle );
+
+  QCOMPARE( QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->value(), joinStyle );
+  QCOMPARE( QgsSettingsRegistryCore::settingsDigitizingOffsetQuadSeg->value(), quadSegments );
+  QCOMPARE( QgsSettingsRegistryCore::settingsDigitizingOffsetMiterLimit->value(), miterLimit );
+  QCOMPARE( QgsSettingsRegistryCore::settingsDigitizingOffsetCapStyle->value(), capStyle );
+}
+
+//runs after all tests
+void TestQgsMapToolOffsetCurve::cleanupTestCase()
+{
+  delete mOffsetCurveTool;
+  delete mCanvas;
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMapToolOffsetCurve::testOffsetCurveDefault()
+{
+  TestQgsMapToolUtils utils( mOffsetCurveTool );
+
+  // positive offset
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 1.25, 1.25 );
+  utils.mouseClick( 1.25, 1.25, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt1 = "Polygon ((0 -0.35, -0.07 -0.35, -0.14 -0.33, -0.2 -0.29, -0.25 -0.25, -0.29 -0.2, -0.33 -0.14, -0.35 -0.07, -0.35 0, -0.35 1, -0.35 1.07, -0.33 1.14, -0.29 1.2, -0.25 1.25, -0.2 1.29, -0.14 1.33, -0.07 1.35, 0 1.35, 1 1.35, 1.07 1.35, 1.14 1.33, 1.2 1.29, 1.25 1.25, 1.29 1.2, 1.33 1.14, 1.35 1.07, 1.35 1, 1.35 0, 1.35 -0.07, 1.33 -0.14, 1.29 -0.2, 1.25 -0.25, 1.2 -0.29, 1.14 -0.33, 1.07 -0.35, 1 -0.35, 0 -0.35))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1);
+
+  mLayerBase->undoStack()->undo();
+
+  // negative offset
+  utils.mouseClick( 2, 0, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 2.1, 0.1 );
+  utils.mouseClick( 2.1, 0.1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt2 = "Polygon ((2.09 0.09, 2.09 4.91, 2.91 4.91, 2.91 0.09, 2.09 0.09))";
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2);
+
+  mLayerBase->undoStack()->undo();
+}
+
+void TestQgsMapToolOffsetCurve::testOffsetCurveJoinStyle()
+{
+  TestQgsMapToolUtils utils( mOffsetCurveTool );
+
+  const Qgis::JoinStyle joinStyle = QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->value();
+  QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->setValue( Qgis::JoinStyle::Miter );
+
+  // positive offset miter
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 1.5, 1.5 );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt1 = "Polygon ((-0.71 -0.71, -0.71 1.71, 1.71 1.71, 1.71 -0.71, -0.71 -0.71))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1);
+
+  mLayerBase->undoStack()->undo();
+
+  // negative offset miter
+  utils.mouseClick( 2, 0, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 2.25, 0.25 );
+  utils.mouseClick( 2.25, 0.25, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt2 = "Polygon ((2.25 0.25, 2.25 4.75, 2.75 4.75, 2.75 0.25, 2.25 0.25))";
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2);
+
+  mLayerBase->undoStack()->undo();
+
+  QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->setValue( Qgis::JoinStyle::Bevel );
+
+  // negative offset bevel
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 0.75, 0.75 );
+  utils.mouseClick( 0.75, 0.75, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt3 = "Polygon ((0.25 0.25, 0.25 0.75, 0.75 0.75, 0.75 0.25, 0.25 0.25))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt3);
+
+  mLayerBase->undoStack()->undo();
+
+  // positive offset bevel
+  utils.mouseClick( 2, 0, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 1.75, -0.25 );
+  utils.mouseClick( 1.75, -0.25, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt4 = "Polygon ((2 -0.35, 1.65 0, 1.65 5, 2 5.35, 3 5.35, 3.35 5, 3.35 0, 3 -0.35, 2 -0.35))";
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt4);
+
+  mLayerBase->undoStack()->undo();
+
+  // reset settings
+  QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->setValue( joinStyle );
+}
+
+void TestQgsMapToolOffsetCurve::testAvoidIntersectionAndTopoEdit()
+{
+  TestQgsMapToolUtils utils( mOffsetCurveTool );
+
+  const Qgis::JoinStyle joinStyle = QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->value();
+  const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
+
+  QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->setValue( Qgis::JoinStyle::Bevel );
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
+  QgsProject::instance()->setTopologicalEditing( true );
+
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 2, 1.75 );
+  utils.mouseClick( 2, 1.75, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt1 = "Polygon ((-1.25 0, -1.25 1, 0 2.25, 1 2.25, 2 1.25, 2 0, 2.25 0, 1 -1.25, 0 -1.25, -1.25 0))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1);
+  const QString wkt2 = "Polygon ((2 0, 2 1.25, 2 5, 3 5, 3 0, 2.25 0, 2 0))";
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2);
+
+  mLayerBase->undoStack()->undo();
+
+  // reset settings
+  QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->setValue( joinStyle );
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+  QgsProject::instance()->setAvoidIntersectionsMode( mode );
+}
+
+QGSTEST_MAIN( TestQgsMapToolOffsetCurve )
+#include "testqgsmaptooloffsetcurve.moc"

--- a/tests/src/app/testqgsmaptooloffsetcurve.cpp
+++ b/tests/src/app/testqgsmaptooloffsetcurve.cpp
@@ -238,7 +238,6 @@ void TestQgsMapToolOffsetCurve::testOffsetCurveControlModifier()
   const QString wkt2 = "Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))";
   QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt2 );
 
-
   mLayerBase->undoStack()->undo();
 
   // negative offset
@@ -284,6 +283,26 @@ void TestQgsMapToolOffsetCurve::testAvoidIntersectionAndTopoEdit()
   QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1 );
   const QString wkt2 = "Polygon ((2 0, 2 1.25, 2 5, 3 5, 3 0, 2.25 0, 2 0))";
   QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2 );
+
+  mLayerBase->undoStack()->undo();
+
+  // with control modifier
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 2, 1.75 );
+  utils.mouseClick( 2, 1.75, Qt::LeftButton, Qt::ControlModifier, true );
+
+  const QString wkt3 = "Polygon ((-1.25 0, -1.25 1, 0 2.25, 1 2.25, 2 1.25, 2 0, 2.25 0, 1 -1.25, 0 -1.25, -1.25 0),(0 0, 1 0, 1 1, 0 1, 0 0))";
+  QgsFeatureIterator fi = mLayerBase->getFeatures();
+  QgsFeature f;
+
+  while ( fi.nextFeature( f ) )
+  {
+    QCOMPARE( f.geometry().asWkt( 2 ), wkt3 );
+    break;
+  }
+
+  const QString wkt4 = "Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt4 );
 
   mLayerBase->undoStack()->undo();
 

--- a/tests/src/app/testqgsmaptooloffsetcurve.cpp
+++ b/tests/src/app/testqgsmaptooloffsetcurve.cpp
@@ -144,7 +144,7 @@ void TestQgsMapToolOffsetCurve::testOffsetCurveDefault()
   utils.mouseClick( 1.25, 1.25, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt1 = "Polygon ((0 -0.35, -0.07 -0.35, -0.14 -0.33, -0.2 -0.29, -0.25 -0.25, -0.29 -0.2, -0.33 -0.14, -0.35 -0.07, -0.35 0, -0.35 1, -0.35 1.07, -0.33 1.14, -0.29 1.2, -0.25 1.25, -0.2 1.29, -0.14 1.33, -0.07 1.35, 0 1.35, 1 1.35, 1.07 1.35, 1.14 1.33, 1.2 1.29, 1.25 1.25, 1.29 1.2, 1.33 1.14, 1.35 1.07, 1.35 1, 1.35 0, 1.35 -0.07, 1.33 -0.14, 1.29 -0.2, 1.25 -0.25, 1.2 -0.29, 1.14 -0.33, 1.07 -0.35, 1 -0.35, 0 -0.35))";
-  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1);
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1 );
 
   mLayerBase->undoStack()->undo();
 
@@ -154,7 +154,7 @@ void TestQgsMapToolOffsetCurve::testOffsetCurveDefault()
   utils.mouseClick( 2.1, 0.1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt2 = "Polygon ((2.09 0.09, 2.09 4.91, 2.91 4.91, 2.91 0.09, 2.09 0.09))";
-  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2);
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2 );
 
   mLayerBase->undoStack()->undo();
 }
@@ -172,7 +172,7 @@ void TestQgsMapToolOffsetCurve::testOffsetCurveJoinStyle()
   utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt1 = "Polygon ((-0.71 -0.71, -0.71 1.71, 1.71 1.71, 1.71 -0.71, -0.71 -0.71))";
-  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1);
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1 );
 
   mLayerBase->undoStack()->undo();
 
@@ -182,7 +182,7 @@ void TestQgsMapToolOffsetCurve::testOffsetCurveJoinStyle()
   utils.mouseClick( 2.25, 0.25, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt2 = "Polygon ((2.25 0.25, 2.25 4.75, 2.75 4.75, 2.75 0.25, 2.25 0.25))";
-  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2);
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2 );
 
   mLayerBase->undoStack()->undo();
 
@@ -194,7 +194,7 @@ void TestQgsMapToolOffsetCurve::testOffsetCurveJoinStyle()
   utils.mouseClick( 0.75, 0.75, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt3 = "Polygon ((0.25 0.25, 0.25 0.75, 0.75 0.75, 0.75 0.25, 0.25 0.25))";
-  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt3);
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt3 );
 
   mLayerBase->undoStack()->undo();
 
@@ -204,7 +204,7 @@ void TestQgsMapToolOffsetCurve::testOffsetCurveJoinStyle()
   utils.mouseClick( 1.75, -0.25, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt4 = "Polygon ((2 -0.35, 1.65 0, 1.65 5, 2 5.35, 3 5.35, 3.35 5, 3.35 0, 3 -0.35, 2 -0.35))";
-  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt4);
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt4 );
 
   mLayerBase->undoStack()->undo();
 
@@ -229,9 +229,9 @@ void TestQgsMapToolOffsetCurve::testAvoidIntersectionAndTopoEdit()
   utils.mouseClick( 2, 1.75, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt1 = "Polygon ((-1.25 0, -1.25 1, 0 2.25, 1 2.25, 2 1.25, 2 0, 2.25 0, 1 -1.25, 0 -1.25, -1.25 0))";
-  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1);
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1 );
   const QString wkt2 = "Polygon ((2 0, 2 1.25, 2 5, 3 5, 3 0, 2.25 0, 2 0))";
-  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2);
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2 );
 
   mLayerBase->undoStack()->undo();
 

--- a/tests/src/app/testqgsmaptooloffsetcurve.cpp
+++ b/tests/src/app/testqgsmaptooloffsetcurve.cpp
@@ -27,7 +27,7 @@
 
 /**
  * \ingroup UnitTests
- * This is a unit test for the offset curve tool
+ * This is a unit test for the vertex tool
  */
 class TestQgsMapToolOffsetCurve: public QObject
 {
@@ -271,6 +271,7 @@ void TestQgsMapToolOffsetCurve::testAvoidIntersectionAndTopoEdit()
   const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
   const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
 
+  // test with bevel
   QgsSettingsRegistryCore::settingsDigitizingOffsetJoinStyle->setValue( Qgis::JoinStyle::Bevel );
   QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
   QgsProject::instance()->setTopologicalEditing( true );

--- a/tests/src/app/testqgsmaptoolrotatefeature.cpp
+++ b/tests/src/app/testqgsmaptoolrotatefeature.cpp
@@ -48,6 +48,7 @@ class TestQgsMapToolRotateFeature: public QObject
     void testCancelManualAnchor();
     void testRotateFeatureManualAnchorAfterStartRotate();
     void testRotateFeatureManualAnchorSnapping();
+    void testAvoidIntersectionsAndTopoEdit();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -239,6 +240,36 @@ void TestQgsMapToolRotateFeature::testRotateFeatureManualAnchorSnapping()
   cfg.setTolerance( tolerance );
   cfg.setUnits( units );
   mCanvas->snappingUtils()->setConfig( cfg );
+
+
+}
+
+void TestQgsMapToolRotateFeature::testAvoidIntersectionsAndTopoEdit()
+{
+  const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
+
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
+  QgsProject::instance()->setTopologicalEditing( true );
+
+  TestQgsMapToolUtils utils( mRotateTool );
+
+  // remove anchor point if it exists
+  utils.mouseClick( 1, 1, Qt::RightButton, Qt::KeyboardModifiers(), true );
+
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 1.6F, 0.5F );
+  utils.mouseClick( 1.6F, 0.5F, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt1 = "Polygon ((0.5 1.21, 1.1 0.61, 1.1 0.39, 0.5 -0.21, -0.21 0.5, 0.5 1.21))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1 );
+  const QString wkt2 = "Polygon ((1.1 0, 1.1 0.39, 1.1 0.61, 1.1 5, 2.1 5, 2.1 0, 1.1 0))";
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), wkt2 );
+
+  mLayerBase->undoStack()->undo();
+
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+  QgsProject::instance()->setAvoidIntersectionsMode( mode );
 }
 
 

--- a/tests/src/app/testqgsmaptoolrotatefeature.cpp
+++ b/tests/src/app/testqgsmaptoolrotatefeature.cpp
@@ -258,8 +258,8 @@ void TestQgsMapToolRotateFeature::testAvoidIntersectionsAndTopoEdit()
   utils.mouseClick( 1, 1, Qt::RightButton, Qt::KeyboardModifiers(), true );
 
   utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
-  utils.mouseMove( 1.6F, 0.5F );
-  utils.mouseClick( 1.6F, 0.5F, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 1.6, 0.5 );
+  utils.mouseClick( 1.6, 0.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   const QString wkt1 = "Polygon ((0.5 1.21, 1.1 0.61, 1.1 0.39, 0.5 -0.21, -0.21 0.5, 0.5 1.21))";
   QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), wkt1 );


### PR DESCRIPTION
## Description

Use the QgsAvoidIntersectionsOperation class to remove overlap from geometries which are edited with the move, rotate, scale and offset curve tools.

Copy and move is not included in this, since the QgsAvoidIntersectionsOperation is part of "app", but the copying and moving is done in core code (QgsVectorLayerTools) and I assume you're not supposed to include headers from app in core.