### PR TITLE
Switch to conditional protobuf-lite target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,9 +375,6 @@ if(WITH_CORE)
 
   find_package(Protobuf CONFIG)
   find_package(Protobuf REQUIRED)
-  if(Protobuf_VERSION GREATER_EQUAL 4.23)
-    set(Protobuf_LITE_LIBRARY protobuf::libprotobuf-lite)
-  endif()
 
   message(STATUS "Found Protobuf: ${Protobuf_LIBRARIES}")
   if (NOT Protobuf_PROTOC_EXECUTABLE)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2460,7 +2460,7 @@ target_link_libraries(qgis_core
   EXPAT::EXPAT
   ${SQLITE3_LIBRARY}
   ${LIBZIP_LIBRARY}
-  ${Protobuf_LITE_LIBRARY}
+  $<TARGET_NAME_IF_EXISTS:protobuf::libprotobuf-lite>
   ${ZLIB_LIBRARIES}
   ${EXIV2_LIBRARY}
   PROJ::proj


### PR DESCRIPTION
The original version number check was probably too high, I had to link against pblite with earlier versions. This check is simpler and selfcontained