### PR TITLE
Import/export 'DXF Export' dialog settings from/to XML

### DIFF
--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -810,7 +810,88 @@ void QgsDxfExportDialog::deselectDataDefinedBlocks()
 
 void QgsDxfExportDialog::loadSettingsFromFile()
 {
+  QgsSettings settings;
+  const QString lastUsedDir = settings.value( QStringLiteral( "dxf/lastSettingsDir" ), QDir::homePath() ).toString();
 
+  const QString fileName = QFileDialog::getOpenFileName( this, tr( "Load DXF Export settings" ), lastUsedDir,
+                           tr( "XML file" ) + " (*.xml)" );
+  if ( fileName.isNull() )
+  {
+    return;
+  }
+
+  bool resultFlag = false;
+
+  QDomDocument myDocument( QStringLiteral( "qgis" ) );
+
+  // location of problem associated with errorMsg
+  int line, column;
+  QString myErrorMessage;
+
+  QFile myFile( fileName );
+  if ( myFile.open( QFile::ReadOnly ) )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "file found %1" ).arg( fileName ), 2 );
+    // read file
+    resultFlag = myDocument.setContent( &myFile, &myErrorMessage, &line, &column );
+    if ( !resultFlag )
+      myErrorMessage = tr( "%1 at line %2 column %3" ).arg( myErrorMessage ).arg( line ).arg( column );
+    myFile.close();
+  }
+
+  resultFlag = loadSettingsFromXML( myDocument, myErrorMessage );
+  if ( !resultFlag )
+    QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1. %2" ).arg( fileName, myErrorMessage ) );
+  else
+  {
+    settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( fileName ).path() );
+    QMessageBox::information( this, tr( "Load DXF settings" ), tr( "DXF Export settings loaded!" ) );
+  }
+}
+
+
+bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorMessage ) const
+{
+  const QDomElement myRoot = doc.firstChildElement( QStringLiteral( "qgis" ) );
+  if ( myRoot.isNull() )
+  {
+    errorMessage = tr( "Root <qgis> element could not be found" );
+    return false;
+  }
+
+  QDomElement mne;
+  mne = myRoot.namedItem( QStringLiteral( "symbology_mode" ) ).toElement();
+  mSymbologyModeComboBox->setCurrentIndex( QgsXmlUtils::readVariant( mne.firstChildElement() ).toInt() );
+
+  mne = myRoot.namedItem( QStringLiteral( "symbology_scale" ) ).toElement();
+  mScaleWidget->setScale( QgsXmlUtils::readVariant( mne.firstChildElement() ).toDouble() );
+
+  mne = myRoot.namedItem( QStringLiteral( "encoding" ) ).toElement();
+  mEncoding->setCurrentText( QgsXmlUtils::readVariant( mne.firstChildElement() ).toString() );
+
+  mne = myRoot.namedItem( QStringLiteral( "crs" ) ).toElement();
+  mCrsSelector->setCrs( QgsXmlUtils::readVariant( mne.firstChildElement() ).value< QgsCoordinateReferenceSystem >() );
+
+  mne = myRoot.namedItem( QStringLiteral( "map_theme" ) ).toElement();
+  mVisibilityPresets->setCurrentText( QgsXmlUtils::readVariant( mne.firstChildElement() ).toString() );
+
+  // layers
+  mne = myRoot.namedItem( QStringLiteral( "use_layer_title" ) ).toElement();
+  mLayerTitleAsName->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+
+  mne = myRoot.namedItem( QStringLiteral( "use_map_extent" ) ).toElement();
+  mMapExtentCheckBox->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+
+  mne = myRoot.namedItem( QStringLiteral( "force_2d" ) ).toElement();
+  mForce2d->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+
+  mne = myRoot.namedItem( QStringLiteral( "mtext" ) ).toElement();
+  mMTextCheckBox->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+
+  mne = myRoot.namedItem( QStringLiteral( "selected_features_only" ) ).toElement();
+  mSelectedFeaturesOnly->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+
+  return true;
 }
 
 
@@ -902,7 +983,7 @@ void QgsDxfExportDialog::saveSettingsToXML( QDomDocument &doc ) const
   {
     QgsVectorLayer *vl = dxfLayer.layer();
     QDomElement layerElement = myDocument.createElement( QStringLiteral( "layer" ) );
-    layerElement.setAttribute( QStringLiteral( "source" ), vl->source() );
+    layerElement.setAttribute( QStringLiteral( "source" ), vl->publicSource() );
     layerElement.setAttribute( QStringLiteral( "attribute-index" ), dxfLayer.layerOutputAttributeIndex() ) ;
     layerElement.setAttribute( QStringLiteral( "use_symbol_blocks" ), dxfLayer.buildDataDefinedBlocks() ) ;
     layerElement.setAttribute( QStringLiteral( "max_number_of_classes" ), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() ) ;

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -33,6 +33,7 @@
 
 #include <QFileDialog>
 #include <QPushButton>
+#include <QMessageBox>
 
 const int LAYER_COL = 0;
 const int OUTPUT_LAYER_ATTRIBUTE_COL = 1;
@@ -734,6 +735,13 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mEncoding->addItems( QgsDxfExport::encodings() );
   mEncoding->setCurrentIndex( mEncoding->findText( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), settings.value( QStringLiteral( "qgis/lastDxfEncoding" ), "CP1252" ).toString() ) ) );
 
+  mBtnLoadSaveSettings = new QPushButton( tr( "Settings" ), this );
+  QMenu *menuSettings = new QMenu( this );
+  menuSettings->addAction( tr( "Load Settings from File…" ), this, &QgsDxfExportDialog::loadSettingsFromFile );
+  menuSettings->addAction( tr( "Save Settings to File…" ), this, &QgsDxfExportDialog::saveSettingsToFile );
+  mBtnLoadSaveSettings->setMenu( menuSettings );
+  buttonBox->addButton( mBtnLoadSaveSettings, QDialogButtonBox::ResetRole );
+
   mModel->loadLayersOutputAttribute( mModel->rootGroup() );
 }
 
@@ -797,6 +805,132 @@ void QgsDxfExportDialog::selectDataDefinedBlocks()
 void QgsDxfExportDialog::deselectDataDefinedBlocks()
 {
   mModel->deselectDataDefinedBlocks();
+}
+
+
+void QgsDxfExportDialog::loadSettingsFromFile()
+{
+
+}
+
+
+void QgsDxfExportDialog::saveSettingsToFile()
+{
+  QgsSettings settings;
+  const QString lastUsedDir = settings.value( QStringLiteral( "dxf/lastSettingsDir" ), QDir::homePath() ).toString();
+
+  QString outputFileName = QFileDialog::getSaveFileName( this, tr( "Save DXF Export settings as XML" ),
+                           lastUsedDir, tr( "XML file" ) + " (*.xml)" );
+  // return dialog focus on Mac
+  activateWindow();
+  raise();
+  if ( outputFileName.isEmpty() )
+  {
+    return;
+  }
+
+  //ensure the user never omitted the extension from the file name
+  if ( !outputFileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive ) )
+  {
+    outputFileName += QStringLiteral( ".xml" );
+  }
+
+  QString myErrorMessage;
+  QDomDocument myDocument;
+
+  saveSettingsToXML( myDocument );
+
+  const QFileInfo myFileInfo( outputFileName );
+  const QFileInfo myDirInfo( myFileInfo.path() );  //excludes file name
+  if ( !myDirInfo.isWritable() )
+  {
+    QMessageBox::information( this, tr( "Save DXF settings" ), tr( "The directory containing your dataset needs to be writable!" ) );
+    return;
+  }
+
+  QFile myFile( outputFileName );
+  if ( myFile.open( QFile::WriteOnly | QFile::Truncate ) )
+  {
+    QTextStream myFileStream( &myFile );
+    // save as utf-8 with 2 spaces for indents
+    myDocument.save( myFileStream, 2 );
+    myFile.close();
+    QMessageBox::information( this, tr( "Save DXF settings" ), tr( "Created DXF settings file as %1" ).arg( outputFileName ) );
+    settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( outputFileName ).absolutePath() );
+    return;
+  }
+  else
+  {
+    QMessageBox::information( this, tr( "Save DXF settings" ), tr( "ERROR: Failed to created DXF Export settings file as %1. Check file permissions and retry." ).arg( outputFileName ) );
+    return;
+  }
+}
+
+
+void QgsDxfExportDialog::saveSettingsToXML( QDomDocument &doc ) const
+{
+  QDomImplementation DomImplementation;
+  const QDomDocumentType documentType = DomImplementation.createDocumentType( QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ), QStringLiteral( "SYSTEM" ) );
+  QDomDocument myDocument( documentType );
+
+  QDomElement myRootNode = myDocument.createElement( QStringLiteral( "qgis" ) );
+  myRootNode.setAttribute( QStringLiteral( "version" ), Qgis::version() );
+  myDocument.appendChild( myRootNode );
+
+  QDomElement symbologyModeElement = myDocument.createElement( QStringLiteral( "symbology_mode" ) );
+  symbologyModeElement.appendChild( QgsXmlUtils::writeVariant( static_cast<int>( symbologyMode() ), doc ) );
+  myRootNode.appendChild( symbologyModeElement );
+
+  QDomElement symbologyScaleElement = myDocument.createElement( QStringLiteral( "symbology_scale" ) );
+  symbologyScaleElement.appendChild( QgsXmlUtils::writeVariant( symbologyScale(), doc ) );
+  myRootNode.appendChild( symbologyScaleElement );
+
+  QDomElement encodingElement = myDocument.createElement( QStringLiteral( "encoding" ) );
+  encodingElement.appendChild( QgsXmlUtils::writeVariant( encoding(), doc ) );
+  myRootNode.appendChild( encodingElement );
+
+  QDomElement crsElement = myDocument.createElement( QStringLiteral( "crs" ) );
+  crsElement.appendChild( QgsXmlUtils::writeVariant( crs(), doc ) );
+  myRootNode.appendChild( crsElement );
+
+  QDomElement mapThemeElement = myDocument.createElement( QStringLiteral( "map_theme" ) );
+  mapThemeElement.appendChild( QgsXmlUtils::writeVariant( mapTheme(), doc ) );
+  myRootNode.appendChild( mapThemeElement );
+
+  QDomElement layersElement = myDocument.createElement( QStringLiteral( "layers" ) );
+  for ( const auto dxfLayer : layers() )
+  {
+    QgsVectorLayer *vl = dxfLayer.layer();
+    QDomElement layerElement = myDocument.createElement( QStringLiteral( "layer" ) );
+    layerElement.setAttribute( QStringLiteral( "source" ), vl->source() );
+    layerElement.setAttribute( QStringLiteral( "attribute-index" ), dxfLayer.layerOutputAttributeIndex() ) ;
+    layerElement.setAttribute( QStringLiteral( "use_symbol_blocks" ), dxfLayer.buildDataDefinedBlocks() ) ;
+    layerElement.setAttribute( QStringLiteral( "max_number_of_classes" ), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() ) ;
+    layersElement.appendChild( layerElement );
+  }
+  myRootNode.appendChild( layersElement );
+
+  QDomElement titleAsNameElement = myDocument.createElement( QStringLiteral( "use_layer_title" ) );
+  titleAsNameElement.appendChild( QgsXmlUtils::writeVariant( layerTitleAsName(), doc ) );
+  myRootNode.appendChild( titleAsNameElement );
+
+  QDomElement useMapExtentElement = myDocument.createElement( QStringLiteral( "use_map_extent" ) );
+  useMapExtentElement.appendChild( QgsXmlUtils::writeVariant( exportMapExtent(), doc ) );
+  myRootNode.appendChild( useMapExtentElement );
+
+  QDomElement force2dElement = myDocument.createElement( QStringLiteral( "force_2d" ) );
+  force2dElement.appendChild( QgsXmlUtils::writeVariant( force2d(), doc ) );
+  myRootNode.appendChild( force2dElement );
+
+  QDomElement useMTextElement = myDocument.createElement( QStringLiteral( "mtext" ) );
+  useMTextElement.appendChild( QgsXmlUtils::writeVariant( useMText(), doc ) );
+  myRootNode.appendChild( useMTextElement );
+
+  QDomElement selectedFeatures = myDocument.createElement( QStringLiteral( "selected_features_only" ) );
+  selectedFeatures.appendChild( QgsXmlUtils::writeVariant( selectedFeaturesOnly(), doc ) );
+  myRootNode.appendChild( selectedFeatures );
+
+  doc = myDocument;
 }
 
 

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -114,7 +114,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QString mapTheme() const;
     QString encoding() const;
     QgsCoordinateReferenceSystem crs() const;
-    bool loadSettingsFromXML( QDomDocument &document ) const;
+    bool loadSettingsFromXML( QDomDocument &document, QString &errorMessage ) const;
     void saveSettingsToXML( QDomDocument &document ) const;
 
   public slots:

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -22,6 +22,7 @@
 #include "qgslayertreemodel.h"
 #include "qgslayertreeview.h"
 #include "qgsdxfexport.h"
+#include "qgsxmlutils.h"
 
 #include <QList>
 #include <QPair>
@@ -113,6 +114,8 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QString mapTheme() const;
     QString encoding() const;
     QgsCoordinateReferenceSystem crs() const;
+    bool loadSettingsFromXML( QDomDocument &document ) const;
+    void saveSettingsToXML( QDomDocument &document ) const;
 
   public slots:
     //! Change the selection of layers in the list
@@ -120,6 +123,8 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     void deSelectAll();
     void selectDataDefinedBlocks();
     void deselectDataDefinedBlocks();
+    void loadSettingsFromFile();
+    void saveSettingsToFile();
 
   private slots:
     void setOkEnabled();
@@ -134,6 +139,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     FieldSelectorDelegate *mFieldSelectorDelegate = nullptr;
     QgsVectorLayerAndAttributeModel *mModel = nullptr;
     QgsDxfExportLayerTreeView *mTreeView = nullptr;
+    QPushButton *mBtnLoadSaveSettings = nullptr;
 
     QgsCoordinateReferenceSystem mCRS;
 };


### PR DESCRIPTION
This PR enables users to save and restore GUI settings for the DXF Export dialog, making it possible to export a number of configurations and reuse them or share them with colleagues.

Settings are exported to an XML file.

![image](https://github.com/qgis/QGIS/assets/652785/0b0c5bb7-7662-49bf-8007-35e7f9c8a892)
