### PR TITLE
[layouts] Defer legend item feature count until layout is drawn

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -41,7 +41,10 @@ QgsLayerTreeModel::QgsLayerTreeModel( QgsLayerTree *rootNode, QObject *parent )
   , mRootNode( rootNode )
   , mFlags( ShowLegend | AllowLegendChangeState | DeferredLegendInvalidation )
 {
-  connectToRootNode();
+  if ( rootNode )
+  {
+    connectToRootNode();
+  }
 
   mFontLayer.setBold( true );
 
@@ -1072,9 +1075,11 @@ void QgsLayerTreeModel::connectToRootNode()
 
 void QgsLayerTreeModel::disconnectFromRootNode()
 {
-  disconnect( mRootNode, nullptr, this, nullptr );
-
-  disconnectFromLayers( mRootNode );
+  if ( mRootNode )
+  {
+    disconnect( mRootNode, nullptr, this, nullptr );
+    disconnectFromLayers( mRootNode );
+  }
 }
 
 void QgsLayerTreeModel::recursivelyEmitDataChanged( const QModelIndex &idx )

--- a/src/core/layout/qgslayoutitemlegend.h
+++ b/src/core/layout/qgslayoutitemlegend.h
@@ -23,7 +23,7 @@
 #include "qgslayoutitem.h"
 #include "qgslayertreemodel.h"
 #include "qgslegendsettings.h"
-#include "qgslayertreegroup.h"
+#include "qgslayertree.h"
 #include "qgsexpressioncontext.h"
 
 class QgsLayerTreeModel;
@@ -156,7 +156,7 @@ class CORE_EXPORT QgsLayoutItemLegend : public QgsLayoutItem
     /**
      * Returns the legend model.
      */
-    QgsLegendModel *model() { return mLegendModel.get(); }
+    QgsLegendModel *model();
 
     /**
      * Sets whether the legend content should auto update to reflect changes in the project's
@@ -634,8 +634,10 @@ class CORE_EXPORT QgsLayoutItemLegend : public QgsLayoutItem
 
     void setModelStyleOverrides( const QMap<QString, QString> &overrides );
 
+    void ensureModelIsInitialized();
     std::unique_ptr< QgsLegendModel > mLegendModel;
-    std::unique_ptr< QgsLayerTreeGroup > mCustomLayerTree;
+    std::unique_ptr< QgsLayerTree > mCustomLayerTree;
+    bool mDeferLegendModelInitialization = true;
 
     QgsLegendSettings mSettings;
 


### PR DESCRIPTION
## Description

This PR further optimizes the recreation of layout legend items on project load by deferring the creation of the legend [tree] model until users either open the layout or exports it. 

More importantly, on complex vector layer renderers (e.g. rule-based renderer relying on overlay_* expressions), the triggering of the feature counter task when creating legend items was causing crashes/freezes with such feature count-enabled layers triggered by simple python scripts which would open a project to trigger a single map rendering.