### PR TITLE
Use proper labels for buttons in the Organize columns dialog

### DIFF
--- a/src/ui/qgsorganizetablecolumnsdialog.ui
+++ b/src/ui/qgsorganizetablecolumnsdialog.ui
@@ -43,7 +43,7 @@
    <item row="2" column="1">
     <widget class="QPushButton" name="mHideAllButton">
      <property name="text">
-      <string>Deselect All</string>
+      <string>Hide All</string>
      </property>
     </widget>
    </item>
@@ -60,7 +60,7 @@
    <item row="2" column="0">
     <widget class="QPushButton" name="mShowAllButton">
      <property name="text">
-      <string>Select All</string>
+      <string>Show All</string>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsorganizetablecolumnsdialog.ui
+++ b/src/ui/qgsorganizetablecolumnsdialog.ui
@@ -45,6 +45,9 @@
      <property name="text">
       <string>Hide All</string>
      </property>
+     <property name="toolTip">
+      <string>Hides all the fields and actions in the table</string>
+     </property>
     </widget>
    </item>
    <item row="2" column="4">
@@ -62,12 +65,18 @@
      <property name="text">
       <string>Show All</string>
      </property>
+     <property name="toolTip">
+      <string>Displays all the fields and actions in the table</string>
+     </property>
     </widget>
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="mToggleSelectionButton">
      <property name="text">
       <string>Toggle Selection</string>
+     </property>
+     <property name="toolTip">
+      <string>Toggles visibility of the selected fields and actions</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
These buttons actually check or uncheck visibility of the fields, they do not (de)select them in the dialog. Multiselection is done with keyboards

