### PR TITLE
[ltr backport] qgswfsgetfeature: Do not invert axis if no SRSNAME is passed

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -461,7 +461,16 @@ namespace QgsWfs
       {
 
         // For WFS 1.1 we honor requested CRS and axis order
-        const QString srsName {request.serverParameters().value( QStringLiteral( "SRSNAME" ) )};
+        // if the CRS is defined in the parameters, use it
+        // otherwise:
+        //  - geojson uses 'EPSG:4326' by default
+        //  - other formats use the default CRS (DefaultSRS, which is the layer's CRS)
+        const QString requestSrsName = request.serverParameters().value( QStringLiteral( "SRSNAME" ) );
+        const QString srsName
+        {
+          !requestSrsName.isEmpty() ? requestSrsName :
+          ( aRequest.outputFormat == QgsWfsParameters::Format::GeoJSON ? QStringLiteral( "EPSG:4326" ) : outputCrs.authid() )
+        };
         const bool invertAxis { mWfsParameters.versionAsNumber() >= QgsProjectVersion( 1, 1, 0 ) &&
                                 outputCrs.hasAxisInverted() &&
                                 ! srsName.startsWith( QLatin1String( "EPSG:" ) ) };
@@ -1248,7 +1257,8 @@ namespace QgsWfs
         if ( format == QgsWfsParameters::Format::GML3 )
         {
           // For WFS 1.1 we honor requested CRS and axis order
-          const QString srsName {request.serverParameters().value( QStringLiteral( "SRSNAME" ) )};
+          const QString requestSrsName = request.serverParameters().value( QStringLiteral( "SRSNAME" ) );
+          const QString srsName = !requestSrsName.isEmpty() ? requestSrsName : crs.authid();
           const bool invertAxis { mWfsParameters.versionAsNumber() >= QgsProjectVersion( 1, 1, 0 ) &&
                                   crs.hasAxisInverted() &&
                                   ! srsName.startsWith( QLatin1String( "EPSG:" ) ) };

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -461,7 +461,11 @@ namespace QgsWfs
       {
 
         // For WFS 1.1 we honor requested CRS and axis order
-        // if the CRS is defined in the parameters, use it
+        // Axis is not inverted if srsName starts with EPSG
+        // It needs to be an EPSG urn, e.g. urn:ogc:def:crs:EPSG::4326
+        // This follows geoserver convention
+        // See: https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html
+        // if the crs is defined in the parameters, use it
         // otherwise:
         //  - geojson uses 'EPSG:4326' by default
         //  - other formats use the default CRS (DefaultSRS, which is the layer's CRS)
@@ -1257,6 +1261,10 @@ namespace QgsWfs
         if ( format == QgsWfsParameters::Format::GML3 )
         {
           // For WFS 1.1 we honor requested CRS and axis order
+          // Axis is not inverted if srsName starts with EPSG
+          // It needs to be an EPSG urn, e.g. urn:ogc:def:crs:EPSG::4326
+          // This follows geoserver convention
+          // See: https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html
           const QString requestSrsName = request.serverParameters().value( QStringLiteral( "SRSNAME" ) );
           const QString srsName = !requestSrsName.isEmpty() ? requestSrsName : crs.authid();
           const bool invertAxis { mWfsParameters.versionAsNumber() >= QgsProjectVersion( 1, 1, 0 ) &&

--- a/tests/testdata/qgis_server/wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname.txt
+++ b/tests/testdata/qgis_server/wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname.txt
@@ -3,21 +3,21 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=text/xml; subtype%3Dgml/3.1.1">
 <gml:boundedBy>
  <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>44.90139484 8.20345931</gml:lowerCorner>
-  <gml:upperCorner>44.90148253 8.20354699</gml:upperCorner>
+  <gml:lowerCorner>8.20345931 44.90139484</gml:lowerCorner>
+  <gml:upperCorner>8.20354699 44.90148253</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.0">
   <gml:boundedBy>
    <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>44.90148253 8.20349634</gml:lowerCorner>
-    <gml:upperCorner>44.90148253 8.20349634</gml:upperCorner>
+    <gml:lowerCorner>8.20349634 44.90148253</gml:lowerCorner>
+    <gml:upperCorner>8.20349634 44.90148253</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
    <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90148253 8.20349634</pos>
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20349634 44.90148253</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>1</qgs:id>


### PR DESCRIPTION
## Description

This is a manual backport of https://github.com/qgis/QGIS/pull/56840
