### PR TITLE
[Backport queued_ltr_backports] Fix QgsSymbol::drawPreviewIcon (fix incorrect preview symbol opacity)

### DIFF
--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -942,7 +942,7 @@ void QgsSymbol::drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext
   const bool prevForceVector = context->forceVectorOutput();
   context->setForceVectorOutput( true );
 
-  const double opacity = expressionContext ? dataDefinedProperties().valueAsDouble( QgsSymbol::PropertyOpacity, *expressionContext, mOpacity ) : mOpacity;
+  const double opacity = expressionContext ? dataDefinedProperties().valueAsDouble( QgsSymbol::PropertyOpacity, *expressionContext, mOpacity * 100 ) * 0.01 : mOpacity;
 
   QgsSymbolRenderContext symbolContext( *context, Qgis::RenderUnit::Unknown, opacity, false, mRenderHints, nullptr );
   symbolContext.setSelected( selected );


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/56797 to the queued_ltr_backports branch.