### PR TITLE
chore(code_layout): use env var and pipe to bypass the "Argument list too long" error

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -154,25 +154,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Install Requirements
         run: |
           sudo apt install -y \
               expect \
               silversearcher-ag
-      - uses: tj-actions/changed-files@v42
+
+      - name: Retrieve changed files
+        uses: tj-actions/changed-files@v43
         id: changed_files
         with:
-          separator: ' '
-          files_ignore: |
-            **/*.sip.in
-            **/*.png
-            **/*.svg
-            **/*.tif*
-            **/*.gpkg
-            **/*.qgz
-            **/*.qgs
+          separator: " "
+
       - name: Spell Test
-        run: ./scripts/spell_check/check_spelling.sh -r "${{ steps.changed_files.outputs.all_changed_files }}"
+        if: steps.changed_files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}
+        run: echo "$ALL_CHANGED_FILES" | ./scripts/spell_check/check_spelling.sh
 
   sip_check:
     runs-on: ubuntu-latest

--- a/scripts/spell_check/check_spelling.sh
+++ b/scripts/spell_check/check_spelling.sh
@@ -61,9 +61,21 @@ while getopts ":rdl:" opt; do
 done
 shift $((OPTIND - 1))
 
-if [ $# -ne 0 ]; then
+# check pipe or command line
+if [ -p /dev/stdin ]; then
+  # with pipe input
+  read SCRIPT_INPUT
+  if [ -z "$SCRIPT_INPUT" ]; then
+    exit 0
+  fi
+else
+  # no pipe input
+  SCRIPT_INPUT="$@"
+fi
+
+if [ -n "$SCRIPT_INPUT" ]; then
   EXCLUDE=$(${GP}sed -e 's/\s*#.*$//' -e '/^\s*$/d' $AGIGNORE | tr '\n' '|' | ${GP}sed -e 's/|$//')
-  INPUTFILES=$(echo "$@" | tr -s '[[:blank:]]' '\n' | ${GP}grep -Eiv "$EXCLUDE" | tr '\n' ' ' )
+  INPUTFILES=$(echo "$SCRIPT_INPUT" | tr -s '[[:blank:]]' '\n' | ${GP}grep -Eiv "$EXCLUDE" | tr '\n' ' ' )
   if [[ -z $INPUTFILES  ]]; then
     exit 0
   fi


### PR DESCRIPTION
Revert previous modifications on `.github/workflows/code_layout.yml` as the error can still appear.

Use an env var to hold the list of changed files and read this list via a pipe.

See https://github.com/qgis/QGIS/pull/56748