### PR TITLE
Don't require a full wildcard string for grass module filtering

### DIFF
--- a/src/plugins/grass/qgsgrasstools.cpp
+++ b/src/plugins/grass/qgsgrasstools.cpp
@@ -630,7 +630,7 @@ void QgsGrassToolsTreeFilterProxyModel::setFilter( const QString &filter )
     return;
   }
   mFilter = filter;
-  mRegExp = QRegularExpression( QRegularExpression::wildcardToRegularExpression( mFilter ), QRegularExpression::CaseInsensitiveOption );
+  mRegExp = QRegularExpression( QRegularExpression::wildcardToRegularExpression( QStringLiteral( "*%1*" ).arg( mFilter.trimmed() ) ), QRegularExpression::CaseInsensitiveOption );
 
   invalidateFilter();
 }


### PR DESCRIPTION
Previously the filter required you to enter "*term*" to search within text, but let's be more tolerant and just do a search within always
