### PR TITLE
Fix needs-documentation action

### DIFF
--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          route: GET /repos/qgis/QGIS/pulls/:pull_number/commits
+          route: GET /repos/qgis/QGIS/pulls/{pull_number}/commits
           pull_number: ${{ github.event.pull_request.number }}
 
       # extracts the matching commits
@@ -152,7 +152,7 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_BOT }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             @${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
See e.g. failure at https://github.com/qgis/QGIS/actions/runs/8374241083

This PR should reinstate addition of the message in the initial pull request referring to the issue created in the docs repo (ping the author).
Also removes a warning message.