### PR TITLE
fix: push docker image only if GH actor == qgis

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -116,7 +116,7 @@ jobs:
           echo QT_VERSION: ${QT_VERSION}
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -129,7 +129,7 @@ jobs:
           context: .
           file: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           tags: qgis/qgis3-build-deps-${{ matrix.distro-version }}-qt${{ matrix.qt-version }}:${{ github.event.pull_request.base.ref || github.ref_name }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
           pull: true
           build-args:
             DISTRO_VERSION=${{ matrix.distro-version }}
@@ -347,7 +347,7 @@ jobs:
           echo CTEST_BUILD_NAME: ${CTEST_BUILD_NAME}
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -360,7 +360,7 @@ jobs:
           context: .
           file: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           tags: qgis/qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only:${{ github.event.pull_request.base.ref || github.ref_name }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
           pull: true
           target: ${{ matrix.docker-target }}
           build-args:
@@ -458,7 +458,7 @@ jobs:
           fetch-depth: 2
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -471,7 +471,7 @@ jobs:
           context: .
           file: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           tags: qgis/qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only:${{ github.event.pull_request.base.ref || github.ref_name }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
           pull: true
           target: ${{ matrix.docker-target }}
           build-args:


### PR DESCRIPTION
## Description

- fixes build error for QTSERIALPORT=false
- disable uploading of docker image if `github.actor != 'qgis'` so GH actions in forked repos won't fail for this reason

Backport
- [ ] backport to 3.36

#Fixes #56944 