### PR TITLE
Fix:  build with `QTSERIALPORT=false`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -116,7 +116,7 @@ jobs:
           echo QT_VERSION: ${QT_VERSION}
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -129,7 +129,7 @@ jobs:
           context: .
           file: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           tags: qgis/qgis3-build-deps-${{ matrix.distro-version }}-qt${{ matrix.qt-version }}:${{ github.event.pull_request.base.ref || github.ref_name }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
           pull: true
           build-args:
             DISTRO_VERSION=${{ matrix.distro-version }}
@@ -347,7 +347,7 @@ jobs:
           echo CTEST_BUILD_NAME: ${CTEST_BUILD_NAME}
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -360,7 +360,7 @@ jobs:
           context: .
           file: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           tags: qgis/qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only:${{ github.event.pull_request.base.ref || github.ref_name }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
           pull: true
           target: ${{ matrix.docker-target }}
           build-args:
@@ -458,7 +458,7 @@ jobs:
           fetch-depth: 2
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -471,7 +471,7 @@ jobs:
           context: .
           file: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           tags: qgis/qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only:${{ github.event.pull_request.base.ref || github.ref_name }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.actor == 'qgis' }}
           pull: true
           target: ${{ matrix.docker-target }}
           build-args:

--- a/python/PyQt6/core/core.sip.in
+++ b/python/PyQt6/core/core.sip.in
@@ -91,15 +91,6 @@ done:
 
 %End
 
-%Import QtXml/QtXmlmod.sip
-%Import QtNetwork/QtNetworkmod.sip
-%Import QtSql/QtSqlmod.sip
-
-%Import QtPrintSupport/QtPrintSupportmod.sip
-%Import QtWidgets/QtWidgetsmod.sip
-%Import QtPositioning/QtPositioningmod.sip
-%Import QtSerialPort/QtSerialPortmod.sip
-
 %Feature HAVE_GUI
 %Feature HAVE_QTSERIALPORT
 %Feature HAVE_QTPRINTER
@@ -107,6 +98,18 @@ done:
 %Feature VECTOR_MAPPED_TYPE
 %Feature HAVE_WEBENGINE_SIP
 %Feature PYQT6
+
+%Import QtXml/QtXmlmod.sip
+%Import QtNetwork/QtNetworkmod.sip
+%Import QtSql/QtSqlmod.sip
+
+%Import QtPrintSupport/QtPrintSupportmod.sip
+%Import QtWidgets/QtWidgetsmod.sip
+%Import QtPositioning/QtPositioningmod.sip
+
+%If (HAVE_QTSERIALPORT)
+%Import QtSerialPort/QtSerialPortmod.sip
+%End
 
 %Include conversions.sip
 %Include qgsexception.sip

--- a/python/core/core.sip.in
+++ b/python/core/core.sip.in
@@ -91,6 +91,13 @@ done:
 
 %End
 
+%Feature HAVE_GUI
+%Feature HAVE_QTSERIALPORT
+%Feature HAVE_QTPRINTER
+%Feature ANDROID
+%Feature VECTOR_MAPPED_TYPE
+%Feature HAVE_WEBENGINE_SIP
+
 %Import QtXml/QtXmlmod.sip
 %Import QtNetwork/QtNetworkmod.sip
 %Import QtSql/QtSqlmod.sip
@@ -98,14 +105,10 @@ done:
 %Import QtPrintSupport/QtPrintSupportmod.sip
 %Import QtWidgets/QtWidgetsmod.sip
 %Import QtPositioning/QtPositioningmod.sip
-%Import QtSerialPort/QtSerialPortmod.sip
 
-%Feature HAVE_GUI
-%Feature HAVE_QTSERIALPORT
-%Feature HAVE_QTPRINTER
-%Feature ANDROID
-%Feature VECTOR_MAPPED_TYPE
-%Feature HAVE_WEBENGINE_SIP
+%If (HAVE_QTSERIALPORT)
+%Import QtSerialPort/QtSerialPortmod.sip
+%End
 
 %Include conversions.sip
 %Include qgsexception.sip


### PR DESCRIPTION
## Description

- fixes build error for `QTSERIALPORT=false`
- disable uploading of docker image if `github.actor != 'qgis'` so GH actions in forked repos won't fail for this reason

Backport
- [ ] backport to 3.36 releases

#Fixes #56944 