### PR TITLE
JSON / List widget UI improvements

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgskeyvaluewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgskeyvaluewidget.sip.in
@@ -38,6 +38,10 @@ Gets the edit value.
 :return: the QVariantMap
 %End
 
+  public slots:
+
+    virtual void setReadOnly( bool readOnly );
+
 };
 
 

--- a/python/PyQt6/gui/auto_generated/qgslistwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgslistwidget.sip.in
@@ -46,6 +46,11 @@ Check the content is valid
 :return: ``True`` if valid
 %End
 
+  public slots:
+
+    virtual void setReadOnly( bool readOnly );
+
+
 };
 
 

--- a/python/PyQt6/gui/auto_generated/qgstablewidgetbase.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgstablewidgetbase.sip.in
@@ -27,6 +27,26 @@ Child classes must call init(QAbstractTableModel*) from their constructor.
 Constructor.
 %End
 
+    bool isReadOnly() const;
+%Docstring
+Returns ``True`` if the widget is shown in a read-only state.
+
+.. seealso:: :py:func:`setReadOnly`
+
+.. versionadded:: 3.38
+%End
+
+  public slots:
+
+    virtual void setReadOnly( bool readOnly );
+%Docstring
+Sets whether the widget should be shown in a read-only state.
+
+.. seealso:: :py:func:`isReadOnly`
+
+.. versionadded:: 3.38
+%End
+
   protected:
 
     void init( QAbstractTableModel *model );

--- a/python/gui/auto_generated/qgskeyvaluewidget.sip.in
+++ b/python/gui/auto_generated/qgskeyvaluewidget.sip.in
@@ -38,6 +38,10 @@ Gets the edit value.
 :return: the QVariantMap
 %End
 
+  public slots:
+
+    virtual void setReadOnly( bool readOnly );
+
 };
 
 

--- a/python/gui/auto_generated/qgslistwidget.sip.in
+++ b/python/gui/auto_generated/qgslistwidget.sip.in
@@ -46,6 +46,11 @@ Check the content is valid
 :return: ``True`` if valid
 %End
 
+  public slots:
+
+    virtual void setReadOnly( bool readOnly );
+
+
 };
 
 

--- a/python/gui/auto_generated/qgstablewidgetbase.sip.in
+++ b/python/gui/auto_generated/qgstablewidgetbase.sip.in
@@ -27,6 +27,26 @@ Child classes must call init(QAbstractTableModel*) from their constructor.
 Constructor.
 %End
 
+    bool isReadOnly() const;
+%Docstring
+Returns ``True`` if the widget is shown in a read-only state.
+
+.. seealso:: :py:func:`setReadOnly`
+
+.. versionadded:: 3.38
+%End
+
+  public slots:
+
+    virtual void setReadOnly( bool readOnly );
+%Docstring
+Sets whether the widget should be shown in a read-only state.
+
+.. seealso:: :py:func:`isReadOnly`
+
+.. versionadded:: 3.38
+%End
+
   protected:
 
     void init( QAbstractTableModel *model );

--- a/src/gui/editorwidgets/qgsjsoneditwidget.cpp
+++ b/src/gui/editorwidgets/qgsjsoneditwidget.cpp
@@ -26,8 +26,8 @@
 
 QgsJsonEditWidget::QgsJsonEditWidget( QWidget *parent )
   : QWidget( parent )
-  , mCopyValueAction( new QAction( tr( "Copy value" ), this ) )
-  , mCopyKeyAction( new QAction( tr( "Copy key" ), this ) )
+  , mCopyValueAction( new QAction( tr( "Copy Value" ), this ) )
+  , mCopyKeyAction( new QAction( tr( "Copy Key" ), this ) )
 {
   setupUi( this );
 

--- a/src/gui/editorwidgets/qgsjsoneditwidget.cpp
+++ b/src/gui/editorwidgets/qgsjsoneditwidget.cpp
@@ -40,8 +40,6 @@ QgsJsonEditWidget::QgsJsonEditWidget( QWidget *parent )
   mCodeEditorJson->SendScintilla( QsciScintillaBase::SCI_SETINDICATORCURRENT, SCINTILLA_UNDERLINE_INDICATOR_INDEX );
   mCodeEditorJson->SendScintilla( QsciScintillaBase::SCI_SETMOUSEDWELLTIME, 400 );
 
-  mTreeWidget->setStyleSheet( QStringLiteral( "font-family: %1;" ).arg( QgsCodeEditor::getMonospaceFont().family() ) );
-
   mTreeWidget->setContextMenuPolicy( Qt::ActionsContextMenu );
   mTreeWidget->addAction( mCopyValueAction );
   mTreeWidget->addAction( mCopyKeyAction );
@@ -261,6 +259,7 @@ void QgsJsonEditWidget::refreshTreeView( const QJsonDocument &jsonDocument )
     {
       const QJsonValue jsonValue = jsonDocument.object().value( key );
       QTreeWidgetItem *treeWidgetItem = new QTreeWidgetItem( mTreeWidget, QStringList() << key );
+      treeWidgetItem->setFont( 0, monospaceFont() );
       refreshTreeViewItem( treeWidgetItem, jsonValue );
       mTreeWidget->addTopLevelItem( treeWidgetItem );
       mTreeWidget->expandItem( treeWidgetItem );
@@ -281,6 +280,7 @@ void QgsJsonEditWidget::refreshTreeView( const QJsonDocument &jsonDocument )
     for ( auto index = decltype( arraySize ) {0}; index < arraySize; index++ )
     {
       QTreeWidgetItem *treeWidgetItem = new QTreeWidgetItem( mTreeWidget, QStringList() << QString::number( index ) );
+      treeWidgetItem->setFont( 0, monospaceFont() );
       if ( arraySize <= MAX_ELTS || ( index < MAX_ELTS / 2 || index + MAX_ELTS / 2 > arraySize ) )
       {
         refreshTreeViewItem( treeWidgetItem, array.at( index ) );
@@ -334,6 +334,7 @@ void QgsJsonEditWidget::refreshTreeViewItem( QTreeWidgetItem *treeWidgetItem, co
       {
         QLabel *label = new QLabel( QString( "<a href='%1'>%1</a>" ).arg( jsonValueString ) );
         label->setOpenExternalLinks( true );
+        label->setFont( monospaceFont() );
         mTreeWidget->setItemWidget( treeWidgetItem, static_cast<int>( TreeWidgetColumn::Value ), label );
 
         mClickableLinkList.append( jsonValueString );
@@ -359,6 +360,7 @@ void QgsJsonEditWidget::refreshTreeViewItem( QTreeWidgetItem *treeWidgetItem, co
       for ( auto index = decltype( arraySize ) {0}; index < arraySize; index++ )
       {
         QTreeWidgetItem *treeWidgetItemChild = new QTreeWidgetItem( treeWidgetItem, QStringList() << QString::number( index ) );
+        treeWidgetItemChild->setFont( 0, monospaceFont() );
         if ( arraySize <= MAX_ELTS || ( index < MAX_ELTS / 2 || index + MAX_ELTS / 2 > arraySize ) )
         {
           refreshTreeViewItem( treeWidgetItemChild, jsonArray.at( index ) );
@@ -382,6 +384,7 @@ void QgsJsonEditWidget::refreshTreeViewItem( QTreeWidgetItem *treeWidgetItem, co
       for ( const QString &key : keys )
       {
         QTreeWidgetItem *treeWidgetItemChild = new QTreeWidgetItem( treeWidgetItem, QStringList() << key );
+        treeWidgetItemChild->setFont( 0, monospaceFont() );
         refreshTreeViewItem( treeWidgetItemChild, jsonObject.value( key ) );
         treeWidgetItem->addChild( treeWidgetItemChild );
         treeWidgetItem->setExpanded( true );
@@ -399,7 +402,17 @@ void QgsJsonEditWidget::refreshTreeViewItem( QTreeWidgetItem *treeWidgetItem, co
 void QgsJsonEditWidget::refreshTreeViewItemValue( QTreeWidgetItem *treeWidgetItem, const QString &jsonValueString, const QColor &textColor )
 {
   QLabel *label = new QLabel( jsonValueString );
+  label->setFont( monospaceFont() );
+
   if ( textColor.isValid() )
     label->setStyleSheet( QStringLiteral( "color: %1;" ).arg( textColor.name() ) );
   mTreeWidget->setItemWidget( treeWidgetItem, static_cast<int>( TreeWidgetColumn::Value ), label );
+}
+
+QFont QgsJsonEditWidget::monospaceFont() const
+{
+  QFont f = QgsCodeEditor::getMonospaceFont();
+  // use standard widget font size, not code editor font size
+  f.setPointSize( font().pointSize() );
+  return f;
 }

--- a/src/gui/editorwidgets/qgsjsoneditwidget.h
+++ b/src/gui/editorwidgets/qgsjsoneditwidget.h
@@ -116,6 +116,8 @@ class GUI_EXPORT QgsJsonEditWidget : public QWidget, private Ui::QgsJsonEditWidg
     void refreshTreeViewItem( QTreeWidgetItem *treeWidgetItemParent, const QJsonValue &jsonValue );
     void refreshTreeViewItemValue( QTreeWidgetItem *treeWidgetItem, const QString &jsonValueString, const QColor &textColor );
 
+    QFont monospaceFont() const;
+
     QString mJsonText;
 
     FormatJson mFormatJsonMode = FormatJson::Indented;

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -33,6 +33,14 @@ void QgsKeyValueWidgetWrapper::showIndeterminateState()
   mWidget->setMap( QVariantMap() );
 }
 
+void QgsKeyValueWidgetWrapper::setEnabled( bool enabled )
+{
+  if ( mWidget )
+  {
+    mWidget->setReadOnly( !enabled );
+  }
+}
+
 QWidget *QgsKeyValueWidgetWrapper::createWidget( QWidget *parent )
 {
   if ( isInTable( parent ) )

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
@@ -49,6 +49,8 @@ class GUI_EXPORT QgsKeyValueWidgetWrapper : public QgsEditorWidgetWrapper
   public:
     QVariant value() const override;
     void showIndeterminateState() override;
+  public slots:
+    void setEnabled( bool enabled ) override;
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -27,6 +27,14 @@ void QgsListWidgetWrapper::showIndeterminateState()
   mWidget->setList( QVariantList() );
 }
 
+void QgsListWidgetWrapper::setEnabled( bool enabled )
+{
+  if ( mWidget )
+  {
+    mWidget->setReadOnly( !enabled );
+  }
+}
+
 QWidget *QgsListWidgetWrapper::createWidget( QWidget *parent )
 {
   if ( isInTable( parent ) )

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -37,20 +37,19 @@ void QgsListWidgetWrapper::setEnabled( bool enabled )
 
 QWidget *QgsListWidgetWrapper::createWidget( QWidget *parent )
 {
+  QFrame *ret = new QFrame( parent );
+  ret->setFrameShape( QFrame::StyledPanel );
+  QHBoxLayout *layout = new QHBoxLayout( ret );
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  QgsListWidget *widget = new QgsListWidget( field().subType(), ret );
+  layout->addWidget( widget );
+
   if ( isInTable( parent ) )
   {
-    // if to be put in a table, draw a border and set a decent size
-    QFrame *ret = new QFrame( parent );
-    ret->setFrameShape( QFrame::StyledPanel );
-    QHBoxLayout *layout = new QHBoxLayout( ret );
-    layout->addWidget( new QgsListWidget( field().subType(), ret ) );
+    // if to be put in a table, set a decent size
     ret->setMinimumSize( QSize( 320, 110 ) );
-    return ret;
   }
-  else
-  {
-    return new QgsListWidget( field().subType(), parent );
-  }
+  return ret;
 }
 
 void QgsListWidgetWrapper::initWidget( QWidget *editor )

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.h
@@ -50,6 +50,9 @@ class GUI_EXPORT QgsListWidgetWrapper : public QgsEditorWidgetWrapper
     QVariant value() const override;
     void showIndeterminateState() override;
 
+  public slots:
+    void setEnabled( bool enabled ) override;
+
   protected:
     QWidget *createWidget( QWidget *parent ) override;
     void initWidget( QWidget *editor ) override;

--- a/src/gui/qgskeyvaluewidget.cpp
+++ b/src/gui/qgskeyvaluewidget.cpp
@@ -28,6 +28,12 @@ void QgsKeyValueWidget::setMap( const QVariantMap &map )
   mModel.setMap( map );
 }
 
+void QgsKeyValueWidget::setReadOnly( bool readOnly )
+{
+  mModel.setReadOnly( readOnly );
+  QgsTableWidgetBase::setReadOnly( readOnly );
+}
+
 ///@cond PRIVATE
 void QgsKeyValueModel::setMap( const QVariantMap &map )
 {
@@ -96,6 +102,9 @@ QVariant QgsKeyValueModel::data( const QModelIndex &index, int role ) const
 
 bool QgsKeyValueModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
+  if ( mReadOnly )
+    return false;
+
   if ( index.row() < 0 || index.row() >= mLines.count() || role != Qt::EditRole )
   {
     return false;
@@ -114,11 +123,17 @@ bool QgsKeyValueModel::setData( const QModelIndex &index, const QVariant &value,
 
 Qt::ItemFlags QgsKeyValueModel::flags( const QModelIndex &index ) const
 {
-  return QAbstractTableModel::flags( index ) | Qt::ItemIsEditable;
+  if ( !mReadOnly )
+    return QAbstractTableModel::flags( index ) | Qt::ItemIsEditable;
+  else
+    return QAbstractTableModel::flags( index );
 }
 
 bool QgsKeyValueModel::insertRows( int position, int rows, const QModelIndex &parent )
 {
+  if ( mReadOnly )
+    return false;
+
   Q_UNUSED( parent )
   beginInsertRows( QModelIndex(), position, position + rows - 1 );
   for ( int i = 0; i < rows; ++i )
@@ -131,10 +146,18 @@ bool QgsKeyValueModel::insertRows( int position, int rows, const QModelIndex &pa
 
 bool QgsKeyValueModel::removeRows( int position, int rows, const QModelIndex &parent )
 {
+  if ( mReadOnly )
+    return false;
+
   Q_UNUSED( parent )
   beginRemoveRows( QModelIndex(), position, position + rows - 1 );
   mLines.remove( position, rows );
   endRemoveRows();
   return true;
+}
+
+void QgsKeyValueModel::setReadOnly( bool readOnly )
+{
+  mReadOnly = readOnly;
 }
 ///@endcond

--- a/src/gui/qgskeyvaluewidget.h
+++ b/src/gui/qgskeyvaluewidget.h
@@ -48,10 +48,11 @@ class GUI_EXPORT QgsKeyValueModel : public QAbstractTableModel
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
     bool insertRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
     bool removeRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
-
+    void setReadOnly( bool readOnly );
     typedef QPair<QString, QVariant> Line;
 
   private:
+    bool mReadOnly = false;
     QVector<Line> mLines;
 };
 ///@endcond
@@ -83,6 +84,9 @@ class GUI_EXPORT QgsKeyValueWidget: public QgsTableWidgetBase
      */
     QVariantMap map() const { return mModel.map(); }
 
+  public slots:
+
+    void setReadOnly( bool readOnly ) override;
   private:
     QgsKeyValueModel mModel;
 };

--- a/src/gui/qgslistwidget.cpp
+++ b/src/gui/qgslistwidget.cpp
@@ -29,6 +29,12 @@ void QgsListWidget::setList( const QVariantList &list )
   mModel.setList( list );
 }
 
+void QgsListWidget::setReadOnly( bool readOnly )
+{
+  mModel.setReadOnly( readOnly );
+  QgsTableWidgetBase::setReadOnly( readOnly );
+}
+
 
 ///@cond PRIVATE
 QgsListModel::QgsListModel( QVariant::Type subType, QObject *parent ) :
@@ -101,6 +107,9 @@ QVariant QgsListModel::data( const QModelIndex &index, int role ) const
 
 bool QgsListModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
+  if ( mReadOnly )
+    return false;
+
   if ( index.row() < 0 || index.row() >= mLines.count() ||
        index.column() != 0 || role != Qt::EditRole )
   {
@@ -113,11 +122,17 @@ bool QgsListModel::setData( const QModelIndex &index, const QVariant &value, int
 
 Qt::ItemFlags QgsListModel::flags( const QModelIndex &index ) const
 {
-  return QAbstractTableModel::flags( index ) | Qt::ItemIsEditable;
+  if ( !mReadOnly )
+    return QAbstractTableModel::flags( index ) | Qt::ItemIsEditable;
+  else
+    return QAbstractTableModel::flags( index );
 }
 
 bool QgsListModel::insertRows( int position, int rows, const QModelIndex &parent )
 {
+  if ( mReadOnly )
+    return false;
+
   Q_UNUSED( parent )
   beginInsertRows( QModelIndex(), position, position + rows - 1 );
   for ( int i = 0; i < rows; ++i )
@@ -130,11 +145,19 @@ bool QgsListModel::insertRows( int position, int rows, const QModelIndex &parent
 
 bool QgsListModel::removeRows( int position, int rows, const QModelIndex &parent )
 {
+  if ( mReadOnly )
+    return false;
+
   Q_UNUSED( parent )
   beginRemoveRows( QModelIndex(), position, position + rows - 1 );
   for ( int i = 0; i < rows; ++i )
     mLines.removeAt( position );
   endRemoveRows();
   return true;
+}
+
+void QgsListModel::setReadOnly( bool readOnly )
+{
+  mReadOnly = readOnly;
 }
 ///@endcond

--- a/src/gui/qgslistwidget.h
+++ b/src/gui/qgslistwidget.h
@@ -48,8 +48,9 @@ class GUI_EXPORT QgsListModel : public QAbstractTableModel
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
     bool insertRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
     bool removeRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
-
+    void setReadOnly( bool readOnly );
   private:
+    bool mReadOnly = false;
     QVariantList mLines;
     QVariant::Type mSubType;
 };
@@ -88,6 +89,10 @@ class GUI_EXPORT QgsListWidget: public QgsTableWidgetBase
      * \returns TRUE if valid
      */
     bool valid() const { return mModel.valid(); }
+
+  public slots:
+
+    void setReadOnly( bool readOnly ) override;
 
   private:
     QgsListModel mModel;

--- a/src/gui/qgstablewidgetbase.cpp
+++ b/src/gui/qgstablewidgetbase.cpp
@@ -71,4 +71,15 @@ void QgsTableWidgetBase::setReadOnly( bool readOnly )
 
   addButton->setEnabled( !mReadOnly );
   removeButton->setEnabled( !mReadOnly && tableView->selectionModel()->hasSelection() );
+
+  if ( mReadOnly )
+  {
+    mWidgetActions->hide();
+    layout()->setSpacing( 0 );
+  }
+  else
+  {
+    mWidgetActions->show();
+    layout()->setSpacing( 6 );
+  }
 }

--- a/src/gui/qgstablewidgetbase.cpp
+++ b/src/gui/qgstablewidgetbase.cpp
@@ -34,6 +34,9 @@ void QgsTableWidgetBase::init( QAbstractTableModel *model )
 
 void QgsTableWidgetBase::addButton_clicked()
 {
+  if ( mReadOnly )
+    return;
+
   const QItemSelectionModel *select = tableView->selectionModel();
   const int pos = select->hasSelection() ? select->selectedRows()[0].row() : 0;
   QAbstractItemModel *model = tableView->model();
@@ -46,6 +49,9 @@ void QgsTableWidgetBase::addButton_clicked()
 
 void QgsTableWidgetBase::removeButton_clicked()
 {
+  if ( mReadOnly )
+    return;
+
   const QItemSelectionModel *select = tableView->selectionModel();
   // The UI is configured to have single row selection.
   if ( select->hasSelection() )
@@ -57,4 +63,12 @@ void QgsTableWidgetBase::removeButton_clicked()
 void QgsTableWidgetBase::onSelectionChanged()
 {
   removeButton->setEnabled( tableView->selectionModel()->hasSelection() );
+}
+
+void QgsTableWidgetBase::setReadOnly( bool readOnly )
+{
+  mReadOnly = readOnly;
+
+  addButton->setEnabled( !mReadOnly );
+  removeButton->setEnabled( !mReadOnly && tableView->selectionModel()->hasSelection() );
 }

--- a/src/gui/qgstablewidgetbase.h
+++ b/src/gui/qgstablewidgetbase.h
@@ -39,6 +39,24 @@ class GUI_EXPORT QgsTableWidgetBase: public QWidget, protected Ui::QgsTableWidge
      */
     explicit QgsTableWidgetBase( QWidget *parent );
 
+    /**
+     * Returns TRUE if the widget is shown in a read-only state.
+     *
+     * \see setReadOnly()
+     * \since QGIS 3.38
+     */
+    bool isReadOnly() const { return mReadOnly; }
+
+  public slots:
+
+    /**
+    * Sets whether the widget should be shown in a read-only state.
+    *
+    * \see isReadOnly()
+    * \since QGIS 3.38
+    */
+    virtual void setReadOnly( bool readOnly );
+
   protected:
 
     /**
@@ -70,6 +88,10 @@ class GUI_EXPORT QgsTableWidgetBase: public QWidget, protected Ui::QgsTableWidge
      * Called when the selection is changed to enable/disable the delete button.
      */
     void onSelectionChanged();
+
+  private:
+
+    bool mReadOnly = false;
 
     friend class TestQgsKeyValueWidget;
     friend class TestQgsListWidget;

--- a/src/ui/editorwidgets/qgsjsoneditwidget.ui
+++ b/src/ui/editorwidgets/qgsjsoneditwidget.ui
@@ -26,72 +26,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QWidget" name="mControlsWidget" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QToolButton" name="mTextToolButton">
-        <property name="toolTip">
-         <string>Show text</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../images/images.qrc">
-          <normaloff>:/images/themes/default/mIconFieldText.svg</normaloff>:/images/themes/default/mIconFieldText.svg</iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="mTreeToolButton">
-        <property name="toolTip">
-         <string>Show tree</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../images/images.qrc">
-          <normaloff>:/images/themes/default/mIconTreeView.svg</normaloff>:/images/themes/default/mIconTreeView.svg</iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
       <number>1</number>
@@ -150,6 +85,84 @@
      </widget>
     </widget>
    </item>
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mTextToolButton">
+       <property name="toolTip">
+        <string>Show text</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../images/images.qrc">
+         <normaloff>:/images/themes/default/mIconFieldText.svg</normaloff>:/images/themes/default/mIconFieldText.svg</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mTreeToolButton">
+       <property name="toolTip">
+        <string>Show tree</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../images/images.qrc">
+         <normaloff>:/images/themes/default/mIconTreeView.svg</normaloff>:/images/themes/default/mIconTreeView.svg</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="QWidget" name="mControlsWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -159,6 +172,11 @@
    <header>qgscodeeditorjson.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mTreeWidget</tabstop>
+  <tabstop>mTextToolButton</tabstop>
+  <tabstop>mTreeToolButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgstablewidgetuibase.ui
+++ b/src/ui/qgstablewidgetuibase.ui
@@ -33,6 +33,31 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="QTableView" name="tableView">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::CurrentChanged|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+    </widget>
+   </item>
+   <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QToolButton" name="addButton">
@@ -79,31 +104,6 @@
       </spacer>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QTableView" name="tableView">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::CurrentChanged|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>false</bool>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgstablewidgetuibase.ui
+++ b/src/ui/qgstablewidgetuibase.ui
@@ -58,7 +58,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
+    <layout class="QVBoxLayout" name="mActionLayout">
      <item>
       <widget class="QToolButton" name="addButton">
        <property name="toolTip">

--- a/src/ui/qgstablewidgetuibase.ui
+++ b/src/ui/qgstablewidgetuibase.ui
@@ -69,7 +69,7 @@
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionAdd.svg</normaloff>:/images/themes/default/mActionAdd.svg</iconset>
+         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
        </property>
       </widget>
      </item>
@@ -86,7 +86,7 @@
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionRemove.svg</normaloff>:/images/themes/default/mActionRemove.svg</iconset>
+         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
        </property>
       </widget>
      </item>

--- a/src/ui/qgstablewidgetuibase.ui
+++ b/src/ui/qgstablewidgetuibase.ui
@@ -58,55 +58,74 @@
     </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="mActionLayout">
-     <item>
-      <widget class="QToolButton" name="addButton">
-       <property name="toolTip">
-        <string>Add entry</string>
-       </property>
-       <property name="text">
-        <string>…</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="removeButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Remove entry</string>
-       </property>
-       <property name="text">
-        <string>…</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QWidget" name="mWidgetActions" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QToolButton" name="addButton">
+        <property name="toolTip">
+         <string>Add entry</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="removeButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Remove entry</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tableView</tabstop>
+  <tabstop>addButton</tabstop>
+  <tabstop>removeButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/tests/src/gui/testqgslistwidget.cpp
+++ b/tests/src/gui/testqgslistwidget.cpp
@@ -73,7 +73,7 @@ class TestQgsListWidget : public QObject
       QVERIFY( wrapper );
       const QSignalSpy spy( wrapper, SIGNAL( valueChanged( const QVariant & ) ) );
 
-      QgsListWidget *widget = qobject_cast< QgsListWidget * >( wrapper->widget() );
+      QgsListWidget *widget = wrapper->widget()->findChild<QgsListWidget *>();
       QVERIFY( widget );
 
       QStringList initial;
@@ -108,7 +108,7 @@ class TestQgsListWidget : public QObject
       QVERIFY( wrapper );
       QSignalSpy spy( wrapper, SIGNAL( valueChanged( const QVariant & ) ) );
 
-      QgsListWidget *widget = qobject_cast< QgsListWidget * >( wrapper->widget() );
+      QgsListWidget *widget = wrapper->widget()->findChild<QgsListWidget *>();
       QVERIFY( widget );
 
       QVariantList initial;
@@ -160,7 +160,7 @@ class TestQgsListWidget : public QObject
       QVERIFY( vl_array_int->isValid( ) );
 
       QgsListWidgetWrapper w_array_int( vl_array_int, vl_array_int->fields().indexOf( QLatin1String( "location" ) ), nullptr, nullptr );
-      QgsListWidget *widget = qobject_cast< QgsListWidget * >( w_array_int.widget( ) );
+      QgsListWidget *widget = w_array_int.widget( )->findChild<QgsListWidget *>();
 
       vl_array_int->startEditing( );
       QVariantList newList;
@@ -204,7 +204,7 @@ class TestQgsListWidget : public QObject
       QVERIFY( vl_array_str->isValid() );
 
       QgsListWidgetWrapper w_array_str( vl_array_str, vl_array_str->fields().indexOf( QLatin1String( "value" ) ), nullptr, nullptr );
-      widget = qobject_cast< QgsListWidget * >( w_array_str.widget( ) );
+      widget = w_array_str.widget( )->findChild<QgsListWidget *>();
       vl_array_str->startEditing( );
       QVariantList newListStr;
 


### PR DESCRIPTION
Implements a number of improvements to the UI of the JSON and list widgets

Issues fixed include:

-  Incorrect menu font in context menu for json editor
- Fix action button placement for list widget, use correct icons
- Fix list widget can't be scrolled for read-only layers, making some items impossible to see
- Hide non-functional buttons in list widget when layer is read only, fixing the alignment of widgets in the form

Before:

![image](https://github.com/qgis/QGIS/assets/1829991/a83a2237-11fe-4953-94af-2c41e0c312b6)


After:

![image](https://github.com/qgis/QGIS/assets/1829991/1671a0ca-c023-4362-950c-38760789be6d)