### PR TITLE
[sensorthings] Support feature expansion

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -42,9 +42,24 @@ Converts a string value corresponding to a SensorThings entity set to a :py:clas
 Returns :py:class:`Qgis`.SensorThingsEntity.Invalid if the string could not be converted to a known entity set type.
 %End
 
+    static QString entityToSetString( Qgis::SensorThingsEntity type );
+%Docstring
+Converts a SensorThings entity set to a SensorThings entity set string.
+
+.. versionadded:: 3.38
+%End
+
     static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
 %Docstring
 Returns the fields which correspond to a specified entity ``type``.
+%End
+
+    static QgsFields fieldsForExpandedEntityType( Qgis::SensorThingsEntity baseType, const QList< Qgis::SensorThingsEntity > &expandedTypes );
+%Docstring
+Returns the fields which correspond to a specified entity ``baseType``, expanded
+using the specified list of ``expandedTypes``.
+
+.. versionadded:: 3.38
 %End
 
     static QString geometryFieldForEntityType( Qgis::SensorThingsEntity type );
@@ -97,6 +112,13 @@ Returns a list of available geometry types for the server at the specified ``uri
 and entity ``type``.
 
 This method will block while network requests are made to the server.
+%End
+
+    static QList< QList< Qgis::SensorThingsEntity > > expandableTargets( Qgis::SensorThingsEntity type );
+%Docstring
+Returns a list of permissible expand targets for a given base entity ``type``.
+
+.. versionadded:: 3.38
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -128,9 +128,25 @@ Returns a list of permissible expand targets for a given base entity ``type``.
 .. versionadded:: 3.38
 %End
 
-    static QString asQueryString( const QList< QgsSensorThingsExpansionDefinition > &expansions );
+    static Qgis::RelationshipCardinality relationshipCardinality( Qgis::SensorThingsEntity baseType, Qgis::SensorThingsEntity relatedType, bool &valid /Out/ );
+%Docstring
+Returns the cardinality of the relationship between a base entity type and a related entity type.
+
+:param baseType: base entity type
+:param relatedType: related entity type
+
+:return: - relationship cardinality
+         - valid: will be set to ``True`` if a relationship exists between the entity types, or ``False`` if no relationship exists
+
+
+.. versionadded:: 3.38
+%End
+
+    static QString asQueryString( Qgis::SensorThingsEntity baseType, const QList< QgsSensorThingsExpansionDefinition > &expansions );
 %Docstring
 Returns a list of ``expansions`` as a valid SensorThings API query string, eg "$expand=Locations($orderby=id desc;$top=3;$expand=Datastreams($top=101))".
+
+The base entity type for the query must be specified.
 
 .. versionadded:: 3.38
 %End
@@ -246,9 +262,11 @@ Returns a QgsSensorThingsExpansionDefinition from a string representation.
 .. seealso:: :py:func:`toString`
 %End
 
-    QString asQueryString( const QStringList &additionalOptions = QStringList() ) const;
+    QString asQueryString( Qgis::SensorThingsEntity parentEntityType, const QStringList &additionalOptions = QStringList() ) const;
 %Docstring
 Returns the expansion as a valid SensorThings API query string, eg "$expand=Observations($orderby=phenomenonTime desc;$top=10)".
+
+The parent entity type for the expansion must be specified.
 
 Optionally a list of additional query options can be specified for the expansion.
 %End

--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -261,24 +261,25 @@ Optionally a list of additional query options can be specified for the expansion
     if ( !sipCpp->isValid() )
     {
       sipRes = PyUnicode_FromString( "<QgsSensorThingsExpansionDefinition: invalid>" );
-      return;
     }
-
-    QString innerDefinition;
-    if ( !sipCpp->orderBy().isEmpty() )
+    else
     {
-      innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
-    }
-    if ( sipCpp->limit() >= 0 )
-    {
-      if ( !innerDefinition.isEmpty() )
-        innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
-      else
-        innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
-    }
+      QString innerDefinition;
+      if ( !sipCpp->orderBy().isEmpty() )
+      {
+        innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
+      }
+      if ( sipCpp->limit() >= 0 )
+      {
+        if ( !innerDefinition.isEmpty() )
+          innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
+        else
+          innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+      }
 
-    QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
-    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+      QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
+      sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    }
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -49,6 +49,13 @@ Converts a SensorThings entity set to a SensorThings entity set string.
 .. versionadded:: 3.38
 %End
 
+    static QStringList propertiesForEntityType( Qgis::SensorThingsEntity type );
+%Docstring
+Returns the SensorThings properties which correspond to a specified entity ``type``.
+
+.. versionadded:: 3.38
+%End
+
     static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
 %Docstring
 Returns the fields which correspond to a specified entity ``type``.
@@ -114,11 +121,164 @@ and entity ``type``.
 This method will block while network requests are made to the server.
 %End
 
-    static QList< QList< Qgis::SensorThingsEntity > > expandableTargets( Qgis::SensorThingsEntity type );
+    static QList< Qgis::SensorThingsEntity > expandableTargets( Qgis::SensorThingsEntity type );
 %Docstring
 Returns a list of permissible expand targets for a given base entity ``type``.
 
 .. versionadded:: 3.38
+%End
+
+    static QString asQueryString( const QList< QgsSensorThingsExpansionDefinition > &expansions );
+%Docstring
+Returns a list of ``expansions`` as a valid SensorThings API query string, eg "$expand=Locations($orderby=id desc;$top=3;$expand=Datastreams($top=101))".
+
+.. versionadded:: 3.38
+%End
+
+};
+
+
+class QgsSensorThingsExpansionDefinition
+{
+%Docstring(signature="appended")
+Encapsulates information about how relationships in a SensorThings API service should be expanded.
+
+.. versionadded:: 3.38
+%End
+
+%TypeHeaderCode
+#include "qgssensorthingsutils.h"
+%End
+  public:
+
+    QgsSensorThingsExpansionDefinition( Qgis::SensorThingsEntity childEntity = Qgis::SensorThingsEntity::Invalid,
+                                        const QString &orderBy = QString(),
+                                        Qt::SortOrder sortOrder = Qt::SortOrder::AscendingOrder,
+                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
+%Docstring
+Constructor for QgsSensorThingsExpansionDefinition, targeting the specified child entity type.
+%End
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if the definition is valid.
+%End
+
+    Qgis::SensorThingsEntity childEntity() const;
+%Docstring
+Returns the target child entity which should be expanded.
+
+.. seealso:: :py:func:`setChildEntity`
+%End
+
+    void setChildEntity( Qgis::SensorThingsEntity entity );
+%Docstring
+Sets the target child ``entity`` which should be expanded.
+
+.. seealso:: :py:func:`childEntity`
+%End
+
+    QString orderBy() const;
+%Docstring
+Returns the field name to order the expanded child entities by.
+
+.. seealso:: :py:func:`sortOrder`
+
+.. seealso:: :py:func:`setOrderBy`
+%End
+
+    void setOrderBy( const QString &field );
+%Docstring
+Sets the ``field`` name to order the expanded child entities by.
+
+.. seealso:: :py:func:`orderBy`
+
+.. seealso:: :py:func:`setSortOrder`
+%End
+
+    Qt::SortOrder sortOrder() const;
+%Docstring
+Returns the sort order for the expanded child entities.
+
+.. seealso:: :py:func:`orderBy`
+
+.. seealso:: :py:func:`setSortOrder`
+%End
+
+    void setSortOrder( Qt::SortOrder order );
+%Docstring
+Sets the sort order for the expanded child entities.
+
+.. seealso:: :py:func:`setOrderBy`
+
+.. seealso:: :py:func:`sortOrder`
+%End
+
+    int limit() const;
+%Docstring
+Returns the limit on the number of child features to fetch.
+
+Returns -1 if no limit is defined.
+
+.. seealso:: :py:func:`setLimit`
+%End
+
+    void setLimit( int limit );
+%Docstring
+Sets the ``limit`` on the number of child features to fetch.
+
+Set to -1 if no limit is desired.
+
+.. seealso:: :py:func:`limit`
+%End
+
+    QString toString() const;
+%Docstring
+Returns a string encapsulation of the expansion definition.
+
+.. seealso:: :py:func:`fromString`
+%End
+
+    static QgsSensorThingsExpansionDefinition fromString( const QString &string );
+%Docstring
+Returns a QgsSensorThingsExpansionDefinition from a string representation.
+
+.. seealso:: :py:func:`toString`
+%End
+
+    QString asQueryString( const QStringList &additionalOptions = QStringList() ) const;
+%Docstring
+Returns the expansion as a valid SensorThings API query string, eg "$expand=Observations($orderby=phenomenonTime desc;$top=10)".
+
+Optionally a list of additional query options can be specified for the expansion.
+%End
+
+    bool operator==( const QgsSensorThingsExpansionDefinition &other ) const;
+    bool operator!=( const QgsSensorThingsExpansionDefinition &other ) const;
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    if ( !sipCpp->isValid() )
+    {
+      sipRes = PyUnicode_FromString( "<QgsSensorThingsExpansionDefinition: invalid>" );
+      return;
+    }
+
+    QString innerDefinition;
+    if ( !sipCpp->orderBy().isEmpty() )
+    {
+      innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
+    }
+    if ( sipCpp->limit() >= 0 )
+    {
+      if ( !innerDefinition.isEmpty() )
+        innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
+      else
+        innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+    }
+
+    QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
 };

--- a/python/PyQt6/core/conversions.sip
+++ b/python/PyQt6/core/conversions.sip
@@ -1039,6 +1039,107 @@ which are not wrapped by PyQt:
 %End
 };
 
+// adapted from the qpymultimedia_qlist.sip file from the PyQt6 sources
+%MappedType QList<Qgis::SensorThingsEntity>
+    /TypeHintIn="Iterable[Qgis.SensorThingsEntity]",
+    TypeHintOut="List[Qgis.SensorThingsEntity]", TypeHintValue="[]"/
+{
+    %TypeHeaderCode
+#include "qgis.h"
+        %End
+
+        %ConvertFromTypeCode
+            PyObject *l = PyList_New(sipCpp->size());
+
+    if (!l)
+        return 0;
+
+    for (int i = 0; i < sipCpp->size(); ++i)
+    {
+        PyObject *eobj = sipConvertFromEnum(static_cast<int>(sipCpp->at(i)),
+                                            sipType_Qgis_SensorThingsEntity);
+
+        if (!eobj)
+        {
+            Py_DECREF(l);
+
+            return 0;
+        }
+
+        PyList_SetItem(l, i, eobj);
+    }
+
+    return l;
+    %End
+
+        %ConvertToTypeCode
+            PyObject *iter = PyObject_GetIter(sipPy);
+
+    if (!sipIsErr)
+    {
+        PyErr_Clear();
+        Py_XDECREF(iter);
+
+        return (iter && !PyBytes_Check(sipPy) && !PyUnicode_Check(sipPy));
+    }
+
+    if (!iter)
+    {
+        *sipIsErr = 1;
+
+        return 0;
+    }
+
+    QList<Qgis::SensorThingsEntity> *ql = new QList<Qgis::SensorThingsEntity>;
+
+    for (Py_ssize_t i = 0; ; ++i)
+    {
+        PyErr_Clear();
+        PyObject *itm = PyIter_Next(iter);
+
+        if (!itm)
+        {
+            if (PyErr_Occurred())
+            {
+                delete ql;
+                Py_DECREF(iter);
+                *sipIsErr = 1;
+
+                return 0;
+            }
+
+            break;
+        }
+
+        int v = sipConvertToEnum(itm, sipType_Qgis_SensorThingsEntity);
+
+        if (PyErr_Occurred())
+        {
+            PyErr_Format(PyExc_TypeError,
+                         "index %zd has type '%s' but 'Qgis.SensorThingsEntity' is expected",
+                         i, sipPyTypeName(Py_TYPE(itm)));
+
+            Py_DECREF(itm);
+            delete ql;
+            Py_DECREF(iter);
+            *sipIsErr = 1;
+
+            return 0;
+        }
+
+        ql->append(static_cast<Qgis::SensorThingsEntity>(v));
+
+        Py_DECREF(itm);
+    }
+
+    Py_DECREF(iter);
+
+    *sipCppPtr = ql;
+
+    return sipGetState(sipTransferObj);
+    %End
+};
+
 template <TYPE>
 %MappedType QVector< QVector<TYPE> >
 {

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -42,9 +42,24 @@ Converts a string value corresponding to a SensorThings entity set to a :py:clas
 Returns :py:class:`Qgis`.SensorThingsEntity.Invalid if the string could not be converted to a known entity set type.
 %End
 
+    static QString entityToSetString( Qgis::SensorThingsEntity type );
+%Docstring
+Converts a SensorThings entity set to a SensorThings entity set string.
+
+.. versionadded:: 3.38
+%End
+
     static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
 %Docstring
 Returns the fields which correspond to a specified entity ``type``.
+%End
+
+    static QgsFields fieldsForExpandedEntityType( Qgis::SensorThingsEntity baseType, const QList< Qgis::SensorThingsEntity > &expandedTypes );
+%Docstring
+Returns the fields which correspond to a specified entity ``baseType``, expanded
+using the specified list of ``expandedTypes``.
+
+.. versionadded:: 3.38
 %End
 
     static QString geometryFieldForEntityType( Qgis::SensorThingsEntity type );
@@ -97,6 +112,13 @@ Returns a list of available geometry types for the server at the specified ``uri
 and entity ``type``.
 
 This method will block while network requests are made to the server.
+%End
+
+    static QList< QList< Qgis::SensorThingsEntity > > expandableTargets( Qgis::SensorThingsEntity type );
+%Docstring
+Returns a list of permissible expand targets for a given base entity ``type``.
+
+.. versionadded:: 3.38
 %End
 
 };

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -128,9 +128,25 @@ Returns a list of permissible expand targets for a given base entity ``type``.
 .. versionadded:: 3.38
 %End
 
-    static QString asQueryString( const QList< QgsSensorThingsExpansionDefinition > &expansions );
+    static Qgis::RelationshipCardinality relationshipCardinality( Qgis::SensorThingsEntity baseType, Qgis::SensorThingsEntity relatedType, bool &valid /Out/ );
+%Docstring
+Returns the cardinality of the relationship between a base entity type and a related entity type.
+
+:param baseType: base entity type
+:param relatedType: related entity type
+
+:return: - relationship cardinality
+         - valid: will be set to ``True`` if a relationship exists between the entity types, or ``False`` if no relationship exists
+
+
+.. versionadded:: 3.38
+%End
+
+    static QString asQueryString( Qgis::SensorThingsEntity baseType, const QList< QgsSensorThingsExpansionDefinition > &expansions );
 %Docstring
 Returns a list of ``expansions`` as a valid SensorThings API query string, eg "$expand=Locations($orderby=id desc;$top=3;$expand=Datastreams($top=101))".
+
+The base entity type for the query must be specified.
 
 .. versionadded:: 3.38
 %End
@@ -246,9 +262,11 @@ Returns a QgsSensorThingsExpansionDefinition from a string representation.
 .. seealso:: :py:func:`toString`
 %End
 
-    QString asQueryString( const QStringList &additionalOptions = QStringList() ) const;
+    QString asQueryString( Qgis::SensorThingsEntity parentEntityType, const QStringList &additionalOptions = QStringList() ) const;
 %Docstring
 Returns the expansion as a valid SensorThings API query string, eg "$expand=Observations($orderby=phenomenonTime desc;$top=10)".
+
+The parent entity type for the expansion must be specified.
 
 Optionally a list of additional query options can be specified for the expansion.
 %End

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -261,24 +261,25 @@ Optionally a list of additional query options can be specified for the expansion
     if ( !sipCpp->isValid() )
     {
       sipRes = PyUnicode_FromString( "<QgsSensorThingsExpansionDefinition: invalid>" );
-      return;
     }
-
-    QString innerDefinition;
-    if ( !sipCpp->orderBy().isEmpty() )
+    else
     {
-      innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
-    }
-    if ( sipCpp->limit() >= 0 )
-    {
-      if ( !innerDefinition.isEmpty() )
-        innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
-      else
-        innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
-    }
+      QString innerDefinition;
+      if ( !sipCpp->orderBy().isEmpty() )
+      {
+        innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
+      }
+      if ( sipCpp->limit() >= 0 )
+      {
+        if ( !innerDefinition.isEmpty() )
+          innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
+        else
+          innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+      }
 
-    QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
-    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+      QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
+      sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    }
 %End
 
 };

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -49,6 +49,13 @@ Converts a SensorThings entity set to a SensorThings entity set string.
 .. versionadded:: 3.38
 %End
 
+    static QStringList propertiesForEntityType( Qgis::SensorThingsEntity type );
+%Docstring
+Returns the SensorThings properties which correspond to a specified entity ``type``.
+
+.. versionadded:: 3.38
+%End
+
     static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
 %Docstring
 Returns the fields which correspond to a specified entity ``type``.
@@ -114,11 +121,164 @@ and entity ``type``.
 This method will block while network requests are made to the server.
 %End
 
-    static QList< QList< Qgis::SensorThingsEntity > > expandableTargets( Qgis::SensorThingsEntity type );
+    static QList< Qgis::SensorThingsEntity > expandableTargets( Qgis::SensorThingsEntity type );
 %Docstring
 Returns a list of permissible expand targets for a given base entity ``type``.
 
 .. versionadded:: 3.38
+%End
+
+    static QString asQueryString( const QList< QgsSensorThingsExpansionDefinition > &expansions );
+%Docstring
+Returns a list of ``expansions`` as a valid SensorThings API query string, eg "$expand=Locations($orderby=id desc;$top=3;$expand=Datastreams($top=101))".
+
+.. versionadded:: 3.38
+%End
+
+};
+
+
+class QgsSensorThingsExpansionDefinition
+{
+%Docstring(signature="appended")
+Encapsulates information about how relationships in a SensorThings API service should be expanded.
+
+.. versionadded:: 3.38
+%End
+
+%TypeHeaderCode
+#include "qgssensorthingsutils.h"
+%End
+  public:
+
+    QgsSensorThingsExpansionDefinition( Qgis::SensorThingsEntity childEntity = Qgis::SensorThingsEntity::Invalid,
+                                        const QString &orderBy = QString(),
+                                        Qt::SortOrder sortOrder = Qt::SortOrder::AscendingOrder,
+                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
+%Docstring
+Constructor for QgsSensorThingsExpansionDefinition, targeting the specified child entity type.
+%End
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if the definition is valid.
+%End
+
+    Qgis::SensorThingsEntity childEntity() const;
+%Docstring
+Returns the target child entity which should be expanded.
+
+.. seealso:: :py:func:`setChildEntity`
+%End
+
+    void setChildEntity( Qgis::SensorThingsEntity entity );
+%Docstring
+Sets the target child ``entity`` which should be expanded.
+
+.. seealso:: :py:func:`childEntity`
+%End
+
+    QString orderBy() const;
+%Docstring
+Returns the field name to order the expanded child entities by.
+
+.. seealso:: :py:func:`sortOrder`
+
+.. seealso:: :py:func:`setOrderBy`
+%End
+
+    void setOrderBy( const QString &field );
+%Docstring
+Sets the ``field`` name to order the expanded child entities by.
+
+.. seealso:: :py:func:`orderBy`
+
+.. seealso:: :py:func:`setSortOrder`
+%End
+
+    Qt::SortOrder sortOrder() const;
+%Docstring
+Returns the sort order for the expanded child entities.
+
+.. seealso:: :py:func:`orderBy`
+
+.. seealso:: :py:func:`setSortOrder`
+%End
+
+    void setSortOrder( Qt::SortOrder order );
+%Docstring
+Sets the sort order for the expanded child entities.
+
+.. seealso:: :py:func:`setOrderBy`
+
+.. seealso:: :py:func:`sortOrder`
+%End
+
+    int limit() const;
+%Docstring
+Returns the limit on the number of child features to fetch.
+
+Returns -1 if no limit is defined.
+
+.. seealso:: :py:func:`setLimit`
+%End
+
+    void setLimit( int limit );
+%Docstring
+Sets the ``limit`` on the number of child features to fetch.
+
+Set to -1 if no limit is desired.
+
+.. seealso:: :py:func:`limit`
+%End
+
+    QString toString() const;
+%Docstring
+Returns a string encapsulation of the expansion definition.
+
+.. seealso:: :py:func:`fromString`
+%End
+
+    static QgsSensorThingsExpansionDefinition fromString( const QString &string );
+%Docstring
+Returns a QgsSensorThingsExpansionDefinition from a string representation.
+
+.. seealso:: :py:func:`toString`
+%End
+
+    QString asQueryString( const QStringList &additionalOptions = QStringList() ) const;
+%Docstring
+Returns the expansion as a valid SensorThings API query string, eg "$expand=Observations($orderby=phenomenonTime desc;$top=10)".
+
+Optionally a list of additional query options can be specified for the expansion.
+%End
+
+    bool operator==( const QgsSensorThingsExpansionDefinition &other ) const;
+    bool operator!=( const QgsSensorThingsExpansionDefinition &other ) const;
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    if ( !sipCpp->isValid() )
+    {
+      sipRes = PyUnicode_FromString( "<QgsSensorThingsExpansionDefinition: invalid>" );
+      return;
+    }
+
+    QString innerDefinition;
+    if ( !sipCpp->orderBy().isEmpty() )
+    {
+      innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
+    }
+    if ( sipCpp->limit() >= 0 )
+    {
+      if ( !innerDefinition.isEmpty() )
+        innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
+      else
+        innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+    }
+
+    QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
 };

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -1039,6 +1039,107 @@ which are not wrapped by PyQt:
 %End
 };
 
+// adapted from the qpymultimedia_qlist.sip file from the PyQt6 sources
+%MappedType QList<Qgis::SensorThingsEntity>
+    /TypeHintIn="Iterable[Qgis.SensorThingsEntity]",
+    TypeHintOut="List[Qgis.SensorThingsEntity]", TypeHintValue="[]"/
+{
+    %TypeHeaderCode
+#include "qgis.h"
+        %End
+
+        %ConvertFromTypeCode
+            PyObject *l = PyList_New(sipCpp->size());
+
+    if (!l)
+        return 0;
+
+    for (int i = 0; i < sipCpp->size(); ++i)
+    {
+        PyObject *eobj = sipConvertFromEnum(static_cast<int>(sipCpp->at(i)),
+                                            sipType_Qgis_SensorThingsEntity);
+
+        if (!eobj)
+        {
+            Py_DECREF(l);
+
+            return 0;
+        }
+
+        PyList_SetItem(l, i, eobj);
+    }
+
+    return l;
+    %End
+
+        %ConvertToTypeCode
+            PyObject *iter = PyObject_GetIter(sipPy);
+
+    if (!sipIsErr)
+    {
+        PyErr_Clear();
+        Py_XDECREF(iter);
+
+        return (iter && !PyBytes_Check(sipPy) && !PyUnicode_Check(sipPy));
+    }
+
+    if (!iter)
+    {
+        *sipIsErr = 1;
+
+        return 0;
+    }
+
+    QList<Qgis::SensorThingsEntity> *ql = new QList<Qgis::SensorThingsEntity>;
+
+    for (Py_ssize_t i = 0; ; ++i)
+    {
+        PyErr_Clear();
+        PyObject *itm = PyIter_Next(iter);
+
+        if (!itm)
+        {
+            if (PyErr_Occurred())
+            {
+                delete ql;
+                Py_DECREF(iter);
+                *sipIsErr = 1;
+
+                return 0;
+            }
+
+            break;
+        }
+
+        int v = sipConvertToEnum(itm, sipType_Qgis_SensorThingsEntity);
+
+        if (PyErr_Occurred())
+        {
+            PyErr_Format(PyExc_TypeError,
+                         "index %zd has type '%s' but 'Qgis.SensorThingsEntity' is expected",
+                         i, sipPyTypeName(Py_TYPE(itm)));
+
+            Py_DECREF(itm);
+            delete ql;
+            Py_DECREF(iter);
+            *sipIsErr = 1;
+
+            return 0;
+        }
+
+        ql->append(static_cast<Qgis::SensorThingsEntity>(v));
+
+        Py_DECREF(itm);
+    }
+
+    Py_DECREF(iter);
+
+    *sipCppPtr = ql;
+
+    return sipGetState(sipTransferObj);
+    %End
+};
+
 template <TYPE>
 %MappedType QVector< QVector<TYPE> >
 {

--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -3285,7 +3285,7 @@ geometricians:geometers
 geomtry:geometry
 gerat:great
 get's:gets
-geting:getting
+geting:getting:*
 Ghandi:Gandhi
 gived:given
 glight:flight

--- a/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
@@ -377,6 +377,10 @@ QVariantMap QgsSensorThingsProviderMetadata::decodeUri( const QString &uri ) con
   if ( entity != Qgis::SensorThingsEntity::Invalid )
     components.insert( QStringLiteral( "entity" ), qgsEnumValueToKey( entity ) );
 
+  const QString expandToParam = dsUri.param( QStringLiteral( "expandTo" ) );
+  if ( !expandToParam.isEmpty() )
+    components.insert( QStringLiteral( "expandTo" ), expandToParam.split( ',' ) );
+
   bool ok = false;
   const int maxPageSizeParam = dsUri.param( QStringLiteral( "pageSize" ) ).toInt( &ok );
   if ( ok )
@@ -465,6 +469,10 @@ QString QgsSensorThingsProviderMetadata::encodeUri( const QVariantMap &parts ) c
     dsUri.setParam( QStringLiteral( "entity" ),
                     qgsEnumValueToKey( entity ) );
   }
+
+  const QStringList expandToParam = parts.value( QStringLiteral( "expandTo" ) ).toStringList();
+  if ( !expandToParam.isEmpty() )
+    dsUri.setParam( QStringLiteral( "expandTo" ), expandToParam.join( ',' ) );
 
   bool ok = false;
   const int maxPageSizeParam = parts.value( QStringLiteral( "pageSize" ) ).toInt( &ok );

--- a/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
@@ -394,6 +394,12 @@ QVariantMap QgsSensorThingsProviderMetadata::decodeUri( const QString &uri ) con
   {
     components.insert( QStringLiteral( "featureLimit" ), featureLimitParam );
   }
+  ok = false;
+  const int expansionLimitParam = dsUri.param( QStringLiteral( "expansionLimit" ) ).toInt( &ok );
+  if ( ok )
+  {
+    components.insert( QStringLiteral( "expansionLimit" ), expansionLimitParam );
+  }
 
   switch ( QgsWkbTypes::geometryType( dsUri.wkbType() ) )
   {
@@ -486,6 +492,12 @@ QString QgsSensorThingsProviderMetadata::encodeUri( const QVariantMap &parts ) c
   if ( ok )
   {
     dsUri.setParam( QStringLiteral( "featureLimit" ), QString::number( featureLimitParam ) );
+  }
+  ok = false;
+  const int expansionLimitParam = parts.value( QStringLiteral( "expansionLimit" ) ).toInt( &ok );
+  if ( ok )
+  {
+    dsUri.setParam( QStringLiteral( "expansionLimit" ), QString::number( expansionLimitParam ) );
   }
 
   const QString geometryType = parts.value( QStringLiteral( "geometryType" ) ).toString();

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
@@ -34,7 +34,24 @@ QgsSensorThingsSharedData::QgsSensorThingsSharedData( const QString &uri )
   const QVariantMap uriParts = QgsSensorThingsProviderMetadata().decodeUri( uri );
 
   mEntityType = qgsEnumKeyToValue( uriParts.value( QStringLiteral( "entity" ) ).toString(), Qgis::SensorThingsEntity::Invalid );
-  mFields = QgsSensorThingsUtils::fieldsForEntityType( mEntityType );
+  const QStringList expandTo = uriParts.value( QStringLiteral( "expandTo" ) ).toStringList();
+  QStringList expandQueryParts;
+  for ( const QString &expand : expandTo )
+  {
+    const Qgis::SensorThingsEntity expandToEntityType = qgsEnumKeyToValue( expand, Qgis::SensorThingsEntity::Invalid );
+    if ( expandToEntityType != Qgis::SensorThingsEntity::Invalid )
+    {
+      mExpandTo.append( expandToEntityType );
+      // NOTE: from the specifications, it looks look SOMETIMES plural is used, sometimes singular??
+      // We might need to be more flexible here to support all connections
+      expandQueryParts.append( QgsSensorThingsUtils::entityToSetString( expandToEntityType ) );
+    }
+  }
+  if ( !expandQueryParts.empty() )
+    mExpandQueryString = QStringLiteral( "$expand=" ) + expandQueryParts.join( '/' );
+
+  mFields = QgsSensorThingsUtils::fieldsForExpandedEntityType( mEntityType, mExpandTo );
+
   mGeometryField = QgsSensorThingsUtils::geometryFieldForEntityType( mEntityType );
   // use initial value of maximum page size as default
   mMaximumPageSize = uriParts.value( QStringLiteral( "pageSize" ), mMaximumPageSize ).toInt();
@@ -165,6 +182,14 @@ long long QgsSensorThingsSharedData::featureCount( QgsFeedback *feedback ) const
   locker.changeMode( QgsReadWriteLocker::Write );
   mError.clear();
 
+  // MISSING PART -- how to handle feature count when we are expanding features?
+  // This situation is not handled by the SensorThings standard at all, so we'll just have
+  // to return an unknown count whenever expansion is used
+  if ( !mExpandTo.isEmpty() )
+  {
+    return static_cast< long long >( Qgis::FeatureCountState::UnknownCount );
+  }
+
   // return no features, just the total count
   QString countUri = QStringLiteral( "%1?$top=0&$count=true" ).arg( mEntityBaseUri );
   const QString typeFilter = QgsSensorThingsUtils::filterForWkbType( mEntityType, mGeometryType );
@@ -229,7 +254,7 @@ bool QgsSensorThingsSharedData::hasCachedAllFeatures() const
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   return mHasCachedAllFeatures
          || ( mFeatureCount > 0 && mCachedFeatures.size() == mFeatureCount )
-         || ( mFeatureLimit > 0 && mCachedFeatures.size() >= mFeatureLimit );
+         || ( mFeatureLimit > 0 && mRetrievedBaseFeatureCount >= mFeatureLimit );
 }
 
 bool QgsSensorThingsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *feedback )
@@ -257,7 +282,7 @@ bool QgsSensorThingsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsF
     if ( mFeatureLimit > 0 && ( mCachedFeatures.size() + thisPageSize ) > mFeatureLimit )
       thisPageSize = mFeatureLimit - mCachedFeatures.size();
 
-    mNextPage = QStringLiteral( "%1?$top=%2&$count=false" ).arg( mEntityBaseUri ).arg( thisPageSize );
+    mNextPage = QStringLiteral( "%1?$top=%2&$count=false%3" ).arg( mEntityBaseUri ).arg( thisPageSize ).arg( !mExpandQueryString.isEmpty() ? ( QStringLiteral( "&" ) + mExpandQueryString ) : QString() );
     const QString typeFilter = QgsSensorThingsUtils::filterForWkbType( mEntityType, mGeometryType );
     const QString extentFilter = QgsSensorThingsUtils::filterForExtent( mGeometryField, mFilterExtent );
     const QString filterString = QgsSensorThingsUtils::combineFilters( { typeFilter, extentFilter, mSubsetString } );
@@ -320,7 +345,7 @@ QgsFeatureIds QgsSensorThingsSharedData::getFeatureIdsInExtent( const QgsRectang
   }
   else
   {
-    queryUrl = QStringLiteral( "%1?$top=%2&$count=false%3" ).arg( mEntityBaseUri ).arg( thisPageSize ).arg( filterString );
+    queryUrl = QStringLiteral( "%1?$top=%2&$count=false%3%4" ).arg( mEntityBaseUri ).arg( thisPageSize ).arg( filterString, !mExpandQueryString.isEmpty() ? ( QStringLiteral( "&" ) + mExpandQueryString ) : QString() );
   }
 
   if ( thisPage.isEmpty() && mCachedExtent.intersects( extentGeom ) )
@@ -384,6 +409,7 @@ bool QgsSensorThingsSharedData::processFeatureRequest( QString &nextPage, QgsFee
   const QString authcfg = mAuthCfg;
   const QgsHttpHeaders headers = mHeaders;
   const QgsFields fields = mFields;
+  const QList< Qgis::SensorThingsEntity > expandTo = mExpandTo;
 
   while ( continueFetchingCallback() )
   {
@@ -555,158 +581,19 @@ bool QgsSensorThingsSharedData::processFeatureRequest( QString &nextPage, QgsFee
                 return { QVariant(), QVariant() };
               };
 
-              // Set attributes
               const QString iotId = getString( featureData, "@iot.id" ).toString();
-              auto existingFeatureIdIt = mIotIdToFeatureId.constFind( iotId );
-              if ( existingFeatureIdIt != mIotIdToFeatureId.constEnd() )
+              if ( expandTo.isEmpty() )
               {
-                // we've previously fetched and cached this feature, skip it
-                fetchedFeatureCallback( *mCachedFeatures.find( *existingFeatureIdIt ) );
-                continue;
+                auto existingFeatureIdIt = mIotIdToFeatureId.constFind( iotId );
+                if ( existingFeatureIdIt != mIotIdToFeatureId.constEnd() )
+                {
+                  // we've previously fetched and cached this feature, skip it
+                  fetchedFeatureCallback( *mCachedFeatures.find( *existingFeatureIdIt ) );
+                  continue;
+                }
               }
 
               QgsFeature feature( fields );
-              feature.setId( mNextFeatureId++ );
-
-              const QString selfLink = getString( featureData, "@iot.selfLink" ).toString();
-
-              const QVariant properties = getVariantMap( featureData, "properties" );
-              // NOLINTBEGIN(bugprone-branch-clone)
-              switch ( mEntityType )
-              {
-                case Qgis::SensorThingsEntity::Invalid:
-                  break;
-
-                case Qgis::SensorThingsEntity::Thing:
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getString( featureData, "name" )
-                    << getString( featureData, "description" )
-                    << properties
-                  );
-                  break;
-
-                case Qgis::SensorThingsEntity::Location:
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getString( featureData, "name" )
-                    << getString( featureData, "description" )
-                    << properties
-                  );
-                  break;
-
-                case Qgis::SensorThingsEntity::HistoricalLocation:
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getDateTime( featureData, "time" )
-                  );
-                  break;
-
-                case Qgis::SensorThingsEntity::Datastream:
-                {
-                  std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( featureData, "phenomenonTime" );
-                  std::pair< QVariant, QVariant > resultTime = getDateTimeRange( featureData, "resultTime" );
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getString( featureData, "name" )
-                    << getString( featureData, "description" )
-                    << getVariantMap( featureData, "unitOfMeasurement" )
-                    << getString( featureData, "observationType" )
-                    << properties
-                    << phenomenonTime.first
-                    << phenomenonTime.second
-                    << resultTime.first
-                    << resultTime.second
-                  );
-                  break;
-                }
-
-                case Qgis::SensorThingsEntity::Sensor:
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getString( featureData, "name" )
-                    << getString( featureData, "description" )
-                    << getString( featureData, "metadata" )
-                    << properties
-                  );
-                  break;
-
-                case Qgis::SensorThingsEntity::ObservedProperty:
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getString( featureData, "name" )
-                    << getString( featureData, "definition" )
-                    << getString( featureData, "description" )
-                    << properties
-                  );
-                  break;
-
-                case Qgis::SensorThingsEntity::Observation:
-                {
-                  std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( featureData, "phenomenonTime", true );
-                  std::pair< QVariant, QVariant > validTime = getDateTimeRange( featureData, "validTime" );
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << phenomenonTime.first
-                    << phenomenonTime.second
-                    << getString( featureData, "result" ) // TODO -- result type handling!
-                    << getDateTime( featureData, "resultTime" )
-                    << getStringList( featureData, "resultQuality" )
-                    << validTime.first
-                    << validTime.second
-                    << getVariantMap( featureData, "parameters" )
-                  );
-                  break;
-                }
-
-                case Qgis::SensorThingsEntity::FeatureOfInterest:
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getString( featureData, "name" )
-                    << getString( featureData, "description" )
-                    << properties
-                  );
-                  break;
-
-                case Qgis::SensorThingsEntity::MultiDatastream:
-                {
-                  std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( featureData, "phenomenonTime" );
-                  std::pair< QVariant, QVariant > resultTime = getDateTimeRange( featureData, "resultTime" );
-                  feature.setAttributes(
-                    QgsAttributes()
-                    << iotId
-                    << selfLink
-                    << getString( featureData, "name" )
-                    << getString( featureData, "description" )
-                    << getVariantList( featureData, "unitOfMeasurements" )
-                    << getString( featureData, "observationType" )
-                    << getStringList( featureData, "multiObservationDataTypes" )
-                    << properties
-                    << phenomenonTime.first
-                    << phenomenonTime.second
-                    << resultTime.first
-                    << resultTime.second
-                  );
-                  break;
-                }
-              }
-              // NOLINTEND(bugprone-branch-clone)
 
               // Set geometry
               if ( mGeometryType != Qgis::WkbType::NoGeometry )
@@ -721,32 +608,240 @@ bool QgsSensorThingsSharedData::processFeatureRequest( QString &nextPage, QgsFee
                 }
               }
 
-              mCachedFeatures.insert( feature.id(), feature );
-              mIotIdToFeatureId.insert( iotId, feature.id() );
-              mSpatialIndex.addFeature( feature );
-              mFetchedFeatureExtent.combineExtentWith( feature.geometry().boundingBox() );
+              auto extendAttributes = [&getString, &getVariantMap, &getDateTimeRange, &getDateTime, &getStringList, &getVariantList]( Qgis::SensorThingsEntity entityType, const auto & entityData, QgsAttributes & attributes )
+              {
+                const QString iotId = getString( entityData, "@iot.id" ).toString();
+                const QString selfLink = getString( entityData, "@iot.selfLink" ).toString();
 
-              fetchedFeatureCallback( feature );
+                const QVariant properties = getVariantMap( entityData, "properties" );
 
-              if ( mFeatureLimit > 0 && mFeatureLimit <= mCachedFeatures.size() )
-                break;
-            }
-            locker.unlock();
+                // NOLINTBEGIN(bugprone-branch-clone)
+                switch ( entityType )
+                {
+                  case Qgis::SensorThingsEntity::Invalid:
+                    break;
 
-            if ( rootContent.contains( "@iot.nextLink" ) && ( mFeatureLimit == 0 || mFeatureLimit > mCachedFeatures.size() ) )
-            {
-              nextPage = QString::fromStdString( rootContent["@iot.nextLink"].get<std::string>() );
-            }
-            else
-            {
-              onNoMoreFeaturesCallback();
-            }
+                  case Qgis::SensorThingsEntity::Thing:
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getString( entityData, "name" )
+                        << getString( entityData, "description" )
+                        << properties;
+                    break;
 
-            // if target feature was added to cache, return it
-            if ( !continueFetchingCallback() )
-            {
-              return true;
+                  case Qgis::SensorThingsEntity::Location:
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getString( entityData, "name" )
+                        << getString( entityData, "description" )
+                        << properties;
+                    break;
+
+                  case Qgis::SensorThingsEntity::HistoricalLocation:
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getDateTime( entityData, "time" );
+                    break;
+
+                  case Qgis::SensorThingsEntity::Datastream:
+                  {
+                    std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( entityData, "phenomenonTime", true );
+                    std::pair< QVariant, QVariant > resultTime = getDateTimeRange( entityData, "resultTime" );
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getString( entityData, "name" )
+                        << getString( entityData, "description" )
+                        << getVariantMap( entityData, "unitOfMeasurement" )
+                        << getString( entityData, "observationType" )
+                        << properties
+                        << phenomenonTime.first
+                        << phenomenonTime.second
+                        << resultTime.first
+                        << resultTime.second;
+                    break;
+                  }
+
+                  case Qgis::SensorThingsEntity::Sensor:
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getString( entityData, "name" )
+                        << getString( entityData, "description" )
+                        << getString( entityData, "metadata" )
+                        << properties;
+                    break;
+
+                  case Qgis::SensorThingsEntity::ObservedProperty:
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getString( entityData, "name" )
+                        << getString( entityData, "definition" )
+                        << getString( entityData, "description" )
+                        << properties;
+                    break;
+
+                  case Qgis::SensorThingsEntity::Observation:
+                  {
+                    std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( entityData, "phenomenonTime" );
+                    std::pair< QVariant, QVariant > validTime = getDateTimeRange( entityData, "validTime" );
+                    attributes
+                        << iotId
+                        << selfLink
+                        << phenomenonTime.first
+                        << phenomenonTime.second
+                        << getString( entityData, "result" ) // TODO -- result type handling!
+                        << getDateTime( entityData, "resultTime" )
+                        << getStringList( entityData, "resultQuality" )
+                        << validTime.first
+                        << validTime.second
+                        << getVariantMap( entityData, "parameters" );
+                    break;
+                  }
+
+                  case Qgis::SensorThingsEntity::FeatureOfInterest:
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getString( entityData, "name" )
+                        << getString( entityData, "description" )
+                        << properties;
+                    break;
+
+                  case Qgis::SensorThingsEntity::MultiDatastream:
+                  {
+                    std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( entityData, "phenomenonTime" );
+                    std::pair< QVariant, QVariant > resultTime = getDateTimeRange( entityData, "resultTime" );
+                    attributes
+                        << iotId
+                        << selfLink
+                        << getString( entityData, "name" )
+                        << getString( entityData, "description" )
+                        << getVariantList( entityData, "unitOfMeasurements" )
+                        << getString( entityData, "observationType" )
+                        << getStringList( entityData, "multiObservationDataTypes" )
+                        << properties
+                        << phenomenonTime.first
+                        << phenomenonTime.second
+                        << resultTime.first
+                        << resultTime.second;
+                    break;
+                  }
+                }
+                // NOLINTEND(bugprone-branch-clone)
+              };
+
+              QgsAttributes attributes;
+              attributes.reserve( fields.size() );
+              extendAttributes( mEntityType, featureData, attributes );
+
+              auto processFeature = [this, &fetchedFeatureCallback]( QgsFeature & feature, const QString & rawFeatureId )
+              {
+                feature.setId( mNextFeatureId++ );
+
+                mCachedFeatures.insert( feature.id(), feature );
+                mIotIdToFeatureId.insert( rawFeatureId, feature.id() );
+                mSpatialIndex.addFeature( feature );
+                mFetchedFeatureExtent.combineExtentWith( feature.geometry().boundingBox() );
+
+                fetchedFeatureCallback( feature );
+              };
+
+              const QString baseFeatureId = getString( featureData, "@iot.id" ).toString();
+              if ( !expandTo.empty() )
+              {
+                mRetrievedBaseFeatureCount++;
+
+                std::function< void( const nlohmann::json &, const QList<Qgis::SensorThingsEntity > &, const QString &, const QgsAttributes & ) > traverseExpansion;
+                traverseExpansion = [this, &feature, &getString, &traverseExpansion, &fetchedFeatureCallback, &extendAttributes, &processFeature]( const nlohmann::json & currentLevelData, const QList<Qgis::SensorThingsEntity > &expansionTargets, const QString & lowerLevelId, const QgsAttributes & lowerLevelAttributes )
+                {
+                  const Qgis::SensorThingsEntity currentExpansionTarget = expansionTargets.at( 0 );
+                  const QList< Qgis::SensorThingsEntity > remainingExpansionTargets = expansionTargets.mid( 1 );
+
+                  const QString currentExpansionPropertyString = QgsSensorThingsUtils::entityToSetString( currentExpansionTarget );
+                  if ( currentLevelData.contains( currentExpansionPropertyString.toLocal8Bit().constData() ) )
+                  {
+                    const auto &expandedEntity = currentLevelData[currentExpansionPropertyString.toLocal8Bit().constData()];
+                    if ( expandedEntity.is_array() )
+                    {
+                      for ( const auto &expandedEntityElement : expandedEntity )
+                      {
+                        QgsAttributes expandedAttributes = lowerLevelAttributes;
+                        const QString expandedEntityIotId = getString( expandedEntityElement, "@iot.id" ).toString();
+                        const QString expandedFeatureId = lowerLevelId + '_' + expandedEntityIotId;
+
+                        if ( remainingExpansionTargets.empty() )
+                        {
+                          auto existingFeatureIdIt = mIotIdToFeatureId.constFind( expandedFeatureId );
+                          if ( existingFeatureIdIt != mIotIdToFeatureId.constEnd() )
+                          {
+                            // we've previously fetched and cached this feature, skip it
+                            fetchedFeatureCallback( *mCachedFeatures.find( *existingFeatureIdIt ) );
+                            continue;
+                          }
+                        }
+
+
+                        extendAttributes( currentExpansionTarget, expandedEntityElement, expandedAttributes );
+                        if ( !remainingExpansionTargets.empty() )
+                        {
+                          // traverse deeper
+                          traverseExpansion( expandedEntityElement, remainingExpansionTargets, expandedFeatureId, expandedAttributes );
+                        }
+                        else
+                        {
+                          feature.setAttributes( expandedAttributes );
+                          processFeature( feature, expandedFeatureId );
+
+                        }
+                      }
+                      // NOTE: What do we do when the expanded entity has a next link? Does this situation ever arise?
+                      // The specification doesn't explicitly state whether pagination is supported for expansion, so we assume
+                      // it's not possible.
+                    }
+                  }
+                  else
+                  {
+                    // No expansion for this parent feature.
+                    // Maybe we should NULL out the attributes and return the parent feature? Right now we just
+                    // skip it if there's no child features...
+                  }
+                };
+
+                traverseExpansion( featureData, expandTo, baseFeatureId, attributes );
+
+                if ( mFeatureLimit > 0 && mFeatureLimit <= mRetrievedBaseFeatureCount )
+                  break;
+              }
+              else
+              {
+                feature.setAttributes( attributes );
+                processFeature( feature, baseFeatureId );
+                mRetrievedBaseFeatureCount++;
+                if ( mFeatureLimit > 0 && mFeatureLimit <= mRetrievedBaseFeatureCount )
+                  break;
+              }
             }
+          }
+          locker.unlock();
+
+          if ( rootContent.contains( "@iot.nextLink" ) && ( mFeatureLimit == 0 || mFeatureLimit > mCachedFeatures.size() ) )
+          {
+            nextPage = QString::fromStdString( rootContent["@iot.nextLink"].get<std::string>() );
+          }
+          else
+          {
+            onNoMoreFeaturesCallback();
+          }
+
+          // if target feature was added to cache, return it
+          if ( !continueFetchingCallback() )
+          {
+            return true;
           }
         }
       }

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
@@ -47,8 +47,13 @@ QgsSensorThingsSharedData::QgsSensorThingsSharedData( const QString &uri )
       expandQueryParts.append( QgsSensorThingsUtils::entityToSetString( expandToEntityType ) );
     }
   }
+  mExpansionLimit = uriParts.value( QStringLiteral( "expansionLimit" ) ).toInt();
   if ( !expandQueryParts.empty() )
+  {
     mExpandQueryString = QStringLiteral( "$expand=" ) + expandQueryParts.join( '/' );
+    if ( mExpansionLimit > 0 )
+      mExpandQueryString += QStringLiteral( "($top=%1)" ).arg( mExpansionLimit );
+  }
 
   mFields = QgsSensorThingsUtils::fieldsForExpandedEntityType( mEntityType, mExpandTo );
 

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.h
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.h
@@ -79,8 +79,10 @@ class QgsSensorThingsSharedData
 
     QString mEntityBaseUri;
     QString mSubsetString;
+    QString mExpandQueryString;
 
     Qgis::SensorThingsEntity mEntityType = Qgis::SensorThingsEntity::Invalid;
+    QList< Qgis::SensorThingsEntity > mExpandTo;
 
     int mFeatureLimit = 0;
     Qgis::WkbType mGeometryType = Qgis::WkbType::Unknown;
@@ -95,6 +97,7 @@ class QgsSensorThingsSharedData
     QgsCoordinateReferenceSystem mSourceCRS;
 
     mutable long long mFeatureCount = static_cast< long long >( Qgis::FeatureCountState::Uncounted );
+    mutable long long mRetrievedBaseFeatureCount = 0;
 
     QHash<QString, QgsFeatureId> mIotIdToFeatureId;
     QMap<QgsFeatureId, QgsFeature> mCachedFeatures;

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.h
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.h
@@ -82,10 +82,9 @@ class QgsSensorThingsSharedData
     QString mExpandQueryString;
 
     Qgis::SensorThingsEntity mEntityType = Qgis::SensorThingsEntity::Invalid;
-    QList< Qgis::SensorThingsEntity > mExpandTo;
+    QList< QgsSensorThingsExpansionDefinition > mExpansions;
 
     int mFeatureLimit = 0;
-    int mExpansionLimit = 0;
     Qgis::WkbType mGeometryType = Qgis::WkbType::Unknown;
     QString mGeometryField;
     QgsFields mFields;

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.h
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.h
@@ -85,6 +85,7 @@ class QgsSensorThingsSharedData
     QList< Qgis::SensorThingsEntity > mExpandTo;
 
     int mFeatureLimit = 0;
+    int mExpansionLimit = 0;
     Qgis::WkbType mGeometryType = Qgis::WkbType::Unknown;
     QString mGeometryField;
     QgsFields mFields;

--- a/src/core/providers/sensorthings/qgssensorthingsutils.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.cpp
@@ -785,6 +785,8 @@ QList<Qgis::GeometryType> QgsSensorThingsUtils::availableGeometryTypes( const QS
 QList<Qgis::SensorThingsEntity> QgsSensorThingsUtils::expandableTargets( Qgis::SensorThingsEntity type )
 {
   // note that we are restricting these choices so that the geometry enabled entity type MUST be the base type
+
+  // NOLINTBEGIN(bugprone-branch-clone)
   switch ( type )
   {
     case Qgis::SensorThingsEntity::Invalid:
@@ -852,6 +854,8 @@ QList<Qgis::SensorThingsEntity> QgsSensorThingsUtils::expandableTargets( Qgis::S
         Qgis::SensorThingsEntity::Observation
       };
   }
+  // NOLINTEND(bugprone-branch-clone)
+
   BUILTIN_UNREACHABLE
 }
 

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -152,11 +152,26 @@ class CORE_EXPORT QgsSensorThingsUtils
     static QList< Qgis::SensorThingsEntity > expandableTargets( Qgis::SensorThingsEntity type );
 
     /**
-     * Returns a list of \a expansions as a valid SensorThings API query string, eg "$expand=Locations($orderby=id desc;$top=3;$expand=Datastreams($top=101))".
+     * Returns the cardinality of the relationship between a base entity type and a related entity type.
+     *
+     * \param baseType base entity type
+     * \param relatedType related entity type
+     * \param valid will be set to TRUE if a relationship exists between the entity types, or FALSE if no relationship exists
+     *
+     * \returns relationship cardinality
      *
      * \since QGIS 3.38
      */
-    static QString asQueryString( const QList< QgsSensorThingsExpansionDefinition > &expansions );
+    static Qgis::RelationshipCardinality relationshipCardinality( Qgis::SensorThingsEntity baseType, Qgis::SensorThingsEntity relatedType, bool &valid SIP_OUT );
+
+    /**
+     * Returns a list of \a expansions as a valid SensorThings API query string, eg "$expand=Locations($orderby=id desc;$top=3;$expand=Datastreams($top=101))".
+     *
+     * The base entity type for the query must be specified.
+     *
+     * \since QGIS 3.38
+     */
+    static QString asQueryString( Qgis::SensorThingsEntity baseType, const QList< QgsSensorThingsExpansionDefinition > &expansions );
 
 };
 
@@ -265,9 +280,11 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
     /**
      * Returns the expansion as a valid SensorThings API query string, eg "$expand=Observations($orderby=phenomenonTime desc;$top=10)".
      *
+     * The parent entity type for the expansion must be specified.
+     *
      * Optionally a list of additional query options can be specified for the expansion.
      */
-    QString asQueryString( const QStringList &additionalOptions = QStringList() ) const;
+    QString asQueryString( Qgis::SensorThingsEntity parentEntityType, const QStringList &additionalOptions = QStringList() ) const;
 
     bool operator==( const QgsSensorThingsExpansionDefinition &other ) const;
     bool operator!=( const QgsSensorThingsExpansionDefinition &other ) const;

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -40,6 +40,9 @@ class CORE_EXPORT QgsSensorThingsUtils
     //! Default limit on number of features fetched
     static constexpr int DEFAULT_FEATURE_LIMIT = 10000; SIP_SKIP
 
+    //! Default limit on number of expanded features fetched
+    static constexpr int DEFAULT_EXPANSION_LIMIT = 100; SIP_SKIP
+
     /**
      * Converts a string value to a Qgis::SensorThingsEntity type.
      *

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -278,24 +278,25 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
     if ( !sipCpp->isValid() )
     {
       sipRes = PyUnicode_FromString( "<QgsSensorThingsExpansionDefinition: invalid>" );
-      return;
     }
-
-    QString innerDefinition;
-    if ( !sipCpp->orderBy().isEmpty() )
+    else
     {
-      innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
-    }
-    if ( sipCpp->limit() >= 0 )
-    {
-      if ( !innerDefinition.isEmpty() )
-        innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
-      else
-        innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
-    }
+      QString innerDefinition;
+      if ( !sipCpp->orderBy().isEmpty() )
+      {
+        innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
+      }
+      if ( sipCpp->limit() >= 0 )
+      {
+        if ( !innerDefinition.isEmpty() )
+          innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
+        else
+          innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+      }
 
-    QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
-    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+      QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
+      sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    }
     % End
 #endif
 

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -55,16 +55,31 @@ class CORE_EXPORT QgsSensorThingsUtils
     static QString displayString( Qgis::SensorThingsEntity type, bool plural = false );
 
     /**
-    * Converts a string value corresponding to a SensorThings entity set to a Qgis::SensorThingsEntity type.
-    *
-    * Returns Qgis::SensorThingsEntity::Invalid if the string could not be converted to a known entity set type.
+     * Converts a string value corresponding to a SensorThings entity set to a Qgis::SensorThingsEntity type.
+     *
+     * Returns Qgis::SensorThingsEntity::Invalid if the string could not be converted to a known entity set type.
     */
     static Qgis::SensorThingsEntity entitySetStringToEntity( const QString &type );
+
+    /**
+     * Converts a SensorThings entity set to a SensorThings entity set string.
+     *
+     * \since QGIS 3.38
+    */
+    static QString entityToSetString( Qgis::SensorThingsEntity type );
 
     /**
      * Returns the fields which correspond to a specified entity \a type.
      */
     static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
+
+    /**
+     * Returns the fields which correspond to a specified entity \a baseType, expanded
+     * using the specified list of \a expandedTypes.
+     *
+     * \since QGIS 3.38
+     */
+    static QgsFields fieldsForExpandedEntityType( Qgis::SensorThingsEntity baseType, const QList< Qgis::SensorThingsEntity > &expandedTypes );
 
     /**
      * Returns the geometry field for a specified entity \a type.
@@ -117,6 +132,13 @@ class CORE_EXPORT QgsSensorThingsUtils
      * This method will block while network requests are made to the server.
      */
     static QList< Qgis::GeometryType > availableGeometryTypes( const QString &uri, Qgis::SensorThingsEntity type, QgsFeedback *feedback = nullptr, const QString &authCfg = QString() );
+
+    /**
+     * Returns a list of permissible expand targets for a given base entity \a type.
+     *
+     * \since QGIS 3.38
+     */
+    static QList< QList< Qgis::SensorThingsEntity > > expandableTargets( Qgis::SensorThingsEntity type );
 
 };
 

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -22,6 +22,7 @@
 class QgsFields;
 class QgsFeedback;
 class QgsRectangle;
+class QgsSensorThingsExpansionDefinition;
 
 /**
  * \ingroup core
@@ -70,6 +71,13 @@ class CORE_EXPORT QgsSensorThingsUtils
      * \since QGIS 3.38
     */
     static QString entityToSetString( Qgis::SensorThingsEntity type );
+
+    /**
+     * Returns the SensorThings properties which correspond to a specified entity \a type.
+     *
+     * \since QGIS 3.38
+     */
+    static QStringList propertiesForEntityType( Qgis::SensorThingsEntity type );
 
     /**
      * Returns the fields which correspond to a specified entity \a type.
@@ -141,8 +149,163 @@ class CORE_EXPORT QgsSensorThingsUtils
      *
      * \since QGIS 3.38
      */
-    static QList< QList< Qgis::SensorThingsEntity > > expandableTargets( Qgis::SensorThingsEntity type );
+    static QList< Qgis::SensorThingsEntity > expandableTargets( Qgis::SensorThingsEntity type );
+
+    /**
+     * Returns a list of \a expansions as a valid SensorThings API query string, eg "$expand=Locations($orderby=id desc;$top=3;$expand=Datastreams($top=101))".
+     *
+     * \since QGIS 3.38
+     */
+    static QString asQueryString( const QList< QgsSensorThingsExpansionDefinition > &expansions );
 
 };
+
+
+/**
+ * \ingroup core
+ * \brief Encapsulates information about how relationships in a SensorThings API service should be expanded.
+ *
+ * \since QGIS 3.38
+ */
+class CORE_EXPORT QgsSensorThingsExpansionDefinition
+{
+  public:
+
+    /**
+     * Constructor for QgsSensorThingsExpansionDefinition, targeting the specified child entity type.
+     */
+    QgsSensorThingsExpansionDefinition( Qgis::SensorThingsEntity childEntity = Qgis::SensorThingsEntity::Invalid,
+                                        const QString &orderBy = QString(),
+                                        Qt::SortOrder sortOrder = Qt::SortOrder::AscendingOrder,
+                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
+
+    /**
+     * Returns TRUE if the definition is valid.
+     */
+    bool isValid() const;
+
+    /**
+     * Returns the target child entity which should be expanded.
+     *
+     * \see setChildEntity()
+     */
+    Qgis::SensorThingsEntity childEntity() const;
+
+    /**
+    * Sets the target child \a entity which should be expanded.
+    *
+    * \see childEntity()
+    */
+    void setChildEntity( Qgis::SensorThingsEntity entity );
+
+    /**
+     * Returns the field name to order the expanded child entities by.
+     *
+     * \see sortOrder()
+     * \see setOrderBy()
+     */
+    QString orderBy() const;
+
+    /**
+     * Sets the \a field name to order the expanded child entities by.
+     *
+     * \see orderBy()
+     * \see setSortOrder()
+     */
+    void setOrderBy( const QString &field );
+
+    /**
+     * Returns the sort order for the expanded child entities.
+     *
+     * \see orderBy()
+     * \see setSortOrder()
+     */
+    Qt::SortOrder sortOrder() const;
+
+    /**
+     * Sets the sort order for the expanded child entities.
+     *
+     * \see setOrderBy()
+     * \see sortOrder()
+     */
+    void setSortOrder( Qt::SortOrder order );
+
+    /**
+     * Returns the limit on the number of child features to fetch.
+     *
+     * Returns -1 if no limit is defined.
+     *
+     * \see setLimit()
+     */
+    int limit() const;
+
+    /**
+     * Sets the \a limit on the number of child features to fetch.
+     *
+     * Set to -1 if no limit is desired.
+     *
+     * \see limit()
+     */
+    void setLimit( int limit );
+
+    /**
+     * Returns a string encapsulation of the expansion definition.
+     *
+     * \see fromString()
+     */
+    QString toString() const;
+
+    /**
+     * Returns a QgsSensorThingsExpansionDefinition from a string representation.
+     *
+     * \see toString()
+     */
+    static QgsSensorThingsExpansionDefinition fromString( const QString &string );
+
+    /**
+     * Returns the expansion as a valid SensorThings API query string, eg "$expand=Observations($orderby=phenomenonTime desc;$top=10)".
+     *
+     * Optionally a list of additional query options can be specified for the expansion.
+     */
+    QString asQueryString( const QStringList &additionalOptions = QStringList() ) const;
+
+    bool operator==( const QgsSensorThingsExpansionDefinition &other ) const;
+    bool operator!=( const QgsSensorThingsExpansionDefinition &other ) const;
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    if ( !sipCpp->isValid() )
+    {
+      sipRes = PyUnicode_FromString( "<QgsSensorThingsExpansionDefinition: invalid>" );
+      return;
+    }
+
+    QString innerDefinition;
+    if ( !sipCpp->orderBy().isEmpty() )
+    {
+      innerDefinition = QStringLiteral( "by %1 (%2)" ).arg( sipCpp->orderBy(), sipCpp->sortOrder() == Qt::SortOrder::AscendingOrder ? QStringLiteral( "asc" ) : QStringLiteral( "desc" ) );
+    }
+    if ( sipCpp->limit() >= 0 )
+    {
+      if ( !innerDefinition.isEmpty() )
+        innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
+      else
+        innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+    }
+
+    QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
+  private:
+
+    Qgis::SensorThingsEntity mChildEntity = Qgis::SensorThingsEntity::Invalid;
+    QString mOrderBy;
+    Qt::SortOrder mSortOrder = Qt::SortOrder::AscendingOrder;
+    int mLimit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT;
+};
+Q_DECLARE_METATYPE( QgsSensorThingsExpansionDefinition )
 
 #endif // QGSSENSORTHINGSUTILS_H

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -86,6 +86,7 @@
 #include "qgsinterval.h"
 #include "qgsgpsconnection.h"
 #include "qgssensorregistry.h"
+#include "qgssensorthingsutils.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -313,6 +314,7 @@ void QgsApplication::init( QString profileFolder )
     qRegisterMetaType<QList<QNetworkReply::RawHeaderPair>>( "QList<QNetworkReply::RawHeaderPair>" );
     qRegisterMetaType< QAuthenticator * >( "QAuthenticator*" );
     qRegisterMetaType< QgsGpsInformation >( "QgsGpsInformation" );
+    qRegisterMetaType< QgsSensorThingsExpansionDefinition >( "QgsSensorThingsExpansionDefinition" );
   } );
 
   ( void ) resolvePkgPath();

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
@@ -25,9 +25,14 @@
 #include "qgssensorthingsconnectionpropertiestask.h"
 #include "qgsapplication.h"
 #include "qgsextentwidget.h"
+#include "qgsgui.h"
+#include "qgsspinbox.h"
+#include <QHeaderView>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QStandardItemModel>
+#include <QDialogButtonBox>
+#include <QTableView>
 
 QgsSensorThingsSourceWidget::QgsSensorThingsSourceWidget( QWidget *parent )
   : QgsProviderSourceWidget( parent )
@@ -42,16 +47,11 @@ QgsSensorThingsSourceWidget::QgsSensorThingsSourceWidget( QWidget *parent )
   vl->addWidget( mExtentWidget );
   mExtentLimitFrame->setLayout( vl );
 
-  mSpinExpansionLimit->setEnabled( false );
-
   mSpinPageSize->setClearValue( 0, tr( "Default (%1)" ).arg( QgsSensorThingsUtils::DEFAULT_PAGE_SIZE ) );
   mSpinFeatureLimit->setClearValue( 0, tr( "No limit" ) );
-  mSpinExpansionLimit->setClearValue( 0, tr( "No limit" ) );
-  mSpinExpansionLimit->setToolTip( tr( "Limits the maximum number of related features to fetch when expanding child features" ) );
 
   // set a relatively conservative feature limit by default, to make it so they have to opt-in to shoot themselves in the foot!
   mSpinFeatureLimit->setValue( QgsSensorThingsUtils::DEFAULT_FEATURE_LIMIT );
-  mSpinExpansionLimit->setValue( QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
 
   for ( Qgis::SensorThingsEntity type :
         {
@@ -78,11 +78,8 @@ QgsSensorThingsSourceWidget::QgsSensorThingsSourceWidget( QWidget *parent )
   connect( mRetrieveTypesButton, &QToolButton::clicked, this, &QgsSensorThingsSourceWidget::retrieveTypes );
   mRetrieveTypesButton->setEnabled( false );
   connect( mExtentWidget, &QgsExtentWidget::extentChanged, this, &QgsSensorThingsSourceWidget::validate );
-  connect( mComboExpandTo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
-  {
-    mSpinExpansionLimit->setEnabled( mComboExpandTo->currentData().isValid() );
-    validate();
-  } );
+  connect( mConfigureExpansions, &QToolButton::clicked, this, &QgsSensorThingsSourceWidget::configureExpansions );
+
   validate();
 }
 
@@ -134,23 +131,6 @@ void QgsSensorThingsSourceWidget::setSourceUri( const QString &uri )
     mSpinFeatureLimit->setValue( QgsSensorThingsUtils::DEFAULT_FEATURE_LIMIT );
   }
 
-  ok = false;
-  const int expansionLimitParam = mSourceParts.value( QStringLiteral( "expansionLimit" ) ).toInt( &ok );
-  if ( ok )
-  {
-    mSpinExpansionLimit->setValue( expansionLimitParam );
-  }
-  else if ( type != Qgis::SensorThingsEntity::Invalid )
-  {
-    // if not setting an initial uri for a new layer, use "no limit" if it's not present in the uri
-    mSpinExpansionLimit->clear();
-  }
-  else
-  {
-    // when setting an initial uri, use the default, not "no limit"
-    mSpinExpansionLimit->setValue( QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
-  }
-
   const QgsRectangle bounds = mSourceParts.value( QStringLiteral( "bounds" ) ).value< QgsRectangle >();
   if ( !bounds.isNull() )
   {
@@ -162,13 +142,19 @@ void QgsSensorThingsSourceWidget::setSourceUri( const QString &uri )
     mExtentWidget->clear();
   }
 
-  const QStringList expandTo = mSourceParts.value( QStringLiteral( "expandTo" ) ).toStringList();
-  if ( !expandTo.isEmpty() )
+  const QVariantList expandTo = mSourceParts.value( QStringLiteral( "expandTo" ) ).toList();
+  mExpansions.clear();
+  QStringList expansionsLabelText;
+  for ( const QVariant &expandVariant : expandTo )
   {
-    mComboExpandTo->setCurrentIndex( mComboExpandTo->findData( expandTo.join( ',' ) ) );
+    const QgsSensorThingsExpansionDefinition definition = expandVariant.value< QgsSensorThingsExpansionDefinition >();
+    if ( definition.isValid() )
+    {
+      mExpansions.append( definition );
+      expansionsLabelText.append( QgsSensorThingsUtils::displayString( definition.childEntity() ) );
+    }
   }
-  if ( mComboExpandTo->currentIndex() < 0 )
-    mComboExpandTo->setCurrentIndex( 0 );
+  mExpansionsLabel->setText( expansionsLabelText.join( tr( ", " ) ) );
 
   mIsValid = true;
 }
@@ -253,22 +239,18 @@ QString QgsSensorThingsSourceWidget::updateUriFromGui( const QString &connection
     parts.remove( QStringLiteral( "featureLimit" ) );
   }
 
-  if ( mSpinExpansionLimit->value() > 0 )
-  {
-    parts.insert( QStringLiteral( "expansionLimit" ), QString::number( mSpinExpansionLimit->value() ) );
-  }
-  else
-  {
-    parts.remove( QStringLiteral( "expansionLimit" ) );
-  }
-
-  if ( !mComboExpandTo->currentData().isValid() )
+  if ( mExpansions.isEmpty() )
   {
     parts.remove( QStringLiteral( "expandTo" ) );
   }
   else
   {
-    parts.insert( QStringLiteral( "expandTo" ), mComboExpandTo->currentData().toString().split( ',' ) );
+    QVariantList expansionsList;
+    for ( const QgsSensorThingsExpansionDefinition &def : std::as_const( mExpansions ) )
+    {
+      expansionsList.append( QVariant::fromValue( def ) );
+    }
+    parts.insert( QStringLiteral( "expandTo" ), expansionsList );
   }
 
   if ( mExtentWidget->outputExtent().isNull() )
@@ -346,6 +328,28 @@ void QgsSensorThingsSourceWidget::connectionPropertiesTaskCompleted()
     mComboGeometryType->setCurrentIndex( 0 );
 }
 
+void QgsSensorThingsSourceWidget::configureExpansions()
+{
+  QgsSensorThingsConfigureExpansionsDialog dialog( currentEntityType() );
+  dialog.setExpansions( mExpansions );
+  if ( dialog.exec() && dialog.expansions() != mExpansions )
+  {
+    mExpansions = dialog.expansions();
+
+    QStringList expansionsLabelText;
+    for ( const QgsSensorThingsExpansionDefinition &expandVariant : mExpansions )
+    {
+      if ( expandVariant.isValid() )
+      {
+        expansionsLabelText.append( QgsSensorThingsUtils::displayString( expandVariant.childEntity() ) );
+      }
+    }
+    mExpansionsLabel->setText( expansionsLabelText.join( tr( ", " ) ) );
+
+    emit changed();
+  }
+}
+
 void QgsSensorThingsSourceWidget::setCurrentEntityType( Qgis::SensorThingsEntity type )
 {
   if ( mPropertiesTask )
@@ -398,37 +402,6 @@ void QgsSensorThingsSourceWidget::setCurrentEntityType( Qgis::SensorThingsEntity
     mComboGeometryType->addItem( QgsIconUtils::iconForWkbType( Qgis::WkbType::NoGeometry ), tr( "No Geometry" ), QVariant::fromValue( Qgis::WkbType::NoGeometry ) );
     setCurrentGeometryTypeFromString( mSourceParts.value( QStringLiteral( "geometryType" ) ).toString() ); mComboGeometryType->setCurrentIndex( 0 );
   }
-
-  mComboExpandTo->clear();
-  mComboExpandTo->addItem( QString() );
-  const QList< QList< Qgis::SensorThingsEntity > > expandToEntities = QgsSensorThingsUtils::expandableTargets( type );
-  QList< std::pair< QString, QVariant > > sortedExpandToEntities;
-  sortedExpandToEntities.reserve( expandToEntities.size() );
-  for ( const QList< Qgis::SensorThingsEntity > &expandTypes : expandToEntities )
-  {
-    QStringList expandToTranslatedStrings;
-    QStringList expandToRawStrings;
-    expandToTranslatedStrings.reserve( expandTypes.size() );
-    expandToRawStrings.reserve( expandTypes.size() );
-    for ( Qgis::SensorThingsEntity entity : expandTypes )
-    {
-      expandToTranslatedStrings.append( QgsSensorThingsUtils::displayString( entity, true ) );
-      expandToRawStrings.append( qgsEnumValueToKey( entity ) );
-    }
-
-    sortedExpandToEntities.append( {expandToTranslatedStrings.join( QStringLiteral( " > " ) ), expandToRawStrings.join( ',' ) } );
-  }
-  std::sort( sortedExpandToEntities.begin(), sortedExpandToEntities.end(), []( const std::pair< QString, QVariant > &a, const std::pair< QString, QVariant > &b ) -> bool
-  {
-    return QString::localeAwareCompare( a.first, b.first ) < 0;
-  } );
-
-  for ( const std::pair< QString, QVariant > &expandTo : sortedExpandToEntities )
-  {
-    mComboExpandTo->addItem( expandTo.first, expandTo.second );
-  }
-
-  mComboExpandTo->setCurrentIndex( 0 );
 }
 
 void QgsSensorThingsSourceWidget::setCurrentGeometryTypeFromString( const QString &geometryType )
@@ -459,5 +432,476 @@ void QgsSensorThingsSourceWidget::setCurrentGeometryTypeFromString( const QStrin
   }
 }
 
+//
+// QgsSensorThingsExpansionsModel
+//
+
+QgsSensorThingsExpansionsModel::QgsSensorThingsExpansionsModel( QObject *parent )
+  : QAbstractItemModel( parent )
+{
+
+}
+
+int QgsSensorThingsExpansionsModel::columnCount( const QModelIndex & ) const
+{
+  return 4;
+}
+
+int QgsSensorThingsExpansionsModel::rowCount( const QModelIndex &parent ) const
+{
+  if ( parent.isValid() )
+    return 0;
+  return mExpansions.size();
+}
+
+QModelIndex QgsSensorThingsExpansionsModel::index( int row, int column, const QModelIndex &parent ) const
+{
+  if ( hasIndex( row, column, parent ) )
+  {
+    return createIndex( row, column, row );
+  }
+
+  return QModelIndex();
+}
+
+QModelIndex QgsSensorThingsExpansionsModel::parent( const QModelIndex &child ) const
+{
+  Q_UNUSED( child )
+  return QModelIndex();
+}
+
+Qt::ItemFlags QgsSensorThingsExpansionsModel::flags( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return Qt::ItemFlags();
+
+  if ( index.row() < 0 || index.row() >= mExpansions.size() || index.column() < 0 || index.column() >= columnCount() )
+    return Qt::ItemFlags();
+
+  switch ( index.column() )
+  {
+    case Column::Entity:
+    case Column::Limit:
+    case Column::OrderBy:
+    case Column::SortOrder:
+      return Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsEditable | Qt::ItemFlag::ItemIsSelectable;
+    default:
+      break;
+  }
+
+  return Qt::ItemFlags();
+}
+
+QVariant QgsSensorThingsExpansionsModel::data( const QModelIndex &index, int role ) const
+{
+  if ( !index.isValid() )
+    return QVariant();
+
+  if ( index.row() < 0 || index.row() >= mExpansions.size() || index.column() < 0 || index.column() >= columnCount() )
+    return QVariant();
+
+  const QgsSensorThingsExpansionDefinition &expansion = mExpansions.at( index.row() );
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    case Qt::ToolTipRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Entity:
+          return QgsSensorThingsUtils::displayString( expansion.childEntity() );
+
+        case Column::Limit:
+          return !expansion.isValid() ? QVariant() : ( expansion.limit() > -1 ? QVariant( expansion.limit() ) : QVariant( tr( "No limit" ) ) );
+
+        case Column::OrderBy:
+          return !expansion.isValid() ? QVariant() : ( expansion.orderBy().isEmpty() ? QVariant() : expansion.orderBy() );
+
+        case Column::SortOrder:
+          return !expansion.isValid() ? QVariant() : ( expansion.sortOrder() == Qt::SortOrder::AscendingOrder ? tr( "Ascending" ) : tr( "Descending" ) );
+
+        default:
+          break;
+      }
+      break;
+    }
+
+    case Qt::EditRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Entity:
+          return QVariant::fromValue( expansion.childEntity() );
+
+        case Column::Limit:
+          return expansion.limit();
+
+        case Column::OrderBy:
+          return expansion.orderBy().isEmpty() ? QVariant() : expansion.orderBy();
+
+        case Column::SortOrder:
+          return expansion.sortOrder();
+
+        default:
+          break;
+      }
+      break;
+    }
+
+    case Qt::TextAlignmentRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Entity:
+        case Column::OrderBy:
+        case Column::SortOrder:
+          return static_cast<Qt::Alignment::Int>( Qt::AlignLeft | Qt::AlignVCenter );
+
+        case Column::Limit:
+          return static_cast<Qt::Alignment::Int>( Qt::AlignRight | Qt::AlignVCenter );
+        default:
+          break;
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+  return QVariant();
+}
+
+QVariant QgsSensorThingsExpansionsModel::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  if ( role == Qt::DisplayRole && orientation == Qt::Horizontal )
+  {
+    switch ( section )
+    {
+      case Column::Entity:
+        return tr( "Entity" );
+      case Column::Limit:
+        return tr( "Limit" );
+      case Column::OrderBy:
+        return tr( "Order By" );
+      case Column::SortOrder:
+        return tr( "Sort Order" );
+      default:
+        break;
+    }
+  }
+  return QAbstractItemModel::headerData( section, orientation, role );
+}
+
+bool QgsSensorThingsExpansionsModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( !index.isValid() )
+    return false;
+
+  if ( index.row() > mExpansions.size() || index.row() < 0 )
+    return false;
+
+  QgsSensorThingsExpansionDefinition &expansion = mExpansions[index.row()];
+
+  switch ( role )
+  {
+    case Qt::EditRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Entity:
+        {
+          const bool wasInvalid = !expansion.isValid();
+          if ( !value.isValid() || value.value< Qgis::SensorThingsEntity >() == Qgis::SensorThingsEntity::Invalid )
+          {
+            if ( wasInvalid )
+              break;
+
+            // entity type cleared, remove row, and all subsequent ones
+            beginRemoveRows( QModelIndex(), index.row() + 1, mExpansions.size() - 1 );
+            mExpansions = mExpansions.mid( 0, index.row() );
+            mExpansions.append( QgsSensorThingsExpansionDefinition() );
+            endRemoveRows();
+          }
+          else
+          {
+            expansion.setChildEntity( value.value< Qgis::SensorThingsEntity >() );
+          }
+          emit dataChanged( index, index, QVector<int>() << role );
+          if ( wasInvalid )
+          {
+            beginInsertRows( QModelIndex(), mExpansions.size(), mExpansions.size() );
+            mExpansions.append( QgsSensorThingsExpansionDefinition() );
+            endInsertRows();
+          }
+          break;
+        }
+
+        case Column::Limit:
+        {
+          bool ok = false;
+          int newValue = value.toInt( &ok );
+          if ( !ok )
+            return false;
+
+          expansion.setLimit( newValue );
+          emit dataChanged( index, index, QVector<int>() << role );
+          break;
+        }
+
+        case Column::OrderBy:
+        {
+          expansion.setOrderBy( value.toString() );
+          emit dataChanged( index, index, QVector<int>() << role );
+          break;
+        }
+
+        case Column::SortOrder:
+        {
+          expansion.setSortOrder( value.value< Qt::SortOrder >() );
+          emit dataChanged( index, index, QVector<int>() << role );
+          break;
+        }
+
+        default:
+          break;
+      }
+      return true;
+    }
+
+    default:
+      break;
+  }
+
+  return false;
+}
+
+bool QgsSensorThingsExpansionsModel::insertRows( int position, int rows, const QModelIndex &parent )
+{
+  Q_UNUSED( parent )
+  beginInsertRows( QModelIndex(), position, position + rows - 1 );
+  for ( int i = 0; i < rows; ++i )
+  {
+    mExpansions.insert( position, QgsSensorThingsExpansionDefinition() );
+  }
+  endInsertRows();
+  return true;
+}
+
+bool QgsSensorThingsExpansionsModel::removeRows( int position, int rows, const QModelIndex &parent )
+{
+  Q_UNUSED( parent )
+  beginRemoveRows( QModelIndex(), position, position + rows - 1 );
+  for ( int i = 0; i < rows; ++i )
+    mExpansions.removeAt( position );
+  endRemoveRows();
+  return true;
+}
+
+void QgsSensorThingsExpansionsModel::setExpansions( const QList<QgsSensorThingsExpansionDefinition> &expansions )
+{
+  beginResetModel();
+  mExpansions = expansions;
+  // last entry should always be a blank entry
+  if ( mExpansions.isEmpty() || mExpansions.last().isValid() )
+    mExpansions.append( QgsSensorThingsExpansionDefinition() );
+  endResetModel();
+}
+
+//
+// QgsSensorThingsConfigureExpansionsDialog
+//
+
+QgsSensorThingsConfigureExpansionsDialog::QgsSensorThingsConfigureExpansionsDialog( Qgis::SensorThingsEntity baseEntityType, QWidget *parent, Qt::WindowFlags f )
+  : QDialog( parent, f )
+  , mBaseEntityType( baseEntityType )
+{
+  setWindowTitle( tr( "Configure SensorThings Expansions" ) );
+  setObjectName( "QgsSensorThingsConfigureExpansionsDialog" );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  QVBoxLayout *vLayout = new QVBoxLayout( );
+  QHBoxLayout *hLayout = new QHBoxLayout( );
+  hLayout->setContentsMargins( 0, 0, 0, 0 );
+
+  mModel = new QgsSensorThingsExpansionsModel( this );
+  mTable = new QTableView();
+  mTable->setModel( mModel );
+
+  QgsSensorThingsExpansionsDelegate *tableDelegate = new QgsSensorThingsExpansionsDelegate( mTable, mBaseEntityType );
+  mTable->setItemDelegateForColumn( 0, tableDelegate );
+  mTable->setItemDelegateForColumn( 1, tableDelegate );
+  mTable->setItemDelegateForColumn( 2, tableDelegate );
+  mTable->setItemDelegateForColumn( 3, tableDelegate );
+  mTable->setEditTriggers( QAbstractItemView::AllEditTriggers );
+  mTable->verticalHeader()->hide();
+  const QFontMetrics fm( font() );
+  mTable->horizontalHeader()->resizeSection( QgsSensorThingsExpansionsModel::Column::Entity, fm.horizontalAdvance( '0' ) * 30 );
+  mTable->horizontalHeader()->resizeSection( QgsSensorThingsExpansionsModel::Column::Limit, fm.horizontalAdvance( '0' ) * 15 );
+  mTable->horizontalHeader()->resizeSection( QgsSensorThingsExpansionsModel::Column::OrderBy, fm.horizontalAdvance( '0' ) * 30 );
+  mTable->horizontalHeader()->resizeSection( QgsSensorThingsExpansionsModel::Column::SortOrder, fm.horizontalAdvance( '0' ) * 15 );
+
+  hLayout->addWidget( mTable, 1 );
+
+  vLayout->addLayout( hLayout, 1 );
+
+  QDialogButtonBox *buttonBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel );
+  connect( buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  vLayout->addWidget( buttonBox );
+
+  setLayout( vLayout );
+}
+
+void QgsSensorThingsConfigureExpansionsDialog::setExpansions( const QList<QgsSensorThingsExpansionDefinition> &expansions )
+{
+  mModel->setExpansions( expansions );
+}
+
+QList<QgsSensorThingsExpansionDefinition> QgsSensorThingsConfigureExpansionsDialog::expansions() const
+{
+  return mModel->expansions();
+}
+
+//
+// QgsSensorThingsExpansionsDelegate
+//
+
+QgsSensorThingsExpansionsDelegate::QgsSensorThingsExpansionsDelegate( QObject *parent, Qgis::SensorThingsEntity baseEntityType )
+  : QStyledItemDelegate( parent )
+  , mBaseEntityType( baseEntityType )
+{
+
+}
+
+QWidget *QgsSensorThingsExpansionsDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index ) const
+{
+  switch ( index.column() )
+  {
+    case QgsSensorThingsExpansionsModel::Column::Entity:
+    {
+      // need to find out entity type for the previous row (or the base entity type for the first row)
+      const Qgis::SensorThingsEntity entityType = index.row() == 0 ? mBaseEntityType
+          : index.model()->data( index.model()->index( index.row() - 1, 0 ), Qt::EditRole ).value< Qgis::SensorThingsEntity >();
+
+      QList< Qgis::SensorThingsEntity > compatibleEntities = QgsSensorThingsUtils::expandableTargets( entityType );
+      // remove all entities which are already part of the expansion in previous rows -- we don't support "circular" expansion
+      for ( int row = index.row() - 1; row >= 0; row-- )
+      {
+        const Qgis::SensorThingsEntity rowEntityType = index.model()->data( index.model()->index( row, 0 ), Qt::EditRole ).value< Qgis::SensorThingsEntity >();
+        compatibleEntities.removeAll( rowEntityType );
+      }
+
+      QComboBox *combo = new QComboBox( parent );
+      combo->addItem( QString() );
+      for ( Qgis::SensorThingsEntity type : compatibleEntities )
+      {
+        combo->addItem( QgsSensorThingsUtils::displayString( type, true ), QVariant::fromValue( type ) );
+      }
+      return combo;
+    }
+
+    case QgsSensorThingsExpansionsModel::Column::Limit:
+    {
+      QgsSpinBox *spin = new QgsSpinBox( parent );
+      spin->setMinimum( -1 );
+      spin->setMaximum( 999999999 );
+      spin->setClearValue( -1, tr( "No limit" ) );
+      return spin;
+    }
+
+    case QgsSensorThingsExpansionsModel::Column::OrderBy:
+    {
+      // need to find out entity type for this row
+      const Qgis::SensorThingsEntity entityType = index.model()->data( index.model()->index( index.row(), 0 ), Qt::EditRole ).value< Qgis::SensorThingsEntity >();
+      const QStringList availableProperties = QgsSensorThingsUtils::propertiesForEntityType( entityType );
+
+      QComboBox *combo = new QComboBox( parent );
+      combo->addItem( QString() );
+      for ( const QString &property : availableProperties )
+      {
+        combo->addItem( property, property );
+      }
+      return combo;
+    }
+
+    case QgsSensorThingsExpansionsModel::Column::SortOrder:
+    {
+      QComboBox *combo = new QComboBox( parent );
+      combo->addItem( tr( "Ascending" ), QVariant::fromValue( Qt::SortOrder::AscendingOrder ) );
+      combo->addItem( tr( "Descending" ), QVariant::fromValue( Qt::SortOrder::DescendingOrder ) );
+      return combo;
+    }
+    default:
+      break;
+  }
+  return nullptr;
+}
+
+void QgsSensorThingsExpansionsDelegate::setEditorData( QWidget *editor, const QModelIndex &index ) const
+{
+  switch ( index.column() )
+  {
+    case QgsSensorThingsExpansionsModel::Column::Entity:
+    case QgsSensorThingsExpansionsModel::Column::SortOrder:
+    case QgsSensorThingsExpansionsModel::Column::OrderBy:
+    {
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        combo->setCurrentIndex( combo->findData( index.data( Qt::EditRole ) ) );
+        if ( combo->currentIndex() < 0 )
+          combo->setCurrentIndex( 0 );
+      }
+      return;
+    }
+
+    default:
+      break;
+  }
+  QStyledItemDelegate::setEditorData( editor, index );
+}
+
+void QgsSensorThingsExpansionsDelegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
+{
+  switch ( index.column() )
+  {
+    case QgsSensorThingsExpansionsModel::Column::Entity:
+    {
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        model->setData( index, combo->currentData() );
+      }
+      break;
+    }
+
+    case QgsSensorThingsExpansionsModel::Column::Limit:
+    {
+      if ( QgsSpinBox *spin = qobject_cast< QgsSpinBox * >( editor ) )
+      {
+        model->setData( index, spin->value() );
+      }
+      break;
+    }
+
+    case QgsSensorThingsExpansionsModel::Column::OrderBy:
+    {
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        model->setData( index, combo->currentData() );
+      }
+      break;
+    }
+
+    case QgsSensorThingsExpansionsModel::Column::SortOrder:
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        model->setData( index, combo->currentData() );
+      }
+      break;
+
+    default:
+      break;
+  }
+}
 
 ///@endcond

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
@@ -58,7 +58,7 @@ class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui
     void connectionPropertiesTaskCompleted();
 
   private:
-    void rebuildGeometryTypes( Qgis::SensorThingsEntity type );
+    void setCurrentEntityType( Qgis::SensorThingsEntity type );
     void setCurrentGeometryTypeFromString( const QString &geometryType );
 
     QgsExtentWidget *mExtentWidget = nullptr;

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
@@ -45,7 +45,8 @@ class QgsSensorThingsExpansionsModel : public QAbstractItemModel
       Entity = 0,
       Limit = 1,
       OrderBy = 2,
-      SortOrder = 3
+      SortOrder = 3,
+      Actions = 4,
     };
 
     QgsSensorThingsExpansionsModel( QObject *parent );
@@ -85,6 +86,24 @@ class QgsSensorThingsExpansionsDelegate : public QStyledItemDelegate
 
     Qgis::SensorThingsEntity mBaseEntityType = Qgis::SensorThingsEntity::Invalid;
 };
+
+
+class QgsSensorThingsRemoveExpansionDelegate : public QStyledItemDelegate SIP_SKIP
+{
+    Q_OBJECT
+
+  public:
+    QgsSensorThingsRemoveExpansionDelegate( QObject *parent );
+    bool eventFilter( QObject *obj, QEvent *event ) override;
+  protected:
+    void paint( QPainter *painter,
+                const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+  private:
+    void setHoveredIndex( const QModelIndex &index );
+
+    QModelIndex mHoveredIndex;
+};
+
 
 class QgsSensorThingsConfigureExpansionsDialog : public QDialog
 {

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
@@ -18,16 +18,91 @@
 #define QGSSENSORTHINGSSOURCEWIDGET_H
 
 #include "qgsprovidersourcewidget.h"
+#include "qgssensorthingsutils.h"
 #include "qgis.h"
 #include "ui_qgssensorthingssourcewidgetbase.h"
+#include <QDialog>
 #include <QVariantMap>
 #include <QPointer>
+#include <QStyledItemDelegate>
 
 class QgsExtentWidget;
 class QgsSensorThingsConnectionPropertiesTask;
+class QTableView;
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
+
+
+class QgsSensorThingsExpansionsModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+  public:
+
+    enum Column
+    {
+      Entity = 0,
+      Limit = 1,
+      OrderBy = 2,
+      SortOrder = 3
+    };
+
+    QgsSensorThingsExpansionsModel( QObject *parent );
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex parent( const QModelIndex &child ) const override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+    bool insertRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
+    bool removeRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
+
+    void setExpansions( const QList< QgsSensorThingsExpansionDefinition> &expansions );
+    QList< QgsSensorThingsExpansionDefinition> expansions() const { return mExpansions; }
+
+  private:
+
+    QList< QgsSensorThingsExpansionDefinition> mExpansions;
+};
+
+
+class QgsSensorThingsExpansionsDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+
+    QgsSensorThingsExpansionsDelegate( QObject *parent, Qgis::SensorThingsEntity baseEntityType );
+
+  protected:
+    QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem & /*option*/, const QModelIndex &index ) const override;
+    void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+    void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+  private:
+
+    Qgis::SensorThingsEntity mBaseEntityType = Qgis::SensorThingsEntity::Invalid;
+};
+
+class QgsSensorThingsConfigureExpansionsDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+
+    QgsSensorThingsConfigureExpansionsDialog( Qgis::SensorThingsEntity baseEntityType, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
+    void setExpansions( const QList< QgsSensorThingsExpansionDefinition> &expansions );
+    QList< QgsSensorThingsExpansionDefinition> expansions() const;
+
+  private:
+
+    Qgis::SensorThingsEntity mBaseEntityType = Qgis::SensorThingsEntity::Invalid;
+    QgsSensorThingsExpansionsModel *mModel = nullptr;
+    QTableView *mTable = nullptr;
+
+};
 
 class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui::QgsSensorThingsSourceWidgetBase
 {
@@ -56,13 +131,14 @@ class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui
     void validate();
     void retrieveTypes();
     void connectionPropertiesTaskCompleted();
-
+    void configureExpansions();
   private:
     void setCurrentEntityType( Qgis::SensorThingsEntity type );
     void setCurrentGeometryTypeFromString( const QString &geometryType );
 
     QgsExtentWidget *mExtentWidget = nullptr;
     QVariantMap mSourceParts;
+    QList< QgsSensorThingsExpansionDefinition> mExpansions;
     bool mIsValid = false;
     QPointer< QgsSensorThingsConnectionPropertiesTask > mPropertiesTask;
 };

--- a/src/ui/qgssensorthingssourcewidgetbase.ui
+++ b/src/ui/qgssensorthingssourcewidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>537</width>
-    <height>213</height>
+    <height>198</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,10 +26,45 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="4" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
+     <property name="maximum">
+      <number>999999999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QWidget" name="mExtentLimitFrame" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Geometry type</string>
+      <string>Feature limit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Page size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Extent limit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Entity type</string>
      </property>
     </widget>
    </item>
@@ -60,12 +95,11 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Extent limit</string>
-     </property>
-    </widget>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mComboGeometryType"/>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="mComboEntityType"/>
    </item>
    <item row="2" column="1" colspan="2">
     <widget class="QgsSpinBox" name="mSpinPageSize">
@@ -74,68 +108,31 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="mComboGeometryType"/>
-   </item>
-   <item row="7" column="1" colspan="2">
-    <widget class="QWidget" name="mExtentLimitFrame" native="true">
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_6">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Feature limit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QComboBox" name="mComboExpandTo"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Page size</string>
+      <string>Geometry type</string>
      </property>
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label_4">
+    <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>Expand to</string>
+      <string>Expansions</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
+   <item row="5" column="2">
+    <widget class="QToolButton" name="mConfigureExpansions">
      <property name="text">
-      <string>Entity type</string>
+      <string>...</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
-     <property name="maximum">
-      <number>999999999</number>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mComboEntityType"/>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_7">
+   <item row="5" column="1">
+    <widget class="QLabel" name="mExpansionsLabel">
      <property name="text">
-      <string>Expansion limit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinExpansionLimit">
-     <property name="maximum">
-      <number>999999999</number>
+      <string/>
      </property>
     </widget>
    </item>
@@ -154,8 +151,7 @@
   <tabstop>mRetrieveTypesButton</tabstop>
   <tabstop>mSpinPageSize</tabstop>
   <tabstop>mSpinFeatureLimit</tabstop>
-  <tabstop>mComboExpandTo</tabstop>
-  <tabstop>mSpinExpansionLimit</tabstop>
+  <tabstop>mConfigureExpansions</tabstop>
   <tabstop>mExtentLimitFrame</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgssensorthingssourcewidgetbase.ui
+++ b/src/ui/qgssensorthingssourcewidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>537</width>
-    <height>134</height>
+    <height>180</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,16 +26,6 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="mComboGeometryType"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Entity type</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="2">
     <widget class="QToolButton" name="mRetrieveTypesButton">
      <property name="minimumSize">
@@ -63,26 +53,53 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinPageSize">
-     <property name="maximum">
-      <number>9999999</number>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Extent limit</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
+   <item row="5" column="1" colspan="2">
     <widget class="QWidget" name="mExtentLimitFrame" native="true">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="mComboEntityType"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Page size</string>
+      <string>Entity type</string>
      </property>
     </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Expand to</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Feature limit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
+     <property name="maximum">
+      <number>999999999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QComboBox" name="mComboExpandTo"/>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_2">
@@ -91,27 +108,20 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_5">
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mComboGeometryType"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Extent limit</string>
+      <string>Page size</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mComboEntityType"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Feature limit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
+   <item row="2" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinPageSize">
      <property name="maximum">
-      <number>999999999</number>
+      <number>9999999</number>
      </property>
     </widget>
    </item>
@@ -129,6 +139,7 @@
   <tabstop>mComboGeometryType</tabstop>
   <tabstop>mRetrieveTypesButton</tabstop>
   <tabstop>mSpinPageSize</tabstop>
+  <tabstop>mComboExpandTo</tabstop>
   <tabstop>mSpinFeatureLimit</tabstop>
   <tabstop>mExtentLimitFrame</tabstop>
  </tabstops>

--- a/src/ui/qgssensorthingssourcewidgetbase.ui
+++ b/src/ui/qgssensorthingssourcewidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>537</width>
-    <height>180</height>
+    <height>213</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,6 +26,13 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Geometry type</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="2">
     <widget class="QToolButton" name="mRetrieveTypesButton">
      <property name="minimumSize">
@@ -53,34 +60,27 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Extent limit</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="2">
+   <item row="2" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinPageSize">
+     <property name="maximum">
+      <number>9999999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mComboGeometryType"/>
+   </item>
+   <item row="7" column="1" colspan="2">
     <widget class="QWidget" name="mExtentLimitFrame" native="true">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mComboEntityType"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Entity type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Expand to</string>
      </property>
     </widget>
    </item>
@@ -91,25 +91,8 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
-     <property name="maximum">
-      <number>999999999</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
+   <item row="5" column="1" colspan="2">
     <widget class="QComboBox" name="mComboExpandTo"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Geometry type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="mComboGeometryType"/>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_3">
@@ -118,10 +101,41 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinPageSize">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Expand to</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Entity type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
      <property name="maximum">
-      <number>9999999</number>
+      <number>999999999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="mComboEntityType"/>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Expansion limit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinExpansionLimit">
+     <property name="maximum">
+      <number>999999999</number>
      </property>
     </widget>
    </item>
@@ -139,8 +153,9 @@
   <tabstop>mComboGeometryType</tabstop>
   <tabstop>mRetrieveTypesButton</tabstop>
   <tabstop>mSpinPageSize</tabstop>
-  <tabstop>mComboExpandTo</tabstop>
   <tabstop>mSpinFeatureLimit</tabstop>
+  <tabstop>mComboExpandTo</tabstop>
+  <tabstop>mSpinExpansionLimit</tabstop>
   <tabstop>mExtentLimitFrame</tabstop>
  </tabstops>
  <resources/>

--- a/tests/src/python/test_provider_sensorthings.py
+++ b/tests/src/python/test_provider_sensorthings.py
@@ -188,6 +188,101 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             Qgis.SensorThingsEntity.MultiDatastream,
         )
 
+    def test_utils_entity_to_set_string(self):
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.Invalid),
+            '',
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.Thing),
+            "Things"
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.Location),
+            "Locations",
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.HistoricalLocation),
+            "HistoricalLocations",
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.Datastream),
+            "Datastreams",
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.Sensor),
+            "Sensors"
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.ObservedProperty),
+            "ObservedProperties",
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.Observation),
+            "Observations"
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.FeatureOfInterest),
+            "FeaturesOfInterest",
+        )
+        self.assertEqual(
+            QgsSensorThingsUtils.entityToSetString(Qgis.SensorThingsEntity.MultiDatastream),
+            "MultiDatastreams",
+        )
+
+    def test_fields_for_expanded_entity(self):
+        """
+        Test calculating fields for an expanded entity
+        """
+        fields = QgsSensorThingsUtils.fieldsForExpandedEntityType(
+            Qgis.SensorThingsEntity.Location,
+            [])
+        self.assertEqual([field.name() for field in fields],
+                         ['id', 'selfLink', 'name', 'description',
+                          'properties'])
+        fields = QgsSensorThingsUtils.fieldsForExpandedEntityType(
+            Qgis.SensorThingsEntity.Location,
+            [Qgis.SensorThingsEntity.Thing])
+        self.assertEqual([field.name() for field in fields],
+                         ['id', 'selfLink', 'name', 'description',
+                          'properties', 'Thing_id', 'Thing_selfLink',
+                          'Thing_name', 'Thing_description',
+                          'Thing_properties'])
+        fields = QgsSensorThingsUtils.fieldsForExpandedEntityType(
+            Qgis.SensorThingsEntity.Location,
+            [Qgis.SensorThingsEntity.Thing,
+             Qgis.SensorThingsEntity.Datastream])
+        self.assertEqual([field.name() for field in fields],
+                         ['id', 'selfLink', 'name', 'description',
+                          'properties', 'Thing_id', 'Thing_selfLink',
+                          'Thing_name', 'Thing_description',
+                          'Thing_properties', 'Thing_Datastream_id',
+                          'Thing_Datastream_selfLink', 'Thing_Datastream_name',
+                          'Thing_Datastream_description',
+                          'Thing_Datastream_unitOfMeasurement',
+                          'Thing_Datastream_observationType',
+                          'Thing_Datastream_properties',
+                          'Thing_Datastream_phenomenonTimeStart',
+                          'Thing_Datastream_phenomenonTimeEnd',
+                          'Thing_Datastream_resultTimeStart',
+                          'Thing_Datastream_resultTimeEnd'])
+
+    def test_expandable_targets(self):
+        """
+        Test valid expansion targets for entity types
+        """
+        self.assertEqual(QgsSensorThingsUtils.expandableTargets(
+            Qgis.SensorThingsEntity.Thing),
+            [[Qgis.SensorThingsEntity.HistoricalLocation],
+             [Qgis.SensorThingsEntity.Datastream],
+             [Qgis.SensorThingsEntity.Datastream,
+             Qgis.SensorThingsEntity.Sensor],
+             [Qgis.SensorThingsEntity.Datastream,
+              Qgis.SensorThingsEntity.ObservedProperty],
+             [Qgis.SensorThingsEntity.Datastream,
+              Qgis.SensorThingsEntity.Observation]]
+        )
+
     def test_filter_for_extent(self):
         """
         Test constructing valid filter strings for features which intersect
@@ -3578,6 +3673,461 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                  'Polygon ((103 0, 104 0, 104 1, 103 1, 103 0))'],
             )
 
+    def test_feature_expansion(self):
+        """
+        Test a layer using feature expansion
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_path = temp_dir.replace("\\", "/")
+            endpoint = base_path + "/fake_qgis_http_endpoint"
+            with open(sanitize(endpoint, ""), "wt", encoding="utf8") as f:
+                f.write(
+                    """
+{
+  "value": [
+    {
+      "name": "Locations",
+      "url": "endpoint/Locations"
+    }
+  ],
+  "serverSettings": {
+  }
+}""".replace(
+                        "endpoint", "http://" + endpoint
+                    )
+                )
+
+            with open(
+                sanitize(endpoint,
+                         "/Locations?$top=0&$count=true&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"),
+                "wt",
+                encoding="utf8",
+            ) as f:
+                f.write("""{"@iot.count":3,"value":[]}""")
+
+            with open(
+                sanitize(endpoint,
+                         "/Locations?$top=2&$count=false&$expand=Things/Datastreams&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"),
+                "wt",
+                encoding="utf8",
+            ) as f:
+                f.write(
+                    """
+{
+  "value": [
+    {
+      "@iot.selfLink": "endpoint/Locations(1)",
+      "@iot.id": 1,
+      "name": "Location 1",
+      "description": "Desc 1",
+      "unitOfMeasurements": [
+          {
+            "name": "ug.m-3",
+            "symbol": "ug.m-3",
+            "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+          }
+      ],
+      "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+      "multiObservationDataTypes": ["http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"],
+      "phenomenonTime": "2017-12-31T23:00:00Z/2018-01-12T04:00:00Z",
+      "resultTime": "2017-12-31T23:30:00Z/2017-12-31T23:31:00Z",
+      "properties": {
+        "owner": "owner 1"
+      },
+      "Things": [
+        {
+          "@iot.selfLink": "endpoint/Things(1)",
+          "@iot.id": 1,
+          "name": "Thing 1",
+          "description": "Description Thing 1",
+          "properties": {
+            "countryCode": "AT"
+          },
+          "Datastreams": [
+            {
+              "@iot.selfLink": "endpoint/Datastreams(45)",
+              "@iot.id": 45,
+              "name": "Datastream 45",
+              "description": "Description datastream 45",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            },
+            {
+              "@iot.selfLink": "endpoint/Datastreams(46)",
+              "@iot.id": 46,
+              "name": "Datastream 46",
+              "description": "Description datastream 46",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2018-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            }
+            ]
+        }
+       ],
+      "location": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [100, 0], [101, 0], [101, 1], [100, 1], [100, 0]
+              ]
+            ]
+          },
+      "Things@iot.navigationLink": "endpoint/Locations(1)/Things",
+      "HistoricalLocations@iot.navigationLink": "endpoint/Locations(1)/HistoricalLocations"
+    },
+    {
+      "@iot.selfLink": "endpoint/Locations(2)",
+      "@iot.id": 2,
+      "name": "Location 2",
+      "description": "Desc 2",
+      "unitOfMeasurements": [
+      {
+        "name": "ug.m-3",
+        "symbol": "ug.m-3",
+        "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+      }],
+      "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+      "multiObservationDataTypes": ["http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"],
+      "phenomenonTime": "2018-12-31T23:00:00Z/2019-01-12T04:00:00Z",
+      "resultTime": "2018-12-31T23:30:00Z/2018-12-31T23:31:00Z",
+      "properties": {
+        "owner": "owner 2"
+      },
+      "Things": [
+        {
+          "@iot.selfLink": "endpoint/Things(2)",
+          "@iot.id": 2,
+          "name": "Thing 2",
+          "description": "Description Thing 2",
+          "properties": {
+            "countryCode": "AT"
+          },
+          "Datastreams": [
+            {
+              "@iot.selfLink": "endpoint/Datastreams(51)",
+              "@iot.id": 51,
+              "name": "Datastream 51",
+              "description": "Description datastream 51",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            }
+            ]
+        },
+        {
+          "@iot.selfLink": "endpoint/Things(3)",
+          "@iot.id": 3,
+          "name": "Thing 3",
+          "description": "Description Thing 3",
+          "properties": {
+            "countryCode": "AT"
+          },
+          "Datastreams": [
+            {
+              "@iot.selfLink": "endpoint/Datastreams(52)",
+              "@iot.id": 52,
+              "name": "Datastream 52",
+              "description": "Description datastream 52",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            }
+            ]
+        }
+       ],
+            "location": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [102, 0], [103, 0], [103, 1], [102, 1], [102, 0]
+              ]
+            ]
+          },
+      "Things@iot.navigationLink": "endpoint/Locations(2)/Things",
+      "HistoricalLocations@iot.navigationLink": "endpoint/Locations(2)/HistoricalLocations"
+
+    }
+  ],
+  "@iot.nextLink": "endpoint/Locations?$top=2&$skip=2&$expand=Things/Datastreams&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"
+}
+                """.replace(
+                        "endpoint", "http://" + endpoint
+                    )
+                )
+
+                with open(
+                    sanitize(endpoint,
+                             "/Locations?$top=2&$skip=2&$expand=Things/Datastreams&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"),
+                    "wt",
+                    encoding="utf8",
+                ) as f:
+                    f.write(
+                        """
+            {
+              "value": [
+                {
+                  "@iot.selfLink": "endpoint/Locations(3)",
+                  "@iot.id": 3,
+                  "name": "Location 3",
+                  "description": "Desc 3",
+                  "unitOfMeasurements": [{
+                    "name": "ug.m-3",
+                    "symbol": "ug.m-3",
+                    "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+                  }],
+                  "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+                  "multiObservationDataTypes": ["http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"],
+                  "phenomenonTime": "2020-12-31T23:00:00Z/2021-01-12T04:00:00Z",
+                  "resultTime": "2020-12-31T23:30:00Z/2020-12-31T23:31:00Z",
+                  "properties": {
+                    "owner": "owner 3"
+                  },
+                  "Things": [
+        {
+          "@iot.selfLink": "endpoint/Things(8)",
+          "@iot.id": 8,
+          "name": "Thing 8",
+          "description": "Description Thing 8",
+          "properties": {
+            "countryCode": "AT"
+          },
+          "Datastreams": [
+            {
+              "@iot.selfLink": "endpoint/Datastreams(59)",
+              "@iot.id": 59,
+              "name": "Datastream 59",
+              "description": "Description datastream 59",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            },
+            {
+              "@iot.selfLink": "endpoint/Datastreams(60)",
+              "@iot.id": 60,
+              "name": "Datastream 60",
+              "description": "Description datastream 60",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            }
+            ]
+        }
+       ],
+                        "location": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [103, 0], [104, 0], [104, 1], [103, 1], [103, 0]
+              ]
+            ]
+          },
+                  "Things@iot.navigationLink": "endpoint/Locations(3)/Things",
+                  "HistoricalLocations@iot.navigationLink": "endpoint/Locations(3)/HistoricalLocations"
+                }
+              ]
+            }
+                            """.replace(
+                            "endpoint", "http://" + endpoint
+                        )
+                    )
+
+            vl = QgsVectorLayer(
+                f"url='http://{endpoint}' pageSize=2 type=MultiPolygonZ entity='Location' expandTo='Thing,Datastream'",
+                "test",
+                "sensorthings",
+            )
+            self.assertTrue(vl.isValid())
+            # basic layer properties tests
+            self.assertEqual(vl.storageType(), "OGC SensorThings API")
+            self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiPolygonZ)
+
+            self.assertEqual(vl.featureCount(), -1)
+            self.assertEqual(vl.crs().authid(), 'EPSG:4326')
+            self.assertIn("Entity Type</td><td>Location</td>",
+                          vl.htmlMetadata())
+            self.assertIn(f'href="http://{endpoint}/Locations"',
+                          vl.htmlMetadata())
+
+            self.assertEqual(
+                [f.name() for f in vl.fields()],
+                ['id', 'selfLink', 'name', 'description', 'properties',
+                 'Thing_id', 'Thing_selfLink', 'Thing_name',
+                 'Thing_description', 'Thing_properties',
+                 'Thing_Datastream_id', 'Thing_Datastream_selfLink',
+                 'Thing_Datastream_name', 'Thing_Datastream_description',
+                 'Thing_Datastream_unitOfMeasurement',
+                 'Thing_Datastream_observationType',
+                 'Thing_Datastream_properties',
+                 'Thing_Datastream_phenomenonTimeStart',
+                 'Thing_Datastream_phenomenonTimeEnd',
+                 'Thing_Datastream_resultTimeStart',
+                 'Thing_Datastream_resultTimeEnd'],
+            )
+            self.assertEqual(
+                [f.type() for f in vl.fields()],
+                [
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.DateTime,
+                    QVariant.DateTime,
+                    QVariant.DateTime,
+                    QVariant.DateTime,
+                ],
+            )
+
+            # test retrieving all features from layer
+            features = list(vl.getFeatures())
+            self.assertEqual([f.id() for f in features],
+                             [0, 1, 2, 3, 4, 5])
+            self.assertEqual([f["id"] for f in features],
+                             ["1", "1", "2", "2", "3", "3"])
+            self.assertEqual(
+                [f["selfLink"][-13:] for f in features],
+                ["/Locations(1)", "/Locations(1)",
+                 "/Locations(2)", "/Locations(2)",
+                 "/Locations(3)", "/Locations(3)"],
+            )
+            self.assertEqual(
+                [f["name"] for f in features],
+                ["Location 1", "Location 1",
+                 "Location 2", "Location 2",
+                 "Location 3", "Location 3"],
+            )
+            self.assertEqual(
+                [f["description"] for f in features],
+                ["Desc 1", "Desc 1",
+                 "Desc 2", "Desc 2",
+                 "Desc 3", "Desc 3"]
+            )
+            self.assertEqual(
+                [f["properties"] for f in features],
+                [{'owner': 'owner 1'}, {'owner': 'owner 1'},
+                 {'owner': 'owner 2'}, {'owner': 'owner 2'},
+                 {'owner': 'owner 3'}, {'owner': 'owner 3'}]
+            )
+            self.assertEqual(
+                [f["Thing_id"] for f in features],
+                ['1', '1', '2', '3', '8', '8']
+            )
+            self.assertEqual(
+                [f["Thing_selfLink"][-10:] for f in features],
+                ['/Things(1)', '/Things(1)', '/Things(2)', '/Things(3)',
+                 '/Things(8)', '/Things(8)']
+            )
+            self.assertEqual(
+                [f["Thing_name"] for f in features],
+                ['Thing 1', 'Thing 1', 'Thing 2', 'Thing 3', 'Thing 8',
+                 'Thing 8']
+            )
+            self.assertEqual(
+                [f["Thing_description"] for f in features],
+                ['Description Thing 1', 'Description Thing 1',
+                 'Description Thing 2', 'Description Thing 3',
+                 'Description Thing 8', 'Description Thing 8']
+            )
+            self.assertEqual(
+                [f["Thing_properties"] for f in features],
+                [{'countryCode': 'AT'}, {'countryCode': 'AT'},
+                 {'countryCode': 'AT'}, {'countryCode': 'AT'},
+                 {'countryCode': 'AT'}, {'countryCode': 'AT'}]
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_id"] for f in features],
+                ['45', '46', '51', '52', '59', '60']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_selfLink"][-16:] for f in features],
+                ['/Datastreams(45)', '/Datastreams(46)',
+                 '/Datastreams(51)',
+                 '/Datastreams(52)', '/Datastreams(59)',
+                 '/Datastreams(60)']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_name"] for f in features],
+                ['Datastream 45', 'Datastream 46', 'Datastream 51',
+                 'Datastream 52', 'Datastream 59', 'Datastream 60']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_description"] for f in features],
+                ['Description datastream 45', 'Description datastream 46',
+                 'Description datastream 51', 'Description datastream 52',
+                 'Description datastream 59', 'Description datastream 60']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_properties"] for f in features],
+                [{'owner': 'someone'}, {'owner': 'someone'},
+                 {'owner': 'someone'}, {'owner': 'someone'},
+                 {'owner': 'someone'}, {'owner': 'someone'}]
+            )
+
+            self.assertEqual(
+                [f.geometry().asWkt() for f in features],
+                ['Polygon ((100 0, 101 0, 101 1, 100 1, 100 0))',
+                 'Polygon ((100 0, 101 0, 101 1, 100 1, 100 0))',
+                 'Polygon ((102 0, 103 0, 103 1, 102 1, 102 0))',
+                 'Polygon ((102 0, 103 0, 103 1, 102 1, 102 0))',
+                 'Polygon ((103 0, 104 0, 104 1, 103 1, 103 0))',
+                 'Polygon ((103 0, 104 0, 104 1, 103 1, 103 0))'],
+            )
+
     def testDecodeUri(self):
         """
         Test decoding a SensorThings uri
@@ -3672,6 +4222,19 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             },
         )
 
+        uri = "url='https://sometest.com/api' type=MultiPolygonZ authcfg='abc' expandTo='Thing,Datastream' entity='Location'"
+        parts = QgsProviderRegistry.instance().decodeUri("sensorthings", uri)
+        self.assertEqual(
+            parts,
+            {
+                "url": "https://sometest.com/api",
+                "entity": "Location",
+                "geometryType": "polygon",
+                "authcfg": "abc",
+                "expandTo": ['Thing', 'Datastream']
+            },
+        )
+
     def testEncodeUri(self):
         """
         Test encoding a SensorThings uri
@@ -3762,6 +4325,19 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
         self.assertEqual(
             uri,
             "authcfg=aaaaa type=MultiPolygonZ entity='Location' featureLimit='50' url='http://blah.com'",
+        )
+
+        parts = {
+            "url": "http://blah.com",
+            "authcfg": "aaaaa",
+            "entity": "location",
+            "geometryType": "polygon",
+            "expandTo": ["Thing", "Datastream"]
+        }
+        uri = QgsProviderRegistry.instance().encodeUri("sensorthings", parts)
+        self.assertEqual(
+            uri,
+            "authcfg=aaaaa type=MultiPolygonZ entity='Location' expandTo='Thing,Datastream' url='http://blah.com'",
         )
 
 

--- a/tests/src/python/test_provider_sensorthings.py
+++ b/tests/src/python/test_provider_sensorthings.py
@@ -4128,6 +4128,387 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                  'Polygon ((103 0, 104 0, 104 1, 103 1, 103 0))'],
             )
 
+    def test_feature_expansion_with_limit(self):
+        """
+        Test a layer using feature expansion with limited child features
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_path = temp_dir.replace("\\", "/")
+            endpoint = base_path + "/fake_qgis_http_endpoint"
+            with open(sanitize(endpoint, ""), "wt", encoding="utf8") as f:
+                f.write(
+                    """
+{
+  "value": [
+    {
+      "name": "Locations",
+      "url": "endpoint/Locations"
+    }
+  ],
+  "serverSettings": {
+  }
+}""".replace(
+                        "endpoint", "http://" + endpoint
+                    )
+                )
+
+            with open(
+                sanitize(endpoint,
+                         "/Locations?$top=0&$count=true&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"),
+                "wt",
+                encoding="utf8",
+            ) as f:
+                f.write("""{"@iot.count":3,"value":[]}""")
+
+            with open(
+                sanitize(endpoint,
+                         "/Locations?$top=2&$count=false&$expand=Things/Datastreams($top=1)&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"),
+                "wt",
+                encoding="utf8",
+            ) as f:
+                f.write(
+                    """
+{
+  "value": [
+    {
+      "@iot.selfLink": "endpoint/Locations(1)",
+      "@iot.id": 1,
+      "name": "Location 1",
+      "description": "Desc 1",
+      "unitOfMeasurements": [
+          {
+            "name": "ug.m-3",
+            "symbol": "ug.m-3",
+            "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+          }
+      ],
+      "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+      "multiObservationDataTypes": ["http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"],
+      "phenomenonTime": "2017-12-31T23:00:00Z/2018-01-12T04:00:00Z",
+      "resultTime": "2017-12-31T23:30:00Z/2017-12-31T23:31:00Z",
+      "properties": {
+        "owner": "owner 1"
+      },
+      "Things": [
+        {
+          "@iot.selfLink": "endpoint/Things(1)",
+          "@iot.id": 1,
+          "name": "Thing 1",
+          "description": "Description Thing 1",
+          "properties": {
+            "countryCode": "AT"
+          },
+          "Datastreams": [
+            {
+              "@iot.selfLink": "endpoint/Datastreams(45)",
+              "@iot.id": 45,
+              "name": "Datastream 45",
+              "description": "Description datastream 45",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            }
+            ]
+        }
+       ],
+      "location": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [100, 0], [101, 0], [101, 1], [100, 1], [100, 0]
+              ]
+            ]
+          },
+      "Things@iot.navigationLink": "endpoint/Locations(1)/Things",
+      "HistoricalLocations@iot.navigationLink": "endpoint/Locations(1)/HistoricalLocations"
+    },
+    {
+      "@iot.selfLink": "endpoint/Locations(2)",
+      "@iot.id": 2,
+      "name": "Location 2",
+      "description": "Desc 2",
+      "unitOfMeasurements": [
+      {
+        "name": "ug.m-3",
+        "symbol": "ug.m-3",
+        "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+      }],
+      "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+      "multiObservationDataTypes": ["http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"],
+      "phenomenonTime": "2018-12-31T23:00:00Z/2019-01-12T04:00:00Z",
+      "resultTime": "2018-12-31T23:30:00Z/2018-12-31T23:31:00Z",
+      "properties": {
+        "owner": "owner 2"
+      },
+      "Things": [
+        {
+          "@iot.selfLink": "endpoint/Things(2)",
+          "@iot.id": 2,
+          "name": "Thing 2",
+          "description": "Description Thing 2",
+          "properties": {
+            "countryCode": "AT"
+          },
+          "Datastreams": [
+            {
+              "@iot.selfLink": "endpoint/Datastreams(51)",
+              "@iot.id": 51,
+              "name": "Datastream 51",
+              "description": "Description datastream 51",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            }
+            ]
+        }
+       ],
+            "location": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [102, 0], [103, 0], [103, 1], [102, 1], [102, 0]
+              ]
+            ]
+          },
+      "Things@iot.navigationLink": "endpoint/Locations(2)/Things",
+      "HistoricalLocations@iot.navigationLink": "endpoint/Locations(2)/HistoricalLocations"
+
+    }
+  ],
+  "@iot.nextLink": "endpoint/Locations?$top=2&$skip=2&$expand=Things/Datastreams($top=1)&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"
+}
+                """.replace(
+                        "endpoint", "http://" + endpoint
+                    )
+                )
+
+                with open(
+                    sanitize(endpoint,
+                             "/Locations?$top=2&$skip=2&$expand=Things/Datastreams($top=1)&$filter=location/type eq 'Polygon' or location/geometry/type eq 'Polygon'"),
+                    "wt",
+                    encoding="utf8",
+                ) as f:
+                    f.write(
+                        """
+            {
+              "value": [
+                {
+                  "@iot.selfLink": "endpoint/Locations(3)",
+                  "@iot.id": 3,
+                  "name": "Location 3",
+                  "description": "Desc 3",
+                  "unitOfMeasurements": [{
+                    "name": "ug.m-3",
+                    "symbol": "ug.m-3",
+                    "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+                  }],
+                  "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+                  "multiObservationDataTypes": ["http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"],
+                  "phenomenonTime": "2020-12-31T23:00:00Z/2021-01-12T04:00:00Z",
+                  "resultTime": "2020-12-31T23:30:00Z/2020-12-31T23:31:00Z",
+                  "properties": {
+                    "owner": "owner 3"
+                  },
+                  "Things": [
+        {
+          "@iot.selfLink": "endpoint/Things(8)",
+          "@iot.id": 8,
+          "name": "Thing 8",
+          "description": "Description Thing 8",
+          "properties": {
+            "countryCode": "AT"
+          },
+          "Datastreams": [
+            {
+              "@iot.selfLink": "endpoint/Datastreams(59)",
+              "@iot.id": 59,
+              "name": "Datastream 59",
+              "description": "Description datastream 59",
+              "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+              "unitOfMeasurement": {
+                "name": "ug.m-3",
+                "symbol": "ug.m-3",
+                "definition": "http://dd.eionet.europa.eu/vocabulary/uom/concentration/ug.m-3"
+              },
+              "phenomenonTime": "2017-12-31T23:00:00Z/2024-03-25T04:00:00Z",
+              "properties": {
+                "owner": "someone"
+              }
+            }
+            ]
+        }
+       ],
+                        "location": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [103, 0], [104, 0], [104, 1], [103, 1], [103, 0]
+              ]
+            ]
+          },
+                  "Things@iot.navigationLink": "endpoint/Locations(3)/Things",
+                  "HistoricalLocations@iot.navigationLink": "endpoint/Locations(3)/HistoricalLocations"
+                }
+              ]
+            }
+                            """.replace(
+                            "endpoint", "http://" + endpoint
+                        )
+                    )
+
+            vl = QgsVectorLayer(
+                f"url='http://{endpoint}' pageSize=2 type=MultiPolygonZ entity='Location' expansionLimit=1 expandTo='Thing,Datastream'",
+                "test",
+                "sensorthings",
+            )
+            self.assertTrue(vl.isValid())
+            # basic layer properties tests
+            self.assertEqual(vl.storageType(), "OGC SensorThings API")
+            self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiPolygonZ)
+
+            self.assertEqual(vl.featureCount(), -1)
+            self.assertEqual(vl.crs().authid(), 'EPSG:4326')
+            self.assertIn("Entity Type</td><td>Location</td>",
+                          vl.htmlMetadata())
+            self.assertIn(f'href="http://{endpoint}/Locations"',
+                          vl.htmlMetadata())
+
+            self.assertEqual(
+                [f.name() for f in vl.fields()],
+                ['id', 'selfLink', 'name', 'description', 'properties',
+                 'Thing_id', 'Thing_selfLink', 'Thing_name',
+                 'Thing_description', 'Thing_properties',
+                 'Thing_Datastream_id', 'Thing_Datastream_selfLink',
+                 'Thing_Datastream_name', 'Thing_Datastream_description',
+                 'Thing_Datastream_unitOfMeasurement',
+                 'Thing_Datastream_observationType',
+                 'Thing_Datastream_properties',
+                 'Thing_Datastream_phenomenonTimeStart',
+                 'Thing_Datastream_phenomenonTimeEnd',
+                 'Thing_Datastream_resultTimeStart',
+                 'Thing_Datastream_resultTimeEnd'],
+            )
+            self.assertEqual(
+                [f.type() for f in vl.fields()],
+                [
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.String,
+                    QVariant.Map,
+                    QVariant.DateTime,
+                    QVariant.DateTime,
+                    QVariant.DateTime,
+                    QVariant.DateTime,
+                ],
+            )
+
+            # test retrieving all features from layer
+            features = list(vl.getFeatures())
+            self.assertEqual([f.id() for f in features],
+                             [0, 1, 2])
+            self.assertEqual([f["id"] for f in features],
+                             ["1", "2", "3"])
+            self.assertEqual(
+                [f["selfLink"][-13:] for f in features],
+                ["/Locations(1)", "/Locations(2)",
+                 "/Locations(3)"],
+            )
+            self.assertEqual(
+                [f["name"] for f in features],
+                ["Location 1", "Location 2",
+                 "Location 3"],
+            )
+            self.assertEqual(
+                [f["description"] for f in features],
+                ["Desc 1", "Desc 2",
+                 "Desc 3"]
+            )
+            self.assertEqual(
+                [f["properties"] for f in features],
+                [{'owner': 'owner 1'},
+                 {'owner': 'owner 2'},
+                 {'owner': 'owner 3'}]
+            )
+            self.assertEqual(
+                [f["Thing_id"] for f in features],
+                ['1', '2', '8']
+            )
+            self.assertEqual(
+                [f["Thing_selfLink"][-10:] for f in features],
+                ['/Things(1)', '/Things(2)', '/Things(8)']
+            )
+            self.assertEqual(
+                [f["Thing_name"] for f in features],
+                ['Thing 1', 'Thing 2', 'Thing 8']
+            )
+            self.assertEqual(
+                [f["Thing_description"] for f in features],
+                ['Description Thing 1', 'Description Thing 2',
+                 'Description Thing 8']
+            )
+            self.assertEqual(
+                [f["Thing_properties"] for f in features],
+                [{'countryCode': 'AT'}, {'countryCode': 'AT'},
+                 {'countryCode': 'AT'}]
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_id"] for f in features],
+                ['45', '51', '59']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_selfLink"][-16:] for f in features],
+                ['/Datastreams(45)', '/Datastreams(51)',
+                 '/Datastreams(59)']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_name"] for f in features],
+                ['Datastream 45', 'Datastream 51', 'Datastream 59']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_description"] for f in features],
+                ['Description datastream 45', 'Description datastream 51',
+                 'Description datastream 59']
+            )
+            self.assertEqual(
+                [f["Thing_Datastream_properties"] for f in features],
+                [{'owner': 'someone'}, {'owner': 'someone'},
+                 {'owner': 'someone'}]
+            )
+
+            self.assertEqual(
+                [f.geometry().asWkt() for f in features],
+                ['Polygon ((100 0, 101 0, 101 1, 100 1, 100 0))',
+                 'Polygon ((102 0, 103 0, 103 1, 102 1, 102 0))',
+                 'Polygon ((103 0, 104 0, 104 1, 103 1, 103 0))'],
+            )
+
     def testDecodeUri(self):
         """
         Test decoding a SensorThings uri
@@ -4222,7 +4603,7 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             },
         )
 
-        uri = "url='https://sometest.com/api' type=MultiPolygonZ authcfg='abc' expandTo='Thing,Datastream' entity='Location'"
+        uri = "url='https://sometest.com/api' type=MultiPolygonZ authcfg='abc' expandTo='Thing,Datastream' expansionLimit=30 entity='Location'"
         parts = QgsProviderRegistry.instance().decodeUri("sensorthings", uri)
         self.assertEqual(
             parts,
@@ -4231,6 +4612,7 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                 "entity": "Location",
                 "geometryType": "polygon",
                 "authcfg": "abc",
+                'expansionLimit': 30,
                 "expandTo": ['Thing', 'Datastream']
             },
         )
@@ -4332,12 +4714,13 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             "authcfg": "aaaaa",
             "entity": "location",
             "geometryType": "polygon",
-            "expandTo": ["Thing", "Datastream"]
+            "expandTo": ["Thing", "Datastream"],
+            'expansionLimit': 30
         }
         uri = QgsProviderRegistry.instance().encodeUri("sensorthings", parts)
         self.assertEqual(
             uri,
-            "authcfg=aaaaa type=MultiPolygonZ entity='Location' expandTo='Thing,Datastream' url='http://blah.com'",
+            "authcfg=aaaaa type=MultiPolygonZ entity='Location' expandTo='Thing,Datastream' expansionLimit='30' url='http://blah.com'",
         )
 
 


### PR DESCRIPTION
This change allows SensorThings entities to be expanded to contain their related child feature attributes, exposing the relational SensorThings model as a traditional "flat" GIS-friendly table structure.

Eg when selecting Location entities, you can now opt to expand to "Things > Datastreams > Observations". This would result in multiple "stacked" point location features, one corresponding to each observation, with the attributes for each point feature containing the location, thing, datastream and observation attributes.

Best used combined with some extent, feature limit, or custom filter option, as this can otherwise result in very heavy
requests to the backend service! There's also an option to limit then number of child features returned when expanding, and we default to a very conservative amount here in order to reduce load on services. (I.e. users need to explicitly "opt in" to fetch large amounts of features)

![Peek 2024-03-25 15-47](https://github.com/qgis/QGIS/assets/1829991/9b6c2353-09b0-46da-a931-8d69fc89537c)

Here's an example of a feature returned when the expansion option out to "Location > Thing > Datastream" is used. Note how the "Thing" and "Thing_Datastream" attributes are appended on to the base "Location" attributes:

![image](https://github.com/qgis/QGIS/assets/1829991/3bcf6884-27ec-48a1-856f-69c4a0c5da5d)

Fixes https://github.com/qgis/QGIS/issues/56805