### PR TITLE
Consider settings to insert new layers also if adding qlr

### DIFF
--- a/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
@@ -25,13 +25,33 @@ files also store the layer tree info for the exported layers, including group in
 #include "qgslayerdefinition.h"
 %End
   public:
-    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/ );
+
+    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR at path into QGIS.  New layers are added to given project into layer tree specified by rootGroup
+
+:param path: file path to the qlr
+:param project: the current project
+:param rootGroup: the layer tree group to insert the qlr content
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+
+:return: - true in case of success
+         - errorMessage: the returned error message
 %End
-    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context );
+
+    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
+
+:param doc: the xml document
+:param project: the current project
+:param rootGroup: the layer tree group to insert the qlr content
+:param context: the read write context
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+:param true: in case of success
+
+:return: - true in case of success
+         - errorMessage: the returned error message
 %End
 
     static bool exportLayerDefinition( const QString &path, const QList<QgsLayerTreeNode *> &selectedTreeNodes, QString &errorMessage /Out/ );

--- a/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
@@ -26,20 +26,21 @@ files also store the layer tree info for the exported layers, including group in
 %End
   public:
 
-    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
+    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, Qgis::LayerTreeInsertionMethod insertMethod = Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR at path into QGIS.  New layers are added to given project into layer tree specified by rootGroup
 
 :param path: file path to the qlr
 :param project: the current project
 :param rootGroup: the layer tree group to insert the qlr content
-:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+:param insertMethod: method for layer tree (since QGIS 3.38)
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
 
 :return: - true in case of success
          - errorMessage: the returned error message
 %End
 
-    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
+    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context, Qgis::LayerTreeInsertionMethod insertMethod = Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
 
@@ -47,7 +48,8 @@ Loads the QLR from the XML document.  New layers are added to given project into
 :param project: the current project
 :param rootGroup: the layer tree group to insert the qlr content
 :param context: the read write context
-:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+:param insertMethod: method for layer tree (since QGIS 3.38)
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
 
 :return: - true in case of success
          - errorMessage: the returned error message

--- a/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
@@ -48,7 +48,6 @@ Loads the QLR from the XML document.  New layers are added to given project into
 :param rootGroup: the layer tree group to insert the qlr content
 :param context: the read write context
 :param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
-:param true: in case of success
 
 :return: - true in case of success
          - errorMessage: the returned error message

--- a/python/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/core/auto_generated/qgslayerdefinition.sip.in
@@ -25,13 +25,33 @@ files also store the layer tree info for the exported layers, including group in
 #include "qgslayerdefinition.h"
 %End
   public:
-    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/ );
+
+    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR at path into QGIS.  New layers are added to given project into layer tree specified by rootGroup
+
+:param path: file path to the qlr
+:param project: the current project
+:param rootGroup: the layer tree group to insert the qlr content
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+
+:return: - true in case of success
+         - errorMessage: the returned error message
 %End
-    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context );
+
+    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
+
+:param doc: the xml document
+:param project: the current project
+:param rootGroup: the layer tree group to insert the qlr content
+:param context: the read write context
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+:param true: in case of success
+
+:return: - true in case of success
+         - errorMessage: the returned error message
 %End
 
     static bool exportLayerDefinition( const QString &path, const QList<QgsLayerTreeNode *> &selectedTreeNodes, QString &errorMessage /Out/ );

--- a/python/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/core/auto_generated/qgslayerdefinition.sip.in
@@ -26,20 +26,21 @@ files also store the layer tree info for the exported layers, including group in
 %End
   public:
 
-    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
+    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, Qgis::LayerTreeInsertionMethod insertMethod = Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR at path into QGIS.  New layers are added to given project into layer tree specified by rootGroup
 
 :param path: file path to the qlr
 :param project: the current project
 :param rootGroup: the layer tree group to insert the qlr content
-:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+:param insertMethod: method for layer tree (since QGIS 3.38)
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
 
 :return: - true in case of success
          - errorMessage: the returned error message
 %End
 
-    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
+    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage /Out/, QgsReadWriteContext &context, Qgis::LayerTreeInsertionMethod insertMethod = Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = 0 );
 %Docstring
 Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
 
@@ -47,7 +48,8 @@ Loads the QLR from the XML document.  New layers are added to given project into
 :param project: the current project
 :param rootGroup: the layer tree group to insert the qlr content
 :param context: the read write context
-:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
+:param insertMethod: method for layer tree (since QGIS 3.38)
+:param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
 
 :return: - true in case of success
          - errorMessage: the returned error message

--- a/python/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/core/auto_generated/qgslayerdefinition.sip.in
@@ -48,7 +48,6 @@ Loads the QLR from the XML document.  New layers are added to given project into
 :param rootGroup: the layer tree group to insert the qlr content
 :param context: the read write context
 :param insertPoint: describes where in rootGroup the qlr layers/groups shall be inserted
-:param true: in case of success
 
 :return: - true in case of success
          - errorMessage: the returned error message

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -1236,7 +1236,9 @@ void QgsAppLayerHandling::openLayerDefinition( const QString &filename, const Qg
       context.setPathResolver( QgsPathResolver( filename ) );
       context.setProjectTranslator( QgsProject::instance() );
 
-      loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMessage, context, insertPoint );
+      QgsSettings settings;
+      Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
+      loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMessage, context, insertionMethod, insertPoint );
     }
   }
 

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -1209,7 +1209,7 @@ void QgsAppLayerHandling::addMapLayer( QgsMapLayer *mapLayer, bool addToLegend )
   }
 }
 
-void QgsAppLayerHandling::openLayerDefinition( const QString &filename )
+void QgsAppLayerHandling::openLayerDefinition( const QString &filename, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
 {
   QString errorMessage;
   QgsReadWriteContext context;
@@ -1236,7 +1236,7 @@ void QgsAppLayerHandling::openLayerDefinition( const QString &filename )
       context.setPathResolver( QgsPathResolver( filename ) );
       context.setProjectTranslator( QgsProject::instance() );
 
-      loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMessage, context );
+      loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMessage, context, insertPoint );
     }
   }
 
@@ -1260,7 +1260,7 @@ void QgsAppLayerHandling::openLayerDefinition( const QString &filename )
   }
 }
 
-void QgsAppLayerHandling::addLayerDefinition()
+void QgsAppLayerHandling::addLayerDefinition( const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
 {
   QgsSettings settings;
   QString lastUsedDir = settings.value( QStringLiteral( "UI/lastQLRDir" ), QDir::homePath() ).toString();
@@ -1272,7 +1272,7 @@ void QgsAppLayerHandling::addLayerDefinition()
   QFileInfo fi( path );
   settings.setValue( QStringLiteral( "UI/lastQLRDir" ), fi.path() );
 
-  openLayerDefinition( path );
+  openLayerDefinition( path, insertPoint );
 }
 
 QList< QgsMapLayer * > QgsAppLayerHandling::addDatabaseLayers( const QStringList &layerPathList, const QString &providerKey, bool &ok )

--- a/src/app/layers/qgsapplayerhandling.h
+++ b/src/app/layers/qgsapplayerhandling.h
@@ -20,6 +20,7 @@
 #include "qgsconfig.h"
 #include "qgsmaplayer.h"
 #include "qgsvectorlayerref.h"
+#include "qgslayertreeregistrybridge.h"
 
 #include <QObject>
 
@@ -149,10 +150,18 @@ class APP_EXPORT QgsAppLayerHandling
     //! Add a 'pre-made' map layer to the project
     static void addMapLayer( QgsMapLayer *mapLayer, bool addToLegend = true );
 
-    static void openLayerDefinition( const QString &filename );
+    /**
+     * Opens qlr
+     * \param filename file path to the qlr
+     * \param insertPoint describes where the qlr layers/groups shall be inserted
+     */
+    static void openLayerDefinition( const QString &filename, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );
 
-    //! Add a Layer Definition file
-    static void addLayerDefinition();
+    /**
+     * Add a Layer Definition file
+     * \param insertPoint describes where the qlr layers/groups shall be inserted
+     */
+    static void addLayerDefinition( const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint );
 
     //! Add a list of database layers to the map
     static QList< QgsMapLayer * > addDatabaseLayers( const QStringList &layerPathList, const QString &providerKey, bool &ok );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10791,8 +10791,11 @@ void QgisApp::pasteLayer()
       root = QgsProject::instance()->layerTreeRoot();
     }
 
+    QgsSettings settings;
+    Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
+    QgsLayerTreeRegistryBridge::InsertionPoint insertionPoint = layerTreeInsertionPoint();
     bool loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), root,
-                  errorMessage, readWriteContext );
+                  errorMessage, readWriteContext, insertionMethod, &insertionPoint );
 
     if ( !loaded || !errorMessage.isEmpty() )
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -863,6 +863,12 @@ void QgisApp::annotationItemTypeAdded( int id )
   } );
 }
 
+void QgisApp::addLayerDefinition()
+{
+  QgsLayerTreeRegistryBridge::InsertionPoint pt = layerTreeInsertionPoint();
+  QgsAppLayerHandling::addLayerDefinition( &pt );
+}
+
 /*
  * This function contains forced validation of CRS used in QGIS.
  * There are 4 options depending on the settings:
@@ -3030,7 +3036,7 @@ void QgisApp::createActions()
   connect( mActionShowRasterCalculator, &QAction::triggered, this, &QgisApp::showRasterCalculator );
   connect( mActionShowMeshCalculator, &QAction::triggered, this, &QgisApp::showMeshCalculator );
   connect( mActionEmbedLayers, &QAction::triggered, this, &QgisApp::embedLayers );
-  connect( mActionAddLayerDefinition, &QAction::triggered, this, [] { QgsAppLayerHandling::addLayerDefinition(); } );
+  connect( mActionAddLayerDefinition, &QAction::triggered, this, &QgisApp::addLayerDefinition );
   connect( mActionAddOgrLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "ogr" ) ); } );
   connect( mActionAddRasterLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "gdal" ) ); } );
   connect( mActionAddMeshLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "mdal" ) ); } );
@@ -7062,7 +7068,8 @@ QList< QgsMapLayer * > QgisApp::openFile( const QString &fileName, const QString
   }
   else if ( fi.suffix().compare( QLatin1String( "qlr" ), Qt::CaseInsensitive ) == 0 )
   {
-    QgsAppLayerHandling::openLayerDefinition( fileName );
+    QgsLayerTreeRegistryBridge::InsertionPoint p = layerTreeInsertionPoint();
+    QgsAppLayerHandling::openLayerDefinition( fileName, &p );
   }
   else if ( fi.suffix().compare( QLatin1String( "qpt" ), Qt::CaseInsensitive ) == 0 )
   {

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2117,6 +2117,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void annotationItemTypeAdded( int id );
 
+    /**
+     * Open a qlr file
+    */
+    void addLayerDefinition();
+
   signals:
 
     /**

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -38,7 +38,7 @@
 #include "qgslayertreegroup.h"
 #include "qgslayertreelayer.h"
 
-bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage )
+bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
 {
   QFile file( path );
   if ( !file.open( QIODevice::ReadOnly ) )
@@ -62,10 +62,10 @@ bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *p
   context.setPathResolver( QgsPathResolver( path ) );
   context.setProjectTranslator( project );
 
-  return loadLayerDefinition( doc, project, rootGroup, errorMessage, context );
+  return loadLayerDefinition( doc, project, rootGroup, errorMessage, context, insertPoint );
 }
 
-bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage, QgsReadWriteContext &context )
+bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
 {
   errorMessage.clear();
 
@@ -195,7 +195,26 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsProject *proj
   root->abandonChildren();
   delete root;
 
-  rootGroup->insertChildNodes( -1, nodes );
+  QgsSettings settings;
+  if ( !insertPoint )
+  {
+    rootGroup->insertChildNodes( -1, nodes );
+  }
+  else
+  {
+    Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( QStringLiteral( "qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::AboveInsertionPoint );
+    switch ( insertionMethod )
+    {
+      case Qgis::LayerTreeInsertionMethod::AboveInsertionPoint:
+        insertPoint->group->insertChildNodes( insertPoint->position, nodes );
+        break;
+      case Qgis::LayerTreeInsertionMethod::TopOfTree:
+        rootGroup->insertChildNodes( 0, nodes );
+        break;
+      default:
+        rootGroup->insertChildNodes( -1, nodes ); //Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup does not really make sense for qlr
+    }
+  }
 
   return true;
 }

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -196,24 +196,25 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsProject *proj
   delete root;
 
   QgsSettings settings;
-  if ( !insertPoint )
+
+  Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
+  switch ( insertionMethod )
   {
-    rootGroup->insertChildNodes( -1, nodes );
-  }
-  else
-  {
-    Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( QStringLiteral( "qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::AboveInsertionPoint );
-    switch ( insertionMethod )
-    {
-      case Qgis::LayerTreeInsertionMethod::AboveInsertionPoint:
+    case Qgis::LayerTreeInsertionMethod::AboveInsertionPoint:
+      if ( insertPoint )
+      {
         insertPoint->group->insertChildNodes( insertPoint->position, nodes );
-        break;
-      case Qgis::LayerTreeInsertionMethod::TopOfTree:
-        rootGroup->insertChildNodes( 0, nodes );
-        break;
-      default:
-        rootGroup->insertChildNodes( -1, nodes ); //Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup does not really make sense for qlr
-    }
+      }
+      else
+      {
+        rootGroup->insertChildNodes( -1, nodes );
+      }
+      break;
+    case Qgis::LayerTreeInsertionMethod::TopOfTree:
+      rootGroup->insertChildNodes( 0, nodes );
+      break;
+    default: //Keep current behavior for Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup
+      rootGroup->insertChildNodes( -1, nodes );
   }
 
   return true;

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -38,7 +38,7 @@
 #include "qgslayertreegroup.h"
 #include "qgslayertreelayer.h"
 
-bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
+bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage, Qgis::LayerTreeInsertionMethod insertMethod, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
 {
   QFile file( path );
   if ( !file.open( QIODevice::ReadOnly ) )
@@ -62,10 +62,10 @@ bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *p
   context.setPathResolver( QgsPathResolver( path ) );
   context.setProjectTranslator( project );
 
-  return loadLayerDefinition( doc, project, rootGroup, errorMessage, context, insertPoint );
+  return loadLayerDefinition( doc, project, rootGroup, errorMessage, context, insertMethod, insertPoint );
 }
 
-bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
+bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage, QgsReadWriteContext &context, Qgis::LayerTreeInsertionMethod insertMethod, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint )
 {
   errorMessage.clear();
 
@@ -195,10 +195,7 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsProject *proj
   root->abandonChildren();
   delete root;
 
-  QgsSettings settings;
-
-  Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
-  switch ( insertionMethod )
+  switch ( insertMethod )
   {
     case Qgis::LayerTreeInsertionMethod::AboveInsertionPoint:
       if ( insertPoint )

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsLayerDefinition
      *  \param rootGroup the layer tree group to insert the qlr content
      *  \param errorMessage the returned error message
      *  \param context the read write context
-     *  \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted
+     *  \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
      *  \return true in case of success
      */
     static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -65,7 +65,6 @@ class CORE_EXPORT QgsLayerDefinition
      *  \param errorMessage the returned error message
      *  \param context the read write context
      *  \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted
-     *  \param true in case of success
      *  \return true in case of success
      */
     static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -52,10 +52,11 @@ class CORE_EXPORT QgsLayerDefinition
      * \param project the current project
      * \param rootGroup the layer tree group to insert the qlr content
      * \param errorMessage the returned error message
+     * \param insertMethod method for layer tree (since QGIS 3.38)
      * \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
      * \return true in case of success
     */
-    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );
+    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, Qgis::LayerTreeInsertionMethod insertMethod = Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );
 
     /**
      * Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
@@ -64,10 +65,11 @@ class CORE_EXPORT QgsLayerDefinition
      *  \param rootGroup the layer tree group to insert the qlr content
      *  \param errorMessage the returned error message
      *  \param context the read write context
+     *  \param insertMethod method for layer tree (since QGIS 3.38)
      *  \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
      *  \return true in case of success
      */
-    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );
+    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, QgsReadWriteContext &context, Qgis::LayerTreeInsertionMethod insertMethod = Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );
 
     /**
      * Exports the selected layer tree nodes to a QLR file.

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -19,6 +19,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgis.h"
+#include "qgslayertreeregistrybridge.h"
 
 #include <QString>
 #include <QVector>
@@ -44,10 +45,30 @@ class QgsProject;
 class CORE_EXPORT QgsLayerDefinition
 {
   public:
-    //! Loads the QLR at path into QGIS.  New layers are added to given project into layer tree specified by rootGroup
-    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT );
-    //! Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
-    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, QgsReadWriteContext &context );
+
+    /**
+     * Loads the QLR at path into QGIS.  New layers are added to given project into layer tree specified by rootGroup
+     * \param path file path to the qlr
+     * \param project the current project
+     * \param rootGroup the layer tree group to insert the qlr content
+     * \param errorMessage the returned error message
+     * \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted
+     * \return true in case of success
+    */
+    static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );
+
+    /**
+     * Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
+     *  \param doc the xml document
+     *  \param project the current project
+     *  \param rootGroup the layer tree group to insert the qlr content
+     *  \param errorMessage the returned error message
+     *  \param context the read write context
+     *  \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted
+     *  \param true in case of success
+     *  \return true in case of success
+     */
+    static bool loadLayerDefinition( QDomDocument doc,  QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, QgsReadWriteContext &context, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );
 
     /**
      * Exports the selected layer tree nodes to a QLR file.

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -52,7 +52,7 @@ class CORE_EXPORT QgsLayerDefinition
      * \param project the current project
      * \param rootGroup the layer tree group to insert the qlr content
      * \param errorMessage the returned error message
-     * \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted
+     * \param insertPoint describes where in rootGroup the qlr layers/groups shall be inserted (since QGIS 3.38)
      * \return true in case of success
     */
     static bool loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage SIP_OUT, const QgsLayerTreeRegistryBridge::InsertionPoint *insertPoint = nullptr );

--- a/tests/src/core/testqgslayerdefinition.cpp
+++ b/tests/src/core/testqgslayerdefinition.cpp
@@ -97,10 +97,8 @@ void TestQgsLayerDefinition::testFindLayers()
 
 void TestQgsLayerDefinition::testLoadTopOfTree()
 {
-  QgsSettings settings;
-  settings.setEnumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::TopOfTree );
   QString errorMsg;
-  QgsLayerDefinition::loadLayerDefinition( TEST_DATA_DIR + QStringLiteral( "/vector_and_raster.qlr" ), QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMsg );
+  QgsLayerDefinition::loadLayerDefinition( TEST_DATA_DIR + QStringLiteral( "/vector_and_raster.qlr" ), QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMsg, Qgis::LayerTreeInsertionMethod::TopOfTree );
   //todo: test if new layers are on top
   QList<QgsMapLayer *> orderedLayers = QgsProject::instance()->layerTreeRoot()->layerOrder();
   QCOMPARE( orderedLayers.length(), 3 );

--- a/tests/src/core/testqgslayerdefinition.cpp
+++ b/tests/src/core/testqgslayerdefinition.cpp
@@ -99,7 +99,7 @@ void TestQgsLayerDefinition::testLoadTopOfTree()
 {
   QString errorMsg;
   QgsLayerDefinition::loadLayerDefinition( TEST_DATA_DIR + QStringLiteral( "/vector_and_raster.qlr" ), QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMsg, Qgis::LayerTreeInsertionMethod::TopOfTree );
-  //todo: test if new layers are on top
+  //test if new layers are on top
   QList<QgsMapLayer *> orderedLayers = QgsProject::instance()->layerTreeRoot()->layerOrder();
   QCOMPARE( orderedLayers.length(), 3 );
   QVERIFY( orderedLayers.at( 1 )->name() == QStringLiteral( "rgb256x256" ) );

--- a/tests/src/core/testqgslayerdefinition.cpp
+++ b/tests/src/core/testqgslayerdefinition.cpp
@@ -42,6 +42,11 @@ class TestQgsLayerDefinition: public QObject
     void testFindLayers();
 
     /**
+     * Tests loading a qlr placing the content at the top of the layer tree
+     */
+    void testLoadTopOfTree();
+
+    /**
      * test that export does not crash: regression #18981
      * https://github.com/qgis/QGIS/issues/26812 - Save QLR crashes QGIS 3
      */
@@ -88,6 +93,19 @@ void TestQgsLayerDefinition::testFindLayers()
   QCOMPARE( QgsProject::instance()->layerTreeRoot()->findLayers().count(), 2 );
   QCOMPARE( QgsProject::instance()->layerTreeRoot()->findLayers().at( 0 )->name(), QStringLiteral( "DTK/D850" ) );
   QCOMPARE( QgsProject::instance()->layerTreeRoot()->findLayers().at( 1 )->name(), QStringLiteral( "NewMemory" ) );
+}
+
+void TestQgsLayerDefinition::testLoadTopOfTree()
+{
+  QgsSettings settings;
+  settings.setEnumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::TopOfTree );
+  QString errorMsg;
+  QgsLayerDefinition::loadLayerDefinition( TEST_DATA_DIR + QStringLiteral( "/vector_and_raster.qlr" ), QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMsg );
+  //todo: test if new layers are on top
+  QList<QgsMapLayer *> orderedLayers = QgsProject::instance()->layerTreeRoot()->layerOrder();
+  QCOMPARE( orderedLayers.length(), 3 );
+  QVERIFY( orderedLayers.at( 1 )->name() == QStringLiteral( "rgb256x256" ) );
+  QVERIFY( orderedLayers.at( 0 )->name() == QStringLiteral( "memoryLayer" ) );
 }
 
 void TestQgsLayerDefinition::testExportDoesNotCrash()


### PR DESCRIPTION
Since some time, there is the option in QGIS where to insert new layers (above the current layer / at the top of the layer tree / optimal placement). This PR adds code to consider the settings 'above the current layer' and 'top of the layer tree' also if qlr files are imported. The third option 'optimal placement' does not make much sense for qlr import, so I kept the current behavior of placing new content at the bottom of the layer tree.