### PR TITLE
[dxf] Make sure selected attribute index is respected when resetting fieldsComboBox index

### DIFF
--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -48,7 +48,9 @@ QgsProcessingDxfLayerDetailsWidget::QgsProcessingDxfLayerDetailsWidget( const QV
     return;
 
   mFieldsComboBox->setLayer( mLayer );
-  mFieldsComboBox->setCurrentIndex( layer.layerOutputAttributeIndex() );
+
+  if ( mLayer->fields().exists( layer.layerOutputAttributeIndex() ) )
+    mFieldsComboBox->setField( mLayer->fields().at( layer.layerOutputAttributeIndex() ).name() );
 
   connect( mFieldsComboBox, &QgsFieldComboBox::fieldChanged, this, &QgsPanelWidget::widgetChanged );
 }


### PR DESCRIPTION
The attribute index does not correspond to a `fieldsComboBox` index because it has a `setAllowEmptyFieldName` set to `true`. 

This PR makes sure that we always select the correct index in the aforementioned widget.

Before

https://github.com/qgis/QGIS/assets/652785/917fe461-48f9-4881-91af-3f09f440c4dd

After

https://github.com/qgis/QGIS/assets/652785/3ce06270-a1d7-42e9-a8c2-171ef9278dc4

-----

cc @alexbruy 