### PR TITLE
Clear welcome page even when a non-spatial layer is added

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1137,7 +1137,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   centralLayout->addWidget( mCentralContainer, 0, 0, 2, 1 );
   mInfoBar->raise();
 
-  connect( mMapCanvas, &QgsMapCanvas::layersChanged, this, &QgisApp::showMapCanvas );
+  connect( QgsProject::instance(), &QgsProject::layersAdded, this, &QgisApp::showMapCanvas );
 
   mCentralContainer->setCurrentIndex( mProjOpen ? 0 : 1 );
 


### PR DESCRIPTION
Previously we only cleared the welcome page when a spatial layer was added, which resulted in a weird UX where eg dragging a csv onto QGIS left the welcome page in place, even though a project is now open!

Instead, clear the welcome page whenever ANY type of layer is added to the project
