### PR TITLE
[dxf] Import/export 'DXF Export' dialog settings from/to XML

### DIFF
--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -819,30 +819,30 @@ void QgsDxfExportDialog::loadSettingsFromFile()
 
   bool resultFlag = false;
 
-  QDomDocument myDocument( QStringLiteral( "qgis" ) );
+  QDomDocument domDocument( QStringLiteral( "qgis" ) );
 
   // location of problem associated with errorMsg
   int line, column;
-  QString myErrorMessage;
+  QString errorMessage;
 
-  QFile myFile( fileName );
-  if ( myFile.open( QFile::ReadOnly ) )
+  QFile file( fileName );
+  if ( file.open( QFile::ReadOnly ) )
   {
     QgsDebugMsgLevel( QStringLiteral( "file found %1" ).arg( fileName ), 2 );
     // read file
-    resultFlag = myDocument.setContent( &myFile, &myErrorMessage, &line, &column );
+    resultFlag = domDocument.setContent( &file, &errorMessage, &line, &column );
     if ( !resultFlag )
-      myErrorMessage = tr( "%1 at line %2 column %3" ).arg( myErrorMessage ).arg( line ).arg( column );
-    myFile.close();
+      errorMessage = tr( "%1 at line %2 column %3" ).arg( errorMessage ).arg( line ).arg( column );
+    file.close();
   }
 
   if ( QMessageBox::question( this,
                               tr( "DXF Export load from XML file" ),
                               tr( "Are you sure you want to load settings from XML? This will change some values in the DXF Export dialog." ) ) == QMessageBox::Yes )
   {
-    resultFlag = loadSettingsFromXML( myDocument, myErrorMessage );
+    resultFlag = loadSettingsFromXML( domDocument, errorMessage );
     if ( !resultFlag )
-      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1. %2" ).arg( fileName, myErrorMessage ) );
+      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1. %2" ).arg( fileName, errorMessage ) );
     else
     {
       settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( fileName ).path() );
@@ -854,8 +854,8 @@ void QgsDxfExportDialog::loadSettingsFromFile()
 
 bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorMessage ) const
 {
-  const QDomElement myRoot = doc.firstChildElement( QStringLiteral( "qgis" ) );
-  if ( myRoot.isNull() )
+  const QDomElement rootElement = doc.firstChildElement( QStringLiteral( "qgis" ) );
+  if ( rootElement.isNull() )
   {
     errorMessage = tr( "Root <qgis> element could not be found" );
     return false;
@@ -864,52 +864,52 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
   QDomElement mne;
   QVariant value;
 
-  mne = myRoot.namedItem( QStringLiteral( "symbology_mode" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "symbology_mode" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mSymbologyModeComboBox->setCurrentIndex( value.toInt() );
 
-  mne = myRoot.namedItem( QStringLiteral( "symbology_scale" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "symbology_scale" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mScaleWidget->setScale( value.toDouble() );
 
-  mne = myRoot.namedItem( QStringLiteral( "encoding" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "encoding" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mEncoding->setCurrentText( value.toString() );
 
-  mne = myRoot.namedItem( QStringLiteral( "crs" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "crs" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mCrsSelector->setCrs( value.value< QgsCoordinateReferenceSystem >() );
 
-  mne = myRoot.namedItem( QStringLiteral( "map_theme" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "map_theme" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mVisibilityPresets->setCurrentText( value.toString() );
 
-  mne = myRoot.namedItem( QStringLiteral( "use_layer_title" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "use_layer_title" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mLayerTitleAsName->setChecked( value == true );
 
-  mne = myRoot.namedItem( QStringLiteral( "use_map_extent" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "use_map_extent" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mMapExtentCheckBox->setChecked( value == true );
 
-  mne = myRoot.namedItem( QStringLiteral( "force_2d" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "force_2d" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mForce2d->setChecked( value == true );
 
-  mne = myRoot.namedItem( QStringLiteral( "mtext" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "mtext" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mMTextCheckBox->setChecked( value == true );
 
-  mne = myRoot.namedItem( QStringLiteral( "selected_features_only" ) ).toElement();
+  mne = rootElement.namedItem( QStringLiteral( "selected_features_only" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mSelectedFeaturesOnly->setChecked( value == true );
@@ -939,26 +939,26 @@ void QgsDxfExportDialog::saveSettingsToFile()
     outputFileName += QStringLiteral( ".xml" );
   }
 
-  QString myErrorMessage;
-  QDomDocument myDocument;
+  QString errorMessage;
+  QDomDocument domDocument;
 
-  saveSettingsToXML( myDocument );
+  saveSettingsToXML( domDocument );
 
-  const QFileInfo myFileInfo( outputFileName );
-  const QFileInfo myDirInfo( myFileInfo.path() );  //excludes file name
-  if ( !myDirInfo.isWritable() )
+  const QFileInfo fileInfo( outputFileName );
+  const QFileInfo dirInfo( fileInfo.path() );  //excludes file name
+  if ( !dirInfo.isWritable() )
   {
     QMessageBox::information( this, tr( "Save DXF settings" ), tr( "The directory containing your dataset needs to be writable!" ) );
     return;
   }
 
-  QFile myFile( outputFileName );
-  if ( myFile.open( QFile::WriteOnly | QFile::Truncate ) )
+  QFile file( outputFileName );
+  if ( file.open( QFile::WriteOnly | QFile::Truncate ) )
   {
-    QTextStream myFileStream( &myFile );
+    QTextStream fileStream( &file );
     // save as utf-8 with 2 spaces for indents
-    myDocument.save( myFileStream, 2 );
-    myFile.close();
+    domDocument.save( fileStream, 2 );
+    file.close();
     QMessageBox::information( this, tr( "Save DXF settings" ), tr( "Created DXF settings file as %1" ).arg( outputFileName ) );
     settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( outputFileName ).absolutePath() );
     return;
@@ -975,66 +975,66 @@ void QgsDxfExportDialog::saveSettingsToXML( QDomDocument &doc ) const
 {
   QDomImplementation DomImplementation;
   const QDomDocumentType documentType = DomImplementation.createDocumentType( QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ), QStringLiteral( "SYSTEM" ) );
-  QDomDocument myDocument( documentType );
+  QDomDocument domDocument( documentType );
 
-  QDomElement myRootNode = myDocument.createElement( QStringLiteral( "qgis" ) );
-  myRootNode.setAttribute( QStringLiteral( "version" ), Qgis::version() );
-  myDocument.appendChild( myRootNode );
+  QDomElement rootElement = domDocument.createElement( QStringLiteral( "qgis" ) );
+  rootElement.setAttribute( QStringLiteral( "version" ), Qgis::version() );
+  domDocument.appendChild( rootElement );
 
-  QDomElement symbologyModeElement = myDocument.createElement( QStringLiteral( "symbology_mode" ) );
+  QDomElement symbologyModeElement = domDocument.createElement( QStringLiteral( "symbology_mode" ) );
   symbologyModeElement.appendChild( QgsXmlUtils::writeVariant( static_cast<int>( symbologyMode() ), doc ) );
-  myRootNode.appendChild( symbologyModeElement );
+  rootElement.appendChild( symbologyModeElement );
 
-  QDomElement symbologyScaleElement = myDocument.createElement( QStringLiteral( "symbology_scale" ) );
+  QDomElement symbologyScaleElement = domDocument.createElement( QStringLiteral( "symbology_scale" ) );
   symbologyScaleElement.appendChild( QgsXmlUtils::writeVariant( symbologyScale(), doc ) );
-  myRootNode.appendChild( symbologyScaleElement );
+  rootElement.appendChild( symbologyScaleElement );
 
-  QDomElement encodingElement = myDocument.createElement( QStringLiteral( "encoding" ) );
+  QDomElement encodingElement = domDocument.createElement( QStringLiteral( "encoding" ) );
   encodingElement.appendChild( QgsXmlUtils::writeVariant( encoding(), doc ) );
-  myRootNode.appendChild( encodingElement );
+  rootElement.appendChild( encodingElement );
 
-  QDomElement crsElement = myDocument.createElement( QStringLiteral( "crs" ) );
+  QDomElement crsElement = domDocument.createElement( QStringLiteral( "crs" ) );
   crsElement.appendChild( QgsXmlUtils::writeVariant( crs(), doc ) );
-  myRootNode.appendChild( crsElement );
+  rootElement.appendChild( crsElement );
 
-  QDomElement mapThemeElement = myDocument.createElement( QStringLiteral( "map_theme" ) );
+  QDomElement mapThemeElement = domDocument.createElement( QStringLiteral( "map_theme" ) );
   mapThemeElement.appendChild( QgsXmlUtils::writeVariant( mapTheme(), doc ) );
-  myRootNode.appendChild( mapThemeElement );
+  rootElement.appendChild( mapThemeElement );
 
-  QDomElement layersElement = myDocument.createElement( QStringLiteral( "layers" ) );
+  QDomElement layersElement = domDocument.createElement( QStringLiteral( "layers" ) );
   for ( const auto dxfLayer : layers() )
   {
     QgsVectorLayer *vl = dxfLayer.layer();
-    QDomElement layerElement = myDocument.createElement( QStringLiteral( "layer" ) );
+    QDomElement layerElement = domDocument.createElement( QStringLiteral( "layer" ) );
     layerElement.setAttribute( QStringLiteral( "source" ), vl->publicSource() );
     layerElement.setAttribute( QStringLiteral( "attribute-index" ), dxfLayer.layerOutputAttributeIndex() ) ;
     layerElement.setAttribute( QStringLiteral( "use_symbol_blocks" ), dxfLayer.buildDataDefinedBlocks() ) ;
     layerElement.setAttribute( QStringLiteral( "max_number_of_classes" ), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() ) ;
     layersElement.appendChild( layerElement );
   }
-  myRootNode.appendChild( layersElement );
+  rootElement.appendChild( layersElement );
 
-  QDomElement titleAsNameElement = myDocument.createElement( QStringLiteral( "use_layer_title" ) );
+  QDomElement titleAsNameElement = domDocument.createElement( QStringLiteral( "use_layer_title" ) );
   titleAsNameElement.appendChild( QgsXmlUtils::writeVariant( layerTitleAsName(), doc ) );
-  myRootNode.appendChild( titleAsNameElement );
+  rootElement.appendChild( titleAsNameElement );
 
-  QDomElement useMapExtentElement = myDocument.createElement( QStringLiteral( "use_map_extent" ) );
+  QDomElement useMapExtentElement = domDocument.createElement( QStringLiteral( "use_map_extent" ) );
   useMapExtentElement.appendChild( QgsXmlUtils::writeVariant( exportMapExtent(), doc ) );
-  myRootNode.appendChild( useMapExtentElement );
+  rootElement.appendChild( useMapExtentElement );
 
-  QDomElement force2dElement = myDocument.createElement( QStringLiteral( "force_2d" ) );
+  QDomElement force2dElement = domDocument.createElement( QStringLiteral( "force_2d" ) );
   force2dElement.appendChild( QgsXmlUtils::writeVariant( force2d(), doc ) );
-  myRootNode.appendChild( force2dElement );
+  rootElement.appendChild( force2dElement );
 
-  QDomElement useMTextElement = myDocument.createElement( QStringLiteral( "mtext" ) );
+  QDomElement useMTextElement = domDocument.createElement( QStringLiteral( "mtext" ) );
   useMTextElement.appendChild( QgsXmlUtils::writeVariant( useMText(), doc ) );
-  myRootNode.appendChild( useMTextElement );
+  rootElement.appendChild( useMTextElement );
 
-  QDomElement selectedFeatures = myDocument.createElement( QStringLiteral( "selected_features_only" ) );
+  QDomElement selectedFeatures = domDocument.createElement( QStringLiteral( "selected_features_only" ) );
   selectedFeatures.appendChild( QgsXmlUtils::writeVariant( selectedFeaturesOnly(), doc ) );
-  myRootNode.appendChild( selectedFeatures );
+  rootElement.appendChild( selectedFeatures );
 
-  doc = myDocument;
+  doc = domDocument;
 }
 
 

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -807,10 +807,8 @@ void QgsDxfExportDialog::deselectDataDefinedBlocks()
 
 void QgsDxfExportDialog::loadSettingsFromFile()
 {
-  QgsSettings settings;
-  const QString lastUsedDir = settings.value( QStringLiteral( "dxf/lastSettingsDir" ), QDir::homePath() ).toString();
-
-  const QString fileName = QFileDialog::getOpenFileName( this, tr( "Load DXF Export settings" ), lastUsedDir,
+  const QString fileName = QFileDialog::getOpenFileName( this, tr( "Load DXF Export settings" ),
+                           QgsDxfExportDialog::settingsDxfLastSettingsDir->value(),
                            tr( "XML file" ) + " (*.xml)" );
   if ( fileName.isNull() )
   {
@@ -845,7 +843,7 @@ void QgsDxfExportDialog::loadSettingsFromFile()
       QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1. %2" ).arg( fileName, errorMessage ) );
     else
     {
-      settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( fileName ).path() );
+      QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( fileName ).path() );
       QMessageBox::information( this, tr( "Load DXF settings" ), tr( "DXF Export settings loaded!" ) );
     }
   }
@@ -920,11 +918,9 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
 
 void QgsDxfExportDialog::saveSettingsToFile()
 {
-  QgsSettings settings;
-  const QString lastUsedDir = settings.value( QStringLiteral( "dxf/lastSettingsDir" ), QDir::homePath() ).toString();
-
   QString outputFileName = QFileDialog::getSaveFileName( this, tr( "Save DXF Export settings as XML" ),
-                           lastUsedDir, tr( "XML file" ) + " (*.xml)" );
+                           QgsDxfExportDialog::settingsDxfLastSettingsDir->value(),
+                           tr( "XML file" ) + " (*.xml)" );
   // return dialog focus on Mac
   activateWindow();
   raise();
@@ -960,7 +956,7 @@ void QgsDxfExportDialog::saveSettingsToFile()
     domDocument.save( fileStream, 2 );
     file.close();
     QMessageBox::information( this, tr( "Save DXF settings" ), tr( "Created DXF settings file as %1" ).arg( outputFileName ) );
-    settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( outputFileName ).absolutePath() );
+    QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( outputFileName ).absolutePath() );
     return;
   }
   else

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -836,13 +836,18 @@ void QgsDxfExportDialog::loadSettingsFromFile()
     myFile.close();
   }
 
-  resultFlag = loadSettingsFromXML( myDocument, myErrorMessage );
-  if ( !resultFlag )
-    QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1. %2" ).arg( fileName, myErrorMessage ) );
-  else
+  if ( QMessageBox::question( this,
+                              tr( "DXF Export load from XML file" ),
+                              tr( "Are you sure you want to load settings from XML? This will change some values in the DXF Export dialog." ) ) == QMessageBox::Yes )
   {
-    settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( fileName ).path() );
-    QMessageBox::information( this, tr( "Load DXF settings" ), tr( "DXF Export settings loaded!" ) );
+    resultFlag = loadSettingsFromXML( myDocument, myErrorMessage );
+    if ( !resultFlag )
+      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1. %2" ).arg( fileName, myErrorMessage ) );
+    else
+    {
+      settings.setValue( QStringLiteral( "dxf/lastSettingsDir" ), QFileInfo( fileName ).path() );
+      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "DXF Export settings loaded!" ) );
+    }
   }
 }
 
@@ -857,36 +862,57 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
   }
 
   QDomElement mne;
+  QVariant value;
+
   mne = myRoot.namedItem( QStringLiteral( "symbology_mode" ) ).toElement();
-  mSymbologyModeComboBox->setCurrentIndex( QgsXmlUtils::readVariant( mne.firstChildElement() ).toInt() );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mSymbologyModeComboBox->setCurrentIndex( value.toInt() );
 
   mne = myRoot.namedItem( QStringLiteral( "symbology_scale" ) ).toElement();
-  mScaleWidget->setScale( QgsXmlUtils::readVariant( mne.firstChildElement() ).toDouble() );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mScaleWidget->setScale( value.toDouble() );
 
   mne = myRoot.namedItem( QStringLiteral( "encoding" ) ).toElement();
-  mEncoding->setCurrentText( QgsXmlUtils::readVariant( mne.firstChildElement() ).toString() );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mEncoding->setCurrentText( value.toString() );
 
   mne = myRoot.namedItem( QStringLiteral( "crs" ) ).toElement();
-  mCrsSelector->setCrs( QgsXmlUtils::readVariant( mne.firstChildElement() ).value< QgsCoordinateReferenceSystem >() );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mCrsSelector->setCrs( value.value< QgsCoordinateReferenceSystem >() );
 
   mne = myRoot.namedItem( QStringLiteral( "map_theme" ) ).toElement();
-  mVisibilityPresets->setCurrentText( QgsXmlUtils::readVariant( mne.firstChildElement() ).toString() );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mVisibilityPresets->setCurrentText( value.toString() );
 
-  // layers
   mne = myRoot.namedItem( QStringLiteral( "use_layer_title" ) ).toElement();
-  mLayerTitleAsName->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mLayerTitleAsName->setChecked( value == true );
 
   mne = myRoot.namedItem( QStringLiteral( "use_map_extent" ) ).toElement();
-  mMapExtentCheckBox->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mMapExtentCheckBox->setChecked( value == true );
 
   mne = myRoot.namedItem( QStringLiteral( "force_2d" ) ).toElement();
-  mForce2d->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mForce2d->setChecked( value == true );
 
   mne = myRoot.namedItem( QStringLiteral( "mtext" ) ).toElement();
-  mMTextCheckBox->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mMTextCheckBox->setChecked( value == true );
 
   mne = myRoot.namedItem( QStringLiteral( "selected_features_only" ) ).toElement();
-  mSelectedFeaturesOnly->setChecked( QgsXmlUtils::readVariant( mne.firstChildElement() ) == true );
+  value = QgsXmlUtils::readVariant( mne.firstChildElement() );
+  if ( !value.isNull() )
+    mSelectedFeaturesOnly->setChecked( value == true );
 
   return true;
 }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -732,12 +732,12 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mEncoding->addItems( QgsDxfExport::encodings() );
   mEncoding->setCurrentIndex( mEncoding->findText( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), settings.value( QStringLiteral( "qgis/lastDxfEncoding" ), "CP1252" ).toString() ) ) );
 
-  mBtnLoadSaveSettings = new QPushButton( tr( "Settings" ), this );
+  QPushButton *btnLoadSaveSettings = new QPushButton( tr( "Settings" ), this );
   QMenu *menuSettings = new QMenu( this );
   menuSettings->addAction( tr( "Load Settings from File…" ), this, &QgsDxfExportDialog::loadSettingsFromFile );
   menuSettings->addAction( tr( "Save Settings to File…" ), this, &QgsDxfExportDialog::saveSettingsToFile );
-  mBtnLoadSaveSettings->setMenu( menuSettings );
-  buttonBox->addButton( mBtnLoadSaveSettings, QDialogButtonBox::ResetRole );
+  btnLoadSaveSettings->setMenu( menuSettings );
+  buttonBox->addButton( btnLoadSaveSettings, QDialogButtonBox::ResetRole );
 
   mMessageBar = new QgsMessageBar();
   mMessageBar->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Fixed );
@@ -844,7 +844,9 @@ void QgsDxfExportDialog::loadSettingsFromFile()
   {
     resultFlag = loadSettingsFromXML( domDocument, errorMessage );
     if ( !resultFlag )
-      QMessageBox::information( this, tr( "Load DXF Export Settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1.\n\n%2" ).arg( fileName, errorMessage ) );
+    {
+      mMessageBar->pushWarning( tr( "Load DXF Export Settings" ), tr( "Failed to load DXF Export settings file as %1. Details: %2" ).arg( fileName, errorMessage ) );
+    }
     else
     {
       QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( fileName ).path() );
@@ -859,14 +861,14 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
   const QDomElement rootElement = doc.firstChildElement( QStringLiteral( "qgis" ) );
   if ( rootElement.isNull() )
   {
-    errorMessage = tr( "Root <qgis> element could not be found" );
+    errorMessage = tr( "Root &lt;qgis&gt; element could not be found." );
     return false;
   }
 
   const QDomElement dxfElement = rootElement.firstChildElement( QStringLiteral( "dxf_settings" ) );
   if ( dxfElement.isNull() )
   {
-    errorMessage = tr( "The XML file does not correspond to DXF Export settings. It must have a <dxf-settings> element." );
+    errorMessage = tr( "The XML file does not correspond to DXF Export settings. It must have a &lt;dxf-settings&gt; element." );
     return false;
   }
 
@@ -989,7 +991,7 @@ void QgsDxfExportDialog::saveSettingsToFile()
   const QFileInfo dirInfo( fileInfo.path() );  //excludes file name
   if ( !dirInfo.isWritable() )
   {
-    QMessageBox::information( this, tr( "Save DXF Export Settings" ), tr( "The directory containing your dataset needs to be writable!" ) );
+    mMessageBar->pushInfo( tr( "Save DXF Export Settings" ), tr( "The directory containing your dataset needs to be writable!" ) );
     return;
   }
 
@@ -1000,13 +1002,13 @@ void QgsDxfExportDialog::saveSettingsToFile()
     // save as utf-8 with 2 spaces for indents
     domDocument.save( fileStream, 2 );
     file.close();
-    QMessageBox::information( this, tr( "Save DXF Export Settings" ), tr( "Created DXF Export settings file as %1" ).arg( outputFileName ) );
+    mMessageBar->pushSuccess( tr( "Save DXF Export Settings" ), tr( "Created DXF Export settings file as %1" ).arg( outputFileName ) );
     QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( outputFileName ).absolutePath() );
     return;
   }
   else
   {
-    QMessageBox::information( this, tr( "Save DXF Export Settings" ), tr( "ERROR: Failed to created DXF Export settings file as %1. Check file permissions and retry." ).arg( outputFileName ) );
+    mMessageBar->pushWarning( tr( "Save DXF Export Settings" ), tr( "Failed to created DXF Export settings file as %1. Check file permissions and retry." ).arg( outputFileName ) );
     return;
   }
 }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -811,7 +811,7 @@ void QgsDxfExportDialog::deselectDataDefinedBlocks()
 
 void QgsDxfExportDialog::loadSettingsFromFile()
 {
-  const QString fileName = QFileDialog::getOpenFileName( this, tr( "Load DXF Export settings" ),
+  const QString fileName = QFileDialog::getOpenFileName( this, tr( "Load DXF Export Settings" ),
                            QgsDxfExportDialog::settingsDxfLastSettingsDir->value(),
                            tr( "XML file" ) + " (*.xml)" );
   if ( fileName.isNull() )
@@ -839,12 +839,12 @@ void QgsDxfExportDialog::loadSettingsFromFile()
   }
 
   if ( QMessageBox::question( this,
-                              tr( "DXF Export load from XML file" ),
+                              tr( "DXF Export - Load from XML File" ),
                               tr( "Are you sure you want to load settings from XML? This will change some values in the DXF Export dialog." ) ) == QMessageBox::Yes )
   {
     resultFlag = loadSettingsFromXML( domDocument, errorMessage );
     if ( !resultFlag )
-      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1.\n\n%2" ).arg( fileName, errorMessage ) );
+      QMessageBox::information( this, tr( "Load DXF Export Settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1.\n\n%2" ).arg( fileName, errorMessage ) );
     else
     {
       QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( fileName ).path() );
@@ -866,7 +866,7 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
   const QDomElement dxfElement = rootElement.firstChildElement( QStringLiteral( "dxf_settings" ) );
   if ( dxfElement.isNull() )
   {
-    errorMessage = tr( "The XML file does not correspond to DXF settings. It must have a <dxf-settings> element." );
+    errorMessage = tr( "The XML file does not correspond to DXF Export settings. It must have a <dxf-settings> element." );
     return false;
   }
 
@@ -928,7 +928,7 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
       }
       else
       {
-        QgsDebugMsgLevel( QStringLiteral( " Layer '%1' found in the DXF settings XML file, but not present in the project." ).arg( element.attribute( QStringLiteral( "name" ) ) ), 1 );
+        QgsDebugMsgLevel( QStringLiteral( " Layer '%1' found in the DXF Export settings XML file, but not present in the project." ).arg( element.attribute( QStringLiteral( "name" ) ) ), 1 );
       }
     }
   }
@@ -964,7 +964,7 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
 
 void QgsDxfExportDialog::saveSettingsToFile()
 {
-  QString outputFileName = QFileDialog::getSaveFileName( this, tr( "Save DXF Export settings as XML" ),
+  QString outputFileName = QFileDialog::getSaveFileName( this, tr( "Save DXF Export Settings as XML" ),
                            QgsDxfExportDialog::settingsDxfLastSettingsDir->value(),
                            tr( "XML file" ) + " (*.xml)" );
   // return dialog focus on Mac
@@ -981,7 +981,6 @@ void QgsDxfExportDialog::saveSettingsToFile()
     outputFileName += QStringLiteral( ".xml" );
   }
 
-  QString errorMessage;
   QDomDocument domDocument;
 
   saveSettingsToXML( domDocument );
@@ -990,7 +989,7 @@ void QgsDxfExportDialog::saveSettingsToFile()
   const QFileInfo dirInfo( fileInfo.path() );  //excludes file name
   if ( !dirInfo.isWritable() )
   {
-    QMessageBox::information( this, tr( "Save DXF settings" ), tr( "The directory containing your dataset needs to be writable!" ) );
+    QMessageBox::information( this, tr( "Save DXF Export Settings" ), tr( "The directory containing your dataset needs to be writable!" ) );
     return;
   }
 
@@ -1001,13 +1000,13 @@ void QgsDxfExportDialog::saveSettingsToFile()
     // save as utf-8 with 2 spaces for indents
     domDocument.save( fileStream, 2 );
     file.close();
-    QMessageBox::information( this, tr( "Save DXF settings" ), tr( "Created DXF settings file as %1" ).arg( outputFileName ) );
+    QMessageBox::information( this, tr( "Save DXF Export Settings" ), tr( "Created DXF Export settings file as %1" ).arg( outputFileName ) );
     QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( outputFileName ).absolutePath() );
     return;
   }
   else
   {
-    QMessageBox::information( this, tr( "Save DXF settings" ), tr( "ERROR: Failed to created DXF Export settings file as %1. Check file permissions and retry." ).arg( outputFileName ) );
+    QMessageBox::information( this, tr( "Save DXF Export Settings" ), tr( "ERROR: Failed to created DXF Export settings file as %1. Check file permissions and retry." ).arg( outputFileName ) );
     return;
   }
 }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -739,6 +739,10 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mBtnLoadSaveSettings->setMenu( menuSettings );
   buttonBox->addButton( mBtnLoadSaveSettings, QDialogButtonBox::ResetRole );
 
+  mMessageBar = new QgsMessageBar();
+  mMessageBar->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Fixed );
+  mainLayout->insertWidget( 0, mMessageBar );
+
   mModel->loadLayersOutputAttribute( mModel->rootGroup() );
 }
 
@@ -844,7 +848,7 @@ void QgsDxfExportDialog::loadSettingsFromFile()
     else
     {
       QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( fileName ).path() );
-      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "DXF Export settings loaded!" ) );
+      mMessageBar->pushMessage( QString(), tr( "DXF Export settings loaded!" ), Qgis::MessageLevel::Success, 0 );
     }
   }
 }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -840,7 +840,7 @@ void QgsDxfExportDialog::loadSettingsFromFile()
   {
     resultFlag = loadSettingsFromXML( domDocument, errorMessage );
     if ( !resultFlag )
-      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1. %2" ).arg( fileName, errorMessage ) );
+      QMessageBox::information( this, tr( "Load DXF settings" ), tr( "ERROR: Failed to load DXF Export settings file as %1.\n\n%2" ).arg( fileName, errorMessage ) );
     else
     {
       QgsDxfExportDialog::settingsDxfLastSettingsDir->setValue( QFileInfo( fileName ).path() );
@@ -859,55 +859,62 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
     return false;
   }
 
+  const QDomElement dxfElement = rootElement.firstChildElement( QStringLiteral( "dxf_settings" ) );
+  if ( dxfElement.isNull() )
+  {
+    errorMessage = tr( "The XML file does not correspond to DXF settings. It must have a <dxf-settings> element." );
+    return false;
+  }
+
   QDomElement mne;
   QVariant value;
 
-  mne = rootElement.namedItem( QStringLiteral( "symbology_mode" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "symbology_mode" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mSymbologyModeComboBox->setCurrentIndex( value.toInt() );
 
-  mne = rootElement.namedItem( QStringLiteral( "symbology_scale" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "symbology_scale" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mScaleWidget->setScale( value.toDouble() );
 
-  mne = rootElement.namedItem( QStringLiteral( "encoding" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "encoding" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mEncoding->setCurrentText( value.toString() );
 
-  mne = rootElement.namedItem( QStringLiteral( "crs" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "crs" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mCrsSelector->setCrs( value.value< QgsCoordinateReferenceSystem >() );
 
-  mne = rootElement.namedItem( QStringLiteral( "map_theme" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "map_theme" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mVisibilityPresets->setCurrentText( value.toString() );
 
-  mne = rootElement.namedItem( QStringLiteral( "use_layer_title" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "use_layer_title" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mLayerTitleAsName->setChecked( value == true );
 
-  mne = rootElement.namedItem( QStringLiteral( "use_map_extent" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "use_map_extent" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mMapExtentCheckBox->setChecked( value == true );
 
-  mne = rootElement.namedItem( QStringLiteral( "force_2d" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "force_2d" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mForce2d->setChecked( value == true );
 
-  mne = rootElement.namedItem( QStringLiteral( "mtext" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "mtext" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mMTextCheckBox->setChecked( value == true );
 
-  mne = rootElement.namedItem( QStringLiteral( "selected_features_only" ) ).toElement();
+  mne = dxfElement.namedItem( QStringLiteral( "selected_features_only" ) ).toElement();
   value = QgsXmlUtils::readVariant( mne.firstChildElement() );
   if ( !value.isNull() )
     mSelectedFeaturesOnly->setChecked( value == true );
@@ -977,25 +984,28 @@ void QgsDxfExportDialog::saveSettingsToXML( QDomDocument &doc ) const
   rootElement.setAttribute( QStringLiteral( "version" ), Qgis::version() );
   domDocument.appendChild( rootElement );
 
+  QDomElement dxfElement = domDocument.createElement( QStringLiteral( "dxf_settings" ) );
+  rootElement.appendChild( dxfElement );
+
   QDomElement symbologyModeElement = domDocument.createElement( QStringLiteral( "symbology_mode" ) );
   symbologyModeElement.appendChild( QgsXmlUtils::writeVariant( static_cast<int>( symbologyMode() ), doc ) );
-  rootElement.appendChild( symbologyModeElement );
+  dxfElement.appendChild( symbologyModeElement );
 
   QDomElement symbologyScaleElement = domDocument.createElement( QStringLiteral( "symbology_scale" ) );
   symbologyScaleElement.appendChild( QgsXmlUtils::writeVariant( symbologyScale(), doc ) );
-  rootElement.appendChild( symbologyScaleElement );
+  dxfElement.appendChild( symbologyScaleElement );
 
   QDomElement encodingElement = domDocument.createElement( QStringLiteral( "encoding" ) );
   encodingElement.appendChild( QgsXmlUtils::writeVariant( encoding(), doc ) );
-  rootElement.appendChild( encodingElement );
+  dxfElement.appendChild( encodingElement );
 
   QDomElement crsElement = domDocument.createElement( QStringLiteral( "crs" ) );
   crsElement.appendChild( QgsXmlUtils::writeVariant( crs(), doc ) );
-  rootElement.appendChild( crsElement );
+  dxfElement.appendChild( crsElement );
 
   QDomElement mapThemeElement = domDocument.createElement( QStringLiteral( "map_theme" ) );
   mapThemeElement.appendChild( QgsXmlUtils::writeVariant( mapTheme(), doc ) );
-  rootElement.appendChild( mapThemeElement );
+  dxfElement.appendChild( mapThemeElement );
 
   QDomElement layersElement = domDocument.createElement( QStringLiteral( "layers" ) );
   for ( const auto dxfLayer : layers() )
@@ -1008,27 +1018,27 @@ void QgsDxfExportDialog::saveSettingsToXML( QDomDocument &doc ) const
     layerElement.setAttribute( QStringLiteral( "max_number_of_classes" ), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() ) ;
     layersElement.appendChild( layerElement );
   }
-  rootElement.appendChild( layersElement );
+  dxfElement.appendChild( layersElement );
 
   QDomElement titleAsNameElement = domDocument.createElement( QStringLiteral( "use_layer_title" ) );
   titleAsNameElement.appendChild( QgsXmlUtils::writeVariant( layerTitleAsName(), doc ) );
-  rootElement.appendChild( titleAsNameElement );
+  dxfElement.appendChild( titleAsNameElement );
 
   QDomElement useMapExtentElement = domDocument.createElement( QStringLiteral( "use_map_extent" ) );
   useMapExtentElement.appendChild( QgsXmlUtils::writeVariant( exportMapExtent(), doc ) );
-  rootElement.appendChild( useMapExtentElement );
+  dxfElement.appendChild( useMapExtentElement );
 
   QDomElement force2dElement = domDocument.createElement( QStringLiteral( "force_2d" ) );
   force2dElement.appendChild( QgsXmlUtils::writeVariant( force2d(), doc ) );
-  rootElement.appendChild( force2dElement );
+  dxfElement.appendChild( force2dElement );
 
   QDomElement useMTextElement = domDocument.createElement( QStringLiteral( "mtext" ) );
   useMTextElement.appendChild( QgsXmlUtils::writeVariant( useMText(), doc ) );
-  rootElement.appendChild( useMTextElement );
+  dxfElement.appendChild( useMTextElement );
 
   QDomElement selectedFeatures = domDocument.createElement( QStringLiteral( "selected_features_only" ) );
   selectedFeatures.appendChild( QgsXmlUtils::writeVariant( selectedFeaturesOnly(), doc ) );
-  rootElement.appendChild( selectedFeatures );
+  dxfElement.appendChild( selectedFeatures );
 
   doc = domDocument;
 }

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -119,7 +119,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QString mapTheme() const;
     QString encoding() const;
     QgsCoordinateReferenceSystem crs() const;
-    bool loadSettingsFromXML( QDomDocument &document ) const;
+    bool loadSettingsFromXML( QDomDocument &document, QString &errorMessage ) const;
     void saveSettingsToXML( QDomDocument &document ) const;
 
   public slots:

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -102,6 +102,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
   public:
     static inline QgsSettingsTreeNode *sTreeAppDdxf = QgsSettingsTree::sTreeApp->createChildNode( QStringLiteral( "dxf" ) );
     static const inline QgsSettingsEntryBool *settingsDxfEnableDDBlocks = new QgsSettingsEntryBool( QStringLiteral( "enable-datadefined-blocks" ), sTreeAppDdxf,  false );
+    static const inline QgsSettingsEntryString *settingsDxfLastSettingsDir = new QgsSettingsEntryString( QStringLiteral( "last-settings-dir" ), sTreeAppDdxf,  QDir::homePath() );
 
     QgsDxfExportDialog( QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
     ~QgsDxfExportDialog() override;

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -24,6 +24,7 @@
 #include "qgsdxfexport.h"
 #include "qgssettingstree.h"
 #include "qgssettingsentryimpl.h"
+#include "qgsxmlutils.h"
 
 #include <QList>
 #include <QPair>
@@ -118,6 +119,8 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QString mapTheme() const;
     QString encoding() const;
     QgsCoordinateReferenceSystem crs() const;
+    bool loadSettingsFromXML( QDomDocument &document ) const;
+    void saveSettingsToXML( QDomDocument &document ) const;
 
   public slots:
     //! Change the selection of layers in the list
@@ -125,6 +128,8 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     void deSelectAll();
     void selectDataDefinedBlocks();
     void deselectDataDefinedBlocks();
+    void loadSettingsFromFile();
+    void saveSettingsToFile();
 
   private slots:
     void setOkEnabled();
@@ -139,6 +144,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     FieldSelectorDelegate *mFieldSelectorDelegate = nullptr;
     QgsVectorLayerAndAttributeModel *mModel = nullptr;
     QgsDxfExportLayerTreeView *mTreeView = nullptr;
+    QPushButton *mBtnLoadSaveSettings = nullptr;
 
     QgsCoordinateReferenceSystem mCRS;
 };

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -147,7 +147,6 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     FieldSelectorDelegate *mFieldSelectorDelegate = nullptr;
     QgsVectorLayerAndAttributeModel *mModel = nullptr;
     QgsDxfExportLayerTreeView *mTreeView = nullptr;
-    QPushButton *mBtnLoadSaveSettings = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 
     QgsCoordinateReferenceSystem mCRS;

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -26,6 +26,7 @@
 #include "qgssettingsentryimpl.h"
 #include "qgsxmlutils.h"
 #include "qgsvectorlayerref.h"
+#include "qgsmessagebar.h"
 
 #include <QList>
 #include <QPair>
@@ -147,6 +148,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QgsVectorLayerAndAttributeModel *mModel = nullptr;
     QgsDxfExportLayerTreeView *mTreeView = nullptr;
     QPushButton *mBtnLoadSaveSettings = nullptr;
+    QgsMessageBar *mMessageBar = nullptr;
 
     QgsCoordinateReferenceSystem mCRS;
 };

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -25,6 +25,7 @@
 #include "qgssettingstree.h"
 #include "qgssettingsentryimpl.h"
 #include "qgsxmlutils.h"
+#include "qgsvectorlayerref.h"
 
 #include <QList>
 #include <QPair>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -147,14 +147,14 @@
      <item row="0" column="2">
       <widget class="QPushButton" name="mSelectDataDefinedBlocks">
        <property name="text">
-        <string>Select Data DefinedBlocks</string>
+        <string>Select Data Defined Blocks</string>
        </property>
       </widget>
      </item>
      <item row="0" column="3">
       <widget class="QPushButton" name="mDeselectDataDefinedBlocks">
        <property name="text">
-        <string>Deselect Data DefinedBlocks</string>
+        <string>Deselect Data Defined Blocks</string>
        </property>
       </widget>
      </item>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -13,91 +13,119 @@
   <property name="windowTitle">
    <string>DXF Export</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="1" column="0">
-    <widget class="QLabel" name="mSymbologyModeLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Symbology mode</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mSaveAsLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Save as</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="mSymbologyModeComboBox"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="mSymbologyScaleLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Symbology scale</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="mEncoding"/>
-   </item>
+  <layout class="QVBoxLayout" name="mainLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QLabel" name="mSaveAsLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Save as</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QgsFileWidget" name="mFileName"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="mSymbologyModeLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Symbology mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="mSymbologyModeComboBox"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="mSymbologyScaleLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Symbology scale</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsScaleWidget" name="mScaleWidget">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="showCurrentScaleButton">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Encoding</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="mEncoding"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>CRS</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="mSymbologyScaleLabel_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Map themes</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="mVisibilityPresets"/>
+     </item>
    <item row="7" column="0" colspan="2">
      <widget class="QWidget" name="mTreeViewContainer">
     <layout class="QHBoxLayout" name="mTreeViewLayout"/>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QgsScaleWidget" name="mScaleWidget">
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-     <property name="showCurrentScaleButton">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="mVisibilityPresets"/>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsFileWidget" name="mFileName"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>CRS</string>
-     </property>
     </widget>
    </item>
    <item row="9" column="0" colspan="2">
@@ -131,32 +159,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Encoding</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="mSymbologyScaleLabel_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Map themes</string>
-     </property>
-    </widget>
    </item>
    <item row="11" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout">
@@ -224,6 +226,8 @@
     </widget>
    </item>
   </layout>
+  </item>
+ </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -257,9 +257,12 @@
   <tabstop>mVisibilityPresets</tabstop>
   <tabstop>mSelectAllButton</tabstop>
   <tabstop>mDeselectAllButton</tabstop>
+  <tabstop>mSelectDataDefinedBlocks</tabstop>
+  <tabstop>mDeselectDataDefinedBlocks</tabstop>
   <tabstop>mLayerTitleAsName</tabstop>
   <tabstop>mMTextCheckBox</tabstop>
   <tabstop>mMapExtentCheckBox</tabstop>
+  <tabstop>mSelectedFeaturesOnly</tabstop>
   <tabstop>mForce2d</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>


### PR DESCRIPTION
This PR enables users to save and restore GUI settings for the DXF Export dialog, making it possible to export a number of configurations and reuse them or share them with colleagues.

Settings are exported to an XML file (see [sample file content](https://github.com/qgis/QGIS/files/14771343/dxf_settings.xml.txt)).

https://github.com/gacarrillor/QGIS/assets/652785/0ea63c1b-47cf-4c64-a475-c6b3c549d8b8

Buttons to save/load to/from DXF Export settings file:

![image](https://github.com/qgis/QGIS/assets/652785/0b0c5bb7-7662-49bf-8007-35e7f9c8a892)

Confirmation message before overriding dialog settings with those present in the XML file:

![image](https://github.com/qgis/QGIS/assets/652785/4ce49bc2-53c2-46d9-839d-e2d6de84d692)

Non-blocking confirmation of settings applied:

![image](https://github.com/qgis/QGIS/assets/652785/c217d1a3-3e71-4467-aeea-f22f04c07d42)



-----
Funded by the [QGIS user group Switzerland](https://qgis.ch/).