### PR TITLE
[elevation profile] update the plot if the project elevation properties have changed

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -890,7 +890,7 @@ void QgsElevationProfileWidget::exportResults( Qgis::ProfileExportType type )
 
   const QList< QgsMapLayer * > layersToGenerate = mCanvas->layers();
   QList< QgsAbstractProfileSource * > sources;
-  sources.reserve( layersToGenerate .size() );
+  sources.reserve( layersToGenerate.size() );
   for ( QgsMapLayer *layer : layersToGenerate )
   {
     if ( QgsAbstractProfileSource *source = dynamic_cast< QgsAbstractProfileSource * >( layer ) )

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -25,6 +25,7 @@
 #include "qgsmaptoolprofilecurve.h"
 #include "qgsmaptoolprofilecurvefromfeature.h"
 #include "qgsprojectelevationproperties.h"
+#include "qgsvectorlayerelevationproperties.h"
 #include "qgsrubberband.h"
 #include "qgsplottoolpan.h"
 #include "qgsplottoolxaxiszoom.h"
@@ -475,6 +476,8 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
 
   // initially populate layer tree with project layers
   mLayerTreeView->populateInitialLayers( QgsProject::instance() );
+
+  connect( QgsProject::instance()->elevationProperties(), &QgsProjectElevationProperties::changed, this, &QgsElevationProfileWidget::onProjectElevationPropertiesChanged );
 
   updateCanvasLayers();
 }
@@ -1033,6 +1036,32 @@ void QgsElevationProfileWidget::createOrUpdateRubberBands( )
   {
     if ( mToleranceRubberBand )
       mToleranceRubberBand->hide();
+  }
+}
+
+void QgsElevationProfileWidget::onProjectElevationPropertiesChanged()
+{
+  // Only the vector layers whose clamping depend on the terrain need to be updated
+  // if the project elevation properties have changed.
+  // Therefore, update the plot if this criteria is met.
+  for ( QgsMapLayer *layer : mCanvas->layers() )
+  {
+    if ( layer->type() == Qgis::LayerType::Vector )
+    {
+      QgsVectorLayerElevationProperties *elevationProperties = qgis::down_cast< QgsVectorLayerElevationProperties * >( layer->elevationProperties() );
+      switch ( elevationProperties->clamping() )
+      {
+        case Qgis::AltitudeClamping::Relative:
+        case Qgis::AltitudeClamping::Terrain:
+        {
+          scheduleUpdate();
+          break;
+        }
+
+        case Qgis::AltitudeClamping::Absolute:
+          break;
+      }
+    }
   }
 }
 

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -135,6 +135,7 @@ class QgsElevationProfileWidget : public QWidget
     void nudgeRight();
     void nudgeCurve( Qgis::BufferSide side );
     void axisScaleLockToggled( bool active );
+    void onProjectElevationPropertiesChanged();
 
   private:
     QgsElevationProfileCanvas *mCanvas = nullptr;

--- a/src/core/project/qgsprojectelevationproperties.cpp
+++ b/src/core/project/qgsprojectelevationproperties.cpp
@@ -111,8 +111,11 @@ void QgsProjectElevationProperties::setTerrainProvider( QgsAbstractTerrainProvid
   if ( mTerrainProvider.get() == provider )
     return;
 
+  const bool hasChanged = ( provider && mTerrainProvider ) ? !mTerrainProvider->equals( provider ) : ( static_cast< bool >( provider ) != static_cast< bool >( mTerrainProvider.get() ) );
+
   mTerrainProvider.reset( provider );
-  emit changed();
+  if ( hasChanged )
+    emit changed();
 }
 
 void QgsProjectElevationProperties::setElevationRange( const QgsDoubleRange &range )


### PR DESCRIPTION
## Description

From the main commit: 

```
The vector layer elevation rendering depends on the elevation
properties of the project because its clamping may depend of the
terrain. However, the plot is never updated when the elevation
properties change.

This issue is fixed by listening to the
`QgsProjectElevationProperties::changed` signal of the
`QgsProject`. When this signal is triggered, the plot is updated if it
contains at least one vector layer whose elevation binding is set to
'Terrain' or 'Relative'.
```