### PR TITLE
[tiledscenesource, sensorthingssource, vectortilesource] select a new connection by default

### DIFF
--- a/src/gui/providers/sensorthings/qgssensorthingssourceselect.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssourceselect.cpp
@@ -100,6 +100,8 @@ void QgsSensorThingsSourceSelect::btnNew_clicked()
 
     QgsSensorThingsProviderConnection::addConnection( nc.connectionName(), connectionData );
     populateConnectionList();
+    QgsSensorThingsProviderConnection::setSelectedConnection( nc.connectionName() );
+    setConnectionListPosition();
     emit connectionsChanged();
   }
 }

--- a/src/gui/tiledscene/qgstiledscenesourceselect.cpp
+++ b/src/gui/tiledscene/qgstiledscenesourceselect.cpp
@@ -93,6 +93,8 @@ void QgsTiledSceneSourceSelect::btnNewCesium3DTiles_clicked()
 
     QgsTiledSceneProviderConnection::addConnection( nc.connectionName(), connectionData );
     populateConnectionList();
+    QgsTiledSceneProviderConnection::setSelectedConnection( nc.connectionName() );
+    setConnectionListPosition();
     emit connectionsChanged();
   }
 }

--- a/src/gui/vectortile/qgsvectortilesourceselect.cpp
+++ b/src/gui/vectortile/qgsvectortilesourceselect.cpp
@@ -98,6 +98,8 @@ void QgsVectorTileSourceSelect::btnNew_clicked()
   {
     QgsVectorTileProviderConnection::addConnection( nc.connectionName(), QgsVectorTileProviderConnection::decodedUri( nc.connectionUri() ) );
     populateConnectionList();
+    QgsVectorTileProviderConnection::setSelectedConnection( nc.connectionName() );
+    setConnectionListPosition();
     emit connectionsChanged();
   }
 }


### PR DESCRIPTION
## Description

When a new connection is created, in most cases, this connection is gonna be loaded by the user. Therefore, it seems logic to select a new connection once it is created.
