### PR TITLE
[temporal] Fix first canvas rendering on project not respecting cumulative state

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -270,7 +270,15 @@ double QgsTemporalNavigationObject::framesPerSecond() const
 
 void QgsTemporalNavigationObject::setTemporalRangeCumulative( bool state )
 {
+  if ( mCumulativeTemporalRange == state )
+    return;
+
   mCumulativeTemporalRange = state;
+
+  if ( !mBlockUpdateTemporalRangeSignal && mNavigationMode == Qgis::TemporalNavigationMode::Animated )
+  {
+    emit updateTemporalRange( dateTimeRangeForFrameNumber( mCurrentFrameNumber ) );
+  }
 }
 
 bool QgsTemporalNavigationObject::temporalRangeCumulative() const

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -272,13 +272,14 @@ void TestQgsTemporalNavigationObject::frameSettings()
 
   // Test if, when changing to Cumulative mode, the dateTimeRange for frame 2 (with 2 hours frames) is indeed the full range
   navigationObject->setTemporalRangeCumulative( true );
+  QCOMPARE( temporalRangeSignal.count(), 8 );
   QCOMPARE( navigationObject->dateTimeRangeForFrameNumber( 1 ), QgsDateTimeRange(
               QDateTime( QDate( 2020, 1, 1 ), QTime( 8, 0, 0 ) ),
               QDateTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) ),
               true,
               false
             ) );
-  QCOMPARE( temporalRangeSignal.count(), 7 );
+  QCOMPARE( temporalRangeSignal.count(), 8 );
 
   navigationObject->setTemporalRangeCumulative( false );
   // interval which doesn't fit exactly into overall range


### PR DESCRIPTION
## Description

Without this fix, project loading that restores an temporal navigation set to animated will ignore the cumulative state, leaving users with missing features during the first rendering of the map canvas.