### PR TITLE
DXF: fix bug with some rotated symbols in data defined blocks

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -2644,6 +2644,7 @@ void QgsDxfExport::createDDBlockInfo()
           }
 
           sctx.setFeature( &fet );
+          sctx.renderContext().expressionContext().setFeature( fet );
 
           DataDefinedBlockInfo blockInfo;
           blockInfo.blockName = QStringLiteral( "symbolLayer%1class%2" ).arg( symbolLayerNr ).arg( symbolHash );

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -169,6 +169,7 @@ void TestQgsDxfExport::init()
   const QString blueMarkerSvgPath = QgsSymbolLayerUtils::svgSymbolNameToPath( QStringLiteral( "/symbol/blue-marker.svg" ), QgsPathResolver() );
   QString expressionString = QString( "CASE WHEN \"CLASS\" = 'B52' THEN '%1' WHEN \"CLASS\" = 'Biplane' THEN '%2' WHEN \"CLASS\" = 'Jet' THEN '%3' END" ).arg( planeSvgPath ).arg( planeOrangeSvgPath ).arg( blueMarkerSvgPath );
   ddProperties.setProperty( QgsSymbolLayer::Property::Name, QgsProperty::fromExpression( expressionString ) );
+  ddProperties.setProperty( QgsSymbolLayer::Property::Angle, QgsProperty::fromExpression( "Heading" ) );
   svgSymbolLayer->setDataDefinedProperties( ddProperties );
   QgsSymbolLayerList ddSymbolLayerList;
   ddSymbolLayerList << svgSymbolLayer;
@@ -276,7 +277,10 @@ void TestQgsDxfExport::testPointsDataDefinedSizeSymbol()
   dxfBuffer.close();
 
   QString dxfString = QString::fromLatin1( dxfByteArray );
+  //test if data defined blocks have been created
   QVERIFY( dxfString.contains( QStringLiteral( "symbolLayer0class" ) ) );
+  //test a rotation for a referenced block
+  QVERIFY( dxfString.contains( QStringLiteral( "50\n5.0" ) ) );
 }
 
 void TestQgsDxfExport::testLines()


### PR DESCRIPTION
Fixes a bug with referencing data defined blocks. I'm going to add a unit test to this PR in the afternoon.
