### PR TITLE
SERVER: fix legend of cascaded WMS layers #42063

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1336,6 +1336,15 @@ namespace QgsWms
     settings.rstyle( QgsLegendStyle::Style::Symbol ).setMargin( QgsLegendStyle::Side::Top, symbolSpaceAsDouble() );
     settings.rstyle( QgsLegendStyle::Style::SymbolLabel ).setMargin( QgsLegendStyle::Side::Left, iconLabelSpaceAsDouble() );
 
+    // When processing a request involving an upstream WMS server, any responses from such a remote
+    // server must be awaited. This was not the case for GetLegendGraphic requests (#42063). If not,
+    // the response to the current request will never contain any data from upstream.
+    // A quick way to fix this is to force upstream `GetLegendRequest' requests to be synchronous.
+    // The problem with this approach is that if the GetLegendGraphic contains multiple layers, the
+    // remote calls are made one at a time. This increases the response time. Making concurrent
+    // asynchronous requests and waiting for them all would be a better approach.
+    settings.setSynchronousLegendRequests( true );
+
     return settings;
   }
 


### PR DESCRIPTION
## Description
When processing GetLegendGraphic, legend was fetched asynchronously from upstream WMS server and was not awaited. Thus response sent to the client could never contain any data from upstream.

Setting  the `synchronous` `QgsWmsLegendNode::getLegendGraphic` parameter to `true` fixed this.
This pull request set it in the `QgsWmsParameters` constructor using the `QgsLegendSettings::setSynchronousLegendRequests` method.

Fixes QGIS/qgis#42063

The  `QgsLegendSettings::setSynchronousLegendRequests` has been introduced  in 3.34, hence, this PR could be backported to 3.36 and 3.34.

As mentioned in the committed file, this is a quick fix. A much more elegant solution can be written. Unfortunately, I'm not familiar enough with the code base, nor with C++, nor with QT to do it...
