### PR TITLE
[ui] Fix floating dock panels hidden when toggling reduced view

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7336,7 +7336,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
 
     for ( QDockWidget *dock : docks )
     {
-      if ( dock->isVisible() && dockWidgetArea( dock ) != Qt::NoDockWidgetArea )
+      if ( dock->isVisible() && !dock->isFloating() && dockWidgetArea( dock ) != Qt::NoDockWidgetArea )
       {
         // remember the active docs
         docksTitle << dock->windowTitle();


### PR DESCRIPTION
## Description

This fixes floating dock panels wrongly hidden when toggling the main window's reduced view. The logic was always for panels to remain open when floating, which it does for floating dock containing more than one panel. However, the conditional check didn't take into account that single floating panel will return their last docked position when calling dockWidgetArea().

With this fix in, it becomes easy for users to have a floating temporal navigation panel and hit ctrl+shift+tab to have a nice immersive experience:

![image](https://github.com/qgis/QGIS/assets/1728657/e95b3018-b5d4-4958-99a2-e64790924c53)
