### PR TITLE
Don't share GEOS contexts across threads 

### DIFF
--- a/src/analysis/vector/qgsgeometrysnapper.cpp
+++ b/src/analysis/vector/qgsgeometrysnapper.cpp
@@ -109,7 +109,7 @@ bool QgsSnapIndex::SegmentSnapItem::withinSquaredDistance( const QgsPoint &p, co
 
 QgsSnapIndex::QgsSnapIndex()
 {
-  mSTRTree = GEOSSTRtree_create_r( QgsGeos::getGEOSHandler(), ( size_t )10 );
+  mSTRTree = GEOSSTRtree_create_r( QgsGeosContext::get(), ( size_t )10 );
 }
 
 QgsSnapIndex::~QgsSnapIndex()
@@ -117,14 +117,14 @@ QgsSnapIndex::~QgsSnapIndex()
   qDeleteAll( mCoordIdxs );
   qDeleteAll( mSnapItems );
 
-  GEOSSTRtree_destroy_r( QgsGeos::getGEOSHandler(), mSTRTree );
+  GEOSSTRtree_destroy_r( QgsGeosContext::get(), mSTRTree );
 }
 
 void QgsSnapIndex::addPoint( const CoordIdx *idx, bool isEndPoint )
 {
   const QgsPoint p = idx->point();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   geos::unique_ptr point( GEOSGeom_createPointFromXY_r( geosctxt, p.x(), p.y() ) );
 
   PointSnapItem *item = new PointSnapItem( idx, isEndPoint );
@@ -137,7 +137,7 @@ void QgsSnapIndex::addSegment( const CoordIdx *idxFrom, const CoordIdx *idxTo )
   const QgsPoint pointFrom = idxFrom->point();
   const QgsPoint pointTo = idxTo->point();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   GEOSCoordSequence *coord = GEOSCoordSeq_create_r( geosctxt, 2, 2 );
   GEOSCoordSeq_setXY_r( geosctxt, coord, 0, pointFrom.x(), pointFrom.y() );
@@ -191,7 +191,7 @@ void _GEOSQueryCallback( void *item, void *userdata )
 
 QgsPoint QgsSnapIndex::getClosestSnapToPoint( const QgsPoint &startPoint, const QgsPoint &midPoint )
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   // Look for intersections on segment from the target point to the point opposite to the point reference point
   // p2 = p1 + 2 * (q - p1)
@@ -231,7 +231,7 @@ QgsPoint QgsSnapIndex::getClosestSnapToPoint( const QgsPoint &startPoint, const 
 
 QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const double tolerance, QgsSnapIndex::PointSnapItem **pSnapPoint, QgsSnapIndex::SegmentSnapItem **pSnapSegment, bool endPointOnly ) const
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   GEOSCoordSequence *coord = GEOSCoordSeq_create_r( geosctxt, 2, 2 );
   GEOSCoordSeq_setXY_r( geosctxt, coord, 0, pos.x() - tolerance, pos.y() - tolerance );

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -94,45 +94,49 @@ static void printGEOSNotice( const char *fmt, ... )
 #endif
 }
 
-class GEOSInit
+//
+// QgsGeosContext
+//
+
+thread_local QgsGeosContext QgsGeosContext::sGeosContext;
+
+QgsGeosContext::QgsGeosContext()
 {
-  public:
-    GEOSContextHandle_t ctxt;
+  mContext = initGEOS_r( printGEOSNotice, throwGEOSException );
+}
 
-    GEOSInit()
-    {
-      ctxt = initGEOS_r( printGEOSNotice, throwGEOSException );
-    }
+QgsGeosContext::~QgsGeosContext()
+{
+  finishGEOS_r( mContext );
+}
 
-    ~GEOSInit()
-    {
-      finishGEOS_r( ctxt );
-    }
+GEOSContextHandle_t QgsGeosContext::get()
+{
+  return sGeosContext.mContext;
+}
 
-    GEOSInit( const GEOSInit &rh ) = delete;
-    GEOSInit &operator=( const GEOSInit &rh ) = delete;
-};
-
-Q_GLOBAL_STATIC( GEOSInit, geosinit )
+//
+// geos
+//
 
 void geos::GeosDeleter::operator()( GEOSGeometry *geom ) const
 {
-  GEOSGeom_destroy_r( geosinit()->ctxt, geom );
+  GEOSGeom_destroy_r( QgsGeosContext::get(), geom );
 }
 
 void geos::GeosDeleter::operator()( const GEOSPreparedGeometry *geom ) const
 {
-  GEOSPreparedGeom_destroy_r( geosinit()->ctxt, geom );
+  GEOSPreparedGeom_destroy_r( QgsGeosContext::get(), geom );
 }
 
 void geos::GeosDeleter::operator()( GEOSBufferParams *params ) const
 {
-  GEOSBufferParams_destroy_r( geosinit()->ctxt, params );
+  GEOSBufferParams_destroy_r( QgsGeosContext::get(), params );
 }
 
 void geos::GeosDeleter::operator()( GEOSCoordSequence *sequence ) const
 {
-  GEOSCoordSeq_destroy_r( geosinit()->ctxt, sequence );
+  GEOSCoordSeq_destroy_r( QgsGeosContext::get(), sequence );
 }
 
 
@@ -150,7 +154,7 @@ QgsGeos::QgsGeos( const QgsAbstractGeometry *geometry, double precision, bool al
 QgsGeometry QgsGeos::geometryFromGeos( GEOSGeometry *geos )
 {
   QgsGeometry g( QgsGeos::fromGeos( geos ) );
-  GEOSGeom_destroy_r( QgsGeos::getGEOSHandler(), geos );
+  GEOSGeom_destroy_r( QgsGeosContext::get(), geos );
   return g;
 }
 
@@ -167,6 +171,8 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::makeValid( Qgis::MakeValidMethod m
     return nullptr;
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
+
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<10
   if ( method != Qgis::MakeValidMethod::Linework )
     throw QgsNotSupportedException( QObject::tr( "The structured method to make geometries valid requires a QGIS build based on GEOS 3.10 or later" ) );
@@ -176,32 +182,32 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::makeValid( Qgis::MakeValidMethod m
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSMakeValid_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSMakeValid_r( context, mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 #else
 
-  GEOSMakeValidParams *params = GEOSMakeValidParams_create_r( geosinit()->ctxt );
+  GEOSMakeValidParams *params = GEOSMakeValidParams_create_r( context );
   switch ( method )
   {
     case Qgis::MakeValidMethod::Linework:
-      GEOSMakeValidParams_setMethod_r( geosinit()->ctxt, params, GEOS_MAKE_VALID_LINEWORK );
+      GEOSMakeValidParams_setMethod_r( context, params, GEOS_MAKE_VALID_LINEWORK );
       break;
 
     case Qgis::MakeValidMethod::Structure:
-      GEOSMakeValidParams_setMethod_r( geosinit()->ctxt, params, GEOS_MAKE_VALID_STRUCTURE );
+      GEOSMakeValidParams_setMethod_r( context, params, GEOS_MAKE_VALID_STRUCTURE );
       break;
   }
 
-  GEOSMakeValidParams_setKeepCollapsed_r( geosinit()->ctxt,
+  GEOSMakeValidParams_setKeepCollapsed_r( context,
                                           params,
                                           keepCollapsed ? 1 : 0 );
 
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSMakeValidWithParams_r( geosinit()->ctxt, mGeos.get(), params ) );
-    GEOSMakeValidParams_destroy_r( geosinit()->ctxt, params );
+    geos.reset( GEOSMakeValidWithParams_r( context, mGeos.get(), params ) );
+    GEOSMakeValidParams_destroy_r( context, params );
   }
   catch ( GEOSException &e )
   {
@@ -209,7 +215,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::makeValid( Qgis::MakeValidMethod m
     {
       *errorMsg = e.what();
     }
-    GEOSMakeValidParams_destroy_r( geosinit()->ctxt, params );
+    GEOSMakeValidParams_destroy_r( context, params );
     return nullptr;
   }
 #endif
@@ -258,7 +264,7 @@ void QgsGeos::prepareGeometry()
   }
   if ( mGeos )
   {
-    mGeosPrepared.reset( GEOSPrepare_r( geosinit()->ctxt, mGeos.get() ) );
+    mGeosPrepared.reset( GEOSPrepare_r( QgsGeosContext::get(), mGeos.get() ) );
   }
 }
 
@@ -296,7 +302,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QS
 
   try
   {
-    geos::unique_ptr opGeom( GEOSClipByRect_r( geosinit()->ctxt, mGeos.get(), rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() ) );
+    geos::unique_ptr opGeom( GEOSClipByRect_r( QgsGeosContext::get(), mGeos.get(), rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() ) );
     return fromGeos( opGeom.get() );
   }
   catch ( GEOSException &e )
@@ -310,12 +316,10 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QS
   }
 }
 
-
-
-
 void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes, int depth, QgsGeometryCollection *parts, const QgsRectangle &clipRect, double gridSize ) const
 {
-  int partType = GEOSGeomTypeId_r( geosinit()->ctxt, currentPart );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  int partType = GEOSGeomTypeId_r( context, currentPart );
   if ( qgsDoubleNear( clipRect.width(), 0.0 ) && qgsDoubleNear( clipRect.height(), 0.0 ) )
   {
     if ( partType == GEOS_POINT )
@@ -331,10 +335,10 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
 
   if ( partType == GEOS_MULTILINESTRING || partType == GEOS_MULTIPOLYGON || partType == GEOS_GEOMETRYCOLLECTION )
   {
-    int partCount = GEOSGetNumGeometries_r( geosinit()->ctxt, currentPart );
+    int partCount = GEOSGetNumGeometries_r( context, currentPart );
     for ( int i = 0; i < partCount; ++i )
     {
-      subdivideRecursive( GEOSGetGeometryN_r( geosinit()->ctxt, currentPart, i ), maxNodes, depth, parts, clipRect, gridSize );
+      subdivideRecursive( GEOSGetGeometryN_r( context, currentPart, i ), maxNodes, depth, parts, clipRect, gridSize );
     }
     return;
   }
@@ -345,7 +349,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
     return;
   }
 
-  int vertexCount = GEOSGetNumCoordinates_r( geosinit()->ctxt, currentPart );
+  int vertexCount = GEOSGetNumCoordinates_r( context, currentPart );
   if ( vertexCount == 0 )
   {
     return;
@@ -387,8 +391,8 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
     halfClipRect2.setXMaximum( halfClipRect2.xMaximum() + std::numeric_limits<double>::epsilon() );
   }
 
-  geos::unique_ptr clipPart1( GEOSClipByRect_r( geosinit()->ctxt, currentPart, halfClipRect1.xMinimum(), halfClipRect1.yMinimum(), halfClipRect1.xMaximum(), halfClipRect1.yMaximum() ) );
-  geos::unique_ptr clipPart2( GEOSClipByRect_r( geosinit()->ctxt, currentPart, halfClipRect2.xMinimum(), halfClipRect2.yMinimum(), halfClipRect2.xMaximum(), halfClipRect2.yMaximum() ) );
+  geos::unique_ptr clipPart1( GEOSClipByRect_r( context, currentPart, halfClipRect1.xMinimum(), halfClipRect1.yMinimum(), halfClipRect1.xMaximum(), halfClipRect1.yMaximum() ) );
+  geos::unique_ptr clipPart2( GEOSClipByRect_r( context, currentPart, halfClipRect2.xMinimum(), halfClipRect2.yMinimum(), halfClipRect2.xMaximum(), halfClipRect2.yMaximum() ) );
 
   ++depth;
 
@@ -396,7 +400,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
   {
     if ( gridSize > 0 )
     {
-      clipPart1.reset( GEOSIntersectionPrec_r( geosinit()->ctxt, mGeos.get(), clipPart1.get(), gridSize ) );
+      clipPart1.reset( GEOSIntersectionPrec_r( context, mGeos.get(), clipPart1.get(), gridSize ) );
     }
     subdivideRecursive( clipPart1.get(), maxNodes, depth, parts, halfClipRect1, gridSize );
   }
@@ -404,7 +408,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
   {
     if ( gridSize > 0 )
     {
-      clipPart2.reset( GEOSIntersectionPrec_r( geosinit()->ctxt, mGeos.get(), clipPart2.get(), gridSize ) );
+      clipPart2.reset( GEOSIntersectionPrec_r( context, mGeos.get(), clipPart2.get(), gridSize ) );
     }
     subdivideRecursive( clipPart2.get(), maxNodes, depth, parts, halfClipRect2, gridSize );
   }
@@ -447,17 +451,18 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsAbstractGeometry *> &geo
     geosGeometries.emplace_back( asGeos( g, mPrecision ) );
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   geos::unique_ptr geomUnion;
   try
   {
     geos::unique_ptr geomCollection = createGeosCollection( GEOS_GEOMETRYCOLLECTION, geosGeometries );
     if ( parameters.gridSize() > 0 )
     {
-      geomUnion.reset( GEOSUnaryUnionPrec_r( geosinit()->ctxt, geomCollection.get(), parameters.gridSize() ) );
+      geomUnion.reset( GEOSUnaryUnionPrec_r( context, geomCollection.get(), parameters.gridSize() ) );
     }
     else
     {
-      geomUnion.reset( GEOSUnaryUnion_r( geosinit()->ctxt, geomCollection.get() ) );
+      geomUnion.reset( GEOSUnaryUnion_r( context, geomCollection.get() ) );
     }
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
@@ -478,6 +483,7 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsGeometry> &geomList, QSt
     geosGeometries.emplace_back( asGeos( g.constGet(), mPrecision ) );
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   geos::unique_ptr geomUnion;
   try
   {
@@ -485,11 +491,11 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsGeometry> &geomList, QSt
 
     if ( parameters.gridSize() > 0 )
     {
-      geomUnion.reset( GEOSUnaryUnionPrec_r( geosinit()->ctxt, geomCollection.get(), parameters.gridSize() ) );
+      geomUnion.reset( GEOSUnaryUnionPrec_r( context, geomCollection.get(), parameters.gridSize() ) );
     }
     else
     {
-      geomUnion.reset( GEOSUnaryUnion_r( geosinit()->ctxt, geomCollection.get() ) );
+      geomUnion.reset( GEOSUnaryUnion_r( context, geomCollection.get() ) );
     }
 
   }
@@ -518,15 +524,16 @@ double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) c
     return distance;
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     if ( mGeosPrepared )
     {
-      GEOSPreparedDistance_r( geosinit()->ctxt, mGeosPrepared.get(), otherGeosGeom.get(), &distance );
+      GEOSPreparedDistance_r( context, mGeosPrepared.get(), otherGeosGeom.get(), &distance );
     }
     else
     {
-      GEOSDistance_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), &distance );
+      GEOSDistance_r( context, mGeos.get(), otherGeosGeom.get(), &distance );
     }
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
@@ -546,15 +553,16 @@ double QgsGeos::distance( double x, double y, QString *errorMsg ) const
   if ( !point )
     return distance;
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     if ( mGeosPrepared )
     {
-      GEOSPreparedDistance_r( geosinit()->ctxt, mGeosPrepared.get(), point.get(), &distance );
+      GEOSPreparedDistance_r( context, mGeosPrepared.get(), point.get(), &distance );
     }
     else
     {
-      GEOSDistance_r( geosinit()->ctxt, mGeos.get(), point.get(), &distance );
+      GEOSDistance_r( context, mGeos.get(), point.get(), &distance );
     }
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
@@ -580,23 +588,23 @@ bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, Q
   // distance
   double distance;
 
-
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     if ( mGeosPrepared )
     {
 #if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=10 )
-      return GEOSPreparedDistanceWithin_r( geosinit()->ctxt, mGeosPrepared.get(), otherGeosGeom.get(), maxdist );
+      return GEOSPreparedDistanceWithin_r( context, mGeosPrepared.get(), otherGeosGeom.get(), maxdist );
 #else
-      GEOSPreparedDistance_r( geosinit()->ctxt, mGeosPrepared.get(), otherGeosGeom.get(), &distance );
+      GEOSPreparedDistance_r( context, mGeosPrepared.get(), otherGeosGeom.get(), &distance );
 #endif
     }
     else
     {
 #if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=10 )
-      return GEOSDistanceWithin_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), maxdist );
+      return GEOSDistanceWithin_r( context, mGeos.get(), otherGeosGeom.get(), maxdist );
 #else
-      GEOSDistance_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), &distance );
+      GEOSDistance_r( context, mGeos.get(), otherGeosGeom.get(), &distance );
 #endif
     }
   }
@@ -612,14 +620,15 @@ bool QgsGeos::contains( double x, double y, QString *errorMsg ) const
     return false;
 
   bool result = false;
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     if ( mGeosPrepared ) //use faster version with prepared geometry
     {
-      return GEOSPreparedContains_r( geosinit()->ctxt, mGeosPrepared.get(), point.get() ) == 1;
+      return GEOSPreparedContains_r( context, mGeosPrepared.get(), point.get() ) == 1;
     }
 
-    result = ( GEOSContains_r( geosinit()->ctxt, mGeos.get(), point.get() ) == 1 );
+    result = ( GEOSContains_r( context, mGeos.get(), point.get() ) == 1 );
   }
   catch ( GEOSException &e )
   {
@@ -650,7 +659,7 @@ double QgsGeos::hausdorffDistance( const QgsAbstractGeometry *geom, QString *err
 
   try
   {
-    GEOSHausdorffDistance_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), &distance );
+    GEOSHausdorffDistance_r( QgsGeosContext::get(), mGeos.get(), otherGeosGeom.get(), &distance );
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
 
@@ -673,7 +682,7 @@ double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, doubl
 
   try
   {
-    GEOSHausdorffDistanceDensify_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), densifyFraction, &distance );
+    GEOSHausdorffDistanceDensify_r( QgsGeosContext::get(), mGeos.get(), otherGeosGeom.get(), densifyFraction, &distance );
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
 
@@ -696,7 +705,7 @@ double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *error
 
   try
   {
-    GEOSFrechetDistance_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), &distance );
+    GEOSFrechetDistance_r( QgsGeosContext::get(), mGeos.get(), otherGeosGeom.get(), &distance );
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
 
@@ -719,7 +728,7 @@ double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double 
 
   try
   {
-    GEOSFrechetDistanceDensify_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), densifyFraction, &distance );
+    GEOSFrechetDistanceDensify_r( QgsGeosContext::get(), mGeos.get(), otherGeosGeom.get(), densifyFraction, &distance );
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
 
@@ -775,13 +784,14 @@ QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg ) co
   }
 
   QString result;
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    char *r = GEOSRelate_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() );
+    char *r = GEOSRelate_r( context, mGeos.get(), geosGeom.get() );
     if ( r )
     {
       result = QString( r );
-      GEOSFree_r( geosinit()->ctxt, r );
+      GEOSFree_r( context, r );
     }
   }
   catch ( GEOSException &e )
@@ -810,9 +820,10 @@ bool QgsGeos::relatePattern( const QgsAbstractGeometry *geom, const QString &pat
   }
 
   bool result = false;
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    result = ( GEOSRelatePattern_r( geosinit()->ctxt, mGeos.get(), geosGeom.get(), pattern.toLocal8Bit().constData() ) == 1 );
+    result = ( GEOSRelatePattern_r( context, mGeos.get(), geosGeom.get(), pattern.toLocal8Bit().constData() ) == 1 );
   }
   catch ( GEOSException &e )
   {
@@ -836,7 +847,7 @@ double QgsGeos::area( QString *errorMsg ) const
 
   try
   {
-    if ( GEOSArea_r( geosinit()->ctxt, mGeos.get(), &area ) != 1 )
+    if ( GEOSArea_r( QgsGeosContext::get(), mGeos.get(), &area ) != 1 )
       return -1.0;
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
@@ -852,7 +863,7 @@ double QgsGeos::length( QString *errorMsg ) const
   }
   try
   {
-    if ( GEOSLength_r( geosinit()->ctxt, mGeos.get(), &length ) != 1 )
+    if ( GEOSLength_r( QgsGeosContext::get(), mGeos.get(), &length ) != 1 )
       return -1.0;
   }
   CATCH_GEOS_WITH_ERRMSG( -1.0 )
@@ -878,7 +889,8 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitGeometry( const QgsLineSt
     return SplitCannotSplitPoint; //cannot split points
   }
 
-  if ( !GEOSisValid_r( geosinit()->ctxt, mGeos.get() ) )
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  if ( !GEOSisValid_r( context, mGeos.get() ) )
     return InvalidBaseGeometry;
 
   //make sure splitLine is valid
@@ -904,7 +916,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitGeometry( const QgsLineSt
       return InvalidInput;
     }
 
-    if ( !GEOSisValid_r( geosinit()->ctxt, splitLineGeos.get() ) || !GEOSisSimple_r( geosinit()->ctxt, splitLineGeos.get() ) )
+    if ( !GEOSisValid_r( context, splitLineGeos.get() ) || !GEOSisSimple_r( context, splitLineGeos.get() ) )
     {
       return InvalidInput;
     }
@@ -950,21 +962,22 @@ bool QgsGeos::topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPoin
     return false;
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     testPoints.clear();
-    geos::unique_ptr intersectionGeom( GEOSIntersection_r( geosinit()->ctxt, mGeos.get(), splitLine ) );
+    geos::unique_ptr intersectionGeom( GEOSIntersection_r( context, mGeos.get(), splitLine ) );
     if ( !intersectionGeom )
       return false;
 
     bool simple = false;
     int nIntersectGeoms = 1;
-    if ( GEOSGeomTypeId_r( geosinit()->ctxt, intersectionGeom.get() ) == GEOS_LINESTRING
-         || GEOSGeomTypeId_r( geosinit()->ctxt, intersectionGeom.get() ) == GEOS_POINT )
+    if ( GEOSGeomTypeId_r( context, intersectionGeom.get() ) == GEOS_LINESTRING
+         || GEOSGeomTypeId_r( context, intersectionGeom.get() ) == GEOS_POINT )
       simple = true;
 
     if ( !simple )
-      nIntersectGeoms = GEOSGetNumGeometries_r( geosinit()->ctxt, intersectionGeom.get() );
+      nIntersectGeoms = GEOSGetNumGeometries_r( context, intersectionGeom.get() );
 
     for ( int i = 0; i < nIntersectGeoms; ++i )
     {
@@ -972,16 +985,16 @@ bool QgsGeos::topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPoin
       if ( simple )
         currentIntersectGeom = intersectionGeom.get();
       else
-        currentIntersectGeom = GEOSGetGeometryN_r( geosinit()->ctxt, intersectionGeom.get(), i );
+        currentIntersectGeom = GEOSGetGeometryN_r( context, intersectionGeom.get(), i );
 
-      const GEOSCoordSequence *lineSequence = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, currentIntersectGeom );
+      const GEOSCoordSequence *lineSequence = GEOSGeom_getCoordSeq_r( context, currentIntersectGeom );
       unsigned int sequenceSize = 0;
       double x, y, z;
-      if ( GEOSCoordSeq_getSize_r( geosinit()->ctxt, lineSequence, &sequenceSize ) != 0 )
+      if ( GEOSCoordSeq_getSize_r( context, lineSequence, &sequenceSize ) != 0 )
       {
         for ( unsigned int i = 0; i < sequenceSize; ++i )
         {
-          if ( GEOSCoordSeq_getXYZ_r( geosinit()->ctxt, lineSequence, i, &x, &y, &z ) )
+          if ( GEOSCoordSeq_getXYZ_r( context, lineSequence, i, &x, &y, &z ) )
           {
             testPoints.push_back( QgsPoint( x, y, z ) );
           }
@@ -996,7 +1009,8 @@ bool QgsGeos::topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPoin
 
 geos::unique_ptr QgsGeos::linePointDifference( GEOSGeometry *GEOSsplitPoint ) const
 {
-  int type = GEOSGeomTypeId_r( geosinit()->ctxt, mGeos.get() );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  int type = GEOSGeomTypeId_r( context, mGeos.get() );
 
   std::unique_ptr< QgsMultiCurve > multiCurve;
   if ( type == GEOS_MULTILINESTRING )
@@ -1145,14 +1159,14 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitLinearGeometry( const GEO
   if ( !mGeos )
     return InvalidBaseGeometry;
 
-  GEOSContextHandle_t geosctxt = geosinit()->ctxt;
+  GEOSContextHandle_t context = QgsGeosContext::get();
 
-  geos::unique_ptr intersectGeom( GEOSIntersection_r( geosctxt, splitLine, mGeos.get() ) );
-  if ( !intersectGeom || GEOSisEmpty_r( geosctxt, intersectGeom.get() ) )
+  geos::unique_ptr intersectGeom( GEOSIntersection_r( context, splitLine, mGeos.get() ) );
+  if ( !intersectGeom || GEOSisEmpty_r( context, intersectGeom.get() ) )
     return NothingHappened;
 
   //check that split line has no linear intersection
-  const int linearIntersect = GEOSRelatePattern_r( geosctxt, mGeos.get(), splitLine, "1********" );
+  const int linearIntersect = GEOSRelatePattern_r( context, mGeos.get(), splitLine, "1********" );
   if ( linearIntersect > 0 )
     return InvalidInput;
 
@@ -1163,18 +1177,18 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitLinearGeometry( const GEO
 
   std::vector<geos::unique_ptr> lineGeoms;
 
-  const int splitType = GEOSGeomTypeId_r( geosctxt, splitGeom.get() );
+  const int splitType = GEOSGeomTypeId_r( context, splitGeom.get() );
   if ( splitType == GEOS_MULTILINESTRING )
   {
-    const int nGeoms = GEOSGetNumGeometries_r( geosctxt, splitGeom.get() );
+    const int nGeoms = GEOSGetNumGeometries_r( context, splitGeom.get() );
     lineGeoms.reserve( nGeoms );
     for ( int i = 0; i < nGeoms; ++i )
-      lineGeoms.emplace_back( GEOSGeom_clone_r( geosctxt, GEOSGetGeometryN_r( geosctxt, splitGeom.get(), i ) ) );
+      lineGeoms.emplace_back( GEOSGeom_clone_r( context, GEOSGetGeometryN_r( context, splitGeom.get(), i ) ) );
 
   }
   else
   {
-    lineGeoms.emplace_back( GEOSGeom_clone_r( geosctxt, splitGeom.get() ) );
+    lineGeoms.emplace_back( GEOSGeom_clone_r( context, splitGeom.get() ) );
   }
 
   mergeGeometriesMultiTypeSplit( lineGeoms );
@@ -1200,10 +1214,10 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( const GE
   if ( !mGeosPrepared )
     return EngineError;
 
-  GEOSContextHandle_t geosctxt = geosinit()->ctxt;
+  GEOSContextHandle_t context = QgsGeosContext::get();
 
   //first test if linestring intersects geometry. If not, return straight away
-  if ( !skipIntersectionCheck && !GEOSPreparedIntersects_r( geosctxt, mGeosPrepared.get(), splitLine ) )
+  if ( !skipIntersectionCheck && !GEOSPreparedIntersects_r( context, mGeosPrepared.get(), splitLine ) )
     return NothingHappened;
 
   //first union all the polygon rings together (to get them noded, see JTS developer guide)
@@ -1212,7 +1226,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( const GE
     return NodedGeometryError; //an error occurred during noding
 
   const GEOSGeometry *noded = nodedGeometry.get();
-  geos::unique_ptr polygons( GEOSPolygonize_r( geosctxt, &noded, 1 ) );
+  geos::unique_ptr polygons( GEOSPolygonize_r( context, &noded, 1 ) );
   if ( !polygons )
   {
     return InvalidBaseGeometry;
@@ -1232,11 +1246,11 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( const GE
   // those would be also returned by polygonize and we need to skip them)
   for ( int i = 0; i < numberOfGeometriesPolygon; i++ )
   {
-    const GEOSGeometry *polygon = GEOSGetGeometryN_r( geosctxt, polygons.get(), i );
+    const GEOSGeometry *polygon = GEOSGetGeometryN_r( context, polygons.get(), i );
 
-    geos::unique_ptr pointOnSurface( GEOSPointOnSurface_r( geosctxt, polygon ) );
-    if ( pointOnSurface && GEOSPreparedIntersects_r( geosctxt, mGeosPrepared.get(), pointOnSurface.get() ) )
-      testedGeometries.emplace_back( GEOSGeom_clone_r( geosctxt, polygon ) );
+    geos::unique_ptr pointOnSurface( GEOSPointOnSurface_r( context, polygon ) );
+    if ( pointOnSurface && GEOSPreparedIntersects_r( context, mGeosPrepared.get(), pointOnSurface.get() ) )
+      testedGeometries.emplace_back( GEOSGeom_clone_r( context, polygon ) );
   }
 
   const size_t nGeometriesThis = numberOfGeometries( mGeos.get() ); //original number of geometries
@@ -1253,7 +1267,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( const GE
   mergeGeometriesMultiTypeSplit( testedGeometries );
 
   size_t i;
-  for ( i = 0; i < testedGeometries.size() && GEOSisValid_r( geosctxt, testedGeometries[i].get() ); ++i )
+  for ( i = 0; i < testedGeometries.size() && GEOSisValid_r( context, testedGeometries[i].get() ); ++i )
     ;
 
   if ( i < testedGeometries.size() )
@@ -1275,13 +1289,14 @@ geos::unique_ptr QgsGeos::nodeGeometries( const GEOSGeometry *splitLine, const G
     return nullptr;
 
   geos::unique_ptr geometryBoundary;
-  if ( GEOSGeomTypeId_r( geosinit()->ctxt, geom ) == GEOS_POLYGON || GEOSGeomTypeId_r( geosinit()->ctxt, geom ) == GEOS_MULTIPOLYGON )
-    geometryBoundary.reset( GEOSBoundary_r( geosinit()->ctxt, geom ) );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  if ( GEOSGeomTypeId_r( context, geom ) == GEOS_POLYGON || GEOSGeomTypeId_r( context, geom ) == GEOS_MULTIPOLYGON )
+    geometryBoundary.reset( GEOSBoundary_r( context, geom ) );
   else
-    geometryBoundary.reset( GEOSGeom_clone_r( geosinit()->ctxt, geom ) );
+    geometryBoundary.reset( GEOSGeom_clone_r( context, geom ) );
 
-  geos::unique_ptr splitLineClone( GEOSGeom_clone_r( geosinit()->ctxt, splitLine ) );
-  geos::unique_ptr unionGeometry( GEOSUnion_r( geosinit()->ctxt, splitLineClone.get(), geometryBoundary.get() ) );
+  geos::unique_ptr splitLineClone( GEOSGeom_clone_r( context, splitLine ) );
+  geos::unique_ptr unionGeometry( GEOSUnion_r( context, splitLineClone.get(), geometryBoundary.get() ) );
 
   return unionGeometry;
 }
@@ -1292,7 +1307,8 @@ int QgsGeos::mergeGeometriesMultiTypeSplit( std::vector<geos::unique_ptr> &split
     return 1;
 
   //convert mGeos to geometry collection
-  int type = GEOSGeomTypeId_r( geosinit()->ctxt, mGeos.get() );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  int type = GEOSGeomTypeId_r( context, mGeos.get() );
   if ( type != GEOS_GEOMETRYCOLLECTION &&
        type != GEOS_MULTILINESTRING &&
        type != GEOS_MULTIPOLYGON &&
@@ -1308,9 +1324,9 @@ int QgsGeos::mergeGeometriesMultiTypeSplit( std::vector<geos::unique_ptr> &split
   {
     //is this geometry a part of the original multitype?
     bool isPart = false;
-    for ( int j = 0; j < GEOSGetNumGeometries_r( geosinit()->ctxt, mGeos.get() ); j++ )
+    for ( int j = 0; j < GEOSGetNumGeometries_r( context, mGeos.get() ); j++ )
     {
-      if ( GEOSEquals_r( geosinit()->ctxt, splitResult[i].get(), GEOSGetGeometryN_r( geosinit()->ctxt, mGeos.get(), j ) ) )
+      if ( GEOSEquals_r( context, splitResult[i].get(), GEOSGetGeometryN_r( context, mGeos.get(), j ) ) )
       {
         isPart = true;
         break;
@@ -1352,11 +1368,12 @@ geos::unique_ptr QgsGeos::createGeosCollection( int typeId, std::vector<geos::un
   std::vector<GEOSGeometry *> geomarr;
   geomarr.reserve( geoms.size() );
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   for ( geos::unique_ptr &geomUniquePtr : geoms )
   {
     if ( geomUniquePtr )
     {
-      if ( !GEOSisEmpty_r( geosinit()->ctxt, geomUniquePtr.get() ) )
+      if ( !GEOSisEmpty_r( context, geomUniquePtr.get() ) )
       {
         // don't add empty parts to a geos collection, it can cause crashes in GEOS
         // transfer ownership of the geometries to GEOSGeom_createCollection_r()
@@ -1368,13 +1385,13 @@ geos::unique_ptr QgsGeos::createGeosCollection( int typeId, std::vector<geos::un
 
   try
   {
-    geomRes.reset( GEOSGeom_createCollection_r( geosinit()->ctxt, typeId, geomarr.data(), geomarr.size() ) );
+    geomRes.reset( GEOSGeom_createCollection_r( context, typeId, geomarr.data(), geomarr.size() ) );
   }
   catch ( GEOSException & )
   {
     for ( GEOSGeometry *geom : geomarr )
     {
-      GEOSGeom_destroy_r( geosinit()->ctxt, geom );
+      GEOSGeom_destroy_r( context, geom );
     }
   }
 
@@ -1388,21 +1405,22 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     return nullptr;
   }
 
-  int nCoordDims = GEOSGeom_getCoordinateDimension_r( geosinit()->ctxt, geos );
-  int nDims = GEOSGeom_getDimensions_r( geosinit()->ctxt, geos );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  int nCoordDims = GEOSGeom_getCoordinateDimension_r( context, geos );
+  int nDims = GEOSGeom_getDimensions_r( context, geos );
   bool hasZ = ( nCoordDims == 3 );
   bool hasM = ( ( nDims - nCoordDims ) == 1 );
 
-  switch ( GEOSGeomTypeId_r( geosinit()->ctxt, geos ) )
+  switch ( GEOSGeomTypeId_r( context, geos ) )
   {
     case GEOS_POINT:                 // a point
     {
-      if ( GEOSisEmpty_r( geosinit()->ctxt, geos ) )
+      if ( GEOSisEmpty_r( context, geos ) )
         return nullptr;
 
-      const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, geos );
+      const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( context, geos );
       unsigned int nPoints = 0;
-      GEOSCoordSeq_getSize_r( geosinit()->ctxt, cs, &nPoints );
+      GEOSCoordSeq_getSize_r( context, cs, &nPoints );
       return nPoints > 0 ? std::unique_ptr<QgsAbstractGeometry>( coordSeqPoint( cs, 0, hasZ, hasM ).clone() ) : nullptr;
     }
     case GEOS_LINESTRING:
@@ -1416,15 +1434,15 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     case GEOS_MULTIPOINT:
     {
       std::unique_ptr< QgsMultiPoint > multiPoint( new QgsMultiPoint() );
-      int nParts = GEOSGetNumGeometries_r( geosinit()->ctxt, geos );
+      int nParts = GEOSGetNumGeometries_r( context, geos );
       multiPoint->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
-        const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, GEOSGetGeometryN_r( geosinit()->ctxt, geos, i ) );
+        const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( context, GEOSGetGeometryN_r( context, geos, i ) );
         if ( cs )
         {
           unsigned int nPoints = 0;
-          GEOSCoordSeq_getSize_r( geosinit()->ctxt, cs, &nPoints );
+          GEOSCoordSeq_getSize_r( context, cs, &nPoints );
           if ( nPoints > 0 )
             multiPoint->addGeometry( coordSeqPoint( cs, 0, hasZ, hasM ).clone() );
         }
@@ -1434,11 +1452,11 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     case GEOS_MULTILINESTRING:
     {
       std::unique_ptr< QgsMultiLineString > multiLineString( new QgsMultiLineString() );
-      int nParts = GEOSGetNumGeometries_r( geosinit()->ctxt, geos );
+      int nParts = GEOSGetNumGeometries_r( context, geos );
       multiLineString->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
-        std::unique_ptr< QgsLineString >line( sequenceToLinestring( GEOSGetGeometryN_r( geosinit()->ctxt, geos, i ), hasZ, hasM ) );
+        std::unique_ptr< QgsLineString >line( sequenceToLinestring( GEOSGetGeometryN_r( context, geos, i ), hasZ, hasM ) );
         if ( line )
         {
           multiLineString->addGeometry( line.release() );
@@ -1450,11 +1468,11 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     {
       std::unique_ptr< QgsMultiPolygon > multiPolygon( new QgsMultiPolygon() );
 
-      int nParts = GEOSGetNumGeometries_r( geosinit()->ctxt, geos );
+      int nParts = GEOSGetNumGeometries_r( context, geos );
       multiPolygon->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
-        std::unique_ptr< QgsPolygon > poly = fromGeosPolygon( GEOSGetGeometryN_r( geosinit()->ctxt, geos, i ) );
+        std::unique_ptr< QgsPolygon > poly = fromGeosPolygon( GEOSGetGeometryN_r( context, geos, i ) );
         if ( poly )
         {
           multiPolygon->addGeometry( poly.release() );
@@ -1465,11 +1483,11 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     case GEOS_GEOMETRYCOLLECTION:
     {
       std::unique_ptr< QgsGeometryCollection > geomCollection( new QgsGeometryCollection() );
-      int nParts = GEOSGetNumGeometries_r( geosinit()->ctxt, geos );
+      int nParts = GEOSGetNumGeometries_r( context, geos );
       geomCollection->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
-        std::unique_ptr< QgsAbstractGeometry > geom( fromGeos( GEOSGetGeometryN_r( geosinit()->ctxt, geos, i ) ) );
+        std::unique_ptr< QgsAbstractGeometry > geom( fromGeos( GEOSGetGeometryN_r( context, geos, i ) ) );
         if ( geom )
         {
           geomCollection->addGeometry( geom.release() );
@@ -1483,30 +1501,31 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
 
 std::unique_ptr<QgsPolygon> QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
 {
-  if ( GEOSGeomTypeId_r( geosinit()->ctxt, geos ) != GEOS_POLYGON )
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  if ( GEOSGeomTypeId_r( context, geos ) != GEOS_POLYGON )
   {
     return nullptr;
   }
 
-  int nCoordDims = GEOSGeom_getCoordinateDimension_r( geosinit()->ctxt, geos );
-  int nDims = GEOSGeom_getDimensions_r( geosinit()->ctxt, geos );
+  int nCoordDims = GEOSGeom_getCoordinateDimension_r( context, geos );
+  int nDims = GEOSGeom_getDimensions_r( context, geos );
   bool hasZ = ( nCoordDims == 3 );
   bool hasM = ( ( nDims - nCoordDims ) == 1 );
 
   std::unique_ptr< QgsPolygon > polygon( new QgsPolygon() );
 
-  const GEOSGeometry *ring = GEOSGetExteriorRing_r( geosinit()->ctxt, geos );
+  const GEOSGeometry *ring = GEOSGetExteriorRing_r( context, geos );
   if ( ring )
   {
     polygon->setExteriorRing( sequenceToLinestring( ring, hasZ, hasM ).release() );
   }
 
   QVector<QgsCurve *> interiorRings;
-  const int ringCount = GEOSGetNumInteriorRings_r( geosinit()->ctxt, geos );
+  const int ringCount = GEOSGetNumInteriorRings_r( context, geos );
   interiorRings.reserve( ringCount );
   for ( int i = 0; i < ringCount; ++i )
   {
-    ring = GEOSGetInteriorRingN_r( geosinit()->ctxt, geos, i );
+    ring = GEOSGetInteriorRingN_r( context, geos, i );
     if ( ring )
     {
       interiorRings.push_back( sequenceToLinestring( ring, hasZ, hasM ).release() );
@@ -1519,10 +1538,11 @@ std::unique_ptr<QgsPolygon> QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
 
 std::unique_ptr<QgsLineString> QgsGeos::sequenceToLinestring( const GEOSGeometry *geos, bool hasZ, bool hasM )
 {
-  const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, geos );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( context, geos );
 
   unsigned int nPoints;
-  GEOSCoordSeq_getSize_r( geosinit()->ctxt, cs, &nPoints );
+  GEOSCoordSeq_getSize_r( context, cs, &nPoints );
 
   QVector< double > xOut( nPoints );
   QVector< double > yOut( nPoints );
@@ -1539,17 +1559,17 @@ std::unique_ptr<QgsLineString> QgsGeos::sequenceToLinestring( const GEOSGeometry
   double *m = mOut.data();
 
 #if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=10 )
-  GEOSCoordSeq_copyToArrays_r( geosinit()->ctxt, cs, x, y, hasZ ? z : nullptr, hasM ? m : nullptr );
+  GEOSCoordSeq_copyToArrays_r( context, cs, x, y, hasZ ? z : nullptr, hasM ? m : nullptr );
 #else
   for ( unsigned int i = 0; i < nPoints; ++i )
   {
     if ( hasZ )
-      GEOSCoordSeq_getXYZ_r( geosinit()->ctxt, cs, i, x++, y++, z++ );
+      GEOSCoordSeq_getXYZ_r( context, cs, i, x++, y++, z++ );
     else
-      GEOSCoordSeq_getXY_r( geosinit()->ctxt, cs, i, x++, y++ );
+      GEOSCoordSeq_getXY_r( context, cs, i, x++, y++ );
     if ( hasM )
     {
-      GEOSCoordSeq_getOrdinate_r( geosinit()->ctxt, cs, i, 3, m++ );
+      GEOSCoordSeq_getOrdinate_r( context, cs, i, 3, m++ );
     }
   }
 #endif
@@ -1562,13 +1582,14 @@ int QgsGeos::numberOfGeometries( GEOSGeometry *g )
   if ( !g )
     return 0;
 
-  int geometryType = GEOSGeomTypeId_r( geosinit()->ctxt, g );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  int geometryType = GEOSGeomTypeId_r( context, g );
   if ( geometryType == GEOS_POINT || geometryType == GEOS_LINESTRING || geometryType == GEOS_LINEARRING
        || geometryType == GEOS_POLYGON )
     return 1;
 
   //calling GEOSGetNumGeometries is save for multi types and collections also in geos2
-  return GEOSGetNumGeometries_r( geosinit()->ctxt, g );
+  return GEOSGetNumGeometries_r( context, g );
 }
 
 QgsPoint QgsGeos::coordSeqPoint( const GEOSCoordSequence *cs, int i, bool hasZ, bool hasM )
@@ -1578,16 +1599,18 @@ QgsPoint QgsGeos::coordSeqPoint( const GEOSCoordSequence *cs, int i, bool hasZ, 
     return QgsPoint();
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
+
   double x, y;
   double z = 0;
   double m = 0;
   if ( hasZ )
-    GEOSCoordSeq_getXYZ_r( geosinit()->ctxt, cs, i, &x, &y, &z );
+    GEOSCoordSeq_getXYZ_r( context, cs, i, &x, &y, &z );
   else
-    GEOSCoordSeq_getXY_r( geosinit()->ctxt, cs, i, &x, &y );
+    GEOSCoordSeq_getXY_r( context, cs, i, &x, &y );
   if ( hasM )
   {
-    GEOSCoordSeq_getOrdinate_r( geosinit()->ctxt, cs, i, 3, &m );
+    GEOSCoordSeq_getOrdinate_r( context, cs, i, 3, &m );
   }
 
   Qgis::WkbType t = Qgis::WkbType::Point;
@@ -1702,6 +1725,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
 
   const double gridSize = parameters.gridSize();
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     geos::unique_ptr opGeom;
@@ -1710,22 +1734,22 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
       case OverlayIntersection:
         if ( gridSize > 0 )
         {
-          opGeom.reset( GEOSIntersectionPrec_r( geosinit()->ctxt, mGeos.get(), geosGeom.get(), gridSize ) );
+          opGeom.reset( GEOSIntersectionPrec_r( context, mGeos.get(), geosGeom.get(), gridSize ) );
         }
         else
         {
-          opGeom.reset( GEOSIntersection_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) );
+          opGeom.reset( GEOSIntersection_r( context, mGeos.get(), geosGeom.get() ) );
         }
         break;
 
       case OverlayDifference:
         if ( gridSize > 0 )
         {
-          opGeom.reset( GEOSDifferencePrec_r( geosinit()->ctxt, mGeos.get(), geosGeom.get(), gridSize ) );
+          opGeom.reset( GEOSDifferencePrec_r( context, mGeos.get(), geosGeom.get(), gridSize ) );
         }
         else
         {
-          opGeom.reset( GEOSDifference_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) );
+          opGeom.reset( GEOSDifference_r( context, mGeos.get(), geosGeom.get() ) );
         }
         break;
 
@@ -1734,16 +1758,16 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
         geos::unique_ptr unionGeometry;
         if ( gridSize > 0 )
         {
-          unionGeometry.reset( GEOSUnionPrec_r( geosinit()->ctxt, mGeos.get(), geosGeom.get(), gridSize ) );
+          unionGeometry.reset( GEOSUnionPrec_r( context, mGeos.get(), geosGeom.get(), gridSize ) );
         }
         else
         {
-          unionGeometry.reset( GEOSUnion_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) );
+          unionGeometry.reset( GEOSUnion_r( context, mGeos.get(), geosGeom.get() ) );
         }
 
-        if ( unionGeometry && GEOSGeomTypeId_r( geosinit()->ctxt, unionGeometry.get() ) == GEOS_MULTILINESTRING )
+        if ( unionGeometry && GEOSGeomTypeId_r( context, unionGeometry.get() ) == GEOS_MULTILINESTRING )
         {
-          geos::unique_ptr mergedLines( GEOSLineMerge_r( geosinit()->ctxt, unionGeometry.get() ) );
+          geos::unique_ptr mergedLines( GEOSLineMerge_r( context, unionGeometry.get() ) );
           if ( mergedLines )
           {
             unionGeometry = std::move( mergedLines );
@@ -1757,11 +1781,11 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
       case OverlaySymDifference:
         if ( gridSize > 0 )
         {
-          opGeom.reset( GEOSSymDifferencePrec_r( geosinit()->ctxt, mGeos.get(), geosGeom.get(), gridSize ) );
+          opGeom.reset( GEOSSymDifferencePrec_r( context, mGeos.get(), geosGeom.get(), gridSize ) );
         }
         else
         {
-          opGeom.reset( GEOSSymDifference_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) );
+          opGeom.reset( GEOSSymDifference_r( context, mGeos.get(), geosGeom.get() ) );
         }
         break;
     }
@@ -1791,6 +1815,7 @@ bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *er
     return false;
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   bool result = false;
   try
   {
@@ -1799,25 +1824,25 @@ bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *er
       switch ( r )
       {
         case RelationIntersects:
-          result = ( GEOSPreparedIntersects_r( geosinit()->ctxt, mGeosPrepared.get(), geosGeom.get() ) == 1 );
+          result = ( GEOSPreparedIntersects_r( context, mGeosPrepared.get(), geosGeom.get() ) == 1 );
           break;
         case RelationTouches:
-          result = ( GEOSPreparedTouches_r( geosinit()->ctxt, mGeosPrepared.get(), geosGeom.get() ) == 1 );
+          result = ( GEOSPreparedTouches_r( context, mGeosPrepared.get(), geosGeom.get() ) == 1 );
           break;
         case RelationCrosses:
-          result = ( GEOSPreparedCrosses_r( geosinit()->ctxt, mGeosPrepared.get(), geosGeom.get() ) == 1 );
+          result = ( GEOSPreparedCrosses_r( context, mGeosPrepared.get(), geosGeom.get() ) == 1 );
           break;
         case RelationWithin:
-          result = ( GEOSPreparedWithin_r( geosinit()->ctxt, mGeosPrepared.get(), geosGeom.get() ) == 1 );
+          result = ( GEOSPreparedWithin_r( context, mGeosPrepared.get(), geosGeom.get() ) == 1 );
           break;
         case RelationContains:
-          result = ( GEOSPreparedContains_r( geosinit()->ctxt, mGeosPrepared.get(), geosGeom.get() ) == 1 );
+          result = ( GEOSPreparedContains_r( context, mGeosPrepared.get(), geosGeom.get() ) == 1 );
           break;
         case RelationDisjoint:
-          result = ( GEOSPreparedDisjoint_r( geosinit()->ctxt, mGeosPrepared.get(), geosGeom.get() ) == 1 );
+          result = ( GEOSPreparedDisjoint_r( context, mGeosPrepared.get(), geosGeom.get() ) == 1 );
           break;
         case RelationOverlaps:
-          result = ( GEOSPreparedOverlaps_r( geosinit()->ctxt, mGeosPrepared.get(), geosGeom.get() ) == 1 );
+          result = ( GEOSPreparedOverlaps_r( context, mGeosPrepared.get(), geosGeom.get() ) == 1 );
           break;
       }
       return result;
@@ -1826,25 +1851,25 @@ bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *er
     switch ( r )
     {
       case RelationIntersects:
-        result = ( GEOSIntersects_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) == 1 );
+        result = ( GEOSIntersects_r( context, mGeos.get(), geosGeom.get() ) == 1 );
         break;
       case RelationTouches:
-        result = ( GEOSTouches_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) == 1 );
+        result = ( GEOSTouches_r( context, mGeos.get(), geosGeom.get() ) == 1 );
         break;
       case RelationCrosses:
-        result = ( GEOSCrosses_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) == 1 );
+        result = ( GEOSCrosses_r( context, mGeos.get(), geosGeom.get() ) == 1 );
         break;
       case RelationWithin:
-        result = ( GEOSWithin_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) == 1 );
+        result = ( GEOSWithin_r( context, mGeos.get(), geosGeom.get() ) == 1 );
         break;
       case RelationContains:
-        result = ( GEOSContains_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) == 1 );
+        result = ( GEOSContains_r( context, mGeos.get(), geosGeom.get() ) == 1 );
         break;
       case RelationDisjoint:
-        result = ( GEOSDisjoint_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) == 1 );
+        result = ( GEOSDisjoint_r( context, mGeos.get(), geosGeom.get() ) == 1 );
         break;
       case RelationOverlaps:
-        result = ( GEOSOverlaps_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() ) == 1 );
+        result = ( GEOSOverlaps_r( context, mGeos.get(), geosGeom.get() ) == 1 );
         break;
     }
   }
@@ -1871,7 +1896,7 @@ QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, QString *er
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSBuffer_r( geosinit()->ctxt, mGeos.get(), distance, segments ) );
+    geos.reset( GEOSBuffer_r( QgsGeosContext::get(), mGeos.get(), distance, segments ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
@@ -1887,7 +1912,7 @@ QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, Qgis::EndCa
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSBufferWithStyle_r( geosinit()->ctxt, mGeos.get(), distance, segments, static_cast< int >( endCapStyle ), static_cast< int >( joinStyle ), miterLimit ) );
+    geos.reset( GEOSBufferWithStyle_r( QgsGeosContext::get(), mGeos.get(), distance, segments, static_cast< int >( endCapStyle ), static_cast< int >( joinStyle ), miterLimit ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
@@ -1902,7 +1927,7 @@ QgsAbstractGeometry *QgsGeos::simplify( double tolerance, QString *errorMsg ) co
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSTopologyPreserveSimplify_r( geosinit()->ctxt, mGeos.get(), tolerance ) );
+    geos.reset( GEOSTopologyPreserveSimplify_r( QgsGeosContext::get(), mGeos.get(), tolerance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
@@ -1917,7 +1942,7 @@ QgsAbstractGeometry *QgsGeos::interpolate( double distance, QString *errorMsg ) 
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSInterpolate_r( geosinit()->ctxt, mGeos.get(), distance ) );
+    geos.reset( GEOSInterpolate_r( QgsGeosContext::get(), mGeos.get(), distance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
@@ -1934,15 +1959,16 @@ QgsPoint *QgsGeos::centroid( QString *errorMsg ) const
   double x;
   double y;
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    geos.reset( GEOSGetCentroid_r( geosinit()->ctxt,  mGeos.get() ) );
+    geos.reset( GEOSGetCentroid_r( context,  mGeos.get() ) );
 
     if ( !geos )
       return nullptr;
 
-    GEOSGeomGetX_r( geosinit()->ctxt, geos.get(), &x );
-    GEOSGeomGetY_r( geosinit()->ctxt, geos.get(), &y );
+    GEOSGeomGetX_r( context, geos.get(), &x );
+    GEOSGeomGetY_r( context, geos.get(), &y );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 
@@ -1958,7 +1984,7 @@ QgsAbstractGeometry *QgsGeos::envelope( QString *errorMsg ) const
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSEnvelope_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSEnvelope_r( QgsGeosContext::get(), mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
@@ -1974,18 +2000,19 @@ QgsPoint *QgsGeos::pointOnSurface( QString *errorMsg ) const
   double x;
   double y;
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSPointOnSurface_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSPointOnSurface_r( context, mGeos.get() ) );
 
-    if ( !geos || GEOSisEmpty_r( geosinit()->ctxt, geos.get() ) != 0 )
+    if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )
     {
       return nullptr;
     }
 
-    GEOSGeomGetX_r( geosinit()->ctxt, geos.get(), &x );
-    GEOSGeomGetY_r( geosinit()->ctxt, geos.get(), &y );
+    GEOSGeomGetX_r( context, geos.get(), &x );
+    GEOSGeomGetY_r( context, geos.get(), &y );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 
@@ -2001,7 +2028,7 @@ QgsAbstractGeometry *QgsGeos::convexHull( QString *errorMsg ) const
 
   try
   {
-    geos::unique_ptr cHull( GEOSConvexHull_r( geosinit()->ctxt, mGeos.get() ) );
+    geos::unique_ptr cHull( GEOSConvexHull_r( QgsGeosContext::get(), mGeos.get() ) );
     std::unique_ptr< QgsAbstractGeometry > cHullGeom = fromGeos( cHull.get() );
     return cHullGeom.release();
   }
@@ -2023,7 +2050,7 @@ QgsAbstractGeometry *QgsGeos::concaveHull( double targetPercent, bool allowHoles
 
   try
   {
-    geos::unique_ptr concaveHull( GEOSConcaveHull_r( geosinit()->ctxt, mGeos.get(), targetPercent, allowHoles ) );
+    geos::unique_ptr concaveHull( GEOSConcaveHull_r( QgsGeosContext::get(), mGeos.get(), targetPercent, allowHoles ) );
     std::unique_ptr< QgsAbstractGeometry > concaveHullGeom = fromGeos( concaveHull.get() );
     return concaveHullGeom.release();
   }
@@ -2046,17 +2073,18 @@ Qgis::CoverageValidityResult QgsGeos::validateCoverage( double gapWidth, std::un
     return Qgis::CoverageValidityResult::Error;
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     GEOSGeometry *invalidEdgesGeos = nullptr;
-    const int result = GEOSCoverageIsValid_r( geosinit()->ctxt, mGeos.get(), gapWidth, invalidEdges ? &invalidEdgesGeos : nullptr );
+    const int result = GEOSCoverageIsValid_r( context, mGeos.get(), gapWidth, invalidEdges ? &invalidEdgesGeos : nullptr );
     if ( invalidEdges && invalidEdgesGeos )
     {
       *invalidEdges = fromGeos( invalidEdgesGeos );
     }
     if ( invalidEdgesGeos )
     {
-      GEOSGeom_destroy_r( geosinit()->ctxt, invalidEdgesGeos );
+      GEOSGeom_destroy_r( context, invalidEdgesGeos );
       invalidEdgesGeos = nullptr;
     }
 
@@ -2092,7 +2120,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::simplifyCoverageVW( double toleran
 
   try
   {
-    geos::unique_ptr simplified( GEOSCoverageSimplifyVW_r( geosinit()->ctxt, mGeos.get(), tolerance, preserveBoundary ? 1 : 0 ) );
+    geos::unique_ptr simplified( GEOSCoverageSimplifyVW_r( QgsGeosContext::get(), mGeos.get(), tolerance, preserveBoundary ? 1 : 0 ) );
     std::unique_ptr< QgsAbstractGeometry > simplifiedGeom = fromGeos( simplified.get() );
     return simplifiedGeom;
   }
@@ -2111,7 +2139,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::unionCoverage( QString *errorMsg )
 
   try
   {
-    geos::unique_ptr unioned( GEOSCoverageUnion_r( geosinit()->ctxt, mGeos.get() ) );
+    geos::unique_ptr unioned( GEOSCoverageUnion_r( QgsGeosContext::get(), mGeos.get() ) );
     std::unique_ptr< QgsAbstractGeometry > result = fromGeos( unioned.get() );
     return result;
   }
@@ -2127,18 +2155,19 @@ bool QgsGeos::isValid( QString *errorMsg, const bool allowSelfTouchingHoles, Qgs
     return false;
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     GEOSGeometry *g1 = nullptr;
     char *r = nullptr;
-    char res = GEOSisValidDetail_r( geosinit()->ctxt, mGeos.get(), allowSelfTouchingHoles ? GEOSVALID_ALLOW_SELFTOUCHING_RING_FORMING_HOLE : 0, &r, &g1 );
+    char res = GEOSisValidDetail_r( context, mGeos.get(), allowSelfTouchingHoles ? GEOSVALID_ALLOW_SELFTOUCHING_RING_FORMING_HOLE : 0, &r, &g1 );
     const bool invalid = res != 1;
 
     QString error;
     if ( r )
     {
       error = QString( r );
-      GEOSFree_r( geosinit()->ctxt, r );
+      GEOSFree_r( context, r );
     }
 
     if ( invalid && errorMsg )
@@ -2170,7 +2199,7 @@ bool QgsGeos::isValid( QString *errorMsg, const bool allowSelfTouchingHoles, Qgs
       }
       else if ( g1 )
       {
-        GEOSGeom_destroy_r( geosinit()->ctxt, g1 );
+        GEOSGeom_destroy_r( context, g1 );
       }
     }
     return !invalid;
@@ -2192,7 +2221,7 @@ bool QgsGeos::isEqual( const QgsAbstractGeometry *geom, QString *errorMsg ) cons
     {
       return false;
     }
-    bool equal = GEOSEquals_r( geosinit()->ctxt, mGeos.get(), geosGeom.get() );
+    bool equal = GEOSEquals_r( QgsGeosContext::get(), mGeos.get(), geosGeom.get() );
     return equal;
   }
   CATCH_GEOS_WITH_ERRMSG( false )
@@ -2207,7 +2236,7 @@ bool QgsGeos::isEmpty( QString *errorMsg ) const
 
   try
   {
-    return GEOSisEmpty_r( geosinit()->ctxt, mGeos.get() );
+    return GEOSisEmpty_r( QgsGeosContext::get(), mGeos.get() );
   }
   CATCH_GEOS_WITH_ERRMSG( false )
 }
@@ -2221,14 +2250,14 @@ bool QgsGeos::isSimple( QString *errorMsg ) const
 
   try
   {
-    return GEOSisSimple_r( geosinit()->ctxt, mGeos.get() );
+    return GEOSisSimple_r( QgsGeosContext::get(), mGeos.get() );
   }
   CATCH_GEOS_WITH_ERRMSG( false )
 }
 
 GEOSCoordSequence *QgsGeos::createCoordinateSequence( const QgsCurve *curve, double precision, bool forceClose )
 {
-  GEOSContextHandle_t ctxt = geosinit()->ctxt;
+  GEOSContextHandle_t context = QgsGeosContext::get();
 
   std::unique_ptr< QgsLineString > segmentized;
   const QgsLineString *line = qgsgeometry_cast<const QgsLineString *>( curve );
@@ -2257,7 +2286,7 @@ GEOSCoordSequence *QgsGeos::createCoordinateSequence( const QgsCurve *curve, dou
       // use optimised method if we don't have to force close an open ring
       try
       {
-        coordSeq = GEOSCoordSeq_copyFromArrays_r( ctxt, line->xData(), line->yData(), line->zData(), nullptr, numPoints );
+        coordSeq = GEOSCoordSeq_copyFromArrays_r( context, line->xData(), line->yData(), line->zData(), nullptr, numPoints );
         if ( !coordSeq )
         {
           QgsDebugError( QStringLiteral( "GEOS Exception: Could not create coordinate sequence for %1 points" ).arg( numPoints ) );
@@ -2279,7 +2308,7 @@ GEOSCoordSequence *QgsGeos::createCoordinateSequence( const QgsCurve *curve, dou
         z.append( z.at( 0 ) );
       try
       {
-        coordSeq = GEOSCoordSeq_copyFromArrays_r( ctxt, x.constData(), y.constData(), !hasZ ? nullptr : z.constData(), nullptr, numPoints + 1 );
+        coordSeq = GEOSCoordSeq_copyFromArrays_r( context, x.constData(), y.constData(), !hasZ ? nullptr : z.constData(), nullptr, numPoints + 1 );
         if ( !coordSeq )
         {
           QgsDebugError( QStringLiteral( "GEOS Exception: Could not create closed coordinate sequence for %1 points" ).arg( numPoints + 1 ) );
@@ -2312,7 +2341,7 @@ GEOSCoordSequence *QgsGeos::createCoordinateSequence( const QgsCurve *curve, dou
 
   try
   {
-    coordSeq = GEOSCoordSeq_create_r( ctxt, numOutPoints, coordDims );
+    coordSeq = GEOSCoordSeq_create_r( context, numOutPoints, coordDims );
     if ( !coordSeq )
     {
       QgsDebugError( QStringLiteral( "GEOS Exception: Could not create coordinate sequence for %1 points in %2 dimensions" ).arg( numPoints ).arg( coordDims ) );
@@ -2338,15 +2367,15 @@ GEOSCoordSequence *QgsGeos::createCoordinateSequence( const QgsCurve *curve, dou
         }
         if ( hasZ )
         {
-          GEOSCoordSeq_setXYZ_r( ctxt, coordSeq, i, std::round( *xData++ / precision ) * precision, std::round( *yData++ / precision ) * precision, std::round( *zData++ / precision ) * precision );
+          GEOSCoordSeq_setXYZ_r( context, coordSeq, i, std::round( *xData++ / precision ) * precision, std::round( *yData++ / precision ) * precision, std::round( *zData++ / precision ) * precision );
         }
         else
         {
-          GEOSCoordSeq_setXY_r( ctxt, coordSeq, i, std::round( *xData++ / precision ) * precision, std::round( *yData++ / precision ) * precision );
+          GEOSCoordSeq_setXY_r( context, coordSeq, i, std::round( *xData++ / precision ) * precision, std::round( *yData++ / precision ) * precision );
         }
         if ( hasM )
         {
-          GEOSCoordSeq_setOrdinate_r( ctxt, coordSeq, i, 3, *mData++ );
+          GEOSCoordSeq_setOrdinate_r( context, coordSeq, i, 3, *mData++ );
         }
       }
     }
@@ -2364,15 +2393,15 @@ GEOSCoordSequence *QgsGeos::createCoordinateSequence( const QgsCurve *curve, dou
         }
         if ( hasZ )
         {
-          GEOSCoordSeq_setXYZ_r( ctxt, coordSeq, i, *xData++, *yData++, *zData++ );
+          GEOSCoordSeq_setXYZ_r( context, coordSeq, i, *xData++, *yData++, *zData++ );
         }
         else
         {
-          GEOSCoordSeq_setXY_r( ctxt, coordSeq, i, *xData++, *yData++ );
+          GEOSCoordSeq_setXY_r( context, coordSeq, i, *xData++, *yData++ );
         }
         if ( hasM )
         {
-          GEOSCoordSeq_setOrdinate_r( ctxt, coordSeq, i, 3, *mData++ );
+          GEOSCoordSeq_setOrdinate_r( context, coordSeq, i, 3, *mData++ );
         }
       }
     }
@@ -2397,19 +2426,20 @@ geos::unique_ptr QgsGeos::createGeosPointXY( double x, double y, bool hasZ, doub
   Q_UNUSED( m )
 
   geos::unique_ptr geosPoint;
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     if ( coordDims == 2 )
     {
       // optimised constructor
       if ( precision > 0. )
-        geosPoint.reset( GEOSGeom_createPointFromXY_r( geosinit()->ctxt, std::round( x / precision ) * precision, std::round( y / precision ) * precision ) );
+        geosPoint.reset( GEOSGeom_createPointFromXY_r( context, std::round( x / precision ) * precision, std::round( y / precision ) * precision ) );
       else
-        geosPoint.reset( GEOSGeom_createPointFromXY_r( geosinit()->ctxt, x, y ) );
+        geosPoint.reset( GEOSGeom_createPointFromXY_r( context, x, y ) );
       return geosPoint;
     }
 
-    GEOSCoordSequence *coordSeq = GEOSCoordSeq_create_r( geosinit()->ctxt, 1, coordDims );
+    GEOSCoordSequence *coordSeq = GEOSCoordSeq_create_r( context, 1, coordDims );
     if ( !coordSeq )
     {
       QgsDebugError( QStringLiteral( "GEOS Exception: Could not create coordinate sequence for point with %1 dimensions" ).arg( coordDims ) );
@@ -2417,29 +2447,29 @@ geos::unique_ptr QgsGeos::createGeosPointXY( double x, double y, bool hasZ, doub
     }
     if ( precision > 0. )
     {
-      GEOSCoordSeq_setX_r( geosinit()->ctxt, coordSeq, 0, std::round( x / precision ) * precision );
-      GEOSCoordSeq_setY_r( geosinit()->ctxt, coordSeq, 0, std::round( y / precision ) * precision );
+      GEOSCoordSeq_setX_r( context, coordSeq, 0, std::round( x / precision ) * precision );
+      GEOSCoordSeq_setY_r( context, coordSeq, 0, std::round( y / precision ) * precision );
       if ( hasZ )
       {
-        GEOSCoordSeq_setOrdinate_r( geosinit()->ctxt, coordSeq, 0, 2, std::round( z / precision ) * precision );
+        GEOSCoordSeq_setOrdinate_r( context, coordSeq, 0, 2, std::round( z / precision ) * precision );
       }
     }
     else
     {
-      GEOSCoordSeq_setX_r( geosinit()->ctxt, coordSeq, 0, x );
-      GEOSCoordSeq_setY_r( geosinit()->ctxt, coordSeq, 0, y );
+      GEOSCoordSeq_setX_r( context, coordSeq, 0, x );
+      GEOSCoordSeq_setY_r( context, coordSeq, 0, y );
       if ( hasZ )
       {
-        GEOSCoordSeq_setOrdinate_r( geosinit()->ctxt, coordSeq, 0, 2, z );
+        GEOSCoordSeq_setOrdinate_r( context, coordSeq, 0, 2, z );
       }
     }
 #if 0 //disabled until geos supports m-coordinates
     if ( hasM )
     {
-      GEOSCoordSeq_setOrdinate_r( geosinit()->ctxt, coordSeq, 0, 3, m );
+      GEOSCoordSeq_setOrdinate_r( context, coordSeq, 0, 3, m );
     }
 #endif
-    geosPoint.reset( GEOSGeom_createPoint_r( geosinit()->ctxt, coordSeq ) );
+    geosPoint.reset( GEOSGeom_createPoint_r( context, coordSeq ) );
   }
   CATCH_GEOS( nullptr )
   return geosPoint;
@@ -2458,7 +2488,7 @@ geos::unique_ptr QgsGeos::createGeosLinestring( const QgsAbstractGeometry *curve
   geos::unique_ptr geosGeom;
   try
   {
-    geosGeom.reset( GEOSGeom_createLineString_r( geosinit()->ctxt, coordSeq ) );
+    geosGeom.reset( GEOSGeom_createLineString_r( QgsGeosContext::get(), coordSeq ) );
   }
   CATCH_GEOS( nullptr )
   return geosGeom;
@@ -2476,10 +2506,11 @@ geos::unique_ptr QgsGeos::createGeosPolygon( const QgsAbstractGeometry *poly, do
     return nullptr;
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   geos::unique_ptr geosPolygon;
   try
   {
-    geos::unique_ptr exteriorRingGeos( GEOSGeom_createLinearRing_r( geosinit()->ctxt, createCoordinateSequence( exteriorRing, precision, true ) ) );
+    geos::unique_ptr exteriorRingGeos( GEOSGeom_createLinearRing_r( context, createCoordinateSequence( exteriorRing, precision, true ) ) );
 
     int nHoles = polygon->numInteriorRings();
     GEOSGeometry **holes = nullptr;
@@ -2491,9 +2522,9 @@ geos::unique_ptr QgsGeos::createGeosPolygon( const QgsAbstractGeometry *poly, do
     for ( int i = 0; i < nHoles; ++i )
     {
       const QgsCurve *interiorRing = polygon->interiorRing( i );
-      holes[i] = GEOSGeom_createLinearRing_r( geosinit()->ctxt, createCoordinateSequence( interiorRing, precision, true ) );
+      holes[i] = GEOSGeom_createLinearRing_r( context, createCoordinateSequence( interiorRing, precision, true ) );
     }
-    geosPolygon.reset( GEOSGeom_createPolygon_r( geosinit()->ctxt, exteriorRingGeos.release(), holes, nHoles ) );
+    geosPolygon.reset( GEOSGeom_createPolygon_r( context, exteriorRingGeos.release(), holes, nHoles ) );
     delete[] holes;
   }
   CATCH_GEOS( nullptr )
@@ -2513,7 +2544,7 @@ QgsAbstractGeometry *QgsGeos::offsetCurve( double distance, int segments, Qgis::
     // https://github.com/qgis/QGIS/issues/53165#issuecomment-1563470832
     if ( segments < 8 )
       segments = 8;
-    offset.reset( GEOSOffsetCurve_r( geosinit()->ctxt, mGeos.get(), distance, segments, static_cast< int >( joinStyle ), miterLimit ) );
+    offset.reset( GEOSOffsetCurve_r( QgsGeosContext::get(), mGeos.get(), distance, segments, static_cast< int >( joinStyle ), miterLimit ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   std::unique_ptr< QgsAbstractGeometry > offsetGeom = fromGeos( offset.get() );
@@ -2528,19 +2559,20 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer( double distance
   }
 
   geos::unique_ptr geos;
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    geos::buffer_params_unique_ptr bp( GEOSBufferParams_create_r( geosinit()->ctxt ) );
-    GEOSBufferParams_setSingleSided_r( geosinit()->ctxt, bp.get(), 1 );
-    GEOSBufferParams_setQuadrantSegments_r( geosinit()->ctxt, bp.get(), segments );
-    GEOSBufferParams_setJoinStyle_r( geosinit()->ctxt, bp.get(), static_cast< int >( joinStyle ) );
-    GEOSBufferParams_setMitreLimit_r( geosinit()->ctxt, bp.get(), miterLimit );  //#spellok
+    geos::buffer_params_unique_ptr bp( GEOSBufferParams_create_r( context ) );
+    GEOSBufferParams_setSingleSided_r( context, bp.get(), 1 );
+    GEOSBufferParams_setQuadrantSegments_r( context, bp.get(), segments );
+    GEOSBufferParams_setJoinStyle_r( context, bp.get(), static_cast< int >( joinStyle ) );
+    GEOSBufferParams_setMitreLimit_r( context, bp.get(), miterLimit );  //#spellok
 
     if ( side == Qgis::BufferSide::Right )
     {
       distance = -distance;
     }
-    geos.reset( GEOSBufferWithParams_r( geosinit()->ctxt, mGeos.get(), bp.get(), distance ) );
+    geos.reset( GEOSBufferWithParams_r( context, mGeos.get(), bp.get(), distance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
@@ -2556,7 +2588,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::maximumInscribedCircle( double tol
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSMaximumInscribedCircle_r( geosinit()->ctxt, mGeos.get(), tolerance ) );
+    geos.reset( GEOSMaximumInscribedCircle_r( QgsGeosContext::get(), mGeos.get(), tolerance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
@@ -2576,7 +2608,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::largestEmptyCircle( double toleran
     if ( boundary )
       boundaryGeos = asGeos( boundary );
 
-    geos.reset( GEOSLargestEmptyCircle_r( geosinit()->ctxt, mGeos.get(), boundaryGeos.get(), tolerance ) );
+    geos.reset( GEOSLargestEmptyCircle_r( QgsGeosContext::get(), mGeos.get(), boundaryGeos.get(), tolerance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
@@ -2592,7 +2624,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumWidth( QString *errorMsg ) 
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSMinimumWidth_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSMinimumWidth_r( QgsGeosContext::get(), mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
@@ -2609,7 +2641,7 @@ double QgsGeos::minimumClearance( QString *errorMsg ) const
   double res = 0;
   try
   {
-    if ( GEOSMinimumClearance_r( geosinit()->ctxt, mGeos.get(), &res ) != 0 )
+    if ( GEOSMinimumClearance_r( QgsGeosContext::get(), mGeos.get(), &res ) != 0 )
       return std::numeric_limits< double >::quiet_NaN();
   }
   CATCH_GEOS_WITH_ERRMSG( std::numeric_limits< double >::quiet_NaN() )
@@ -2626,7 +2658,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumClearanceLine( QString *err
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSMinimumClearanceLine_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSMinimumClearanceLine_r( QgsGeosContext::get(), mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
@@ -2642,7 +2674,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::node( QString *errorMsg ) const
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSNode_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSNode_r( QgsGeosContext::get(), mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
@@ -2662,7 +2694,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::sharedPaths( const QgsAbstractGeom
     if ( !otherGeos )
       return nullptr;
 
-    geos.reset( GEOSSharedPaths_r( geosinit()->ctxt, mGeos.get(), otherGeos.get() ) );
+    geos.reset( GEOSSharedPaths_r( QgsGeosContext::get(), mGeos.get(), otherGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
@@ -2684,8 +2716,9 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
 
   geos::unique_ptr reshapeLineGeos = createGeosLinestring( &reshapeWithLine, mPrecision );
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   //single or multi?
-  int numGeoms = GEOSGetNumGeometries_r( geosinit()->ctxt, mGeos.get() );
+  int numGeoms = GEOSGetNumGeometries_r( context, mGeos.get() );
   if ( numGeoms == -1 )
   {
     if ( errorCode )
@@ -2696,7 +2729,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
   }
 
   bool isMultiGeom = false;
-  int geosTypeId = GEOSGeomTypeId_r( geosinit()->ctxt, mGeos.get() );
+  int geosTypeId = GEOSGeomTypeId_r( context, mGeos.get() );
   if ( geosTypeId == GEOS_MULTILINESTRING || geosTypeId == GEOS_MULTIPOLYGON )
     isMultiGeom = true;
 
@@ -2732,9 +2765,9 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
       for ( int i = 0; i < numGeoms; ++i )
       {
         if ( isLine )
-          currentReshapeGeometry = reshapeLine( GEOSGetGeometryN_r( geosinit()->ctxt, mGeos.get(), i ), reshapeLineGeos.get(), mPrecision );
+          currentReshapeGeometry = reshapeLine( GEOSGetGeometryN_r( context, mGeos.get(), i ), reshapeLineGeos.get(), mPrecision );
         else
-          currentReshapeGeometry = reshapePolygon( GEOSGetGeometryN_r( geosinit()->ctxt, mGeos.get(), i ), reshapeLineGeos.get(), mPrecision );
+          currentReshapeGeometry = reshapePolygon( GEOSGetGeometryN_r( context, mGeos.get(), i ), reshapeLineGeos.get(), mPrecision );
 
         if ( currentReshapeGeometry )
         {
@@ -2743,18 +2776,18 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
         }
         else
         {
-          newGeoms[i] = GEOSGeom_clone_r( geosinit()->ctxt, GEOSGetGeometryN_r( geosinit()->ctxt, mGeos.get(), i ) );
+          newGeoms[i] = GEOSGeom_clone_r( context, GEOSGetGeometryN_r( context, mGeos.get(), i ) );
         }
       }
 
       geos::unique_ptr newMultiGeom;
       if ( isLine )
       {
-        newMultiGeom.reset( GEOSGeom_createCollection_r( geosinit()->ctxt, GEOS_MULTILINESTRING, newGeoms, numGeoms ) );
+        newMultiGeom.reset( GEOSGeom_createCollection_r( context, GEOS_MULTILINESTRING, newGeoms, numGeoms ) );
       }
       else //multipolygon
       {
-        newMultiGeom.reset( GEOSGeom_createCollection_r( geosinit()->ctxt, GEOS_MULTIPOLYGON, newGeoms, numGeoms ) );
+        newMultiGeom.reset( GEOSGeom_createCollection_r( context, GEOS_MULTIPOLYGON, newGeoms, numGeoms ) );
       }
 
       delete[] newGeoms;
@@ -2791,13 +2824,14 @@ QgsGeometry QgsGeos::mergeLines( QString *errorMsg ) const
     return QgsGeometry();
   }
 
-  if ( GEOSGeomTypeId_r( geosinit()->ctxt, mGeos.get() ) != GEOS_MULTILINESTRING )
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  if ( GEOSGeomTypeId_r( context, mGeos.get() ) != GEOS_MULTILINESTRING )
     return QgsGeometry();
 
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSLineMerge_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSLineMerge_r( context, mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( QgsGeometry() )
   return QgsGeometry( fromGeos( geos.get() ) );
@@ -2816,6 +2850,7 @@ QgsGeometry QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg )
     return QgsGeometry();
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   double nx = 0.0;
   double ny = 0.0;
   try
@@ -2823,15 +2858,15 @@ QgsGeometry QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg )
     geos::coord_sequence_unique_ptr nearestCoord;
     if ( mGeosPrepared ) // use faster version with prepared geometry
     {
-      nearestCoord.reset( GEOSPreparedNearestPoints_r( geosinit()->ctxt, mGeosPrepared.get(), otherGeom.get() ) );
+      nearestCoord.reset( GEOSPreparedNearestPoints_r( context, mGeosPrepared.get(), otherGeom.get() ) );
     }
     else
     {
-      nearestCoord.reset( GEOSNearestPoints_r( geosinit()->ctxt, mGeos.get(), otherGeom.get() ) );
+      nearestCoord.reset( GEOSNearestPoints_r( context, mGeos.get(), otherGeom.get() ) );
     }
 
-    ( void )GEOSCoordSeq_getX_r( geosinit()->ctxt, nearestCoord.get(), 0, &nx );
-    ( void )GEOSCoordSeq_getY_r( geosinit()->ctxt, nearestCoord.get(), 0, &ny );
+    ( void )GEOSCoordSeq_getX_r( context, nearestCoord.get(), 0, &nx );
+    ( void )GEOSCoordSeq_getY_r( context, nearestCoord.get(), 0, &ny );
   }
   catch ( GEOSException &e )
   {
@@ -2867,13 +2902,14 @@ QgsGeometry QgsGeos::shortestLine( const QgsAbstractGeometry *other, QString *er
     return QgsGeometry();
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   double nx1 = 0.0;
   double ny1 = 0.0;
   double nx2 = 0.0;
   double ny2 = 0.0;
   try
   {
-    geos::coord_sequence_unique_ptr nearestCoord( GEOSNearestPoints_r( geosinit()->ctxt, mGeos.get(), otherGeom.get() ) );
+    geos::coord_sequence_unique_ptr nearestCoord( GEOSNearestPoints_r( context, mGeos.get(), otherGeom.get() ) );
 
     if ( !nearestCoord )
     {
@@ -2882,10 +2918,10 @@ QgsGeometry QgsGeos::shortestLine( const QgsAbstractGeometry *other, QString *er
       return QgsGeometry();
     }
 
-    ( void )GEOSCoordSeq_getX_r( geosinit()->ctxt, nearestCoord.get(), 0, &nx1 );
-    ( void )GEOSCoordSeq_getY_r( geosinit()->ctxt, nearestCoord.get(), 0, &ny1 );
-    ( void )GEOSCoordSeq_getX_r( geosinit()->ctxt, nearestCoord.get(), 1, &nx2 );
-    ( void )GEOSCoordSeq_getY_r( geosinit()->ctxt, nearestCoord.get(), 1, &ny2 );
+    ( void )GEOSCoordSeq_getX_r( context, nearestCoord.get(), 0, &nx1 );
+    ( void )GEOSCoordSeq_getY_r( context, nearestCoord.get(), 0, &ny1 );
+    ( void )GEOSCoordSeq_getX_r( context, nearestCoord.get(), 1, &nx2 );
+    ( void )GEOSCoordSeq_getY_r( context, nearestCoord.get(), 1, &ny2 );
   }
   catch ( GEOSException &e )
   {
@@ -2919,7 +2955,7 @@ double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) cons
   double distance = -1;
   try
   {
-    distance = GEOSProject_r( geosinit()->ctxt, mGeos.get(), otherGeom.get() );
+    distance = GEOSProject_r( QgsGeosContext::get(), mGeos.get(), otherGeom.get() );
   }
   catch ( GEOSException &e )
   {
@@ -2948,7 +2984,7 @@ double QgsGeos::lineLocatePoint( double x, double y, QString *errorMsg ) const
   double distance = -1;
   try
   {
-    distance = GEOSProject_r( geosinit()->ctxt, mGeos.get(), point.get() );
+    distance = GEOSProject_r( QgsGeosContext::get(), mGeos.get(), point.get() );
   }
   catch ( GEOSException &e )
   {
@@ -2977,12 +3013,13 @@ QgsGeometry QgsGeos::polygonize( const QVector<const QgsAbstractGeometry *> &geo
     }
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    geos::unique_ptr result( GEOSPolygonize_r( geosinit()->ctxt, lineGeosGeometries, validLines ) );
+    geos::unique_ptr result( GEOSPolygonize_r( context, lineGeosGeometries, validLines ) );
     for ( int i = 0; i < validLines; ++i )
     {
-      GEOSGeom_destroy_r( geosinit()->ctxt, lineGeosGeometries[i] );
+      GEOSGeom_destroy_r( context, lineGeosGeometries[i] );
     }
     delete[] lineGeosGeometries;
     return QgsGeometry( fromGeos( result.get() ) );
@@ -2995,7 +3032,7 @@ QgsGeometry QgsGeos::polygonize( const QVector<const QgsAbstractGeometry *> &geo
     }
     for ( int i = 0; i < validLines; ++i )
     {
-      GEOSGeom_destroy_r( geosinit()->ctxt, lineGeosGeometries[i] );
+      GEOSGeom_destroy_r( context, lineGeosGeometries[i] );
     }
     delete[] lineGeosGeometries;
     return QgsGeometry();
@@ -3020,11 +3057,12 @@ QgsGeometry QgsGeos::voronoiDiagram( const QgsAbstractGeometry *extent, double t
   }
 
   geos::unique_ptr geos;
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    geos.reset( GEOSVoronoiDiagram_r( geosinit()->ctxt, mGeos.get(), extentGeosGeom.get(), tolerance, edgesOnly ) );
+    geos.reset( GEOSVoronoiDiagram_r( context, mGeos.get(), extentGeosGeom.get(), tolerance, edgesOnly ) );
 
-    if ( !geos || GEOSisEmpty_r( geosinit()->ctxt, geos.get() ) != 0 )
+    if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )
     {
       return QgsGeometry();
     }
@@ -3041,12 +3079,13 @@ QgsGeometry QgsGeos::delaunayTriangulation( double tolerance, bool edgesOnly, QS
     return QgsGeometry();
   }
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSDelaunayTriangulation_r( geosinit()->ctxt, mGeos.get(), tolerance, edgesOnly ) );
+    geos.reset( GEOSDelaunayTriangulation_r( context, mGeos.get(), tolerance, edgesOnly ) );
 
-    if ( !geos || GEOSisEmpty_r( geosinit()->ctxt, geos.get() ) != 0 )
+    if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )
     {
       return QgsGeometry();
     }
@@ -3068,11 +3107,12 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::constrainedDelaunayTriangulation( 
   }
 
   geos::unique_ptr geos;
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    geos.reset( GEOSConstrainedDelaunayTriangulation_r( geosinit()->ctxt, mGeos.get() ) );
+    geos.reset( GEOSConstrainedDelaunayTriangulation_r( context, mGeos.get() ) );
 
-    if ( !geos || GEOSisEmpty_r( geosinit()->ctxt, geos.get() ) != 0 )
+    if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )
     {
       return nullptr;
     }
@@ -3094,21 +3134,22 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::constrainedDelaunayTriangulation( 
 //! Extract coordinates of linestring's endpoints. Returns false on error.
 static bool _linestringEndpoints( const GEOSGeometry *linestring, double &x1, double &y1, double &x2, double &y2 )
 {
-  const GEOSCoordSequence *coordSeq = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, linestring );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  const GEOSCoordSequence *coordSeq = GEOSGeom_getCoordSeq_r( context, linestring );
   if ( !coordSeq )
     return false;
 
   unsigned int coordSeqSize;
-  if ( GEOSCoordSeq_getSize_r( geosinit()->ctxt, coordSeq, &coordSeqSize ) == 0 )
+  if ( GEOSCoordSeq_getSize_r( context, coordSeq, &coordSeqSize ) == 0 )
     return false;
 
   if ( coordSeqSize < 2 )
     return false;
 
-  GEOSCoordSeq_getX_r( geosinit()->ctxt, coordSeq, 0, &x1 );
-  GEOSCoordSeq_getY_r( geosinit()->ctxt, coordSeq, 0, &y1 );
-  GEOSCoordSeq_getX_r( geosinit()->ctxt, coordSeq, coordSeqSize - 1, &x2 );
-  GEOSCoordSeq_getY_r( geosinit()->ctxt, coordSeq, coordSeqSize - 1, &y2 );
+  GEOSCoordSeq_getX_r( context, coordSeq, 0, &x1 );
+  GEOSCoordSeq_getY_r( context, coordSeq, 0, &y1 );
+  GEOSCoordSeq_getX_r( context, coordSeq, coordSeqSize - 1, &x2 );
+  GEOSCoordSeq_getY_r( context, coordSeq, coordSeqSize - 1, &y2 );
   return true;
 }
 
@@ -3131,14 +3172,15 @@ static geos::unique_ptr _mergeLinestrings( const GEOSGeometry *line1, const GEOS
     ( intersectionPoint.x() == rx1 && intersectionPoint.y() == ry1 ) ||
     ( intersectionPoint.x() == rx2 && intersectionPoint.y() == ry2 );
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   // the intersection must be at the begin/end of both lines
   if ( intersectionAtOrigLineEndpoint && intersectionAtReshapeLineEndpoint )
   {
-    geos::unique_ptr g1( GEOSGeom_clone_r( geosinit()->ctxt, line1 ) );
-    geos::unique_ptr g2( GEOSGeom_clone_r( geosinit()->ctxt, line2 ) );
+    geos::unique_ptr g1( GEOSGeom_clone_r( context, line1 ) );
+    geos::unique_ptr g2( GEOSGeom_clone_r( context, line2 ) );
     GEOSGeometry *geoms[2] = { g1.release(), g2.release() };
-    geos::unique_ptr multiGeom( GEOSGeom_createCollection_r( geosinit()->ctxt, GEOS_MULTILINESTRING, geoms, 2 ) );
-    geos::unique_ptr res( GEOSLineMerge_r( geosinit()->ctxt, multiGeom.get() ) );
+    geos::unique_ptr multiGeom( GEOSGeom_createCollection_r( context, GEOS_MULTILINESTRING, geoms, 2 ) );
+    geos::unique_ptr res( GEOSLineMerge_r( context, multiGeom.get() ) );
     return res;
   }
   else
@@ -3155,23 +3197,24 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
   bool oneIntersection = false;
   QgsPointXY oneIntersectionPoint;
 
+  GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
     //make sure there are at least two intersection between line and reshape geometry
-    geos::unique_ptr intersectGeom( GEOSIntersection_r( geosinit()->ctxt, line, reshapeLineGeos ) );
+    geos::unique_ptr intersectGeom( GEOSIntersection_r( context, line, reshapeLineGeos ) );
     if ( intersectGeom )
     {
-      const int geomType = GEOSGeomTypeId_r( geosinit()->ctxt, intersectGeom.get() );
-      atLeastTwoIntersections = ( geomType == GEOS_MULTIPOINT && GEOSGetNumGeometries_r( geosinit()->ctxt, intersectGeom.get() ) > 1 )
-                                || ( geomType == GEOS_GEOMETRYCOLLECTION && GEOSGetNumGeometries_r( geosinit()->ctxt, intersectGeom.get() ) > 0 ) // a collection implies at least two points!
-                                || ( geomType == GEOS_MULTILINESTRING && GEOSGetNumGeometries_r( geosinit()->ctxt, intersectGeom.get() ) > 0 );
+      const int geomType = GEOSGeomTypeId_r( context, intersectGeom.get() );
+      atLeastTwoIntersections = ( geomType == GEOS_MULTIPOINT && GEOSGetNumGeometries_r( context, intersectGeom.get() ) > 1 )
+                                || ( geomType == GEOS_GEOMETRYCOLLECTION && GEOSGetNumGeometries_r( context, intersectGeom.get() ) > 0 ) // a collection implies at least two points!
+                                || ( geomType == GEOS_MULTILINESTRING && GEOSGetNumGeometries_r( context, intersectGeom.get() ) > 0 );
       // one point is enough when extending line at its endpoint
-      if ( GEOSGeomTypeId_r( geosinit()->ctxt, intersectGeom.get() ) == GEOS_POINT )
+      if ( GEOSGeomTypeId_r( context, intersectGeom.get() ) == GEOS_POINT )
       {
-        const GEOSCoordSequence *intersectionCoordSeq = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, intersectGeom.get() );
+        const GEOSCoordSequence *intersectionCoordSeq = GEOSGeom_getCoordSeq_r( context, intersectGeom.get() );
         double xi, yi;
-        GEOSCoordSeq_getX_r( geosinit()->ctxt, intersectionCoordSeq, 0, &xi );
-        GEOSCoordSeq_getY_r( geosinit()->ctxt, intersectionCoordSeq, 0, &yi );
+        GEOSCoordSeq_getX_r( context, intersectionCoordSeq, 0, &xi );
+        GEOSCoordSeq_getY_r( context, intersectionCoordSeq, 0, &yi );
         oneIntersection = true;
         oneIntersectionPoint = QgsPointXY( xi, yi );
       }
@@ -3198,8 +3241,8 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
   geos::unique_ptr endLineVertex = createGeosPointXY( x2, y2, false, 0, false, 0, 2, precision );
 
   bool isRing = false;
-  if ( GEOSGeomTypeId_r( geosinit()->ctxt, line ) == GEOS_LINEARRING
-       || GEOSEquals_r( geosinit()->ctxt, beginLineVertex.get(), endLineVertex.get() ) == 1 )
+  if ( GEOSGeomTypeId_r( context, line ) == GEOS_LINEARRING
+       || GEOSEquals_r( context, beginLineVertex.get(), endLineVertex.get() ) == 1 )
     isRing = true;
 
   //node line and reshape line
@@ -3210,18 +3253,18 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
   }
 
   //and merge them together
-  geos::unique_ptr mergedLines( GEOSLineMerge_r( geosinit()->ctxt, nodedGeometry.get() ) );
+  geos::unique_ptr mergedLines( GEOSLineMerge_r( context, nodedGeometry.get() ) );
   if ( !mergedLines )
   {
     return nullptr;
   }
 
-  int numMergedLines = GEOSGetNumGeometries_r( geosinit()->ctxt, mergedLines.get() );
+  int numMergedLines = GEOSGetNumGeometries_r( context, mergedLines.get() );
   if ( numMergedLines < 2 ) //some special cases. Normally it is >2
   {
     if ( numMergedLines == 1 ) //reshape line is from begin to endpoint. So we keep the reshapeline
     {
-      geos::unique_ptr result( GEOSGeom_clone_r( geosinit()->ctxt, reshapeLineGeos ) );
+      geos::unique_ptr result( GEOSGeom_clone_r( context, reshapeLineGeos ) );
       return result;
     }
     else
@@ -3233,7 +3276,7 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
 
   for ( int i = 0; i < numMergedLines; ++i )
   {
-    const GEOSGeometry *currentGeom = GEOSGetGeometryN_r( geosinit()->ctxt, mergedLines.get(), i );
+    const GEOSGeometry *currentGeom = GEOSGetGeometryN_r( context, mergedLines.get(), i );
 
     // have we already added this part?
     bool alreadyAdded = false;
@@ -3241,7 +3284,7 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
     double bufferDistance = std::pow( 10.0L, geomDigits( currentGeom ) - 11 );
     for ( const GEOSGeometry *other : std::as_const( resultLineParts ) )
     {
-      GEOSHausdorffDistance_r( geosinit()->ctxt, currentGeom, other, &distance );
+      GEOSHausdorffDistance_r( context, currentGeom, other, &distance );
       if ( distance < bufferDistance )
       {
         alreadyAdded = true;
@@ -3251,18 +3294,18 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
     if ( alreadyAdded )
       continue;
 
-    const GEOSCoordSequence *currentCoordSeq = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, currentGeom );
+    const GEOSCoordSequence *currentCoordSeq = GEOSGeom_getCoordSeq_r( context, currentGeom );
     unsigned int currentCoordSeqSize;
-    GEOSCoordSeq_getSize_r( geosinit()->ctxt, currentCoordSeq, &currentCoordSeqSize );
+    GEOSCoordSeq_getSize_r( context, currentCoordSeq, &currentCoordSeqSize );
     if ( currentCoordSeqSize < 2 )
       continue;
 
     //get the two endpoints of the current line merge result
     double xBegin, xEnd, yBegin, yEnd;
-    GEOSCoordSeq_getX_r( geosinit()->ctxt, currentCoordSeq, 0, &xBegin );
-    GEOSCoordSeq_getY_r( geosinit()->ctxt, currentCoordSeq, 0, &yBegin );
-    GEOSCoordSeq_getX_r( geosinit()->ctxt, currentCoordSeq, currentCoordSeqSize - 1, &xEnd );
-    GEOSCoordSeq_getY_r( geosinit()->ctxt, currentCoordSeq, currentCoordSeqSize - 1, &yEnd );
+    GEOSCoordSeq_getX_r( context, currentCoordSeq, 0, &xBegin );
+    GEOSCoordSeq_getY_r( context, currentCoordSeq, 0, &yBegin );
+    GEOSCoordSeq_getX_r( context, currentCoordSeq, currentCoordSeqSize - 1, &xEnd );
+    GEOSCoordSeq_getY_r( context, currentCoordSeq, currentCoordSeqSize - 1, &yEnd );
     geos::unique_ptr beginCurrentGeomVertex = createGeosPointXY( xBegin, yBegin, false, 0, false, 0, 2, precision );
     geos::unique_ptr endCurrentGeomVertex = createGeosPointXY( xEnd, yEnd, false, 0, false, 0, 2, precision );
 
@@ -3276,12 +3319,12 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
 
     //check how many endpoints equal the endpoints of the original line
     int nEndpointsSameAsOriginalLine = 0;
-    if ( GEOSEquals_r( geosinit()->ctxt, beginCurrentGeomVertex.get(), beginLineVertex.get() ) == 1
-         || GEOSEquals_r( geosinit()->ctxt, beginCurrentGeomVertex.get(), endLineVertex.get() ) == 1 )
+    if ( GEOSEquals_r( context, beginCurrentGeomVertex.get(), beginLineVertex.get() ) == 1
+         || GEOSEquals_r( context, beginCurrentGeomVertex.get(), endLineVertex.get() ) == 1 )
       nEndpointsSameAsOriginalLine += 1;
 
-    if ( GEOSEquals_r( geosinit()->ctxt, endCurrentGeomVertex.get(), beginLineVertex.get() ) == 1
-         || GEOSEquals_r( geosinit()->ctxt, endCurrentGeomVertex.get(), endLineVertex.get() ) == 1 )
+    if ( GEOSEquals_r( context, endCurrentGeomVertex.get(), beginLineVertex.get() ) == 1
+         || GEOSEquals_r( context, endCurrentGeomVertex.get(), endLineVertex.get() ) == 1 )
       nEndpointsSameAsOriginalLine += 1;
 
     //check if the current geometry overlaps the original geometry (GEOSOverlap does not seem to work with linestrings)
@@ -3296,24 +3339,24 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
     //logic to decide if this part belongs to the result
     if ( !isRing && nEndpointsSameAsOriginalLine == 1 && nEndpointsOnOriginalLine == 2 && currentGeomOverlapsOriginalGeom )
     {
-      resultLineParts.push_back( GEOSGeom_clone_r( geosinit()->ctxt, currentGeom ) );
+      resultLineParts.push_back( GEOSGeom_clone_r( context, currentGeom ) );
     }
     //for closed rings, we take one segment from the candidate list
     else if ( isRing && nEndpointsOnOriginalLine == 2 && currentGeomOverlapsOriginalGeom )
     {
-      probableParts.push_back( GEOSGeom_clone_r( geosinit()->ctxt, currentGeom ) );
+      probableParts.push_back( GEOSGeom_clone_r( context, currentGeom ) );
     }
     else if ( nEndpointsOnOriginalLine == 2 && !currentGeomOverlapsOriginalGeom )
     {
-      resultLineParts.push_back( GEOSGeom_clone_r( geosinit()->ctxt, currentGeom ) );
+      resultLineParts.push_back( GEOSGeom_clone_r( context, currentGeom ) );
     }
     else if ( nEndpointsSameAsOriginalLine == 2 && !currentGeomOverlapsOriginalGeom )
     {
-      resultLineParts.push_back( GEOSGeom_clone_r( geosinit()->ctxt, currentGeom ) );
+      resultLineParts.push_back( GEOSGeom_clone_r( context, currentGeom ) );
     }
     else if ( currentGeomOverlapsOriginalGeom && currentGeomOverlapsReshapeLine )
     {
-      resultLineParts.push_back( GEOSGeom_clone_r( geosinit()->ctxt, currentGeom ) );
+      resultLineParts.push_back( GEOSGeom_clone_r( context, currentGeom ) );
     }
   }
 
@@ -3327,7 +3370,7 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
     for ( int i = 0; i < probableParts.size(); ++i )
     {
       currentGeom = probableParts.at( i );
-      GEOSLength_r( geosinit()->ctxt, currentGeom, &currentLength );
+      GEOSLength_r( context, currentGeom, &currentLength );
       if ( currentLength > maxLength )
       {
         maxLength = currentLength;
@@ -3335,7 +3378,7 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
       }
       else
       {
-        GEOSGeom_destroy_r( geosinit()->ctxt, currentGeom );
+        GEOSGeom_destroy_r( context, currentGeom );
       }
     }
     resultLineParts.push_back( maxGeom.release() );
@@ -3358,15 +3401,15 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
     }
 
     //create multiline from resultLineParts
-    geos::unique_ptr multiLineGeom( GEOSGeom_createCollection_r( geosinit()->ctxt, GEOS_MULTILINESTRING, lineArray, resultLineParts.size() ) );
+    geos::unique_ptr multiLineGeom( GEOSGeom_createCollection_r( context, GEOS_MULTILINESTRING, lineArray, resultLineParts.size() ) );
     delete [] lineArray;
 
     //then do a linemerge with the newly combined partstrings
-    result.reset( GEOSLineMerge_r( geosinit()->ctxt, multiLineGeom.get() ) );
+    result.reset( GEOSLineMerge_r( context, multiLineGeom.get() ) );
   }
 
   //now test if the result is a linestring. Otherwise something went wrong
-  if ( GEOSGeomTypeId_r( geosinit()->ctxt, result.get() ) != GEOS_LINESTRING )
+  if ( GEOSGeomTypeId_r( context, result.get() ) != GEOS_LINESTRING )
   {
     return nullptr;
   }
@@ -3381,13 +3424,14 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
   int lastIntersectingRing = -2;
   const GEOSGeometry *lastIntersectingGeom = nullptr;
 
-  int nRings = GEOSGetNumInteriorRings_r( geosinit()->ctxt, polygon );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  int nRings = GEOSGetNumInteriorRings_r( context, polygon );
   if ( nRings < 0 )
     return nullptr;
 
   //does outer ring intersect?
-  const GEOSGeometry *outerRing = GEOSGetExteriorRing_r( geosinit()->ctxt, polygon );
-  if ( GEOSIntersects_r( geosinit()->ctxt, outerRing, reshapeLineGeos ) == 1 )
+  const GEOSGeometry *outerRing = GEOSGetExteriorRing_r( context, polygon );
+  if ( GEOSIntersects_r( context, outerRing, reshapeLineGeos ) == 1 )
   {
     ++nIntersections;
     lastIntersectingRing = -1;
@@ -3401,8 +3445,8 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
   {
     for ( int i = 0; i < nRings; ++i )
     {
-      innerRings[i] = GEOSGetInteriorRingN_r( geosinit()->ctxt, polygon, i );
-      if ( GEOSIntersects_r( geosinit()->ctxt, innerRings[i], reshapeLineGeos ) == 1 )
+      innerRings[i] = GEOSGetInteriorRingN_r( context, polygon, i );
+      if ( GEOSIntersects_r( context, innerRings[i], reshapeLineGeos ) == 1 )
       {
         ++nIntersections;
         lastIntersectingRing = i;
@@ -3431,12 +3475,12 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
 
   //if reshaping took place, we need to reassemble the polygon and its rings
   GEOSGeometry *newRing = nullptr;
-  const GEOSCoordSequence *reshapeSequence = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, reshapeResult.get() );
-  GEOSCoordSequence *newCoordSequence = GEOSCoordSeq_clone_r( geosinit()->ctxt, reshapeSequence );
+  const GEOSCoordSequence *reshapeSequence = GEOSGeom_getCoordSeq_r( context, reshapeResult.get() );
+  GEOSCoordSequence *newCoordSequence = GEOSCoordSeq_clone_r( context, reshapeSequence );
 
   reshapeResult.reset();
 
-  newRing = GEOSGeom_createLinearRing_r( geosinit()->ctxt, newCoordSequence );
+  newRing = GEOSGeom_createLinearRing_r( context, newCoordSequence );
   if ( !newRing )
   {
     delete [] innerRings;
@@ -3447,13 +3491,13 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
   if ( lastIntersectingRing == -1 )
     newOuterRing = newRing;
   else
-    newOuterRing = GEOSGeom_clone_r( geosinit()->ctxt, outerRing );
+    newOuterRing = GEOSGeom_clone_r( context, outerRing );
 
   //check if all the rings are still inside the outer boundary
   QVector<GEOSGeometry *> ringList;
   if ( nRings > 0 )
   {
-    GEOSGeometry *outerRingPoly = GEOSGeom_createPolygon_r( geosinit()->ctxt, GEOSGeom_clone_r( geosinit()->ctxt, newOuterRing ), nullptr, 0 );
+    GEOSGeometry *outerRingPoly = GEOSGeom_createPolygon_r( context, GEOSGeom_clone_r( context, newOuterRing ), nullptr, 0 );
     if ( outerRingPoly )
     {
       ringList.reserve( nRings );
@@ -3463,16 +3507,16 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
         if ( lastIntersectingRing == i )
           currentRing = newRing;
         else
-          currentRing = GEOSGeom_clone_r( geosinit()->ctxt, innerRings[i] );
+          currentRing = GEOSGeom_clone_r( context, innerRings[i] );
 
         //possibly a ring is no longer contained in the result polygon after reshape
-        if ( GEOSContains_r( geosinit()->ctxt, outerRingPoly, currentRing ) == 1 )
+        if ( GEOSContains_r( context, outerRingPoly, currentRing ) == 1 )
           ringList.push_back( currentRing );
         else
-          GEOSGeom_destroy_r( geosinit()->ctxt, currentRing );
+          GEOSGeom_destroy_r( context, currentRing );
       }
     }
-    GEOSGeom_destroy_r( geosinit()->ctxt, outerRingPoly );
+    GEOSGeom_destroy_r( context, outerRingPoly );
   }
 
   GEOSGeometry **newInnerRings = new GEOSGeometry*[ringList.size()];
@@ -3481,7 +3525,7 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
 
   delete [] innerRings;
 
-  geos::unique_ptr reshapedPolygon( GEOSGeom_createPolygon_r( geosinit()->ctxt, newOuterRing, newInnerRings, ringList.size() ) );
+  geos::unique_ptr reshapedPolygon( GEOSGeom_createPolygon_r( context, newOuterRing, newInnerRings, ringList.size() ) );
   delete[] newInnerRings;
 
   return reshapedPolygon;
@@ -3496,18 +3540,19 @@ int QgsGeos::lineContainedInLine( const GEOSGeometry *line1, const GEOSGeometry 
 
   double bufferDistance = std::pow( 10.0L, geomDigits( line2 ) - 11 );
 
-  geos::unique_ptr bufferGeom( GEOSBuffer_r( geosinit()->ctxt, line2, bufferDistance, DEFAULT_QUADRANT_SEGMENTS ) );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  geos::unique_ptr bufferGeom( GEOSBuffer_r( context, line2, bufferDistance, DEFAULT_QUADRANT_SEGMENTS ) );
   if ( !bufferGeom )
     return -2;
 
-  geos::unique_ptr intersectionGeom( GEOSIntersection_r( geosinit()->ctxt, bufferGeom.get(), line1 ) );
+  geos::unique_ptr intersectionGeom( GEOSIntersection_r( context, bufferGeom.get(), line1 ) );
 
   //compare ratio between line1Length and intersectGeomLength (usually close to 1 if line1 is contained in line2)
   double intersectGeomLength;
   double line1Length;
 
-  GEOSLength_r( geosinit()->ctxt, intersectionGeom.get(), &intersectGeomLength );
-  GEOSLength_r( geosinit()->ctxt, line1, &line1Length );
+  GEOSLength_r( context, intersectionGeom.get(), &intersectGeomLength );
+  GEOSLength_r( context, line1, &line1Length );
 
   double intersectRatio = line1Length / intersectGeomLength;
   if ( intersectRatio > 0.9 && intersectRatio < 1.1 )
@@ -3523,12 +3568,13 @@ int QgsGeos::pointContainedInLine( const GEOSGeometry *point, const GEOSGeometry
 
   double bufferDistance = std::pow( 10.0L, geomDigits( line ) - 11 );
 
-  geos::unique_ptr lineBuffer( GEOSBuffer_r( geosinit()->ctxt, line, bufferDistance, 8 ) );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  geos::unique_ptr lineBuffer( GEOSBuffer_r( context, line, bufferDistance, 8 ) );
   if ( !lineBuffer )
     return -2;
 
   bool contained = false;
-  if ( GEOSContains_r( geosinit()->ctxt, lineBuffer.get(), point ) == 1 )
+  if ( GEOSContains_r( context, lineBuffer.get(), point ) == 1 )
     contained = true;
 
   return contained;
@@ -3536,44 +3582,40 @@ int QgsGeos::pointContainedInLine( const GEOSGeometry *point, const GEOSGeometry
 
 int QgsGeos::geomDigits( const GEOSGeometry *geom )
 {
-  geos::unique_ptr bbox( GEOSEnvelope_r( geosinit()->ctxt, geom ) );
+  GEOSContextHandle_t context = QgsGeosContext::get();
+  geos::unique_ptr bbox( GEOSEnvelope_r( context, geom ) );
   if ( !bbox.get() )
     return -1;
 
-  const GEOSGeometry *bBoxRing = GEOSGetExteriorRing_r( geosinit()->ctxt, bbox.get() );
+  const GEOSGeometry *bBoxRing = GEOSGetExteriorRing_r( context, bbox.get() );
   if ( !bBoxRing )
     return -1;
 
-  const GEOSCoordSequence *bBoxCoordSeq = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, bBoxRing );
+  const GEOSCoordSequence *bBoxCoordSeq = GEOSGeom_getCoordSeq_r( context, bBoxRing );
 
   if ( !bBoxCoordSeq )
     return -1;
 
   unsigned int nCoords = 0;
-  if ( !GEOSCoordSeq_getSize_r( geosinit()->ctxt, bBoxCoordSeq, &nCoords ) )
+  if ( !GEOSCoordSeq_getSize_r( context, bBoxCoordSeq, &nCoords ) )
     return -1;
 
   int maxDigits = -1;
   for ( unsigned int i = 0; i < nCoords - 1; ++i )
   {
     double t;
-    GEOSCoordSeq_getX_r( geosinit()->ctxt, bBoxCoordSeq, i, &t );
+    GEOSCoordSeq_getX_r( context, bBoxCoordSeq, i, &t );
 
     int digits;
     digits = std::ceil( std::log10( std::fabs( t ) ) );
     if ( digits > maxDigits )
       maxDigits = digits;
 
-    GEOSCoordSeq_getY_r( geosinit()->ctxt, bBoxCoordSeq, i, &t );
+    GEOSCoordSeq_getY_r( context, bBoxCoordSeq, i, &t );
     digits = std::ceil( std::log10( std::fabs( t ) ) );
     if ( digits > maxDigits )
       maxDigits = digits;
   }
 
   return maxDigits;
-}
-
-GEOSContextHandle_t QgsGeos::getGEOSHandler()
-{
-  return geosinit()->ctxt;
 }

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -102,12 +102,22 @@ thread_local QgsGeosContext QgsGeosContext::sGeosContext;
 
 QgsGeosContext::QgsGeosContext()
 {
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=5 )
+  mContext = GEOS_init_r();
+  GEOSContext_setNoticeHandler_r( mContext, printGEOSNotice );
+  GEOSContext_setErrorHandler_r( mContext, throwGEOSException );
+#else
   mContext = initGEOS_r( printGEOSNotice, throwGEOSException );
+#endif
 }
 
 QgsGeosContext::~QgsGeosContext()
 {
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=5 )
+  GEOS_finish_r( mContext );
+#else
   finishGEOS_r( mContext );
+#endif
 }
 
 GEOSContextHandle_t QgsGeosContext::get()

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -28,6 +28,36 @@ class QgsPolygon;
 class QgsGeometry;
 class QgsGeometryCollection;
 
+
+/**
+   * \class QgsGeosContext
+   * \ingroup core
+   * \brief Used to create and store a proj context object, correctly freeing the context upon destruction.
+   * \note Not available in Python bindings
+   * \since QGIS 3.38
+   */
+class CORE_EXPORT QgsGeosContext
+{
+  public:
+
+    QgsGeosContext();
+    ~QgsGeosContext();
+
+    /**
+     * Returns a thread local instance of a GEOS context, safe for use in the current thread.
+     */
+    static GEOSContextHandle_t get();
+
+  private:
+    GEOSContextHandle_t mContext = nullptr;
+
+    /**
+     * Thread local GEOS context storage. A new GEOS context will be created
+     * for every thread.
+     */
+    static thread_local QgsGeosContext sGeosContext;
+};
+
 /**
  * Contains geos related utilities and functions.
  * \note not available in Python bindings.
@@ -659,9 +689,6 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      */
     static geos::unique_ptr asGeos( const QgsAbstractGeometry *geometry, double precision = 0, bool allowInvalidSubGeom = true );
     static QgsPoint coordSeqPoint( const GEOSCoordSequence *cs, int i, bool hasZ, bool hasM );
-
-    static GEOSContextHandle_t getGEOSHandler();
-
 
   private:
     mutable geos::unique_ptr mGeos;

--- a/src/core/labeling/qgslabelfeature.cpp
+++ b/src/core/labeling/qgslabelfeature.cpp
@@ -51,7 +51,7 @@ void QgsLabelFeature::setPermissibleZone( const QgsGeometry &geometry )
   if ( !mPermissibleZoneGeos )
     return;
 
-  mPermissibleZoneGeosPrepared.reset( GEOSPrepare_r( QgsGeos::getGEOSHandler(), mPermissibleZoneGeos.get() ) );
+  mPermissibleZoneGeosPrepared.reset( GEOSPrepare_r( QgsGeosContext::get(), mPermissibleZoneGeos.get() ) );
 }
 
 QgsFeature QgsLabelFeature::feature() const

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -93,7 +93,7 @@ FeaturePart::~FeaturePart()
 void FeaturePart::extractCoords( const GEOSGeometry *geom )
 {
   const GEOSCoordSequence *coordSeq = nullptr;
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   type = GEOSGeomTypeId_r( geosctxt, geom );
 
@@ -410,7 +410,7 @@ std::unique_ptr<LabelPosition> FeaturePart::createCandidatePointOnSurface( Point
   double px, py;
   try
   {
-    GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+    GEOSContextHandle_t geosctxt = QgsGeosContext::get();
     geos::unique_ptr pointGeom( GEOSPointOnSurface_r( geosctxt, mapShape->geos() ) );
     if ( pointGeom )
     {
@@ -1995,7 +1995,7 @@ std::size_t FeaturePart::createCandidatesOutsidePolygon( std::vector<std::unique
   double cx, cy;
   getCentroid( cx, cy, false );
 
-  GEOSContextHandle_t ctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t ctxt = QgsGeosContext::get();
 
   // be a bit sneaky and only buffer out 50% here, and then do the remaining 50% when we make the label candidate itself.
   // this avoids candidates being created immediately over the buffered ring and always intersecting with it...
@@ -2253,7 +2253,7 @@ void FeaturePart::addSizePenalty( std::vector< std::unique_ptr< LabelPosition > 
   if ( !mGeos )
     createGeosGeom();
 
-  GEOSContextHandle_t ctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t ctxt = QgsGeosContext::get();
   int geomType = GEOSGeomTypeId_r( ctxt, mGeos );
 
   double sizeCost = 0;
@@ -2320,7 +2320,7 @@ bool FeaturePart::isConnected( FeaturePart *p2 )
   const double p2otherX = p2startTouches ? x2last : x2first;
   const double p2otherY = p2startTouches ? y2last : y2first;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   GEOSCoordSequence *coord = GEOSCoordSeq_create_r( geosctxt, 1, 2 );
   GEOSCoordSeq_setXY_r( geosctxt, coord, 0, p2otherX, p2otherY );
@@ -2345,7 +2345,7 @@ bool FeaturePart::mergeWithFeaturePart( FeaturePart *other )
   if ( !other->mGeos )
     other->createGeosGeom();
 
-  GEOSContextHandle_t ctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t ctxt = QgsGeosContext::get();
   try
   {
     GEOSGeometry *g1 = GEOSGeom_clone_r( ctxt, mGeos );

--- a/src/core/pal/geomfunction.cpp
+++ b/src/core/pal/geomfunction.cpp
@@ -308,7 +308,7 @@ bool GeomFunction::containsCandidate( const GEOSPreparedGeometry *geom, double x
 
   try
   {
-    GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+    GEOSContextHandle_t geosctxt = QgsGeosContext::get();
     GEOSCoordSequence *coord = GEOSCoordSeq_create_r( geosctxt, 5, 2 );
 
     GEOSCoordSeq_setXY_r( geosctxt, coord, 0, x, y );

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -169,7 +169,7 @@ LabelPosition::~LabelPosition()
 {
   if ( mPreparedOuterBoundsGeos )
   {
-    GEOSPreparedGeom_destroy_r( QgsGeos::getGEOSHandler(), mPreparedOuterBoundsGeos );
+    GEOSPreparedGeom_destroy_r( QgsGeosContext::get(), mPreparedOuterBoundsGeos );
     mPreparedOuterBoundsGeos = nullptr;
   }
 }
@@ -182,7 +182,7 @@ bool LabelPosition::intersects( const GEOSPreparedGeometry *geometry )
 
   try
   {
-    if ( GEOSPreparedIntersects_r( QgsGeos::getGEOSHandler(), geometry, mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
+    if ( GEOSPreparedIntersects_r( QgsGeosContext::get(), geometry, mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
     {
       return true;
     }
@@ -209,7 +209,7 @@ bool LabelPosition::within( const GEOSPreparedGeometry *geometry )
 
   try
   {
-    if ( GEOSPreparedContains_r( QgsGeos::getGEOSHandler(), geometry, mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) != 1 )
+    if ( GEOSPreparedContains_r( QgsGeosContext::get(), geometry, mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) != 1 )
     {
       return false;
     }
@@ -260,7 +260,7 @@ bool LabelPosition::isInConflict( const LabelPosition *lp ) const
       if ( !mOuterBoundsGeos && !mGeos )
         createGeosGeom();
 
-      GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+      GEOSContextHandle_t geosctxt = QgsGeosContext::get();
       try
       {
         const bool result = ( GEOSPreparedIntersects_r( geosctxt, lp->preparedOuterBoundsGeom() ? lp->preparedOuterBoundsGeom() : lp->preparedGeom(),
@@ -289,7 +289,7 @@ bool LabelPosition::isInConflictMultiPart( const LabelPosition *lp ) const
   if ( !lp->mMultipartGeos )
     lp->createMultiPartGeosGeom();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   try
   {
     const bool result = ( GEOSPreparedIntersects_r( geosctxt, preparedMultiPartGeom(), lp->mMultipartGeos ) == 1 );
@@ -311,7 +311,7 @@ void LabelPosition::createOuterBoundsGeom()
   if ( outerBounds.isNull() )
     return;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   const double beta = this->alpha + M_PI_2;
 
@@ -356,7 +356,7 @@ void LabelPosition::createOuterBoundsGeom()
 
   mOuterBoundsGeos.reset( GEOSGeom_createPolygon_r( geosctxt, GEOSGeom_createLinearRing_r( geosctxt, coord ), nullptr, 0 ) );
 
-  mPreparedOuterBoundsGeos = GEOSPrepare_r( QgsGeos::getGEOSHandler(), mOuterBoundsGeos.get() );
+  mPreparedOuterBoundsGeos = GEOSPrepare_r( QgsGeosContext::get(), mOuterBoundsGeos.get() );
 
   auto xminmax = std::minmax_element( mOuterBoundsX.begin(), mOuterBoundsX.end() );
   mOuterBoundsXMin = *xminmax.first;
@@ -505,7 +505,7 @@ void LabelPosition::insertIntoIndex( PalRtree<LabelPosition> &index )
 
 void LabelPosition::createMultiPartGeosGeom() const
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   std::vector< const GEOSGeometry * > geometries;
   const LabelPosition *tmp1 = this;
@@ -535,7 +535,7 @@ const GEOSPreparedGeometry *LabelPosition::preparedMultiPartGeom() const
 
   if ( !mMultipartPreparedGeos )
   {
-    mMultipartPreparedGeos = GEOSPrepare_r( QgsGeos::getGEOSHandler(), mMultipartGeos );
+    mMultipartPreparedGeos = GEOSPrepare_r( QgsGeosContext::get(), mMultipartGeos );
   }
   return mMultipartPreparedGeos;
 }
@@ -549,7 +549,7 @@ double LabelPosition::getDistanceToPoint( double xp, double yp, bool useOuterBou
 {
   // this method may consider the label's outer bounds!
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   //first check if inside, if so then distance is -1
   bool contains = false;
@@ -655,7 +655,7 @@ bool LabelPosition::crossesLine( PointSet *line ) const
   if ( !line->mGeos )
     line->createGeosGeom();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   try
   {
     if ( GEOSPreparedIntersects_r( geosctxt, line->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
@@ -686,7 +686,7 @@ bool LabelPosition::crossesBoundary( PointSet *polygon ) const
   if ( !polygon->mGeos )
     polygon->createGeosGeom();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   try
   {
     if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1
@@ -726,7 +726,7 @@ bool LabelPosition::intersectsWithPolygon( PointSet *polygon ) const
   if ( !polygon->mGeos )
     polygon->createGeosGeom();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   try
   {
     if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
@@ -759,7 +759,7 @@ double LabelPosition::polygonIntersectionCostForParts( PointSet *polygon ) const
   if ( !polygon->mGeos )
     polygon->createGeosGeom();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   double cost = 0;
   try
   {

--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -107,7 +107,7 @@ bool Layer::registerFeature( QgsLabelFeature *lf )
     throw InternalException::UnknownGeometry();
   }
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   const bool featureGeomIsObstacleGeom = lf->obstacleSettings().obstacleGeometry().isNull();
 
@@ -364,7 +364,7 @@ int Layer::connectedFeatureId( QgsFeatureId featureId ) const
 
 void Layer::chopFeaturesAtRepeatDistance()
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   std::deque< std::unique_ptr< FeaturePart > > newFeatureParts;
   while ( !mFeatureParts.empty() )
   {

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<Problem> Pal::extractProblem( const QgsRectangle &extent, const 
 
   // prepare map boundary
   geos::unique_ptr mapBoundaryGeos( QgsGeos::asGeos( mapBoundary ) );
-  geos::prepared_unique_ptr mapBoundaryPrepared( GEOSPrepare_r( QgsGeos::getGEOSHandler(), mapBoundaryGeos.get() ) );
+  geos::prepared_unique_ptr mapBoundaryPrepared( GEOSPrepare_r( QgsGeosContext::get(), mapBoundaryGeos.get() ) );
 
   int obstacleCount = 0;
 

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -92,14 +92,14 @@ PointSet::PointSet( const PointSet &ps )
 
   if ( ps.mGeos )
   {
-    mGeos = GEOSGeom_clone_r( QgsGeos::getGEOSHandler(), ps.mGeos );
+    mGeos = GEOSGeom_clone_r( QgsGeosContext::get(), ps.mGeos );
     mOwnsGeom = true;
   }
 }
 
 void PointSet::createGeosGeom() const
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   bool needClose = false;
   if ( type == GEOS_POLYGON && ( !qgsDoubleNear( x[0], x[ nbPoints - 1] ) || !qgsDoubleNear( y[0], y[ nbPoints - 1 ] ) ) )
@@ -159,14 +159,14 @@ const GEOSPreparedGeometry *PointSet::preparedGeom() const
 
   if ( !mPreparedGeom )
   {
-    mPreparedGeom = GEOSPrepare_r( QgsGeos::getGEOSHandler(), mGeos );
+    mPreparedGeom = GEOSPrepare_r( QgsGeosContext::get(), mGeos );
   }
   return mPreparedGeom;
 }
 
 void PointSet::invalidateGeos() const
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   if ( mOwnsGeom ) // delete old geometry if we own it
     GEOSGeom_destroy_r( geosctxt, mGeos );
   mOwnsGeom = false;
@@ -201,7 +201,7 @@ void PointSet::invalidateGeos() const
 
 PointSet::~PointSet()
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   if ( mGeos && mOwnsGeom )
   {
@@ -270,7 +270,7 @@ std::unique_ptr<PointSet> PointSet::clone() const
 
 bool PointSet::containsPoint( double x, double y ) const
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   try
   {
     geos::unique_ptr point( GEOSGeom_createPointFromXY_r( geosctxt, x, y ) );
@@ -551,7 +551,7 @@ void PointSet::offsetCurveByDistance( double distance )
   if ( !mGeos || type != GEOS_LINESTRING )
     return;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   geos::unique_ptr newGeos = nullptr;
   try
   {
@@ -866,7 +866,7 @@ double PointSet::minDistanceToPoint( double px, double py, double *rx, double *r
   if ( !mGeos )
     return 0;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
   try
   {
     geos::unique_ptr geosPt( GEOSGeom_createPointFromXY_r( geosctxt, px, py ) );
@@ -925,7 +925,7 @@ void PointSet::getCentroid( double &px, double &py, bool forceInside ) const
 
   try
   {
-    GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+    GEOSContextHandle_t geosctxt = QgsGeosContext::get();
     geos::unique_ptr centroidGeom( GEOSGetCentroid_r( geosctxt, mGeos ) );
     if ( centroidGeom )
     {
@@ -1020,7 +1020,7 @@ geos::unique_ptr PointSet::interpolatePoint( double distance ) const
 
   try
   {
-    geos::unique_ptr res( GEOSInterpolate_r( QgsGeos::getGEOSHandler(), thisGeos, distance ) );
+    geos::unique_ptr res( GEOSInterpolate_r( QgsGeosContext::get(), thisGeos, distance ) );
     return res;
   }
   catch ( GEOSException &e )
@@ -1039,7 +1039,7 @@ double PointSet::lineLocatePoint( const GEOSGeometry *point ) const
   double distance = -1;
   try
   {
-    distance = GEOSProject_r( QgsGeos::getGEOSHandler(), thisGeos, point );
+    distance = GEOSProject_r( QgsGeosContext::get(), thisGeos, point );
   }
   catch ( GEOSException &e )
   {
@@ -1069,7 +1069,7 @@ double PointSet::length() const
   if ( !mGeos )
     return -1;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   try
   {
@@ -1095,7 +1095,7 @@ double PointSet::area() const
   if ( !mGeos )
     return -1;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   try
   {
@@ -1121,7 +1121,7 @@ QString PointSet::toWkt() const
   if ( !mGeos )
     createGeosGeom();
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   try
   {

--- a/src/core/pal/util.cpp
+++ b/src/core/pal/util.cpp
@@ -44,7 +44,7 @@ QLinkedList<const GEOSGeometry *> *pal::Util::unmulti( const GEOSGeometry *the_g
   int nGeom;
   int i;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   while ( !queue->isEmpty() )
   {

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -37,18 +37,18 @@
 
 QgsPointCloudLayerProfileResults::QgsPointCloudLayerProfileResults()
 {
-  mPointIndex = GEOSSTRtree_create_r( QgsGeos::getGEOSHandler(), ( size_t )10 );
+  mPointIndex = GEOSSTRtree_create_r( QgsGeosContext::get(), ( size_t )10 );
 }
 
 QgsPointCloudLayerProfileResults::~QgsPointCloudLayerProfileResults()
 {
-  GEOSSTRtree_destroy_r( QgsGeos::getGEOSHandler(), mPointIndex );
+  GEOSSTRtree_destroy_r( QgsGeosContext::get(), mPointIndex );
   mPointIndex = nullptr;
 }
 
 void QgsPointCloudLayerProfileResults::finalize( QgsFeedback *feedback )
 {
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   const std::size_t size = results.size();
   PointResult *pointData = results.data();
@@ -240,7 +240,7 @@ QgsProfileSnapResult QgsPointCloudLayerProfileResults::snapPoint( const QgsProfi
 {
   QgsProfileSnapResult result;
 
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   const double minDistance = point.distance() - context.maximumPointDistanceDelta;
   const double maxDistance = point.distance() + context.maximumPointDistanceDelta;

--- a/src/core/qgstracer.cpp
+++ b/src/core/qgstracer.cpp
@@ -558,7 +558,7 @@ bool QgsTracer::initGraph()
     t2a.start();
     // GEOSNode_r may throw an exception
     geos::unique_ptr allGeomGeos( QgsGeos::asGeos( allGeom ) );
-    geos::unique_ptr allNoded( GEOSNode_r( QgsGeos::getGEOSHandler(), allGeomGeos.get() ) );
+    geos::unique_ptr allNoded( GEOSNode_r( QgsGeosContext::get(), allGeomGeos.get() ) );
     timeNodingCall = t2a.elapsed();
 
     QgsGeometry noded = QgsGeos::geometryFromGeos( allNoded.release() );

--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -470,7 +470,7 @@ ErrorList topolTest::checkGaps( QgsVectorLayer *layer1, QgsVectorLayer *layer2, 
 
   int i = 0;
   ErrorList errorList;
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+  GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
   // could be enabled for lines and points too
   // so duplicate rule may be removed?

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -592,7 +592,7 @@ void TestQgsGeometry::geos()
   polyWithEmptyParts.addGeometry( new QgsPolygon( new QgsLineString() ) );
   polyWithEmptyParts.addGeometry( new QgsPolygon( new QgsLineString( QVector< QgsPoint >() << QgsPoint( 10, 0 ) << QgsPoint( 10, 1 ) << QgsPoint( 11, 1 ) << QgsPoint( 10, 0 ) ) ) );
   asGeos = QgsGeos::asGeos( &polyWithEmptyParts );
-  QCOMPARE( GEOSGetNumGeometries_r( QgsGeos::getGEOSHandler(), asGeos.get() ), 2 );
+  QCOMPARE( GEOSGetNumGeometries_r( QgsGeosContext::get(), asGeos.get() ), 2 );
   res = QgsGeometry( QgsGeos::fromGeos( asGeos.get() ) );
   QCOMPARE( res.asWkt(), QStringLiteral( "MultiPolygon (((0 0, 0 1, 1 1, 0 0)),((10 0, 10 1, 11 1, 10 0)))" ) );
 


### PR DESCRIPTION
GEOS contexts have always been documented as for use by a single thread, but we've gotten away with a single shared context across threads just because of how GEOS previously wasn't doing any non-thread safe internally with them.

But recent GEOS versions DO, and it's no longer safe to share a single context across threads.

Use the same approach as we use for thread local proj context handling for geos contexts

Identified by the incorrect point contains result flagged in https://github.com/qgis/QGIS/pull/57068