### PR TITLE
Move server specific layer properties to QgsMapLayerServerProperties

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -209,156 +209,132 @@ Returns the layer's data provider, it may be ``None``.
 %End
 
 
-    void setShortName( const QString &shortName );
+ void setShortName( const QString &shortName ) /Deprecated/;
 %Docstring
-Sets the short name of the layer
-used by QGIS Server to identify the layer.
+Sets the short name of the layer used by QGIS Server to identify the layer.
 
-.. seealso:: :py:func:`shortName`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setShortName` instead.
 %End
 
-    QString shortName() const;
+ QString shortName() const /Deprecated/;
 %Docstring
-Returns the short name of the layer
-used by QGIS Server to identify the layer.
+Returns the short name of the layer used by QGIS Server to identify the layer.
 
-.. seealso:: :py:func:`setShortName`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.shortName` instead.
 %End
 
-    void setTitle( const QString &title );
+ void setTitle( const QString &title ) /Deprecated/;
 %Docstring
-Sets the title of the layer
-used by QGIS Server in GetCapabilities request.
+Sets the title of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`title`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setTitle` instead.
 %End
 
-    QString title() const;
+ QString title() const /Deprecated/;
 %Docstring
-Returns the title of the layer
-used by QGIS Server in GetCapabilities request.
+Returns the title of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer title
-
-.. seealso:: :py:func:`setTitle`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.title` instead.
 %End
 
-    void setAbstract( const QString &abstract );
+ void setAbstract( const QString &abstract ) /Deprecated/;
 %Docstring
-Sets the abstract of the layer
-used by QGIS Server in GetCapabilities request.
+Sets the abstract of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`abstract`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAbstract` instead.
 %End
 
-    QString abstract() const;
+ QString abstract() const /Deprecated/;
 %Docstring
-Returns the abstract of the layer
-used by QGIS Server in GetCapabilities request.
+Returns the abstract of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer abstract
-
-.. seealso:: :py:func:`setAbstract`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.abstract` instead.
 %End
 
-    void setKeywordList( const QString &keywords );
+ void setKeywordList( const QString &keywords ) /Deprecated/;
 %Docstring
-Sets the keyword list of the layer
-used by QGIS Server in GetCapabilities request.
+Sets the keyword list of the layerused by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`keywordList`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setKeywordList` instead.
 %End
 
-    QString keywordList() const;
+ QString keywordList() const /Deprecated/;
 %Docstring
-Returns the keyword list of the layer
-used by QGIS Server in GetCapabilities request.
+Returns the keyword list of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer keyword list
-
-.. seealso:: :py:func:`setKeywordList`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.keywordList` instead.
 %End
 
-
-    void setDataUrl( const QString &dataUrl );
+ void setDataUrl( const QString &dataUrl ) /Deprecated/;
 %Docstring
-Sets the DataUrl of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`dataUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrl` instead.
 %End
 
-    QString dataUrl() const;
+ QString dataUrl() const /Deprecated/;
 %Docstring
-Returns the DataUrl of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer DataUrl
-
-.. seealso:: :py:func:`setDataUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrl` instead.
 %End
 
-    void setDataUrlFormat( const QString &dataUrlFormat );
+ void setDataUrlFormat( const QString &dataUrlFormat ) /Deprecated/;
 %Docstring
-Sets the DataUrl format of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Sets the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`dataUrlFormat`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrlFormat` instead.
 %End
 
-    QString dataUrlFormat() const;
+ QString dataUrlFormat() const /Deprecated/;
 %Docstring
-Returns the DataUrl format of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer DataUrl format
-
-.. seealso:: :py:func:`setDataUrlFormat`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrlFormat` instead.
 %End
 
-
-    void setAttribution( const QString &attrib );
+ void setAttribution( const QString &attrib ) /Deprecated/;
 %Docstring
-Sets the attribution of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Sets the attribution of the layerused by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`attribution`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttribution` instead.
 %End
 
-    QString attribution() const;
+ QString attribution() const /Deprecated/;
 %Docstring
-Returns the attribution of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer attribution
-
-.. seealso:: :py:func:`setAttribution`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.attribution` instead.
 %End
 
-    void setAttributionUrl( const QString &attribUrl );
+ void setAttributionUrl( const QString &attribUrl ) /Deprecated/;
 %Docstring
-Sets the attribution URL of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Sets the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`attributionUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttributionUrl` instead.
 %End
 
-    QString attributionUrl() const;
+ QString attributionUrl() const /Deprecated/;
 %Docstring
-Returns the attribution URL of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer attribution URL
-
-.. seealso:: :py:func:`setAttributionUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.attributionUrl` instead.
 %End
 
 
@@ -2127,10 +2103,6 @@ happens.
 
 .. versionadded:: 3.20
 %End
-
-
-
-
 
 
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -243,6 +243,166 @@ Reset properties to default
 .. versionadded:: 3.22
 %End
 
+    void setShortName( const QString &name );
+%Docstring
+Sets the short ``name`` of the layer used by QGIS Server to identify the layer.
+
+.. seealso:: :py:func:`shortName`
+
+.. versionadded:: 3.38
+%End
+
+    QString shortName() const;
+%Docstring
+Returns the short name of the layer used by QGIS Server to identify the layer.
+
+.. seealso:: :py:func:`setShortName`
+
+.. versionadded:: 3.38
+%End
+
+    void setTitle( const QString &title );
+%Docstring
+Sets the ``title`` of the layer used by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`title`
+
+.. versionadded:: 3.38
+%End
+
+    QString title() const;
+%Docstring
+Returns the title of the layer used by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`setTitle`
+
+.. versionadded:: 3.38
+%End
+
+    void setAbstract( const QString &abstract );
+%Docstring
+Sets the ``abstract`` of the layer used by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`abstract`
+
+.. versionadded:: 3.38
+%End
+
+    QString abstract() const;
+%Docstring
+Returns the abstract of the layerused by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`setAbstract`
+
+.. versionadded:: 3.38
+%End
+
+    void setKeywordList( const QString &keywords );
+%Docstring
+Sets the ``keywords``  list of the layerused by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`keywordList`
+
+.. versionadded:: 3.38
+%End
+
+    QString keywordList() const;
+%Docstring
+Returns the keyword list of the layerused by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`setKeywordList`
+
+.. versionadded:: 3.38
+%End
+
+    void setDataUrl( const QString &dataUrl );
+%Docstring
+Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`dataUrl`
+
+.. versionadded:: 3.38
+%End
+
+    QString dataUrl() const;
+%Docstring
+Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`setDataUrl`
+
+.. versionadded:: 3.38
+%End
+
+    void setDataUrlFormat( const QString &dataUrlFormat );
+%Docstring
+Sets the DataUrl ``format`` of the layerused by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`dataUrlFormat`
+
+.. versionadded:: 3.38
+%End
+
+    QString dataUrlFormat() const;
+%Docstring
+Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`setDataUrlFormat`
+
+.. versionadded:: 3.38
+%End
+
+    void setAttribution( const QString &attrib );
+%Docstring
+Sets the ``attribution`` of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`attribution`
+
+.. versionadded:: 3.38
+%End
+
+    QString attribution() const;
+%Docstring
+Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`setAttribution`
+
+.. versionadded:: 3.38
+%End
+
+    void setAttributionUrl( const QString &url );
+%Docstring
+Sets the attribution ``url`` of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`attributionUrl`
+
+.. versionadded:: 3.38
+%End
+
+    QString attributionUrl() const;
+%Docstring
+Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`setAttributionUrl`
+
+.. versionadded:: 3.38
+%End
+
     virtual const QgsMapLayer *layer() const;
 %Docstring
 Gets the parent layer

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -209,156 +209,132 @@ Returns the layer's data provider, it may be ``None``.
 %End
 
 
-    void setShortName( const QString &shortName );
+ void setShortName( const QString &shortName ) /Deprecated/;
 %Docstring
-Sets the short name of the layer
-used by QGIS Server to identify the layer.
+Sets the short name of the layer used by QGIS Server to identify the layer.
 
-.. seealso:: :py:func:`shortName`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setShortName` instead.
 %End
 
-    QString shortName() const;
+ QString shortName() const /Deprecated/;
 %Docstring
-Returns the short name of the layer
-used by QGIS Server to identify the layer.
+Returns the short name of the layer used by QGIS Server to identify the layer.
 
-.. seealso:: :py:func:`setShortName`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.shortName` instead.
 %End
 
-    void setTitle( const QString &title );
+ void setTitle( const QString &title ) /Deprecated/;
 %Docstring
-Sets the title of the layer
-used by QGIS Server in GetCapabilities request.
+Sets the title of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`title`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setTitle` instead.
 %End
 
-    QString title() const;
+ QString title() const /Deprecated/;
 %Docstring
-Returns the title of the layer
-used by QGIS Server in GetCapabilities request.
+Returns the title of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer title
-
-.. seealso:: :py:func:`setTitle`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.title` instead.
 %End
 
-    void setAbstract( const QString &abstract );
+ void setAbstract( const QString &abstract ) /Deprecated/;
 %Docstring
-Sets the abstract of the layer
-used by QGIS Server in GetCapabilities request.
+Sets the abstract of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`abstract`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAbstract` instead.
 %End
 
-    QString abstract() const;
+ QString abstract() const /Deprecated/;
 %Docstring
-Returns the abstract of the layer
-used by QGIS Server in GetCapabilities request.
+Returns the abstract of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer abstract
-
-.. seealso:: :py:func:`setAbstract`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.abstract` instead.
 %End
 
-    void setKeywordList( const QString &keywords );
+ void setKeywordList( const QString &keywords ) /Deprecated/;
 %Docstring
-Sets the keyword list of the layer
-used by QGIS Server in GetCapabilities request.
+Sets the keyword list of the layerused by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`keywordList`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setKeywordList` instead.
 %End
 
-    QString keywordList() const;
+ QString keywordList() const /Deprecated/;
 %Docstring
-Returns the keyword list of the layer
-used by QGIS Server in GetCapabilities request.
+Returns the keyword list of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer keyword list
-
-.. seealso:: :py:func:`setKeywordList`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.keywordList` instead.
 %End
 
-
-    void setDataUrl( const QString &dataUrl );
+ void setDataUrl( const QString &dataUrl ) /Deprecated/;
 %Docstring
-Sets the DataUrl of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`dataUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrl` instead.
 %End
 
-    QString dataUrl() const;
+ QString dataUrl() const /Deprecated/;
 %Docstring
-Returns the DataUrl of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer DataUrl
-
-.. seealso:: :py:func:`setDataUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrl` instead.
 %End
 
-    void setDataUrlFormat( const QString &dataUrlFormat );
+ void setDataUrlFormat( const QString &dataUrlFormat ) /Deprecated/;
 %Docstring
-Sets the DataUrl format of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Sets the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`dataUrlFormat`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrlFormat` instead.
 %End
 
-    QString dataUrlFormat() const;
+ QString dataUrlFormat() const /Deprecated/;
 %Docstring
-Returns the DataUrl format of the layer
-used by QGIS Server in GetCapabilities request.
-DataUrl is a a link to the underlying data represented by a particular layer.
+Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer DataUrl format
-
-.. seealso:: :py:func:`setDataUrlFormat`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrlFormat` instead.
 %End
 
-
-    void setAttribution( const QString &attrib );
+ void setAttribution( const QString &attrib ) /Deprecated/;
 %Docstring
-Sets the attribution of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Sets the attribution of the layerused by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`attribution`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttribution` instead.
 %End
 
-    QString attribution() const;
+ QString attribution() const /Deprecated/;
 %Docstring
-Returns the attribution of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer attribution
-
-.. seealso:: :py:func:`setAttribution`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.attribution` instead.
 %End
 
-    void setAttributionUrl( const QString &attribUrl );
+ void setAttributionUrl( const QString &attribUrl ) /Deprecated/;
 %Docstring
-Sets the attribution URL of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Sets the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
-.. seealso:: :py:func:`attributionUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttributionUrl` instead.
 %End
 
-    QString attributionUrl() const;
+ QString attributionUrl() const /Deprecated/;
 %Docstring
-Returns the attribution URL of the layer
-used by QGIS Server in GetCapabilities request.
-Attribution indicates the provider of a layer or collection of layers.
+Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
-:return: the layer attribution URL
-
-.. seealso:: :py:func:`setAttributionUrl`
+.. deprecated:: QGIS 3.38
+   use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.attributionUrl` instead.
 %End
 
 
@@ -2127,10 +2103,6 @@ happens.
 
 .. versionadded:: 3.20
 %End
-
-
-
-
 
 
 

--- a/python/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -243,6 +243,166 @@ Reset properties to default
 .. versionadded:: 3.22
 %End
 
+    void setShortName( const QString &name );
+%Docstring
+Sets the short ``name`` of the layer used by QGIS Server to identify the layer.
+
+.. seealso:: :py:func:`shortName`
+
+.. versionadded:: 3.38
+%End
+
+    QString shortName() const;
+%Docstring
+Returns the short name of the layer used by QGIS Server to identify the layer.
+
+.. seealso:: :py:func:`setShortName`
+
+.. versionadded:: 3.38
+%End
+
+    void setTitle( const QString &title );
+%Docstring
+Sets the ``title`` of the layer used by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`title`
+
+.. versionadded:: 3.38
+%End
+
+    QString title() const;
+%Docstring
+Returns the title of the layer used by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`setTitle`
+
+.. versionadded:: 3.38
+%End
+
+    void setAbstract( const QString &abstract );
+%Docstring
+Sets the ``abstract`` of the layer used by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`abstract`
+
+.. versionadded:: 3.38
+%End
+
+    QString abstract() const;
+%Docstring
+Returns the abstract of the layerused by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`setAbstract`
+
+.. versionadded:: 3.38
+%End
+
+    void setKeywordList( const QString &keywords );
+%Docstring
+Sets the ``keywords``  list of the layerused by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`keywordList`
+
+.. versionadded:: 3.38
+%End
+
+    QString keywordList() const;
+%Docstring
+Returns the keyword list of the layerused by QGIS Server in GetCapabilities request.
+
+.. seealso:: :py:func:`setKeywordList`
+
+.. versionadded:: 3.38
+%End
+
+    void setDataUrl( const QString &dataUrl );
+%Docstring
+Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`dataUrl`
+
+.. versionadded:: 3.38
+%End
+
+    QString dataUrl() const;
+%Docstring
+Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`setDataUrl`
+
+.. versionadded:: 3.38
+%End
+
+    void setDataUrlFormat( const QString &dataUrlFormat );
+%Docstring
+Sets the DataUrl ``format`` of the layerused by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`dataUrlFormat`
+
+.. versionadded:: 3.38
+%End
+
+    QString dataUrlFormat() const;
+%Docstring
+Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
+
+DataUrl is a a link to the underlying data represented by a particular layer.
+
+.. seealso:: :py:func:`setDataUrlFormat`
+
+.. versionadded:: 3.38
+%End
+
+    void setAttribution( const QString &attrib );
+%Docstring
+Sets the ``attribution`` of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`attribution`
+
+.. versionadded:: 3.38
+%End
+
+    QString attribution() const;
+%Docstring
+Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`setAttribution`
+
+.. versionadded:: 3.38
+%End
+
+    void setAttributionUrl( const QString &url );
+%Docstring
+Sets the attribution ``url`` of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`attributionUrl`
+
+.. versionadded:: 3.38
+%End
+
+    QString attributionUrl() const;
+%Docstring
+Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
+
+Attribution indicates the provider of a layer or collection of layers.
+
+.. seealso:: :py:func:`setAttributionUrl`
+
+.. versionadded:: 3.38
+%End
+
     virtual const QgsMapLayer *layer() const;
 %Docstring
 Gets the parent layer

--- a/src/analysis/processing/qgsalgorithmexportlayersinformation.cpp
+++ b/src/analysis/processing/qgsalgorithmexportlayersinformation.cpp
@@ -141,7 +141,7 @@ QVariantMap QgsExportLayersInformationAlgorithm::processAlgorithm( const QVarian
       attributes << QVariant() << QVariant() << QVariant() << QVariant();
     }
     attributes << layer->metadata().rights().join( ';' )
-               << layer->abstract();
+               << layer->serverProperties()->abstract();
     feature.setAttributes( attributes );
 
     QgsRectangle rect = layer->extent();

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -2384,7 +2384,9 @@ QStringList QgsDxfExport::encodings()
 QString QgsDxfExport::layerName( QgsVectorLayer *vl ) const
 {
   Q_ASSERT( vl );
-  return mLayerTitleAsName && !vl->title().isEmpty() ? vl->title() : vl->name();
+  return mLayerTitleAsName && ( !vl->metadata().title().isEmpty() ||  !vl->serverProperties()->title().isEmpty() )
+         ? ( !vl->metadata().title().isEmpty() ? vl->metadata().title() : vl->serverProperties()->title() )
+         : vl->name();
 }
 
 void QgsDxfExport::drawLabel( const QString &layerId, QgsRenderContext &context, pal::LabelPosition *label, const QgsPalLayerSettings &settings )

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -41,7 +41,8 @@ struct DxfLayerJob
       , crs( vl->crs() )
       , layerName( vl->name() )
       , splitLayerAttribute( splitLayerAttribute )
-      , layerTitle( vl->title().isEmpty() ? vl->name() : vl->title() )
+      , layerTitle( !vl->metadata().title().isEmpty() ? vl->metadata().title()
+                    : vl->serverProperties()->title().isEmpty() ? vl->name() : vl->serverProperties()->title() )
     {
       if ( !layerStyleOverride.isNull() )
       {

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -175,7 +175,7 @@ class GetLayoutMapLayerCredits : public QgsScopedExpressionFunction
       res.reserve( layers.size() );
       for ( const QgsMapLayer *layer : std::as_const( layers ) )
       {
-        const QStringList credits = !layer->metadata().rights().isEmpty() ? layer->metadata().rights() : QStringList() << layer->attribution();
+        const QStringList credits = !layer->metadata().rights().isEmpty() ? layer->metadata().rights() : QStringList() << layer->serverProperties()->attribution();
         for ( const QString &credit : credits )
         {
           if ( credit.trimmed().isEmpty() )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6470,9 +6470,9 @@ static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpres
     else if ( QString::compare( layerProperty, QStringLiteral( "id" ), Qt::CaseInsensitive ) == 0 )
       return layer->id();
     else if ( QString::compare( layerProperty, QStringLiteral( "title" ), Qt::CaseInsensitive ) == 0 )
-      return !layer->metadata().title().isEmpty() ? layer->metadata().title() : layer->title();
+      return !layer->metadata().title().isEmpty() ? layer->metadata().title() : layer->serverProperties()->title();
     else if ( QString::compare( layerProperty, QStringLiteral( "abstract" ), Qt::CaseInsensitive ) == 0 )
-      return !layer->metadata().abstract().isEmpty() ? layer->metadata().abstract() : layer->abstract();
+      return !layer->metadata().abstract().isEmpty() ? layer->metadata().abstract() : layer->serverProperties()->abstract();
     else if ( QString::compare( layerProperty, QStringLiteral( "keywords" ), Qt::CaseInsensitive ) == 0 )
     {
       QStringList keywords;
@@ -6483,16 +6483,16 @@ static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpres
       }
       if ( !keywords.isEmpty() )
         return keywords;
-      return layer->keywordList();
+      return layer->serverProperties()->keywordList();
     }
     else if ( QString::compare( layerProperty, QStringLiteral( "data_url" ), Qt::CaseInsensitive ) == 0 )
-      return layer->dataUrl();
+      return layer->serverProperties()->dataUrl();
     else if ( QString::compare( layerProperty, QStringLiteral( "attribution" ), Qt::CaseInsensitive ) == 0 )
     {
-      return !layer->metadata().rights().isEmpty() ? QVariant( layer->metadata().rights() ) : QVariant( layer->attribution() );
+      return !layer->metadata().rights().isEmpty() ? QVariant( layer->metadata().rights() ) : QVariant( layer->serverProperties()->attribution() );
     }
     else if ( QString::compare( layerProperty, QStringLiteral( "attribution_url" ), Qt::CaseInsensitive ) == 0 )
-      return layer->attributionUrl();
+      return layer->serverProperties()->attributionUrl();
     else if ( QString::compare( layerProperty, QStringLiteral( "source" ), Qt::CaseInsensitive ) == 0 )
       return layer->publicSource();
     else if ( QString::compare( layerProperty, QStringLiteral( "min_scale" ), Qt::CaseInsensitive ) == 0 )

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -277,10 +277,10 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
     {
       if ( QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer() )
       {
-        QString title =
-          !layer->title().isEmpty() ? layer->title() :
-          !layer->shortName().isEmpty() ? layer->shortName() :
-          layer->name();
+        QString title = !layer->metadata().title().isEmpty() ? layer->metadata().title() :
+                        !layer->serverProperties()->title().isEmpty() ? layer->serverProperties()->title() :
+                        !layer->serverProperties()->shortName().isEmpty() ? layer->serverProperties()->shortName() :
+                        layer->name();
 
         title = "<b>" + title.toHtmlEscaped() + "</b>";
 
@@ -295,10 +295,11 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
         QStringList parts;
         parts << title;
 
-        if ( !layer->abstract().isEmpty() )
+        const QString abstract = !layer->metadata().abstract().isEmpty() ? layer->metadata().abstract() : layer->serverProperties()->abstract();
+        if ( !abstract.isEmpty() )
         {
           parts << QString();
-          const QStringList abstractLines = layer->abstract().split( '\n' );
+          const QStringList abstractLines = abstract.split( '\n' );
           for ( const auto &l : abstractLines )
           {
             parts << l.toHtmlEscaped();

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -4278,9 +4278,9 @@ QList<QgsMapLayer *> QgsProject::mapLayersByShortName( const QString &shortName 
   const auto constMapLayers { mLayerStore->mapLayers() };
   for ( const auto &l : constMapLayers )
   {
-    if ( ! l->shortName().isEmpty() )
+    if ( ! l->serverProperties()->shortName().isEmpty() )
     {
-      if ( l->shortName() == shortName )
+      if ( l->serverProperties()->shortName() == shortName )
         layers << l;
     }
     else if ( l->name() == shortName )

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1201,9 +1201,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
       const auto constMapLayers { mLayerStore->layers<T>() };
       for ( const auto l : constMapLayers )
       {
-        if ( ! l->shortName().isEmpty() )
+        if ( ! l->serverProperties()->shortName().isEmpty() )
         {
-          if ( l->shortName() == shortName )
+          if ( l->serverProperties()->shortName() == shortName )
             layers << l;
         }
         else if ( l->name() == shortName )

--- a/src/core/project/qgsprojectservervalidator.cpp
+++ b/src/core/project/qgsprojectservervalidator.cpp
@@ -63,7 +63,7 @@ void QgsProjectServerValidator::browseLayerTree( QgsLayerTreeGroup *treeGroup, Q
       QgsMapLayer *layer = treeLayer->layer();
       if ( layer )
       {
-        const QString shortName = layer->shortName();
+        const QString shortName = layer->serverProperties()->shortName();
         if ( shortName.isEmpty() )
           owsNames << layer->name();
         else

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -138,7 +138,6 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   }
 
   layer->setName( name() );
-  layer->setShortName( shortName() );
 
   if ( layer->dataProvider() && layer->dataProvider()->elevationProperties() )
   {
@@ -151,13 +150,6 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   layer->setMaximumScale( maximumScale() );
   layer->setMinimumScale( minimumScale() );
   layer->setScaleBasedVisibility( hasScaleBasedVisibility() );
-  layer->setTitle( title() );
-  layer->setAbstract( abstract() );
-  layer->setKeywordList( keywordList() );
-  layer->setDataUrl( dataUrl() );
-  layer->setDataUrlFormat( dataUrlFormat() );
-  layer->setAttribution( attribution() );
-  layer->setAttributionUrl( attributionUrl() );
   layer->setLegendUrl( legendUrl() );
   layer->setLegendUrlFormat( legendUrlFormat() );
   layer->setDependencies( dependencies() );
@@ -245,11 +237,117 @@ const QgsDataProvider *QgsMapLayer::dataProvider() const
   return nullptr;
 }
 
+void QgsMapLayer::setShortName( const QString &shortName )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setShortName( shortName );
+}
+
 QString QgsMapLayer::shortName() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return mShortName;
+  return mServerProperties->shortName();
+}
+
+void QgsMapLayer::setTitle( const QString &title )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setTitle( title );
+}
+
+QString QgsMapLayer::title() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->title();
+}
+
+void QgsMapLayer::setAbstract( const QString &abstract )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setAbstract( abstract );
+}
+
+QString QgsMapLayer::abstract() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->abstract();
+}
+
+void QgsMapLayer::setKeywordList( const QString &keywords )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setKeywordList( keywords );
+}
+
+QString QgsMapLayer::keywordList() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->keywordList();
+}
+
+void QgsMapLayer::setDataUrl( const QString &dataUrl )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setDataUrl( dataUrl );
+}
+
+QString QgsMapLayer::dataUrl() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->dataUrl();
+}
+
+void QgsMapLayer::setDataUrlFormat( const QString &dataUrlFormat )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setDataUrlFormat( dataUrlFormat );
+}
+
+QString QgsMapLayer::dataUrlFormat() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->dataUrlFormat();
+}
+
+void QgsMapLayer::setAttribution( const QString &attrib )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setAttribution( attrib );
+}
+
+QString QgsMapLayer::attribution() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->attribution();
+}
+
+void QgsMapLayer::setAttributionUrl( const QString &attribUrl )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mServerProperties->setAttributionUrl( attribUrl );
+}
+
+QString QgsMapLayer::attributionUrl() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->attributionUrl();
+
 }
 
 void QgsMapLayer::setMetadataUrl( const QString &metaUrl )
@@ -510,61 +608,12 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   QgsCoordinateReferenceSystem::setCustomCrsValidation( savedValidation );
   mCRS = savedCRS;
 
-  //short name
-  const QDomElement shortNameElem = layerElement.firstChildElement( QStringLiteral( "shortname" ) );
-  if ( !shortNameElem.isNull() )
-  {
-    mShortName = shortNameElem.text();
-  }
-
-  //title
-  const QDomElement titleElem = layerElement.firstChildElement( QStringLiteral( "title" ) );
-  if ( !titleElem.isNull() )
-  {
-    mTitle = titleElem.text();
-  }
-
-  //abstract
-  const QDomElement abstractElem = layerElement.firstChildElement( QStringLiteral( "abstract" ) );
-  if ( !abstractElem.isNull() )
-  {
-    mAbstract = abstractElem.text();
-  }
-
-  //keywordList
-  const QDomElement keywordListElem = layerElement.firstChildElement( QStringLiteral( "keywordList" ) );
-  if ( !keywordListElem.isNull() )
-  {
-    QStringList kwdList;
-    for ( QDomNode n = keywordListElem.firstChild(); !n.isNull(); n = n.nextSibling() )
-    {
-      kwdList << n.toElement().text();
-    }
-    mKeywordList = kwdList.join( QLatin1String( ", " ) );
-  }
-
-  //dataUrl
-  const QDomElement dataUrlElem = layerElement.firstChildElement( QStringLiteral( "dataUrl" ) );
-  if ( !dataUrlElem.isNull() )
-  {
-    mDataUrl = dataUrlElem.text();
-    mDataUrlFormat = dataUrlElem.attribute( QStringLiteral( "format" ), QString() );
-  }
-
   //legendUrl
   const QDomElement legendUrlElem = layerElement.firstChildElement( QStringLiteral( "legendUrl" ) );
   if ( !legendUrlElem.isNull() )
   {
     mLegendUrl = legendUrlElem.text();
     mLegendUrlFormat = legendUrlElem.attribute( QStringLiteral( "format" ), QString() );
-  }
-
-  //attribution
-  const QDomElement attribElem = layerElement.firstChildElement( QStringLiteral( "attribution" ) );
-  if ( !attribElem.isNull() )
-  {
-    mAttribution = attribElem.text();
-    mAttributionUrl = attribElem.attribute( QStringLiteral( "href" ), QString() );
   }
 
   serverProperties()->readXml( layerElement );
@@ -687,34 +736,37 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   layerElement.appendChild( layerName );
 
   // layer short name
-  if ( !mShortName.isEmpty() )
+
+  // TODO -- ideally this would be in QgsMapLayerServerProperties::writeXml, but that's currently
+  // only called for SOME map layer subclasses!
+  if ( !mServerProperties->shortName().isEmpty() )
   {
     QDomElement layerShortName = document.createElement( QStringLiteral( "shortname" ) );
-    const QDomText layerShortNameText = document.createTextNode( mShortName );
+    const QDomText layerShortNameText = document.createTextNode( mServerProperties->shortName() );
     layerShortName.appendChild( layerShortNameText );
     layerElement.appendChild( layerShortName );
   }
 
   // layer title
-  if ( !mTitle.isEmpty() )
+  if ( !mServerProperties->title().isEmpty() )
   {
     QDomElement layerTitle = document.createElement( QStringLiteral( "title" ) );
-    const QDomText layerTitleText = document.createTextNode( mTitle );
+    const QDomText layerTitleText = document.createTextNode( mServerProperties->title() );
     layerTitle.appendChild( layerTitleText );
     layerElement.appendChild( layerTitle );
   }
 
   // layer abstract
-  if ( !mAbstract.isEmpty() )
+  if ( !mServerProperties->abstract().isEmpty() )
   {
     QDomElement layerAbstract = document.createElement( QStringLiteral( "abstract" ) );
-    const QDomText layerAbstractText = document.createTextNode( mAbstract );
+    const QDomText layerAbstractText = document.createTextNode( mServerProperties->abstract() );
     layerAbstract.appendChild( layerAbstractText );
     layerElement.appendChild( layerAbstract );
   }
 
   // layer keyword list
-  const QStringList keywordStringList = keywordList().split( ',' );
+  const QStringList keywordStringList = mServerProperties->keywordList().split( ',' );
   if ( !keywordStringList.isEmpty() )
   {
     QDomElement layerKeywordList = document.createElement( QStringLiteral( "keywordList" ) );
@@ -729,13 +781,13 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   }
 
   // layer dataUrl
-  const QString aDataUrl = dataUrl();
+  const QString aDataUrl = mServerProperties->dataUrl();
   if ( !aDataUrl.isEmpty() )
   {
     QDomElement layerDataUrl = document.createElement( QStringLiteral( "dataUrl" ) );
     const QDomText layerDataUrlText = document.createTextNode( aDataUrl );
     layerDataUrl.appendChild( layerDataUrlText );
-    layerDataUrl.setAttribute( QStringLiteral( "format" ), dataUrlFormat() );
+    layerDataUrl.setAttribute( QStringLiteral( "format" ), mServerProperties->dataUrlFormat() );
     layerElement.appendChild( layerDataUrl );
   }
 
@@ -751,13 +803,13 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   }
 
   // layer attribution
-  const QString aAttribution = attribution();
+  const QString aAttribution = mServerProperties->attribution();
   if ( !aAttribution.isEmpty() )
   {
     QDomElement layerAttribution = document.createElement( QStringLiteral( "attribution" ) );
     const QDomText layerAttributionText = document.createTextNode( aAttribution );
     layerAttribution.appendChild( layerAttributionText );
-    layerAttribution.setAttribute( QStringLiteral( "href" ), attributionUrl() );
+    layerAttribution.setAttribute( QStringLiteral( "href" ), mServerProperties->attributionUrl() );
     layerElement.appendChild( layerAttribution );
   }
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -283,135 +283,116 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual const QgsDataProvider *dataProvider() const SIP_SKIP;
 
     /**
-     * Sets the short name of the layer
-     *  used by QGIS Server to identify the layer.
-     * \see shortName()
+     * Sets the short name of the layer used by QGIS Server to identify the layer.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setShortName() instead.
      */
-    void setShortName( const QString &shortName ) { mShortName = shortName; }
+    Q_DECL_DEPRECATED void setShortName( const QString &shortName ) SIP_DEPRECATED;
 
     /**
-     * Returns the short name of the layer
-     *  used by QGIS Server to identify the layer.
-     * \see setShortName()
+     * Returns the short name of the layer used by QGIS Server to identify the layer.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->shortName() instead.
      */
-    QString shortName() const;
+    Q_DECL_DEPRECATED QString shortName() const SIP_DEPRECATED;
 
     /**
-     * Sets the title of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     * \see title()
+     * Sets the title of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setTitle() instead.
      */
-    void setTitle( const QString &title ) { mTitle = title; }
+    Q_DECL_DEPRECATED void setTitle( const QString &title ) SIP_DEPRECATED;
 
     /**
-     * Returns the title of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     * \returns the layer title
-     * \see setTitle()
+     * Returns the title of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->title() instead.
      */
-    QString title() const { return mTitle; }
+    Q_DECL_DEPRECATED QString title() const SIP_DEPRECATED;
 
     /**
-     * Sets the abstract of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     * \see abstract()
+     * Sets the abstract of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setAbstract() instead.
      */
-    void setAbstract( const QString &abstract ) { mAbstract = abstract; }
+    Q_DECL_DEPRECATED void setAbstract( const QString &abstract ) SIP_DEPRECATED;
 
     /**
-     * Returns the abstract of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     * \returns the layer abstract
-     * \see setAbstract()
+     * Returns the abstract of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->abstract() instead.
      */
-    QString abstract() const { return mAbstract; }
+    Q_DECL_DEPRECATED QString abstract() const SIP_DEPRECATED;
 
     /**
-     * Sets the keyword list of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     * \see keywordList()
+     * Sets the keyword list of the layerused by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setKeywordList() instead.
      */
-    void setKeywordList( const QString &keywords ) { mKeywordList = keywords; }
+    Q_DECL_DEPRECATED void setKeywordList( const QString &keywords ) SIP_DEPRECATED;
 
     /**
-     * Returns the keyword list of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     * \returns the layer keyword list
-     * \see setKeywordList()
+     * Returns the keyword list of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->keywordList() instead.
      */
-    QString keywordList() const { return mKeywordList; }
-
-    /* Layer dataUrl information */
+    Q_DECL_DEPRECATED QString keywordList() const SIP_DEPRECATED;
 
     /**
-     * Sets the DataUrl of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  DataUrl is a a link to the underlying data represented by a particular layer.
-     * \see dataUrl()
+     * Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setDataUrl() instead.
      */
-    void setDataUrl( const QString &dataUrl ) { mDataUrl = dataUrl; }
+    Q_DECL_DEPRECATED void setDataUrl( const QString &dataUrl ) SIP_DEPRECATED;
 
     /**
-     * Returns the DataUrl of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  DataUrl is a a link to the underlying data represented by a particular layer.
-     * \returns the layer DataUrl
-     * \see setDataUrl()
+     * Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->dataUrl() instead.
      */
-    QString dataUrl() const { return mDataUrl; }
+    Q_DECL_DEPRECATED QString dataUrl() const SIP_DEPRECATED;
 
     /**
-     * Sets the DataUrl format of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  DataUrl is a a link to the underlying data represented by a particular layer.
-     * \see dataUrlFormat()
+     * Sets the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setDataUrlFormat() instead.
      */
-    void setDataUrlFormat( const QString &dataUrlFormat ) { mDataUrlFormat = dataUrlFormat; }
+    Q_DECL_DEPRECATED void setDataUrlFormat( const QString &dataUrlFormat ) SIP_DEPRECATED;
 
     /**
-     * Returns the DataUrl format of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  DataUrl is a a link to the underlying data represented by a particular layer.
-     * \returns the layer DataUrl format
-     * \see setDataUrlFormat()
+     * Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->dataUrlFormat() instead.
      */
-    QString dataUrlFormat() const { return mDataUrlFormat; }
-
-    /* Layer attribution information */
+    Q_DECL_DEPRECATED QString dataUrlFormat() const SIP_DEPRECATED;
 
     /**
-     * Sets the attribution of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  Attribution indicates the provider of a layer or collection of layers.
-     * \see attribution()
+     * Sets the attribution of the layerused by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setAttribution() instead.
      */
-    void setAttribution( const QString &attrib ) { mAttribution = attrib; }
+    Q_DECL_DEPRECATED void setAttribution( const QString &attrib ) SIP_DEPRECATED;
 
     /**
-     * Returns the attribution of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  Attribution indicates the provider of a layer or collection of layers.
-     * \returns the layer attribution
-     * \see setAttribution()
+     * Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->attribution() instead.
      */
-    QString attribution() const { return mAttribution; }
+    Q_DECL_DEPRECATED QString attribution() const SIP_DEPRECATED;
 
     /**
-     * Sets the attribution URL of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  Attribution indicates the provider of a layer or collection of layers.
-     * \see attributionUrl()
+     * Sets the attribution URL of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->setAttributionUrl() instead.
      */
-    void setAttributionUrl( const QString &attribUrl ) { mAttributionUrl = attribUrl; }
+    Q_DECL_DEPRECATED void setAttributionUrl( const QString &attribUrl ) SIP_DEPRECATED;
 
     /**
-     * Returns the attribution URL of the layer
-     *  used by QGIS Server in GetCapabilities request.
-     *  Attribution indicates the provider of a layer or collection of layers.
-     * \returns the layer attribution URL
-     * \see setAttributionUrl()
+     * Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \deprecated since QGIS 3.38 use serverProperties()->attributionUrl() instead.
      */
-    QString attributionUrl() const { return mAttributionUrl; }
+    Q_DECL_DEPRECATED QString attributionUrl() const SIP_DEPRECATED;
 
     /* Layer metadataUrl information */
 
@@ -2122,21 +2103,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! Name of the layer - used for display
     QString mLayerName;
-
-    QString mShortName;
-    QString mTitle;
-
-    //! Description of the layer
-    QString mAbstract;
-    QString mKeywordList;
-
-    //! DataUrl of the layer
-    QString mDataUrl;
-    QString mDataUrlFormat;
-
-    //! Attribution of the layer
-    QString mAttribution;
-    QString mAttributionUrl;
 
     //! WMS legend
     QString mLegendUrl;

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsmaplayermodel.h"
 #include "qgsproject.h"
-#include "qgsapplication.h"
 #include "qgsvectorlayer.h"
 #include "qgsiconutils.h"
 #include "qgsmaplayerlistutils_p.h"
@@ -368,7 +367,7 @@ QVariant QgsMapLayerModel::data( const QModelIndex &index, int role ) const
       if ( layer )
       {
         QStringList parts;
-        QString title = layer->title().isEmpty() ? layer->shortName() : layer->title();
+        QString title = !layer->metadata().title().isEmpty() ? layer->metadata().title() : ( layer->serverProperties()->title().isEmpty() ? layer->serverProperties()->shortName() : layer->serverProperties()->title() );
         if ( title.isEmpty() )
           title = layer->name();
         title = "<b>" + title + "</b>";
@@ -381,8 +380,9 @@ QVariant QgsMapLayerModel::data( const QModelIndex &index, int role ) const
         }
         parts << title;
 
-        if ( !layer->abstract().isEmpty() )
-          parts << "<br/>" + layer->abstract().replace( QLatin1String( "\n" ), QLatin1String( "<br/>" ) );
+        QString abstract = !layer->metadata().abstract().isEmpty() ? layer->metadata().abstract() : layer->serverProperties()->abstract();
+        if ( !abstract.isEmpty() )
+          parts << "<br/>" + abstract.replace( QLatin1String( "\n" ), QLatin1String( "<br/>" ) );
         parts << "<i>" + layer->publicSource() + "</i>";
         return parts.join( QLatin1String( "<br/>" ) );
       }

--- a/src/core/qgsmaplayerserverproperties.h
+++ b/src/core/qgsmaplayerserverproperties.h
@@ -307,11 +307,184 @@ class CORE_EXPORT QgsMapLayerServerProperties: public QgsServerMetadataUrlProper
      */
     void reset();
 
+    /**
+     * Sets the short \a name of the layer used by QGIS Server to identify the layer.
+     *
+     * \see shortName()
+     *
+     * \since QGIS 3.38
+     */
+    void setShortName( const QString &name ) { mShortName = name; }
+
+    /**
+     * Returns the short name of the layer used by QGIS Server to identify the layer.
+     *
+     * \see setShortName()
+     *
+     * \since QGIS 3.38
+     */
+    QString shortName() const { return mShortName; }
+
+    /**
+     * Sets the \a title of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \see title()
+     *
+     * \since QGIS 3.38
+     */
+    void setTitle( const QString &title ) { mTitle = title; }
+
+    /**
+     * Returns the title of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \see setTitle()
+     *
+     * \since QGIS 3.38
+     */
+    QString title() const { return mTitle; }
+
+    /**
+     * Sets the \a abstract of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * \see abstract()
+     *
+     * \since QGIS 3.38
+     */
+    void setAbstract( const QString &abstract ) { mAbstract = abstract; }
+
+    /**
+     * Returns the abstract of the layerused by QGIS Server in GetCapabilities request.
+     *
+     * \see setAbstract()
+     *
+     * \since QGIS 3.38
+     */
+    QString abstract() const { return mAbstract; }
+
+    /**
+     * Sets the \a keywords  list of the layerused by QGIS Server in GetCapabilities request.
+     *
+     * \see keywordList()
+     *
+     * \since QGIS 3.38
+     */
+    void setKeywordList( const QString &keywords ) { mKeywordList = keywords; }
+
+    /**
+     * Returns the keyword list of the layerused by QGIS Server in GetCapabilities request.
+     *
+     * \see setKeywordList()
+     *
+     * \since QGIS 3.38
+     */
+    QString keywordList() const { return mKeywordList; }
+
+    /**
+     * Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * DataUrl is a a link to the underlying data represented by a particular layer.
+     *
+     * \see dataUrl()
+     *
+     * \since QGIS 3.38
+     */
+    void setDataUrl( const QString &dataUrl ) { mDataUrl = dataUrl; }
+
+    /**
+     * Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * DataUrl is a a link to the underlying data represented by a particular layer.
+     *
+     * \see setDataUrl()
+     *
+     * \since QGIS 3.38
+     */
+    QString dataUrl() const { return mDataUrl; }
+
+    /**
+     * Sets the DataUrl \a format of the layerused by QGIS Server in GetCapabilities request.
+     *
+     * DataUrl is a a link to the underlying data represented by a particular layer.
+     *
+     * \see dataUrlFormat()
+     *
+     * \since QGIS 3.38
+     */
+    void setDataUrlFormat( const QString &dataUrlFormat ) { mDataUrlFormat = dataUrlFormat; }
+
+    /**
+     * Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * DataUrl is a a link to the underlying data represented by a particular layer.
+     *
+     * \see setDataUrlFormat()
+     *
+     * \since QGIS 3.38
+     */
+    QString dataUrlFormat() const { return mDataUrlFormat; }
+
+    /**
+     * Sets the \a attribution of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * Attribution indicates the provider of a layer or collection of layers.
+     *
+     * \see attribution()
+     *
+     * \since QGIS 3.38
+     */
+    void setAttribution( const QString &attrib ) { mAttribution = attrib; }
+
+    /**
+     * Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * Attribution indicates the provider of a layer or collection of layers.
+     *
+     * \see setAttribution()
+     *
+     * \since QGIS 3.38
+     */
+    QString attribution() const { return mAttribution; }
+
+    /**
+     * Sets the attribution \a url of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * Attribution indicates the provider of a layer or collection of layers.
+     *
+     * \see attributionUrl()
+     *
+     * \since QGIS 3.38
+     */
+    void setAttributionUrl( const QString &url ) { mAttributionUrl = url; }
+
+    /**
+     * Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
+     *
+     * Attribution indicates the provider of a layer or collection of layers.
+     *
+     * \see setAttributionUrl()
+     *
+     * \since QGIS 3.38
+     */
+    QString attributionUrl() const { return mAttributionUrl; }
+
     //! Gets the parent layer
     const QgsMapLayer *layer() const override { return mLayer; };
 
   private:
     QgsMapLayer *mLayer = nullptr;
+
+    QString mShortName;
+    QString mTitle;
+
+    QString mAttribution;
+    QString mAttributionUrl;
+
+    QString mDataUrl;
+    QString mDataUrlFormat;
+
+    QString mAbstract;
+    QString mKeywordList;
+
 };
 
 /**

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1849,17 +1849,19 @@ bool QgsRasterLayer::writeSld( QDomNode &node, QDomDocument &doc, QString &error
       userStyleElem.appendChild( nameElem );
     }
 
-    if ( !abstract().isEmpty() )
+    const QString abstract = !metadata().abstract().isEmpty() ? metadata().abstract() : serverProperties()->abstract();
+    if ( !abstract.isEmpty() )
     {
       QDomElement abstractElem = doc.createElement( QStringLiteral( "sld:Abstract" ) );
-      abstractElem.appendChild( doc.createTextNode( abstract() ) );
+      abstractElem.appendChild( doc.createTextNode( abstract ) );
       userStyleElem.appendChild( abstractElem );
     }
 
-    if ( !title().isEmpty() )
+    const QString title = !metadata().title().isEmpty() ? metadata().title() : serverProperties()->title();
+    if ( !title.isEmpty() )
     {
       QDomElement titleElem = doc.createElement( QStringLiteral( "sld:Title" ) );
-      titleElem.appendChild( doc.createTextNode( title() ) );
+      titleElem.appendChild( doc.createTextNode( title ) );
       userStyleElem.appendChild( titleElem );
     }
 

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -214,8 +214,9 @@ QVariant QgsElevationProfileLayerTreeModel::data( const QModelIndex &index, int 
         if ( QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer() )
         {
           QString title =
-            !layer->title().isEmpty() ? layer->title() :
-            !layer->shortName().isEmpty() ? layer->shortName() :
+            !layer->metadata().title().isEmpty() ? layer->metadata().title() :
+            !layer->serverProperties()->title().isEmpty() ? layer->serverProperties()->title() :
+            !layer->serverProperties()->shortName().isEmpty() ? layer->serverProperties()->shortName() :
             layer->name();
 
           title = "<b>" + title.toHtmlEscaped() + "</b>";

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -844,25 +844,25 @@ void QgsRasterLayerProperties::sync()
   updateInformationContent();
 
   // WMS Name as layer short name
-  mLayerShortNameLineEdit->setText( mRasterLayer->shortName() );
+  mLayerShortNameLineEdit->setText( mRasterLayer->serverProperties()->shortName() );
   // WMS Name validator
   QValidator *shortNameValidator = new QRegularExpressionValidator( QgsApplication::shortNameRegularExpression(), this );
   mLayerShortNameLineEdit->setValidator( shortNameValidator );
 
   //layer title and abstract
-  mLayerTitleLineEdit->setText( mRasterLayer->title() );
-  mLayerAbstractTextEdit->setPlainText( mRasterLayer->abstract() );
-  mLayerKeywordListLineEdit->setText( mRasterLayer->keywordList() );
-  mLayerDataUrlLineEdit->setText( mRasterLayer->dataUrl() );
+  mLayerTitleLineEdit->setText( mRasterLayer->serverProperties()->title() );
+  mLayerAbstractTextEdit->setPlainText( mRasterLayer->serverProperties()->abstract() );
+  mLayerKeywordListLineEdit->setText( mRasterLayer->serverProperties()->keywordList() );
+  mLayerDataUrlLineEdit->setText( mRasterLayer->serverProperties()->dataUrl() );
   mLayerDataUrlFormatComboBox->setCurrentIndex(
     mLayerDataUrlFormatComboBox->findText(
-      mRasterLayer->dataUrlFormat()
+      mRasterLayer->serverProperties()->dataUrlFormat()
     )
   );
 
   //layer attribution
-  mLayerAttributionLineEdit->setText( mRasterLayer->attribution() );
-  mLayerAttributionUrlLineEdit->setText( mRasterLayer->attributionUrl() );
+  mLayerAttributionLineEdit->setText( mRasterLayer->serverProperties()->attribution() );
+  mLayerAttributionUrlLineEdit->setText( mRasterLayer->serverProperties()->attributionUrl() );
 
   // layer metadata url
   const QList<QgsMapLayerServerProperties::MetadataUrl> &metaUrls = mRasterLayer->serverProperties()->metadataUrls();
@@ -1075,38 +1075,38 @@ void QgsRasterLayerProperties::apply()
 
   mRasterLayer->setCrs( mCrsSelector->crs() );
 
-  if ( mRasterLayer->shortName() != mLayerShortNameLineEdit->text() )
+  if ( mRasterLayer->serverProperties()->shortName() != mLayerShortNameLineEdit->text() )
     mMetadataFilled = false;
-  mRasterLayer->setShortName( mLayerShortNameLineEdit->text() );
+  mRasterLayer->serverProperties()->setShortName( mLayerShortNameLineEdit->text() );
 
-  if ( mRasterLayer->title() != mLayerTitleLineEdit->text() )
+  if ( mRasterLayer->serverProperties()->title() != mLayerTitleLineEdit->text() )
     mMetadataFilled = false;
-  mRasterLayer->setTitle( mLayerTitleLineEdit->text() );
+  mRasterLayer->serverProperties()->setTitle( mLayerTitleLineEdit->text() );
 
-  if ( mRasterLayer->abstract() != mLayerAbstractTextEdit->toPlainText() )
+  if ( mRasterLayer->serverProperties()->abstract() != mLayerAbstractTextEdit->toPlainText() )
     mMetadataFilled = false;
-  mRasterLayer->setAbstract( mLayerAbstractTextEdit->toPlainText() );
+  mRasterLayer->serverProperties()->setAbstract( mLayerAbstractTextEdit->toPlainText() );
 
-  if ( mRasterLayer->keywordList() != mLayerKeywordListLineEdit->text() )
+  if ( mRasterLayer->serverProperties()->keywordList() != mLayerKeywordListLineEdit->text() )
     mMetadataFilled = false;
-  mRasterLayer->setKeywordList( mLayerKeywordListLineEdit->text() );
+  mRasterLayer->serverProperties()->setKeywordList( mLayerKeywordListLineEdit->text() );
 
-  if ( mRasterLayer->dataUrl() != mLayerDataUrlLineEdit->text() )
+  if ( mRasterLayer->serverProperties()->dataUrl() != mLayerDataUrlLineEdit->text() )
     mMetadataFilled = false;
-  mRasterLayer->setDataUrl( mLayerDataUrlLineEdit->text() );
+  mRasterLayer->serverProperties()->setDataUrl( mLayerDataUrlLineEdit->text() );
 
-  if ( mRasterLayer->dataUrlFormat() != mLayerDataUrlFormatComboBox->currentText() )
+  if ( mRasterLayer->serverProperties()->dataUrlFormat() != mLayerDataUrlFormatComboBox->currentText() )
     mMetadataFilled = false;
-  mRasterLayer->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
+  mRasterLayer->serverProperties()->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
 
   //layer attribution
-  if ( mRasterLayer->attribution() != mLayerAttributionLineEdit->text() )
+  if ( mRasterLayer->serverProperties()->attribution() != mLayerAttributionLineEdit->text() )
     mMetadataFilled = false;
-  mRasterLayer->setAttribution( mLayerAttributionLineEdit->text() );
+  mRasterLayer->serverProperties()->setAttribution( mLayerAttributionLineEdit->text() );
 
-  if ( mRasterLayer->attributionUrl() != mLayerAttributionUrlLineEdit->text() )
+  if ( mRasterLayer->serverProperties()->attributionUrl() != mLayerAttributionUrlLineEdit->text() )
     mMetadataFilled = false;
-  mRasterLayer->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
+  mRasterLayer->serverProperties()->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
 
   // Metadata URL
   QList<QgsMapLayerServerProperties::MetadataUrl> metaUrls;

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -348,24 +348,24 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mLegendConfigEmbeddedWidget->setLayer( mLayer );
 
   // WMS Name as layer short name
-  mLayerShortNameLineEdit->setText( mLayer->shortName() );
+  mLayerShortNameLineEdit->setText( mLayer->serverProperties()->shortName() );
   // WMS Name validator
   QValidator *shortNameValidator = new QRegularExpressionValidator( QgsApplication::shortNameRegularExpression(), this );
   mLayerShortNameLineEdit->setValidator( shortNameValidator );
 
   //layer title and abstract
-  mLayerTitleLineEdit->setText( mLayer->title() );
-  mLayerAbstractTextEdit->setPlainText( mLayer->abstract() );
-  mLayerKeywordListLineEdit->setText( mLayer->keywordList() );
-  mLayerDataUrlLineEdit->setText( mLayer->dataUrl() );
+  mLayerTitleLineEdit->setText( mLayer->serverProperties()->title() );
+  mLayerAbstractTextEdit->setPlainText( mLayer->serverProperties()->abstract() );
+  mLayerKeywordListLineEdit->setText( mLayer->serverProperties()->keywordList() );
+  mLayerDataUrlLineEdit->setText( mLayer->serverProperties()->dataUrl() );
   mLayerDataUrlFormatComboBox->setCurrentIndex(
     mLayerDataUrlFormatComboBox->findText(
-      mLayer->dataUrlFormat()
+      mLayer->serverProperties()->dataUrlFormat()
     )
   );
   //layer attribution
-  mLayerAttributionLineEdit->setText( mLayer->attribution() );
-  mLayerAttributionUrlLineEdit->setText( mLayer->attributionUrl() );
+  mLayerAttributionLineEdit->setText( mLayer->serverProperties()->attribution() );
+  mLayerAttributionUrlLineEdit->setText( mLayer->serverProperties()->attributionUrl() );
 
   // Setup the layer metadata URL
   tableViewMetadataUrl->setSelectionMode( QAbstractItemView::SingleSelection );
@@ -827,38 +827,38 @@ void QgsVectorLayerProperties::apply()
   }
 
   //layer title and abstract
-  if ( mLayer->shortName() != mLayerShortNameLineEdit->text() )
+  if ( mLayer->serverProperties()->shortName() != mLayerShortNameLineEdit->text() )
     mMetadataFilled = false;
-  mLayer->setShortName( mLayerShortNameLineEdit->text() );
+  mLayer->serverProperties()->setShortName( mLayerShortNameLineEdit->text() );
 
-  if ( mLayer->title() != mLayerTitleLineEdit->text() )
+  if ( mLayer->serverProperties()->title() != mLayerTitleLineEdit->text() )
     mMetadataFilled = false;
-  mLayer->setTitle( mLayerTitleLineEdit->text() );
+  mLayer->serverProperties()->setTitle( mLayerTitleLineEdit->text() );
 
-  if ( mLayer->abstract() != mLayerAbstractTextEdit->toPlainText() )
+  if ( mLayer->serverProperties()->abstract() != mLayerAbstractTextEdit->toPlainText() )
     mMetadataFilled = false;
-  mLayer->setAbstract( mLayerAbstractTextEdit->toPlainText() );
+  mLayer->serverProperties()->setAbstract( mLayerAbstractTextEdit->toPlainText() );
 
-  if ( mLayer->keywordList() != mLayerKeywordListLineEdit->text() )
+  if ( mLayer->serverProperties()->keywordList() != mLayerKeywordListLineEdit->text() )
     mMetadataFilled = false;
-  mLayer->setKeywordList( mLayerKeywordListLineEdit->text() );
+  mLayer->serverProperties()->setKeywordList( mLayerKeywordListLineEdit->text() );
 
-  if ( mLayer->dataUrl() != mLayerDataUrlLineEdit->text() )
+  if ( mLayer->serverProperties()->dataUrl() != mLayerDataUrlLineEdit->text() )
     mMetadataFilled = false;
-  mLayer->setDataUrl( mLayerDataUrlLineEdit->text() );
+  mLayer->serverProperties()->setDataUrl( mLayerDataUrlLineEdit->text() );
 
-  if ( mLayer->dataUrlFormat() != mLayerDataUrlFormatComboBox->currentText() )
+  if ( mLayer->serverProperties()->dataUrlFormat() != mLayerDataUrlFormatComboBox->currentText() )
     mMetadataFilled = false;
-  mLayer->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
+  mLayer->serverProperties()->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
 
   //layer attribution
-  if ( mLayer->attribution() != mLayerAttributionLineEdit->text() )
+  if ( mLayer->serverProperties()->attribution() != mLayerAttributionLineEdit->text() )
     mMetadataFilled = false;
-  mLayer->setAttribution( mLayerAttributionLineEdit->text() );
+  mLayer->serverProperties()->setAttribution( mLayerAttributionLineEdit->text() );
 
-  if ( mLayer->attributionUrl() != mLayerAttributionUrlLineEdit->text() )
+  if ( mLayer->serverProperties()->attributionUrl() != mLayerAttributionUrlLineEdit->text() )
     mMetadataFilled = false;
-  mLayer->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
+  mLayer->serverProperties()->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
 
   // Metadata URL
   QList<QgsMapLayerServerProperties::MetadataUrl> metaUrls;

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -234,7 +234,7 @@ void QgsVectorTileLayerProperties::syncToLayer()
    * Server
    */
   //layer title and abstract
-  mLayer->serverProperties()->setShortName( mLayerShortNameLineEdit->text() );
+  mLayerShortNameLineEdit->setText( mLayer->serverProperties()->shortName() );
   mLayerTitleLineEdit->setText( mLayer->serverProperties()->title() );
   mLayerAbstractTextEdit->setPlainText( mLayer->serverProperties()->abstract() );
   mLayerKeywordListLineEdit->setText( mLayer->serverProperties()->keywordList() );

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -155,16 +155,16 @@ void QgsVectorTileLayerProperties::apply()
   mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
 
   //layer title and abstract
-  mLayer->setShortName( mLayerShortNameLineEdit->text() );
-  mLayer->setTitle( mLayerTitleLineEdit->text() );
-  mLayer->setAbstract( mLayerAbstractTextEdit->toPlainText() );
-  mLayer->setKeywordList( mLayerKeywordListLineEdit->text() );
-  mLayer->setDataUrl( mLayerDataUrlLineEdit->text() );
-  mLayer->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
+  mLayer->serverProperties()->setShortName( mLayerShortNameLineEdit->text() );
+  mLayer->serverProperties()->setTitle( mLayerTitleLineEdit->text() );
+  mLayer->serverProperties()->setAbstract( mLayerAbstractTextEdit->toPlainText() );
+  mLayer->serverProperties()->setKeywordList( mLayerKeywordListLineEdit->text() );
+  mLayer->serverProperties()->setDataUrl( mLayerDataUrlLineEdit->text() );
+  mLayer->serverProperties()->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
 
   //layer attribution
-  mLayer->setAttribution( mLayerAttributionLineEdit->text() );
-  mLayer->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
+  mLayer->serverProperties()->setAttribution( mLayerAttributionLineEdit->text() );
+  mLayer->serverProperties()->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
 
   // LegendURL
   mLayer->setLegendUrl( mLayerLegendUrlLineEdit->text() );
@@ -234,19 +234,19 @@ void QgsVectorTileLayerProperties::syncToLayer()
    * Server
    */
   //layer title and abstract
-  mLayer->setShortName( mLayerShortNameLineEdit->text() );
-  mLayerTitleLineEdit->setText( mLayer->title() );
-  mLayerAbstractTextEdit->setPlainText( mLayer->abstract() );
-  mLayerKeywordListLineEdit->setText( mLayer->keywordList() );
-  mLayerDataUrlLineEdit->setText( mLayer->dataUrl() );
+  mLayer->serverProperties()->setShortName( mLayerShortNameLineEdit->text() );
+  mLayerTitleLineEdit->setText( mLayer->serverProperties()->title() );
+  mLayerAbstractTextEdit->setPlainText( mLayer->serverProperties()->abstract() );
+  mLayerKeywordListLineEdit->setText( mLayer->serverProperties()->keywordList() );
+  mLayerDataUrlLineEdit->setText( mLayer->serverProperties()->dataUrl() );
   mLayerDataUrlFormatComboBox->setCurrentIndex(
     mLayerDataUrlFormatComboBox->findText(
-      mLayer->dataUrlFormat()
+      mLayer->serverProperties()->dataUrlFormat()
     )
   );
   //layer attribution
-  mLayerAttributionLineEdit->setText( mLayer->attribution() );
-  mLayerAttributionUrlLineEdit->setText( mLayer->attributionUrl() );
+  mLayerAttributionLineEdit->setText( mLayer->serverProperties()->attribution() );
+  mLayerAttributionUrlLineEdit->setText( mLayer->serverProperties()->attributionUrl() );
 
   // layer legend url
   mLayerLegendUrlLineEdit->setText( mLayer->legendUrl() );

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -499,8 +499,8 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
         wmsLayer[ "extent" ] = { l->extent().xMinimum(), l->extent().yMinimum(), l->extent().xMaximum(), l->extent().yMaximum() };
 
         // Fill maps
-        const QString layerTitle { l->title().isEmpty() ? l->name() : l->title() };
-        const QString shortName { ! l->shortName().isEmpty() ? l->shortName() : l->name() };
+        const QString layerTitle { l->serverProperties()->title().isEmpty() ? l->name() : l->serverProperties()->title() };
+        const QString shortName { ! l->serverProperties()->shortName().isEmpty() ? l->serverProperties()->shortName() : l->name() };
         const std::string layerIdentifier { useIds ? l->id().toStdString() : shortName.toStdString() };
         wmsLayersTypenameIdMap[ layerIdentifier ] = l->id().toStdString();
         wmsLayersTitleIdMap[ layerTitle.toStdString() ] = layerIdentifier;
@@ -601,12 +601,12 @@ json QgsLandingPageUtils::layerTree( const QgsProject &project, const QStringLis
         rec[ "queryable" ] = wmsLayersQueryable.contains( l->layerId() );
         rec[ "searchable" ] = wmsLayersSearchable.contains( l->layerId() );
         rec[ "wfs_enabled" ] = wfsLayerIds.contains( l->layerId() );
-        const QString layerName { l->layer()->shortName().isEmpty() ? l->layer()->name() : l->layer()->shortName()};
+        const QString layerName { l->layer()->serverProperties()->shortName().isEmpty() ? l->layer()->name() : l->layer()->serverProperties()->shortName()};
         rec[ "typename" ] = useIds ? l->layer()->id().toStdString() : layerName.toStdString();
         // Override title
-        if ( ! l->layer()->title().isEmpty() )
+        if ( ! l->layer()->serverProperties()->title().isEmpty() )
         {
-          title = l->layer()->title();
+          title = l->layer()->serverProperties()->title();
         }
       }
       else

--- a/src/server/services/wcs/qgswcsdescribecoverage.cpp
+++ b/src/server/services/wcs/qgswcsdescribecoverage.cpp
@@ -136,8 +136,8 @@ namespace QgsWcs
       }
 #endif
       QString name = layer->name();
-      if ( !layer->shortName().isEmpty() )
-        name = layer->shortName();
+      if ( !layer->serverProperties()->shortName().isEmpty() )
+        name = layer->serverProperties()->shortName();
       name = name.replace( ' ', '_' );
 
       if ( coveNameList.size() == 0 || coveNameList.contains( name ) )

--- a/src/server/services/wcs/qgswcsgetcoverage.cpp
+++ b/src/server/services/wcs/qgswcsgetcoverage.cpp
@@ -99,8 +99,8 @@ namespace QgsWcs
       }
 #endif
       QString name = layer->name();
-      if ( !layer->shortName().isEmpty() )
-        name = layer->shortName();
+      if ( !layer->serverProperties()->shortName().isEmpty() )
+        name = layer->serverProperties()->shortName();
       name = name.replace( QLatin1String( " " ), QLatin1String( "_" ) );
 
       if ( name == coveName )

--- a/src/server/services/wcs/qgswcsutils.cpp
+++ b/src/server/services/wcs/qgswcsutils.cpp
@@ -43,8 +43,8 @@ namespace QgsWcs
     // create name
     QDomElement nameElem = doc.createElement( QStringLiteral( "name" ) );
     QString name = layer->name();
-    if ( !layer->shortName().isEmpty() )
-      name = layer->shortName();
+    if ( !layer->serverProperties()->shortName().isEmpty() )
+      name = layer->serverProperties()->shortName();
     name = name.replace( ' ', '_' );
     const QDomText nameText = doc.createTextNode( name );
     nameElem.appendChild( nameText );
@@ -52,7 +52,7 @@ namespace QgsWcs
 
     // create label
     QDomElement labelElem = doc.createElement( QStringLiteral( "label" ) );
-    QString title = layer->title();
+    QString title = layer->serverProperties()->title();
     if ( title.isEmpty() )
     {
       title = layer->name();
@@ -62,7 +62,7 @@ namespace QgsWcs
     layerElem.appendChild( labelElem );
 
     //create description
-    const QString abstract = layer->abstract();
+    const QString abstract = layer->serverProperties()->abstract();
     if ( !abstract.isEmpty() )
     {
       QDomElement descriptionElem = doc.createElement( QStringLiteral( "description" ) );

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -475,7 +475,7 @@ namespace QgsWfs
 
       //create Title
       QDomElement titleElem = doc.createElement( QStringLiteral( "Title" ) );
-      QString title = layer->title();
+      QString title = layer->serverProperties()->title();
       if ( title.isEmpty() )
       {
         title = layer->name();
@@ -485,7 +485,7 @@ namespace QgsWfs
       layerElem.appendChild( titleElem );
 
       //create Abstract
-      const QString abstract = layer->abstract();
+      const QString abstract = layer->serverProperties()->abstract();
       if ( !abstract.isEmpty() )
       {
         QDomElement abstractElem = doc.createElement( QStringLiteral( "Abstract" ) );
@@ -495,7 +495,7 @@ namespace QgsWfs
       }
 
       //create keywords
-      const QString keywords = layer->keywordList();
+      const QString keywords = layer->serverProperties()->keywordList();
       if ( !keywords.isEmpty() )
       {
         QDomElement keywordsElem = doc.createElement( QStringLiteral( "ows:Keywords" ) );

--- a/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
@@ -306,8 +306,8 @@ namespace QgsWfs
         //create Name
         QDomElement nameElem = doc.createElement( QStringLiteral( "Name" ) );
         QString typeName = layer->name();
-        if ( !layer->shortName().isEmpty() )
-          typeName = layer->shortName();
+        if ( !layer->serverProperties()->shortName().isEmpty() )
+          typeName = layer->serverProperties()->shortName();
         typeName = typeName.replace( QLatin1String( " " ), QLatin1String( "_" ) );
         const QDomText nameText = doc.createTextNode( typeName );
         nameElem.appendChild( nameText );
@@ -315,7 +315,7 @@ namespace QgsWfs
 
         //create Title
         QDomElement titleElem = doc.createElement( QStringLiteral( "Title" ) );
-        QString title = layer->title();
+        QString title = layer->serverProperties()->title();
         if ( title.isEmpty() )
         {
           title = layer->name();
@@ -325,7 +325,7 @@ namespace QgsWfs
         layerElem.appendChild( titleElem );
 
         //create Abstract
-        const QString abstract = layer->abstract();
+        const QString abstract = layer->serverProperties()->abstract();
         if ( !abstract.isEmpty() )
         {
           QDomElement abstractElem = doc.createElement( QStringLiteral( "Abstract" ) );
@@ -335,7 +335,7 @@ namespace QgsWfs
         }
 
         //create keywords
-        const QString keywords = layer->keywordList();
+        const QString keywords = layer->serverProperties()->keywordList();
         if ( !keywords.isEmpty() )
         {
           QDomElement keywordsElem = doc.createElement( QStringLiteral( "Keywords" ) );

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -68,8 +68,8 @@ namespace QgsWfs
   QString layerTypeName( const QgsMapLayer *layer )
   {
     QString name = layer->name();
-    if ( !layer->shortName().isEmpty() )
-      name = layer->shortName();
+    if ( !layer->serverProperties()->shortName().isEmpty() )
+      name = layer->serverProperties()->shortName();
     name = name.replace( ' ', '_' ).replace( ':', '-' );
     return name;
   }

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -481,8 +481,8 @@ void QgsWfs3CollectionsHandler::handleRequest( const QgsServerApiContext &contex
       // Check if the layer is published, raise not found if it is not
       checkLayerIsAccessible( layer, context );
 
-      const std::string title { layer->title().isEmpty() ? layer->name().toStdString() : layer->title().toStdString() };
-      const QString shortName { layer->shortName().isEmpty() ? layer->name() : layer->shortName() };
+      const std::string title { layer->serverProperties()->title().isEmpty() ? layer->name().toStdString() : layer->serverProperties()->title().toStdString() };
+      const QString shortName { layer->serverProperties()->shortName().isEmpty() ? layer->name() : layer->serverProperties()->shortName() };
       data["collections"].push_back(
       {
         // identifier of the collection used, for example, in URIs
@@ -490,7 +490,7 @@ void QgsWfs3CollectionsHandler::handleRequest( const QgsServerApiContext &contex
         // human readable title of the collection
         { "title", title },
         // a description of the features in the collection
-        { "description", layer->abstract().toStdString() },
+        { "description", layer->serverProperties()->abstract().toStdString() },
         {
           "crs", crss
         },
@@ -626,9 +626,9 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
   // Check if the layer is published, raise not found if it is not
   checkLayerIsAccessible( mapLayer, context );
 
-  const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
+  const std::string title { mapLayer->serverProperties()->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->title().toStdString() };
   const std::string itemsTitle { title + " items" };
-  const QString shortName { mapLayer->shortName().isEmpty() ? mapLayer->name() : mapLayer->shortName() };
+  const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
   json linksList = links( context );
   linksList.push_back(
   {
@@ -709,10 +709,10 @@ json QgsWfs3DescribeCollectionHandler::schema( const QgsServerApiContext &contex
   // Construct the context with collection id
   for ( const auto &mapLayer : layers )
   {
-    const QString shortName { mapLayer->shortName().isEmpty() ? mapLayer->name() : mapLayer->shortName() };
+    const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
     // Use layer id for operationId
     const QString layerId { mapLayer->id() };
-    const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
+    const std::string title { mapLayer->serverProperties()->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->title().toStdString() };
     const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/collections/%1" ).arg( shortName ), context.request()->url() ).toStdString() };
 
     data[ path ] =
@@ -969,8 +969,8 @@ json QgsWfs3CollectionsItemsHandler::schema( const QgsServerApiContext &context 
   // Construct the context with collection id
   for ( const auto &mapLayer : layers )
   {
-    const QString shortName { mapLayer->shortName().isEmpty() ? mapLayer->name() : mapLayer->shortName() };
-    const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
+    const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
+    const std::string title { mapLayer->serverProperties()->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->title().toStdString() };
     // Use layer id for operationId
     const QString layerId { mapLayer->id() };
     const QString path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/collections/%1/items" ).arg( shortName ), context.request()->url() ) };
@@ -1134,7 +1134,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
   // Check if the layer is published, raise not found if it is not
   checkLayerIsAccessible( mapLayer, context );
 
-  const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
+  const std::string title { mapLayer->serverProperties()->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->title().toStdString() };
 
   // Get parameters
   QVariantMap params = values( context );
@@ -1732,7 +1732,7 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
   // Check if the layer is published, raise not found if it is not
   checkLayerIsAccessible( mapLayer, context );
 
-  const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
+  const std::string title { mapLayer->serverProperties()->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->title().toStdString() };
 
   // Retrieve feature from storage
   const QString featureId { match.captured( QStringLiteral( "featureId" ) ) };
@@ -2134,10 +2134,10 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
   // Construct the context with collection id
   for ( const auto &mapLayer : layers )
   {
-    const QString shortName { mapLayer->shortName().isEmpty() ? mapLayer->name() : mapLayer->shortName() };
+    const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
     // Use layer id for operationId
     const QString layerId { mapLayer->id() };
-    const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
+    const std::string title { mapLayer->serverProperties()->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->title().toStdString() };
     const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/collections/%1/items/{featureId}" ).arg( shortName ), context.request()->url() ).toStdString() };
 
     data[ path ] =

--- a/src/server/services/wms/qgswmsdescribelayer.cpp
+++ b/src/server/services/wms/qgswmsdescribelayer.cpp
@@ -133,8 +133,8 @@ namespace QgsWms
       QString name = layer->name();
       if ( useLayerIds )
         name = layer->id();
-      else if ( !layer->shortName().isEmpty() )
-        name = layer->shortName();
+      else if ( !layer->serverProperties()->shortName().isEmpty() )
+        name = layer->serverProperties()->shortName();
 
       if ( !layersList.contains( name ) )
       {

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -676,7 +676,7 @@ namespace QgsWms
         QgsVectorLayer *cLayer = atlas->coverageLayer();
         if ( cLayer )
         {
-          QString layerName = cLayer->shortName();
+          QString layerName = cLayer->serverProperties()->shortName();
           if ( QgsServerProjectUtils::wmsUseLayerIds( *project ) )
           {
             layerName = cLayer->id();
@@ -1123,7 +1123,7 @@ namespace QgsWms
           {
             QDomElement dataUrlElem = doc.createElement( QStringLiteral( "DataURL" ) );
             QDomElement dataUrlFormatElem = doc.createElement( QStringLiteral( "Format" ) );
-            QString dataUrlFormat = l->dataUrlFormat();
+            QString dataUrlFormat = l->serverProperties()->dataUrlFormat();
             QDomText dataUrlFormatText = doc.createTextNode( dataUrlFormat );
             dataUrlFormatElem.appendChild( dataUrlFormatText );
             dataUrlElem.appendChild( dataUrlFormatElem );
@@ -1641,9 +1641,9 @@ namespace QgsWms
         {
           wmsName = l->id();
         }
-        else if ( !l->shortName().isEmpty() )
+        else if ( !l->serverProperties()->shortName().isEmpty() )
         {
-          wmsName = l->shortName();
+          wmsName = l->serverProperties()->shortName();
         }
 
         layerList <<  wmsName;

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -304,9 +304,9 @@ namespace QgsWms
           {
             wmsName = l->id();
           }
-          else if ( !l->shortName().isEmpty() )
+          else if ( !l->serverProperties()->shortName().isEmpty() )
           {
-            wmsName = l->shortName();
+            wmsName = l->serverProperties()->shortName();
           }
           // layer wms name
           layerElem.setAttribute( QStringLiteral( "name" ), wmsName );
@@ -316,7 +316,7 @@ namespace QgsWms
 
           // layer title
           QDomElement titleElem = doc.createElement( QStringLiteral( "ows:Title" ) );
-          QString title = l->title();
+          QString title = l->serverProperties()->title();
           if ( title.isEmpty() )
           {
             title = l->name();
@@ -348,7 +348,7 @@ namespace QgsWms
           serverElem.appendChild( orServerElem );
           layerElem.appendChild( serverElem );
 
-          const QString abstract = l->abstract();
+          const QString abstract = l->serverProperties()->abstract();
           if ( !abstract.isEmpty() )
           {
             QDomElement abstractElem = doc.createElement( QStringLiteral( "ows:Abstract" ) );
@@ -376,9 +376,9 @@ namespace QgsWms
           appendOwsLayerStyles( doc, layerElem, l );
 
           //keyword list
-          if ( !l->keywordList().isEmpty() )
+          if ( !l->serverProperties()->keywordList().isEmpty() )
           {
-            const QStringList keywordStringList = l->keywordList().split( ',' );
+            const QStringList keywordStringList = l->serverProperties()->keywordList().split( ',' );
             const bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
 
             QDomElement keywordsElem = doc.createElement( QStringLiteral( "ows:Keywords" ) );
@@ -397,11 +397,11 @@ namespace QgsWms
           }
 
           // layer data URL
-          const QString dataUrl = l->dataUrl();
+          const QString dataUrl = l->serverProperties()->dataUrl();
           if ( !dataUrl.isEmpty() )
           {
             QDomElement dataUrlElem = doc.createElement( QStringLiteral( "DataURL" ) );
-            const QString dataUrlFormat = l->dataUrlFormat();
+            const QString dataUrlFormat = l->serverProperties()->dataUrlFormat();
             dataUrlElem.setAttribute( QStringLiteral( "format" ), dataUrlFormat );
             QDomElement dataORElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
             dataORElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -339,8 +339,8 @@ namespace QgsWms
       lt->setUseLayerName( false ); // do not modify underlying layer
 
       // name
-      if ( !ml->title().isEmpty() )
-        lt->setName( ml->title() );
+      if ( !ml->serverProperties()->title().isEmpty() )
+        lt->setName( ml->serverProperties()->title() );
 
       // show feature count
       const bool showFeatureCount = context.parameters().showFeatureCountAsBool();

--- a/src/server/services/wms/qgswmslayerinfos.cpp
+++ b/src/server/services/wms/qgswmslayerinfos.cpp
@@ -192,24 +192,24 @@ QMap< QString, QgsWmsLayerInfos > QgsWmsLayerInfos::buildWmsLayerInfos(
     {
       pLayer.name = ml->id();
     }
-    else if ( !ml->shortName().isEmpty() )
+    else if ( !ml->serverProperties()->shortName().isEmpty() )
     {
-      pLayer.name = ml->shortName();
+      pLayer.name = ml->serverProperties()->shortName();
     }
     // layer title
-    pLayer.title = ml->title();
+    pLayer.title = ml->serverProperties()->title();
     if ( pLayer.title.isEmpty() )
     {
       pLayer.title = ml->name();
     }
     // layer abstract
-    pLayer.abstract = ml->abstract();
+    pLayer.abstract = ml->serverProperties()->abstract();
     // layer is queryable
     pLayer.queryable = ml->flags().testFlag( QgsMapLayer::Identifiable );
     // layer keywords
-    if ( !ml->keywordList().isEmpty() )
+    if ( !ml->serverProperties()->keywordList().isEmpty() )
     {
-      pLayer.keywords = ml->keywordList().split( ',' );
+      pLayer.keywords = ml->serverProperties()->keywordList().split( ',' );
     }
     // layer styles
     pLayer.styles = ml->styleManager()->styles();
@@ -225,10 +225,10 @@ QMap< QString, QgsWmsLayerInfos > QgsWmsLayerInfos::buildWmsLayerInfos(
       pLayer.minScale = ml->minimumScale();
     }
     // layer data URL
-    pLayer.dataUrl = ml->dataUrl();
+    pLayer.dataUrl = ml->serverProperties()->dataUrl();
     // layer attribution
-    pLayer.attribution = ml->attribution();
-    pLayer.attributionUrl = ml->attributionUrl();
+    pLayer.attribution = ml->serverProperties()->attribution();
+    pLayer.attributionUrl = ml->serverProperties()->attributionUrl();
     // layer metadata URLs
     pLayer.metadataUrls = ml->serverProperties()->metadataUrls();
 

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -267,7 +267,7 @@ bool QgsWmsRenderContext::updateExtent() const
 
 QString QgsWmsRenderContext::layerNickname( const QgsMapLayer &layer ) const
 {
-  QString name = layer.shortName();
+  QString name = layer.serverProperties()->shortName();
   // For external layers we cannot use the layer id because it's not known to the client, use layer name instead.
   if ( QgsServerProjectUtils::wmsUseLayerIds( *mProject ) &&
        std::find_if( mExternalLayers.cbegin(), mExternalLayers.cend(),

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1649,7 +1649,7 @@ namespace QgsWms
             }
 
             layerElement.setAttribute( QStringLiteral( "name" ), layerName );
-            const QString layerTitle = layer->title();
+            const QString layerTitle = layer->serverProperties()->title();
             if ( !layerTitle.isEmpty() )
             {
               layerElement.setAttribute( QStringLiteral( "title" ), layerTitle );
@@ -1725,7 +1725,7 @@ namespace QgsWms
               const QList<QgsMapLayer *> constLayers { mContext.layerGroups()[ql] };
               for ( const QgsMapLayer *ml : constLayers )
               {
-                if ( ( ! ml->shortName().isEmpty() &&  ml->shortName() == queryLayer ) || ( ml->name() == queryLayer ) )
+                if ( ( ! ml->serverProperties()->shortName().isEmpty() &&  ml->serverProperties()->shortName() == queryLayer ) || ( ml->name() == queryLayer ) )
                 {
                   param.mValue = ql;
                 }

--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -529,12 +529,12 @@ namespace QgsWmts
 
       layerDef pLayer;
       pLayer.id = l->name();
-      if ( !l->shortName().isEmpty() )
-        pLayer.id = l->shortName();
+      if ( !l->serverProperties()->shortName().isEmpty() )
+        pLayer.id = l->serverProperties()->shortName();
       pLayer.id = pLayer.id.replace( ' ', '_' );
 
-      pLayer.title = l->title();
-      pLayer.abstract = l->abstract();
+      pLayer.title = l->serverProperties()->title();
+      pLayer.abstract = l->serverProperties()->abstract();
 
       //transform the layer native CRS into WGS84
       const QgsCoordinateReferenceSystem layerCrs = l->crs();
@@ -693,7 +693,7 @@ namespace QgsWmts
           continue;
         }
 #endif
-        QString layerLayerId = l->shortName();
+        QString layerLayerId = l->serverProperties()->shortName();
         if ( layerLayerId.isEmpty() )
         {
           layerLayerId = l->name();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -113,12 +113,12 @@ class TestQgsExpression: public QObject
       mPointsLayer = new QgsVectorLayer( pointFileInfo.filePath(),
                                          pointFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
       QgsProject::instance()->addMapLayer( mPointsLayer );
-      mPointsLayer->setTitle( QStringLiteral( "layer title" ) );
-      mPointsLayer->setAbstract( QStringLiteral( "layer abstract" ) );
-      mPointsLayer->setKeywordList( QStringLiteral( "layer,keywords" ) );
-      mPointsLayer->setDataUrl( QStringLiteral( "data url" ) );
-      mPointsLayer->setAttribution( QStringLiteral( "layer attribution" ) );
-      mPointsLayer->setAttributionUrl( QStringLiteral( "attribution url" ) );
+      mPointsLayer->serverProperties()->setTitle( QStringLiteral( "layer title" ) );
+      mPointsLayer->serverProperties()->setAbstract( QStringLiteral( "layer abstract" ) );
+      mPointsLayer->serverProperties()->setKeywordList( QStringLiteral( "layer,keywords" ) );
+      mPointsLayer->serverProperties()->setDataUrl( QStringLiteral( "data url" ) );
+      mPointsLayer->serverProperties()->setAttribution( QStringLiteral( "layer attribution" ) );
+      mPointsLayer->serverProperties()->setAttributionUrl( QStringLiteral( "attribution url" ) );
       mPointsLayer->setMinimumScale( 500 );
       mPointsLayer->setMaximumScale( 1000 );
       mPointsLayer->setMapTipTemplate( QStringLiteral( "Maptip with class = [% \"Class\" %]" ) );
@@ -136,12 +136,12 @@ class TestQgsExpression: public QObject
       metadata.setKeywords( keywords );
       metadata.setRights( QStringList() << QStringLiteral( "right1" ) << QStringLiteral( "right2" ) );
       mPointsLayerMetadata->setMetadata( metadata );
-      mPointsLayerMetadata->setTitle( QStringLiteral( "layer title" ) );
-      mPointsLayerMetadata->setAbstract( QStringLiteral( "layer abstract" ) );
-      mPointsLayerMetadata->setKeywordList( QStringLiteral( "layer,keywords" ) );
-      mPointsLayerMetadata->setDataUrl( QStringLiteral( "data url" ) );
-      mPointsLayerMetadata->setAttribution( QStringLiteral( "layer attribution" ) );
-      mPointsLayerMetadata->setAttributionUrl( QStringLiteral( "attribution url" ) );
+      mPointsLayerMetadata->serverProperties()->setTitle( QStringLiteral( "layer title" ) );
+      mPointsLayerMetadata->serverProperties()->setAbstract( QStringLiteral( "layer abstract" ) );
+      mPointsLayerMetadata->serverProperties()->setKeywordList( QStringLiteral( "layer,keywords" ) );
+      mPointsLayerMetadata->serverProperties()->setDataUrl( QStringLiteral( "data url" ) );
+      mPointsLayerMetadata->serverProperties()->setAttribution( QStringLiteral( "layer attribution" ) );
+      mPointsLayerMetadata->serverProperties()->setAttributionUrl( QStringLiteral( "attribution url" ) );
 
       QString rasterFileName = testDataDir + "tenbytenraster.asc";
       QFileInfo rasterFileInfo( rasterFileName );
@@ -1954,12 +1954,12 @@ class TestQgsExpression: public QObject
       QTest::newRow( "layer_property by id" ) << QStringLiteral( "layer_property('%1','name')" ).arg( mPointsLayer->id() ) << false << QVariant( mPointsLayer->name() );
       QTest::newRow( "layer_property name" ) << QStringLiteral( "layer_property('%1','name')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->name() );
       QTest::newRow( "layer_property id" ) << QStringLiteral( "layer_property('%1','id')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->id() );
-      QTest::newRow( "layer_property title" ) << QStringLiteral( "layer_property('%1','title')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->title() );
-      QTest::newRow( "layer_property abstract" ) << QStringLiteral( "layer_property('%1','abstract')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->abstract() );
-      QTest::newRow( "layer_property keywords" ) << QStringLiteral( "layer_property('%1','keywords')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->keywordList() );
-      QTest::newRow( "layer_property data_url" ) << QStringLiteral( "layer_property('%1','data_url')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->dataUrl() );
-      QTest::newRow( "layer_property attribution" ) << QStringLiteral( "layer_property('%1','attribution')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->attribution() );
-      QTest::newRow( "layer_property attribution_url" ) << QStringLiteral( "layer_property('%1','attribution_url')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->attributionUrl() );
+      QTest::newRow( "layer_property title" ) << QStringLiteral( "layer_property('%1','title')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->serverProperties()->title() );
+      QTest::newRow( "layer_property abstract" ) << QStringLiteral( "layer_property('%1','abstract')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->serverProperties()->abstract() );
+      QTest::newRow( "layer_property keywords" ) << QStringLiteral( "layer_property('%1','keywords')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->serverProperties()->keywordList() );
+      QTest::newRow( "layer_property data_url" ) << QStringLiteral( "layer_property('%1','data_url')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->serverProperties()->dataUrl() );
+      QTest::newRow( "layer_property attribution" ) << QStringLiteral( "layer_property('%1','attribution')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->serverProperties()->attribution() );
+      QTest::newRow( "layer_property attribution_url" ) << QStringLiteral( "layer_property('%1','attribution_url')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->serverProperties()->attributionUrl() );
       QTest::newRow( "layer_property source" ) << QStringLiteral( "layer_property('%1','source')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->publicSource() );
       QTest::newRow( "layer_property min_scale" ) << QStringLiteral( "layer_property('%1','min_scale')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->minimumScale() );
       QTest::newRow( "layer_property max_scale" ) << QStringLiteral( "layer_property('%1','max_scale')" ).arg( mPointsLayer->name() ) << false << QVariant( mPointsLayer->maximumScale() );


### PR DESCRIPTION
Eg server layer title, abstract, etc, and deprecate the related methods at the QgsMapLayer level

This should avoid accidental creep of these specifically server-related properties into wider use, and help disambiguate them from the standard layer metadata properties
