### PR TITLE
Improve handling of map canvas cache invalidation

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -763,6 +763,17 @@ void QgsMapCanvas::refreshMap()
   stopRendering(); // if any...
   stopPreviewJobs();
 
+  if ( mCacheInvalidations.testFlag( CacheInvalidationType::Temporal ) )
+  {
+    clearTemporalCache();
+    mCacheInvalidations &= ~( static_cast< int >( CacheInvalidationType::Temporal ) );
+  }
+  if ( mCacheInvalidations.testFlag( CacheInvalidationType::Elevation ) )
+  {
+    clearElevationCache();
+    mCacheInvalidations &= ~( static_cast< int >( CacheInvalidationType::Elevation ) );
+  }
+
   mSettings.setExpressionContext( createExpressionContext() );
 
   // if using the temporal controller in animation mode, get the frame settings from that
@@ -966,8 +977,6 @@ void QgsMapCanvas::rendererJobFinished()
   if ( mRefreshAfterJob )
   {
     mRefreshAfterJob = false;
-    clearTemporalCache();
-    clearElevationCache();
     refresh();
   }
 }
@@ -1338,8 +1347,7 @@ void QgsMapCanvas::setTemporalRange( const QgsDateTimeRange &dateTimeRange )
 
   // we need to discard any previously cached images which have temporal properties enabled, so that these will be updated when
   // the canvas is redrawn
-  if ( !mJob )
-    clearTemporalCache();
+  mCacheInvalidations |= CacheInvalidationType::Temporal;
 
   autoRefreshTriggered();
 }
@@ -1920,8 +1928,7 @@ void QgsMapCanvas::setZRange( const QgsDoubleRange &range )
 
   // we need to discard any previously cached images which are elevation aware, so that these will be updated when
   // the canvas is redrawn
-  if ( !mJob )
-    clearElevationCache();
+  mCacheInvalidations |= CacheInvalidationType::Elevation;
 
   autoRefreshTriggered();
 }

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1287,6 +1287,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
         double mLockedScale;
     };
 
+    enum class CacheInvalidationType
+    {
+      Temporal = 1 << 0,
+      Elevation = 1 << 1,
+    };
+
     QgsOverlayWidgetLayout *mLayout = nullptr;
 
     //! encompases all map settings necessary for map rendering
@@ -1314,6 +1320,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
 
     //! determines whether user has requested to suppress rendering
     bool mRenderFlag = true;
+
+    QFlags<CacheInvalidationType> mCacheInvalidations;
 
     //! current layer in legend
     QPointer< QgsMapLayer > mCurrentLayer;

--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -104,6 +104,17 @@ void QgsQuickMapCanvasMap::refreshMap()
 {
   stopRendering(); // if any...
 
+  if ( mCacheInvalidations.testFlag( CacheInvalidationType::Temporal ) )
+  {
+    clearTemporalCache();
+    mCacheInvalidations &= ~( static_cast< int >( CacheInvalidationType::Temporal ) );
+  }
+  if ( mCacheInvalidations.testFlag( CacheInvalidationType::Elevation ) )
+  {
+    clearElevationCache();
+    mCacheInvalidations &= ~( static_cast< int >( CacheInvalidationType::Elevation ) );
+  }
+
   QgsMapSettings mapSettings = mMapSettings->mapSettings();
   if ( !mapSettings.hasValidSettings() )
     return;
@@ -284,7 +295,7 @@ void QgsQuickMapCanvasMap::onExtentChanged()
 
 void QgsQuickMapCanvasMap::onTemporalStateChanged()
 {
-  clearTemporalCache();
+  mCacheInvalidations |= CacheInvalidationType::Temporal;
 
   // And trigger a new rendering job
   refresh();
@@ -292,7 +303,7 @@ void QgsQuickMapCanvasMap::onTemporalStateChanged()
 
 void QgsQuickMapCanvasMap::onzRangeChanged()
 {
-  clearElevationCache();
+  mCacheInvalidations |= CacheInvalidationType::Elevation;
 
   // And trigger a new rendering job
   refresh();

--- a/src/quickgui/qgsquickmapcanvasmap.h
+++ b/src/quickgui/qgsquickmapcanvasmap.h
@@ -189,6 +189,12 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
 
   private:
 
+    enum class CacheInvalidationType
+    {
+      Temporal = 1 << 0,
+      Elevation = 1 << 1,
+    };
+
     /**
      * Should only be called by stopRendering()!
      */
@@ -196,8 +202,10 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     QgsMapSettings prepareMapSettings() const;
     void updateTransform();
     void zoomToFullExtent();
+
     void clearTemporalCache();
     void clearElevationCache();
+    QFlags<CacheInvalidationType> mCacheInvalidations;
 
     std::unique_ptr<QgsQuickMapSettings> mMapSettings;
     bool mPinching = false;


### PR DESCRIPTION
This PR improves handling of cache invalidation when refreshing the map canvas. The fix insures that we are not needlessly invalidating _elevation_-related cache when merely changing the temporal range (and vice-versa).