### PR TITLE
[api] Add QgsProject::crs3D

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1125,6 +1125,17 @@ An invalid CRS will be returned if the object does not contain a vertical compon
 
 .. seealso:: :py:func:`horizontalCrs`
 
+.. seealso:: :py:func:`hasVerticalAxis`
+
+.. versionadded:: 3.38
+%End
+
+    bool hasVerticalAxis() const;
+%Docstring
+Returns ``True`` if the CRS has a vertical axis.
+
+.. seealso:: :py:func:`verticalCrs`
+
 .. versionadded:: 3.38
 %End
 

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -323,13 +323,20 @@ Creates a CRS from a specified QGIS SRS ID.
 .. seealso:: :py:func:`validSrsIds`
 %End
 
-    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs );
+    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs, QString &error /Out/ );
 %Docstring
 Given a horizontal and vertical CRS, attempts to create a compound CRS
 from them.
 
 Returns an invalid CRS if the inputs are not suitable for a compound CRS,
 or the compound CRS could not be created for the combination.
+
+:param horizontalCrs: horizontal component for CRS
+:param verticalCrs: vertical component for CRS
+
+:return: - compound CRS if it was possible to create one, or an invalid CRS if not
+         - error: will be set to a descriptive error if the compound CRS could not be created
+
 
 .. versionadded:: 3.38
 %End

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -326,9 +326,10 @@ Returns the project's native coordinate reference system.
 Returns the CRS to use for the project when transforming 3D data, or when z/elevation
 value handling is important.
 
-The returned CRS will take into account :py:func:`~QgsProject.verticalCrs`, e.g. by returning a compound
+The returned CRS will take into account :py:func:`~QgsProject.verticalCrs` when appropriate, e.g. it may return a compound
 CRS consisting of :py:func:`~QgsProject.crs` + :py:func:`~QgsProject.verticalCrs`. This method may still return a 2D CRS, e.g in the
-case that :py:func:`~QgsProject.crs` is a 2D CRS and no :py:func:`~QgsProject.verticalCrs` has been set for the project.
+case that :py:func:`~QgsProject.crs` is a 2D CRS and no :py:func:`~QgsProject.verticalCrs` has been set for the project. Check :py:func:`QgsCoordinateReferenceSystem.type()`
+on the returned value to determine the type of CRS returned by this method.
 
 .. warning::
 

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -305,13 +305,44 @@ Sets the ``type`` of paths used when storing file paths in a QGS/QGZ project fil
 %Docstring
 Returns the project's native coordinate reference system.
 
+.. warning::
+
+   Since QGIS 3.38, consider using :py:func:`~QgsProject.crs3D` whenever transforming 3D data or whenever
+   z/elevation value handling is important.
+
 .. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`crs3D`
 
 .. seealso:: :py:func:`verticalCrs`
 
 .. seealso:: :py:func:`ellipsoid`
 
 .. seealso:: :py:func:`crsChanged`
+%End
+
+    QgsCoordinateReferenceSystem crs3D() const;
+%Docstring
+Returns the CRS to use for the project when transforming 3D data, or when z/elevation
+value handling is important.
+
+The returned CRS will take into account :py:func:`~QgsProject.verticalCrs`, e.g. by returning a compound
+CRS consisting of :py:func:`~QgsProject.crs` + :py:func:`~QgsProject.verticalCrs`. This method may still return a 2D CRS, e.g in the
+case that :py:func:`~QgsProject.crs` is a 2D CRS and no :py:func:`~QgsProject.verticalCrs` has been set for the project.
+
+.. warning::
+
+   It is NOT guaranteed that the returned CRS will actually be a 3D CRS, but rather
+   it is guaranteed that the returned CRS is ALWAYS the most appropriate CRS to use when handling 3D data.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`crs3DChanged`
+
+
+.. versionadded:: 3.38
 %End
 
     void setCrs( const QgsCoordinateReferenceSystem &crs, bool adjustEllipsoid = false );
@@ -365,9 +396,17 @@ explicitly set by a call to :py:func:`~QgsProject.setVerticalCrs`.
 
 The returned CRS will be invalid if the project has no vertical CRS.
 
+.. note::
+
+   Consider also using :py:func:`~QgsProject.crs3D`, which will return a CRS which takes into account
+   both :py:func:`~QgsProject.crs` and :py:func:`~QgsProject.verticalCrs`.
+
 .. seealso:: :py:func:`crs`
 
+.. seealso:: :py:func:`crs3D`
+
 .. seealso:: :py:func:`setVerticalCrs`
+
 
 .. versionadded:: 3.38
 %End
@@ -1781,7 +1820,7 @@ Emitted whenever the expression variables stored in the project have been change
 
     void crsChanged();
 %Docstring
-Emitted when the CRS of the project has changed.
+Emitted when the :py:func:`~QgsProject.crs` of the project has changed.
 
 .. seealso:: :py:func:`crs`
 
@@ -1792,15 +1831,32 @@ Emitted when the CRS of the project has changed.
 .. seealso:: :py:func:`ellipsoidChanged`
 %End
 
+    void crs3DChanged();
+%Docstring
+Emitted when the :py:func:`~QgsProject.crs3D` of the project has changed.
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`verticalCrsChanged`
+
+.. seealso:: :py:func:`ellipsoidChanged`
+
+.. versionadded:: 3.38
+%End
+
     void verticalCrsChanged();
 %Docstring
-Emitted when the vertical CRS of the project has changed.
+Emitted when the :py:func:`~QgsProject.verticalCrs` of the project has changed.
 
 This signal will be emitted whenever the vertical CRS of the project is changed, either
 as a direct result of a call to :py:func:`~QgsProject.setVerticalCrs` or when :py:func:`~QgsProject.setCrs` is called with a compound
 CRS.
 
 .. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`crs3DChanged`
 
 .. seealso:: :py:func:`setCrs`
 

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1125,6 +1125,17 @@ An invalid CRS will be returned if the object does not contain a vertical compon
 
 .. seealso:: :py:func:`horizontalCrs`
 
+.. seealso:: :py:func:`hasVerticalAxis`
+
+.. versionadded:: 3.38
+%End
+
+    bool hasVerticalAxis() const;
+%Docstring
+Returns ``True`` if the CRS has a vertical axis.
+
+.. seealso:: :py:func:`verticalCrs`
+
 .. versionadded:: 3.38
 %End
 

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -323,13 +323,20 @@ Creates a CRS from a specified QGIS SRS ID.
 .. seealso:: :py:func:`validSrsIds`
 %End
 
-    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs );
+    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs, QString &error /Out/ );
 %Docstring
 Given a horizontal and vertical CRS, attempts to create a compound CRS
 from them.
 
 Returns an invalid CRS if the inputs are not suitable for a compound CRS,
 or the compound CRS could not be created for the combination.
+
+:param horizontalCrs: horizontal component for CRS
+:param verticalCrs: vertical component for CRS
+
+:return: - compound CRS if it was possible to create one, or an invalid CRS if not
+         - error: will be set to a descriptive error if the compound CRS could not be created
+
 
 .. versionadded:: 3.38
 %End

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -326,9 +326,10 @@ Returns the project's native coordinate reference system.
 Returns the CRS to use for the project when transforming 3D data, or when z/elevation
 value handling is important.
 
-The returned CRS will take into account :py:func:`~QgsProject.verticalCrs`, e.g. by returning a compound
+The returned CRS will take into account :py:func:`~QgsProject.verticalCrs` when appropriate, e.g. it may return a compound
 CRS consisting of :py:func:`~QgsProject.crs` + :py:func:`~QgsProject.verticalCrs`. This method may still return a 2D CRS, e.g in the
-case that :py:func:`~QgsProject.crs` is a 2D CRS and no :py:func:`~QgsProject.verticalCrs` has been set for the project.
+case that :py:func:`~QgsProject.crs` is a 2D CRS and no :py:func:`~QgsProject.verticalCrs` has been set for the project. Check :py:func:`QgsCoordinateReferenceSystem.type()`
+on the returned value to determine the type of CRS returned by this method.
 
 .. warning::
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -305,13 +305,44 @@ Sets the ``type`` of paths used when storing file paths in a QGS/QGZ project fil
 %Docstring
 Returns the project's native coordinate reference system.
 
+.. warning::
+
+   Since QGIS 3.38, consider using :py:func:`~QgsProject.crs3D` whenever transforming 3D data or whenever
+   z/elevation value handling is important.
+
 .. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`crs3D`
 
 .. seealso:: :py:func:`verticalCrs`
 
 .. seealso:: :py:func:`ellipsoid`
 
 .. seealso:: :py:func:`crsChanged`
+%End
+
+    QgsCoordinateReferenceSystem crs3D() const;
+%Docstring
+Returns the CRS to use for the project when transforming 3D data, or when z/elevation
+value handling is important.
+
+The returned CRS will take into account :py:func:`~QgsProject.verticalCrs`, e.g. by returning a compound
+CRS consisting of :py:func:`~QgsProject.crs` + :py:func:`~QgsProject.verticalCrs`. This method may still return a 2D CRS, e.g in the
+case that :py:func:`~QgsProject.crs` is a 2D CRS and no :py:func:`~QgsProject.verticalCrs` has been set for the project.
+
+.. warning::
+
+   It is NOT guaranteed that the returned CRS will actually be a 3D CRS, but rather
+   it is guaranteed that the returned CRS is ALWAYS the most appropriate CRS to use when handling 3D data.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`crs3DChanged`
+
+
+.. versionadded:: 3.38
 %End
 
     void setCrs( const QgsCoordinateReferenceSystem &crs, bool adjustEllipsoid = false );
@@ -365,9 +396,17 @@ explicitly set by a call to :py:func:`~QgsProject.setVerticalCrs`.
 
 The returned CRS will be invalid if the project has no vertical CRS.
 
+.. note::
+
+   Consider also using :py:func:`~QgsProject.crs3D`, which will return a CRS which takes into account
+   both :py:func:`~QgsProject.crs` and :py:func:`~QgsProject.verticalCrs`.
+
 .. seealso:: :py:func:`crs`
 
+.. seealso:: :py:func:`crs3D`
+
 .. seealso:: :py:func:`setVerticalCrs`
+
 
 .. versionadded:: 3.38
 %End
@@ -1781,7 +1820,7 @@ Emitted whenever the expression variables stored in the project have been change
 
     void crsChanged();
 %Docstring
-Emitted when the CRS of the project has changed.
+Emitted when the :py:func:`~QgsProject.crs` of the project has changed.
 
 .. seealso:: :py:func:`crs`
 
@@ -1792,15 +1831,32 @@ Emitted when the CRS of the project has changed.
 .. seealso:: :py:func:`ellipsoidChanged`
 %End
 
+    void crs3DChanged();
+%Docstring
+Emitted when the :py:func:`~QgsProject.crs3D` of the project has changed.
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`verticalCrsChanged`
+
+.. seealso:: :py:func:`ellipsoidChanged`
+
+.. versionadded:: 3.38
+%End
+
     void verticalCrsChanged();
 %Docstring
-Emitted when the vertical CRS of the project has changed.
+Emitted when the :py:func:`~QgsProject.verticalCrs` of the project has changed.
 
 This signal will be emitted whenever the vertical CRS of the project is changed, either
 as a direct result of a call to :py:func:`~QgsProject.setVerticalCrs` or when :py:func:`~QgsProject.setCrs` is called with a compound
 CRS.
 
 .. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`crs3DChanged`
 
 .. seealso:: :py:func:`setCrs`
 

--- a/src/app/project/qgsprojectelevationsettingswidget.cpp
+++ b/src/app/project/qgsprojectelevationsettingswidget.cpp
@@ -192,11 +192,21 @@ void QgsProjectElevationSettingsWidget::updateVerticalCrsOptions()
                                   ) );
       break;
 
+    case Qgis::CrsType::Projected:
+      if ( QgsProject::instance()->crs().hasVerticalAxis() )
+      {
+        mVerticalCrsStackedWidget->setCurrentWidget( mCrsPageDisabled );
+        mCrsDisabledLabel->setText( tr( "Project coordinate reference system is set to a projected 3D CRS (%1), so the vertical CRS cannot be manually specified." ).arg(
+                                      QgsProject::instance()->crs().userFriendlyIdentifier()
+                                    ) );
+        break;
+      }
+      [[fallthrough]];
+
     case Qgis::CrsType::Unknown:
     case Qgis::CrsType::Geodetic:
     case Qgis::CrsType::Geographic2d:
     case Qgis::CrsType::Vertical:
-    case Qgis::CrsType::Projected:
     case Qgis::CrsType::Temporal:
     case Qgis::CrsType::Engineering:
     case Qgis::CrsType::Bound:

--- a/src/app/project/qgsprojectelevationsettingswidget.cpp
+++ b/src/app/project/qgsprojectelevationsettingswidget.cpp
@@ -178,11 +178,23 @@ void QgsProjectElevationSettingsWidget::updateVerticalCrsOptions()
                                   ) );
       break;
 
+    case Qgis::CrsType::Geographic3d:
+      mVerticalCrsStackedWidget->setCurrentWidget( mCrsPageDisabled );
+      mCrsDisabledLabel->setText( tr( "Project coordinate reference system is set to a geographic 3D CRS (%1), so the vertical CRS cannot be manually specified." ).arg(
+                                    QgsProject::instance()->crs().userFriendlyIdentifier()
+                                  ) );
+      break;
+
+    case Qgis::CrsType::Geocentric:
+      mVerticalCrsStackedWidget->setCurrentWidget( mCrsPageDisabled );
+      mCrsDisabledLabel->setText( tr( "Project coordinate reference system is set to a geocentric CRS (%1), so the vertical CRS cannot be manually specified." ).arg(
+                                    QgsProject::instance()->crs().userFriendlyIdentifier()
+                                  ) );
+      break;
+
     case Qgis::CrsType::Unknown:
     case Qgis::CrsType::Geodetic:
-    case Qgis::CrsType::Geocentric:
     case Qgis::CrsType::Geographic2d:
-    case Qgis::CrsType::Geographic3d:
     case Qgis::CrsType::Vertical:
     case Qgis::CrsType::Projected:
     case Qgis::CrsType::Temporal:

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -3081,6 +3081,15 @@ QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::verticalCrs() const
   return QgsCoordinateReferenceSystem();
 }
 
+bool QgsCoordinateReferenceSystem::hasVerticalAxis() const
+{
+  if ( PJ *obj = d->threadLocalProjObject() )
+  {
+    return QgsProjUtils::hasVerticalAxis( obj );
+  }
+  return false;
+}
+
 QString QgsCoordinateReferenceSystem::geographicCrsAuthId() const
 {
   if ( isGeographic() )

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -344,9 +344,15 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * Returns an invalid CRS if the inputs are not suitable for a compound CRS,
      * or the compound CRS could not be created for the combination.
      *
+     * \param horizontalCrs horizontal component for CRS
+     * \param verticalCrs vertical component for CRS
+     * \param error will be set to a descriptive error if the compound CRS could not be created
+     *
+     * \returns compound CRS if it was possible to create one, or an invalid CRS if not
+     *
      * \since QGIS 3.38
      */
-    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs );
+    static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs, QString &error SIP_OUT );
 
     // Misc helper functions -----------------------
 

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -1026,9 +1026,19 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * An invalid CRS will be returned if the object does not contain a vertical component.
      *
      * \see horizontalCrs()
+     * \see hasVerticalAxis()
+     *
      * \since QGIS 3.38
      */
     QgsCoordinateReferenceSystem verticalCrs() const;
+
+    /**
+     * Returns TRUE if the CRS has a vertical axis.
+     *
+     * \see verticalCrs()
+     * \since QGIS 3.38
+     */
+    bool hasVerticalAxis() const;
 
     //! Returns auth id of related geographic CRS
     QString geographicCrsAuthId() const;

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -301,6 +301,7 @@ static void proj_collecting_logger( void *user_data, int /*level*/, const char *
 
 static void proj_logger( void *, int level, const char *message )
 {
+#ifdef QGISDEBUG
   if ( level == PJ_LOG_ERROR )
   {
     QgsDebugError( QString( message ) );
@@ -309,6 +310,10 @@ static void proj_logger( void *, int level, const char *message )
   {
     QgsDebugMsgLevel( QString( message ), 3 );
   }
+#else
+  ( void )level;
+  ( void )message;
+#endif
 }
 
 QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::createCompoundCrs( const PJ *horizontalCrs, const PJ *verticalCrs, QStringList *errors )

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -210,9 +210,11 @@ class CORE_EXPORT QgsProjUtils
     /**
      * Given a PROJ horizontal and vertical CRS, attempt to create a compound CRS from them.
      *
+     * Optionally, the \a errors argument can be set to a string list to collect errors reported by PROJ when attempting to create the compound CRS.
+     *
      * \since QGIS 3.38
      */
-    static proj_pj_unique_ptr createCompoundCrs( const PJ *horizontalCrs, const PJ *verticalCrs );
+    static proj_pj_unique_ptr createCompoundCrs( const PJ *horizontalCrs, const PJ *verticalCrs, QStringList *errors = nullptr );
 
     /**
      * Attempts to identify a \a crs, matching it to a known authority and code within

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -187,6 +187,13 @@ class CORE_EXPORT QgsProjUtils
     static proj_pj_unique_ptr crsToVerticalCrs( const PJ *crs );
 
     /**
+     * Returns TRUE if a PROJ \a crs has a vertical axis.
+     *
+     * \since QGIS 3.38
+     */
+    static bool hasVerticalAxis( const PJ *crs );
+
+    /**
      * Given a PROJ crs (which may be a compound or bound crs, or some other type), ensure that it is not
      * a bound CRS object.
      *

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1097,10 +1097,18 @@ bool QgsProject::setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QStrin
         }
         break;
 
+      case Qgis::CrsType::Projected:
+        if ( mCrs.hasVerticalAxis() && crs != oldVerticalCrs )
+        {
+          if ( errorMessage )
+            *errorMessage = QObject::tr( "Project CRS is a Projected 3D CRS, specified Vertical CRS will be ignored" );
+          return false;
+        }
+        break;
+
       case Qgis::CrsType::Unknown:
       case Qgis::CrsType::Geodetic:
       case Qgis::CrsType::Geographic2d:
-      case Qgis::CrsType::Projected:
       case Qgis::CrsType::Temporal:
       case Qgis::CrsType::Engineering:
       case Qgis::CrsType::Bound:
@@ -1618,6 +1626,14 @@ bool QgsProject::rebuildCrs3D( QString *error )
         mCrs3D = mCrs;
         break;
 
+      case Qgis::CrsType::Projected:
+      {
+        QString tempError;
+        mCrs3D = mCrs.hasVerticalAxis() ? mCrs : QgsCoordinateReferenceSystem::createCompoundCrs( mCrs, mVerticalCrs, error ? *error : tempError );
+        res = mCrs3D.isValid();
+        break;
+      }
+
       case Qgis::CrsType::Vertical:
         // nonsense situation
         mCrs3D = QgsCoordinateReferenceSystem();
@@ -1627,7 +1643,6 @@ bool QgsProject::rebuildCrs3D( QString *error )
       case Qgis::CrsType::Unknown:
       case Qgis::CrsType::Geodetic:
       case Qgis::CrsType::Geographic2d:
-      case Qgis::CrsType::Projected:
       case Qgis::CrsType::Temporal:
       case Qgis::CrsType::Engineering:
       case Qgis::CrsType::Bound:

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1079,11 +1079,27 @@ bool QgsProject::setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QStrin
         }
         break;
 
+      case Qgis::CrsType::Geographic3d:
+        if ( crs != oldVerticalCrs )
+        {
+          if ( errorMessage )
+            *errorMessage = QObject::tr( "Project CRS is a Geographic 3D CRS, specified Vertical CRS will be ignored" );
+          return false;
+        }
+        break;
+
+      case Qgis::CrsType::Geocentric:
+        if ( crs != oldVerticalCrs )
+        {
+          if ( errorMessage )
+            *errorMessage = QObject::tr( "Project CRS is a Geocentric CRS, specified Vertical CRS will be ignored" );
+          return false;
+        }
+        break;
+
       case Qgis::CrsType::Unknown:
       case Qgis::CrsType::Geodetic:
-      case Qgis::CrsType::Geocentric:
       case Qgis::CrsType::Geographic2d:
-      case Qgis::CrsType::Geographic3d:
       case Qgis::CrsType::Projected:
       case Qgis::CrsType::Temporal:
       case Qgis::CrsType::Engineering:
@@ -1597,6 +1613,8 @@ bool QgsProject::rebuildCrs3D( QString *error )
     switch ( mCrs.type() )
     {
       case Qgis::CrsType::Compound:
+      case Qgis::CrsType::Geographic3d:
+      case Qgis::CrsType::Geocentric:
         mCrs3D = mCrs;
         break;
 
@@ -1608,9 +1626,7 @@ bool QgsProject::rebuildCrs3D( QString *error )
 
       case Qgis::CrsType::Unknown:
       case Qgis::CrsType::Geodetic:
-      case Qgis::CrsType::Geocentric:
       case Qgis::CrsType::Geographic2d:
-      case Qgis::CrsType::Geographic3d:
       case Qgis::CrsType::Projected:
       case Qgis::CrsType::Temporal:
       case Qgis::CrsType::Engineering:

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -2356,7 +2356,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     void releaseHandlesToProjectArchive();
 
-    void rebuildCrs3D();
+    bool rebuildCrs3D( QString *error = nullptr );
 
     Qgis::ProjectCapabilities mCapabilities;
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -385,9 +385,10 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * Returns the CRS to use for the project when transforming 3D data, or when z/elevation
      * value handling is important.
      *
-     * The returned CRS will take into account verticalCrs(), e.g. by returning a compound
+     * The returned CRS will take into account verticalCrs() when appropriate, e.g. it may return a compound
      * CRS consisting of crs() + verticalCrs(). This method may still return a 2D CRS, e.g in the
-     * case that crs() is a 2D CRS and no verticalCrs() has been set for the project.
+     * case that crs() is a 2D CRS and no verticalCrs() has been set for the project. Check QgsCoordinateReferenceSystem::type()
+     * on the returned value to determine the type of CRS returned by this method.
      *
      * \warning It is NOT guaranteed that the returned CRS will actually be a 3D CRS, but rather
      * it is guaranteed that the returned CRS is ALWAYS the most appropriate CRS to use when handling 3D data.

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -51,6 +51,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void geographic3d();
     void toHorizontal();
     void toVertical();
+    void hasVerticalAxis();
     void coordinateEpoch();
     void createCompound();
     void saveAsUserCrs();
@@ -351,7 +352,7 @@ void TestQgsCoordinateReferenceSystem::toVertical()
 {
   // invalid
   QVERIFY( !QgsCoordinateReferenceSystem().verticalCrs().isValid() );
-  // horizontal only
+  // horizontal only (projected 2d)
   QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ).verticalCrs().isValid() );
   // compound
   QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ).verticalCrs().authid(), QStringLiteral( "EPSG:5703" ) );
@@ -359,6 +360,65 @@ void TestQgsCoordinateReferenceSystem::toVertical()
   QCOMPARE( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ).verticalCrs().authid(), QStringLiteral( "EPSG:5703" ) );
   // geographic 3d
   QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4979" ) ).verticalCrs().isValid() );
+}
+
+void TestQgsCoordinateReferenceSystem::hasVerticalAxis()
+{
+  // invalid
+  QVERIFY( !QgsCoordinateReferenceSystem().hasVerticalAxis() );
+  // horizontal only (projected 2d)
+  QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ).hasVerticalAxis() );
+  // compound
+  QVERIFY( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ).hasVerticalAxis() );
+  // already vertical
+  QVERIFY( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ).hasVerticalAxis() );
+  // geographic 2d
+  QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ).hasVerticalAxis() );
+  // geographic 3d
+  QVERIFY( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4979" ) ).hasVerticalAxis() );
+  // projected 3d
+  const QString projected3DWkt = QStringLiteral( "PROJCRS[\"NAD83(HARN) / Oregon GIC Lambert (ft)\",\n"
+                                 "    BASEGEOGCRS[\"NAD83(HARN)\",\n"
+                                 "        DATUM[\"NAD83 (High Accuracy Reference Network)\",\n"
+                                 "            ELLIPSOID[\"GRS 1980\",6378137,298.257222101,\n"
+                                 "                LENGTHUNIT[\"metre\",1]]],\n"
+                                 "        PRIMEM[\"Greenwich\",0,\n"
+                                 "            ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+                                 "        ID[\"EPSG\",4957]],\n"
+                                 "    CONVERSION[\"unnamed\",\n"
+                                 "        METHOD[\"Lambert Conic Conformal (2SP)\",\n"
+                                 "            ID[\"EPSG\",9802]],\n"
+                                 "        PARAMETER[\"Latitude of false origin\",41.75,\n"
+                                 "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                                 "            ID[\"EPSG\",8821]],\n"
+                                 "        PARAMETER[\"Longitude of false origin\",-120.5,\n"
+                                 "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                                 "            ID[\"EPSG\",8822]],\n"
+                                 "        PARAMETER[\"Latitude of 1st standard parallel\",43,\n"
+                                 "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                                 "            ID[\"EPSG\",8823]],\n"
+                                 "        PARAMETER[\"Latitude of 2nd standard parallel\",45.5,\n"
+                                 "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                                 "            ID[\"EPSG\",8824]],\n"
+                                 "        PARAMETER[\"Easting at false origin\",1312335.958,\n"
+                                 "            LENGTHUNIT[\"foot\",0.3048],\n"
+                                 "            ID[\"EPSG\",8826]],\n"
+                                 "        PARAMETER[\"Northing at false origin\",0,\n"
+                                 "            LENGTHUNIT[\"foot\",0.3048],\n"
+                                 "            ID[\"EPSG\",8827]]],\n"
+                                 "    CS[Cartesian,3],\n"
+                                 "        AXIS[\"easting\",east,\n"
+                                 "            ORDER[1],\n"
+                                 "            LENGTHUNIT[\"foot\",0.3048]],\n"
+                                 "        AXIS[\"northing\",north,\n"
+                                 "            ORDER[2],\n"
+                                 "            LENGTHUNIT[\"foot\",0.3048]],\n"
+                                 "        AXIS[\"ellipsoidal height (h)\",up,\n"
+                                 "            ORDER[3],\n"
+                                 "            LENGTHUNIT[\"foot\",0.3048]]]" );
+  const QgsCoordinateReferenceSystem projected3D = QgsCoordinateReferenceSystem::fromWkt( projected3DWkt );
+  QVERIFY( projected3D.isValid() );
+  QVERIFY( projected3D.hasVerticalAxis() );
 }
 
 void TestQgsCoordinateReferenceSystem::coordinateEpoch()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -397,13 +397,13 @@ void TestQgsCoordinateReferenceSystem::createCompound()
   QVERIFY( error.isEmpty() );
   // horizontal / vertical flipped
   QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), error ).isValid() );
-  QCOMPARE( error, QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34" ) );
+  QCOMPARE( error.left( 79 ), QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations" ) );
   // horizontal valid / not vertical
   QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3113" ) ), error ).isValid() );
-  QCOMPARE( error, QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34" ) );
+  QCOMPARE( error.left( 79 ), QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations" ) );
   // horizontal already a compound
   QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), error ).isValid() );
-  QCOMPARE( error, QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34" ) );
+  QCOMPARE( error.left( 79 ), QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations" ) );
 }
 
 void TestQgsCoordinateReferenceSystem::createFromId()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -383,22 +383,27 @@ void TestQgsCoordinateReferenceSystem::coordinateEpoch()
 void TestQgsCoordinateReferenceSystem::createCompound()
 {
   //horizontal invalid / vertical invalid
-  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem() ).isValid() );
+  QString error;
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), error ).isValid() );
   // horizontal valid / vertical invalid
-  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem() ).isValid() );
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem(), error ).isValid() );
   // horizontal invalid / vertical valid
-  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ) ).isValid() );
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), error ).isValid() );
   // horizontal valid / vertical valid
-  const QgsCoordinateReferenceSystem compound = QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ) );
+  const QgsCoordinateReferenceSystem compound = QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), error );
   QVERIFY( compound.isValid() );
   QCOMPARE( compound.description(), QStringLiteral( "unnamed" ) );
   QCOMPARE( compound.type(), Qgis::CrsType::Compound );
+  QVERIFY( error.isEmpty() );
   // horizontal / vertical flipped
-  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ) ).isValid() );
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), error ).isValid() );
+  QCOMPARE( error, QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34" ) );
   // horizontal valid / not vertical
-  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3113" ) ) ).isValid() );
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3113" ) ), error ).isValid() );
+  QCOMPARE( error, QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34" ) );
   // horizontal already a compound
-  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ) ).isValid() );
+  QVERIFY( !QgsCoordinateReferenceSystem::createCompoundCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) ), error ).isValid() );
+  QCOMPARE( error, QStringLiteral( "components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34" ) );
 }
 
 void TestQgsCoordinateReferenceSystem::createFromId()

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -37,6 +37,7 @@ class TestQgsProjUtils: public QObject
     void gridsUsed();
     void toHorizontalCrs();
     void toUnboundCrs();
+    void hasVerticalAxis();
 
 };
 
@@ -156,6 +157,64 @@ void TestQgsProjUtils::toUnboundCrs()
   crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::5703" ) );
   unbound = QgsProjUtils::unboundCrs( crs.get() );
   QCOMPARE( QString( proj_get_id_code( unbound.get(), 0 ) ), QStringLiteral( "5703" ) );
+}
+
+void TestQgsProjUtils::hasVerticalAxis()
+{
+  PJ_CONTEXT *context = QgsProjContext::get();
+  // compound crs
+  QgsProjUtils::proj_pj_unique_ptr crs( proj_create( context, "EPSG:5500" ) );
+  QVERIFY( QgsProjUtils::hasVerticalAxis( crs.get() ) );
+
+  // horizontal crs
+  crs.reset( proj_create( context, "EPSG:4759" ) );
+  QVERIFY( !QgsProjUtils::hasVerticalAxis( crs.get() ) );
+
+  // vertical crs
+  crs.reset( proj_create( context, "EPSG:5703" ) );
+  QVERIFY( QgsProjUtils::hasVerticalAxis( crs.get() ) );
+
+  // projected 3d crs
+  crs.reset( proj_create( context, "PROJCRS[\"NAD83(HARN) / Oregon GIC Lambert (ft)\",\n"
+                          "    BASEGEOGCRS[\"NAD83(HARN)\",\n"
+                          "        DATUM[\"NAD83 (High Accuracy Reference Network)\",\n"
+                          "            ELLIPSOID[\"GRS 1980\",6378137,298.257222101,\n"
+                          "                LENGTHUNIT[\"metre\",1]]],\n"
+                          "        PRIMEM[\"Greenwich\",0,\n"
+                          "            ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+                          "        ID[\"EPSG\",4957]],\n"
+                          "    CONVERSION[\"unnamed\",\n"
+                          "        METHOD[\"Lambert Conic Conformal (2SP)\",\n"
+                          "            ID[\"EPSG\",9802]],\n"
+                          "        PARAMETER[\"Latitude of false origin\",41.75,\n"
+                          "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                          "            ID[\"EPSG\",8821]],\n"
+                          "        PARAMETER[\"Longitude of false origin\",-120.5,\n"
+                          "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                          "            ID[\"EPSG\",8822]],\n"
+                          "        PARAMETER[\"Latitude of 1st standard parallel\",43,\n"
+                          "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                          "            ID[\"EPSG\",8823]],\n"
+                          "        PARAMETER[\"Latitude of 2nd standard parallel\",45.5,\n"
+                          "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+                          "            ID[\"EPSG\",8824]],\n"
+                          "        PARAMETER[\"Easting at false origin\",1312335.958,\n"
+                          "            LENGTHUNIT[\"foot\",0.3048],\n"
+                          "            ID[\"EPSG\",8826]],\n"
+                          "        PARAMETER[\"Northing at false origin\",0,\n"
+                          "            LENGTHUNIT[\"foot\",0.3048],\n"
+                          "            ID[\"EPSG\",8827]]],\n"
+                          "    CS[Cartesian,3],\n"
+                          "        AXIS[\"easting\",east,\n"
+                          "            ORDER[1],\n"
+                          "            LENGTHUNIT[\"foot\",0.3048]],\n"
+                          "        AXIS[\"northing\",north,\n"
+                          "            ORDER[2],\n"
+                          "            LENGTHUNIT[\"foot\",0.3048]],\n"
+                          "        AXIS[\"ellipsoidal height (h)\",up,\n"
+                          "            ORDER[3],\n"
+                          "            LENGTHUNIT[\"foot\",0.3048]]]" ) );
+  QVERIFY( QgsProjUtils::hasVerticalAxis( crs.get() ) );
 }
 
 QGSTEST_MAIN( TestQgsProjUtils )

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -256,12 +256,18 @@ class TestQgsProject(QgisTestCase):
         self.assertEqual(project.verticalCrs().authid(), 'EPSG:5703')
         self.assertEqual(len(spy), 1)
 
-        # invalid combination
+        # invalid combinations
         project.setCrs(QgsCoordinateReferenceSystem('EPSG:4979'))
         ok, err = project.setVerticalCrs(QgsCoordinateReferenceSystem('EPSG:5711'))
         self.assertFalse(ok)
-        self.assertEqual(err, 'components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34')
+        self.assertEqual(err, 'Project CRS is a Geographic 3D CRS, specified Vertical CRS will be ignored')
         self.assertEqual(project.crs3D().authid(), 'EPSG:4979')
+
+        project.setCrs(QgsCoordinateReferenceSystem('EPSG:4978'))
+        ok, err = project.setVerticalCrs(QgsCoordinateReferenceSystem('EPSG:5711'))
+        self.assertFalse(ok)
+        self.assertEqual(err, 'Project CRS is a Geocentric CRS, specified Vertical CRS will be ignored')
+        self.assertEqual(project.crs3D().authid(), 'EPSG:4978')
 
     def test_crs_3d(self):
         project = QgsProject()

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -256,6 +256,13 @@ class TestQgsProject(QgisTestCase):
         self.assertEqual(project.verticalCrs().authid(), 'EPSG:5703')
         self.assertEqual(len(spy), 1)
 
+        # invalid combination
+        project.setCrs(QgsCoordinateReferenceSystem('EPSG:4979'))
+        ok, err = project.setVerticalCrs(QgsCoordinateReferenceSystem('EPSG:5711'))
+        self.assertFalse(ok)
+        self.assertEqual(err, 'components of the compound CRS do not belong to one of the allowed combinations of http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#34')
+        self.assertEqual(project.crs3D().authid(), 'EPSG:4979')
+
     def test_crs_3d(self):
         project = QgsProject()
         self.assertFalse(project.crs3D().isValid())


### PR DESCRIPTION
Returns the CRS to use for the project when transforming 3D data, or when z/elevation value handling is important.

The returned CRS will take into account verticalCrs(), e.g. by returning a compound CRS consisting of crs() + verticalCrs().

This method may still return a 2D CRS, e.g in the case that crs() is a 2D CRS and no verticalCrs() has been set for the project. I.E. It is NOT guaranteed that the returned CRS will actually be a 3D CRS, but rather it is guaranteed that the returned CRS is **ALWAYS** the most appropriate CRS to use when handling 3D data.

Refs discussion in https://github.com/qgis/QGIS/pull/56791, https://github.com/qgis/QGIS-Enhancement-Proposals/issues/267