### PR TITLE
Temporarily disable google font downloads

### DIFF
--- a/src/core/textrenderer/qgsfontmanager.cpp
+++ b/src/core/textrenderer/qgsfontmanager.cpp
@@ -1795,6 +1795,8 @@ QString QgsFontManager::urlForFontDownload( const QString &family, QString &matc
     QStringLiteral( "Zilla Slab Highlight" ),
   };
 
+// temporarily unavailable -- see https://github.com/google/fonts/issues/7481
+#if 0
   auto cleanFontFamily = []( const QString & family ) -> QString
   {
     const thread_local QRegularExpression charsToRemove( QStringLiteral( "[^a-z]" ) );
@@ -1807,6 +1809,7 @@ QString QgsFontManager::urlForFontDownload( const QString &family, QString &matc
 
   matchedFamily.clear();
   const QString cleanedFamily = cleanFontFamily( family );
+
   for ( const QString &candidate : sGoogleFonts )
   {
     if ( cleanFontFamily( candidate ) == cleanedFamily )
@@ -1817,6 +1820,11 @@ QString QgsFontManager::urlForFontDownload( const QString &family, QString &matc
       return QStringLiteral( "https://fonts.google.com/download?family=%1" ).arg( paramName );
     }
   }
+#else
+  ( void )family;
+  matchedFamily.clear();
+#endif
+
   return QString();
 }
 

--- a/tests/src/python/test_qgsfontmanager.py
+++ b/tests/src/python/test_qgsfontmanager.py
@@ -187,6 +187,7 @@ class TestQgsFontManager(QgisTestCase):
 
             self.assertEqual(manager.userFontToFamilyMap(), {os.path.join(user_font_dir, 'Fresca-Regular.ttf'): ['Fresca']})
 
+    @unittest.skip('Temporarily disabled')
     def test_font_download_url(self):
         manager = QgsFontManager()
         self.assertEqual(manager.urlForFontDownload('xxx'), ('', ''))


### PR DESCRIPTION
This isn't available since Google removed the static downloads, we'll need another approach to handle this

Refs https://github.com/google/fonts/issues/7481
Refs https://github.com/qgis/QGIS/issues/57070
