### PR TITLE
[processing] Show marker on canvas at picked point location

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -27,6 +27,7 @@
 #include "qgspointcloudattribute.h"
 #include "qgspointcloudlayer.h"
 #include "qgsprocessingmodelchildparametersource.h"
+#include "qobjectuniqueptr.h"
 
 #include <QAbstractButton>
 
@@ -72,6 +73,7 @@ class QgsCheckableComboBox;
 class QgsMapLayerComboBox;
 class QgsProcessingPointCloudExpressionLineEdit;
 class QgsProcessingRasterCalculatorExpressionLineEdit;
+class QgsRubberBand;
 
 ///@cond PRIVATE
 
@@ -1005,6 +1007,7 @@ class GUI_EXPORT QgsProcessingPointPanel : public QWidget
     QgsProcessingPointPanel( QWidget *parent );
     void setMapCanvas( QgsMapCanvas *canvas );
     void setAllowNull( bool allowNull );
+    void setShowPointOnCanvas( bool show );
 
     QVariant value() const;
     void clear();
@@ -1020,15 +1023,20 @@ class GUI_EXPORT QgsProcessingPointPanel : public QWidget
     void selectOnCanvas();
     void updatePoint( const QgsPointXY &point );
     void pointPicked();
+    void textChanged( const QString &text );
 
   private:
+    void updateRubberBand();
 
     QgsFilterLineEdit *mLineEdit = nullptr;
+    bool mShowPointOnCanvas = false;
     QToolButton *mButton = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
     QgsCoordinateReferenceSystem mCrs;
     QPointer< QgsMapTool > mPrevTool;
     std::unique_ptr< QgsProcessingPointMapTool > mTool;
+    QgsPointXY mPoint;
+    QObjectUniquePtr<QgsRubberBand> mMapPointRubberBand;
     friend class TestProcessingGui;
 };
 


### PR DESCRIPTION
When an algorithm has a point parameter and is run from the toolbox, show a X rubber band marker at the picked point on the map canvas

This makes it easier to see where the point parameter is set to.

The marker is cleared as soon as the algorithm dialog is closed.

![image](https://github.com/qgis/QGIS/assets/1829991/5261af29-c391-4392-bf5f-415eb3aba85d)

