### PR TITLE
detailed helpstring to the processing tool "align rasters"

### DIFF
--- a/src/analysis/processing/qgsalgorithmalignrasters.cpp
+++ b/src/analysis/processing/qgsalgorithmalignrasters.cpp
@@ -54,7 +54,7 @@ QString QgsAlignRastersAlgorithm::groupId() const
 
 QString QgsAlignRastersAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Aligns rasters by resampling them to the same cell size and reprojecting to the same CRS." );
+  return QObject::tr( "Aligns rasters by resampling them to the same cell size and reprojecting to the same CRS. \n For each input raster the output file and resampling method has to be defined: go to Input layers (Click on the three dots) and select one (or more) layer(s) with the ckeckboxes. Click on the layer and go to \'Configure Raster...\' in order to define the location for the output file." );
 }
 
 QgsAlignRastersAlgorithm *QgsAlignRastersAlgorithm::createInstance() const


### PR DESCRIPTION
## Description
This pull request adds detailed helpstring to the processing algorithm "align rasters" because the usage of the tool was unclear to some users.

Fixes https://github.com/qgis/QGIS/issues/57096, https://github.com/qgis/QGIS/issues/57102 and https://github.com/qgis/QGIS-Documentation/pull/9005

So far I did not do any test, but hopefully changing a textstring won´t cause any troubles.

<!--

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
