### PR TITLE
Ensure __file__ is set when running python scripts dropped onto QGIS, other related tweaks

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -361,6 +361,7 @@ class Editor(QgsCodeEditorPython):
         autoSave = QgsSettings().value("pythonConsole/autoSaveScript", False, type=bool)
         tabWidget = self.tabwidget.currentWidget()
         filename = tabWidget.path
+        filename_override = None
         msgEditorBlank = QCoreApplication.translate('PythonConsole',
                                                     'Hey, type something to run!')
         if filename is None:
@@ -375,9 +376,12 @@ class Editor(QgsCodeEditorPython):
             elif not filename or self.isModified():
                 # Create a new temp file if the file isn't already saved.
                 filename = self.createTempFile()
+                filename_override = self.tabwidget.tabText(self.tabwidget.currentIndex())
+                if filename_override.startswith('*'):
+                    filename_override = filename_override[1:]
                 deleteTempFile = True
 
-            self.pythonconsole.shell.runFile(filename)
+            self.pythonconsole.shell.runFile(filename, filename_override)
 
             if deleteTempFile:
                 Path(filename).unlink()

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -24,6 +24,7 @@ import os
 import re
 import sys
 import traceback
+from typing import Optional
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -427,7 +428,7 @@ class ShellScintilla(QgsCodeEditorPython):
         if sys.stderr:
             sys.stderr.write(txt)
 
-    def runFile(self, filename):
+    def runFile(self, filename, override_file_name: Optional[str] = None):
         filename = filename.replace("\\", "/")
         dirname = os.path.dirname(filename)
 
@@ -437,7 +438,7 @@ class ShellScintilla(QgsCodeEditorPython):
 
         try:
             # Run the file
-            self.runCommand("exec(Path('{0}').read_text())".format(filename), skipHistory=True)
+            self.runCommand("exec(compile(Path('{0}').read_text(), '{1}', 'exec'))".format(filename, override_file_name or filename), skipHistory=True)
         finally:
             # Remove the directory from the path and delete the __file__ variable
             self._interpreter.execCommandImpl("del __file__", False)

--- a/python/utils.py
+++ b/python/utils.py
@@ -976,7 +976,8 @@ def processing_algorithm_from_script(filepath: str):
         }
 
         with open(filename.encode(sys.getfilesystemencoding())) as input_file:
-            exec(input_file.read(), _locals)
+            code_object = compile(input_file.read(), filename, 'exec')
+            exec(code_object, _locals)
         alg_instance = None
         try:
             alg_instance = alg.instances.pop().createInstance()


### PR DESCRIPTION
Ensure `__file__` is set when running python scripts dropped onto QGIS, and make sure that the filename is correctly shown when exceptions are raised from dropped scripts or scripts executed through the console (instead of just "").

The first commit should be backported only.