### PR TITLE
Indicate that input layers should be individually configured in "Align rasters" algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmalignrasters.cpp
+++ b/src/analysis/processing/qgsalgorithmalignrasters.cpp
@@ -54,7 +54,9 @@ QString QgsAlignRastersAlgorithm::groupId() const
 
 QString QgsAlignRastersAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Aligns rasters by resampling them to the same cell size and reprojecting to the same CRS." );
+  return QObject::tr( "Aligns rasters by resampling them to the same cell size and reprojecting to the same CRS.\n\n"
+                      "A specific output file and resampling method has to be defined for each input raster."
+                    );
 }
 
 QgsAlignRastersAlgorithm *QgsAlignRastersAlgorithm::createInstance() const
@@ -64,8 +66,13 @@ QgsAlignRastersAlgorithm *QgsAlignRastersAlgorithm::createInstance() const
 
 void QgsAlignRastersAlgorithm::initAlgorithm( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterAlignRasterLayers( QStringLiteral( "LAYERS" ), QObject::tr( "Input layers" ) ) );
-  addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "REFERENCE_LAYER" ), QObject::tr( "Reference layer" ) ) );
+  std::unique_ptr<QgsProcessingParameterAlignRasterLayers> inputLayersParam = std::make_unique<QgsProcessingParameterAlignRasterLayers>( QStringLiteral( "LAYERS" ), QObject::tr( "Input layers" ) );
+  inputLayersParam->setHelp( QObject::tr( "Select layers to align and configure their resampling options" ) );
+  addParameter( inputLayersParam.release() );
+
+  std::unique_ptr<QgsProcessingParameterRasterLayer> refLayerParam = std::make_unique<QgsProcessingParameterRasterLayer>( QStringLiteral( "REFERENCE_LAYER" ), QObject::tr( "Reference layer" ) );
+  refLayerParam->setHelp( QObject::tr( "Raster layer used to fetch the default extent, cell size and CRS applied to input layers" ) );
+  addParameter( refLayerParam.release() );
 
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "Override reference CRS" ), QVariant(), true ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "CELL_SIZE_X" ), QObject::tr( "Override reference cell size X" ), Qgis::ProcessingNumberParameterType::Double, QVariant(), true, 1e-9 ) );

--- a/src/gui/processing/qgsprocessingalignrasterlayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingalignrasterlayerswidgetwrapper.cpp
@@ -99,6 +99,7 @@ QgsProcessingAlignRasterLayersPanelWidget::QgsProcessingAlignRasterLayersPanelWi
   connect( listView(), &QListView::doubleClicked, this, &QgsProcessingAlignRasterLayersPanelWidget::configureRaster );
 
   QPushButton *configureLayerButton = new QPushButton( tr( "Configure Raster…" ) );
+  configureLayerButton->setToolTip( tr( "Set resampling options for the selected input layer" ) );
   connect( configureLayerButton, &QPushButton::clicked, this, &QgsProcessingAlignRasterLayersPanelWidget::configureRaster );
   buttonBox()->addButton( configureLayerButton, QDialogButtonBox::ActionRole );
 


### PR DESCRIPTION
Fixes #57096 (may be an alternative to #57127)

![Capture d’écran 2024-04-12 171211](https://github.com/qgis/QGIS/assets/7983394/305a47e1-598b-4a2b-a865-fffde5c2994b)
![Capture d’écran 2024-04-12 171340](https://github.com/qgis/QGIS/assets/7983394/6da2d872-759b-4522-9a47-4b5769dac9b7)

While working on this I came across #57142