### PR TITLE
Attempt to display more columns in the "Export Project to Dxf" dialog

### DIFF
--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -640,8 +640,8 @@ QgsDxfExportLayerTreeView::QgsDxfExportLayerTreeView( QWidget *parent )
 
 void QgsDxfExportLayerTreeView::resizeEvent( QResizeEvent *event )
 {
-  header()->setMinimumSectionSize( viewport()->width() / 2 );
-  header()->setMaximumSectionSize( viewport()->width() / 2 );
+  header()->setMinimumSectionSize( viewport()->width() / 4 );
+  header()->setMaximumSectionSize( viewport()->width() / 4 );
   QTreeView::resizeEvent( event ); // NOLINT(bugprone-parent-virtual-call) clazy:exclude=skipped-base-method
 }
 


### PR DESCRIPTION
I don't think this is the most sustainable fix (_being able to automatically pass the number of expected columns may be_) but it should help fix resurrection of #45441, and avoid hiding the data-defined blocks columns.

That said, I fail to understand why this widget behaves differently to the other ones in which a treeview is involved (let's say the "layer capabilities" or "QGIS Server --> WMTS" in the project properties dialog, ...)