### PR TITLE
use project scales in label rendering and new 2D canvas dock if they are set (fix #51326)

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsscalecombobox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsscalecombobox.sip.in
@@ -112,6 +112,16 @@ Returns ``True`` if the combobox can be set to a NULL value.
 .. versionadded:: 3.8
 %End
 
+    void setPredefinedScales( const QVector< double > &scales );
+%Docstring
+Sets the list of predefined ``scales`` to show in the combobox. List elements
+are expected to be scale denominators, e.g. 1000.0 for a 1:1000 map.
+
+If ``scales`` is empty then the default user scale options will be used instead.
+
+.. versionadded:: 3.38
+%End
+
   signals:
 
     void scaleChanged( double scale );

--- a/python/PyQt6/gui/auto_generated/qgsscalewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsscalewidget.sip.in
@@ -140,6 +140,16 @@ Returns ``True`` if the widget can be set to a NULL value.
 .. versionadded:: 3.8
 %End
 
+    void setPredefinedScales( const QVector< double > &scales );
+%Docstring
+Sets the list of predefined ``scales`` to show in the widget. List elements
+are expected to be scale denominators, e.g. 1000.0 for a 1:1000 map.
+
+If ``scales`` is empty then the default user scale options will be used instead.
+
+.. versionadded:: 3.38
+%End
+
   public slots:
 
     void setScale( double scale );
@@ -152,7 +162,7 @@ The ``scale`` value indicates the scale denominator, e.g. 1000.0 for a 1:1000 ma
 
     void updateScales( const QStringList &scales = QStringList() );
 %Docstring
-Sets the list of predefined ``scales`` to show in the combobox. List elements
+Sets the list of predefined ``scales`` to show in the widget. List elements
 are expected to be valid scale strings, such as "1:1000000".
 %End
 

--- a/python/gui/auto_generated/qgsscalecombobox.sip.in
+++ b/python/gui/auto_generated/qgsscalecombobox.sip.in
@@ -112,6 +112,16 @@ Returns ``True`` if the combobox can be set to a NULL value.
 .. versionadded:: 3.8
 %End
 
+    void setPredefinedScales( const QVector< double > &scales );
+%Docstring
+Sets the list of predefined ``scales`` to show in the combobox. List elements
+are expected to be scale denominators, e.g. 1000.0 for a 1:1000 map.
+
+If ``scales`` is empty then the default user scale options will be used instead.
+
+.. versionadded:: 3.38
+%End
+
   signals:
 
     void scaleChanged( double scale );

--- a/python/gui/auto_generated/qgsscalewidget.sip.in
+++ b/python/gui/auto_generated/qgsscalewidget.sip.in
@@ -140,6 +140,16 @@ Returns ``True`` if the widget can be set to a NULL value.
 .. versionadded:: 3.8
 %End
 
+    void setPredefinedScales( const QVector< double > &scales );
+%Docstring
+Sets the list of predefined ``scales`` to show in the widget. List elements
+are expected to be scale denominators, e.g. 1000.0 for a 1:1000 map.
+
+If ``scales`` is empty then the default user scale options will be used instead.
+
+.. versionadded:: 3.38
+%End
+
   public slots:
 
     void setScale( double scale );
@@ -152,7 +162,7 @@ The ``scale`` value indicates the scale denominator, e.g. 1000.0 for a 1:1000 ma
 
     void updateScales( const QStringList &scales = QStringList() );
 %Docstring
-Sets the list of predefined ``scales`` to show in the combobox. List elements
+Sets the list of predefined ``scales`` to show in the widget. List elements
 are expected to be valid scale strings, such as "1:1000000".
 %End
 

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -30,6 +30,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
 #include "qgsdockablewidgethelper.h"
+#include "qgsprojectviewsettings.h"
 #include "canvas/qgsappcanvasfiltering.h"
 
 #include <QMessageBox>
@@ -597,6 +598,22 @@ QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )
   gLayout->addWidget( label, 2, 0 );
 
   mScaleCombo = new QgsScaleComboBox();
+  // use either global scales or project scales
+  if ( QgsProject::instance()->viewSettings()->useProjectScales() )
+  {
+    const QVector< double > scales = QgsProject::instance()->viewSettings()->mapScales();
+    QStringList textScales;
+    textScales.reserve( scales.size() );
+    for ( const double scale : scales )
+      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
+    mScaleCombo->updateScales( textScales );
+  }
+  else
+  {
+    // use global scales
+    mScaleCombo->updateScales();
+  }
+
   gLayout->addWidget( mScaleCombo, 2, 1 );
 
   mRotationWidget = new QgsDoubleSpinBox();

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -601,12 +601,7 @@ QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )
   // use either global scales or project scales
   if ( QgsProject::instance()->viewSettings()->useProjectScales() )
   {
-    const QVector< double > scales = QgsProject::instance()->viewSettings()->mapScales();
-    QStringList textScales;
-    textScales.reserve( scales.size() );
-    for ( const double scale : scales )
-      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
-    mScaleCombo->updateScales( textScales );
+    mScaleCombo->setPredefinedScales( QgsProject::instance()->viewSettings()->mapScales() );
   }
   else
   {

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -95,12 +95,8 @@ void QgsStatusBarScaleWidget::updateScales()
 {
   if ( QgsProject::instance()->viewSettings()->useProjectScales() )
   {
-    const QVector< double > scales = QgsProject::instance()->viewSettings()->mapScales();
-    QStringList textScales;
-    textScales.reserve( scales.size() );
-    for ( const double scale : scales )
-      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
-    mScale->updateScales( textScales );
+
+    mScale->setPredefinedScales( QgsProject::instance()->viewSettings()->mapScales() );
   }
   else
   {

--- a/src/gui/qgsscalecombobox.cpp
+++ b/src/gui/qgsscalecombobox.cpp
@@ -39,27 +39,22 @@ QgsScaleComboBox::QgsScaleComboBox( QWidget *parent )
 
 void QgsScaleComboBox::updateScales( const QStringList &scales )
 {
-  QStringList myScalesList;
+  QStringList scalesList;
   const QString oldScale = currentText();
 
   if ( scales.isEmpty() )
   {
-    myScalesList = QgsSettingsRegistryCore::settingsMapScales->value();
+    scalesList = QgsSettingsRegistryCore::settingsMapScales->value();
   }
   else
   {
-    QStringList::const_iterator scaleIt = scales.constBegin();
-    for ( ; scaleIt != scales.constEnd(); ++scaleIt )
-    {
-      myScalesList.append( *scaleIt );
-    }
+    scalesList = scales;
   }
 
-  QStringList  myCleanedScalesList;
-
-  for ( int i = 0; i < myScalesList.size(); ++i )
+  QStringList cleanedScalesList;
+  for ( const QString &scale : std::as_const( scalesList ) )
   {
-    const QStringList parts = myScalesList[ i ] .split( ':' );
+    const QStringList parts = scale.split( ':' );
     if ( parts.size() < 2 )
       continue;
 
@@ -67,21 +62,45 @@ void QgsScaleComboBox::updateScales( const QStringList &scales )
     const double denominator = QLocale().toDouble( parts[1], &ok );
     if ( ok )
     {
-      myCleanedScalesList.push_back( toString( denominator ) );
+      cleanedScalesList.push_back( toString( denominator ) );
     }
     else
     {
       const double denominator = parts[1].toDouble( &ok );
       if ( ok )
       {
-        myCleanedScalesList.push_back( toString( denominator ) );
+        cleanedScalesList.push_back( toString( denominator ) );
       }
     }
   }
 
   blockSignals( true );
   clear();
-  addItems( myCleanedScalesList );
+  addItems( cleanedScalesList );
+  setScaleString( oldScale );
+  blockSignals( false );
+}
+
+void QgsScaleComboBox::setPredefinedScales( const QVector<double> &scales )
+{
+  if ( scales.isEmpty() )
+  {
+    updateScales();
+    return;
+  }
+
+  const QString oldScale = currentText();
+
+  QStringList scalesStringList;
+  scalesStringList.reserve( scales.size() );
+  for ( double denominator : scales )
+  {
+    scalesStringList.push_back( toString( denominator ) );
+  }
+
+  blockSignals( true );
+  clear();
+  addItems( scalesStringList );
   setScaleString( oldScale );
   blockSignals( false );
 }

--- a/src/gui/qgsscalecombobox.h
+++ b/src/gui/qgsscalecombobox.h
@@ -111,6 +111,16 @@ class GUI_EXPORT QgsScaleComboBox : public QComboBox
      */
     bool allowNull() const;
 
+    /**
+     * Sets the list of predefined \a scales to show in the combobox. List elements
+     * are expected to be scale denominators, e.g. 1000.0 for a 1:1000 map.
+     *
+     * If \a scales is empty then the default user scale options will be used instead.
+     *
+     * \since QGIS 3.38
+    */
+    void setPredefinedScales( const QVector< double > &scales );
+
   signals:
 
     /**

--- a/src/gui/qgsscalerangewidget.cpp
+++ b/src/gui/qgsscalerangewidget.cpp
@@ -72,16 +72,11 @@ QgsScaleRangeWidget::QgsScaleRangeWidget( QWidget *parent )
 
 void QgsScaleRangeWidget::reloadProjectScales()
 {
-  const bool projectScales = QgsProject::instance()->viewSettings()->useProjectScales();
-  if ( projectScales )
+  if ( QgsProject::instance()->viewSettings()->useProjectScales() )
   {
-    QStringList scalesList;
-    const QVector< double >projectScales = QgsProject::instance()->viewSettings()->mapScales();
-    scalesList.reserve( projectScales.size() );
-    for ( const double scale : projectScales )
-      scalesList << QStringLiteral( "1:%1" ).arg( scale );
-    mMinimumScaleWidget->updateScales( scalesList );
-    mMaximumScaleWidget->updateScales( scalesList );
+    const QVector< double > projectScales = QgsProject::instance()->viewSettings()->mapScales();
+    mMinimumScaleWidget->setPredefinedScales( projectScales );
+    mMaximumScaleWidget->setPredefinedScales( projectScales );
   }
 }
 

--- a/src/gui/qgsscalewidget.cpp
+++ b/src/gui/qgsscalewidget.cpp
@@ -78,6 +78,11 @@ bool QgsScaleWidget::allowNull() const
   return mScaleComboBox->allowNull();
 }
 
+void QgsScaleWidget::setPredefinedScales( const QVector<double> &scales )
+{
+  mScaleComboBox->setPredefinedScales( scales );
+}
+
 void QgsScaleWidget::setScaleFromCanvas()
 {
   if ( !mCanvas )

--- a/src/gui/qgsscalewidget.h
+++ b/src/gui/qgsscalewidget.h
@@ -136,6 +136,16 @@ class GUI_EXPORT QgsScaleWidget : public QWidget
      */
     bool allowNull() const;
 
+    /**
+     * Sets the list of predefined \a scales to show in the widget. List elements
+     * are expected to be scale denominators, e.g. 1000.0 for a 1:1000 map.
+     *
+     * If \a scales is empty then the default user scale options will be used instead.
+     *
+     * \since QGIS 3.38
+    */
+    void setPredefinedScales( const QVector< double > &scales );
+
   public slots:
 
     /**
@@ -146,7 +156,7 @@ class GUI_EXPORT QgsScaleWidget : public QWidget
     void setScale( double scale );
 
     /**
-     * Sets the list of predefined \a scales to show in the combobox. List elements
+     * Sets the list of predefined \a scales to show in the widget. List elements
      * are expected to be valid scale strings, such as "1:1000000".
      */
     void updateScales( const QStringList &scales = QStringList() ) { mScaleComboBox->updateScales( scales ); }

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -854,12 +854,8 @@ void QgsTextFormatWidget::populateDataDefinedButtons()
   if ( QgsProject::instance()->viewSettings()->useProjectScales() )
   {
     const QVector< double > scales = QgsProject::instance()->viewSettings()->mapScales();
-    QStringList textScales;
-    textScales.reserve( scales.size() );
-    for ( const double scale : scales )
-      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
-    mMinScaleWidget->updateScales( textScales );
-    mMaxScaleWidget->updateScales( textScales );
+    mMinScaleWidget->setPredefinedScales( scales );
+    mMaxScaleWidget->setPredefinedScales( scales );
   }
   else
   {

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -43,6 +43,7 @@
 #include "qgssymbollayerreference.h"
 #include "qgsconfig.h"
 #include "qgsprojectstylesettings.h"
+#include "qgsprojectviewsettings.h"
 
 #include <QButtonGroup>
 #include <QMessageBox>
@@ -848,6 +849,24 @@ void QgsTextFormatWidget::populateDataDefinedButtons()
   mScaleBasedVisibilityMinDDBtn->setUsageInfo( ddScaleVisInfo );
   registerDataDefinedButton( mScaleBasedVisibilityMaxDDBtn, QgsPalLayerSettings::Property::MaximumScale );
   mScaleBasedVisibilityMaxDDBtn->setUsageInfo( ddScaleVisInfo );
+
+  // use either global scales or project scales
+  if ( QgsProject::instance()->viewSettings()->useProjectScales() )
+  {
+    const QVector< double > scales = QgsProject::instance()->viewSettings()->mapScales();
+    QStringList textScales;
+    textScales.reserve( scales.size() );
+    for ( const double scale : scales )
+      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
+    mMinScaleWidget->updateScales( textScales );
+    mMaxScaleWidget->updateScales( textScales );
+  }
+  else
+  {
+    // use global scales
+    mMinScaleWidget->updateScales();
+    mMaxScaleWidget->updateScales();
+  }
 
   registerDataDefinedButton( mFontLimitPixelDDBtn, QgsPalLayerSettings::Property::FontLimitPixel );
   mFontLimitPixelDDBtn->registerCheckedWidget( mFontLimitPixelChkBox );

--- a/tests/src/python/test_qgsscalewidget.py
+++ b/tests/src/python/test_qgsscalewidget.py
@@ -12,7 +12,9 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 import math
 
 from qgis.PyQt.QtTest import QSignalSpy
-from qgis.gui import QgsScaleWidget
+from qgis.PyQt.QtWidgets import QComboBox
+
+from qgis.gui import QgsScaleWidget, QgsScaleComboBox
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -41,6 +43,32 @@ class TestQgsScaleWidget(QgisTestCase):
         self.assertEqual(w.scale(), 4000)
         self.assertEqual(len(spy), 3)
         self.assertEqual(spy[-1][0], 4000)
+
+    def test_predefined_scales(self):
+        w = QgsScaleWidget()
+        combo = w.findChild(QComboBox)
+
+        w.updateScales(['1:500', '1:100'])
+        self.assertEqual(combo.count(), 2)
+        self.assertEqual(combo.itemText(0), '1:500')
+        self.assertEqual(combo.itemText(1), '1:100')
+
+        w.setScale(100)
+        self.assertEqual(w.scale(), 100)
+        self.assertEqual(combo.currentText(), '1:100')
+
+        w.setScale(500)
+        self.assertEqual(w.scale(), 500)
+        self.assertEqual(combo.currentText(), '1:500')
+
+        w.setPredefinedScales([10.0, 20.0, 30.0, 500.0])
+        self.assertEqual(combo.count(), 4)
+        self.assertEqual(combo.itemText(0), '1:10')
+        self.assertEqual(combo.itemText(1), '1:20')
+        self.assertEqual(combo.itemText(2), '1:30')
+        self.assertEqual(combo.itemText(3), '1:500')
+        self.assertEqual(w.scale(), 500)
+        self.assertEqual(combo.currentText(), '1:500')
 
     def testNull(self):
         w = QgsScaleWidget()
@@ -89,6 +117,30 @@ class TestQgsScaleWidget(QgisTestCase):
 
         w.setAllowNull(False)
         self.assertFalse(w.allowNull())
+
+    def test_combo(self):
+        w = QgsScaleComboBox()
+        w.updateScales(['1:500', '1:100'])
+        self.assertEqual(w.count(), 2)
+        self.assertEqual(w.itemText(0), '1:500')
+        self.assertEqual(w.itemText(1), '1:100')
+
+        w.setScale(100)
+        self.assertEqual(w.scale(), 100)
+        self.assertEqual(w.currentText(), '1:100')
+
+        w.setScale(500)
+        self.assertEqual(w.scale(), 500)
+        self.assertEqual(w.currentText(), '1:500')
+
+        w.setPredefinedScales([10.0, 20.0, 30.0, 500.0])
+        self.assertEqual(w.count(), 4)
+        self.assertEqual(w.itemText(0), '1:10')
+        self.assertEqual(w.itemText(1), '1:20')
+        self.assertEqual(w.itemText(2), '1:30')
+        self.assertEqual(w.itemText(3), '1:500')
+        self.assertEqual(w.scale(), 500)
+        self.assertEqual(w.currentText(), '1:500')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When user overrides global scales list in the project properties, QGIS uses this overriden list in the scale selector in the status bar, in the atlas settings, in the layer and diagrams rendering settings. However, in it does not applied to the label rendering settings and in the new 2D map views.

Fixes https://github.com/qgis/QGIS/issues/51326.

Supersedes https://github.com/qgis/QGIS/pull/55998