### PR TITLE
[qml] Add a couple of Q_INVOKABLE in QgsProject and QgsVectorLayer to ease layer and feature fetching + editing

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1049,7 +1049,7 @@ Queries the layer for features specified in request.
 Queries the layer for features matching a given expression.
 %End
 
-    QgsFeature getFeature( QgsFeatureId fid ) const;
+    inline QgsFeature getFeature( QgsFeatureId fid ) const;
 %Docstring
 Queries the layer for the feature with the given id.
 If there is no such feature, the returned feature will be invalid.
@@ -1711,7 +1711,7 @@ This also includes fields which have not yet been saved to the provider.
 :return: A list of fields
 %End
 
-    QgsAttributeList attributeList() const;
+    inline QgsAttributeList attributeList() const;
 %Docstring
 Returns list of attribute indexes. i.e. a list from 0 ... :py:func:`~QgsVectorLayer.fieldCount`
 %End
@@ -1991,7 +1991,7 @@ Deletes a list of attribute fields (but does not commit it)
     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) ${SIP_FINAL};
 
 
-    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = 0 );
+    bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes a feature from the layer (but does not commit it).
 
@@ -2006,7 +2006,7 @@ Deletes a feature from the layer (but does not commit it).
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = 0 );
+    bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes a set of features from the layer (but does not commit it)
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1049,7 +1049,7 @@ Queries the layer for features specified in request.
 Queries the layer for features matching a given expression.
 %End
 
-    inline QgsFeature getFeature( QgsFeatureId fid ) const;
+    QgsFeature getFeature( QgsFeatureId fid ) const;
 %Docstring
 Queries the layer for the feature with the given id.
 If there is no such feature, the returned feature will be invalid.
@@ -1711,7 +1711,7 @@ This also includes fields which have not yet been saved to the provider.
 :return: A list of fields
 %End
 
-    inline QgsAttributeList attributeList() const;
+    QgsAttributeList attributeList() const;
 %Docstring
 Returns list of attribute indexes. i.e. a list from 0 ... :py:func:`~QgsVectorLayer.fieldCount`
 %End

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1049,7 +1049,7 @@ Queries the layer for features specified in request.
 Queries the layer for features matching a given expression.
 %End
 
-    QgsFeature getFeature( QgsFeatureId fid ) const;
+    inline QgsFeature getFeature( QgsFeatureId fid ) const;
 %Docstring
 Queries the layer for the feature with the given id.
 If there is no such feature, the returned feature will be invalid.
@@ -1711,7 +1711,7 @@ This also includes fields which have not yet been saved to the provider.
 :return: A list of fields
 %End
 
-    QgsAttributeList attributeList() const;
+    inline QgsAttributeList attributeList() const;
 %Docstring
 Returns list of attribute indexes. i.e. a list from 0 ... :py:func:`~QgsVectorLayer.fieldCount`
 %End
@@ -1991,7 +1991,7 @@ Deletes a list of attribute fields (but does not commit it)
     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) ${SIP_FINAL};
 
 
-    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = 0 );
+    bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes a feature from the layer (but does not commit it).
 
@@ -2006,7 +2006,7 @@ Deletes a feature from the layer (but does not commit it).
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = 0 );
+    bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes a set of features from the layer (but does not commit it)
 

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1049,7 +1049,7 @@ Queries the layer for features specified in request.
 Queries the layer for features matching a given expression.
 %End
 
-    inline QgsFeature getFeature( QgsFeatureId fid ) const;
+    QgsFeature getFeature( QgsFeatureId fid ) const;
 %Docstring
 Queries the layer for the feature with the given id.
 If there is no such feature, the returned feature will be invalid.
@@ -1711,7 +1711,7 @@ This also includes fields which have not yet been saved to the provider.
 :return: A list of fields
 %End
 
-    inline QgsAttributeList attributeList() const;
+    QgsAttributeList attributeList() const;
 %Docstring
 Returns list of attribute indexes. i.e. a list from 0 ... :py:func:`~QgsVectorLayer.fieldCount`
 %End

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -1755,6 +1755,9 @@ while ($LINE_IDX < $LINE_COUNT){
     $IS_OVERRIDE_OR_MAKE_PRIVATE = PREPEND_CODE_VIRTUAL if ( $LINE =~ m/\bFINAL\b/);
     $IS_OVERRIDE_OR_MAKE_PRIVATE = PREPEND_CODE_MAKE_PRIVATE if ( $LINE =~ m/\bSIP_MAKE_PRIVATE\b/);
 
+    # remove Q_INVOKABLE
+    $LINE =~ s/^(\s*)Q_INVOKABLE /$1/;
+
     # keyword fixes
     do {no warnings 'uninitialized';
         $LINE =~ s/^(\s*template\s*<)(?:class|typename) (\w+>)(.*)$/$1$2$3/;
@@ -1860,9 +1863,6 @@ while ($LINE_IDX < $LINE_COUNT){
            }
         }
     }
-
-    # remove Q_INVOKABLE
-    $LINE =~ s/^(\s*)Q_INVOKABLE /$1/;
 
     do {no warnings 'uninitialized';
         # remove keywords

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1185,7 +1185,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \see mapLayer()
      * \see mapLayers()
      */
-    QList<QgsMapLayer *> mapLayersByName( const QString &layerName ) const;
+    Q_INVOKABLE QList<QgsMapLayer *> mapLayersByName( const QString &layerName ) const;
 
     /**
      * Retrieves a list of matching registered layers by layer \a shortName.

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -337,7 +337,7 @@ class CORE_EXPORT QgsFeature
      * \returns FALSE, if the field index does not exist
      * \see setAttributes()
      */
-    bool setAttribute( int field, const QVariant &attr );
+    Q_INVOKABLE bool setAttribute( int field, const QVariant &attr );
 #else
 
     /**
@@ -589,7 +589,7 @@ class CORE_EXPORT QgsFeature
      * \returns FALSE if attribute name could not be converted to index
      * \see setFields()
      */
-    bool setAttribute( const QString &name, const QVariant &value );
+    Q_INVOKABLE bool setAttribute( const QString &name, const QVariant &value );
 #else
 
     /**
@@ -711,7 +711,7 @@ class CORE_EXPORT QgsFeature
      * \returns The value of the attribute, or an invalid/null variant if no such name exists
      * \see setFields
      */
-    QVariant attribute( const QString &name ) const;
+    Q_INVOKABLE QVariant attribute( const QString &name ) const;
 #else
 
     /**
@@ -739,7 +739,7 @@ class CORE_EXPORT QgsFeature
      * \throws KeyError if the field is not found
      * \see setFields
      */
-    SIP_PYOBJECT attribute( const QString &name ) const;
+    Q_INVOKABLE SIP_PYOBJECT attribute( const QString &name ) const;
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1143,7 +1143,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * Queries the layer for the feature with the given id.
      * If there is no such feature, the returned feature will be invalid.
      */
-    inline QgsFeature getFeature( QgsFeatureId fid ) const
+    Q_INVOKABLE inline QgsFeature getFeature( QgsFeatureId fid ) const
     {
       QgsFeature feature;
       getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
@@ -1665,7 +1665,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
      */
-    inline QgsAttributeList attributeList() const { return mFields.allAttributesList(); }
+    Q_INVOKABLE inline QgsAttributeList attributeList() const { return mFields.allAttributesList(); }
 
     /**
      * Returns the list of attributes which make up the layer's primary keys.
@@ -1746,7 +1746,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see changeGeometry()
      * \see updateFeature()
      */
-    bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant(), bool skipDefaultValues = false );
+    Q_INVOKABLE bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant(), bool skipDefaultValues = false );
 
     /**
      * Changes attributes' values for a feature (but does not immediately
@@ -1782,7 +1782,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see changeAttributeValue()
      *
      */
-    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skipDefaultValues = false );
+    Q_INVOKABLE bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skipDefaultValues = false );
 
     /**
      * Add an attribute field (but does not commit it)
@@ -1918,7 +1918,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = nullptr );
+    Q_INVOKABLE bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = nullptr );
 
     /**
      * Deletes a set of features from the layer (but does not commit it)
@@ -1933,7 +1933,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
+    Q_INVOKABLE bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = nullptr );
 
     /**
      * Attempts to commit to the underlying data provider any buffered changes made since the


### PR DESCRIPTION
## Description

Title says it all. This helps make a bunch of nice stuff happen when doing javascript within a QML environment. 