### PR TITLE
[qml] Make QgsFields a QGadet and make some functions Q_INVOKABLE

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsfields.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfields.sip.in
@@ -29,6 +29,9 @@ In addition to storing a list of :py:class:`QgsField` instances, it also:
 #include "qgsfields.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     enum FieldOrigin /BaseType=IntEnum/
     {
@@ -289,7 +292,7 @@ name of the field.
 .. seealso:: :py:func:`lookupField`
 %End
 
-    int lookupField( const QString &fieldName ) const;
+     int lookupField( const QString &fieldName ) const;
 %Docstring
 Looks up field's index from the field name.
 This method matches in the following order:

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -29,6 +29,9 @@ In addition to storing a list of :py:class:`QgsField` instances, it also:
 #include "qgsfields.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     enum FieldOrigin
     {
@@ -289,7 +292,7 @@ name of the field.
 .. seealso:: :py:func:`lookupField`
 %End
 
-    int lookupField( const QString &fieldName ) const;
+     int lookupField( const QString &fieldName ) const;
 %Docstring
 Looks up field's index from the field name.
 This method matches in the following order:

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -45,6 +45,10 @@ class CORE_EXPORT  QgsFields
 {
     Q_GADGET
 
+    Q_PROPERTY( bool isEmpty READ isEmpty )
+    Q_PROPERTY( int count READ count )
+    Q_PROPERTY( QStringList names READ names )
+
   public:
 
     enum FieldOrigin
@@ -144,10 +148,10 @@ class CORE_EXPORT  QgsFields
     void extend( const QgsFields &other );
 
     //! Checks whether the container is empty
-    Q_INVOKABLE bool isEmpty() const;
+    bool isEmpty() const;
 
     //! Returns number of items
-    Q_INVOKABLE int count() const;
+    int count() const;
 
 #ifdef SIP_RUN
     int __len__() const;
@@ -163,12 +167,12 @@ class CORE_EXPORT  QgsFields
 #endif
 
     //! Returns number of items
-    Q_INVOKABLE int size() const;
+    int size() const;
 
     /**
      * Returns a list with field names
      */
-    Q_INVOKABLE QStringList names() const;
+    QStringList names() const;
 
     /**
      * Returns if a field index is valid

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -43,6 +43,8 @@ class QgsFieldsPrivate;
  */
 class CORE_EXPORT  QgsFields
 {
+    Q_GADGET
+
   public:
 
     enum FieldOrigin
@@ -142,10 +144,10 @@ class CORE_EXPORT  QgsFields
     void extend( const QgsFields &other );
 
     //! Checks whether the container is empty
-    bool isEmpty() const;
+    Q_INVOKABLE bool isEmpty() const;
 
     //! Returns number of items
-    int count() const;
+    Q_INVOKABLE int count() const;
 
 #ifdef SIP_RUN
     int __len__() const;
@@ -161,19 +163,19 @@ class CORE_EXPORT  QgsFields
 #endif
 
     //! Returns number of items
-    int size() const;
+    Q_INVOKABLE int size() const;
 
     /**
      * Returns a list with field names
      */
-    QStringList names() const;
+    Q_INVOKABLE QStringList names() const;
 
     /**
      * Returns if a field index is valid
      * \param i  Index of the field which needs to be checked
      * \returns   TRUE if the field exists
      */
-    bool exists( int i ) const;
+    Q_INVOKABLE bool exists( int i ) const;
 
 #ifndef SIP_RUN
     //! Gets field at particular index (must be in range 0..N-1)
@@ -354,7 +356,7 @@ class CORE_EXPORT  QgsFields
      * \returns The field index if found or -1 in case it cannot be found.
      * \see lookupField For a more tolerant alternative.
      */
-    int indexFromName( const QString &fieldName ) const;
+    Q_INVOKABLE int indexFromName( const QString &fieldName ) const;
 
     /**
      * Gets the field index from the field name.
@@ -367,7 +369,7 @@ class CORE_EXPORT  QgsFields
      * \returns The field index if found or -1 in case it cannot be found.
      * \see lookupField For a more tolerant alternative.
      */
-    int indexOf( const QString &fieldName ) const;
+    Q_INVOKABLE int indexOf( const QString &fieldName ) const;
 
     /**
      * Looks up field's index from the field name.
@@ -382,7 +384,7 @@ class CORE_EXPORT  QgsFields
      * \returns The field index if found or -1 in case it cannot be found.
      * \see indexFromName For a more performant and precise but less tolerant alternative.
      */
-    int lookupField( const QString &fieldName ) const;
+    Q_INVOKABLE  int lookupField( const QString &fieldName ) const;
 
     /**
      * Utility function to get list of attribute indexes

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -405,6 +405,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     Q_PROPERTY( QgsEditFormConfig editFormConfig READ editFormConfig WRITE setEditFormConfig NOTIFY editFormConfigChanged )
     Q_PROPERTY( bool readOnly READ isReadOnly WRITE setReadOnly NOTIFY readOnlyChanged )
     Q_PROPERTY( bool supportsEditing READ supportsEditing NOTIFY supportsEditingChanged )
+    Q_PROPERTY( QgsFields fields READ fields NOTIFY updatedFields )
 
   public:
 
@@ -1660,7 +1661,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \returns A list of fields
      */
-    Q_INVOKABLE QgsFields fields() const FINAL;
+    QgsFields fields() const FINAL;
 
     /**
      * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1660,7 +1660,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \returns A list of fields
      */
-    QgsFields fields() const FINAL;
+    Q_INVOKABLE QgsFields fields() const FINAL;
 
     /**
      * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()


### PR DESCRIPTION
## Description

We're already exposing a Q_PROPERTY QgsFields in our QgsFeatue class, but hadn't exposed some basic useful functions (such as index from field name). This PR does that by making QgsFields a QGadget, and make some functions invokable. 