### PR TITLE
Better reporting for invalid field names for some algorithms

### DIFF
--- a/python/plugins/processing/algs/qgis/BasicStatistics.py
+++ b/python/plugins/processing/algs/qgis/BasicStatistics.py
@@ -134,7 +134,11 @@ class BasicStatisticsForField(QgisAlgorithm):
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT_LAYER))
 
         field_name = self.parameterAsString(parameters, self.FIELD_NAME, context)
-        field = source.fields().at(source.fields().lookupField(field_name))
+        field_idx = source.fields().lookupField(field_name)
+        if field_idx < 0:
+            raise QgsProcessingException(self.tr("Invalid field for statistics: “{}” does not exist").format(field_name))
+
+        field = source.fields().at(field_idx)
 
         output_file = self.parameterAsFileOutput(parameters, self.OUTPUT_HTML_FILE, context)
 

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
@@ -121,9 +121,12 @@ QVariantMap QgsJoinByAttributeAlgorithm::processAlgorithm( const QVariantMap &pa
   const QStringList fieldsToCopy = parameterAsStrings( parameters, QStringLiteral( "FIELDS_TO_COPY" ), context );
 
   const int joinField1Index = input->fields().lookupField( field1Name );
+  if ( joinField1Index < 0 )
+    throw QgsProcessingException( QObject::tr( "Invalid join field from layer 1: “%1” does not exist" ).arg( field1Name ) );
+
   const int joinField2Index = input2->fields().lookupField( field2Name );
-  if ( joinField1Index < 0 || joinField2Index < 0 )
-    throw QgsProcessingException( QObject::tr( "Invalid join fields" ) );
+  if ( joinField2Index < 0 )
+    throw QgsProcessingException( QObject::tr( "Invalid join field from layer 2: “%1” does not exist" ).arg( field2Name ) );
 
   QgsFields outFields2;
   QgsAttributeList fields2Indices;


### PR DESCRIPTION
- raise proper error when field does not exist for basic stats instead of a python exception
- report which layers fail when fields don't exist for join by attributes