### PR TITLE
WMS: GetFeatureInfo FEATURE_COUNT set connection default

### DIFF
--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -74,7 +74,7 @@ const QgsSettingsEntryBool *QgsOwsConnection::settingsInvertAxisOrientation = ne
 const QgsSettingsEntryString *QgsOwsConnection::settingsUsername = new QgsSettingsEntryString( QStringLiteral( "username" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsPassword = new QgsSettingsEntryString( QStringLiteral( "password" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsAuthCfg = new QgsSettingsEntryString( QStringLiteral( "authcfg" ), sTreeOwsConnections ) ;
-const QgsSettingsEntryInteger *QgsOwsConnection::settingsDefaultFeatureCount = new QgsSettingsEntryInteger( QStringLiteral( "default-feature-count" ), sTreeOwsConnections, 10 );
+const QgsSettingsEntryInteger *QgsOwsConnection::settingsFeatureCount = new QgsSettingsEntryInteger( QStringLiteral( "feature-count" ), sTreeOwsConnections, 10 );
 
 QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connName )
   : mConnName( connName )
@@ -213,9 +213,9 @@ QgsDataSourceUri &QgsOwsConnection::addWmsWcsConnectionSettings( QgsDataSourceUr
   {
     uri.setParam( QStringLiteral( "tilePixelRatio" ), QString::number( static_cast<int>( settingsTilePixelRatio->value( {service.toLower(), connName} ) ) ) );
   }
-  if ( settingsDefaultFeatureCount->exists( {service.toLower(), connName} ) )
+  if ( settingsFeatureCount->exists( {service.toLower(), connName} ) )
   {
-    uri.setParam( QStringLiteral( "defaultFeatureCount" ), QString::number( settingsDefaultFeatureCount->value( {service.toLower(), connName} ) ) );
+    uri.setParam( QStringLiteral( "featureCount" ), QString::number( settingsFeatureCount->value( {service.toLower(), connName} ) ) );
   }
 
   return uri;

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -74,6 +74,7 @@ const QgsSettingsEntryBool *QgsOwsConnection::settingsInvertAxisOrientation = ne
 const QgsSettingsEntryString *QgsOwsConnection::settingsUsername = new QgsSettingsEntryString( QStringLiteral( "username" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsPassword = new QgsSettingsEntryString( QStringLiteral( "password" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsAuthCfg = new QgsSettingsEntryString( QStringLiteral( "authcfg" ), sTreeOwsConnections ) ;
+const QgsSettingsEntryInteger *QgsOwsConnection::settingsDefaultFeatureCount = new QgsSettingsEntryInteger( QStringLiteral( "default-feature-count" ), sTreeOwsConnections, 10 );
 
 QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connName )
   : mConnName( connName )
@@ -211,6 +212,10 @@ QgsDataSourceUri &QgsOwsConnection::addWmsWcsConnectionSettings( QgsDataSourceUr
   if ( settingsTilePixelRatio->exists( {service.toLower(), connName} ) )
   {
     uri.setParam( QStringLiteral( "tilePixelRatio" ), QString::number( static_cast<int>( settingsTilePixelRatio->value( {service.toLower(), connName} ) ) ) );
+  }
+  if ( settingsDefaultFeatureCount->exists( {service.toLower(), connName} ) )
+  {
+    uri.setParam( QStringLiteral( "defaultFeatureCount" ), QString::number( settingsDefaultFeatureCount->value( {service.toLower(), connName} ) ) );
   }
 
   return uri;

--- a/src/core/qgsowsconnection.h
+++ b/src/core/qgsowsconnection.h
@@ -115,6 +115,7 @@ class CORE_EXPORT QgsOwsConnection : public QObject
     static const QgsSettingsEntryString *settingsUsername;
     static const QgsSettingsEntryString *settingsPassword;
     static const QgsSettingsEntryString *settingsAuthCfg;
+    static const QgsSettingsEntryInteger *settingsDefaultFeatureCount;
 
 #endif
 

--- a/src/core/qgsowsconnection.h
+++ b/src/core/qgsowsconnection.h
@@ -115,7 +115,7 @@ class CORE_EXPORT QgsOwsConnection : public QObject
     static const QgsSettingsEntryString *settingsUsername;
     static const QgsSettingsEntryString *settingsPassword;
     static const QgsSettingsEntryString *settingsAuthCfg;
-    static const QgsSettingsEntryInteger *settingsDefaultFeatureCount;
+    static const QgsSettingsEntryInteger *settingsFeatureCount;
 
 #endif
 

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -141,6 +141,11 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
       cbxIgnoreGetFeatureInfoURI->setVisible( false );
       mGroupBox->layout()->removeWidget( cbxIgnoreGetFeatureInfoURI );
 
+      sbDefaultFeatureCount->setVisible( false );
+      mGroupBox->layout()->removeWidget( sbDefaultFeatureCount );
+      lblDefaultFeatureCount->setVisible( false );
+      mGroupBox->layout()->removeWidget( lblDefaultFeatureCount );
+
       cmbDpiMode->setVisible( false );
       mGroupBox->layout()->removeWidget( cmbDpiMode );
       lblDpiMode->setVisible( false );
@@ -320,6 +325,8 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   Qgis::TilePixelRatio tilePixelRatio = QgsOwsConnection::settingsTilePixelRatio->value( detailsParameters );
   cmbTilePixelRatio->setCurrentIndex( cmbTilePixelRatio->findData( static_cast<int>( tilePixelRatio ) ) );
 
+  sbDefaultFeatureCount->setValue( QgsOwsConnection::settingsDefaultFeatureCount->value( detailsParameters ) );
+
   const QString version = QgsOwsConnection::settingsVersion->value( detailsParameters );
   int versionIdx = WFS_VERSION_MAX; // AUTO
   if ( version == QLatin1String( "1.0.0" ) )
@@ -426,6 +433,7 @@ void QgsNewHttpConnection::accept()
   if ( mTypes & ConnectionWms )
   {
     QgsOwsConnection::settingsIgnoreGetFeatureInfoURI->setValue( cbxIgnoreGetFeatureInfoURI->isChecked(), detailsParameters );
+    QgsOwsConnection::settingsDefaultFeatureCount->setValue( sbDefaultFeatureCount->value(), detailsParameters );
   }
   if ( mTypes & ConnectionWfs )
   {

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -141,10 +141,10 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
       cbxIgnoreGetFeatureInfoURI->setVisible( false );
       mGroupBox->layout()->removeWidget( cbxIgnoreGetFeatureInfoURI );
 
-      sbDefaultFeatureCount->setVisible( false );
-      mGroupBox->layout()->removeWidget( sbDefaultFeatureCount );
-      lblDefaultFeatureCount->setVisible( false );
-      mGroupBox->layout()->removeWidget( lblDefaultFeatureCount );
+      sbFeatureCount->setVisible( false );
+      mGroupBox->layout()->removeWidget( sbFeatureCount );
+      lblFeatureCount->setVisible( false );
+      mGroupBox->layout()->removeWidget( lblFeatureCount );
 
       cmbDpiMode->setVisible( false );
       mGroupBox->layout()->removeWidget( cmbDpiMode );
@@ -325,7 +325,7 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   Qgis::TilePixelRatio tilePixelRatio = QgsOwsConnection::settingsTilePixelRatio->value( detailsParameters );
   cmbTilePixelRatio->setCurrentIndex( cmbTilePixelRatio->findData( static_cast<int>( tilePixelRatio ) ) );
 
-  sbDefaultFeatureCount->setValue( QgsOwsConnection::settingsDefaultFeatureCount->value( detailsParameters ) );
+  sbFeatureCount->setValue( QgsOwsConnection::settingsFeatureCount->value( detailsParameters ) );
 
   const QString version = QgsOwsConnection::settingsVersion->value( detailsParameters );
   int versionIdx = WFS_VERSION_MAX; // AUTO
@@ -433,7 +433,7 @@ void QgsNewHttpConnection::accept()
   if ( mTypes & ConnectionWms )
   {
     QgsOwsConnection::settingsIgnoreGetFeatureInfoURI->setValue( cbxIgnoreGetFeatureInfoURI->isChecked(), detailsParameters );
-    QgsOwsConnection::settingsDefaultFeatureCount->setValue( sbDefaultFeatureCount->value(), detailsParameters );
+    QgsOwsConnection::settingsFeatureCount->setValue( sbFeatureCount->value(), detailsParameters );
   }
   if ( mTypes & ConnectionWfs )
   {

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -463,18 +463,11 @@ QString QgsWMSItemBase::createUri( bool withStyle )
   }
   mDataSourceUri.setParam( QStringLiteral( "crs" ), crs );
 
-  // Set featureCount if the connection has a valid default value
-  if ( mDataSourceUri.hasParam( QStringLiteral( "defaultFeatureCount" ) ) )
+  // Set default featureCount to 10, old connections might miss this
+  // setting.
+  if ( ! mDataSourceUri.hasParam( QStringLiteral( "featureCount" ) ) )
   {
-    bool ok;
-    mDataSourceUri.param( QStringLiteral( "defaultFeatureCount" ) ).toInt( &ok );
-    if ( ok )
-    {
-      // Used by the provider
-      mDataSourceUri.setParam( QStringLiteral( "featureCount" ), mDataSourceUri.param( QStringLiteral( "defaultFeatureCount" ) ) );
-    }
-    // Not used by the provider: remove it
-    mDataSourceUri.removeParam( QStringLiteral( "defaultFeatureCount" ) );
+    mDataSourceUri.setParam( QStringLiteral( "featureCount" ), QStringLiteral( "10" ) );
   }
 
   //uri = rasterLayerPath + "|layers=" + layers.join( "," ) + "|styles=" + styles.join( "," ) + "|format=" + format + "|crs=" + crs;

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -462,6 +462,21 @@ QString QgsWMSItemBase::createUri( bool withStyle )
     crs = mLayerProperty.crs[0];
   }
   mDataSourceUri.setParam( QStringLiteral( "crs" ), crs );
+
+  // Set featureCount if the connection has a valid default value
+  if ( mDataSourceUri.hasParam( QStringLiteral( "defaultFeatureCount" ) ) )
+  {
+    bool ok;
+    mDataSourceUri.param( QStringLiteral( "defaultFeatureCount" ) ).toInt( &ok );
+    if ( ok )
+    {
+      // Used by the provider
+      mDataSourceUri.setParam( QStringLiteral( "featureCount" ), mDataSourceUri.param( QStringLiteral( "defaultFeatureCount" ) ) );
+    }
+    // Not used by the provider: remove it
+    mDataSourceUri.removeParam( QStringLiteral( "defaultFeatureCount" ) );
+  }
+
   //uri = rasterLayerPath + "|layers=" + layers.join( "," ) + "|styles=" + styles.join( "," ) + "|format=" + format + "|crs=" + crs;
 
   return mDataSourceUri.encodedUri();

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -477,7 +477,7 @@ void QgsWMSSourceSelect::btnConnect_clicked()
       mFeatureCount->setText( connection.uri().param( QStringLiteral( "defaultFeatureCount" ) ) );
   }
 
-  // Original default for old connections that didn't allow to specify the default feature count
+  // Original default for old connections with no default feature count
   if ( ! defaultFeatureCountSet )
   {
     mFeatureCount->setText( QStringLiteral( "10" ) );

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -469,16 +469,16 @@ void QgsWMSSourceSelect::btnConnect_clicked()
   QgsWMSConnection connection( cmbConnections->currentText() );
   mUri = connection.uri();
 
-  bool defaultFeatureCountSet { };
-  if ( connection.uri().hasParam( QStringLiteral( "defaultFeatureCount" ) ) && !connection.uri().param( QStringLiteral( "defaultFeatureCount" ) ).isEmpty() )
+  bool featureCountSet { };
+  if ( connection.uri().hasParam( QStringLiteral( "featureCount" ) ) )
   {
-    connection.uri().param( QStringLiteral( "defaultFeatureCount" ) ).toInt( &defaultFeatureCountSet );
-    if ( defaultFeatureCountSet )
-      mFeatureCount->setText( connection.uri().param( QStringLiteral( "defaultFeatureCount" ) ) );
+    connection.uri().param( QStringLiteral( "featureCount" ) ).toInt( &featureCountSet );
+    if ( featureCountSet )
+      mFeatureCount->setText( connection.uri().param( QStringLiteral( "featureCount" ) ) );
   }
 
-  // Original default for old connections with no default feature count
-  if ( ! defaultFeatureCountSet )
+  // Original default for old connections with no default feature count set
+  if ( ! featureCountSet )
   {
     mFeatureCount->setText( QStringLiteral( "10" ) );
   }

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -469,6 +469,20 @@ void QgsWMSSourceSelect::btnConnect_clicked()
   QgsWMSConnection connection( cmbConnections->currentText() );
   mUri = connection.uri();
 
+  bool defaultFeatureCountSet { };
+  if ( connection.uri().hasParam( QStringLiteral( "defaultFeatureCount" ) ) && !connection.uri().param( QStringLiteral( "defaultFeatureCount" ) ).isEmpty() )
+  {
+    connection.uri().param( QStringLiteral( "defaultFeatureCount" ) ).toInt( &defaultFeatureCountSet );
+    if ( defaultFeatureCountSet )
+      mFeatureCount->setText( connection.uri().param( QStringLiteral( "defaultFeatureCount" ) ) );
+  }
+
+  // Original default for old connections that didn't allow to specify the default feature count
+  if ( ! defaultFeatureCountSet )
+  {
+    mFeatureCount->setText( QStringLiteral( "10" ) );
+  }
+
   QgsWmsSettings wmsSettings;
   if ( !wmsSettings.parseUri( mUri.encodedUri() ) )
   {

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -614,6 +614,9 @@ void QgsWMSSourceSelect::addButtonClicked()
   uri.setParam( QStringLiteral( "crs" ), crs );
   QgsDebugMsgLevel( QStringLiteral( "crs=%2 " ).arg( crs ), 2 );
 
+  // Remove in case the default value from the connection settings
+  // is being overridden here
+  uri.removeParam( QStringLiteral( "featureCount" ) );
   if ( mFeatureCount->text().toInt() > 0 )
   {
     uri.setParam( QStringLiteral( "featureCount" ), mFeatureCount->text() );

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -140,43 +140,43 @@
          <string>WMS/WMTS Options</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="5" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWmsIgnoreAxisOrientation">
-           <property name="text">
-            <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
-           <property name="text">
-            <string>Ignore GetFeatureInfo URI reported in capabilities</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
-           <property name="text">
-            <string>Ignore GetMap/GetTile/GetLegendGraphic URI reported in capabilities</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="0" colspan="2">
+         <item row="13" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxSmoothPixmapTransform">
            <property name="text">
             <string>Smooth pixmap transform</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="0" colspan="2">
+         <item row="8" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsIgnoreAxisOrientation">
+           <property name="text">
+            <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QComboBox" name="cmbTilePixelRatio"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblDefaultFeatureCount">
+           <property name="text">
+            <string>Default maximum number of GetFeatureInfo results</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxWmsInvertAxisOrientation">
            <property name="text">
             <string>Invert axis orientation</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cmbDpiMode"/>
+         <item row="6" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
+           <property name="text">
+            <string>Ignore GetFeatureInfo URI reported in capabilities</string>
+           </property>
+          </widget>
          </item>
          <item row="0" column="0">
           <widget class="QLabel" name="lblDpiMode">
@@ -188,8 +188,15 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QComboBox" name="cmbTilePixelRatio"/>
+         <item row="7" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsIgnoreReportedLayerExtents">
+           <property name="text">
+            <string>Ignore reported layer extents</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbDpiMode"/>
          </item>
          <item row="1" column="0">
           <widget class="QLabel" name="lblTilePixelRatio">
@@ -201,10 +208,29 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWmsIgnoreReportedLayerExtents">
+         <item row="5" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
            <property name="text">
-            <string>Ignore reported layer extents</string>
+            <string>Ignore GetMap/GetTile/GetLegendGraphic URI reported in capabilities</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="sbDefaultFeatureCount">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a default value for FEATURE_COUNT when a new layer is created from this connection. &lt;/p&gt;&lt;p&gt;FEATURE_COUNT defines the maximum number of results returned by a GetFeatureInfo request, if not specified the server default value (usually 1) will be used.&lt;/p&gt;&lt;p&gt;Set to 0 to use server default: no FEATURE_COUNT parameter will be added to the request.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="specialValueText">
+            <string>server default</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>10</number>
            </property>
           </widget>
          </item>
@@ -362,6 +388,7 @@
   <tabstop>cbxWfsUseGml2EncodingForTransactions</tabstop>
   <tabstop>cmbDpiMode</tabstop>
   <tabstop>cmbTilePixelRatio</tabstop>
+  <tabstop>sbDefaultFeatureCount</tabstop>
   <tabstop>cbxIgnoreGetMapURI</tabstop>
   <tabstop>cbxIgnoreGetFeatureInfoURI</tabstop>
   <tabstop>cbxWmsIgnoreReportedLayerExtents</tabstop>
@@ -379,8 +406,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>421</x>
-     <y>453</y>
+     <x>428</x>
+     <y>813</y>
     </hint>
     <hint type="destinationlabel">
      <x>430</x>
@@ -395,8 +422,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>330</x>
-     <y>453</y>
+     <x>337</x>
+     <y>813</y>
     </hint>
     <hint type="destinationlabel">
      <x>426</x>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -158,9 +158,9 @@
           <widget class="QComboBox" name="cmbTilePixelRatio"/>
          </item>
          <item row="2" column="0">
-          <widget class="QLabel" name="lblDefaultFeatureCount">
+          <widget class="QLabel" name="lblFeatureCount">
            <property name="text">
-            <string>Default maximum number of GetFeatureInfo results</string>
+            <string>Maximum number of GetFeatureInfo results</string>
            </property>
           </widget>
          </item>
@@ -216,7 +216,7 @@
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QSpinBox" name="sbDefaultFeatureCount">
+          <widget class="QSpinBox" name="sbFeatureCount">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a default value for FEATURE_COUNT when a new layer is created from this connection. &lt;/p&gt;&lt;p&gt;FEATURE_COUNT defines the maximum number of results returned by a GetFeatureInfo request, if not specified the server default value (usually 1) will be used.&lt;/p&gt;&lt;p&gt;Set to 0 to use server default: no FEATURE_COUNT parameter will be added to the request.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -388,7 +388,7 @@
   <tabstop>cbxWfsUseGml2EncodingForTransactions</tabstop>
   <tabstop>cmbDpiMode</tabstop>
   <tabstop>cmbTilePixelRatio</tabstop>
-  <tabstop>sbDefaultFeatureCount</tabstop>
+  <tabstop>sbFeatureCount</tabstop>
   <tabstop>cbxIgnoreGetMapURI</tabstop>
   <tabstop>cbxIgnoreGetFeatureInfoURI</tabstop>
   <tabstop>cbxWmsIgnoreReportedLayerExtents</tabstop>

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -211,6 +211,9 @@
           </item>
           <item row="3" column="2">
            <widget class="QLineEdit" name="mFeatureCount">
+            <property name="toolTip">
+             <string/>
+            </property>
             <property name="text">
              <string>10</string>
             </property>

--- a/tests/src/python/test_qgsowsconnection.py
+++ b/tests/src/python/test_qgsowsconnection.py
@@ -59,7 +59,7 @@ class TestQgsOwsConnection(QgisTestCase):
         self.assertEqual(uri.param('dpiMode'), '4')
         self.assertEqual(uri.param('IgnoreAxisOrientation'), '1')
         self.assertEqual(uri.param('InvertAxisOrientation'), '1')
-        self.assertEqual(uri.param('defaultFeatureCount'), '9')
+        self.assertEqual(uri.param('featureCount'), '9')
 
     def testWmsSettings(self):
         uri = QgsDataSourceUri()

--- a/tests/src/python/test_qgsowsconnection.py
+++ b/tests/src/python/test_qgsowsconnection.py
@@ -38,6 +38,7 @@ class TestQgsOwsConnection(QgisTestCase):
         settings.setValue(key + 'dpi-mode', 4)
         settings.setValue(key + 'ignore-axis-orientation', True)
         settings.setValue(key + 'invert-axis-orientation', True)
+        settings.setValue(key + 'default-feature-count', 9)
 
         key = '/connections/ows/items/wfs/connections/items/test/'
         settings.setValue(key + 'url', 'ccc.ddd.com')
@@ -58,6 +59,7 @@ class TestQgsOwsConnection(QgisTestCase):
         self.assertEqual(uri.param('dpiMode'), '4')
         self.assertEqual(uri.param('IgnoreAxisOrientation'), '1')
         self.assertEqual(uri.param('InvertAxisOrientation'), '1')
+        self.assertEqual(uri.param('defaultFeatureCount'), '9')
 
     def testWmsSettings(self):
         uri = QgsDataSourceUri()
@@ -70,6 +72,7 @@ class TestQgsOwsConnection(QgisTestCase):
         self.assertEqual(uri.param('dpiMode'), '4')
         self.assertEqual(uri.param('IgnoreAxisOrientation'), '1')
         self.assertEqual(uri.param('InvertAxisOrientation'), '1')
+        self.assertEqual(uri.param('defaultFeatureCount'), '9')
 
     def testWfsConnection(self):
         c = QgsOwsConnection('WFS', 'test')

--- a/tests/src/python/test_qgsowsconnection.py
+++ b/tests/src/python/test_qgsowsconnection.py
@@ -38,7 +38,7 @@ class TestQgsOwsConnection(QgisTestCase):
         settings.setValue(key + 'dpi-mode', 4)
         settings.setValue(key + 'ignore-axis-orientation', True)
         settings.setValue(key + 'invert-axis-orientation', True)
-        settings.setValue(key + 'default-feature-count', 9)
+        settings.setValue(key + 'feature-count', 9)
 
         key = '/connections/ows/items/wfs/connections/items/test/'
         settings.setValue(key + 'url', 'ccc.ddd.com')
@@ -72,7 +72,7 @@ class TestQgsOwsConnection(QgisTestCase):
         self.assertEqual(uri.param('dpiMode'), '4')
         self.assertEqual(uri.param('IgnoreAxisOrientation'), '1')
         self.assertEqual(uri.param('InvertAxisOrientation'), '1')
-        self.assertEqual(uri.param('defaultFeatureCount'), '9')
+        self.assertEqual(uri.param('featureCount'), '9')
 
     def testWfsConnection(self):
         c = QgsOwsConnection('WFS', 'test')


### PR DESCRIPTION
Allow to set a default FEATURE_COUNT (default 10) individually for each WMS connection.

This default also works when adding WMS layers from the browser and it can be overridden for each individual layer when added from the datasource manager.

The deafult user experience when adding layers from the datasource manager is not changed: the default of 10 still applies unless it is explicitly set from the connection settings.

Fix #45206

![immagine](https://github.com/qgis/QGIS/assets/142164/753e21ca-d56a-453b-b4e0-fea151e69ea7)


Funded by: QGIS user group Germany (QGIS Anwendergruppe Deutschland e.V.)
