### PR TITLE
fix error when `stdout is None`

### DIFF
--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -94,7 +94,7 @@ def run_startup_script(script_path):
 
     return script_executed
         """,
-        'inline string in qgspythonutilsimpl.cpp',
+        'QgsPythonUtilsImpl::checkSystemImports [run_startup_script]',
         'exec',
     ),
     globals(),

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -60,8 +60,10 @@ bool QgsPythonUtilsImpl::checkSystemImports()
   // it is very useful for cleaning sys.path, which may have undesirable paths, or for
   // isolating/loading the initial environ without requiring a virt env, e.g. homebrew or MacPorts installs on Mac
   runString( QStringLiteral( "pyqgstart = os.getenv('PYQGIS_STARTUP')" ) );
-  runString( QStringLiteral(
-               R""""(
+  runString( QStringLiteral( R""""(
+exec(
+    compile(
+        """
 def run_startup_script(script_path):
     script_executed = False
     if not script_path:
@@ -91,8 +93,14 @@ def run_startup_script(script_path):
         )
 
     return script_executed
-)"""" ).arg( pythonPath() ) );
-  runString( QStringLiteral( "run_startup_script(pyqgstart)" ) );
+        """,
+        'inline string in qgspythonutilsimpl.cpp',
+        'exec',
+    ),
+    globals(),
+)
+)"""" ).arg( pythonPath() ), QObject::tr( "Couldn't create run_startup_script." ), true );
+  runString( QStringLiteral( "is_startup_script_executed = run_startup_script(pyqgstart)" ) );
 
 #ifdef Q_OS_WIN
   runString( "oldhome=None" );


### PR DESCRIPTION
## Description

This should fix error when starting python on Windows (every system with disabled `sys.stdout`).
Detailed reasoning about changes is described in https://github.com/qgis/QGIS/issues/57173#issuecomment-2065527353

The fix is to assign value to new global variable `is_startup_script_executed`, but I also added a "trick" with `exec` and `compile`. 
This gives us additional information about line error in `run_startup_script` (there should not be any obvious error, but actually in Python an error may occur on any line).

Example dialog with error:
![image](https://github.com/qgis/QGIS/assets/23526566/a82a0aff-e1fb-49e5-bd71-98fda26f68c8)


fixes #57173

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
