### PR TITLE
Add api to set QgsMapLayer IDs

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -193,9 +193,12 @@ Returns the layer's unique ID, which is used to access this layer from :py:class
 .. seealso:: :py:func:`idChanged`
 %End
 
-    void setId( const QString &id );
+    bool setId( const QString &id );
 %Docstring
 Sets the layer's ``id``.
+
+Returns ``True`` if the layer ID was successfully changed, or ``False`` if it could not be changed (e.g. because
+the layer is owned by a :py:class:`QgsProject` or :py:class:`QgsMapLayerStore`).
 
 .. warning::
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -189,6 +189,8 @@ Returns the extension of a Property.
 Returns the layer's unique ID, which is used to access this layer from :py:class:`QgsProject`.
 
 .. seealso:: :py:func:`setId`
+
+.. seealso:: :py:func:`idChanged`
 %End
 
     void setId( const QString &id );
@@ -206,6 +208,8 @@ Sets the layer's ``id``.
 
 
 .. seealso:: :py:func:`id`
+
+.. seealso:: :py:func:`idChanged`
 
 .. versionadded:: 3.38
 %End
@@ -1796,6 +1800,17 @@ just before the references of this layer are resolved.
     void statusChanged( const QString &status );
 %Docstring
 Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar)
+%End
+
+    void idChanged( const QString &id );
+%Docstring
+Emitted when the layer's ID has been changed.
+
+.. seealso:: :py:func:`id`
+
+.. seealso:: :py:func:`setId`
+
+.. versionadded:: 3.38
 %End
 
     void nameChanged();

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -187,6 +187,27 @@ Returns the extension of a Property.
     QString id() const;
 %Docstring
 Returns the layer's unique ID, which is used to access this layer from :py:class:`QgsProject`.
+
+.. seealso:: :py:func:`setId`
+%End
+
+    void setId( const QString &id );
+%Docstring
+Sets the layer's ``id``.
+
+.. warning::
+
+   It is the caller's responsibility to ensure that the layer ID is unique in the desired context.
+   Generally this method should not be called, and the auto generated ID should be used instead.
+
+.. warning::
+
+   This method should not be called on layers which already belong to a :py:class:`QgsProject` or :py:class:`QgsMapLayerStore`.
+
+
+.. seealso:: :py:func:`id`
+
+.. versionadded:: 3.38
 %End
 
     void setName( const QString &name );

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -193,9 +193,12 @@ Returns the layer's unique ID, which is used to access this layer from :py:class
 .. seealso:: :py:func:`idChanged`
 %End
 
-    void setId( const QString &id );
+    bool setId( const QString &id );
 %Docstring
 Sets the layer's ``id``.
+
+Returns ``True`` if the layer ID was successfully changed, or ``False`` if it could not be changed (e.g. because
+the layer is owned by a :py:class:`QgsProject` or :py:class:`QgsMapLayerStore`).
 
 .. warning::
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -189,6 +189,8 @@ Returns the extension of a Property.
 Returns the layer's unique ID, which is used to access this layer from :py:class:`QgsProject`.
 
 .. seealso:: :py:func:`setId`
+
+.. seealso:: :py:func:`idChanged`
 %End
 
     void setId( const QString &id );
@@ -206,6 +208,8 @@ Sets the layer's ``id``.
 
 
 .. seealso:: :py:func:`id`
+
+.. seealso:: :py:func:`idChanged`
 
 .. versionadded:: 3.38
 %End
@@ -1796,6 +1800,17 @@ just before the references of this layer are resolved.
     void statusChanged( const QString &status );
 %Docstring
 Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar)
+%End
+
+    void idChanged( const QString &id );
+%Docstring
+Emitted when the layer's ID has been changed.
+
+.. seealso:: :py:func:`id`
+
+.. seealso:: :py:func:`setId`
+
+.. versionadded:: 3.38
 %End
 
     void nameChanged();

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -187,6 +187,27 @@ Returns the extension of a Property.
     QString id() const;
 %Docstring
 Returns the layer's unique ID, which is used to access this layer from :py:class:`QgsProject`.
+
+.. seealso:: :py:func:`setId`
+%End
+
+    void setId( const QString &id );
+%Docstring
+Sets the layer's ``id``.
+
+.. warning::
+
+   It is the caller's responsibility to ensure that the layer ID is unique in the desired context.
+   Generally this method should not be called, and the auto generated ID should be used instead.
+
+.. warning::
+
+   This method should not be called on layers which already belong to a :py:class:`QgsProject` or :py:class:`QgsMapLayerStore`.
+
+
+.. seealso:: :py:func:`id`
+
+.. versionadded:: 3.38
 %End
 
     void setName( const QString &name );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -202,6 +202,13 @@ QString QgsMapLayer::id() const
   return mID;
 }
 
+void QgsMapLayer::setId( const QString &id )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mID = id;
+}
+
 void QgsMapLayer::setName( const QString &name )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -202,14 +202,21 @@ QString QgsMapLayer::id() const
   return mID;
 }
 
-void QgsMapLayer::setId( const QString &id )
+bool QgsMapLayer::setId( const QString &id )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+  if ( qobject_cast< QgsMapLayerStore * >( parent() ) )
+  {
+    // layer is already registered, cannot change id
+    return false;
+  }
+
   if ( id == mID )
-    return;
+    return false;
 
   mID = id;
   emit idChanged( id );
+  return true;
 }
 
 void QgsMapLayer::setName( const QString &name )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -205,8 +205,11 @@ QString QgsMapLayer::id() const
 void QgsMapLayer::setId( const QString &id )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+  if ( id == mID )
+    return;
 
   mID = id;
+  emit idChanged( id );
 }
 
 void QgsMapLayer::setName( const QString &name )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -598,7 +598,12 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
     mne = mnl.toElement();
     if ( ! mne.isNull() && mne.text().length() > 10 ) // should be at least 17 (yyyyMMddhhmmsszzz)
     {
-      mID = mne.text();
+      const QString newId = mne.text();
+      if ( newId != mID )
+      {
+        mID = mne.text();
+        emit idChanged( mID );
+      }
     }
   }
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -75,6 +75,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( QString id READ id WRITE setId NOTIFY idChanged )
     Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
     Q_PROPERTY( int autoRefreshInterval READ autoRefreshInterval WRITE setAutoRefreshInterval NOTIFY autoRefreshIntervalChanged )
     Q_PROPERTY( QgsLayerMetadata metadata READ metadata WRITE setMetadata NOTIFY metadataChanged )
@@ -260,6 +261,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * Returns the layer's unique ID, which is used to access this layer from QgsProject.
      *
      * \see setId()
+     * \see idChanged()
      */
     QString id() const;
 
@@ -272,6 +274,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \warning This method should not be called on layers which already belong to a QgsProject or QgsMapLayerStore.
      *
      * \see id()
+     * \see idChanged()
      * \since QGIS 3.38
      */
     void setId( const QString &id );
@@ -1809,8 +1812,17 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void statusChanged( const QString &status );
 
     /**
-     * Emitted when the name has been changed
+     * Emitted when the layer's ID has been changed.
      *
+     * \see id()
+     * \see setId()
+     *
+     * \since QGIS 3.38
+     */
+    void idChanged( const QString &id );
+
+    /**
+     * Emitted when the name has been changed
      */
     void nameChanged();
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -268,6 +268,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /**
      * Sets the layer's \a id.
      *
+     * Returns TRUE if the layer ID was successfully changed, or FALSE if it could not be changed (e.g. because
+     * the layer is owned by a QgsProject or QgsMapLayerStore).
+     *
      * \warning It is the caller's responsibility to ensure that the layer ID is unique in the desired context.
      * Generally this method should not be called, and the auto generated ID should be used instead.
      *
@@ -277,7 +280,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see idChanged()
      * \since QGIS 3.38
      */
-    void setId( const QString &id );
+    bool setId( const QString &id );
 
     /**
      * Set the display \a name of the layer.

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -256,8 +256,25 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     static QString extensionPropertyType( PropertyType type );
 
-    //! Returns the layer's unique ID, which is used to access this layer from QgsProject.
+    /**
+     * Returns the layer's unique ID, which is used to access this layer from QgsProject.
+     *
+     * \see setId()
+     */
     QString id() const;
+
+    /**
+     * Sets the layer's \a id.
+     *
+     * \warning It is the caller's responsibility to ensure that the layer ID is unique in the desired context.
+     * Generally this method should not be called, and the auto generated ID should be used instead.
+     *
+     * \warning This method should not be called on layers which already belong to a QgsProject or QgsMapLayerStore.
+     *
+     * \see id()
+     * \since QGIS 3.38
+     */
+    void setId( const QString &id );
 
     /**
      * Set the display \a name of the layer.

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -117,8 +117,15 @@ void TestQgsMapLayer::isValid()
 void TestQgsMapLayer::testId()
 {
   std::unique_ptr< QgsVectorLayer > layer = std::make_unique< QgsVectorLayer >( QStringLiteral( "Point" ), QStringLiteral( "a" ), QStringLiteral( "memory" ) );
+  QSignalSpy spy( layer.get(), &QgsMapLayer::idChanged );
   layer->setId( QStringLiteral( "my forced id" ) );
   QCOMPARE( layer->id(), QStringLiteral( "my forced id" ) );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toString(), QStringLiteral( "my forced id " ) );
+
+  // same id, should not emit signal
+  layer->setId( QStringLiteral( "my forced id" ) );
+  QCOMPARE( spy.count(), 1 );
 }
 
 void TestQgsMapLayer::formatName()

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -29,6 +29,8 @@
 #include "qgsvectorlayerref.h"
 #include "qgsmaplayerlistutils_p.h"
 #include "qgsmaplayerproxymodel.h"
+#include "qgsmaplayerstore.h"
+#include "qgsproject.h"
 #include "qgsxmlutils.h"
 
 /**
@@ -118,7 +120,7 @@ void TestQgsMapLayer::testId()
 {
   std::unique_ptr< QgsVectorLayer > layer = std::make_unique< QgsVectorLayer >( QStringLiteral( "Point" ), QStringLiteral( "a" ), QStringLiteral( "memory" ) );
   QSignalSpy spy( layer.get(), &QgsMapLayer::idChanged );
-  layer->setId( QStringLiteral( "my forced id" ) );
+  QVERIFY( layer->setId( QStringLiteral( "my forced id" ) ) );
   QCOMPARE( layer->id(), QStringLiteral( "my forced id" ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.at( 0 ).at( 0 ).toString(), QStringLiteral( "my forced id" ) );
@@ -126,6 +128,28 @@ void TestQgsMapLayer::testId()
   // same id, should not emit signal
   layer->setId( QStringLiteral( "my forced id" ) );
   QCOMPARE( spy.count(), 1 );
+
+  // if layer is owned by QgsMapLayerStore, cannot change ID
+  QgsMapLayerStore store;
+  QgsVectorLayer *layer2 = new QgsVectorLayer( QStringLiteral( "Point" ), QStringLiteral( "a" ), QStringLiteral( "memory" ) );
+  QSignalSpy spy2( layer2, &QgsMapLayer::idChanged );
+  layer2->setId( QStringLiteral( "my forced id" ) );
+  QCOMPARE( spy2.count(), 1 );
+  store.addMapLayer( layer2 );
+  QVERIFY( !layer2->setId( QStringLiteral( "aaa" ) ) );
+  QCOMPARE( layer2->id(), QStringLiteral( "my forced id" ) );
+  QCOMPARE( spy2.count(), 1 );
+
+  // if layer is owned by QgsProject, cannot change ID
+  QgsProject project;
+  QgsVectorLayer *layer3 = new QgsVectorLayer( QStringLiteral( "Point" ), QStringLiteral( "a" ), QStringLiteral( "memory" ) );
+  QSignalSpy spy3( layer3, &QgsMapLayer::idChanged );
+  layer3->setId( QStringLiteral( "my forced id" ) );
+  QCOMPARE( spy3.count(), 1 );
+  project.addMapLayer( layer3 );
+  QVERIFY( !layer3->setId( QStringLiteral( "aaa" ) ) );
+  QCOMPARE( layer3->id(), QStringLiteral( "my forced id" ) );
+  QCOMPARE( spy3.count(), 1 );
 }
 
 void TestQgsMapLayer::formatName()

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -49,6 +49,7 @@ class TestQgsMapLayer : public QObject
     void cleanup(); // will be called after every testfunction.
 
     void isValid();
+    void testId();
     void formatName();
 
     void setBlendMode();
@@ -111,6 +112,13 @@ void TestQgsMapLayer::cleanupTestCase()
 void TestQgsMapLayer::isValid()
 {
   QVERIFY( mpLayer->isValid() );
+}
+
+void TestQgsMapLayer::testId()
+{
+  std::unique_ptr< QgsVectorLayer > layer = std::make_unique< QgsVectorLayer >( QStringLiteral( "Point" ), QStringLiteral( "a" ), QStringLiteral( "memory" ) );
+  layer->setId( QStringLiteral( "my forced id" ) );
+  QCOMPARE( layer->id(), QStringLiteral( "my forced id" ) );
 }
 
 void TestQgsMapLayer::formatName()

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -121,7 +121,7 @@ void TestQgsMapLayer::testId()
   layer->setId( QStringLiteral( "my forced id" ) );
   QCOMPARE( layer->id(), QStringLiteral( "my forced id" ) );
   QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.at( 0 ).at( 0 ).toString(), QStringLiteral( "my forced id " ) );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toString(), QStringLiteral( "my forced id" ) );
 
   // same id, should not emit signal
   layer->setId( QStringLiteral( "my forced id" ) );


### PR DESCRIPTION
With appropriate warnings on when this should be used...

I realise this is a potentially risky API to expose, but there's plenty of other risky APIs we do expose and I have a valid use case for needing to force a layer to a particular ID.

