### PR TITLE
[processing] Harmonize DXF Export app dialog and corresponding algorithm

### DIFF
--- a/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -27,7 +27,7 @@ Exports QGIS layers to the DXF format.
 
     struct DxfLayer
     {
-        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() );
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = DEFAULT_DXF_DATA_DEFINED_BLOCKS, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() );
 
         QgsVectorLayer *layer() const;
 %Docstring

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -27,7 +27,7 @@ Exports QGIS layers to the DXF format.
 
     struct DxfLayer
     {
-        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() );
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = DEFAULT_DXF_DATA_DEFINED_BLOCKS, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() );
 
         QgsVectorLayer *layer() const;
 %Docstring

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -181,7 +181,7 @@ QgsVectorLayerAndAttributeModel::QgsVectorLayerAndAttributeModel( QgsLayerTree *
     const QgsVectorLayer *vLayer = qobject_cast< const QgsVectorLayer *>( QgsProject::instance()->mapLayer( id ) );
     if ( vLayer )
     {
-      mCreateDDBlockInfo[vLayer] = true;
+      mCreateDDBlockInfo[vLayer] = DEFAULT_DXF_DATA_DEFINED_BLOCKS;
       mDDBlocksMaxNumberOfClasses[vLayer] = -1;
     }
   }
@@ -344,7 +344,7 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
       return QVariant();
     }
 
-    bool checked = mCreateDDBlockInfo.contains( vl ) ? mCreateDDBlockInfo[vl] : true;
+    bool checked = mCreateDDBlockInfo.contains( vl ) ? mCreateDDBlockInfo[vl] : DEFAULT_DXF_DATA_DEFINED_BLOCKS;
     if ( role == Qt::CheckStateRole )
     {
       return checked ? Qt::Checked : Qt::Unchecked;
@@ -474,7 +474,7 @@ QList< QgsDxfExport::DxfLayer > QgsVectorLayerAndAttributeModel::layers() const
           layerIdx.insert( vl->id(), layers.size() );
           layers << QgsDxfExport::DxfLayer( vl,
                                             mAttributeIdx.value( vl, -1 ),
-                                            mCreateDDBlockInfo.value( vl, true ),
+                                            mCreateDDBlockInfo.value( vl, DEFAULT_DXF_DATA_DEFINED_BLOCKS ),
                                             mDDBlocksMaxNumberOfClasses.value( vl,  -1 ),
                                             mOverriddenName.value( vl, QString() ) );
         }
@@ -489,7 +489,7 @@ QList< QgsDxfExport::DxfLayer > QgsVectorLayerAndAttributeModel::layers() const
         layerIdx.insert( vl->id(), layers.size() );
         layers << QgsDxfExport::DxfLayer( vl,
                                           mAttributeIdx.value( vl, -1 ),
-                                          mCreateDDBlockInfo.value( vl, true ),
+                                          mCreateDDBlockInfo.value( vl, DEFAULT_DXF_DATA_DEFINED_BLOCKS ),
                                           mDDBlocksMaxNumberOfClasses.value( vl,  -1 ),
                                           mOverriddenName.value( vl, QString() ) );
       }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -597,9 +597,9 @@ void QgsVectorLayerAndAttributeModel::loadLayersOutputAttribute( QgsLayerTreeNod
 
         if ( vl->geometryType() == Qgis::GeometryType::Point )
         {
-          const bool allowDataDefinedBlocks = vl->customProperty( QStringLiteral( "lastAllowDataDefinedBlocks" ), false ).toBool();
+          const bool allowDataDefinedBlocks = vl->customProperty( QStringLiteral( "lastAllowDataDefinedBlocks" ), DEFAULT_DXF_DATA_DEFINED_BLOCKS ).toBool();
 
-          if ( allowDataDefinedBlocks )  // Since False is the default value
+          if ( allowDataDefinedBlocks != DEFAULT_DXF_DATA_DEFINED_BLOCKS )
           {
             mCreateDDBlockInfo[vl] = allowDataDefinedBlocks;
             idx = index( idx.row(), ALLOW_DD_SYMBOL_BLOCKS_COL, idx.parent() );

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -62,6 +62,9 @@ namespace pal // SIP_SKIP
 class CORE_EXPORT QgsDxfExport
 {
 #else
+
+static const bool DEFAULT_DXF_DATA_DEFINED_BLOCKS = true;
+
 class CORE_EXPORT QgsDxfExport : public QgsLabelSink
 {
 #endif
@@ -73,7 +76,7 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
      */
     struct CORE_EXPORT DxfLayer
     {
-        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() )
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = DEFAULT_DXF_DATA_DEFINED_BLOCKS, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() )
           : mLayer( vl )
           , mLayerOutputAttributeIndex( layerOutputAttributeIndex )
           , mBuildDDBlocks( buildDDBlocks )

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -129,7 +129,7 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
         /**
          * \brief try to build data defined symbol blocks if necessary
          */
-        bool mBuildDDBlocks = false;
+        bool mBuildDDBlocks = DEFAULT_DXF_DATA_DEFINED_BLOCKS;
 
         /**
          * \brief Limit for the number of data defined symbol block classes (keep only the most used ones). -1 means no limit

--- a/src/core/processing/qgsprocessingparameterdxflayers.cpp
+++ b/src/core/processing/qgsprocessingparameterdxflayers.cpp
@@ -85,7 +85,11 @@ bool QgsProcessingParameterDxfLayers::checkValueIsAcceptable( const QVariant &in
       {
         const QVariantMap layerMap = variantLayer.toMap();
 
-        if ( !layerMap.contains( QStringLiteral( "layer" ) ) && !layerMap.contains( QStringLiteral( "attributeIndex" ) ) && !layerMap.contains( QStringLiteral( "overriddenLayerName" ) ) )
+        if ( !layerMap.contains( QStringLiteral( "layer" ) ) &&
+             !layerMap.contains( QStringLiteral( "attributeIndex" ) ) &&
+             !layerMap.contains( QStringLiteral( "overriddenLayerName" ) ) &&
+             !layerMap.contains( QStringLiteral( "buildDataDefinedBlocks" ) ) &&
+             !layerMap.contains( QStringLiteral( "dataDefinedBlocksMaximumNumberOfClasses" ) ) )
           return false;
 
         if ( !context )
@@ -149,6 +153,10 @@ QString QgsProcessingParameterDxfLayers::valueAsPythonString( const QVariant &va
       layerDefParts << QStringLiteral( "'attributeIndex': " ) + QgsProcessingUtils::variantToPythonLiteral( layer.layerOutputAttributeIndex() );
 
     layerDefParts << QStringLiteral( "'overriddenLayerName': " ) + QgsProcessingUtils::stringToPythonLiteral( layer.overriddenName() );
+
+    layerDefParts << QStringLiteral( "'buildDataDefinedBlocks': " ) + QgsProcessingUtils::variantToPythonLiteral( layer.buildDataDefinedBlocks() );
+
+    layerDefParts << QStringLiteral( "'dataDefinedBlocksMaximumNumberOfClasses': " ) + QgsProcessingUtils::variantToPythonLiteral( layer.dataDefinedBlocksMaximumNumberOfClasses() );
 
     const QString layerDef = QStringLiteral( "{%1}" ).arg( layerDefParts.join( ',' ) );
     parts << layerDef;
@@ -244,8 +252,8 @@ QgsDxfExport::DxfLayer QgsProcessingParameterDxfLayers::variantMapAsLayer( const
 
   QgsDxfExport::DxfLayer dxfLayer( inputLayer,
                                    layerVariantMap[ QStringLiteral( "attributeIndex" ) ].toInt(),
-                                   false,
-                                   -1,
+                                   layerVariantMap[ QStringLiteral( "buildDataDefinedBlocks" ) ].toBool(),
+                                   layerVariantMap[ QStringLiteral( "dataDefinedBlocksMaximumNumberOfClasses" ) ].toInt(),
                                    layerVariantMap[ QStringLiteral( "overriddenLayerName" ) ].toString() );
   return dxfLayer;
 }
@@ -259,5 +267,7 @@ QVariantMap QgsProcessingParameterDxfLayers::layerAsVariantMap( const QgsDxfExpo
   vm[ QStringLiteral( "layer" )] = layer.layer()->id();
   vm[ QStringLiteral( "attributeIndex" ) ] = layer.layerOutputAttributeIndex();
   vm[ QStringLiteral( "overriddenLayerName" ) ] = layer.overriddenName();
+  vm[ QStringLiteral( "buildDataDefinedBlocks" ) ] = layer.buildDataDefinedBlocks();
+  vm[ QStringLiteral( "dataDefinedBlocksMaximumNumberOfClasses" ) ] = layer.dataDefinedBlocksMaximumNumberOfClasses();
   return vm;
 }

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -122,7 +122,7 @@ QgsProcessingDxfLayersPanelWidget::QgsProcessingDxfLayersPanelWidget(
     vm["layer"] = layer->id();
     vm["attributeIndex"] = -1;
     vm["overriddenLayerName"] = QString();
-    vm["buildDataDefinedBlocks"] = false;
+    vm["buildDataDefinedBlocks"] = DEFAULT_DXF_DATA_DEFINED_BLOCKS;
     vm["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
 
     const QString title = layer->name();

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -51,16 +51,31 @@ QgsProcessingDxfLayerDetailsWidget::QgsProcessingDxfLayerDetailsWidget( const QV
 
   if ( mLayer->fields().exists( layer.layerOutputAttributeIndex() ) )
     mFieldsComboBox->setField( mLayer->fields().at( layer.layerOutputAttributeIndex() ).name() );
+
   mOverriddenName->setText( layer.overriddenName() );
+
+  if ( mLayer->geometryType() == Qgis::GeometryType::Point )
+  {
+    // Data defined blocks are only available for point layers
+    mGroupBoxBlocks->setVisible( true );
+    mGroupBoxBlocks->setChecked( layer.buildDataDefinedBlocks() );
+    mSpinBoxBlocks->setValue( layer.dataDefinedBlocksMaximumNumberOfClasses() );
+  }
+  else
+  {
+    mGroupBoxBlocks->setVisible( false );
+  }
 
   connect( mFieldsComboBox, &QgsFieldComboBox::fieldChanged, this, &QgsPanelWidget::widgetChanged );
   connect( mOverriddenName, &QLineEdit::textChanged, this, &QgsPanelWidget::widgetChanged );
+  connect( mGroupBoxBlocks, &QGroupBox::toggled, this, &QgsPanelWidget::widgetChanged );
+  connect( mSpinBoxBlocks, &QSpinBox::textChanged, this, &QgsPanelWidget::widgetChanged );
 }
 
 QVariant QgsProcessingDxfLayerDetailsWidget::value() const
 {
   const int index = mLayer->fields().lookupField( mFieldsComboBox->currentField() );
-  const QgsDxfExport::DxfLayer layer( mLayer, index, false, -1, mOverriddenName->text().trimmed() );
+  const QgsDxfExport::DxfLayer layer( mLayer, index, mGroupBoxBlocks->isChecked(), mSpinBoxBlocks->value(), mOverriddenName->text().trimmed() );
   return QgsProcessingParameterDxfLayers::layerAsVariantMap( layer );
 }
 
@@ -107,6 +122,8 @@ QgsProcessingDxfLayersPanelWidget::QgsProcessingDxfLayersPanelWidget(
     vm["layer"] = layer->id();
     vm["attributeIndex"] = -1;
     vm["overriddenLayerName"] = QString();
+    vm["buildDataDefinedBlocks"] = false;
+    vm["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
 
     const QString title = layer->name();
     addOption( vm, title, false );

--- a/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
+++ b/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
@@ -7,24 +7,27 @@
     <x>0</x>
     <y>0</y>
     <width>393</width>
-    <height>144</height>
+    <height>228</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="1" colspan="2">
     <widget class="QgsFieldComboBox" name="mFieldsComboBox"/>
    </item>
-   <item row="3" column="2">
+   <item row="7" column="2">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
+   <item row="3" column="0" colspan="3">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Preferred</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -50,6 +53,50 @@
    </item>
    <item row="1" column="1" colspan="2">
     <widget class="QLineEdit" name="mOverriddenName"/>
+   </item>
+   <item row="2" column="0" rowspan="2" colspan="3">
+    <widget class="QGroupBox" name="mGroupBoxBlocks">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Allow data defined symbol blocks</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Maximum number of symbol blocks</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="mSpinBoxBlocks">
+        <property name="toolTip">
+         <string>A value of -1 means no limitation.</string>
+        </property>
+        <property name="minimum">
+         <number>-1</number>
+        </property>
+        <property name="value">
+         <number>-1</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
+++ b/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
@@ -72,7 +72,7 @@
       <bool>true</bool>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">

--- a/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
+++ b/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
@@ -40,7 +40,7 @@
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Attribute</string>
+      <string>Output layer attribute</string>
      </property>
     </widget>
    </item>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -11042,7 +11042,7 @@ void TestQgsProcessing::parameterDxfLayers()
   layerMap["layer"] = "layerName";
   layerMap["attributeIndex"] = -1;
   layerMap["overriddenLayerName"] = QString();
-  layerMap["buildDataDefinedBlocks"] = false;
+  layerMap["buildDataDefinedBlocks"] = DEFAULT_DXF_DATA_DEFINED_BLOCKS;
   layerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   layerList[0] = layerMap;
   QVERIFY( def->checkValueIsAcceptable( layerList ) );
@@ -11060,7 +11060,7 @@ void TestQgsProcessing::parameterDxfLayers()
   layerList[0] = layerMap;
   QVERIFY( def->checkValueIsAcceptable( layerList, &context ) );
 
-  layerMap["buildDataDefinedBlocks"] = true;
+  layerMap["buildDataDefinedBlocks"] = false;
   layerList[0] = layerMap;
   QVERIFY( def->checkValueIsAcceptable( layerList, &context ) );
 
@@ -11090,7 +11090,7 @@ void TestQgsProcessing::parameterDxfLayers()
   wrongLayerMap["layer"] = "NonSpatialLayer";
   wrongLayerMap["attributeIndex"] = -1;
   wrongLayerMap["overriddenLayerName"] = QString();
-  wrongLayerMap["buildDataDefinedBlocks"] = false;
+  wrongLayerMap["buildDataDefinedBlocks"] = DEFAULT_DXF_DATA_DEFINED_BLOCKS;
   wrongLayerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   QVariantList wrongLayerMapList;
   wrongLayerMapList.append( wrongLayerMap );
@@ -11098,9 +11098,9 @@ void TestQgsProcessing::parameterDxfLayers()
 
   // Check values
   const QString valueAsPythonString = def->valueAsPythonString( layerList, context );
-  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': 'My Point Layer','buildDataDefinedBlocks': True,'dataDefinedBlocksMaximumNumberOfClasses': 8}]" ).arg( vectorLayer->source() ) );
+  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': 'My Point Layer','buildDataDefinedBlocks': False,'dataDefinedBlocksMaximumNumberOfClasses': 8}]" ).arg( vectorLayer->source() ) );
   QCOMPARE( QString::fromStdString( QgsJsonUtils::jsonFromVariant( def->valueAsJsonObject( layerList, context ) ).dump() ),
-            QStringLiteral( "[{\"attributeIndex\":-1,\"buildDataDefinedBlocks\":true,\"dataDefinedBlocksMaximumNumberOfClasses\":8,\"layer\":\"memory://%1\",\"overriddenLayerName\":\"My Point Layer\"}]" ).arg( vectorLayer->source() ) );
+            QStringLiteral( "[{\"attributeIndex\":-1,\"buildDataDefinedBlocks\":false,\"dataDefinedBlocksMaximumNumberOfClasses\":8,\"layer\":\"memory://%1\",\"overriddenLayerName\":\"My Point Layer\"}]" ).arg( vectorLayer->source() ) );
   bool ok = false;
   QCOMPARE( def->valueAsString( layerList, context, ok ), QString() );
   QVERIFY( !ok );
@@ -11113,7 +11113,7 @@ void TestQgsProcessing::parameterDxfLayers()
 
   // Default values for parameters other than the vector layer
   layerMap["overriddenLayerName"] = QString();
-  layerMap["buildDataDefinedBlocks"] = false;
+  layerMap["buildDataDefinedBlocks"] = DEFAULT_DXF_DATA_DEFINED_BLOCKS;
   layerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   layerList[0] = layerMap;
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -11042,6 +11042,8 @@ void TestQgsProcessing::parameterDxfLayers()
   layerMap["layer"] = "layerName";
   layerMap["attributeIndex"] = -1;
   layerMap["overriddenLayerName"] = QString();
+  layerMap["buildDataDefinedBlocks"] = false;
+  layerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   layerList[0] = layerMap;
   QVERIFY( def->checkValueIsAcceptable( layerList ) );
   QVERIFY( !def->checkValueIsAcceptable( layerList, &context ) ); //no corresponding layer in the context's project
@@ -11055,6 +11057,14 @@ void TestQgsProcessing::parameterDxfLayers()
   QVERIFY( def->checkValueIsAcceptable( layerList, &context ) );
 
   layerMap["overriddenLayerName"] = QStringLiteral( "My Point Layer" );
+  layerList[0] = layerMap;
+  QVERIFY( def->checkValueIsAcceptable( layerList, &context ) );
+
+  layerMap["buildDataDefinedBlocks"] = true;
+  layerList[0] = layerMap;
+  QVERIFY( def->checkValueIsAcceptable( layerList, &context ) );
+
+  layerMap["dataDefinedBlocksMaximumNumberOfClasses"] = 8;
   layerList[0] = layerMap;
   QVERIFY( def->checkValueIsAcceptable( layerList, &context ) );
 
@@ -11080,15 +11090,17 @@ void TestQgsProcessing::parameterDxfLayers()
   wrongLayerMap["layer"] = "NonSpatialLayer";
   wrongLayerMap["attributeIndex"] = -1;
   wrongLayerMap["overriddenLayerName"] = QString();
+  wrongLayerMap["buildDataDefinedBlocks"] = false;
+  wrongLayerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   QVariantList wrongLayerMapList;
   wrongLayerMapList.append( wrongLayerMap );
   QVERIFY( !def->checkValueIsAcceptable( wrongLayerMapList, &context ) );
 
   // Check values
   const QString valueAsPythonString = def->valueAsPythonString( layerList, context );
-  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': 'My Point Layer'}]" ).arg( vectorLayer->source() ) );
+  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': 'My Point Layer','buildDataDefinedBlocks': True,'dataDefinedBlocksMaximumNumberOfClasses': 8}]" ).arg( vectorLayer->source() ) );
   QCOMPARE( QString::fromStdString( QgsJsonUtils::jsonFromVariant( def->valueAsJsonObject( layerList, context ) ).dump() ),
-            QStringLiteral( "[{\"attributeIndex\":-1,\"layer\":\"memory://%1\",\"overriddenLayerName\":\"My Point Layer\"}]" ).arg( vectorLayer->source() ) );
+            QStringLiteral( "[{\"attributeIndex\":-1,\"buildDataDefinedBlocks\":true,\"dataDefinedBlocksMaximumNumberOfClasses\":8,\"layer\":\"memory://%1\",\"overriddenLayerName\":\"My Point Layer\"}]" ).arg( vectorLayer->source() ) );
   bool ok = false;
   QCOMPARE( def->valueAsString( layerList, context, ok ), QString() );
   QVERIFY( !ok );
@@ -11101,6 +11113,8 @@ void TestQgsProcessing::parameterDxfLayers()
 
   // Default values for parameters other than the vector layer
   layerMap["overriddenLayerName"] = QString();
+  layerMap["buildDataDefinedBlocks"] = false;
+  layerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   layerList[0] = layerMap;
 
   const QgsDxfExport::DxfLayer dxfLayer( vectorLayer );
@@ -11108,14 +11122,20 @@ void TestQgsProcessing::parameterDxfLayers()
   QCOMPARE( dxfList.at( 0 ).layer()->source(), dxfLayer.layer()->source() );
   QCOMPARE( dxfList.at( 0 ).layerOutputAttributeIndex(), dxfLayer.layerOutputAttributeIndex() );
   QCOMPARE( dxfList.at( 0 ).overriddenName(), dxfLayer.overriddenName() );
+  QCOMPARE( dxfList.at( 0 ).buildDataDefinedBlocks(), dxfLayer.buildDataDefinedBlocks() );
+  QCOMPARE( dxfList.at( 0 ).dataDefinedBlocksMaximumNumberOfClasses(), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() );
   dxfList = def->parameterAsLayers( QVariant( QStringList() << vectorLayer->source() ), context );
   QCOMPARE( dxfList.at( 0 ).layer()->source(), dxfLayer.layer()->source() );
   QCOMPARE( dxfList.at( 0 ).layerOutputAttributeIndex(), dxfLayer.layerOutputAttributeIndex() );
   QCOMPARE( dxfList.at( 0 ).overriddenName(), dxfLayer.overriddenName() );
+  QCOMPARE( dxfList.at( 0 ).buildDataDefinedBlocks(), dxfLayer.buildDataDefinedBlocks() );
+  QCOMPARE( dxfList.at( 0 ).dataDefinedBlocksMaximumNumberOfClasses(), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() );
   dxfList = def->parameterAsLayers( layerList, context );
   QCOMPARE( dxfList.at( 0 ).layer()->source(), dxfLayer.layer()->source() );
   QCOMPARE( dxfList.at( 0 ).layerOutputAttributeIndex(), dxfLayer.layerOutputAttributeIndex() );
   QCOMPARE( dxfList.at( 0 ).overriddenName(), dxfLayer.overriddenName() );
+  QCOMPARE( dxfList.at( 0 ).buildDataDefinedBlocks(), dxfLayer.buildDataDefinedBlocks() );
+  QCOMPARE( dxfList.at( 0 ).dataDefinedBlocksMaximumNumberOfClasses(), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() );
 }
 
 void TestQgsProcessing::parameterAnnotationLayer()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -9989,6 +9989,8 @@ void TestProcessingGui::testDxfLayersWrapper()
   layerMap["layer"] = "PointLayer";
   layerMap["attributeIndex"] = -1;
   layerMap["overriddenLayerName"] = QString();
+  layerMap["buildDataDefinedBlocks"] = false;
+  layerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   layerList.append( layerMap );
 
   QVERIFY( definition.checkValueIsAcceptable( layerList, &context ) );
@@ -9999,7 +10001,7 @@ void TestProcessingGui::testDxfLayersWrapper()
 
   QVERIFY( definition.checkValueIsAcceptable( value, &context ) );
   QString valueAsPythonString = definition.valueAsPythonString( value, context );
-  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': ''}]" ).arg( vectorLayer->source() ) );
+  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': '','buildDataDefinedBlocks': False,'dataDefinedBlocksMaximumNumberOfClasses': -1}]" ).arg( vectorLayer->source() ) );
 }
 
 void TestProcessingGui::testAlignRasterLayersWrapper()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -9989,7 +9989,7 @@ void TestProcessingGui::testDxfLayersWrapper()
   layerMap["layer"] = "PointLayer";
   layerMap["attributeIndex"] = -1;
   layerMap["overriddenLayerName"] = QString();
-  layerMap["buildDataDefinedBlocks"] = false;
+  layerMap["buildDataDefinedBlocks"] = DEFAULT_DXF_DATA_DEFINED_BLOCKS;
   layerMap["dataDefinedBlocksMaximumNumberOfClasses"] = -1;
   layerList.append( layerMap );
 
@@ -10001,7 +10001,7 @@ void TestProcessingGui::testDxfLayersWrapper()
 
   QVERIFY( definition.checkValueIsAcceptable( value, &context ) );
   QString valueAsPythonString = definition.valueAsPythonString( value, context );
-  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': '','buildDataDefinedBlocks': False,'dataDefinedBlocksMaximumNumberOfClasses': -1}]" ).arg( vectorLayer->source() ) );
+  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': '','buildDataDefinedBlocks': True,'dataDefinedBlocksMaximumNumberOfClasses': -1}]" ).arg( vectorLayer->source() ) );
 }
 
 void TestProcessingGui::testAlignRasterLayersWrapper()


### PR DESCRIPTION
Follow-up: https://github.com/qgis/QGIS/pull/56147

 + Remember settings for data defined blocks in DXF Export app dialog 
 + Expose DXF Export's data defined blocks functionality to processing

![image](https://github.com/gacarrillor/QGIS/assets/652785/27424604-1b66-426b-97ab-00271574607c)


Fix https://github.com/qgis/QGIS/issues/56853

-----------------

Funded by the [QGIS user group Switzerland](https://qgis.ch/).
