### PR TITLE
[Qt6][Sip] Correctly retrieve PyQt module directory

### DIFF
--- a/cmake/FindPyQt5.cmake
+++ b/cmake/FindPyQt5.cmake
@@ -34,8 +34,8 @@ ELSE(EXISTS PYQT5_VERSION_STR)
     ENDIF(_pyqt5_metadata)
 
     IF(PYQT5_VERSION_STR)
-      SET(PYQT5_MOD_DIR "${Python_SITEARCH}/PyQt5")
-      SET(PYQT5_SIP_DIR "${Python_SITEARCH}/PyQt5/bindings")
+      EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -c "import os; import PyQt5; print(os.path.dirname(PyQt5.__file__), end='')" OUTPUT_VARIABLE PYQT5_MOD_DIR)
+      SET(PYQT5_SIP_DIR "${PYQT5_MOD_DIR}/bindings")
       FIND_PROGRAM(__pyuic5 "pyuic5")
       GET_FILENAME_COMPONENT(PYQT5_BIN_DIR ${__pyuic5} DIRECTORY)
 

--- a/cmake/FindPyQt6.cmake
+++ b/cmake/FindPyQt6.cmake
@@ -34,8 +34,8 @@ ELSE(EXISTS PYQT6_VERSION_STR)
     ENDIF(_pyqt6_metadata)
 
     IF(PYQT6_VERSION_STR)
-      SET(PYQT6_MOD_DIR "${Python_SITEARCH}/PyQt6")
-      SET(PYQT6_SIP_DIR "${Python_SITEARCH}/PyQt6/bindings")
+      EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -c "import os; import PyQt6; print(os.path.dirname(PyQt6.__file__), end='')" OUTPUT_VARIABLE PYQT6_MOD_DIR)
+      SET(PYQT6_SIP_DIR "${PYQT6_MOD_DIR}/bindings")
       FIND_PROGRAM(__pyuic6 "pyuic6")
       GET_FILENAME_COMPONENT(PYQT6_BIN_DIR ${__pyuic6} DIRECTORY)
 


### PR DESCRIPTION

On Debian testing Python_SiteSearch is in `/usr/local/lib/python3.11` while PyQt6 has been installed in `/usr/lib/python3/dist-packages`. This PR propose a more robust way to retrieve module directory
