### PR TITLE
QgsProject: The flag to read extent from xml was set too late

### DIFF
--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1468,11 +1468,16 @@ void QgsProject::setAvoidIntersectionsMode( const Qgis::AvoidIntersectionsMode m
 static  QgsMapLayer::ReadFlags projectFlagsToLayerReadFlags( Qgis::ProjectReadFlags projectReadFlags, Qgis::ProjectFlags projectFlags )
 {
   QgsMapLayer::ReadFlags layerFlags = QgsMapLayer::ReadFlags();
+  // Propagate don't resolve layers
   if ( projectReadFlags & Qgis::ProjectReadFlag::DontResolveLayers )
     layerFlags |= QgsMapLayer::FlagDontResolveLayers;
   // Propagate trust layer metadata flag
+  // Propagate read extent from XML based trust layer metadata flag
   if ( ( projectFlags & Qgis::ProjectFlag::TrustStoredLayerStatistics ) || ( projectReadFlags & Qgis::ProjectReadFlag::TrustLayerMetadata ) )
+  {
     layerFlags |= QgsMapLayer::FlagTrustLayerMetadata;
+    layerFlags |= QgsMapLayer::FlagReadExtentFromXml;
+  }
   // Propagate open layers in read-only mode
   if ( ( projectReadFlags & Qgis::ProjectReadFlag::ForceReadOnlyLayers ) )
     layerFlags |= QgsMapLayer::FlagForceReadOnly;
@@ -1868,7 +1873,7 @@ bool QgsProject::addLayer( const QDomElement &layerElem,
   // apply specific settings to vector layer
   if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mapLayer.get() ) )
   {
-    vl->setReadExtentFromXml( ( mFlags & Qgis::ProjectFlag::TrustStoredLayerStatistics ) || ( flags & Qgis::ProjectReadFlag::TrustLayerMetadata ) );
+    vl->setReadExtentFromXml( layerFlags & QgsMapLayer::FlagReadExtentFromXml );
     if ( vl->dataProvider() )
     {
       const bool evaluateDefaultValues = mFlags & Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -2448,6 +2448,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     bool mMapTipsEnabled = true;
 
     friend class QgsVectorLayer;
+    friend class TestQgsProject;
     friend class TestQgsMapLayer;
 };
 


### PR DESCRIPTION
The `QgsProject::addLayer` method which add a layer from DOM layer element uses the method `projectFlagsToLayerReadFlags` to get layer read flags from project flags. The generated layer read flags is used into the `QgsMapLayer::readLayerFromXml` method. This method read the extent from XML only if the `QgsMapLayer::FlagReadExtentFromXml` flag is set. If it is not set, the layer extent (provided by the provider) and layer extent from xml are empty. So even if the read extent from xml is set to true for vector layer, the extent will be always provided by the provider if the flag `QgsMapLayer::FlagReadExtentFromXml` is not provided to `QgsMapLayer::readLayerFromXml` method.

To fix it, we proposed to update `QgsProject::projectFlagsToLayerReadFlags` method to provide `QgsMapLayer::FlagReadExtentFromXml` from project flags.

Funded by Tenergie