### PR TITLE
Add wms context flags also for pdf GetMap. Fixes problems with extern…

### DIFF
--- a/src/server/services/wms/qgspdfwriter.cpp
+++ b/src/server/services/wms/qgspdfwriter.cpp
@@ -29,6 +29,14 @@ namespace QgsWms
                    QgsServerResponse &response )
   {
     QgsWmsRenderContext context( project, serverIface );
+    context.setFlag( QgsWmsRenderContext::UpdateExtent );
+    context.setFlag( QgsWmsRenderContext::UseOpacity );
+    context.setFlag( QgsWmsRenderContext::UseFilter );
+    context.setFlag( QgsWmsRenderContext::UseSelection );
+    context.setFlag( QgsWmsRenderContext::AddHighlightLayers );
+    context.setFlag( QgsWmsRenderContext::AddExternalLayers );
+    context.setFlag( QgsWmsRenderContext::SetAccessControl );
+    context.setFlag( QgsWmsRenderContext::UseTileBuffer );
     context.setParameters( request.wmsParameters() );
     QTemporaryFile tmpFile;
     tmpFile.open();


### PR DESCRIPTION
Sets the same GetMap context flags for pdf GetMap as for normal (image) GetMap