### PR TITLE
[Oracle] Properly store credentials in cache

### DIFF
--- a/src/providers/oracle/qgsoracletransaction.cpp
+++ b/src/providers/oracle/qgsoracletransaction.cpp
@@ -40,8 +40,7 @@ QgsOracleTransaction::~QgsOracleTransaction()
 bool QgsOracleTransaction::beginTransaction( QString &, int /* statementTimeout */ )
 {
   mConn = QgsOracleConn::connectDb( mConnString, true /*transaction*/ );
-
-  return true;
+  return mConn;
 }
 
 bool QgsOracleTransaction::commitTransaction( QString &error )
@@ -68,6 +67,12 @@ bool QgsOracleTransaction::rollbackTransaction( QString &error )
 
 bool QgsOracleTransaction::executeSql( const QString &sql, QString &errorMsg, bool isDirty, const QString &name )
 {
+  if ( !mConn )
+  {
+    errorMsg = tr( "Connection to the database not available" );
+    return false;
+  }
+
   QString err;
   if ( isDirty )
   {


### PR DESCRIPTION
Before this modification, `username` was prepend to realm before storing credentials, so we failed at retrieving from cache later. And so username/password was requested all the time.

This issue was because of a side effect unveiled after fixing #53201


