### PR TITLE
[FEATURE]: add option to export all lines with minimal width in dxf export 

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsdxfexport.py
+++ b/python/PyQt6/core/auto_additions/qgsdxfexport.py
@@ -1,6 +1,7 @@
 # The following has been generated automatically from src/core/dxf/qgsdxfexport.h
 QgsDxfExport.FlagNoMText = QgsDxfExport.Flag.FlagNoMText
 QgsDxfExport.FlagOnlySelectedFeatures = QgsDxfExport.Flag.FlagOnlySelectedFeatures
+QgsDxfExport.FlagHairlineWidthExport = QgsDxfExport.Flag.FlagHairlineWidthExport
 QgsDxfExport.Flags = lambda flags=0: QgsDxfExport.Flag(flags)
 # monkey patching scoped based enum
 QgsDxfExport.ExportResult.Success.__doc__ = "Successful export"

--- a/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -82,6 +82,7 @@ Returns the overridden layer name to be used in the exported DXF.
     {
       FlagNoMText,
       FlagOnlySelectedFeatures,
+      FlagHairlineWidthExport
     };
     typedef QFlags<QgsDxfExport::Flag> Flags;
 

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -82,6 +82,7 @@ Returns the overridden layer name to be used in the exported DXF.
     {
       FlagNoMText,
       FlagOnlySelectedFeatures,
+      FlagHairlineWidthExport
     };
     typedef QFlags<QgsDxfExport::Flag> Flags;
 

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -76,6 +76,7 @@ void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( useTitleParam.release() );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT elements" ),  true ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "EXPORT_LINES_WITH_ZERO_WIDTH" ), QObject::tr( "Export lines with zero width" ) ), false );
   addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "DXF" ), QObject::tr( "DXF Files" ) + " (*.dxf *.DXF)" ) );
 }
 
@@ -116,6 +117,7 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
   const bool useLayerTitle = parameterAsBool( parameters, QStringLiteral( "USE_LAYER_TITLE" ), context );
   const bool useMText = parameterAsBool( parameters, QStringLiteral( "MTEXT" ), context );
   const bool force2D = parameterAsBool( parameters, QStringLiteral( "FORCE_2D" ), context );
+  const bool exportLinesWithZeroWidth = parameterAsBool( parameters, QStringLiteral( "EXPORT_LINES_WITH_ZERO_WIDTH" ), context );
 
   QgsRectangle extent;
   if ( parameters.value( QStringLiteral( "EXTENT" ) ).isValid() )
@@ -145,6 +147,8 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
     flags = flags | QgsDxfExport::FlagNoMText;
   if ( selectedFeaturesOnly )
     flags = flags | QgsDxfExport::FlagOnlySelectedFeatures;
+  if ( exportLinesWithZeroWidth )
+    flags = flags | QgsDxfExport::FlagHairlineWidthExport;
   dxfExport.setFlags( flags );
 
   QFile dxfFile( outputFile );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6871,6 +6871,8 @@ void QgisApp::dxfExport()
       flags = flags | QgsDxfExport::FlagNoMText;
     if ( d.selectedFeaturesOnly() )
       flags = flags | QgsDxfExport::FlagOnlySelectedFeatures;
+    if ( d.hairlineWidthExport() )
+      flags = flags | QgsDxfExport::FlagHairlineWidthExport;
     dxfExport.setFlags( flags );
 
     if ( auto *lMapCanvas = mapCanvas() )

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -804,6 +804,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mSelectedFeaturesOnly->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSelectedFeaturesOnly" ), settings.value( QStringLiteral( "qgis/lastDxfSelectedFeaturesOnly" ), "false" ).toString() ) != QLatin1String( "false" ) );
   mMTextCheckBox->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfUseMText" ), settings.value( QStringLiteral( "qgis/lastDxfUseMText" ), "true" ).toString() ) != QLatin1String( "false" ) );
   mForce2d->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfForce2d" ), settings.value( QStringLiteral( "qgis/lastDxfForce2d" ), "false" ).toString() ) != QLatin1String( "false" ) );
+  mHairlineWidthExportCheckBox->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfHairlineWidthExport" ), settings.value( QStringLiteral( "qgis/lastDxfHairlineWidthExport" ), "false" ).toString() ) !=  QLatin1String( "false" ) );
 
   QStringList ids = QgsProject::instance()->mapThemeCollection()->mapThemes();
   ids.prepend( QString() );
@@ -1054,6 +1055,11 @@ bool QgsDxfExportDialog::loadSettingsFromXML( QDomDocument &doc, QString &errorM
   if ( !value.isNull() )
     mSelectedFeaturesOnly->setChecked( value == true );
 
+  element = dxfElement.namedItem( QStringLiteral( "hairline_width_export" ) ).toElement();
+  value = QgsXmlUtils::readVariant( element.firstChildElement() );
+  if ( !value.isNull() )
+    mHairlineWidthExportCheckBox->setChecked( value == true );
+
   return true;
 }
 
@@ -1177,6 +1183,11 @@ void QgsDxfExportDialog::saveSettingsToXML( QDomDocument &doc ) const
   selectedFeatures.appendChild( QgsXmlUtils::writeVariant( selectedFeaturesOnly(), doc ) );
   dxfElement.appendChild( selectedFeatures );
 
+  QDomElement hairlineWidthExportElem = domDocument.createElement( QStringLiteral( "hairline_width_export" ) );
+  hairlineWidthExportElem.appendChild( QgsXmlUtils::writeVariant( hairlineWidthExport(), doc ) );
+  dxfElement.appendChild( hairlineWidthExportElem );
+
+
   doc = domDocument;
 }
 
@@ -1252,6 +1263,11 @@ bool QgsDxfExportDialog::useMText() const
   return mMTextCheckBox->isChecked();
 }
 
+bool QgsDxfExportDialog::hairlineWidthExport() const
+{
+  return mHairlineWidthExportCheckBox->isChecked();
+}
+
 void QgsDxfExportDialog::saveSettings()
 {
   QgsSettings settings;
@@ -1266,6 +1282,7 @@ void QgsDxfExportDialog::saveSettings()
   settings.setValue( QStringLiteral( "qgis/lastDxfCrs" ), QString::number( mCRS.srsid() ) );
   settings.setValue( QStringLiteral( "qgis/lastDxfUseMText" ), mMTextCheckBox->isChecked() );
   settings.setValue( QStringLiteral( "qgis/lastDxfForce2d" ), mForce2d->isChecked() );
+  settings.setValue( QStringLiteral( "qgis/lastDxfHairlineWidthExport" ), mHairlineWidthExportCheckBox->isChecked() );
 
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSymbologyMode" ), mSymbologyModeComboBox->currentIndex() );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastSymbologyExportScale" ), mScaleWidget->scale() != 0 ? 1.0 / mScaleWidget->scale() : 0 );
@@ -1277,6 +1294,7 @@ void QgsDxfExportDialog::saveSettings()
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfCrs" ), QString::number( mCRS.srsid() ) );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfUseMText" ), mMTextCheckBox->isChecked() );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfForce2d" ), mForce2d->isChecked() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfHairlineWidthExport" ), mHairlineWidthExportCheckBox->isChecked() );
 
   mModel->saveLayersOutputAttribute( mModel->rootGroup() );
 }

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -119,6 +119,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     bool layerTitleAsName() const;
     bool force2d() const;
     bool useMText() const;
+    bool hairlineWidthExport() const;
     QString mapTheme() const;
     QString encoding() const;
     QgsCoordinateReferenceSystem crs() const;

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -1763,6 +1763,11 @@ void QgsDxfExport::addFeature( QgsSymbolRenderContext &ctx, const QgsCoordinateT
       offset = 0.0;
   }
 
+  if ( mFlags & FlagHairlineWidthExport )
+  {
+    width = 0;
+  }
+
   QString lineStyleName = QStringLiteral( "CONTINUOUS" );
   if ( mSymbologyExport != Qgis::FeatureSymbologyExport::NoSymbology )
   {

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -147,6 +147,7 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
     {
       FlagNoMText = 1 << 1, //!< Export text as TEXT elements. If not set, text will be exported as MTEXT elements.
       FlagOnlySelectedFeatures = 1 << 2, //!< Use only selected features for the export.
+      FlagHairlineWidthExport = 1 << 3 //!Export all lines with minimum width and don't fill polygons. Since QGIS 3.38
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1605,6 +1605,19 @@ namespace QgsWms
     return force2D;
   }
 
+  bool QgsWmsParameters::exportLinesWithZeroWidth() const
+  {
+    bool zeroWidth = false;
+    const QMap<DxfFormatOption, QString> options = formatOptions<QgsWmsParameters::DxfFormatOption>();
+
+    if ( options.contains( DxfFormatOption::EXPORT_LINES_WITH_ZERO_WIDTH ) )
+    {
+      zeroWidth = QVariant( options[ DxfFormatOption::EXPORT_LINES_WITH_ZERO_WIDTH ] ).toBool();
+    }
+
+    return zeroWidth;
+  }
+
   bool QgsWmsParameters::noMText() const
   {
     bool noMText = false;

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -362,7 +362,8 @@ namespace QgsWms
         USE_TITLE_AS_LAYERNAME,
         CODEC,
         NO_MTEXT,
-        FORCE_2D
+        FORCE_2D,
+        EXPORT_LINES_WITH_ZERO_WIDTH
       };
       Q_ENUM( DxfFormatOption )
 
@@ -1408,6 +1409,13 @@ namespace QgsWms
        * \since QGIS 3.12
        */
       bool isForce2D() const;
+
+      /**
+       * \returns true if the lines are export to dxf with minimal (hairline) width
+       *
+       * \since QGIS 3.38
+       */
+      bool exportLinesWithZeroWidth() const;
 
       /**
        * Returns if a GeoPDF shall be exported

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1182,6 +1182,11 @@ namespace QgsWms
     if ( mWmsParameters.noMText() )
       flags.setFlag( QgsDxfExport::Flag::FlagNoMText );
 
+    if ( mWmsParameters.exportLinesWithZeroWidth() )
+    {
+      flags.setFlag( QgsDxfExport::Flag::FlagHairlineWidthExport );
+    }
+
     dxf->setFlags( flags );
 
     return dxf;

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -219,7 +219,7 @@
        <item row="2" column="1">
         <widget class="QCheckBox" name="mHairlineWidthExportCheckBox">
          <property name="text">
-          <string>Export minimum line width</string>
+          <string>Export lines with zero width</string>
          </property>
         </widget>
        </item>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -30,7 +30,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QgsFileWidget" name="mFileName"/>
+      <widget class="QgsFileWidget" name="mFileName" native="true"/>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="mSymbologyModeLabel">
@@ -62,11 +62,11 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QgsScaleWidget" name="mScaleWidget">
+      <widget class="QgsScaleWidget" name="mScaleWidget" native="true">
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>
-       <property name="showCurrentScaleButton">
+       <property name="showCurrentScaleButton" stdset="0">
         <bool>true</bool>
        </property>
       </widget>
@@ -101,7 +101,7 @@
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+      <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>
@@ -123,114 +123,121 @@
      <item row="5" column="1">
       <widget class="QComboBox" name="mVisibilityPresets"/>
      </item>
-   <item row="7" column="0" colspan="2">
-     <widget class="QWidget" name="mTreeViewContainer">
-    <layout class="QHBoxLayout" name="mTreeViewLayout"/>
-    </widget>
-   </item>
-   <item row="9" column="0" colspan="2">
-    <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="0">
-      <widget class="QPushButton" name="mSelectAllButton">
-       <property name="text">
-        <string>Select All Layers</string>
-       </property>
+     <item row="7" column="0" colspan="2">
+      <widget class="QWidget" name="mTreeViewContainer">
+      <layout class="QHBoxLayout" name="mTreeViewLayout"/>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QPushButton" name="mDeselectAllButton">
-       <property name="text">
-        <string>Deselect All Layers</string>
-       </property>
-      </widget>
+     <item row="9" column="0" colspan="2">
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <widget class="QPushButton" name="mSelectAllButton">
+         <property name="text">
+          <string>Select All Layers</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QPushButton" name="mDeselectAllButton">
+         <property name="text">
+          <string>Deselect All Layers</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QPushButton" name="mSelectDataDefinedBlocks">
+         <property name="text">
+          <string>Select Data Defined Blocks</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QPushButton" name="mDeselectDataDefinedBlocks">
+         <property name="text">
+          <string>Deselect Data Defined Blocks</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="mSelectDataDefinedBlocks">
-       <property name="text">
-        <string>Select Data Defined Blocks</string>
-       </property>
-      </widget>
+     <item row="11" column="0" colspan="2">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="mMapExtentCheckBox">
+         <property name="text">
+          <string>Export features intersecting the current map extent</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="mLayerTitleAsName">
+         <property name="toolTip">
+          <string>If no attribute is chosen and layer name is not being overridden, prefer layer title (set in layer properties) to layer name.</string>
+         </property>
+         <property name="text">
+          <string>Use layer title as name if set</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="mForce2d">
+         <property name="text">
+          <string>Force 2d output (eg. to support polyline width)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="mMTextCheckBox">
+         <property name="text">
+          <string>Export labels as MTEXT elements</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="mSelectedFeaturesOnly">
+         <property name="text">
+          <string>Use only selected features</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="mHairlineWidthExportCheckBox">
+         <property name="text">
+          <string>Export minimum line width</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
-     <item row="0" column="3">
-      <widget class="QPushButton" name="mDeselectDataDefinedBlocks">
-       <property name="text">
-        <string>Deselect Data Defined Blocks</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="11" column="0" colspan="2">
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="mMapExtentCheckBox">
-       <property name="text">
-        <string>Export features intersecting the current map extent</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="mLayerTitleAsName">
-       <property name="toolTip">
-        <string>If no attribute is chosen and layer name is not being overridden, prefer layer title (set in layer properties) to layer name.</string>
-       </property>
-       <property name="text">
-        <string>Use layer title as name if set</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="mForce2d">
-       <property name="text">
-        <string>Force 2d output (eg. to support polyline width)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QCheckBox" name="mMTextCheckBox">
-       <property name="text">
-        <string>Export labels as MTEXT elements</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <spacer name="horizontalSpacer_2">
+     <item row="15" column="0" colspan="2">
+      <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="mSelectedFeaturesOnly">
-       <property name="text">
-        <string>Use only selected features</string>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="15" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
   </layout>
-  </item>
- </layout>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
This PR adds an option to the dxf export to write all lines with minimal width 0 (hairline) if enabled. DXF-Lines having zero width stay minimal in the CAD regardless of the zoom-level, so this is quite usefull for doing further CAD-editing with the exported dxf, especially if there are many features next to each other on the map.

Going to add a unit test and support for access via server and processing to the PR.

The option can be enabled/disabled in the dxf dialog:

![dxf_export_minimum_line_width](https://github.com/qgis/QGIS/assets/278939/597518b0-e6fc-4bbf-b6f3-b061d3501b0c)

Funded by [Stadtwerke München](http://www.swm.de/)

