### PR TITLE
Fix non-responsive Qt3D overlay

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -996,6 +996,7 @@ void Qgs3DMapScene::onDebugDepthMapSettingsChanged()
 void Qgs3DMapScene::onDebugOverlayEnabledChanged()
 {
   mEngine->frameGraph()->setDebugOverlayEnabled( mMap.isDebugOverlayEnabled() );
+  mEngine->renderSettings()->setRenderPolicy( mMap.isDebugOverlayEnabled() ? Qt3DRender::QRenderSettings::Always : Qt3DRender::QRenderSettings::OnDemand );
 }
 
 void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()


### PR DESCRIPTION
## Description

Qt3D overlay is drawn using imgui which is imperative, so Qt3D needs to cache events until they are needed for the actual rendering of the overlay, especially since this happens in a different thread.

When render policy is set to OnDemand though, Qt3D does not cache the entire history of events since the previous update and events can go missing or come out of sequence, which confuses imgui.

This patch changes the render policy to Always while the overlay is visible, so it now responds to events. It will also provide more accurate display of performance data in that mode.
