### PR TITLE
[layout] Fix html item freeze QGIS when loading HTML undet Qt6/QtWebkit-less environments

### DIFF
--- a/src/core/layout/qgslayoutitemhtml.cpp
+++ b/src/core/layout/qgslayoutitemhtml.cpp
@@ -241,6 +241,7 @@ void QgsLayoutItemHtml::loadHtml( const bool useCache, const QgsExpressionContex
   if ( !loaded )
     loop.exec( QEventLoop::ExcludeUserInputEvents );
 
+#ifdef WITH_QTWEBKIT
   //inject JSON feature
   if ( !mAtlasFeatureJSON.isEmpty() )
   {
@@ -251,6 +252,7 @@ void QgsLayoutItemHtml::loadHtml( const bool useCache, const QgsExpressionContex
 
     jsLoop.execIfNotDone();
   }
+#endif
 
   recalculateFrameSizes();
   //trigger a repaint


### PR DESCRIPTION
## Description

This PR fixes a QGIS - built against Qt6 (or when WITH_QTWEBKIT=FALSE - freezes when a layout HTML item loads its  content with an atlas context defined. 

When QtWebkit is not present, calling mWebPage->mainFrame()->evaluateJavaScript() does nothing. In turn, it means that the JavascriptExecutorLoop jsLoop object never has its done() function called, leading to QGIS freezing for eternity.
