### PR TITLE
Copy project vertical/3d crs logic to QgsMapLayer

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -808,11 +808,110 @@ after accessing data by :py:func:`~QgsMapLayer.draw` etc.
     QgsCoordinateReferenceSystem crs() const;
 %Docstring
 Returns the layer's spatial reference system.
+
+.. warning::
+
+   Since QGIS 3.38, consider using :py:func:`~QgsMapLayer.crs3D` whenever transforming 3D data or whenever
+   z/elevation value handling is important.
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`crsChanged`
+%End
+
+    QgsCoordinateReferenceSystem verticalCrs() const;
+%Docstring
+Returns the layer's vertical coordinate reference system.
+
+If the layer :py:func:`~QgsMapLayer.crs` is a compound CRS, then the CRS returned will
+be the vertical component of :py:func:`~QgsMapLayer.crs`. Otherwise it will be the value
+explicitly set by a call to :py:func:`~QgsMapLayer.setVerticalCrs`.
+
+The returned CRS will be invalid if the layer has no vertical CRS.
+
+.. note::
+
+   Consider also using :py:func:`~QgsMapLayer.crs3D`, which will return a CRS which takes into account
+   both :py:func:`~QgsMapLayer.crs` and :py:func:`~QgsMapLayer.verticalCrs`.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`setVerticalCrs`
+
+
+.. versionadded:: 3.38
+%End
+
+    QgsCoordinateReferenceSystem crs3D() const;
+%Docstring
+Returns the CRS to use for the layer when transforming 3D data, or when z/elevation
+value handling is important.
+
+The returned CRS will take into account :py:func:`~QgsMapLayer.verticalCrs` when appropriate, e.g. it may return a compound
+CRS consisting of :py:func:`~QgsMapLayer.crs` + :py:func:`~QgsMapLayer.verticalCrs`. This method may still return a 2D CRS, e.g in the
+case that :py:func:`~QgsMapLayer.crs` is a 2D CRS and no :py:func:`~QgsMapLayer.verticalCrs` has been set for the layer. Check :py:func:`QgsCoordinateReferenceSystem.type()`
+on the returned value to determine the type of CRS returned by this method.
+
+.. warning::
+
+   It is NOT guaranteed that the returned CRS will actually be a 3D CRS, but rather
+   it is guaranteed that the returned CRS is ALWAYS the most appropriate CRS to use when handling 3D data.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`crs3DChanged`
+
+
+.. versionadded:: 3.38
 %End
 
     void setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSignal = true );
 %Docstring
-Sets layer's spatial reference system
+Sets layer's spatial reference system.
+
+If ``emitSignal`` is ``True``, changing the CRS will trigger a :py:func:`~QgsMapLayer.crsChanged` signal. Additionally, if ``crs`` is a compound
+CRS, then the :py:func:`~QgsMapLayer.verticalCrsChanged` signal will also be emitted.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`setVerticalCrs`
+%End
+
+    bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage /Out/ = 0 );
+%Docstring
+Sets the layer's vertical coordinate reference system.
+
+The :py:func:`~QgsMapLayer.verticalCrsChanged` signal will be raised if the vertical CRS is changed.
+
+.. note::
+
+   If the layer :py:func:`~QgsMapLayer.crs` is a compound CRS, then the CRS returned for
+   :py:func:`~QgsMapLayer.verticalCrs` will be the vertical component of :py:func:`~QgsMapLayer.crs`. Otherwise it will be the value
+   explicitly set by this call.
+
+:param crs: the vertical CRS
+
+
+:return: - ``True`` if vertical CRS was successfully set
+         - errorMessage: will be set to a descriptive message if the vertical CRS could not be set
+
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`setCrs`
+
+
+.. versionadded:: 3.38
 %End
 
     QgsCoordinateTransformContext transformContext( ) const;
@@ -1823,7 +1922,49 @@ Emitted when the name has been changed
 
     void crsChanged();
 %Docstring
-Emit a signal that layer's CRS has been reset
+Emitted when the :py:func:`~QgsMapLayer.crs` of the layer has changed.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`verticalCrsChanged`
+
+.. seealso:: :py:func:`crs3DChanged`
+%End
+
+    void crs3DChanged();
+%Docstring
+Emitted when the :py:func:`~QgsMapLayer.crs3D` of the layer has changed.
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`verticalCrsChanged`
+
+.. versionadded:: 3.38
+%End
+
+    void verticalCrsChanged();
+%Docstring
+Emitted when the :py:func:`~QgsMapLayer.verticalCrs` of the layer has changed.
+
+This signal will be emitted whenever the vertical CRS of the layer is changed, either
+as a direct result of a call to :py:func:`~QgsMapLayer.setVerticalCrs` or when :py:func:`~QgsMapLayer.setCrs` is called with a compound
+CRS.
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`crs3DChanged`
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`setVerticalCrs`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. versionadded:: 3.38
 %End
 
     void repaintRequested( bool deferredUpdate = false );

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -808,11 +808,110 @@ after accessing data by :py:func:`~QgsMapLayer.draw` etc.
     QgsCoordinateReferenceSystem crs() const;
 %Docstring
 Returns the layer's spatial reference system.
+
+.. warning::
+
+   Since QGIS 3.38, consider using :py:func:`~QgsMapLayer.crs3D` whenever transforming 3D data or whenever
+   z/elevation value handling is important.
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`crsChanged`
+%End
+
+    QgsCoordinateReferenceSystem verticalCrs() const;
+%Docstring
+Returns the layer's vertical coordinate reference system.
+
+If the layer :py:func:`~QgsMapLayer.crs` is a compound CRS, then the CRS returned will
+be the vertical component of :py:func:`~QgsMapLayer.crs`. Otherwise it will be the value
+explicitly set by a call to :py:func:`~QgsMapLayer.setVerticalCrs`.
+
+The returned CRS will be invalid if the layer has no vertical CRS.
+
+.. note::
+
+   Consider also using :py:func:`~QgsMapLayer.crs3D`, which will return a CRS which takes into account
+   both :py:func:`~QgsMapLayer.crs` and :py:func:`~QgsMapLayer.verticalCrs`.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`setVerticalCrs`
+
+
+.. versionadded:: 3.38
+%End
+
+    QgsCoordinateReferenceSystem crs3D() const;
+%Docstring
+Returns the CRS to use for the layer when transforming 3D data, or when z/elevation
+value handling is important.
+
+The returned CRS will take into account :py:func:`~QgsMapLayer.verticalCrs` when appropriate, e.g. it may return a compound
+CRS consisting of :py:func:`~QgsMapLayer.crs` + :py:func:`~QgsMapLayer.verticalCrs`. This method may still return a 2D CRS, e.g in the
+case that :py:func:`~QgsMapLayer.crs` is a 2D CRS and no :py:func:`~QgsMapLayer.verticalCrs` has been set for the layer. Check :py:func:`QgsCoordinateReferenceSystem.type()`
+on the returned value to determine the type of CRS returned by this method.
+
+.. warning::
+
+   It is NOT guaranteed that the returned CRS will actually be a 3D CRS, but rather
+   it is guaranteed that the returned CRS is ALWAYS the most appropriate CRS to use when handling 3D data.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`crs3DChanged`
+
+
+.. versionadded:: 3.38
 %End
 
     void setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSignal = true );
 %Docstring
-Sets layer's spatial reference system
+Sets layer's spatial reference system.
+
+If ``emitSignal`` is ``True``, changing the CRS will trigger a :py:func:`~QgsMapLayer.crsChanged` signal. Additionally, if ``crs`` is a compound
+CRS, then the :py:func:`~QgsMapLayer.verticalCrsChanged` signal will also be emitted.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`setVerticalCrs`
+%End
+
+    bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage /Out/ = 0 );
+%Docstring
+Sets the layer's vertical coordinate reference system.
+
+The :py:func:`~QgsMapLayer.verticalCrsChanged` signal will be raised if the vertical CRS is changed.
+
+.. note::
+
+   If the layer :py:func:`~QgsMapLayer.crs` is a compound CRS, then the CRS returned for
+   :py:func:`~QgsMapLayer.verticalCrs` will be the vertical component of :py:func:`~QgsMapLayer.crs`. Otherwise it will be the value
+   explicitly set by this call.
+
+:param crs: the vertical CRS
+
+
+:return: - ``True`` if vertical CRS was successfully set
+         - errorMessage: will be set to a descriptive message if the vertical CRS could not be set
+
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. seealso:: :py:func:`setCrs`
+
+
+.. versionadded:: 3.38
 %End
 
     QgsCoordinateTransformContext transformContext( ) const;
@@ -1823,7 +1922,49 @@ Emitted when the name has been changed
 
     void crsChanged();
 %Docstring
-Emit a signal that layer's CRS has been reset
+Emitted when the :py:func:`~QgsMapLayer.crs` of the layer has changed.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`verticalCrsChanged`
+
+.. seealso:: :py:func:`crs3DChanged`
+%End
+
+    void crs3DChanged();
+%Docstring
+Emitted when the :py:func:`~QgsMapLayer.crs3D` of the layer has changed.
+
+.. seealso:: :py:func:`crs3D`
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`verticalCrsChanged`
+
+.. versionadded:: 3.38
+%End
+
+    void verticalCrsChanged();
+%Docstring
+Emitted when the :py:func:`~QgsMapLayer.verticalCrs` of the layer has changed.
+
+This signal will be emitted whenever the vertical CRS of the layer is changed, either
+as a direct result of a call to :py:func:`~QgsMapLayer.setVerticalCrs` or when :py:func:`~QgsMapLayer.setCrs` is called with a compound
+CRS.
+
+.. seealso:: :py:func:`crsChanged`
+
+.. seealso:: :py:func:`crs3DChanged`
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`setVerticalCrs`
+
+.. seealso:: :py:func:`verticalCrs`
+
+.. versionadded:: 3.38
 %End
 
     void repaintRequested( bool deferredUpdate = false );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -80,6 +80,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
     Q_PROPERTY( int autoRefreshInterval READ autoRefreshInterval WRITE setAutoRefreshInterval NOTIFY autoRefreshIntervalChanged )
     Q_PROPERTY( QgsLayerMetadata metadata READ metadata WRITE setMetadata NOTIFY metadataChanged )
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
+    Q_PROPERTY( QgsCoordinateReferenceSystem verticalCrs READ verticalCrs WRITE setVerticalCrs NOTIFY verticalCrsChanged )
+    Q_PROPERTY( QgsCoordinateReferenceSystem crs3D READ crs3D NOTIFY crs3DChanged )
     Q_PROPERTY( Qgis::LayerType type READ type CONSTANT )
     Q_PROPERTY( bool isValid READ isValid NOTIFY isValidChanged )
     Q_PROPERTY( double opacity READ opacity WRITE setOpacity NOTIFY opacityChanged )
@@ -966,11 +968,89 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Returns the layer's spatial reference system.
+     *
+     * \warning Since QGIS 3.38, consider using crs3D() whenever transforming 3D data or whenever
+     * z/elevation value handling is important.
+     *
+     * \see setCrs()
+     * \see crs3D()
+     * \see verticalCrs()
+     * \see crsChanged()
      */
     QgsCoordinateReferenceSystem crs() const;
 
-    //! Sets layer's spatial reference system
+    /**
+     * Returns the layer's vertical coordinate reference system.
+     *
+     * If the layer crs() is a compound CRS, then the CRS returned will
+     * be the vertical component of crs(). Otherwise it will be the value
+     * explicitly set by a call to setVerticalCrs().
+     *
+     * The returned CRS will be invalid if the layer has no vertical CRS.
+     *
+     * \note Consider also using crs3D(), which will return a CRS which takes into account
+     * both crs() and verticalCrs().
+     *
+     * \see crs()
+     * \see crs3D()
+     * \see setVerticalCrs()
+     *
+     * \since QGIS 3.38
+     */
+    QgsCoordinateReferenceSystem verticalCrs() const;
+
+    /**
+     * Returns the CRS to use for the layer when transforming 3D data, or when z/elevation
+     * value handling is important.
+     *
+     * The returned CRS will take into account verticalCrs() when appropriate, e.g. it may return a compound
+     * CRS consisting of crs() + verticalCrs(). This method may still return a 2D CRS, e.g in the
+     * case that crs() is a 2D CRS and no verticalCrs() has been set for the layer. Check QgsCoordinateReferenceSystem::type()
+     * on the returned value to determine the type of CRS returned by this method.
+     *
+     * \warning It is NOT guaranteed that the returned CRS will actually be a 3D CRS, but rather
+     * it is guaranteed that the returned CRS is ALWAYS the most appropriate CRS to use when handling 3D data.
+     *
+     * \see crs()
+     * \see verticalCrs()
+     * \see crs3DChanged()
+     *
+     * \since QGIS 3.38
+     */
+    QgsCoordinateReferenceSystem crs3D() const;
+
+    /**
+     * Sets layer's spatial reference system.
+     *
+     * If \a emitSignal is TRUE, changing the CRS will trigger a crsChanged() signal. Additionally, if \a crs is a compound
+     * CRS, then the verticalCrsChanged() signal will also be emitted.
+     *
+     * \see crs()
+     * \see crsChanged()
+     * \see setVerticalCrs()
+     */
     void setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSignal = true );
+
+    /**
+     * Sets the layer's vertical coordinate reference system.
+     *
+     * The verticalCrsChanged() signal will be raised if the vertical CRS is changed.
+     *
+     * \note If the layer crs() is a compound CRS, then the CRS returned for
+     * verticalCrs() will be the vertical component of crs(). Otherwise it will be the value
+     * explicitly set by this call.
+     *
+     * \param crs the vertical CRS
+     * \param errorMessage will be set to a descriptive message if the vertical CRS could not be set
+     *
+     * \returns TRUE if vertical CRS was successfully set
+     *
+     * \see verticalCrs()
+     * \see setCrs()
+     *
+     * \since QGIS 3.38
+     */
+    bool setVerticalCrs( const QgsCoordinateReferenceSystem &crs, QString *errorMessage SIP_OUT = nullptr );
 
     /**
      * Returns the layer data provider coordinate transform context
@@ -1829,8 +1909,43 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void nameChanged();
 
-    //! Emit a signal that layer's CRS has been reset
+    /**
+     * Emitted when the crs() of the layer has changed.
+     *
+     * \see crs()
+     * \see setCrs()
+     * \see verticalCrsChanged()
+     * \see crs3DChanged()
+     */
     void crsChanged();
+
+    /**
+     * Emitted when the crs3D() of the layer has changed.
+     *
+     * \see crs3D()
+     * \see crsChanged()
+     * \see verticalCrsChanged()
+     *
+     * \since QGIS 3.38
+     */
+    void crs3DChanged();
+
+    /**
+     * Emitted when the verticalCrs() of the layer has changed.
+     *
+     * This signal will be emitted whenever the vertical CRS of the layer is changed, either
+     * as a direct result of a call to setVerticalCrs() or when setCrs() is called with a compound
+     * CRS.
+     *
+     * \see crsChanged()
+     * \see crs3DChanged()
+     * \see setCrs()
+     * \see setVerticalCrs()
+     * \see verticalCrs()
+     *
+     * \since QGIS 3.38
+     */
+    void verticalCrsChanged();
 
     /**
      * By emitting this signal the layer tells that either appearance or content have been changed
@@ -2236,6 +2351,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void updateExtent( const QgsRectangle &extent ) const;
     void updateExtent( const QgsBox3D &extent ) const;
 
+    bool rebuildCrs3D( QString *error = nullptr );
+
     /**
      * This method returns TRUE by default but can be overwritten to specify
      * that a certain layer is writable.
@@ -2247,6 +2364,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * private to make sure setCrs must be used and crsChanged() is emitted.
     */
     QgsCoordinateReferenceSystem mCRS;
+    QgsCoordinateReferenceSystem mVerticalCrs;
+    QgsCoordinateReferenceSystem mCrs3D;
 
     //! Unique ID of this layer - used to refer to this layer in map layer registry
     QString mID;


### PR DESCRIPTION
This adds a new verticalCrs property for map layers, and a corresponding crs3D() property. Logic is the same as that for QgsProject.

This is a port of the logic from https://github.com/qgis/QGIS/pull/57107 to the QgsMapLayer level. The intention here is that the a vertical crs can be assigned with a map layer, and then the crs3D from the project and layer used to create a coordinate transform which correctly transforms vertical heights from the layer to the project vertical datum.