### PR TITLE
macos-build.yml: select macos-13 to get x64 build

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   mac_os_build:
     if: github.repository == 'qgis/QGIS'
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
GHA has recently switched the macos-latest alias to be macos-14 which is OSX Arm64.  macos-13 is x64 architecture instead
