### PR TITLE
[Qt6] Avoid crash when deleting QGIS application

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2216,6 +2216,8 @@ QgisApp::~QgisApp()
   mCoordsEdit = nullptr;
   delete mLayerTreeView;
   mLayerTreeView = nullptr;
+  delete mMessageButton;
+  mMessageButton = nullptr;
 
   QgsGui::nativePlatformInterface()->cleanup();
 


### PR DESCRIPTION
At the end of the QgisApp destructor, some close event will eventually toggle message button calling then a signal on the deleted QgisApp. Better disconnect it before.

Appears since Qt 6