### PR TITLE
Avoid calling QMetaEnum::keysToValue with empty keys

### DIFF
--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5493,6 +5493,9 @@ template<class T> QString qgsFlagValueToKeys( const T &value, bool *returnOk = n
  */
 template<class T> T qgsFlagKeysToValue( const QString &keys, const T &defaultValue, bool tryValueAsKey = true,  bool *returnOk = nullptr ) SIP_SKIP
 {
+  if ( keys.isEmpty() )
+    return defaultValue;
+
   const QMetaEnum metaEnum = QMetaEnum::fromType<T>();
   Q_ASSERT( metaEnum.isValid() );
   bool ok = false;


### PR DESCRIPTION
So we don't get that annoying Qt warning message

