### PR TITLE
Processing: do not store configuration keys with default values

### DIFF
--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -355,6 +355,9 @@ class Setting:
     def save(self, qsettings=None):
         if not qsettings:
             qsettings = QgsSettings()
+        if self.value == self.default:
+            qsettings.remove(self.qname)
+            return
         if self.valuetype == self.SELECTION:
             qsettings.setValue(self.qname, self.options.index(self.value))
         else:


### PR DESCRIPTION
If for some reason Processing configuration gets stored into configuration file, previous code saved default menu paths in configuration. Default menu paths are translated to language used in GUI. If GUI language changes, values stored in the configuration take precedence over default ones (= default translated menu paths are not used). This fix removes menu keys from config for default value and thus allows to fall back to default menu items on language switch. Keys can not be set empty as empty means "do not show in GUI" – complete removal is the correct approach.

Fixes #52449 (and related issues)
