### PR TITLE
[processing] Show more detail in history dialog

### DIFF
--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
@@ -35,6 +35,8 @@ This should only be called once -- calling multiple times will result in duplica
 
     virtual QgsHistoryEntryNode *createNodeForEntry( const QgsHistoryEntry &entry, const QgsHistoryWidgetContext &context ) /Factory/;
 
+    virtual void updateNodeForEntry( QgsHistoryEntryNode *node, const QgsHistoryEntry &entry, const QgsHistoryWidgetContext &context );
+
 
   signals:
 

--- a/python/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
@@ -35,6 +35,8 @@ This should only be called once -- calling multiple times will result in duplica
 
     virtual QgsHistoryEntryNode *createNodeForEntry( const QgsHistoryEntry &entry, const QgsHistoryWidgetContext &context ) /Factory/;
 
+    virtual void updateNodeForEntry( QgsHistoryEntryNode *node, const QgsHistoryEntry &entry, const QgsHistoryWidgetContext &context );
+
 
   signals:
 

--- a/src/gui/history/qgshistorywidget.cpp
+++ b/src/gui/history/qgshistorywidget.cpp
@@ -18,10 +18,13 @@
 #include "qgshistoryentrymodel.h"
 #include "qgshistoryentrynode.h"
 #include "qgssettings.h"
+#include "qgsnative.h"
 
 #include <QTextBrowser>
 #include <QtGlobal>
 #include <QMenu>
+#include <QFileInfo>
+#include <QDesktopServices>
 
 QgsHistoryWidget::QgsHistoryWidget( const QString &providerId, Qgis::HistoryProviderBackends backends, QgsHistoryProviderRegistry *registry, const QgsHistoryWidgetContext &context, QWidget *parent )
   : QgsPanelWidget( parent )
@@ -71,8 +74,10 @@ void QgsHistoryWidget::currentItemChanged( const QModelIndex &selected, const QM
       if ( !html.isEmpty() )
       {
         QTextBrowser *htmlBrowser = new QTextBrowser();
-        htmlBrowser->setOpenExternalLinks( true );
+        htmlBrowser->setOpenLinks( false );
         htmlBrowser->setHtml( html );
+        connect( htmlBrowser, &QTextBrowser::anchorClicked, this, &QgsHistoryWidget::urlClicked );
+
         newWidget = htmlBrowser;
       }
     }
@@ -122,6 +127,15 @@ void QgsHistoryWidget::showNodeContextMenu( const QPoint &pos )
     }
     delete menu;
   }
+}
+
+void QgsHistoryWidget::urlClicked( const QUrl &url )
+{
+  const QFileInfo file( url.toLocalFile() );
+  if ( file.exists() && !file.isDir() )
+    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
+  else
+    QDesktopServices::openUrl( url );
 }
 
 //

--- a/src/gui/history/qgshistorywidget.h
+++ b/src/gui/history/qgshistorywidget.h
@@ -81,6 +81,7 @@ class GUI_EXPORT QgsHistoryWidget : public QgsPanelWidget, private Ui::QgsHistor
     void currentItemChanged( const QModelIndex &selected, const QModelIndex &previous );
     void nodeDoubleClicked( const QModelIndex &index );
     void showNodeContextMenu( const QPoint &pos );
+    void urlClicked( const QUrl &url );
 
   private:
 

--- a/src/gui/processing/qgsprocessinghistoryprovider.h
+++ b/src/gui/processing/qgsprocessinghistoryprovider.h
@@ -45,6 +45,7 @@ class GUI_EXPORT QgsProcessingHistoryProvider : public QgsAbstractHistoryProvide
     void portOldLog();
 
     QgsHistoryEntryNode *createNodeForEntry( const QgsHistoryEntry &entry, const QgsHistoryWidgetContext &context ) override SIP_FACTORY;
+    void updateNodeForEntry( QgsHistoryEntryNode *node, const QgsHistoryEntry &entry, const QgsHistoryWidgetContext &context ) override;
 
   signals:
 
@@ -72,7 +73,7 @@ class GUI_EXPORT QgsProcessingHistoryProvider : public QgsAbstractHistoryProvide
     //! Returns the path to the old log file
     QString oldLogPath() const;
 
-    friend class ProcessingHistoryNode;
+    friend class ProcessingHistoryBaseNode;
 
 };
 


### PR DESCRIPTION
Use a tree display for processing history entries, where the root item for each entry shows the full algorithm log when clicked,
and the python/qgis_process commands are instead shown as child items

This provides more useful information for users browsing the history, while still making the all the previous information available

https://github.com/qgis/QGIS/assets/1829991/42a7b8d1-db99-4a92-80a4-65cdb1aaf503

