### PR TITLE
Fix using astyle on wsl

### DIFF
--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -83,12 +83,16 @@ if ! type -p autopep8 >/dev/null; then
 fi
 
 ASTYLEOPTS=$(dirname "$0")/astyle.options
-if type -p cygpath >/dev/null; then
-	ASTYLEOPTS="$(cygpath -w "$ASTYLEOPTS")"
-fi
+# when using `qgisstyle` built alongside QGIS (on windows),
+# convert path to options file
+if [ $ASTYLE != "astyle" ] ; then
+	if type -p cygpath >/dev/null; then
+		ASTYLEOPTS="$(cygpath -w "$ASTYLEOPTS")"
+	fi
 
-if type -p wslpath >/dev/null; then
-	ASTYLEOPTS="$(wslpath -a -w "$ASTYLEOPTS")"
+	if type -p wslpath >/dev/null; then
+		ASTYLEOPTS="$(wslpath -a -w "$ASTYLEOPTS")"
+	fi
 fi
 
 set -e


### PR DESCRIPTION
Paths need only to be converted when using `qgisstyle`, not when using `astyle`

Thanks @iona5 for preparing a fix !

Fixes https://github.com/qgis/QGIS/issues/38089