### PR TITLE
qgs3dmapscene: Fix python bindings availability note

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -18,10 +18,6 @@ class Qgs3DMapScene : QObject
 {
 %Docstring(signature="appended")
 Entity that encapsulates our 3D scene - contains all other entities (such as terrain) as children.
-
-.. note::
-
-   Not available in Python bindings
 %End
 
 %TypeHeaderCode

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -18,10 +18,6 @@ class Qgs3DMapScene : QObject
 {
 %Docstring(signature="appended")
 Entity that encapsulates our 3D scene - contains all other entities (such as terrain) as children.
-
-.. note::
-
-   Not available in Python bindings
 %End
 
 %TypeHeaderCode

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -62,7 +62,6 @@ class QgsDoubleRange;
 /**
  * \ingroup 3d
  * \brief Entity that encapsulates our 3D scene - contains all other entities (such as terrain) as children.
- * \note Not available in Python bindings
  */
 #ifndef SIP_RUN
 class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity


### PR DESCRIPTION
## Description

Qgs3DMapScene is now available in Python bindings.

See: https://github.com/qgis/qGIS/commit/176807bc3540f6a2ea001f6dad4f3899c28fc8a1
