### PR TITLE
Fix loading of raster styles if the layer/table name is not in the datasource url

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -4696,6 +4696,10 @@ QString QgsGdalProviderMetadata::loadStoredStyle( const QString &uri, QString &s
   }
   QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
   QString layerName = uriParts["layerName"].toString();
+  if ( layerName.isEmpty() )
+  {
+    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
+  }
   return QgsOgrUtils::loadStoredStyle( ds.get(), layerName, "", styleName, errCause );
 }
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -4622,6 +4622,10 @@ int QgsGdalProviderMetadata::listStyles( const QString &uri, QStringList &ids, Q
   }
   QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
   QString layerName = uriParts["layerName"].toString();
+  if ( layerName.isEmpty() )
+  {
+    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
+  }
   return QgsOgrUtils::listStyles( ds.get(), layerName, "", ids, names, descriptions, errCause );
 }
 
@@ -4636,6 +4640,10 @@ bool QgsGdalProviderMetadata::styleExists( const QString &uri, const QString &st
   }
   QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
   QString layerName = uriParts["layerName"] .toString();
+  if ( layerName.isEmpty() )
+  {
+    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
+  }
   return QgsOgrUtils::styleExists( ds.get(), layerName, "", styleId, errCause );
 }
 
@@ -4676,6 +4684,10 @@ bool QgsGdalProviderMetadata::saveStyle( const QString &uri, const QString &qmlS
   }
   QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
   QString layerName = uriParts["layerName"].toString();
+  if ( layerName.isEmpty() )
+  {
+    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
+  }
   return QgsOgrUtils::saveStyle( ds.get(), layerName, "", qmlStyle, sldStyle, styleName, styleDescription, uiFileContent, useAsDefault, errCause );
 }
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -37,7 +37,6 @@
 #include "qgsrasterpyramid.h"
 #include "qgspointxy.h"
 #include "qgssettings.h"
-#include "qgsogrutils.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsprovidersublayerdetails.h"
 #include "qgsproviderutils.h"
@@ -4620,12 +4619,8 @@ int QgsGdalProviderMetadata::listStyles( const QString &uri, QStringList &ids, Q
     errCause = QObject::tr( "Cannot open %1." ).arg( uri );
     return -1;
   }
-  QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
-  QString layerName = uriParts["layerName"].toString();
-  if ( layerName.isEmpty() )
-  {
-    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
-  }
+
+  QString layerName = getLayerNameForStyle( uri, ds );
   return QgsOgrUtils::listStyles( ds.get(), layerName, "", ids, names, descriptions, errCause );
 }
 
@@ -4638,12 +4633,8 @@ bool QgsGdalProviderMetadata::styleExists( const QString &uri, const QString &st
     errCause = QObject::tr( "Cannot open %1." ).arg( uri );
     return false;
   }
-  QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
-  QString layerName = uriParts["layerName"] .toString();
-  if ( layerName.isEmpty() )
-  {
-    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
-  }
+
+  QString layerName = getLayerNameForStyle( uri, ds );
   return QgsOgrUtils::styleExists( ds.get(), layerName, "", styleId, errCause );
 }
 
@@ -4682,12 +4673,8 @@ bool QgsGdalProviderMetadata::saveStyle( const QString &uri, const QString &qmlS
     errCause = QObject::tr( "Cannot open %1." ).arg( uri );
     return false;
   }
-  QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
-  QString layerName = uriParts["layerName"].toString();
-  if ( layerName.isEmpty() )
-  {
-    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
-  }
+
+  QString layerName = getLayerNameForStyle( uri, ds );
   return QgsOgrUtils::saveStyle( ds.get(), layerName, "", qmlStyle, sldStyle, styleName, styleDescription, uiFileContent, useAsDefault, errCause );
 }
 
@@ -4706,13 +4693,27 @@ QString QgsGdalProviderMetadata::loadStoredStyle( const QString &uri, QString &s
     errCause = QObject::tr( "Cannot open %1." ).arg( uri );
     return QString();
   }
+
+  QString layerName = getLayerNameForStyle( uri, ds );
+  return QgsOgrUtils::loadStoredStyle( ds.get(), layerName, "", styleName, errCause );
+}
+
+QString QgsGdalProviderMetadata::getLayerNameForStyle( const QString &uri, gdal::dataset_unique_ptr &ds )
+{
   QVariantMap uriParts = QgsGdalProviderBase::decodeGdalUri( uri );
   QString layerName = uriParts["layerName"].toString();
   if ( layerName.isEmpty() )
   {
-    layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
+    GDALDriverH driver = GDALGetDatasetDriver( ds.get() );
+    if ( driver )
+    {
+      if ( GDALGetDriverShortName( driver ) == QStringLiteral( "GPKG" ) )
+      {
+        layerName = GDALGetMetadataItem( ds.get(), "IDENTIFIER", "" );
+      }
+    }
   }
-  return QgsOgrUtils::loadStoredStyle( ds.get(), layerName, "", styleName, errCause );
+  return layerName;
 }
 
 QgsGdalProviderMetadata::QgsGdalProviderMetadata():

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -24,6 +24,7 @@
 #include "qgsgdalproviderbase.h"
 #include "qgsrectangle.h"
 #include "qgscolorrampshader.h"
+#include "qgsogrutils.h"
 #include "qgsrasterbandstats.h"
 #include "qgsprovidermetadata.h"
 #include "qgsprovidersublayerdetails.h"
@@ -416,6 +417,9 @@ class QgsGdalProviderMetadata final: public QgsProviderMetadata
                     const QString &uiFileContent, bool useAsDefault, QString &errCause ) override;
     QString loadStyle( const QString &uri, QString &errCause ) override;
     QString loadStoredStyle( const QString &uri, QString &styleName, QString &errCause ) override;
+  private:
+    //! Get layer name from gdal url
+    static QString getLayerNameForStyle( const QString &uri, gdal::dataset_unique_ptr &ds );
 };
 
 ///@endcond


### PR DESCRIPTION
Currently, the loading of default raster styles from gpkg works only if the table name is in the datasource url, like GPKG:/path/to/file.gpkg:<tablename> . However if a raster gpkg contains only one raster, the layer url is usually only /path/to/file.gpkg . In this case, the table name should be fetched from the IDENTIFIER metadata.
