### PR TITLE
Fix multi edit relation reference

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsfeaturepickermodelbase.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturepickermodelbase.sip.in
@@ -213,7 +213,7 @@ The index at which the extra identifier value is available within the model.
 
     void extraValueDoesNotExistChanged();
 %Docstring
-Flag indicating that the extraIdentifierValue does not exist in the data.
+Notification that the model has found a feature tied to the extraIdentifierValue.
 %End
 
     void beginUpdate();

--- a/python/PyQt6/core/auto_generated/qgsfeaturepickermodelbase.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturepickermodelbase.sip.in
@@ -211,9 +211,9 @@ still be available in the model.
 The index at which the extra identifier value is available within the model.
 %End
 
-    void extraValueDoesNotExistChanged();
+    void extraValueDoesNotExistChanged( bool found );
 %Docstring
-Notification that the model has found a feature tied to the extraIdentifierValue.
+Notification whether the model has ``found`` a feature tied to the extraIdentifierValue or not.
 %End
 
     void beginUpdate();

--- a/python/PyQt6/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -242,6 +242,13 @@ Emitted when the current feature changes
 .. versionadded:: 3.16.5
 %End
 
+    void currentFeatureFoundChanged();
+%Docstring
+Emitted when the feature picker model changes its feature found state
+
+.. versionadded:: 3.38
+%End
+
 };
 
 

--- a/python/PyQt6/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -242,9 +242,9 @@ Emitted when the current feature changes
 .. versionadded:: 3.16.5
 %End
 
-    void currentFeatureFoundChanged();
+    void currentFeatureFoundChanged( bool found );
 %Docstring
-Emitted when the feature picker model changes its feature found state
+Emitted when the feature picker model changes its feature ``found`` state
 
 .. versionadded:: 3.38
 %End

--- a/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
+++ b/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
@@ -213,7 +213,7 @@ The index at which the extra identifier value is available within the model.
 
     void extraValueDoesNotExistChanged();
 %Docstring
-Flag indicating that the extraIdentifierValue does not exist in the data.
+Notification that the model has found a feature tied to the extraIdentifierValue.
 %End
 
     void beginUpdate();

--- a/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
+++ b/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
@@ -211,9 +211,9 @@ still be available in the model.
 The index at which the extra identifier value is available within the model.
 %End
 
-    void extraValueDoesNotExistChanged();
+    void extraValueDoesNotExistChanged( bool found );
 %Docstring
-Notification that the model has found a feature tied to the extraIdentifierValue.
+Notification whether the model has ``found`` a feature tied to the extraIdentifierValue or not.
 %End
 
     void beginUpdate();

--- a/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -242,6 +242,13 @@ Emitted when the current feature changes
 .. versionadded:: 3.16.5
 %End
 
+    void currentFeatureFoundChanged();
+%Docstring
+Emitted when the feature picker model changes its feature found state
+
+.. versionadded:: 3.38
+%End
+
 };
 
 

--- a/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -242,9 +242,9 @@ Emitted when the current feature changes
 .. versionadded:: 3.16.5
 %End
 
-    void currentFeatureFoundChanged();
+    void currentFeatureFoundChanged( bool found );
 %Docstring
-Emitted when the feature picker model changes its feature found state
+Emitted when the feature picker model changes its feature ``found`` state
 
 .. versionadded:: 3.38
 %End

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -606,7 +606,7 @@ void QgsFeaturePickerModelBase::setExtraValueDoesNotExist( bool extraValueDoesNo
     return;
 
   mExtraValueDoesNotExist = extraValueDoesNotExist;
-  emit extraValueDoesNotExistChanged();
+  emit extraValueDoesNotExistChanged( mExtraValueDoesNotExist );
 }
 
 

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -30,7 +30,6 @@ QgsFeaturePickerModelBase::QgsFeaturePickerModelBase( QObject *parent )
   // The fact that the feature changed is a combination of the 2 signals:
   // If the extra value is set to a feature currently not fetched, it will go through an intermediate step while the extra value does not exist (as it call reloadFeature)
   connect( this, &QgsFeaturePickerModelBase::extraIdentifierValueChanged, this, &QgsFeaturePickerModelBase::currentFeatureChanged );
-  connect( this, &QgsFeaturePickerModelBase::extraValueDoesNotExistChanged, this, &QgsFeaturePickerModelBase::currentFeatureChanged );
 }
 
 

--- a/src/core/qgsfeaturepickermodelbase.h
+++ b/src/core/qgsfeaturepickermodelbase.h
@@ -241,9 +241,9 @@ class CORE_EXPORT QgsFeaturePickerModelBase : public QAbstractItemModel SIP_ABST
     void extraIdentifierValueIndexChanged( int index );
 
     /**
-     * Notification that the model has found a feature tied to the extraIdentifierValue.
+     * Notification whether the model has \a found a feature tied to the extraIdentifierValue or not.
      */
-    void extraValueDoesNotExistChanged();
+    void extraValueDoesNotExistChanged( bool found );
 
     /**
      * Notification that the model is about to be changed because a job was completed.

--- a/src/core/qgsfeaturepickermodelbase.h
+++ b/src/core/qgsfeaturepickermodelbase.h
@@ -241,7 +241,7 @@ class CORE_EXPORT QgsFeaturePickerModelBase : public QAbstractItemModel SIP_ABST
     void extraIdentifierValueIndexChanged( int index );
 
     /**
-     * Flag indicating that the extraIdentifierValue does not exist in the data.
+     * Notification that the model has found a feature tied to the extraIdentifierValue.
      */
     void extraValueDoesNotExistChanged();
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -628,7 +628,7 @@ void QgsRelationReferenceWidget::comboReferenceChanged()
   emitForeignKeysChanged( mComboBox->identifierValues() );
 }
 
-void QgsRelationReferenceWidget::comboReferenceFoundChanged()
+void QgsRelationReferenceWidget::comboReferenceFoundChanged( bool )
 {
   mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
   highlightFeature( mFeature );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -494,6 +494,7 @@ void QgsRelationReferenceWidget::init()
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, &QgsFeatureListComboBox::currentFeatureChanged, this, &QgsRelationReferenceWidget::comboReferenceChanged );
+    connect( mComboBox, &QgsFeatureListComboBox::currentFeatureFoundChanged, this, &QgsRelationReferenceWidget::comboReferenceFoundChanged );
 
     QApplication::restoreOverrideCursor();
 
@@ -624,6 +625,13 @@ void QgsRelationReferenceWidget::comboReferenceChanged()
   updateAttributeEditorFrame( mFeature );
 
   emitForeignKeysChanged( mComboBox->identifierValues() );
+}
+
+void QgsRelationReferenceWidget::comboReferenceFoundChanged()
+{
+  mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
+  highlightFeature( mFeature );
+  updateAttributeEditorFrame( mFeature );
 }
 
 void QgsRelationReferenceWidget::updateAttributeEditorFrame( const QgsFeature &feature )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -494,6 +494,7 @@ void QgsRelationReferenceWidget::init()
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, &QgsFeatureListComboBox::currentFeatureChanged, this, &QgsRelationReferenceWidget::comboReferenceChanged );
+    // To avoid wrongly signaling a foreign key change, handle model feature found state following feature gathering separately
     connect( mComboBox, &QgsFeatureListComboBox::currentFeatureFoundChanged, this, &QgsRelationReferenceWidget::comboReferenceFoundChanged );
 
     QApplication::restoreOverrideCursor();

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -294,7 +294,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     void highlightActionTriggered( QAction *action );
     void deleteHighlight();
     void comboReferenceChanged();
-    void comboReferenceFoundChanged();
+    void comboReferenceFoundChanged( bool found );
     void featureIdentified( const QgsFeature &feature );
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -294,6 +294,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     void highlightActionTriggered( QAction *action );
     void deleteHighlight();
     void comboReferenceChanged();
+    void comboReferenceFoundChanged();
     void featureIdentified( const QgsFeature &feature );
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -65,6 +65,7 @@ QgsFeatureListComboBox::QgsFeatureListComboBox( QWidget *parent )
   connect( mLineEdit, &QgsFilterLineEdit::cleared, this, &QgsFeatureListComboBox::onFilterLineEditCleared );
 
   connect( mModel, &QgsFeatureFilterModel::currentFeatureChanged, this, &QgsFeatureListComboBox::currentFeatureChanged );
+  connect( mModel, &QgsFeatureFilterModel::extraValueDoesNotExistChanged, this, &QgsFeatureListComboBox::currentFeatureFoundChanged );
 
   setToolTip( tr( "Just start typing what you are looking for." ) );
 }

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -65,6 +65,7 @@ QgsFeatureListComboBox::QgsFeatureListComboBox( QWidget *parent )
   connect( mLineEdit, &QgsFilterLineEdit::cleared, this, &QgsFeatureListComboBox::onFilterLineEditCleared );
 
   connect( mModel, &QgsFeatureFilterModel::currentFeatureChanged, this, &QgsFeatureListComboBox::currentFeatureChanged );
+  // To avoid wrongly signaling a foreign key change, handle model feature found state following feature gathering separately
   connect( mModel, &QgsFeatureFilterModel::extraValueDoesNotExistChanged, this, &QgsFeatureListComboBox::currentFeatureFoundChanged );
 
   setToolTip( tr( "Just start typing what you are looking for." ) );

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -251,6 +251,12 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
      */
     void currentFeatureChanged();
 
+    /**
+     * Emitted when the feature picker model changes its feature found state
+     * \since QGIS 3.38
+     */
+    void currentFeatureFoundChanged();
+
   private slots:
     void onCurrentTextChanged( const QString &text );
     void onFilterLineEditCleared();

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -252,10 +252,10 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
     void currentFeatureChanged();
 
     /**
-     * Emitted when the feature picker model changes its feature found state
+     * Emitted when the feature picker model changes its feature \a found state
      * \since QGIS 3.38
      */
-    void currentFeatureFoundChanged();
+    void currentFeatureFoundChanged( bool found );
 
   private slots:
     void onCurrentTextChanged( const QString &text );

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -517,30 +517,57 @@ void TestQgsRelationReferenceWidget::testSetGetForeignKey()
 {
   QWidget parentWidget;
   QgsRelationReferenceWidget w( &parentWidget );
+
   w.setRelation( *mRelation, true );
   w.init();
 
   QSignalSpy spy( &w, &QgsRelationReferenceWidget::foreignKeysChanged );
-
-  w.setForeignKeys( QVariantList() << 0 );
-  QCOMPARE( w.foreignKeys().at( 0 ), QVariant( 0 ) );
-  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "(0)" ) );
-  QCOMPARE( spy.count(), 1 );
-
-  w.setForeignKeys( QVariantList() << 11 );
-  QCOMPARE( w.foreignKeys().at( 0 ), QVariant( 11 ) );
-  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "(11)" ) );
-  QCOMPARE( spy.count(), 2 );
-
-  w.setForeignKeys( QVariantList() << 12 );
-  QCOMPARE( w.foreignKeys().at( 0 ), QVariant( 12 ) );
-  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "(12)" ) );
-  QCOMPARE( spy.count(), 3 );
+  QEventLoop loop;
 
   w.setForeignKeys( QVariantList() << QVariant() );
+
+  QTimer::singleShot( 1000, &loop, &QEventLoop::quit );
+  loop.exec();
+
   QVERIFY( w.foreignKeys().at( 0 ).isNull() );
   QVERIFY( w.foreignKeys().at( 0 ).isValid() );
+  QCOMPARE( spy.count(), 1 );
+
+  w.setForeignKeys( QVariantList() << 12 );
+
+  QTimer::singleShot( 1000, &loop, &QEventLoop::quit );
+  loop.exec();
+
+  QCOMPARE( w.foreignKeys().at( 0 ), QVariant( 12 ) );
+  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "12" ) );
+  QCOMPARE( spy.count(), 2 );
+
+  w.setForeignKeys( QVariantList() << 11 );
+
+  QTimer::singleShot( 1000, &loop, &QEventLoop::quit );
+  loop.exec();
+
+  QCOMPARE( w.foreignKeys().at( 0 ), QVariant( 11 ) );
+  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "11" ) );
+  QCOMPARE( spy.count(), 3 );
+
+  w.setForeignKeys( QVariantList() << 0 );
+
+  QTimer::singleShot( 1000, &loop, &QEventLoop::quit );
+  loop.exec();
+
+  QCOMPARE( w.foreignKeys().at( 0 ), QVariant( 0 ) );
+  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "(0)" ) );
   QCOMPARE( spy.count(), 4 );
+
+  w.setForeignKeys( QVariantList() << QVariant() );
+
+  QTimer::singleShot( 1000, &loop, &QEventLoop::quit );
+  loop.exec();
+
+  QVERIFY( w.foreignKeys().at( 0 ).isNull() );
+  QVERIFY( w.foreignKeys().at( 0 ).isValid() );
+  QCOMPARE( spy.count(), 5 );
 }
 
 // Test issue https://github.com/qgis/QGIS/issues/29884


### PR DESCRIPTION
## Description

This PR fixes an issue when the attribute form mode is set to multi editing whereas relation referencing editor widget value is wrongly marked as "edited" upon opening the attribute form (i.e. prior to actually editing the widget value).

![image](https://github.com/qgis/QGIS/assets/1728657/7ba4eba0-7dfe-40b7-bca8-4e66c865f165)
_Note the wrong "value changed" red button in the feature form upon opening the form_

It's a bit of a rabbit hole to follow here, but basically what happens is that the relation referencing editor widget sets the foreign keys value, which is first consumed as a non-found feature as the feature picker model gathers features. Upon having successfully gathered the feature, the model reports that the feature is found. Until now, it was using the feature changed signal, which bubbled back up to the relation referencing editor widget as a "foreign key changed" even though it clearly isn't.

The way around this without a significant refactoring is to add another signal that identifies a feature found state change (vs. using feature changed for both an actual feature values change and a feature values found).