### PR TITLE
Draft: qgswfsfeatureiterator.cpp: Do not invert axis if srsName is EPSG:4326

### DIFF
--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -250,14 +250,12 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
     if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) &&
          !mShared->mURI.ignoreAxisOrientation() )
     {
-      // This is a bit nasty, but if the server reports OGC::CRS84
-      // mSourceCrs will report hasAxisInverted() == false, but srsName()
-      // will be urn:ogc:def:crs:EPSG::4326, so axis inversion is needed...
-      if ( mShared->srsName() == QLatin1String( "urn:ogc:def:crs:EPSG::4326" ) )
-      {
-        invertAxis = true;
-      }
-      else if ( mShared->mSourceCrs.hasAxisInverted() )
+      // For WFS 1.1 and above we honor requested CRS and axis order
+      // Axis is not inverted if srsName starts with EPSG
+      // It needs to be an EPSG urn, e.g. urn:ogc:def:crs:EPSG::4326
+      // This follows geoserver convention
+      // See: https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html
+      if ( mShared->mSourceCrs.hasAxisInverted() && !( mShared->srsName() == QLatin1String( "EPSG:4326" ) ) )
       {
         invertAxis = true;
       }


### PR DESCRIPTION
## Description

This PR tries to solve an issue while displaying WFS features handled by QGIS server with SRS `EPSG:4326`.    
The features are not displayed by QGIS Desktop because the WFS provider inverts the bounding boxes coordinates while QGIS server expects the bounding box to be LONG/LAT (ie. not inverted).

The server is QGIS server version 3.34.6
`GetCapabilities` returns those information: 
- WFS 1.1.0 by default
- Default SRS is EPSG:4326
- bounding boxes are in the LONG/LAT order (not inverted)     
It follows Geoserver convention: https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html

On the other hand, it looks like the WFS provider does not follow Geoserver convention.
Indeed, in the feature iterator, the bounding box coordinates are inverted because `mShared->mSourceCrs.hasAxisInverted()` returns `true` in the `EPSG:4326` case. However, this inversion should not happen. 

The main idea of this PR is to follow the "Geoserver convention". This way, the WFS provider behaves the same way as QGIS server.   
Opened as a draft to start a discussion.

@rouault Any idea? Do you think this is the right approach
cc @troopa81 

The WFS server is publicly available: https://sextant.ifremer.fr/services/wfs/granulats_marins