### PR TITLE
Don't write layer vertical crs if its not set

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -761,6 +761,7 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 
   layerElement.appendChild( layerId );
 
+  if ( mVerticalCrs.isValid() )
   {
     QDomElement verticalSrsNode = document.createElement( QStringLiteral( "verticalCrs" ) );
     mVerticalCrs.writeXml( verticalSrsNode, document );


### PR DESCRIPTION
Avoids some unwanted extra noise in the xml
