### PR TITLE
preserve MDAL mesh metadata when editing mesh layers

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -470,9 +470,11 @@ Creates a new instance of the raster data provider.
       const QgsMesh &mesh,
       const QString &fileName,
       const QString &driverName,
-      const QgsCoordinateReferenceSystem &crs ) const;
+      const QgsCoordinateReferenceSystem &crs,
+      const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const;
 %Docstring
 Creates mesh data source from a file name ``fileName`` and a driver ``driverName``, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+Since QGIS 3.38 the optional ``metadata`` argument can be used to pass metadata to the provider.
 
 .. versionadded:: 3.16
 %End
@@ -480,9 +482,11 @@ Creates mesh data source from a file name ``fileName`` and a driver ``driverName
     virtual bool createMeshData(
       const QgsMesh &mesh,
       const QString &uri,
-      const QgsCoordinateReferenceSystem &crs ) const;
+      const QgsCoordinateReferenceSystem &crs,
+      const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const;
 %Docstring
 Creates mesh data source from an ``uri``, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+Since QGIS 3.38 the optional ``metadata`` argument can be used to pass metadata to the provider.
 
 .. versionadded:: 3.22
 %End

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -470,9 +470,11 @@ Creates a new instance of the raster data provider.
       const QgsMesh &mesh,
       const QString &fileName,
       const QString &driverName,
-      const QgsCoordinateReferenceSystem &crs ) const;
+      const QgsCoordinateReferenceSystem &crs,
+      const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const;
 %Docstring
 Creates mesh data source from a file name ``fileName`` and a driver ``driverName``, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+Since QGIS 3.38 the optional ``metadata`` argument can be used to pass metadata to the provider.
 
 .. versionadded:: 3.16
 %End
@@ -480,9 +482,11 @@ Creates mesh data source from a file name ``fileName`` and a driver ``driverName
     virtual bool createMeshData(
       const QgsMesh &mesh,
       const QString &uri,
-      const QgsCoordinateReferenceSystem &crs ) const;
+      const QgsCoordinateReferenceSystem &crs,
+      const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const;
 %Docstring
 Creates mesh data source from an ``uri``, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+Since QGIS 3.38 the optional ``metadata`` argument can be used to pass metadata to the provider.
 
 .. versionadded:: 3.22
 %End

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -225,14 +225,16 @@ QgsRasterDataProvider *QgsProviderMetadata::createRasterDataProvider(
 bool QgsProviderMetadata::createMeshData( const QgsMesh &,
     const QString &,
     const QString &,
-    const QgsCoordinateReferenceSystem & ) const
+    const QgsCoordinateReferenceSystem &,
+    const QMap<QString, QString> & ) const
 {
   return false;
 }
 
 bool QgsProviderMetadata::createMeshData( const QgsMesh &,
     const QString &,
-    const QgsCoordinateReferenceSystem & ) const
+    const QgsCoordinateReferenceSystem &,
+    const QMap<QString, QString> & ) const
 {
   return false;
 }

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -531,22 +531,26 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
 
     /**
      * Creates mesh data source from a file name \a fileName and a driver \a driverName, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+     * Since QGIS 3.38 the optional \a metadata argument can be used to pass metadata to the provider.
      * \since QGIS 3.16
      */
     virtual bool createMeshData(
       const QgsMesh &mesh,
       const QString &fileName,
       const QString &driverName,
-      const QgsCoordinateReferenceSystem &crs ) const;
+      const QgsCoordinateReferenceSystem &crs,
+      const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const;
 
     /**
      * Creates mesh data source from an \a uri, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+     * Since QGIS 3.38 the optional \a metadata argument can be used to pass metadata to the provider.
      * \since QGIS 3.22
      */
     virtual bool createMeshData(
       const QgsMesh &mesh,
       const QString &uri,
-      const QgsCoordinateReferenceSystem &crs ) const;
+      const QgsCoordinateReferenceSystem &crs,
+      const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const;
 
     /**
      * Returns pyramid resampling methods available for provider

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -132,6 +132,7 @@ class QgsMdalProvider : public QgsMeshDataProvider
     QgsCoordinateReferenceSystem mCrs;
     QStringList mSubLayersUris;
     QString mDriverName;
+    QMap<QString, QString> mMeshMetadata;
 
     /**
      * Closes and reloads dataset
@@ -151,10 +152,12 @@ class QgsMdalProviderMetadata: public QgsProviderMetadata
     bool createMeshData( const QgsMesh &mesh,
                          const QString &fileName,
                          const QString &driverName,
-                         const QgsCoordinateReferenceSystem &crs ) const override;
+                         const QgsCoordinateReferenceSystem &crs,
+                         const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const override;
     bool createMeshData( const QgsMesh &mesh,
                          const QString &uri,
-                         const QgsCoordinateReferenceSystem &crs ) const override;
+                         const QgsCoordinateReferenceSystem &crs,
+                         const QMap<QString, QString> &metadata = QMap<QString, QString>() ) const override;
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;
     QString absoluteToRelativeUri( const QString &uri, const QgsReadWriteContext &context ) const override;


### PR DESCRIPTION
## Description
When editing mesh layers, all MDAL mesh metadata are dropped from the modified file. This can break formats that rely on that metadata, like the mike21 format.

This PR makes sure the MDAL mesh metadata are read when loading the mesh and stored back to the output file when editing is finished.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
