### PR TITLE
Reduce queries to detect select privileges for PostgreSQL relations

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1567,7 +1567,6 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     if ( mSchemaName.isEmpty() )
       mSchemaName = testAccess.PQgetvalue( 0, 2 );
 
-
     // Do not set editable capabilities if the provider has been forced to be
     // in read-only mode or if the database is still in recovery
     if ( !forceReadOnly && !inRecovery )
@@ -1596,20 +1595,19 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
         mEnabledCapabilities |= QgsVectorDataProvider::ChangeGeometries;
       }
 
-    }
-
-    // TODO: merge this with the previous query
-    sql = QString( "SELECT 1 FROM pg_class,pg_namespace WHERE "
-                   "pg_class.relnamespace=pg_namespace.oid AND "
-                   "%3 AND "
-                   "relname=%1 AND nspname=%2" )
-          .arg( quotedValue( mTableName ),
-                quotedValue( mSchemaName ),
-                connectionRO()->pgVersion() < 80100 ? "pg_get_userbyid(relowner)=current_user" : "pg_has_role(relowner,'MEMBER')" );
-    testAccess = connectionRO()->LoggedPQexec( "QgsPostgresProvider", sql );
-    if ( testAccess.PQresultStatus() == PGRES_TUPLES_OK && testAccess.PQntuples() == 1 )
-    {
-      mEnabledCapabilities |= QgsVectorDataProvider::AddAttributes | QgsVectorDataProvider::DeleteAttributes | QgsVectorDataProvider::RenameAttributes;
+      // TODO: merge this with the previous query
+      sql = QString( "SELECT 1 FROM pg_class,pg_namespace WHERE "
+                     "pg_class.relnamespace=pg_namespace.oid AND "
+                     "%3 AND "
+                     "relname=%1 AND nspname=%2" )
+            .arg( quotedValue( mTableName ),
+                  quotedValue( mSchemaName ),
+                  connectionRO()->pgVersion() < 80100 ? "pg_get_userbyid(relowner)=current_user" : "pg_has_role(relowner,'MEMBER')" );
+      testAccess = connectionRO()->LoggedPQexec( "QgsPostgresProvider", sql );
+      if ( testAccess.PQresultStatus() == PGRES_TUPLES_OK && testAccess.PQntuples() == 1 )
+      {
+        mEnabledCapabilities |= QgsVectorDataProvider::AddAttributes | QgsVectorDataProvider::DeleteAttributes | QgsVectorDataProvider::RenameAttributes;
+      }
     }
   }
   else

--- a/tests/src/python/test_provider_postgres_latency.py
+++ b/tests/src/python/test_provider_postgres_latency.py
@@ -156,7 +156,7 @@ class TestPyQgsPostgresProviderLatency(QgisTestCase):
         settings = QgsSettingsTree.node('core').childSetting('provider-parallel-loading')
         settings.setVariantValue(False)
 
-        davg = 8.67
+        davg = 7.61
         dmin = round(davg - 0.2, 2)
         dmax = round(davg + 0.3, 2)
         error_string = 'expected from {0}s to {1}s, got {2}s\nHINT: set davg={2} to pass the test :)'


### PR DESCRIPTION
Use a single query rather than 3 to determine recovery status, select privilege and update/insert/delete privileges.

Also drops the need to evaluate view definitions to determine selectability.
User in chat reported 20 seconds of time for such evaluation.