### PR TITLE
Copy composer grid

### DIFF
--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -1115,6 +1115,13 @@ Retrieves the second fill color for the grid frame.
     virtual void refresh();
 
 
+    void copyProperties( const QgsLayoutItemMapGrid *other );
+%Docstring
+Copies properties from specified map grid.
+
+.. versionadded:: 3.38
+%End
+
   signals:
 
     void crsChanged();

--- a/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -1115,6 +1115,13 @@ Retrieves the second fill color for the grid frame.
     virtual void refresh();
 
 
+    void copyProperties( const QgsLayoutItemMapGrid *other );
+%Docstring
+Copies properties from specified map grid.
+
+.. versionadded:: 3.38
+%End
+
   signals:
 
     void crsChanged();

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -1912,7 +1912,6 @@ bool QgsLayoutItemMapGrid::shouldShowForDisplayMode( QgsLayoutItemMapGrid::Annot
          || ( mode == QgsLayoutItemMapGrid::LongitudeOnly && coordinate == QgsLayoutItemMapGrid::Longitude );
 }
 
-
 QgsLayoutItemMapGrid::DisplayMode gridAnnotationDisplayModeFromDD( QString ddValue, QgsLayoutItemMapGrid::DisplayMode defValue )
 {
   if ( ddValue.compare( QLatin1String( "x_only" ), Qt::CaseInsensitive ) == 0 )
@@ -1926,7 +1925,6 @@ QgsLayoutItemMapGrid::DisplayMode gridAnnotationDisplayModeFromDD( QString ddVal
   else
     return defValue;
 }
-
 
 void QgsLayoutItemMapGrid::refreshDataDefinedProperties()
 {
@@ -1986,7 +1984,6 @@ void QgsLayoutItemMapGrid::refreshDataDefinedProperties()
   mEvaluatedRightFrameDivisions = gridAnnotationDisplayModeFromDD( mDataDefinedProperties.valueAsString( QgsLayoutObject::DataDefinedProperty::MapGridFrameDivisionsRight, context ), mRightFrameDivisions );
   mEvaluatedTopFrameDivisions = gridAnnotationDisplayModeFromDD( mDataDefinedProperties.valueAsString( QgsLayoutObject::DataDefinedProperty::MapGridFrameDivisionsTop, context ), mTopFrameDivisions );
   mEvaluatedBottomFrameDivisions = gridAnnotationDisplayModeFromDD( mDataDefinedProperties.valueAsString( QgsLayoutObject::DataDefinedProperty::MapGridFrameDivisionsBottom, context ), mBottomFrameDivisions );
-
 }
 
 double QgsLayoutItemMapGrid::mapWidth() const
@@ -2636,4 +2633,79 @@ QList<QPolygonF> QgsLayoutItemMapGrid::trimLinesToMap( const QPolygonF &line, co
     trimmedLines << ( *geomIt ).asQPolygonF();
   }
   return trimmedLines;
+}
+
+void QgsLayoutItemMapGrid::copyProperties( const QgsLayoutItemMapGrid *other )
+{
+  // grid
+  setStyle( other->style() );
+  setIntervalX( other->intervalX() );
+  setIntervalY( other->intervalY() );
+  setOffsetX( other->offsetX() );
+  setOffsetY( other->offsetX() );
+  setCrossLength( other->crossLength() );
+  setFrameStyle( other->frameStyle() );
+  setFrameSideFlags( other->frameSideFlags() );
+  setFrameWidth( other->frameWidth() );
+  setFrameMargin( other->frameMargin() );
+  setFramePenSize( other->framePenSize() );
+  setFramePenColor( other->framePenColor() );
+  setFrameFillColor1( other->frameFillColor1() );
+  setFrameFillColor2( other->frameFillColor2() );
+
+  setFrameDivisions( other->frameDivisions( QgsLayoutItemMapGrid::BorderSide::Left ), QgsLayoutItemMapGrid::BorderSide::Left );
+  setFrameDivisions( other->frameDivisions( QgsLayoutItemMapGrid::BorderSide::Right ), QgsLayoutItemMapGrid::BorderSide::Right );
+  setFrameDivisions( other->frameDivisions( QgsLayoutItemMapGrid::BorderSide::Bottom ), QgsLayoutItemMapGrid::BorderSide::Bottom );
+  setFrameDivisions( other->frameDivisions( QgsLayoutItemMapGrid::BorderSide::Top ), QgsLayoutItemMapGrid::BorderSide::Top );
+
+  setRotatedTicksLengthMode( other->rotatedTicksLengthMode() );
+  setRotatedTicksEnabled( other->rotatedTicksEnabled() );
+  setRotatedTicksMinimumAngle( other->rotatedTicksMinimumAngle() );
+  setRotatedTicksMarginToCorner( other->rotatedTicksMarginToCorner() );
+  setRotatedAnnotationsLengthMode( other->rotatedAnnotationsLengthMode() );
+  setRotatedAnnotationsEnabled( other->rotatedAnnotationsEnabled() );
+  setRotatedAnnotationsMinimumAngle( other->rotatedAnnotationsMinimumAngle() );
+  setRotatedAnnotationsMarginToCorner( other->rotatedAnnotationsMarginToCorner() );
+
+  if ( other->lineSymbol() )
+  {
+    setLineSymbol( other->lineSymbol()->clone() );
+  }
+
+  if ( other->markerSymbol() )
+  {
+    setMarkerSymbol( other->markerSymbol()->clone() );
+  }
+
+  setCrs( other->crs() );
+
+  setBlendMode( other->blendMode() );
+
+  //annotation
+  setAnnotationEnabled( other->annotationEnabled() );
+  setAnnotationFormat( other->annotationFormat() );
+  setAnnotationExpression( other->annotationExpression() );
+
+  setAnnotationPosition( other->annotationPosition( QgsLayoutItemMapGrid::BorderSide::Left ), QgsLayoutItemMapGrid::BorderSide::Left );
+  setAnnotationPosition( other->annotationPosition( QgsLayoutItemMapGrid::BorderSide::Right ), QgsLayoutItemMapGrid::BorderSide::Right );
+  setAnnotationPosition( other->annotationPosition( QgsLayoutItemMapGrid::BorderSide::Bottom ), QgsLayoutItemMapGrid::BorderSide::Bottom );
+  setAnnotationPosition( other->annotationPosition( QgsLayoutItemMapGrid::BorderSide::Top ), QgsLayoutItemMapGrid::BorderSide::Top );
+  setAnnotationDisplay( other->annotationDisplay( QgsLayoutItemMapGrid::BorderSide::Left ), QgsLayoutItemMapGrid::BorderSide::Left );
+  setAnnotationDisplay( other->annotationDisplay( QgsLayoutItemMapGrid::BorderSide::Right ), QgsLayoutItemMapGrid::BorderSide::Right );
+  setAnnotationDisplay( other->annotationDisplay( QgsLayoutItemMapGrid::BorderSide::Bottom ), QgsLayoutItemMapGrid::BorderSide::Bottom );
+  setAnnotationDisplay( other->annotationDisplay( QgsLayoutItemMapGrid::BorderSide::Top ), QgsLayoutItemMapGrid::BorderSide::Top );
+  setAnnotationDirection( other->annotationDirection( QgsLayoutItemMapGrid::BorderSide::Left ), QgsLayoutItemMapGrid::BorderSide::Left );
+  setAnnotationDirection( other->annotationDirection( QgsLayoutItemMapGrid::BorderSide::Right ), QgsLayoutItemMapGrid::BorderSide::Right );
+  setAnnotationDirection( other->annotationDirection( QgsLayoutItemMapGrid::BorderSide::Bottom ), QgsLayoutItemMapGrid::BorderSide::Bottom );
+  setAnnotationDirection( other->annotationDirection( QgsLayoutItemMapGrid::BorderSide::Top ), QgsLayoutItemMapGrid::BorderSide::Top );
+  setAnnotationFrameDistance( other->annotationFrameDistance() );
+  setAnnotationTextFormat( other->annotationTextFormat() );
+
+  setAnnotationPrecision( other->annotationPrecision() );
+  setUnits( other->units() );
+  setMinimumIntervalWidth( other->minimumIntervalWidth() );
+  setMaximumIntervalWidth( other->maximumIntervalWidth() );
+
+  setDataDefinedProperties( other->dataDefinedProperties() );
+  refreshDataDefinedProperties();
 }

--- a/src/core/layout/qgslayoutitemmapgrid.h
+++ b/src/core/layout/qgslayoutitemmapgrid.h
@@ -1005,6 +1005,13 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
     void refresh() override;
 
+    /**
+     * Copies properties from specified map grid.
+     *
+     * \since QGIS 3.38
+     */
+    void copyProperties( const QgsLayoutItemMapGrid *other );
+
   signals:
 
     /**

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -1255,7 +1255,23 @@ void QgsLayoutMapWidget::mCopyGridPushButton_clicked()
   }
 
   QgsLayoutItemMapGrid *sourceGrid = mMapItem->grids()->grid( item->data( Qt::UserRole ).toString() );
-  const QString itemName = tr( "Grid %1" ).arg( mMapItem->grids()->size() + 1 );
+  int i = 0;
+  bool found = true;
+  QString itemName = tr( "%1 - Copy" ).arg( sourceGrid->name() );
+  QList< QgsLayoutItemMapGrid * > grids = mMapItem->grids()->asList();
+  while ( found )
+  {
+    for ( const QgsLayoutItemMapGrid *grd : std::as_const( grids ) )
+    {
+      if ( grd->name() == itemName )
+      {
+        i++;
+        itemName = tr( "%1 - Copy %2" ).arg( sourceGrid->name() ).arg( i );
+      }
+    }
+    found = false;
+  }
+  //const QString itemName = tr( "Grid %1" ).arg( mMapItem->grids()->size() + 1 );
   QgsLayoutItemMapGrid *grid = new QgsLayoutItemMapGrid( itemName, mMapItem );
   grid->copyProperties( sourceGrid );
 

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -73,6 +73,7 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   connect( mAtlasPredefinedScaleRadio, &QRadioButton::toggled, this, &QgsLayoutMapWidget::mAtlasPredefinedScaleRadio_toggled );
   connect( mAddGridPushButton, &QPushButton::clicked, this, &QgsLayoutMapWidget::mAddGridPushButton_clicked );
   connect( mRemoveGridPushButton, &QPushButton::clicked, this, &QgsLayoutMapWidget::mRemoveGridPushButton_clicked );
+  connect( mCopyGridPushButton, &QPushButton::clicked, this, &QgsLayoutMapWidget::mCopyGridPushButton_clicked );
   connect( mGridUpButton, &QPushButton::clicked, this, &QgsLayoutMapWidget::mGridUpButton_clicked );
   connect( mGridDownButton, &QPushButton::clicked, this, &QgsLayoutMapWidget::mGridDownButton_clicked );
   connect( mGridListWidget, &QListWidget::currentItemChanged, this, &QgsLayoutMapWidget::mGridListWidget_currentItemChanged );
@@ -1243,6 +1244,30 @@ void QgsLayoutMapWidget::mRemoveGridPushButton_clicked()
   mMapItem->endCommand();
   mMapItem->updateBoundingRect();
   mMapItem->update();
+}
+
+void QgsLayoutMapWidget::mCopyGridPushButton_clicked()
+{
+  QListWidgetItem *item = mGridListWidget->currentItem();
+  if ( !item )
+  {
+    return;
+  }
+
+  QgsLayoutItemMapGrid *sourceGrid = mMapItem->grids()->grid( item->data( Qt::UserRole ).toString() );
+  const QString itemName = tr( "Grid %1" ).arg( mMapItem->grids()->size() + 1 );
+  QgsLayoutItemMapGrid *grid = new QgsLayoutItemMapGrid( itemName, mMapItem );
+  grid->copyProperties( sourceGrid );
+
+  mMapItem->layout()->undoStack()->beginCommand( mMapItem, tr( "Duplicate Map Grid" ) );
+  mMapItem->grids()->addGrid( grid );
+  mMapItem->layout()->undoStack()->endCommand();
+  mMapItem->updateBoundingRect();
+  mMapItem->update();
+
+  addGridListItem( grid->id(), grid->name() );
+  mGridListWidget->setCurrentRow( 0 );
+  mGridListWidget_currentItemChanged( mGridListWidget->currentItem(), nullptr );
 }
 
 void QgsLayoutMapWidget::mGridUpButton_clicked()

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -1256,22 +1256,19 @@ void QgsLayoutMapWidget::mCopyGridPushButton_clicked()
 
   QgsLayoutItemMapGrid *sourceGrid = mMapItem->grids()->grid( item->data( Qt::UserRole ).toString() );
   int i = 0;
-  bool found = true;
   QString itemName = tr( "%1 - Copy" ).arg( sourceGrid->name() );
   QList< QgsLayoutItemMapGrid * > grids = mMapItem->grids()->asList();
-  while ( found )
+  while ( true )
   {
-    for ( const QgsLayoutItemMapGrid *grd : std::as_const( grids ) )
+    const auto it = std::find_if( grids.begin(), grids.end(), [&itemName]( const QgsLayoutItemMapGrid * grd ) { return grd->name() == itemName; } );
+    if ( it != grids.end() )
     {
-      if ( grd->name() == itemName )
-      {
-        i++;
-        itemName = tr( "%1 - Copy %2" ).arg( sourceGrid->name() ).arg( i );
-      }
+      i++;
+      itemName = tr( "%1 - Copy %2" ).arg( sourceGrid->name() ).arg( i );
+      continue;
     }
-    found = false;
+    break;
   }
-  //const QString itemName = tr( "Grid %1" ).arg( mMapItem->grids()->size() + 1 );
   QgsLayoutItemMapGrid *grid = new QgsLayoutItemMapGrid( itemName, mMapItem );
   grid->copyProperties( sourceGrid );
 

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -1255,6 +1255,10 @@ void QgsLayoutMapWidget::mCopyGridPushButton_clicked()
   }
 
   QgsLayoutItemMapGrid *sourceGrid = mMapItem->grids()->grid( item->data( Qt::UserRole ).toString() );
+  if ( !sourceGrid )
+  {
+    return;
+  }
   int i = 0;
   QString itemName = tr( "%1 - Copy" ).arg( sourceGrid->name() );
   QList< QgsLayoutItemMapGrid * > grids = mMapItem->grids()->asList();

--- a/src/gui/layout/qgslayoutmapwidget.h
+++ b/src/gui/layout/qgslayoutmapwidget.h
@@ -86,6 +86,7 @@ class GUI_EXPORT QgsLayoutMapWidget: public QgsLayoutItemBaseWidget, private Ui:
 
     void mAddGridPushButton_clicked();
     void mRemoveGridPushButton_clicked();
+    void mCopyGridPushButton_clicked();
     void mGridUpButton_clicked();
     void mGridDownButton_clicked();
 

--- a/src/ui/layout/qgslayoutmapwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapwidgetbase.ui
@@ -88,9 +88,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-123</y>
-        <width>548</width>
-        <height>1478</height>
+        <y>-798</y>
+        <width>539</width>
+        <height>1640</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -762,7 +762,7 @@
               </property>
               <property name="icon">
                <iconset resource="../../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+                <normaloff>:/images/themes/default/mActionDuplicateLayout.svg</normaloff>:/images/themes/default/mActionDuplicateLayout.svg</iconset>
               </property>
              </widget>
             </item>

--- a/src/ui/layout/qgslayoutmapwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapwidgetbase.ui
@@ -753,6 +753,20 @@
              </widget>
             </item>
             <item>
+             <widget class="QPushButton" name="mCopyGridPushButton">
+              <property name="toolTip">
+               <string>Duplicate selected grid</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../../../images/images.qrc">
+                <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QPushButton" name="mGridUpButton">
               <property name="toolTip">
                <string>Move selected grid up</string>

--- a/tests/src/python/test_qgslayoutmapgrid.py
+++ b/tests/src/python/test_qgslayoutmapgrid.py
@@ -1097,6 +1097,67 @@ class TestQgsLayoutMapGrid(QgisTestCase):
         grid.setCrs(QgsCoordinateReferenceSystem("EPSG:3111"))
         self.assertEqual(len(spy), 9)
 
+    def testCopyGrid(self):
+        layout = QgsLayout(QgsProject.instance())
+        layout.initializeDefaults()
+        map = QgsLayoutItemMap(layout)
+        map.attemptSetSceneRect(QRectF(20, 20, 200, 100))
+        map.setFrameEnabled(True)
+        map.setBackgroundColor(QColor(150, 100, 100))
+        layout.addLayoutItem(map)
+        myRectangle = QgsRectangle(781662.375, 3339523.125, 793062.375, 3345223.125)
+        map.setExtent(myRectangle)
+        map.grid().setEnabled(True)
+        map.grid().setIntervalX(2000)
+        map.grid().setIntervalY(2000)
+        map.grid().setAnnotationEnabled(True)
+        map.grid().setGridLineColor(QColor(0, 255, 0))
+        map.grid().setGridLineWidth(0.5)
+
+        format = QgsTextFormat.fromQFont(getTestFont("Bold", 20))
+        format.setColor(QColor(255, 0, 0))
+        format.setOpacity(150 / 255)
+        map.grid().setAnnotationTextFormat(format)
+
+        map.grid().setAnnotationPrecision(0)
+        map.grid().setAnnotationDisplay(
+            QgsLayoutItemMapGrid.DisplayMode.HideAll, QgsLayoutItemMapGrid.BorderSide.Left
+        )
+        map.grid().setAnnotationPosition(
+            QgsLayoutItemMapGrid.AnnotationPosition.OutsideMapFrame, QgsLayoutItemMapGrid.BorderSide.Right
+        )
+        map.grid().setAnnotationDisplay(
+            QgsLayoutItemMapGrid.DisplayMode.HideAll, QgsLayoutItemMapGrid.BorderSide.Top
+        )
+        map.grid().setAnnotationPosition(
+            QgsLayoutItemMapGrid.AnnotationPosition.OutsideMapFrame, QgsLayoutItemMapGrid.BorderSide.Bottom
+        )
+        map.grid().setAnnotationDirection(
+            QgsLayoutItemMapGrid.AnnotationDirection.Horizontal, QgsLayoutItemMapGrid.BorderSide.Right
+        )
+        map.grid().setAnnotationDirection(
+            QgsLayoutItemMapGrid.AnnotationDirection.Horizontal, QgsLayoutItemMapGrid.BorderSide.Bottom
+        )
+        map.grid().setBlendMode(QPainter.CompositionMode.CompositionMode_Overlay)
+        map.updateBoundingRect()
+
+        map.grid().dataDefinedProperties().setProperty(
+            QgsLayoutObject.DataDefinedProperty.MapGridLabelDistance, QgsProperty.fromValue(10)
+        )
+        map.grid().refresh()
+
+        source_grid = map.grid()
+        grid = QgsLayoutItemMapGrid("testGrid", map)
+        grid.copyProperties(source_grid)
+        map.grids().removeGrid(source_grid.id())
+        self.assertEqual(map.grids().size(), 0)
+        map.grids().addGrid(grid)
+        map.grid().refresh()
+        self.assertTrue(
+            self.render_layout_check("composermap_datadefined_annotationdistance",
+                                     layout)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Add a button to copy (duplicate) selected composer grid in the print composer. This simplifies process of creating new grids which has only a few differences.

![image](https://github.com/qgis/QGIS/assets/776954/f1eb5b5e-e543-4c4f-8c6e-2d13543f8060)

Fixes #47511.

Funded by [NaturalGIS](https://naturalgis.pt).
