### PR TITLE
Display more columns in the "Export Project to Dxf" dialog (take 2 )

### DIFF
--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -726,26 +726,10 @@ void QgsVectorLayerAndAttributeModel::enableDataDefinedBlocks( bool enabled )
   emit dataChanged( index( 0, 0 ), index( rowCount() - 1, 0 ) );
 }
 
-QgsDxfExportLayerTreeView::QgsDxfExportLayerTreeView( QWidget *parent )
-  : QgsLayerTreeView( parent )
-{
-}
-
-void QgsDxfExportLayerTreeView::resizeEvent( QResizeEvent *event )
-{
-  header()->setMinimumSectionSize( viewport()->width() / 4 );
-  header()->setMaximumSectionSize( viewport()->width() / 4 );
-  QTreeView::resizeEvent( event ); // NOLINT(bugprone-parent-virtual-call) clazy:exclude=skipped-base-method
-}
-
 QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   : QDialog( parent, f )
 {
   setupUi( this );
-
-  mTreeView = new QgsDxfExportLayerTreeView( this );
-  mTreeViewContainer->layout()->addWidget( mTreeView );
-
   QgsGui::enableAutoGeometryRestore( this );
 
   connect( mVisibilityPresets, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsDxfExportDialog::mVisibilityPresets_currentIndexChanged );

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -733,8 +733,8 @@ QgsDxfExportLayerTreeView::QgsDxfExportLayerTreeView( QWidget *parent )
 
 void QgsDxfExportLayerTreeView::resizeEvent( QResizeEvent *event )
 {
-  header()->setMinimumSectionSize( viewport()->width() / 2 );
-  header()->setMaximumSectionSize( viewport()->width() / 2 );
+  header()->setMinimumSectionSize( viewport()->width() / 4 );
+  header()->setMaximumSectionSize( viewport()->width() / 4 );
   QTreeView::resizeEvent( event ); // NOLINT(bugprone-parent-virtual-call) clazy:exclude=skipped-base-method
 }
 

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -746,8 +746,10 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
 
   mModel = new QgsVectorLayerAndAttributeModel( mLayerTreeGroup, this );
   mModel->setFlags( QgsLayerTreeModel::Flags() );
-
   mTreeView->setModel( mModel );
+  mTreeView->resizeColumnToContents( 0 );
+  mTreeView->resizeColumnToContents( 1 );
+  mTreeView->header()->setSectionResizeMode( QHeaderView::ResizeMode::Interactive );
   mTreeView->header()->show();
 
   mFileName->setStorageMode( QgsFileWidget::SaveFile );

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -89,15 +89,6 @@ class QgsVectorLayerAndAttributeModel : public QgsLayerTreeModel
     void enableDataDefinedBlocks( bool enabled );
 };
 
-class QgsDxfExportLayerTreeView : public QgsLayerTreeView
-{
-    Q_OBJECT
-  public:
-    explicit QgsDxfExportLayerTreeView( QWidget *parent = nullptr );
-
-  protected:
-    void resizeEvent( QResizeEvent *event ) override;
-};
 
 class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
 {
@@ -147,7 +138,6 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QgsLayerTree *mLayerTreeGroup = nullptr;
     FieldSelectorDelegate *mFieldSelectorDelegate = nullptr;
     QgsVectorLayerAndAttributeModel *mModel = nullptr;
-    QgsDxfExportLayerTreeView *mTreeView = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 
     QgsCoordinateReferenceSystem mCRS;

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -123,12 +123,17 @@
      <item row="5" column="1">
       <widget class="QComboBox" name="mVisibilityPresets"/>
      </item>
-     <item row="7" column="0" colspan="2">
-      <widget class="QWidget" name="mTreeViewContainer">
-      <layout class="QHBoxLayout" name="mTreeViewLayout"/>
+     <item row="6" column="0" colspan="2">
+      <widget class="QTreeView" name="mTreeView">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
       </widget>
      </item>
-     <item row="9" column="0" colspan="2">
+     <item row="7" column="0" colspan="2">
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0">
         <widget class="QPushButton" name="mSelectAllButton">
@@ -160,7 +165,7 @@
        </item>
       </layout>
      </item>
-     <item row="11" column="0" colspan="2">
+     <item row="8" column="0" colspan="2">
       <layout class="QGridLayout" name="gridLayout">
        <item row="1" column="0">
         <widget class="QCheckBox" name="mMapExtentCheckBox">
@@ -186,7 +191,7 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
+       <item row="0" column="2">
         <widget class="QCheckBox" name="mMTextCheckBox">
          <property name="text">
           <string>Export labels as MTEXT elements</string>
@@ -196,7 +201,7 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
+       <item row="0" column="3">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -209,23 +214,39 @@
          </property>
         </spacer>
        </item>
-       <item row="1" column="1">
+       <item row="1" column="2">
         <widget class="QCheckBox" name="mSelectedFeaturesOnly">
          <property name="text">
           <string>Use only selected features</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="2" column="2">
         <widget class="QCheckBox" name="mHairlineWidthExportCheckBox">
          <property name="text">
           <string>Export lines with zero width</string>
          </property>
         </widget>
        </item>
+       <item row="0" column="1">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </item>
-     <item row="15" column="0" colspan="2">
+     <item row="9" column="0" colspan="2">
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -265,6 +286,7 @@
   <tabstop>mEncoding</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mVisibilityPresets</tabstop>
+  <tabstop>mTreeView</tabstop>
   <tabstop>mSelectAllButton</tabstop>
   <tabstop>mDeselectAllButton</tabstop>
   <tabstop>mSelectDataDefinedBlocks</tabstop>
@@ -274,6 +296,7 @@
   <tabstop>mMapExtentCheckBox</tabstop>
   <tabstop>mSelectedFeaturesOnly</tabstop>
   <tabstop>mForce2d</tabstop>
+  <tabstop>mHairlineWidthExportCheckBox</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This PR is an alternative approach to #57155: instead of a QgsLayerTreeView it uses a QTreeView for automatically displaying all the columns in the dialog. This seems to be the actual widget type used in the other dialogs that display layer tree along with other columns (see https://github.com/qgis/QGIS/pull/57155#issuecomment-2106376166).
It reverts #56082 that looks more like a hack to me, as we need to adjust width bounds whenever number of columns changes.

https://github.com/qgis/QGIS/assets/7983394/278db898-9fb3-4df7-b5a0-5e4af50c4080

The bad news: it doesn't work. I can get the dialog with columns visible and I could export a project. But some interactions with the dialog (e.g. double-click in a cell, resizing dialog not the columns) lead to a freeze then a crash (of my whole computer). An issue with the Q_ASSERT below but this is a too high level for my c++ understanding.

https://github.com/qgis/QGIS/blob/8d9c68b52756577e4bfbcda8303ba881ea3f185e/src/app/qgsdxfexportdialog.cpp#L151-L154