### PR TITLE
Fix wrong text color on Windows in the Night Mapping theme

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -226,7 +226,6 @@ QLineEdit
     padding: 0.12em;
     border: 1px solid @itemdarkbackground;
     background-color: @itembackground;
-    color: @text;
     selection-background-color: @selection;
     selection-color: @textlight;
 }
@@ -1307,4 +1306,12 @@ QgsAttributeFormWidget QComboBox:disabled {
 
 QgsAttributeFormWidget QComboBox::down-arrow:disabled {
      image: none;
+}
+
+QWidget#mCadWidget QLineEdit {
+    color: @textlight;
+}
+
+QWidget#mCadWidget QLineEdit:disabled {
+    color: @text;
 }

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -226,6 +226,7 @@ QLineEdit
     padding: 0.12em;
     border: 1px solid @itemdarkbackground;
     background-color: @itembackground;
+    color: @text;
     selection-background-color: @selection;
     selection-color: @textlight;
 }
@@ -333,6 +334,11 @@ QToolButton::menu-indicator:disabled
     width: 0.8em;
     height: 1.2em;
 }
+
+QToolBox::tab {
+    color: @text;
+}
+
 QToolBar QToolButton, QToolButton::menu-button
 {
     border-color: rgba(0,0,0,0);


### PR DESCRIPTION
This PR fixes two color display errors in the Night Mapping theme that only occur on Windows.

@mblesius: Can you confirm this?

Fixes #54565, #57182