### PR TITLE
Update the pull request milestone when it is merged

### DIFF
--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - closed
 
 permissions:
   contents: read


### PR DESCRIPTION
Why?
1. When a PR is created, a milestone is attached to it. That milestone is then added in the issue report generated in the docs repo, to indicate the version.
1. That version information is reused in the docs repo to assign appropriate version label and milestone to the issue. So we know in which docs a fix should go.
2.  Issue is that, currently, a PR opened during dev cycle A but merged in cycle B still kept the A milestone attached hence old version assigned. Meaning that in the docs repo, we end up with wrong information assigned to the issues that are created, and potentially could backport some fixes to a docs version they do not belong to.


What I'm not sure of with this fix is whether the milestone will be updated before the issue report is created in docs repo. Hence based on https://docs.github.com/en/actions/using-workflows/reusing-workflows, I have [that other branch](https://github.com/qgis/QGIS/compare/master...DelazJ:QGIS:pr4MilestoneDocs_caller?expand=1) I can't really test (any GH actions guru?) that, from my understanding, should circumvent that.