### PR TITLE
Show warning locations in QgsCodeEditorWidget scrollbars

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -72,6 +72,26 @@ Returns the scrollbar highlight controller, which can be used to add highlights
 in the code editor scrollbar.
 %End
 
+    void addWarning( int lineNumber, const QString &warning );
+%Docstring
+Adds a ``warning`` message and indicator to the specified a ``lineNumber``.
+
+This method calls :py:func:`QgsCodeEditor.addWarning()`, but also automatically adds
+highlights to the widget scrollbars locating the warning location.
+
+.. seealso:: :py:func:`clearWarnings`
+%End
+
+    void clearWarnings();
+%Docstring
+Clears all warning messages from the editor.
+
+This method calls :py:func:`QgsCodeEditor.clearWarnings()`, but also removes
+highlights from the widget scrollbars at the warning locations.
+
+.. seealso:: :py:func:`addWarning`
+%End
+
   public slots:
 
     void showSearchBar();

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -46,6 +46,11 @@ feedback, otherwise an integrated message bar will be used.
 %End
     ~QgsCodeEditorWidget();
 
+    virtual void resizeEvent( QResizeEvent *event );
+
+    virtual void showEvent( QShowEvent *event );
+
+
     QgsCodeEditor *editor();
 %Docstring
 Returns the wrapped code editor.
@@ -59,6 +64,12 @@ Returns ``True`` if the search bar is visible.
     QgsMessageBar *messageBar();
 %Docstring
 Returns the message bar associated with the widget, to use for user feedback.
+%End
+
+    QgsScrollBarHighlightController *scrollbarHighlightController();
+%Docstring
+Returns the scrollbar highlight controller, which can be used to add highlights
+in the code editor scrollbar.
 %End
 
   public slots:

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -91,6 +91,7 @@ class Editor(QgsCodeEditorPython):
         self.editor_tab: EditorTab = editor_tab
         self.console_widget: PythonConsoleWidget = console_widget
         self.tab_widget: EditorTabWidget = tab_widget
+        self.code_editor_widget: Optional[QgsCodeEditorWidget] = None
 
         self.path: Optional[str] = None
         #  recent modification time
@@ -384,7 +385,7 @@ class Editor(QgsCodeEditorPython):
         self.setFocus()
 
     def syntaxCheck(self):
-        self.clearWarnings()
+        self.code_editor_widget.clearWarnings()
         source = self.text().encode("utf-8")
         try:
             compile(source, "", "exec")
@@ -393,7 +394,7 @@ class Editor(QgsCodeEditorPython):
             eline -= 1
             ecolumn = detail.offset or 1
             edescr = detail.msg
-            self.addWarning(eline, edescr)
+            self.code_editor_widget.addWarning(eline, edescr)
             self.setCursorPosition(eline, ecolumn - 1)
             self.ensureLineVisible(eline)
             return False
@@ -546,6 +547,7 @@ class EditorTab(QWidget):
         self._editor_code_widget = QgsCodeEditorWidget(
             self._editor
         )
+        self._editor.code_editor_widget = self._editor_code_widget
         self._editor_code_widget.searchBarToggled.connect(
             self.search_bar_toggled
         )

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -72,6 +72,26 @@ Returns the scrollbar highlight controller, which can be used to add highlights
 in the code editor scrollbar.
 %End
 
+    void addWarning( int lineNumber, const QString &warning );
+%Docstring
+Adds a ``warning`` message and indicator to the specified a ``lineNumber``.
+
+This method calls :py:func:`QgsCodeEditor.addWarning()`, but also automatically adds
+highlights to the widget scrollbars locating the warning location.
+
+.. seealso:: :py:func:`clearWarnings`
+%End
+
+    void clearWarnings();
+%Docstring
+Clears all warning messages from the editor.
+
+This method calls :py:func:`QgsCodeEditor.clearWarnings()`, but also removes
+highlights from the widget scrollbars at the warning locations.
+
+.. seealso:: :py:func:`addWarning`
+%End
+
   public slots:
 
     void showSearchBar();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -46,6 +46,11 @@ feedback, otherwise an integrated message bar will be used.
 %End
     ~QgsCodeEditorWidget();
 
+    virtual void resizeEvent( QResizeEvent *event );
+
+    virtual void showEvent( QShowEvent *event );
+
+
     QgsCodeEditor *editor();
 %Docstring
 Returns the wrapped code editor.
@@ -59,6 +64,12 @@ Returns ``True`` if the search bar is visible.
     QgsMessageBar *messageBar();
 %Docstring
 Returns the message bar associated with the widget, to use for user feedback.
+%End
+
+    QgsScrollBarHighlightController *scrollbarHighlightController();
+%Docstring
+Returns the scrollbar highlight controller, which can be used to add highlights
+in the code editor scrollbar.
 %End
 
   public slots:

--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -26,6 +26,8 @@
 #include <QCheckBox>
 #include <QShortcut>
 
+constexpr int WARNING_HIGHLIGHT_CATEGORY = 48;
+
 QgsCodeEditorWidget::QgsCodeEditorWidget(
   QgsCodeEditor *editor,
   QgsMessageBar *messageBar,
@@ -190,6 +192,29 @@ QgsMessageBar *QgsCodeEditorWidget::messageBar()
 QgsScrollBarHighlightController *QgsCodeEditorWidget::scrollbarHighlightController()
 {
   return mHighlightController.get();
+}
+
+void QgsCodeEditorWidget::addWarning( int lineNumber, const QString &warning )
+{
+  mEditor->addWarning( lineNumber, warning );
+
+  mHighlightController->addHighlight(
+    QgsScrollBarHighlight(
+      WARNING_HIGHLIGHT_CATEGORY,
+      lineNumber,
+      QColor( 255, 0, 0 ),
+      QgsScrollBarHighlight::Priority::HighestPriority
+    )
+  );
+}
+
+void QgsCodeEditorWidget::clearWarnings()
+{
+  mEditor->clearWarnings();
+
+  mHighlightController->removeHighlights(
+    WARNING_HIGHLIGHT_CATEGORY
+  );
 }
 
 void QgsCodeEditorWidget::showSearchBar()

--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -163,6 +163,18 @@ QgsCodeEditorWidget::QgsCodeEditorWidget(
   mHighlightController->setScrollArea( mEditor );
 }
 
+void QgsCodeEditorWidget::resizeEvent( QResizeEvent *event )
+{
+  QgsPanelWidget::resizeEvent( event );
+  updateHighlightController();
+}
+
+void QgsCodeEditorWidget::showEvent( QShowEvent *event )
+{
+  QgsPanelWidget::showEvent( event );
+  updateHighlightController();
+}
+
 QgsCodeEditorWidget::~QgsCodeEditorWidget() = default;
 
 bool QgsCodeEditorWidget::isSearchBarVisible() const
@@ -173,6 +185,11 @@ bool QgsCodeEditorWidget::isSearchBarVisible() const
 QgsMessageBar *QgsCodeEditorWidget::messageBar()
 {
   return mMessageBar;
+}
+
+QgsScrollBarHighlightController *QgsCodeEditorWidget::scrollbarHighlightController()
+{
+  return mHighlightController.get();
 }
 
 void QgsCodeEditorWidget::showSearchBar()
@@ -260,8 +277,7 @@ void QgsCodeEditorWidget::addSearchHighlights()
   long startPos = 0;
   long docEnd = mEditor->length();
 
-  mHighlightController->setLineHeight( QFontMetrics( mEditor->font() ).lineSpacing() );
-  mHighlightController->setVisibleRange( mEditor->viewport()->rect().height() );
+  updateHighlightController();
 
   int searchFlags = 0;
   const bool isRegEx = mRegexButton->isChecked();
@@ -354,5 +370,11 @@ void QgsCodeEditorWidget::findText( bool forward, bool findFirst, bool showNotFo
   {
     mLineEditFind->setStyleSheet( QString() );
   }
+}
+
+void QgsCodeEditorWidget::updateHighlightController()
+{
+  mHighlightController->setLineHeight( QFontMetrics( mEditor->font() ).lineSpacing() );
+  mHighlightController->setVisibleRange( mEditor->viewport()->rect().height() );
 }
 

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -86,6 +86,26 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      */
     QgsScrollBarHighlightController *scrollbarHighlightController();
 
+    /**
+     * Adds a \a warning message and indicator to the specified a \a lineNumber.
+     *
+     * This method calls QgsCodeEditor::addWarning(), but also automatically adds
+     * highlights to the widget scrollbars locating the warning location.
+     *
+     * \see clearWarnings()
+     */
+    void addWarning( int lineNumber, const QString &warning );
+
+    /**
+     * Clears all warning messages from the editor.
+     *
+     * This method calls QgsCodeEditor::clearWarnings(), but also removes
+     * highlights from the widget scrollbars at the warning locations.
+     *
+     * \see addWarning()
+     */
+    void clearWarnings();
+
   public slots:
 
     /**

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -62,6 +62,9 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
                          QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsCodeEditorWidget() override;
 
+    void resizeEvent( QResizeEvent *event ) override;
+    void showEvent( QShowEvent *event ) override;
+
     /**
      * Returns the wrapped code editor.
      */
@@ -76,6 +79,12 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      * Returns the message bar associated with the widget, to use for user feedback.
      */
     QgsMessageBar *messageBar();
+
+    /**
+     * Returns the scrollbar highlight controller, which can be used to add highlights
+     * in the code editor scrollbar.
+     */
+    QgsScrollBarHighlightController *scrollbarHighlightController();
 
   public slots:
 
@@ -131,6 +140,7 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
     void addSearchHighlights();
     int searchFlags() const;
     void findText( bool forward, bool findFirst, bool showNotFoundWarning = false );
+    void updateHighlightController();
 
     enum HighlightCategory
     {


### PR DESCRIPTION
When warnings are shown inline in the code editors, also add a red highlight to the scrollbar