### PR TITLE
Speed up QgsRenderChecker 

### DIFF
--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -633,6 +633,8 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
   const int maxHeight = std::min( expectedImage.height(), myResultImage.height() );
   const int maxWidth = std::min( expectedImage.width(), myResultImage.width() );
 
+  const int maskWidth = maskImage.width();
+
   mMismatchCount = 0;
   const int colorTolerance = static_cast< int >( mColorTolerance );
   for ( int y = 0; y < maxHeight; ++y )
@@ -644,8 +646,9 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
 
     for ( int x = 0; x < maxWidth; ++x )
     {
-      const int maskTolerance = ( maskScanline && maskImage.width() > x ) ? qRed( maskScanline[ x ] ) : 0;
-      const int pixelTolerance = std::max( colorTolerance, maskTolerance );
+      const int pixelTolerance = maskScanline
+                                 ? std::max( colorTolerance, ( maskWidth > x ) ? qRed( maskScanline[ x ] ) : 0 )
+                                 : colorTolerance;
       if ( pixelTolerance == 255 )
       {
         //skip pixel

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -315,22 +315,6 @@ bool QgsRenderChecker::runTest( const QString &testName,
 
   mRenderedImage = job.renderedImage();
   Q_ASSERT( mRenderedImage.devicePixelRatioF() == mMapSettings.devicePixelRatio() );
-
-  //create a world file to go with the image...
-
-  QFile wldFile( QDir::tempPath() + '/' + testName + "_result.wld" );
-  if ( wldFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
-  {
-    const QgsRectangle r = mMapSettings.extent();
-
-    QTextStream stream( &wldFile );
-    stream << QStringLiteral( "%1\r\n0 \r\n0 \r\n%2\r\n%3\r\n%4\r\n" )
-           .arg( qgsDoubleToString( mMapSettings.mapUnitsPerPixel() ),
-                 qgsDoubleToString( -mMapSettings.mapUnitsPerPixel() ),
-                 qgsDoubleToString( r.xMinimum() + mMapSettings.mapUnitsPerPixel() / 2.0 ),
-                 qgsDoubleToString( r.yMaximum() - mMapSettings.mapUnitsPerPixel() / 2.0 ) );
-  }
-
   const bool res = compareImages( testName, mismatchCount, QString(), flags );
 
   if ( ! res )
@@ -348,6 +332,20 @@ bool QgsRenderChecker::runTest( const QString &testName,
 
       performPostTestActions( flags );
       return mResult;
+    }
+
+    //create a world file to go with the image...
+    QFile wldFile( QDir::tempPath() + '/' + testName + "_result.wld" );
+    if ( wldFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+    {
+      const QgsRectangle r = mMapSettings.extent();
+
+      QTextStream stream( &wldFile );
+      stream << QStringLiteral( "%1\r\n0 \r\n0 \r\n%2\r\n%3\r\n%4\r\n" )
+             .arg( qgsDoubleToString( mMapSettings.mapUnitsPerPixel() ),
+                   qgsDoubleToString( -mMapSettings.mapUnitsPerPixel() ),
+                   qgsDoubleToString( r.xMinimum() + mMapSettings.mapUnitsPerPixel() / 2.0 ),
+                   qgsDoubleToString( r.yMaximum() - mMapSettings.mapUnitsPerPixel() / 2.0 ) );
     }
   }
 

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -21,6 +21,7 @@
 #include <QColor>
 #include <QPainter>
 #include <QImage>
+#include <QImageReader>
 #include <QCryptographicHash>
 #include <QByteArray>
 #include <QDebug>
@@ -282,8 +283,8 @@ bool QgsRenderChecker::runTest( const QString &testName,
   //
   // Load the expected result pixmap
   //
-  const QImage myExpectedImage( mExpectedImageFile );
-  if ( myExpectedImage.isNull() )
+  const QImageReader expectedImageReader( mExpectedImageFile );
+  if ( !expectedImageReader.canRead() )
   {
     qDebug() << "QgsRenderChecker::runTest failed - Could not load expected image from " << mExpectedImageFile;
     mReport = "<table>"
@@ -294,13 +295,15 @@ bool QgsRenderChecker::runTest( const QString &testName,
     performPostTestActions( flags );
     return mResult;
   }
-  mMatchTarget = myExpectedImage.width() * myExpectedImage.height();
+
+  const QSize expectedSize = expectedImageReader.size();
+  mMatchTarget = expectedSize.width() * expectedSize.height();
   //
   // Now render our layers onto a pixmap
   //
   mMapSettings.setBackgroundColor( qRgb( 152, 219, 249 ) );
   mMapSettings.setFlag( Qgis::MapSettingsFlag::Antialiasing );
-  mMapSettings.setOutputSize( QSize( myExpectedImage.width(), myExpectedImage.height() ) / mMapSettings.devicePixelRatio() );
+  mMapSettings.setOutputSize( expectedSize / mMapSettings.devicePixelRatio() );
 
   QElapsedTimer myTime;
   myTime.start();

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -300,6 +300,7 @@ class CORE_EXPORT QgsRenderChecker
     QString mMarkdownReport;
     unsigned int mMatchTarget = 0;
     int mElapsedTime = 0;
+    QImage mRenderedImage;
     QString mRenderedImageFile;
     QString mExpectedImageFile;
 


### PR DESCRIPTION
Avoid unnecessary work when tests pass, and optimise the comparison of reference images

Cuts down the runtime for labeling tests to about 60% of previous times.