### PR TITLE
Fix pyqt5_to_pqt6 script when src_to_tokens returns duplicate tokens

### DIFF
--- a/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
+++ b/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
@@ -427,6 +427,7 @@ def fix_file(filename: str, qgis3_compat: bool) -> int:
     for i, token in reversed_enumerate(tokens):
         if token.offset in import_offsets:
             end_import_offset = Offset(*import_offsets[token.offset][-2:])
+            del import_offsets[token.offset]
             assert tokens[i].src == 'from'
             token_index = i + 1
             while not tokens[token_index].src.strip():


### PR DESCRIPTION
Sometimes src_to_tokens returns multiple tokens at the same offset. This is likely a bug in some versions of tokenize_rt, but this workaround avoids an exception occurring in the QGIS script.
