### PR TITLE
Don't write groups in random order in exported GeoPDFs

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -4599,7 +4599,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
     mLayout->setCustomProperty( QStringLiteral( "pdfOgcBestPracticeFormat" ), useOgcBestPracticeFormat ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfExportThemes" ), exportThemes.join( QLatin1String( "~~~" ) ) );
     mLayout->setCustomProperty( QStringLiteral( "pdfLayerOrder" ), geoPdfLayerOrder.join( QLatin1String( "~~~" ) ) );
-    mLayout->setCustomProperty( QStringLiteral( "pdfGroupOrder" ), dialog.geoPdfGroupOrder().join( QLatin1String( "~~~" ) ) );
+    mLayout->setCustomProperty( QStringLiteral( "pdfGroupOrder" ), dialog.geoPdfGroupOrder() );
     mLayout->setCustomProperty( QStringLiteral( "pdfLosslessImages" ), losslessImages ? 1 : 0 );
   }
 

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -4599,6 +4599,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
     mLayout->setCustomProperty( QStringLiteral( "pdfOgcBestPracticeFormat" ), useOgcBestPracticeFormat ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfExportThemes" ), exportThemes.join( QLatin1String( "~~~" ) ) );
     mLayout->setCustomProperty( QStringLiteral( "pdfLayerOrder" ), geoPdfLayerOrder.join( QLatin1String( "~~~" ) ) );
+    mLayout->setCustomProperty( QStringLiteral( "pdfGroupOrder" ), dialog.geoPdfGroupOrder().join( QLatin1String( "~~~" ) ) );
     mLayout->setCustomProperty( QStringLiteral( "pdfLosslessImages" ), losslessImages ? 1 : 0 );
   }
 

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -688,6 +688,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
       details.customLayerTreeGroups = geoPdfExporter->customLayerTreeGroups();
       details.initialLayerVisibility = geoPdfExporter->initialLayerVisibility();
       details.layerOrder = geoPdfExporter->layerOrder();
+      details.layerTreeGroupOrder = geoPdfExporter->layerTreeGroupOrder();
       details.includeFeatures = settings.includeGeoPdfFeatures;
       details.useOgcBestPracticeFormatGeoreferencing = settings.useOgcBestPracticeFormatGeoreferencing;
       details.useIso32000ExtensionFormatGeoreferencing = settings.useIso32000ExtensionFormatGeoreferencing;

--- a/src/core/layout/qgslayoutgeopdfexporter.cpp
+++ b/src/core/layout/qgslayoutgeopdfexporter.cpp
@@ -142,9 +142,7 @@ QgsLayoutGeoPdfExporter::QgsLayoutGeoPdfExporter( QgsLayout *layout )
     map->addRenderedFeatureHandler( handler );
   }
 
-  const QString presetGroupOrder = mLayout->customProperty( QStringLiteral( "pdfGroupOrder" ) ).toString();
-  if ( !presetGroupOrder.isEmpty() )
-    mLayerTreeGroupOrder = presetGroupOrder.split( QStringLiteral( "~~~" ) );
+  mLayerTreeGroupOrder = mLayout->customProperty( QStringLiteral( "pdfGroupOrder" ) ).toStringList();
 
   // start with project layer order, and then apply custom layer order if set
   QStringList geoPdfLayerOrder;

--- a/src/core/layout/qgslayoutgeopdfexporter.cpp
+++ b/src/core/layout/qgslayoutgeopdfexporter.cpp
@@ -142,6 +142,10 @@ QgsLayoutGeoPdfExporter::QgsLayoutGeoPdfExporter( QgsLayout *layout )
     map->addRenderedFeatureHandler( handler );
   }
 
+  const QString presetGroupOrder = mLayout->customProperty( QStringLiteral( "pdfGroupOrder" ) ).toString();
+  if ( !presetGroupOrder.isEmpty() )
+    mLayerTreeGroupOrder = presetGroupOrder.split( QStringLiteral( "~~~" ) );
+
   // start with project layer order, and then apply custom layer order if set
   QStringList geoPdfLayerOrder;
   const QString presetLayerOrder = mLayout->customProperty( QStringLiteral( "pdfLayerOrder" ) ).toString();

--- a/src/core/layout/qgslayoutgeopdfexporter.h
+++ b/src/core/layout/qgslayoutgeopdfexporter.h
@@ -57,6 +57,8 @@ class CORE_EXPORT QgsLayoutGeoPdfExporter : public QgsAbstractGeoPdfExporter
 
     /**
      * Returns any custom layer tree groups defined in the layer's settings.
+     *
+     * \see layerTreeGroupOrder()
      */
     QMap< QString, QString > customLayerTreeGroups() const { return mCustomLayerTreeGroups; }
 
@@ -72,9 +74,22 @@ class CORE_EXPORT QgsLayoutGeoPdfExporter : public QgsAbstractGeoPdfExporter
      * Optional list of map layer IDs in the order they should be shown in the generated GeoPDF layer tree.
      * Layer IDs earlier in the list will appear higher in the GeoPDF layer tree.
      *
+     * \see layerTreeGroupOrder()
      * \since QGIS 3.14
      */
     QStringList layerOrder() const { return mLayerOrder; }
+
+    /**
+     * Specifies the ordering of layer tree groups in the generated GeoPDF file.
+     *
+     * Groups appearing earlier in the list will show earlier in the GeoPDF layer tree list.
+     *
+     * \see layerOrder()
+     * \see customLayerTreeGroups()
+     *
+     * \since QGIS 3.38
+     */
+    QStringList layerTreeGroupOrder() const { return mLayerTreeGroupOrder; }
 
   private:
 
@@ -86,6 +101,7 @@ class CORE_EXPORT QgsLayoutGeoPdfExporter : public QgsAbstractGeoPdfExporter
     QMap< QString, bool > mInitialLayerVisibility;
     QMap< QString, QString > mCustomLayerTreeGroups;
     QStringList mLayerOrder;
+    QStringList mLayerTreeGroupOrder;
 
     friend class TestQgsLayoutGeoPdfExport;
 };

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -368,7 +368,7 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
   // filter out groups which don't have any content
   layerTreeGroupOrder.erase( std::remove_if( layerTreeGroupOrder.begin(), layerTreeGroupOrder.end(), [&details]( const QString & group )
   {
-    return details.customLayerTreeGroups.keys( group ).empty();
+    return details.customLayerTreeGroups.key( group ).isEmpty();
   } ), layerTreeGroupOrder.end() );
 
   QMap< QString, QString > customGroupNamesToIds;

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -270,7 +270,6 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
 
   QMap< QString, QSet< QString > > createdLayerIds;
   QMap< QString, QDomElement > groupLayerMap;
-  QMap< QString, QString > customGroupNamesToIds;
 
   QMultiMap< QString, QDomElement > pendingLayerTreeElements;
 
@@ -357,16 +356,32 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
   //layerTree.setAttribute( QStringLiteral("displayOnlyOnVisiblePages"), QStringLiteral("true"));
 
   // create custom layer tree entries
+  QStringList layerTreeGroupOrder = details.layerTreeGroupOrder;
+
+  // add any missing groups to end of order
   for ( auto it = details.customLayerTreeGroups.constBegin(); it != details.customLayerTreeGroups.constEnd(); ++it )
   {
-    if ( customGroupNamesToIds.contains( it.value() ) )
+    if ( layerTreeGroupOrder.contains( it.value() ) )
+      continue;
+    layerTreeGroupOrder.append( it.value() );
+  }
+  // filter out groups which don't have any content
+  layerTreeGroupOrder.erase( std::remove_if( layerTreeGroupOrder.begin(), layerTreeGroupOrder.end(), [&details]( const QString & group )
+  {
+    return details.customLayerTreeGroups.keys( group ).empty();
+  } ), layerTreeGroupOrder.end() );
+
+  QMap< QString, QString > customGroupNamesToIds;
+  for ( const QString &group : std::as_const( layerTreeGroupOrder ) )
+  {
+    if ( customGroupNamesToIds.contains( group ) )
       continue;
 
     QDomElement layer = doc.createElement( QStringLiteral( "Layer" ) );
     const QString id = QUuid::createUuid().toString();
-    customGroupNamesToIds[ it.value() ] = id;
+    customGroupNamesToIds[ group ] = id;
     layer.setAttribute( QStringLiteral( "id" ), id );
-    layer.setAttribute( QStringLiteral( "name" ), it.value() );
+    layer.setAttribute( QStringLiteral( "name" ), group );
     layer.setAttribute( QStringLiteral( "initiallyVisible" ), QStringLiteral( "true" ) );
     layerTree.appendChild( layer );
   }

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -259,6 +259,8 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
        *
        * Layers which are not included in this group will always have their own individual layer tree entry
        * created for them automatically.
+       *
+       * \see layerTreeGroupOrder
        */
       QMap< QString, QString > customLayerTreeGroups;
 
@@ -282,9 +284,23 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
        *
        * Layers appearing earlier in the list will show earlier in the GeoPDF layer tree list.
        *
+       * \see layerTreeGroupOrder
+       *
        * \since QGIS 3.14
        */
       QStringList layerOrder;
+
+      /**
+       * Specifies the ordering of layer tree groups in the generated GeoPDF file.
+       *
+       * Groups appearing earlier in the list will show earlier in the GeoPDF layer tree list.
+       *
+       * \see layerOrder
+       * \see customLayerTreeGroups
+       *
+       * \since QGIS 3.38
+       */
+      QStringList layerTreeGroupOrder;
 
     };
 

--- a/src/gui/layout/qgslayoutpdfexportoptionsdialog.cpp
+++ b/src/gui/layout/qgslayoutpdfexportoptionsdialog.cpp
@@ -261,6 +261,21 @@ QStringList QgsLayoutPdfExportOptionsDialog::geoPdfLayerOrder() const
   return order;
 }
 
+QStringList QgsLayoutPdfExportOptionsDialog::geoPdfGroupOrder() const
+{
+  // we don't explicitly expose a "group order" widget in the dialog -- rather
+  // we use the ordering of the layers, and build the group ordering based
+  // on grouped layers which appear first
+  QStringList groupOrder;
+  for ( int row = 0; row < mGeoPdfStructureProxyModel->rowCount(); ++row )
+  {
+    const QString group = mGeoPdfStructureProxyModel->data( mGeoPdfStructureProxyModel->index( row, QgsGeoPdfLayerTreeModel::GroupColumn ), Qt::DisplayRole ).toString().trimmed();
+    if ( !group.isEmpty() && !groupOrder.contains( group ) )
+      groupOrder << group;
+  }
+  return groupOrder;
+}
+
 void QgsLayoutPdfExportOptionsDialog::setOpenAfterExporting( bool enabled )
 {
   mOpenAfterExportingCheckBox->setChecked( enabled );

--- a/src/gui/layout/qgslayoutpdfexportoptionsdialog.h
+++ b/src/gui/layout/qgslayoutpdfexportoptionsdialog.h
@@ -107,6 +107,9 @@ class GUI_EXPORT QgsLayoutPdfExportOptionsDialog: public QDialog, private Ui::Qg
     //! Returns a list of map layer IDs in the desired order they should appear in a generated GeoPDF file
     QStringList geoPdfLayerOrder() const;
 
+    //! Returns a list of groups in the desired order they should appear in a generated GeoPDF file
+    QStringList geoPdfGroupOrder() const;
+
     //! Sets whether to open the pdf after exporting it
     void setOpenAfterExporting( bool enabled );
     //! Returns whether the pdf should be opened after exporting it

--- a/tests/src/core/testqgslayout.cpp
+++ b/tests/src/core/testqgslayout.cpp
@@ -161,30 +161,35 @@ void TestQgsLayout::name()
 void TestQgsLayout::customProperties()
 {
   QgsProject p;
-  QgsLayout *layout = new QgsLayout( &p );
+  QgsLayout layout( &p );
 
-  QCOMPARE( layout->customProperty( "noprop", "defaultval" ).toString(), QString( "defaultval" ) );
-  QVERIFY( layout->customProperties().isEmpty() );
-  layout->setCustomProperty( QStringLiteral( "testprop" ), "testval" );
-  QCOMPARE( layout->customProperty( "testprop", "defaultval" ).toString(), QString( "testval" ) );
-  QCOMPARE( layout->customProperties().length(), 1 );
-  QCOMPARE( layout->customProperties().at( 0 ), QString( "testprop" ) );
+  QCOMPARE( layout.customProperty( "noprop", "defaultval" ).toString(), QString( "defaultval" ) );
+  QVERIFY( layout.customProperties().isEmpty() );
+  layout.setCustomProperty( QStringLiteral( "testprop" ), "testval" );
+  QCOMPARE( layout.customProperty( "testprop", "defaultval" ).toString(), QString( "testval" ) );
+  QCOMPARE( layout.customProperties().length(), 1 );
+  QCOMPARE( layout.customProperties().at( 0 ), QString( "testprop" ) );
 
   //test no crash
-  layout->removeCustomProperty( QStringLiteral( "badprop" ) );
+  layout.removeCustomProperty( QStringLiteral( "badprop" ) );
 
-  layout->removeCustomProperty( QStringLiteral( "testprop" ) );
-  QVERIFY( layout->customProperties().isEmpty() );
-  QCOMPARE( layout->customProperty( "noprop", "defaultval" ).toString(), QString( "defaultval" ) );
+  layout.removeCustomProperty( QStringLiteral( "testprop" ) );
+  QVERIFY( layout.customProperties().isEmpty() );
+  QCOMPARE( layout.customProperty( "noprop", "defaultval" ).toString(), QString( "defaultval" ) );
 
-  layout->setCustomProperty( QStringLiteral( "testprop1" ), "testval1" );
-  layout->setCustomProperty( QStringLiteral( "testprop2" ), "testval2" );
-  const QStringList keys = layout->customProperties();
+  layout.setCustomProperty( QStringLiteral( "testprop1" ), "testval1" );
+  layout.setCustomProperty( QStringLiteral( "testprop2" ), "testval2" );
+  const QStringList keys = layout.customProperties();
   QCOMPARE( keys.length(), 2 );
   QVERIFY( keys.contains( "testprop1" ) );
   QVERIFY( keys.contains( "testprop2" ) );
 
-  delete layout;
+  // list value
+  layout.setCustomProperty( QStringLiteral( "a_list" ), QStringList{ QStringLiteral( "value 1" ),
+                            QStringLiteral( "value 2" ),
+                            QStringLiteral( "value 3" )} );
+  const QStringList res = layout.customProperty( QStringLiteral( "a_list" ) ).toStringList();
+  QCOMPARE( res, QStringList() << "value 1" << "value 2" << "value 3" );
 }
 
 void TestQgsLayout::writeRetrieveCustomProperties()
@@ -192,6 +197,10 @@ void TestQgsLayout::writeRetrieveCustomProperties()
   QgsLayout layout( QgsProject::instance() );
   layout.setCustomProperty( QStringLiteral( "testprop" ), "testval" );
   layout.setCustomProperty( QStringLiteral( "testprop2" ), 5 );
+  // list value
+  layout.setCustomProperty( QStringLiteral( "a_list" ), QStringList{ QStringLiteral( "value 1" ),
+                            QStringLiteral( "value 2" ),
+                            QStringLiteral( "value 3" )} );
 
   //test writing composition with custom properties
   QDomImplementation DomImplementation;
@@ -207,11 +216,13 @@ void TestQgsLayout::writeRetrieveCustomProperties()
   QVERIFY( readLayout.readXml( layoutNode, doc, QgsReadWriteContext() ) );
 
   //test retrieved custom properties
-  QCOMPARE( readLayout.customProperties().length(), 2 );
+  QCOMPARE( readLayout.customProperties().length(), 3 );
   QVERIFY( readLayout.customProperties().contains( QString( "testprop" ) ) );
   QVERIFY( readLayout.customProperties().contains( QString( "testprop2" ) ) );
   QCOMPARE( readLayout.customProperty( "testprop" ).toString(), QString( "testval" ) );
   QCOMPARE( readLayout.customProperty( "testprop2" ).toInt(), 5 );
+  const QStringList res = readLayout.customProperty( QStringLiteral( "a_list" ) ).toStringList();
+  QCOMPARE( res, QStringList() << "value 1" << "value 2" << "value 3" );
 }
 
 void TestQgsLayout::variablesEdited()

--- a/tests/src/core/testqgslayoutgeopdfexport.cpp
+++ b/tests/src/core/testqgslayoutgeopdfexport.cpp
@@ -41,6 +41,7 @@ class TestQgsLayoutGeoPdfExport : public QgsTest
     void testCollectingFeatures();
     void skipLayers();
     void layerOrder();
+    void groupOrder();
 };
 
 void TestQgsLayoutGeoPdfExport::initTestCase()
@@ -434,6 +435,27 @@ void TestQgsLayoutGeoPdfExport::layerOrder()
   l.setCustomProperty( QStringLiteral( "pdfLayerOrder" ), QStringLiteral( "%1~~~%2" ).arg( linesLayer->id(), polygonLayer->id() ) );
   const QgsLayoutGeoPdfExporter geoPdfExporter2( &l );
   QCOMPARE( geoPdfExporter2.layerOrder(), QStringList() << linesLayer->id() << polygonLayer->id() << pointsLayer->id() );
+}
+
+void TestQgsLayoutGeoPdfExport::groupOrder()
+{
+  QgsProject p;
+
+  QgsLayout l( &p );
+  l.initializeDefaults();
+  QgsLayoutItemMap *map = new QgsLayoutItemMap( &l );
+  map->attemptSetSceneRect( QRectF( 20, 20, 200, 100 ) );
+  map->setFrameEnabled( true );
+  l.addLayoutItem( map );
+
+  // no group ordering for layout
+  const QgsLayoutGeoPdfExporter geoPdfExporter( &l );
+  QVERIFY( geoPdfExporter.layerTreeGroupOrder().isEmpty() );
+
+  // custom group order is specified, respect that
+  l.setCustomProperty( QStringLiteral( "pdfGroupOrder" ), QStringLiteral( "group 1~~~GROUP C~~~group 2" ) );
+  const QgsLayoutGeoPdfExporter geoPdfExporter2( &l );
+  QCOMPARE( geoPdfExporter2.layerTreeGroupOrder(), QStringList() << QStringLiteral( "group 1" ) << QStringLiteral( "GROUP C" ) << QStringLiteral( "group 2" ) );
 }
 
 QGSTEST_MAIN( TestQgsLayoutGeoPdfExport )

--- a/tests/src/core/testqgslayoutgeopdfexport.cpp
+++ b/tests/src/core/testqgslayoutgeopdfexport.cpp
@@ -453,7 +453,7 @@ void TestQgsLayoutGeoPdfExport::groupOrder()
   QVERIFY( geoPdfExporter.layerTreeGroupOrder().isEmpty() );
 
   // custom group order is specified, respect that
-  l.setCustomProperty( QStringLiteral( "pdfGroupOrder" ), QStringLiteral( "group 1~~~GROUP C~~~group 2" ) );
+  l.setCustomProperty( QStringLiteral( "pdfGroupOrder" ), QStringList{ QStringLiteral( "group 1" ), QStringLiteral( "group 2" ) } );
   const QgsLayoutGeoPdfExporter geoPdfExporter2( &l );
   QCOMPARE( geoPdfExporter2.layerTreeGroupOrder(), QStringList() << QStringLiteral( "group 1" ) << QStringLiteral( "GROUP C" ) << QStringLiteral( "group 2" ) );
 }

--- a/tests/src/core/testqgslayoutgeopdfexport.cpp
+++ b/tests/src/core/testqgslayoutgeopdfexport.cpp
@@ -453,7 +453,7 @@ void TestQgsLayoutGeoPdfExport::groupOrder()
   QVERIFY( geoPdfExporter.layerTreeGroupOrder().isEmpty() );
 
   // custom group order is specified, respect that
-  l.setCustomProperty( QStringLiteral( "pdfGroupOrder" ), QStringList{ QStringLiteral( "group 1" ), QStringLiteral( "group 2" ) } );
+  l.setCustomProperty( QStringLiteral( "pdfGroupOrder" ), QStringList{ QStringLiteral( "group 1" ), QStringLiteral( "GROUP C" ), QStringLiteral( "group 2" ) } );
   const QgsLayoutGeoPdfExporter geoPdfExporter2( &l );
   QCOMPARE( geoPdfExporter2.layerTreeGroupOrder(), QStringList() << QStringLiteral( "group 1" ) << QStringLiteral( "GROUP C" ) << QStringLiteral( "group 2" ) );
 }


### PR DESCRIPTION
Previously, if layer groups were configured for a GeoPDF export then the resultant groups in the GeoPDF would be listed in a random order within the PDF viewer.

Instead, ensure that the groups are created to respect the ordering of layers from the GeoPDF export dialog, so that users can drag/drop and rearrange the layers and their corresponding groups and get a logical/predicatable order within the PDF.

Sponsored by Rubicon Concierge Real Estate Services
