### PR TITLE
[Grass] Fix East and West coordinates for mapset extent were flipped

### DIFF
--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -768,7 +768,7 @@ void QgsGrassNewMapset::setSelectedRegion()
     const QgsCoordinateReferenceSystem source( QStringLiteral( "EPSG:4326" ) );
     if ( !source.isValid() )
     {
-      QgsGrass::warning( tr( "Cannot create QgsCoordinateReferenceSystem" ) );
+      QgsGrass::warning( tr( "Cannot create Coordinate Reference System" ) );
       return;
     }
 
@@ -776,7 +776,7 @@ void QgsGrassNewMapset::setSelectedRegion()
 
     if ( !dest.isValid() )
     {
-      QgsGrass::warning( tr( "Cannot create QgsCoordinateReferenceSystem" ) );
+      QgsGrass::warning( tr( "Cannot create Coordinate Reference System" ) );
       return;
     }
 
@@ -882,8 +882,8 @@ void QgsGrassNewMapset::drawRegion()
   const QgsRectangle extent = mExtentWidget->outputExtent();
   double n = extent.yMaximum();
   double s = extent.yMinimum();
-  double e = extent.xMinimum();
-  double w = extent.xMaximum();
+  double e = extent.xMaximum();
+  double w = extent.xMinimum();
 
   // Shift if LL and W > E
   if ( mCellHead.proj == PROJECTION_LL && w > e )
@@ -931,7 +931,7 @@ void QgsGrassNewMapset::drawRegion()
 
     if ( !source.isValid() )
     {
-      QgsGrass::warning( tr( "Cannot create QgsCoordinateReferenceSystem" ) );
+      QgsGrass::warning( tr( "Cannot create Coordinate Reference System" ) );
       return;
     }
 
@@ -939,7 +939,7 @@ void QgsGrassNewMapset::drawRegion()
 
     if ( !dest.isValid() )
     {
-      QgsGrass::warning( tr( "Cannot create QgsCoordinateReferenceSystem" ) );
+      QgsGrass::warning( tr( "Cannot create Coordinate Reference System" ) );
       return;
     }
 


### PR DESCRIPTION
refs https://github.com/qgis/QGIS-Documentation/issues/9092
Before 
![image](https://github.com/qgis/QGIS/assets/7983394/7321b6ca-ac96-4571-9edc-90a04c8e9de8)

After
![image](https://github.com/qgis/QGIS/assets/7983394/2e311a02-72ea-4278-a50b-6752a98c8b48)
