### PR TITLE
pyqt5_to_pyqt6: Handle QPainter.HighQualityAntialiasing

### DIFF
--- a/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
+++ b/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
@@ -158,6 +158,7 @@ deprecated_renamed_enums = {
     ('Qt', 'MidButton'): ('MouseButton', 'MiddleButton'),
     ('Qt', 'TextColorRole'): ('ItemDataRole', 'ForegroundRole'),
     ('Qt', 'BackgroundColorRole'): ('ItemDataRole', 'BackgroundRole'),
+    ('QPainter', 'HighQualityAntialiasing'): ('RenderHint', 'Antialiasing'),
 }
 
 rename_function_attributes = {


### PR DESCRIPTION
This is obsolete even in Qt5, should be QPainter.RenderHint.Antialiasing
