### PR TITLE
Optimize python QgsFeature.setAttribute(s) calls

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsattributes.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsattributes.sip.in
@@ -81,6 +81,22 @@ typedef QVector<QVariant> QgsAttributes;
     {
       qv->append( QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( obj ) )
+    {
+      qv->append( QVariant( PyObject_IsTrue( obj ) == 1 ) );
+    }
+    else if ( PyLong_Check( obj ) )
+    {
+      qv->append( QVariant( PyLong_AsLongLong( obj ) ) );
+    }
+    else if ( PyFloat_Check( obj ) )
+    {
+      qv->append( QVariant( PyFloat_AsDouble( obj ) ) );
+    }
+    else if ( PyUnicode_Check( obj ) )
+    {
+      qv->append( QVariant( QString::fromUtf8( PyUnicode_AsUTF8( obj ) ) ) );
+    }
     else
     {
       int state;

--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -71,17 +71,47 @@ geometry and a list of field/values attributes.
     }
 %End
 
-    void __setitem__( int key, QVariant value /GetWrapper/ );
+    void __setitem__( int key, SIP_PYOBJECT value /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %MethodCode
     bool rv;
 
-    if ( a1Wrapper == Py_None )
+    if ( a1 == Py_None )
     {
       rv = sipCpp->setAttribute( a0, QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+    }
+    else if ( PyLong_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyLong_AsLongLong( a1 ) ) );
+    }
+    else if ( PyFloat_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyFloat_AsDouble( a1 ) ) );
+    }
+    else if ( PyUnicode_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+    }
+    else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+    {
+      int state;
+      QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        rv = false;
+      }
+      else
+      {
+        rv = sipCpp->setAttribute( a0, *qvariant );
+      }
+      sipReleaseType( qvariant, sipType_QVariant, state );
+    }
     else
     {
-      rv = sipCpp->setAttribute( a0, *a1 );
+      rv = false;
     }
 
     if ( !rv )
@@ -91,7 +121,7 @@ geometry and a list of field/values attributes.
     }
 %End
 
-    void __setitem__( const QString &key, QVariant value /GetWrapper/ );
+    void __setitem__( const QString &key, SIP_PYOBJECT value /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )
@@ -101,13 +131,39 @@ geometry and a list of field/values attributes.
     }
     else
     {
-      if ( a1Wrapper == Py_None )
+      if ( a1 == Py_None )
       {
-        sipCpp->setAttribute( *a0, QVariant( QVariant::Int ) );
+        sipCpp->setAttribute( fieldIdx, QVariant( QVariant::Int ) );
+      }
+      else if ( PyBool_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+      }
+      else if ( PyLong_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyLong_AsLongLong( a1 ) ) );
+      }
+      else if ( PyFloat_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyFloat_AsDouble( a1 ) ) );
+      }
+      else if ( PyUnicode_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+      }
+      else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+      {
+        int state;
+        QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( !sipIsErr )
+        {
+          sipCpp->setAttribute( fieldIdx, *qvariant );
+        }
+        sipReleaseType( qvariant, sipType_QVariant, state );
       }
       else
       {
-        sipCpp->setAttribute( fieldIdx, *a1 );
+        sipIsErr = 1;
       }
     }
 %End

--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -277,7 +277,7 @@ The number of provided attributes need to exactly match the number of the featur
 %End
 
 
-    bool setAttribute( int field, const QVariant &attr /GetWrapper/ );
+    bool setAttribute( int field, SIP_PYOBJECT attr /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %Docstring
 Sets an attribute's value by field index.
 
@@ -307,13 +307,43 @@ Alternatively, in Python it is possible to directly set a field's value via the 
 %MethodCode
     bool rv;
 
-    if ( a1Wrapper == Py_None )
+    if ( a1 == Py_None )
     {
       rv = sipCpp->setAttribute( a0, QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+    }
+    else if ( PyLong_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyLong_AsLongLong( a1 ) ) );
+    }
+    else if ( PyFloat_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyFloat_AsDouble( a1 ) ) );
+    }
+    else if ( PyUnicode_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+    }
+    else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+    {
+      int state;
+      QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        rv = false;
+      }
+      else
+      {
+        rv = sipCpp->setAttribute( a0, *qvariant );
+      }
+      sipReleaseType( qvariant, sipType_QVariant, state );
+    }
     else
     {
-      rv = sipCpp->setAttribute( a0, *a1 );
+      rv = false;
     }
 
     if ( !rv )
@@ -518,7 +548,7 @@ Returns the field map associated with the feature.
 %End
 
 
-    void setAttribute( const QString &name, const QVariant &value /GetWrapper/ );
+    void setAttribute( const QString &name, SIP_PYOBJECT value /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %Docstring
 Insert a value into attribute, by field ``name``.
 
@@ -556,13 +586,39 @@ Alternatively, in Python it is possible to directly set a field's value via the 
     }
     else
     {
-      if ( a1Wrapper == Py_None )
+      if ( a1 == Py_None )
       {
-        sipCpp->setAttribute( *a0, QVariant( QVariant::Int ) );
+        sipCpp->setAttribute( fieldIdx, QVariant( QVariant::Int ) );
+      }
+      else if ( PyBool_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+      }
+      else if ( PyLong_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyLong_AsLongLong( a1 ) ) );
+      }
+      else if ( PyFloat_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyFloat_AsDouble( a1 ) ) );
+      }
+      else if ( PyUnicode_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+      }
+      else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+      {
+        int state;
+        QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( !sipIsErr )
+        {
+          sipCpp->setAttribute( fieldIdx, *qvariant );
+        }
+        sipReleaseType( qvariant, sipType_QVariant, state );
       }
       else
       {
-        sipCpp->setAttribute( fieldIdx, *a1 );
+        sipIsErr = 1;
       }
     }
 %End

--- a/python/core/auto_generated/qgsattributes.sip.in
+++ b/python/core/auto_generated/qgsattributes.sip.in
@@ -81,6 +81,22 @@ typedef QVector<QVariant> QgsAttributes;
     {
       qv->append( QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( obj ) )
+    {
+      qv->append( QVariant( PyObject_IsTrue( obj ) == 1 ) );
+    }
+    else if ( PyLong_Check( obj ) )
+    {
+      qv->append( QVariant( PyLong_AsLongLong( obj ) ) );
+    }
+    else if ( PyFloat_Check( obj ) )
+    {
+      qv->append( QVariant( PyFloat_AsDouble( obj ) ) );
+    }
+    else if ( PyUnicode_Check( obj ) )
+    {
+      qv->append( QVariant( QString::fromUtf8( PyUnicode_AsUTF8( obj ) ) ) );
+    }
     else
     {
       int state;

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -71,17 +71,47 @@ geometry and a list of field/values attributes.
     }
 %End
 
-    void __setitem__( int key, QVariant value /GetWrapper/ );
+    void __setitem__( int key, SIP_PYOBJECT value /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %MethodCode
     bool rv;
 
-    if ( a1Wrapper == Py_None )
+    if ( a1 == Py_None )
     {
       rv = sipCpp->setAttribute( a0, QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+    }
+    else if ( PyLong_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyLong_AsLongLong( a1 ) ) );
+    }
+    else if ( PyFloat_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyFloat_AsDouble( a1 ) ) );
+    }
+    else if ( PyUnicode_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+    }
+    else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+    {
+      int state;
+      QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        rv = false;
+      }
+      else
+      {
+        rv = sipCpp->setAttribute( a0, *qvariant );
+      }
+      sipReleaseType( qvariant, sipType_QVariant, state );
+    }
     else
     {
-      rv = sipCpp->setAttribute( a0, *a1 );
+      rv = false;
     }
 
     if ( !rv )
@@ -91,7 +121,7 @@ geometry and a list of field/values attributes.
     }
 %End
 
-    void __setitem__( const QString &key, QVariant value /GetWrapper/ );
+    void __setitem__( const QString &key, SIP_PYOBJECT value /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )
@@ -101,13 +131,39 @@ geometry and a list of field/values attributes.
     }
     else
     {
-      if ( a1Wrapper == Py_None )
+      if ( a1 == Py_None )
       {
-        sipCpp->setAttribute( *a0, QVariant( QVariant::Int ) );
+        sipCpp->setAttribute( fieldIdx, QVariant( QVariant::Int ) );
+      }
+      else if ( PyBool_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+      }
+      else if ( PyLong_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyLong_AsLongLong( a1 ) ) );
+      }
+      else if ( PyFloat_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyFloat_AsDouble( a1 ) ) );
+      }
+      else if ( PyUnicode_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+      }
+      else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+      {
+        int state;
+        QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( !sipIsErr )
+        {
+          sipCpp->setAttribute( fieldIdx, *qvariant );
+        }
+        sipReleaseType( qvariant, sipType_QVariant, state );
       }
       else
       {
-        sipCpp->setAttribute( fieldIdx, *a1 );
+        sipIsErr = 1;
       }
     }
 %End

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -277,7 +277,7 @@ The number of provided attributes need to exactly match the number of the featur
 %End
 
 
-    bool setAttribute( int field, const QVariant &attr /GetWrapper/ );
+    bool setAttribute( int field, SIP_PYOBJECT attr /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %Docstring
 Sets an attribute's value by field index.
 
@@ -307,13 +307,43 @@ Alternatively, in Python it is possible to directly set a field's value via the 
 %MethodCode
     bool rv;
 
-    if ( a1Wrapper == Py_None )
+    if ( a1 == Py_None )
     {
       rv = sipCpp->setAttribute( a0, QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+    }
+    else if ( PyLong_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyLong_AsLongLong( a1 ) ) );
+    }
+    else if ( PyFloat_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyFloat_AsDouble( a1 ) ) );
+    }
+    else if ( PyUnicode_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+    }
+    else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+    {
+      int state;
+      QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        rv = false;
+      }
+      else
+      {
+        rv = sipCpp->setAttribute( a0, *qvariant );
+      }
+      sipReleaseType( qvariant, sipType_QVariant, state );
+    }
     else
     {
-      rv = sipCpp->setAttribute( a0, *a1 );
+      rv = false;
     }
 
     if ( !rv )
@@ -518,7 +548,7 @@ Returns the field map associated with the feature.
 %End
 
 
-    void setAttribute( const QString &name, const QVariant &value /GetWrapper/ );
+    void setAttribute( const QString &name, SIP_PYOBJECT value /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ );
 %Docstring
 Insert a value into attribute, by field ``name``.
 
@@ -556,13 +586,39 @@ Alternatively, in Python it is possible to directly set a field's value via the 
     }
     else
     {
-      if ( a1Wrapper == Py_None )
+      if ( a1 == Py_None )
       {
-        sipCpp->setAttribute( *a0, QVariant( QVariant::Int ) );
+        sipCpp->setAttribute( fieldIdx, QVariant( QVariant::Int ) );
+      }
+      else if ( PyBool_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+      }
+      else if ( PyLong_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyLong_AsLongLong( a1 ) ) );
+      }
+      else if ( PyFloat_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyFloat_AsDouble( a1 ) ) );
+      }
+      else if ( PyUnicode_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+      }
+      else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+      {
+        int state;
+        QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( !sipIsErr )
+        {
+          sipCpp->setAttribute( fieldIdx, *qvariant );
+        }
+        sipReleaseType( qvariant, sipType_QVariant, state );
       }
       else
       {
-        sipCpp->setAttribute( fieldIdx, *a1 );
+        sipIsErr = 1;
       }
     }
 %End

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -201,6 +201,22 @@ typedef QVector<QVariant> QgsAttributes;
     {
       qv->append( QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( obj ) )
+    {
+      qv->append( QVariant( PyObject_IsTrue( obj ) == 1 ) );
+    }
+    else if ( PyLong_Check( obj ) )
+    {
+      qv->append( QVariant( PyLong_AsLongLong( obj ) ) );
+    }
+    else if ( PyFloat_Check( obj ) )
+    {
+      qv->append( QVariant( PyFloat_AsDouble( obj ) ) );
+    }
+    else if ( PyUnicode_Check( obj ) )
+    {
+      qv->append( QVariant( QString::fromUtf8( PyUnicode_AsUTF8( obj ) ) ) );
+    }
     else
     {
       int state;

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -106,17 +106,47 @@ class CORE_EXPORT QgsFeature
     }
     % End
 
-    void __setitem__( int key, QVariant value / GetWrapper / );
+    void __setitem__( int key, SIP_PYOBJECT value SIP_TYPEHINT( Optional[Union[bool, int, float, str, QVariant]] ) );
     % MethodCode
     bool rv;
 
-    if ( a1Wrapper == Py_None )
+    if ( a1 == Py_None )
     {
       rv = sipCpp->setAttribute( a0, QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+    }
+    else if ( PyLong_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyLong_AsLongLong( a1 ) ) );
+    }
+    else if ( PyFloat_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyFloat_AsDouble( a1 ) ) );
+    }
+    else if ( PyUnicode_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+    }
+    else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+    {
+      int state;
+      QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        rv = false;
+      }
+      else
+      {
+        rv = sipCpp->setAttribute( a0, *qvariant );
+      }
+      sipReleaseType( qvariant, sipType_QVariant, state );
+    }
     else
     {
-      rv = sipCpp->setAttribute( a0, *a1 );
+      rv = false;
     }
 
     if ( !rv )
@@ -126,7 +156,7 @@ class CORE_EXPORT QgsFeature
     }
     % End
 
-    void __setitem__( const QString &key, QVariant value / GetWrapper / );
+    void __setitem__( const QString &key, SIP_PYOBJECT value SIP_TYPEHINT( Optional[Union[bool, int, float, str, QVariant]] ) );
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )
@@ -136,13 +166,39 @@ class CORE_EXPORT QgsFeature
     }
     else
     {
-      if ( a1Wrapper == Py_None )
+      if ( a1 == Py_None )
       {
-        sipCpp->setAttribute( *a0, QVariant( QVariant::Int ) );
+        sipCpp->setAttribute( fieldIdx, QVariant( QVariant::Int ) );
+      }
+      else if ( PyBool_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+      }
+      else if ( PyLong_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyLong_AsLongLong( a1 ) ) );
+      }
+      else if ( PyFloat_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyFloat_AsDouble( a1 ) ) );
+      }
+      else if ( PyUnicode_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+      }
+      else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+      {
+        int state;
+        QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( !sipIsErr )
+        {
+          sipCpp->setAttribute( fieldIdx, *qvariant );
+        }
+        sipReleaseType( qvariant, sipType_QVariant, state );
       }
       else
       {
-        sipCpp->setAttribute( fieldIdx, *a1 );
+        sipIsErr = 1;
       }
     }
     % End

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -364,17 +364,47 @@ class CORE_EXPORT QgsFeature
      * \throws KeyError if the field index does not exist
      * \see setAttributes()
      */
-    bool setAttribute( int field, const QVariant &attr / GetWrapper / );
+    bool setAttribute( int field, SIP_PYOBJECT attr SIP_TYPEHINT( Optional[Union[bool, int, float, str, QVariant]] ) );
     % MethodCode
     bool rv;
 
-    if ( a1Wrapper == Py_None )
+    if ( a1 == Py_None )
     {
       rv = sipCpp->setAttribute( a0, QVariant( QVariant::Int ) );
     }
+    else if ( PyBool_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+    }
+    else if ( PyLong_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyLong_AsLongLong( a1 ) ) );
+    }
+    else if ( PyFloat_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( PyFloat_AsDouble( a1 ) ) );
+    }
+    else if ( PyUnicode_Check( a1 ) )
+    {
+      rv = sipCpp->setAttribute( a0, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+    }
+    else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+    {
+      int state;
+      QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        rv = false;
+      }
+      else
+      {
+        rv = sipCpp->setAttribute( a0, *qvariant );
+      }
+      sipReleaseType( qvariant, sipType_QVariant, state );
+    }
     else
     {
-      rv = sipCpp->setAttribute( a0, *a1 );
+      rv = false;
     }
 
     if ( !rv )
@@ -618,7 +648,7 @@ class CORE_EXPORT QgsFeature
      * \throws KeyError if the attribute name could not could not be matched.
      * \see setFields()
      */
-    void setAttribute( const QString &name, const QVariant &value / GetWrapper / );
+    void setAttribute( const QString &name, SIP_PYOBJECT value SIP_TYPEHINT( Optional[Union[bool, int, float, str, QVariant]] ) );
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )
@@ -628,13 +658,39 @@ class CORE_EXPORT QgsFeature
     }
     else
     {
-      if ( a1Wrapper == Py_None )
+      if ( a1 == Py_None )
       {
-        sipCpp->setAttribute( *a0, QVariant( QVariant::Int ) );
+        sipCpp->setAttribute( fieldIdx, QVariant( QVariant::Int ) );
+      }
+      else if ( PyBool_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyObject_IsTrue( a1 ) == 1 ) );
+      }
+      else if ( PyLong_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyLong_AsLongLong( a1 ) ) );
+      }
+      else if ( PyFloat_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( PyFloat_AsDouble( a1 ) ) );
+      }
+      else if ( PyUnicode_Check( a1 ) )
+      {
+        sipCpp->setAttribute( fieldIdx, QVariant( QString::fromUtf8( PyUnicode_AsUTF8( a1 ) ) ) );
+      }
+      else if ( sipCanConvertToType( a1, sipType_QVariant, SIP_NOT_NONE ) )
+      {
+        int state;
+        QVariant *qvariant = reinterpret_cast<QVariant *>( sipConvertToType( a1, sipType_QVariant, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( !sipIsErr )
+        {
+          sipCpp->setAttribute( fieldIdx, *qvariant );
+        }
+        sipReleaseType( qvariant, sipType_QVariant, state );
       }
       else
       {
-        sipCpp->setAttribute( fieldIdx, *a1 );
+        sipIsErr = 1;
       }
     }
     % End

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -234,6 +234,52 @@ class TestQgsFeature(QgisTestCase):
             feat[0] = attribute
             self.assertEqual(feat.attribute(0), attribute)
 
+    def test_SetAttributeByName(self):
+        fields = QgsFields()
+        field1 = QgsField('my_field')
+        fields.append(field1)
+        field2 = QgsField('my_field2')
+        fields.append(field2)
+
+        feat = QgsFeature(fields)
+        feat.initAttributes(2)
+
+        feat['my_field'] = 'foo'
+        feat['my_field2'] = 'bah'
+        self.assertEqual(feat.attributes(), ['foo', 'bah'])
+        self.assertEqual(feat.attribute('my_field'), 'foo')
+        self.assertEqual(feat.attribute('my_field2'), 'bah')
+
+        # Test different type of attributes
+        attributes = [
+            {'name': 'int', 'value': -9585674563452},
+            {'name': 'float', 'value': 34.3},
+            {'name': 'bool', 'value': False},
+            {'name': 'string', 'value': 'QGIS'},
+            {'name': 'variant', 'value': QVariant('foo')},
+            {'name': 'date', 'value': QDate(2023, 1, 1)},
+            {'name': 'time', 'value': QTime(12, 11, 10)},
+            {'name': 'datetime', 'value': QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10))}
+        ]
+        fields = QgsFields()
+        for attribute in attributes:
+            fields.append(QgsField(attribute['name']))
+
+        feat = QgsFeature(fields)
+        feat.initAttributes(len(attributes))
+
+        for attr in attributes:
+            name = attr['name']
+            value = attr['value']
+            feat.setAttribute(name, value)
+            self.assertEqual(feat.attribute(name), value)
+
+            feat.setAttribute(name, None)
+            self.assertEqual(feat.attribute(name), NULL)
+
+            feat[name] = value
+            self.assertEqual(feat.attribute(name), value)
+
     def test_DeleteAttribute(self):
         feat = QgsFeature()
         feat.initAttributes(3)

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -25,6 +25,8 @@ from qgis.core import (
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
+from qgis.PyQt.QtCore import QVariant, QDate, QTime, QDateTime
+
 from utilities import unitTestDataPath
 
 start_app()
@@ -183,6 +185,24 @@ class TestQgsFeature(QgisTestCase):
         feat.setAttributes([NULL])
         assert [NULL] == feat.attributes()
 
+        # Test different type of attributes
+        attributes = [
+            -95985674563452,
+            12,
+            34.3,
+            False,
+            "QGIS",
+            "some value",
+            QVariant("foo"),
+            QDate(2023, 1, 1),
+            QTime(12, 11, 10),
+            QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)),
+            True
+        ]
+        feat.initAttributes(len(attributes))
+        feat.setAttributes(attributes)
+        self.assertEqual(feat.attributes(), attributes)
+
     def test_setAttribute(self):
         feat = QgsFeature()
         feat.initAttributes(1)
@@ -191,6 +211,28 @@ class TestQgsFeature(QgisTestCase):
         with self.assertRaises(KeyError):
             feat.setAttribute(10, 5)
         self.assertTrue(feat.setAttribute(0, 5))
+
+        # Test different type of attributes
+        attributes = [
+            -9585674563452,
+            34.3,
+            False,
+            "QGIS",
+            QVariant("foo"),
+            QDate(2023, 1, 1),
+            QTime(12, 11, 10),
+            QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10))
+        ]
+        self.assertEqual(feat.attributeCount(), 1)
+        for attribute in attributes:
+            self.assertTrue(feat.setAttribute(0, attribute))
+            self.assertEqual(feat.attribute(0), attribute)
+
+            feat.setAttribute(0, None)
+            self.assertEqual(feat.attribute(0), NULL)
+
+            feat[0] = attribute
+            self.assertEqual(feat.attribute(0), attribute)
 
     def test_DeleteAttribute(self):
         feat = QgsFeature()


### PR DESCRIPTION
## Description

### Context
I have encountered some performance issues while working on a [python plugin](https://plugins.qgis.org/plugins/qduckdb/) to provide a [duckdb](https://duckdb.org/) provider. DuckDB is a file based database (like SQLite) which has an extension to handle spatial data. Is is well suited to handle tabular data and formats such as [parquet](https://parquet.apache.org/).

I wanted to benchmark some performance of the `duckdb` provider.     
I used some dataset of the buildings of New York City. It contains 1_607_055 geometries and 5 attributes (1 integer and 4 string). The database was saved in the duckdb and shapefile format. 
The `ogr` format needs 6 seconds to read all the features while the `duckdb` provider needs 18.2 seconds.    
I have found this result quite puzzling. Of course, I did not expect the `duckdb` provider to beat the `ogr` provider. A provider written in python could not beat come some c++ code but I would not have expected such a difference.    

The python code of the provider itself is quite simple. It just creates a SQL query  based on the QGIS request, calls duckdb to execute it and then sets features by calling QgsFeature.setId / setGeometry / setAttributes and so on. There is not much that could be achieved on the python side. 

### Some initial benchmark

So, I have tried to understand what takes most of the time. It turns out than a python provider which does absolutely nothing needs 3.4 seconds to process 1_607_055 features. I guess, this is price we have to pay because of the python overlay.    
However, I was surprised that most of the time is spent on the `QgsFeature.setAttributes` call. Some details

| operation | duration | total percentage | accumulated time |
|-----------|-------|-------------|----|
| empty loop | 3.40s | 18.72% |3.40s |
| duckdb "SELECT" request | 0.23s | 1.26% | 3.63s |
| fetch (duckdb) | 2.72s | 14.98% | 6.35s |
| feature.setFields | 0.98s | 5.40% | 7.33s |
| QgsGeomettry creation + feature.setGeometry | 3.44s | 18.94% | 10.77s |
| feature.setId | 0.36s | 1.98% | 11.13s  |
| feature.setAttributes | 7.03s | 38.71% | 18.16s |


In other words, this means that this simple python code takes 7.33 seconds:

```py
feature = QgsFeature()
for _ in range(1_607_055):
    feature.setAttributes([42, "foo", "bah", "hello world", "QGIS"])
```
Could we do better? I hope so. 

### The setAttributes performance improvement

On the c++ side, a `QgsAttributes` is nothing more than a List of `QVariant` and the sip call to instantiate it just iterates the python list and calls `sipConvertToType`. This call takes a lot of time. Based of some investigation it looks this function needs to make an intermediate allocation which slows things down a lot.   
It turns out, that in some cases, on can simply avoid the `sipConvertToType`. The idea is to check the type of the input `attribute`. If this is a boolean, an integer, a float or a string, one can directly call the appropriate function of the python c API.

With this change, the previous `setAttributes` call now takes only 2s. A **72.7%** increased performance. Not bad. Not bad at all :-)

### Let's improve setAttribute too

The python `QgsFeature.setAttribute` has the same issue. So, I have made a similar change and I have measured up to **80%** gain.  Yeah :-)     
Moreover, there is no loss of performance if the attribute is already a `QVariant`. I have just measured how much times it takes to call 1_607_055 times `setAttribute`

|  | before | after|
| ------ | ------ |------ |
| integer |  1.71 s | 0.34 s |
| boolean |  1.70 s | 0.29 s |
| float |  1.79 s | 0.42 s |
| string |  2.07 s | 0.59 s |
| QVariant |  2.68 s | 2.68 s |

### The Qt6 situation 

The tests were done with the Qt5 version of QGIS in release mode. I have tried both sip4 and sip6. I got similar results. It looks like the sip version has no effect on the performance. 

I have also tested the Qt6 version of QGIS. It looks like Qt6 gained some performance to handle `QVariant`. However, one call still measure a lot nice improvements: 

|  | before | after|
| ------ | ------ |------ |
| integer |  0.81 s | 0,36 s |
| boolean |  0.76 s | 0.31 s |
| float |  0.90 s | 0.44 s |
| string |  1.28 s | 0.82 s |
| QVariant |  1.39 s | 1.39 s |
| setAttributes (1 integer et 4 strings) | 3.12 s | 1.04 s |


I am well aware that this PR changes some critical part of QGIS core source code. However, I think that the new performance is quite promising. I have tried all the unit test and I haven't noticed any regression. What do you think? Suggestions welcome!
