### PR TITLE
Fix wrongly displayed action widget

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -707,10 +707,9 @@ QModelIndex QgsAttributeTableFilterModel::mapToSource( const QModelIndex &proxyI
 
   int sourceColumn = mapColumnToSource( proxyIndex.column() );
 
-  // For the action column there is no matching column in the source model, just return the first one
-  // so we are still able to query for the feature id, the feature...
+  // For the action column there is no matching column in the source model, just return invalid
   if ( sourceColumn == -1 )
-    sourceColumn = 0;
+    return QModelIndex();
 
   return QSortFilterProxyModel::mapToSource( index( proxyIndex.row(), sourceColumn, proxyIndex.parent() ) );
 }
@@ -738,4 +737,19 @@ Qt::ItemFlags QgsAttributeTableFilterModel::flags( const QModelIndex &index ) co
 
   const QModelIndex source_index = mapToSource( index );
   return masterModel()->flags( source_index );
+}
+
+QModelIndex QgsAttributeTableFilterModel::mapToMaster( const QModelIndex &proxyIndex ) const
+{
+  if ( !proxyIndex.isValid() )
+    return QModelIndex();
+
+  int sourceColumn = mapColumnToSource( proxyIndex.column() );
+
+  // For the action column there is no matching column in the source model, just return the first one
+  // so we are still able to query for the feature id, the feature...
+  if ( sourceColumn == -1 )
+    sourceColumn = 0;
+
+  return QSortFilterProxyModel::mapToSource( index( proxyIndex.row(), sourceColumn, proxyIndex.parent() ) );
 }

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -191,7 +191,7 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
 
     QModelIndexList fidToIndexList( QgsFeatureId fid );
 
-    inline QModelIndex mapToMaster( const QModelIndex &proxyIndex ) const { return mapToSource( proxyIndex ); }
+    QModelIndex mapToMaster( const QModelIndex &proxyIndex ) const;
 
     inline QModelIndex mapFromMaster( const QModelIndex &sourceIndex ) const { return mapFromSource( sourceIndex ); }
 

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -638,6 +638,15 @@ void TestQgsAttributeTable::testOrderColumn()
 
   // column 0 is indeed column 2 since we move it
   QCOMPARE( filterModel->sortColumn(), 2 );
+
+  // Assume an action column at the index 0,3
+  // When we request the source index, it should be invalid (because there is no source of this column)
+  index = filterModel->mapToSource( filterModel->sourceModel()->index( 0, 3 ) );
+  QVERIFY( index.isValid() );
+  // "hen we request the source index by mapToMaster, there should be returned the source index of the first column
+  // that's done to provide the feature
+  index = filterModel->mapToMaster( filterModel->sourceModel()->index( 0, 3 ) );
+  QCOMPARE( index.column(), 0 );
 }
 
 void TestQgsAttributeTable::testFilteredFeatures()


### PR DESCRIPTION
Issue was, that the action widget magically appeared on the column of the field that had the index.column 0 in the source model. This even could lead to crashes, when you clicked them. 

The widget was painted wrongly, because after sort / delete / insert - basically every model reset - it requests apparently the index of the action with `mapToSource`, cannot find it's source, returns the source of the first column and redraws the widget where it's represented in the filter model view. This was all done in background. I deeply investigated into the function `onActionColumnItemPainted` with `setWidgetIndex` but it's all good there.

The function `mapToSource` is reimplemented, because it needs to map the correct column (because they could be reordered). There, if the index of the actionWidget is requested, there is no valid source, so it's passing back the source index of the first "real" column instead. This because sometimes it needs just the information of the feature. E.g. to provide the feature list in the form view (of the attribute table) - if the action has been the first column, there where problems then.

But since it's an override it somehow calls this function and triggers the map to 0 for invalid indexes, what it shouldn't. I've seen then, that this function `mapToSource` was usually called directly by `mapToMaster`. So I decided to implement this function with passing back the column 0 there instead in an override function. 

 This fixes #33464 and fixes #57398 and fixes #56966

I'm wondering if it should be the same for `mapFromMaster` passing to `mapFromSource`, where it uses 0 as well as the column if the column cannot be mapped *from* the source. But I cannot imagine this use case - maybe for hidden columns? Anyway, I prefer not to do things here that are not needed. After all it's the attribute table...


