### PR TITLE
Assorted set of fixes related to DateTime Z formatter

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5807,9 +5807,13 @@ static QVariant fcnFormatNumber( const QVariantList &values, const QgsExpression
 
 static QVariant fcnFormatDate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
+  QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
   const QString format = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   const QString language = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+
+  // Convert to UTC if the format string includes a Z, as QLocale::toString() doesn't do it
+  if ( format.indexOf( "Z" ) > 0 )
+    datetime = datetime.toUTC();
 
   QLocale locale = !language.isEmpty() ? QLocale( language ) : QLocale();
   return locale.toString( datetime, format );

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
@@ -95,6 +95,10 @@ QString QgsDateTimeFieldFormatter::representValue( QgsVectorLayer *layer, int fi
     }
     else
     {
+      // Convert to UTC if the format string includes a Z, as QLocale::toString() doesn't do it
+      if ( displayFormat.indexOf( "Z" ) > 0 )
+        date = date.toUTC();
+
       result = date.toString( displayFormat );
     }
   }

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -354,6 +354,9 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     void invalidateNetworkCache();
 
     bool mShapefileHadSpatialIndex = false;
+
+    //! Whether to convert Qt DateTime with local time to UTC
+    bool mConvertLocalTimeToUTC = false;
 };
 
 ///@endcond

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -346,6 +346,9 @@ void QgsDateTimeEdit::setDateTime( const QDateTime &dateTime )
   {
     // changed emits a signal, so don't allow it to be emitted from setDateTime
     mBlockChangedSignal++;
+    // We need to set the time spec of the set datetime to the widget, otherwise
+    // the dateTime() getter would loose edit, and return local time.
+    QDateTimeEdit::setTimeSpec( dateTime.timeSpec() );
     QDateTimeEdit::setDateTime( dateTime );
     mBlockChangedSignal--;
     changed( dateTime );

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -411,6 +411,18 @@ QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer *vl, int fieldIdx, 
 
 void QgsDateTimeEditConfig::updateDemoWidget()
 {
+  // Use a UTC datetime if the format string includes a Z
+  if ( mDisplayFormatEdit->text().indexOf( "Z" ) > 0 )
+  {
+    mDemoDateTimeEdit->setTimeSpec( Qt::UTC );
+    mDemoDateTimeEdit->setDateTime( QDateTime::currentDateTimeUtc() );
+  }
+  else
+  {
+    mDemoDateTimeEdit->setTimeSpec( Qt::LocalTime );
+    mDemoDateTimeEdit->setDateTime( QDateTime::currentDateTime() );
+  }
+
   mDemoDateTimeEdit->setDisplayFormat( mDisplayFormatEdit->text() );
   mDemoDateTimeEdit->setCalendarPopup( mCalendarPopupCheckBox->isChecked() );
 }

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -271,6 +271,12 @@ void QgsDateTimeEditWrapper::updateValues( const QVariant &value, const QVariant
 
   if ( mQgsDateTimeEdit )
   {
+    // Convert to UTC if the format string includes a Z
+    if ( mQgsDateTimeEdit->displayFormat().indexOf( "Z" ) > 0 )
+    {
+      dateTime = dateTime.toUTC();
+    }
+
     mQgsDateTimeEdit->setDateTime( dateTime );
   }
   else

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1875,6 +1875,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "time from format and language" ) << "to_time('12:34:56','HH:mm:ss','fr')" << false << QVariant( QTime( 12, 34, 56 ) );
       QTest::newRow( "formatted string from date" ) << "format_date('2019-06-29','MMMM d, yyyy')" << false << QVariant( QString( "June 29, 2019" ) );
       QTest::newRow( "formatted string from date with language" ) << "format_date('2019-06-29','d MMMM yyyy','fr')" << false << QVariant( QString( "29 juin 2019" ) );
+      QTest::newRow( "formatted string with Z" ) << "format_date(to_datetime('2019-06-29T13:34:56+01:00'),'yyyy-MM-ddTHH:mm:ssZ')" << false << QVariant( QString( "2019-06-29T12:34:56Z" ) );
 
       // Color functions
       QTest::newRow( "ramp color" ) << "ramp_color('Spectral',0.3)" << false << QVariant( "253,190,116,255" );

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -2715,6 +2715,34 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
         got = [feat for feat in vl.getFeatures()]
         self.assertEqual(got[0]["dt"], new_dt)
 
+    def testWriteDateTimeFromLocalTime(self):
+
+        tmpfile = os.path.join(self.basetestpath, 'testWriteDateTimeFromLocalTime.gpkg')
+        ds = ogr.GetDriverByName('GPKG').CreateDataSource(tmpfile)
+        lyr = ds.CreateLayer('test', geom_type=ogr.wkbNone)
+        lyr.CreateField(ogr.FieldDefn('dt', ogr.OFTDateTime))
+        ds = None
+
+        vl = QgsVectorLayer(tmpfile, 'test', 'ogr')
+
+        f = QgsFeature(vl.fields())
+        dt = QDateTime(QDate(2023, 1, 28), QTime(12, 34, 56, 789), Qt.TimeSpec.LocalTime)
+        f.setAttribute(1, dt)
+        self.assertTrue(vl.startEditing())
+        self.assertTrue(vl.addFeatures([f]))
+        self.assertTrue(vl.commitChanges())
+
+        got = [feat for feat in vl.getFeatures()]
+        self.assertEqual(got[0]["dt"], dt.toUTC())
+
+        self.assertTrue(vl.startEditing())
+        dt = QDateTime(QDate(2024, 1, 1), QTime(12, 34, 56, 789), Qt.TimeSpec.LocalTime)
+        self.assertTrue(vl.changeAttributeValue(1, 1, dt))
+        self.assertTrue(vl.commitChanges())
+
+        got = [feat for feat in vl.getFeatures()]
+        self.assertEqual(got[0]["dt"], dt.toUTC())
+
     def testTransactionModeAutoWithFilter(self):
 
         temp_dir = QTemporaryDir()

--- a/tests/src/python/test_qgsdatetimeedit.py
+++ b/tests/src/python/test_qgsdatetimeedit.py
@@ -17,6 +17,7 @@ from qgis.testing import start_app, QgisTestCase
 start_app()
 
 DATE = QDateTime.fromString('2018-01-01 01:02:03', Qt.DateFormat.ISODate)
+DATE_Z = QDateTime.fromString('2018-01-01 01:02:03Z', Qt.DateFormat.ISODate)
 
 
 class TestQgsDateTimeEdit(QgisTestCase):
@@ -31,6 +32,17 @@ class TestQgsDateTimeEdit(QgisTestCase):
         # date should remain when setting an invalid date
         w.setDateTime(QDateTime())
         self.assertEqual(w.dateTime(), DATE)
+
+    def testSettersGetters_DATE_Z(self):
+        """ test widget handling with Z time spec """
+        w = QgsDateTimeEdit()
+        w.setAllowNull(False)
+
+        w.setDateTime(DATE_Z)
+        self.assertEqual(w.dateTime(), DATE_Z)
+        # date should remain when setting an invalid date
+        w.setDateTime(QDateTime())
+        self.assertEqual(w.dateTime(), DATE_Z)
 
     def testNullValueHandling(self):
         """ test widget handling of null values """

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -711,6 +711,11 @@ class TestQgsDateTimeFieldFormatter(QgisTestCase):
                                                         QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.TimeSpec.OffsetFromUTC, 3600)),
                          '04/03/2020 12:13:14')
 
+        config = {"display_format": "dd/MM/yyyy HH:mm:ssZ"}
+        self.assertEqual(field_formatter.representValue(layer, 0, config, None,
+                                                        QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.TimeSpec.OffsetFromUTC, 3600)),
+                         '04/03/2020 11:13:14Z')
+
         locale_assertions = {
             QLocale(QLocale.Language.English): {
                 "date_format": 'M/d/yy',


### PR DESCRIPTION
I'm perhaps missing something but it seems Qt cannot handle the Z formatter and doesn't automatically perform conversion to UTC when the input datetime is in another time spec.