### PR TITLE
Fix missing representation of layer's custom property list in the info page (HtmlMetadata)

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -3254,12 +3254,7 @@ QString QgsMapLayer::generalHtmlMetadata() const
 
       const QVariant propValue = customProperty( key );
       QString stringValue;
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-      const QMetaType::Type propType = QgsVariantUtils::variantTypeToMetaType( propValue.type() );
-#else
-      const QMetaType::Type propType = propValue.metaType();
-#endif
-      if ( propType == QMetaType::QVariantList || propType == QMetaType::QStringList )
+      if ( propValue.type() == QVariant::List || propValue.type() == QVariant::StringList )
       {
         for ( const QString &s : propValue.toStringList() )
         {

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -3261,12 +3261,9 @@ QString QgsMapLayer::generalHtmlMetadata() const
 #endif
       if ( propType == QMetaType::QVariantList || propType == QMetaType::QStringList )
       {
-        const QStringList &stringList = propValue.toStringList();
-        for ( const QString &s : stringList )
+        for ( const QString &s : propValue.toStringList() )
         {
-          stringValue += s.toHtmlEscaped();
-          if ( &s != &stringList.back() )
-            stringValue += QStringLiteral( "<br>" );
+          stringValue += "<p style=\"margin: 0;\">" + s.toHtmlEscaped() + "</p>";
         }
       }
       else

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -3253,7 +3253,24 @@ QString QgsMapLayer::generalHtmlMetadata() const
         continue;
 
       const QVariant propValue = customProperty( key );
-      metadata += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>" ).arg( key.toHtmlEscaped(), propValue.toString().toHtmlEscaped() );
+      QString stringValue = QString();
+      if ( propValue.canConvert<QStringList>() && propValue.toStringList().count() > 1 )
+      {
+        for ( const QString &s : propValue.toStringList() )
+        {
+          stringValue += s.toHtmlEscaped() + QStringLiteral( "<br>" );
+        }
+      }
+      else if ( propValue.canConvert<QString>() || propValue.isNull() )
+      {
+        stringValue = propValue.toString().toHtmlEscaped();
+      }
+      else
+      {
+        stringValue = tr( "<i>cannot be represented</i>" );
+      }
+
+      metadata += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>" ).arg( key.toHtmlEscaped(), stringValue );
     }
     metadata += QLatin1String( "</tbody></table>\n" );
     metadata += QLatin1String( "<br><br>\n" );


### PR DESCRIPTION
This covers lists and in only one level deepness. 

Other types that cannot be converted to a string or a stringlist are not represented (by the text *value cannot be displayed*).

![image](https://github.com/qgis/QGIS/assets/28384354/220c4a98-5163-445e-8dc4-2a6157d5f6f8)

("weirdoType" is manually added with type "Map")

It probably makes sense to have a more powerful representation, but then I suggest to go deeper into the content like proposed here https://github.com/qgis/QGIS/issues/57335 But this is IMHO an extension and not scope of this small "fix" here.

This fixes #57334
