### PR TITLE
Better handle non GET/POST requests in network logger

### DIFF
--- a/src/app/devtools/networklogger/qgsnetworkloggernode.h
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.h
@@ -163,6 +163,7 @@ class QgsNetworkLoggerRequestGroup final : public QgsDevToolsModelGroup
     QUrl mUrl;
     int mRequestId = 0;
     QNetworkAccessManager::Operation mOperation;
+    QString mVerb;
     QElapsedTimer mTimer;
     qint64 mTotalTime = 0;
     int mHttpStatus = -1;


### PR DESCRIPTION
Fixes some bugs related to non GET/POST requests in the network logger:

- Show actual custom verb instead of just "CUSTOM"
- Correctly generate curl command for non GET/POST requests
- Handle data content for non POST requests
