### PR TITLE
Apply avoid overlap with the copy move map tool

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2091,6 +2091,7 @@ QgisApp::QgisApp()
   mMapTools = std::make_unique< QgsAppMapTools >( mMapCanvas, mAdvancedDigitizingDockWidget );
   mDigitizingTechniqueManager = new QgsMapToolsDigitizingTechniqueManager( this );
 
+  mVectorLayerTools = new QgsGuiVectorLayerTools();
   mBearingNumericFormat.reset( QgsLocalDefaultSettings::bearingFormat() );
 
   connect( mLayerTreeView, &QgsLayerTreeView::currentLayerChanged, this, &QgisApp::onActiveLayerChanged );

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -18,12 +18,14 @@
 
 #include "qgsguivectorlayertools.h"
 
+#include "qgsavoidintersectionsoperation.h"
 #include "qgisapp.h"
 #include "qgsfeatureaction.h"
 #include "qgsmessagebar.h"
 #include "qgsmessagebaritem.h"
 #include "qgsmessageviewer.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayerutils.h"
 
 bool QgsGuiVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feat, QWidget *parentWidget, bool showModal, bool hideParent ) const
 {
@@ -160,6 +162,134 @@ bool QgsGuiVectorLayerTools::stopEditing( QgsVectorLayer *layer, bool allowCance
     layer->triggerRepaint();
   }
 
+  return res;
+}
+
+bool QgsGuiVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double dx, double dy, QString *errorMsg, const bool topologicalEditing, QgsVectorLayer *topologicalLayer, QString *childrenInfoMsg ) const
+{
+//  bool res = QgsVectorLayerTools::copyMoveFeatures( layer, request, dx, dy, errorMsg, topologicalEditing, topologicalLayer, childrenInfoMsg );
+//  qDebug() << "overridden";
+//  return res;
+  bool res = false;
+  if ( !layer || !layer->isEditable() )
+  {
+    return false;
+  }
+
+  QgsFeatureIterator fi = layer->getFeatures( request );
+  QgsFeature f;
+
+  int browsedFeatureCount = 0;
+  int couldNotWriteCount = 0;
+  int noGeometryCount = 0;
+
+  QgsFeatureIds fidList;
+  QgsVectorLayerUtils::QgsDuplicateFeatureContext duplicateFeatureContext;
+  QMap<QString, int> duplicateFeatureCount;
+  while ( fi.nextFeature( f ) )
+  {
+    browsedFeatureCount++;
+
+    if ( f.hasGeometry() )
+    {
+      QgsGeometry geom = f.geometry();
+      geom.translate( dx, dy );
+      f.setGeometry( geom );
+    }
+
+    QgsFeature newFeature;
+    if ( QgsProject::instance() )
+    {
+      newFeature = QgsVectorLayerUtils::duplicateFeature( layer, f, QgsProject::instance(), duplicateFeatureContext );
+      if ( !newFeature.isValid() )
+      {
+        couldNotWriteCount++;
+        QgsDebugError( QStringLiteral( "Could not add new feature. Original copied feature id: %1" ).arg( f.id() ) );
+      }
+      else
+      {
+        fidList.insert( newFeature.id() );
+      }
+
+      const auto duplicateFeatureContextLayers = duplicateFeatureContext.layers();
+      for ( QgsVectorLayer *chl : duplicateFeatureContextLayers )
+      {
+        if ( duplicateFeatureCount.contains( chl->name() ) )
+        {
+          duplicateFeatureCount[chl->name()] += duplicateFeatureContext.duplicatedFeatures( chl ).size();
+        }
+        else
+        {
+          duplicateFeatureCount[chl->name()] = duplicateFeatureContext.duplicatedFeatures( chl ).size();
+        }
+      }
+    }
+    else
+    {
+      newFeature = QgsVectorLayerUtils::createFeature( layer, f.geometry(), f.attributes().toMap() );
+      if ( !layer->addFeature( newFeature ) )
+      {
+        couldNotWriteCount++;
+        QgsDebugError( QStringLiteral( "Could not add new feature. Original copied feature id: %1" ).arg( f.id() ) );
+      }
+      else
+      {
+        fidList.insert( newFeature.id() );
+      }
+    }
+
+    // translate
+    if ( newFeature.hasGeometry() )
+    {
+      QgsGeometry geom = newFeature.geometry();
+      if ( topologicalEditing )
+      {
+        if ( topologicalLayer )
+        {
+          topologicalLayer->addTopologicalPoints( geom );
+        }
+        layer->addTopologicalPoints( geom );
+      }
+    }
+    else
+    {
+      noGeometryCount++;
+    }
+  }
+
+  QString childrenInfo;
+  for ( auto it = duplicateFeatureCount.constBegin(); it != duplicateFeatureCount.constEnd(); ++it )
+  {
+    childrenInfo += ( tr( "\n%n children on layer %1 duplicated", nullptr, it.value() ).arg( it.key() ) );
+  }
+
+  request = QgsFeatureRequest();
+  request.setFilterFids( fidList );
+
+  if ( childrenInfoMsg && !childrenInfo.isEmpty() )
+  {
+    childrenInfoMsg->append( childrenInfo );
+  }
+
+  if ( !couldNotWriteCount && !noGeometryCount )
+  {
+    res = true;
+  }
+  else if ( errorMsg )
+  {
+    errorMsg = new QString( tr( "Only %1 out of %2 features were copied." )
+                            .arg( browsedFeatureCount - couldNotWriteCount - noGeometryCount, browsedFeatureCount ) );
+    if ( noGeometryCount )
+    {
+      errorMsg->append( " " );
+      errorMsg->append( tr( "Some features have no geometry." ) );
+    }
+    if ( couldNotWriteCount )
+    {
+      errorMsg->append( " " );
+      errorMsg->append( tr( "Some could not be created on the layer." ) );
+    }
+  }
   return res;
 }
 

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -198,7 +198,7 @@ bool QgsGuiVectorLayerTools::avoidIntersection( QgsVectorLayer *layer, QgsFeatur
       if ( errorMsg )
       {
         *errorMsg = ( geom.isEmpty() ) ?
-                    tr( "The feature cannot be moved because the resulting geometry would be empty" ) :
+                    tr( "The feature cannot be moved because 1 or more resulting geometries would be empty" ) :
                     tr( "An error was reported during intersection removal" );
       }
 

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -167,130 +167,47 @@ bool QgsGuiVectorLayerTools::stopEditing( QgsVectorLayer *layer, bool allowCance
 
 bool QgsGuiVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double dx, double dy, QString *errorMsg, const bool topologicalEditing, QgsVectorLayer *topologicalLayer, QString *childrenInfoMsg ) const
 {
-//  bool res = QgsVectorLayerTools::copyMoveFeatures( layer, request, dx, dy, errorMsg, topologicalEditing, topologicalLayer, childrenInfoMsg );
-//  qDebug() << "overridden";
-//  return res;
-  bool res = false;
-  if ( !layer || !layer->isEditable() )
+  bool res = QgsVectorLayerTools::copyMoveFeatures( layer, request, dx, dy, errorMsg, topologicalEditing, topologicalLayer, childrenInfoMsg );
+
+  if ( res && layer->geometryType() == Qgis::GeometryType::Polygon )
   {
-    return false;
+    res = avoidIntersection( layer, request, errorMsg );
   }
+
+  return res;
+}
+
+bool QgsGuiVectorLayerTools::avoidIntersection( QgsVectorLayer *layer, QgsFeatureRequest &request, QString *errorMsg ) const
+{
+  QgsAvoidIntersectionsOperation avoidIntersections;
 
   QgsFeatureIterator fi = layer->getFeatures( request );
   QgsFeature f;
 
-  int browsedFeatureCount = 0;
-  int couldNotWriteCount = 0;
-  int noGeometryCount = 0;
+  const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures {{ layer, request.filterFids() }};
 
-  QgsFeatureIds fidList;
-  QgsVectorLayerUtils::QgsDuplicateFeatureContext duplicateFeatureContext;
-  QMap<QString, int> duplicateFeatureCount;
   while ( fi.nextFeature( f ) )
   {
-    browsedFeatureCount++;
+    QgsGeometry geom = f.geometry();
+    const QgsFeatureId id = f.id();
 
-    if ( f.hasGeometry() )
-    {
-      QgsGeometry geom = f.geometry();
-      geom.translate( dx, dy );
-      f.setGeometry( geom );
-    }
+    const QgsAvoidIntersectionsOperation::Result res = avoidIntersections.apply( layer, id, geom, ignoreFeatures );
 
-    QgsFeature newFeature;
-    if ( QgsProject::instance() )
+    if ( res.operationResult == Qgis::GeometryOperationResult::InvalidInputGeometryType || geom.isEmpty() )
     {
-      newFeature = QgsVectorLayerUtils::duplicateFeature( layer, f, QgsProject::instance(), duplicateFeatureContext );
-      if ( !newFeature.isValid() )
+      if ( errorMsg )
       {
-        couldNotWriteCount++;
-        QgsDebugError( QStringLiteral( "Could not add new feature. Original copied feature id: %1" ).arg( f.id() ) );
-      }
-      else
-      {
-        fidList.insert( newFeature.id() );
+        *errorMsg = ( geom.isEmpty() ) ?
+                    tr( "The feature cannot be moved because the resulting geometry would be empty" ) :
+                    tr( "An error was reported during intersection removal" );
       }
 
-      const auto duplicateFeatureContextLayers = duplicateFeatureContext.layers();
-      for ( QgsVectorLayer *chl : duplicateFeatureContextLayers )
-      {
-        if ( duplicateFeatureCount.contains( chl->name() ) )
-        {
-          duplicateFeatureCount[chl->name()] += duplicateFeatureContext.duplicatedFeatures( chl ).size();
-        }
-        else
-        {
-          duplicateFeatureCount[chl->name()] = duplicateFeatureContext.duplicatedFeatures( chl ).size();
-        }
-      }
+      return false;
     }
-    else
-    {
-      newFeature = QgsVectorLayerUtils::createFeature( layer, f.geometry(), f.attributes().toMap() );
-      if ( !layer->addFeature( newFeature ) )
-      {
-        couldNotWriteCount++;
-        QgsDebugError( QStringLiteral( "Could not add new feature. Original copied feature id: %1" ).arg( f.id() ) );
-      }
-      else
-      {
-        fidList.insert( newFeature.id() );
-      }
-    }
-
-    // translate
-    if ( newFeature.hasGeometry() )
-    {
-      QgsGeometry geom = newFeature.geometry();
-      if ( topologicalEditing )
-      {
-        if ( topologicalLayer )
-        {
-          topologicalLayer->addTopologicalPoints( geom );
-        }
-        layer->addTopologicalPoints( geom );
-      }
-    }
-    else
-    {
-      noGeometryCount++;
-    }
+    layer->changeGeometry( id, geom );
   }
 
-  QString childrenInfo;
-  for ( auto it = duplicateFeatureCount.constBegin(); it != duplicateFeatureCount.constEnd(); ++it )
-  {
-    childrenInfo += ( tr( "\n%n children on layer %1 duplicated", nullptr, it.value() ).arg( it.key() ) );
-  }
-
-  request = QgsFeatureRequest();
-  request.setFilterFids( fidList );
-
-  if ( childrenInfoMsg && !childrenInfo.isEmpty() )
-  {
-    childrenInfoMsg->append( childrenInfo );
-  }
-
-  if ( !couldNotWriteCount && !noGeometryCount )
-  {
-    res = true;
-  }
-  else if ( errorMsg )
-  {
-    errorMsg = new QString( tr( "Only %1 out of %2 features were copied." )
-                            .arg( browsedFeatureCount - couldNotWriteCount - noGeometryCount, browsedFeatureCount ) );
-    if ( noGeometryCount )
-    {
-      errorMsg->append( " " );
-      errorMsg->append( tr( "Some features have no geometry." ) );
-    }
-    if ( couldNotWriteCount )
-    {
-      errorMsg->append( " " );
-      errorMsg->append( tr( "Some could not be created on the layer." ) );
-    }
-  }
-  return res;
+  return true;
 }
 
 void QgsGuiVectorLayerTools::commitError( QgsVectorLayer *vlayer ) const

--- a/src/app/qgsguivectorlayertools.h
+++ b/src/app/qgsguivectorlayertools.h
@@ -79,6 +79,23 @@ class QgsGuiVectorLayerTools : public QgsVectorLayerTools
      */
     bool saveEdits( QgsVectorLayer *layer ) const override;
 
+    /**
+     * Copy and move features with defined translation.
+     *
+     * \param layer The layer
+     * \param request The request for the features to be moved. It will be assigned to a new feature request with the newly copied features.
+     * \param dx The translation on x
+     * \param dy The translation on y
+     * \param errorMsg If given, it will contain the error message
+     * \param topologicalEditing If TRUE, the function will perform topological
+     * editing of the vertices of \a layer on \a layer and \a topologicalLayer
+     * \param topologicalLayer The layer where vertices from the moved features of \a layer will be added
+     * \param childrenInfoMsg If given, it will contain messages related to the creation of child features
+     * \returns TRUE if all features could be copied.
+     *
+     */
+    bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr, QString *childrenInfoMsg = nullptr ) const override;
+
   private:
     void commitError( QgsVectorLayer *vlayer ) const;
 

--- a/src/app/qgsguivectorlayertools.h
+++ b/src/app/qgsguivectorlayertools.h
@@ -96,11 +96,9 @@ class QgsGuiVectorLayerTools : public QgsVectorLayerTools
      */
     bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr, QString *childrenInfoMsg = nullptr ) const override;
 
-  protected:
-    virtual bool avoidIntersection( QgsVectorLayer *layer, QgsFeatureRequest &request, QString *errorMsg = nullptr ) const;
-
   private:
     void commitError( QgsVectorLayer *vlayer ) const;
+    bool avoidIntersection( QgsVectorLayer *layer, QgsFeatureRequest &request, QString *errorMsg = nullptr ) const;
 
 };
 

--- a/src/app/qgsguivectorlayertools.h
+++ b/src/app/qgsguivectorlayertools.h
@@ -96,6 +96,9 @@ class QgsGuiVectorLayerTools : public QgsVectorLayerTools
      */
     bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr, QString *childrenInfoMsg = nullptr ) const override;
 
+  protected:
+    virtual bool avoidIntersection( QgsVectorLayer *layer, QgsFeatureRequest &request, QString *errorMsg = nullptr ) const;
+
   private:
     void commitError( QgsVectorLayer *vlayer ) const;
 

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -266,6 +266,8 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         deleteRubberband();
         mSnapIndicator->setMatch( QgsPointLocator::Match() );
         cadDockWidget()->clear();
+
+        vlayer->endEditCommand();
         break;
       }
       case CopyMove:
@@ -277,7 +279,13 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         {
           emit messageEmitted( errorMsg, Qgis::MessageLevel::Critical );
           deleteRubberband();
+          vlayer->deleteFeatures( request.filterFids() );
+          vlayer->destroyEditCommand();
           mSnapIndicator->setMatch( QgsPointLocator::Match() );
+        }
+        else
+        {
+          vlayer->endEditCommand();
         }
         if ( !childrenInfoMsg.isEmpty() )
         {
@@ -286,7 +294,6 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         break;
     }
 
-    vlayer->endEditCommand();
     vlayer->triggerRepaint();
   }
 }

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -266,8 +266,6 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         deleteRubberband();
         mSnapIndicator->setMatch( QgsPointLocator::Match() );
         cadDockWidget()->clear();
-
-        vlayer->endEditCommand();
         break;
       }
       case CopyMove:
@@ -282,10 +280,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           vlayer->deleteFeatures( request.filterFids() );
           vlayer->destroyEditCommand();
           mSnapIndicator->setMatch( QgsPointLocator::Match() );
-        }
-        else
-        {
-          vlayer->endEditCommand();
+          return;
         }
         if ( !childrenInfoMsg.isEmpty() )
         {
@@ -294,6 +289,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         break;
     }
 
+    vlayer->endEditCommand();
     vlayer->triggerRepaint();
   }
 }

--- a/tests/src/app/testqgsmaptoolmovefeature.cpp
+++ b/tests/src/app/testqgsmaptoolmovefeature.cpp
@@ -49,6 +49,7 @@ class TestQgsMapToolMoveFeature: public QObject
     void testCopyMoveFeature();
     void testTopologicalMoveFeature();
     void testAvoidIntersectionAndTopoEdit();
+    void testAvoidIntersectionsCopyMove();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -217,6 +218,43 @@ void TestQgsMapToolMoveFeature::testAvoidIntersectionAndTopoEdit()
   QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt(), wkt2 );
 
   mLayerBase->undoStack()->undo();
+
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+  QgsProject::instance()->setAvoidIntersectionsMode( mode );
+}
+
+void TestQgsMapToolMoveFeature::testAvoidIntersectionsCopyMove()
+{
+  const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
+
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
+  QgsProject::instance()->setTopologicalEditing( true );
+
+  mCanvas->setMapTool( mCopyMoveTool );
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCopyMoveTool );
+
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 2.5, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  const QString wkt1 = "Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))";
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt(), wkt1 );
+  const QString wkt2 = "Polygon ((2 0, 2 1, 2 5, 3 5, 3 0, 2.5 0, 2 0))";
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt(), wkt2 );
+
+  // copied feature
+  const QString wkt3 = "Polygon ((1.5 1, 2 1, 2 0, 1.5 0, 1.5 1))";
+  QgsFeatureIterator fi1 = mLayerBase->getFeatures();
+  QgsFeature f1;
+
+  while ( fi1.nextFeature( f1 ) )
+  {
+    QCOMPARE( f1.geometry().asWkt( 2 ), wkt3 );
+    break;
+  }
+
+  mLayerBase->undoStack()->undo();
+  mCanvas->setMapTool( mCaptureTool );
 
   QgsProject::instance()->setTopologicalEditing( topologicalEditing );
   QgsProject::instance()->setAvoidIntersectionsMode( mode );


### PR DESCRIPTION
## Description

This is a continuation of #56873. As per @troopa81's suggestion (in the previous PR comments), I've overridden the `copyMoveFeatures()` method in QgsGuiVectorLayerTools and added a virtual protected method `avoidIntersection()` that performs an intersection removal operation for a QgsFeatureRequest.

I also added a test for using the copy move tool, which didn't exist before and also a test for intersection removal with the copy move tool.