### PR TITLE
Make brush and stroke style combo box icons visible on dark themes

### DIFF
--- a/src/gui/symbology/qgsbrushstylecombobox.cpp
+++ b/src/gui/symbology/qgsbrushstylecombobox.cpp
@@ -22,6 +22,7 @@
 #include <QBrush>
 #include <QPainter>
 #include <QPen>
+#include <QAbstractItemView>
 
 QgsBrushStyleComboBox::QgsBrushStyleComboBox( QWidget *parent )
   : QComboBox( parent )
@@ -76,7 +77,7 @@ QIcon QgsBrushStyleComboBox::iconForBrush( Qt::BrushStyle style )
   pix.fill( Qt::transparent );
 
   p.begin( &pix );
-  const QBrush brush( QColor( 100, 100, 100 ), style );
+  const QBrush brush( view()->palette().color( QPalette::Text ), style );
   p.setBrush( brush );
   const QPen pen( Qt::NoPen );
   p.setPen( pen );

--- a/src/gui/symbology/qgspenstylecombobox.cpp
+++ b/src/gui/symbology/qgspenstylecombobox.cpp
@@ -21,6 +21,7 @@
 #include <QList>
 #include <QPair>
 
+#include <QAbstractItemView>
 #include <QPainter>
 #include <QPen>
 
@@ -66,6 +67,8 @@ QIcon QgsPenStyleComboBox::iconForPen( Qt::PenStyle style )
   p.begin( &pix );
   QPen pen( style );
   pen.setWidth( 2 );
+  pen.setColor( view()->palette().color( QPalette::Text ) );
+
   p.setPen( pen );
   const double mid = iconSize().height() / 2.0;
   p.drawLine( 0, mid, iconSize().width(), mid );


### PR DESCRIPTION
Match the icon color to the text color, instead of just drawing the icons in black

![image](https://github.com/qgis/QGIS/assets/1829991/c1a5eb51-6cbb-47ba-826c-826d24746ce4)