### PR TITLE
Query widget UI tweaks

### DIFF
--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -240,7 +240,9 @@ void QgsQueryResultWidget::updateButtons()
 {
   mFilterLineEdit->setEnabled( mFirstRowFetched );
   mFilterToolButton->setEnabled( mFirstRowFetched );
-  mExecuteButton->setEnabled( ! mSqlEditor->text().isEmpty() );
+  const bool isEmpty = mSqlEditor->text().isEmpty();
+  mExecuteButton->setEnabled( !isEmpty );
+  mClearButton->setEnabled( !isEmpty );
   mLoadAsNewLayerGroupBox->setVisible( mConnection && mConnection->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::SqlLayers ) );
   mLoadAsNewLayerGroupBox->setEnabled(
     mSqlErrorMessage.isEmpty() &&

--- a/src/ui/qgsqueryresultwidgetbase.ui
+++ b/src/ui/qgsqueryresultwidgetbase.ui
@@ -70,9 +70,19 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="mClearButton">
+      <widget class="QToolButton" name="mClearButton">
+       <property name="toolTip">
+        <string>Clear</string>
+       </property>
        <property name="text">
         <string>Clear</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/console/iconClearConsole.svg</normaloff>:/images/themes/default/console/iconClearConsole.svg</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -244,6 +254,8 @@
   <tabstop>mLayerNameLineEdit</tabstop>
   <tabstop>mLoadLayerPushButton</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
- Disable clear SQL query button when query is empty
- Use a smaller button for clear query. This is a destructive action, lets not make it such as large target:

![image](https://github.com/qgis/QGIS/assets/1829991/22ec25b5-217d-4efb-befe-26fe5fc60c99)