### PR TITLE
[processing] Report error when creating temporary layers

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1427,11 +1427,27 @@ QString convertToCompatibleFormatInternal( const QgsVectorLayer *vl, bool select
     else
       it = vl->getFeatures( request );
 
+    constexpr int maxErrors { 10 };
+    unsigned long errorCounter { 0 };
     while ( it.nextFeature( f ) )
     {
       if ( feedback && feedback->isCanceled() )
         return QString();
-      writer->addFeature( f, QgsFeatureSink::FastInsert );
+
+      if ( !writer->addFeature( f, QgsFeatureSink::FastInsert ) && feedback )
+      {
+        QString errorText;
+        if ( errorCounter++ < maxErrors )
+        {
+          errorText = QObject::tr( "Error writing feature # %1 to output layer: %2" ).arg( QString::number( f.id() ), writer->errorMessage() );
+
+          feedback->reportError( errorText );
+        }
+      }
+    }
+    if ( errorCounter >= maxErrors )
+    {
+      feedback->reportError( QObject::tr( "There were %1 errors writing features, only the first %2 have beeen reported." ).arg( QString::number( errorCounter ), QString::number( maxErrors ) ) );
     }
     return temp;
   }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -837,6 +837,7 @@ class TestQgsProcessing: public QgsTest
     void asJsonMap();
     void tempUtils();
     void convertCompatible();
+    void convertCompatibleDuplicateFids();
     void create();
     void combineFields();
     void fieldNamesToIndices();
@@ -12632,6 +12633,44 @@ void TestQgsProcessing::convertCompatible()
   out = QgsProcessingParameters::parameterAsCompatibleSourceLayerPathAndLayerName( def.get(), params, context, QStringList() << "shp", QString( "shp" ), &feedback, &layerName );
   QCOMPARE( out, QString( testDataDir + "points.shp" ) );
   QCOMPARE( layerName, QString() );
+}
+
+void TestQgsProcessing::convertCompatibleDuplicateFids()
+{
+  // Create a memory layer
+  QgsVectorLayer *layer = new QgsVectorLayer{"Point", "vl", "memory"};
+  // Add fields
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "fid" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "name" ), QVariant::String ) );
+  layer->dataProvider()->addAttributes( fields.toList() );
+  layer->updateFields();
+
+  // Add features with duplicate FIDs
+  for ( int i = 1; i <= 12; ++i )
+  {
+    QgsFeature f( fields, i );
+    f.setAttributes( {{ 123, QString::number( i ) }} );
+    f.setGeometry( QgsGeometry( new QgsPoint( i, i ) ) );
+    QVERIFY( layer->dataProvider()->addFeature( f ) );
+  }
+
+  QgsProject p;
+  p.addMapLayer( layer );
+
+  QgsProcessingContext context;
+  context.setProject( &p );
+
+  QgsProcessingFeedback feedback;
+  std::unique_ptr< QgsProcessingParameterDefinition > def( new QgsProcessingParameterFeatureSource( QStringLiteral( "source" ) ) );
+  QVariantMap params;
+  params.insert( QStringLiteral( "source" ), QgsProcessingFeatureSourceDefinition( layer->id(), false ) );
+
+  QgsProcessingParameters::parameterAsCompatibleSourceLayerPath( def.get(), params, context, QStringList() << "gpkg", QString( "gpkg" ), &feedback );
+  const QStringList logs( feedback.textLog().split( '\n', Qt::SplitBehaviorFlags::SkipEmptyParts ) );
+  QCOMPARE( logs.size(), 11 );
+  QVERIFY( logs.first().startsWith( QStringLiteral( "Error writing feature # 2" ) ) );
+  QVERIFY( logs.last().startsWith( QStringLiteral( "There were 11 errors writing features" ) ) );
 }
 
 void TestQgsProcessing::create()


### PR DESCRIPTION
Errors were silently ignored, they are now shown to the user.

Fix #57343

![immagine](https://github.com/qgis/QGIS/assets/142164/3052471c-d036-4a5b-ae70-0d8fbef1aabe)
