### PR TITLE
Fix update apply-on-update-default-values Add Feature (pressing OK)

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1373,6 +1373,11 @@ bool QgsVectorLayer::addFeature( QgsFeature &feature, Flags )
       success = mJoinBuffer->addFeature( feature );
   }
 
+  if ( success && !mDefaultValueOnUpdateFields.isEmpty() )
+  {
+    updateDefaultValues( feature.id() );
+  }
+
   return success;
 }
 

--- a/tests/src/python/test_qgsattributeform.py
+++ b/tests/src/python/test_qgsattributeform.py
@@ -312,10 +312,10 @@ class TestQgsAttributeForm(QgisTestCase):
         # don't update numbers
         self.assertEqual(form.currentFormFeature()['numbers'], [1, 10])
 
-        # save form - this leads not to any updates (because it's a newly created features)
+        # save form - this leads to updates
         form.save()
 
-        # read the feature and check, that nothing updated after save
+        # read the feature and check, that other function expressions updated (pos and rand)
         feature = next(layer.getFeatures())
 
         # don't updated age
@@ -324,10 +324,10 @@ class TestQgsAttributeForm(QgisTestCase):
         self.assertEqual(feature.attribute('year'), 2024)
         # don't updated birthday
         self.assertEqual(feature.attribute('birthday'), 2014)
-        # don't updated pos (because newly created feature)
-        self.assertEqual(feature.attribute('pos'), 110)
-        # don't updated random (because newly created feature)
-        self.assertEqual(feature.attribute('random'), 100)
+        # updated pos (volatile)
+        self.assertEqual(feature.attribute('pos'), 120)
+        # updated random (volatile)
+        self.assertEqual(feature.attribute('random'), 200)
         # don't updated numbers
         self.assertEqual(feature.attribute('numbers'), [1, 10])
 
@@ -344,9 +344,9 @@ class TestQgsAttributeForm(QgisTestCase):
         # don't update birthday
         self.assertEqual(form.currentFormFeature()['birthday'], 2014)
         # don't update pos (because newly created feature)
-        self.assertEqual(form.currentFormFeature()['pos'], 110)
+        self.assertEqual(form.currentFormFeature()['pos'], 120)
         # don't update random (because newly created feature)
-        self.assertEqual(form.currentFormFeature()['random'], 100)
+        self.assertEqual(form.currentFormFeature()['random'], 200)
         # don't update numbers
         self.assertEqual(form.currentFormFeature()['numbers'], [1, 10])
 
@@ -359,9 +359,9 @@ class TestQgsAttributeForm(QgisTestCase):
         # don't update year
         self.assertEqual(form.currentFormFeature()['year'], 2024)
         # don't update pos
-        self.assertEqual(form.currentFormFeature()['pos'], 110)
+        self.assertEqual(form.currentFormFeature()['pos'], 120)
         # don't update random
-        self.assertEqual(form.currentFormFeature()['random'], 100)
+        self.assertEqual(form.currentFormFeature()['random'], 200)
 
         # editing age
         form.changeAttribute('age', 41)
@@ -372,13 +372,13 @@ class TestQgsAttributeForm(QgisTestCase):
         # update birthday because of age
         self.assertEqual(form.currentFormFeature()['birthday'], 1983)
         # update pos because of age
-        self.assertEqual(form.currentFormFeature()['pos'], 151)
+        self.assertEqual(form.currentFormFeature()['pos'], 161)
         # don't update random (yet)
-        self.assertEqual(form.currentFormFeature()['random'], 100)
+        self.assertEqual(form.currentFormFeature()['random'], 200)
         # update number because of age
         self.assertEqual(form.currentFormFeature()['numbers'], [1, 41])
 
-        # save form - this leads to updates, because existing feature
+        # save form - this leads to updates
         form.save()
 
         # read the feature and check, that other function expressions updated (pos and rand)
@@ -390,10 +390,10 @@ class TestQgsAttributeForm(QgisTestCase):
         self.assertEqual(feature.attribute('year'), 2024)
         # don't updated birthday
         self.assertEqual(feature.attribute('birthday'), 1983)
-        # again updated pos
-        self.assertEqual(feature.attribute('pos'), 192)
-        # updated random
-        self.assertEqual(feature.attribute('random'), 200)
+        # again updated pos (volatile)
+        self.assertEqual(feature.attribute('pos'), 202)
+        # updated random (volatile)
+        self.assertEqual(feature.attribute('random'), 400)
         # don't updated numbers
         self.assertEqual(feature.attribute('numbers'), [1, 41])
 

--- a/tests/src/python/test_qgsvectorlayereditutils.py
+++ b/tests/src/python/test_qgsvectorlayereditutils.py
@@ -607,14 +607,13 @@ class TestQgsVectorLayerEditUtils(QgisTestCase):
         feature = QgsVectorLayerUtils.createFeature(temp_layer,
                                                     QgsGeometry.fromWkt('LineString( 0 0, 10 0)'))
         feature[1] = 3301
-        feature[5] = 3305
         self.assertTrue(temp_layer.addFeature(feature))
 
         temp_layer.commitChanges()
 
         original_feature = next(temp_layer.getFeatures())
         self.assertEqual(original_feature.attributes(),
-                         [None, 3301.0, 302.0, 303.0, 304.0, 3305.0])
+                         [None, 3301.0, 302.0, 303.0, 304.0, 305.0])
 
         temp_layer.startEditing()
 


### PR DESCRIPTION
To have it aligned with the behavior on editing a feature.

This is compatible with the additional information from here #55633 and the fix here #56189 where volatile functions are not applied realtime but on pressing OK instead (on "Identify and open Form") - This behavior is now introduced for Add Feature as well, to have it aligned. 

This means:

#### Identify and open Form
- apply-on-update-default-values depending on fields are updated realtime in form
- apply-on-update-default-values are updated on OK (means volatile functions are relevant here, others do not change)

#### Add feature
- apply-on-update-default-values are set on form opens (like other default values)
- apply-on-update-default-values depending on fields are updated realtime in form
- apply-on-update-default-values are updated on OK (means volatile functions are relevant here, others do not change) *

\* but as well apply-on-update-default-values of invisible fields (fields that are not added by drag-n-drop) but depending on fields. This is basicly what this PR is about. So it fixes #57411