### PR TITLE
[advanced digitizing] Fix snapping to line extensions for multi geometry as well as polygons

### DIFF
--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -262,16 +262,26 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     const QPointF snappedPoint = toCanvasCoordinates( snap.point() );
 
     const QgsFeature feature = snap.layer()->getFeature( snap.featureId() );
-    const QgsGeometry geom = feature.geometry();
+    const QgsGeometry geometry = feature.geometry();
+    const QgsAbstractGeometry *geom = geometry.constGet();
 
     QgsPoint vertex;
-    if ( lineExtensionSide == Qgis::LineExtensionSide::BeforeVertex )
+    QgsVertexId vertexId;
+    geometry.vertexIdFromVertexNr( snap.vertexIndex(), vertexId );
+    if ( vertexId.isValid() )
     {
-      vertex = geom.vertexAt( snap.vertexIndex() - 1 );
-    }
-    else
-    {
-      vertex = geom.vertexAt( snap.vertexIndex() + 1 );
+      QgsVertexId previousVertexId;
+      QgsVertexId nextVertexId;
+      geom->adjacentVertices( vertexId, previousVertexId, nextVertexId );
+
+      if ( lineExtensionSide == Qgis::LineExtensionSide::BeforeVertex )
+      {
+        vertex = geom->vertexAt( previousVertexId );
+      }
+      else
+      {
+        vertex = geom->vertexAt( nextVertexId );
+      }
     }
 
     if ( !vertex.isEmpty() )

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -772,7 +772,6 @@ void QgsAdvancedDigitizingDockWidget::releaseLocks( bool releaseRepeatingLocks )
       mMConstraint->setValue( mCadPointList.constLast().m(), true );
     }
   }
-
 }
 
 #if 0


### PR DESCRIPTION
## Description

This PR fixes advanced digitizing's snapping to line extension against multipart geometries as well as polygons. The tool's prior logic was only working correctly provided a singlepart line.

The improvements include:
- for polygons, when we snap to the last vertex and check for segment/line extension, we loop back to the second vertex to get a functional snap against the first segment
- we also now handle rings, which in turn fixes weird snapping angles when the code was previously trying to create a segment out of the last outer ring vertex + the inner ring's first vertex
- for both line and polygons, we handle multipart geometries properly now (i.e., we're not going to try and create a segment using the last vertex of a part against the first vertex of the next part)

This makes this line extension snapping usable/reliable under all scenarios.

https://github.com/qgis/QGIS/assets/1728657/2b89fc30-a42a-43bd-b19f-ea7cd924ea8e

