### PR TITLE
[ux] Fix labeling small font size freeze

### DIFF
--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1282,12 +1282,12 @@ void QgsTextFormatWidget::changeTextColor( const QColor &color )
   updatePreview();
 }
 
-void QgsTextFormatWidget::updateFont( const QFont &font )
+void QgsTextFormatWidget::updateFont( const QFont &newFont )
 {
   // update background reference font
-  if ( font != mRefFont )
+  if ( newFont != mRefFont )
   {
-    mRefFont = font;
+    mRefFont = newFont;
   }
 
   // test if font is actually available
@@ -1296,8 +1296,10 @@ void QgsTextFormatWidget::updateFont( const QFont &font )
 
   if ( mDirectSymbolsFrame->isVisible() )
   {
-    mDirectSymbLeftLineEdit->setFont( mRefFont );
-    mDirectSymbRightLineEdit->setFont( mRefFont );
+    QFont symbolFont = mRefFont;
+    symbolFont.setPointSize( font().pointSize() );
+    mDirectSymbLeftLineEdit->setFont( symbolFont );
+    mDirectSymbRightLineEdit->setFont( symbolFont );
   }
 
   blockFontChangeSignals( true );

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1294,8 +1294,11 @@ void QgsTextFormatWidget::updateFont( const QFont &font )
   // NOTE: QgsFontUtils::fontMatchOnSystem may fail here, just crosscheck family
   mFontMissingLabel->setVisible( !QgsFontUtils::fontFamilyMatchOnSystem( mRefFont.family() ) );
 
-  mDirectSymbLeftLineEdit->setFont( mRefFont );
-  mDirectSymbRightLineEdit->setFont( mRefFont );
+  if ( mDirectSymbolsFrame->isVisible() )
+  {
+    mDirectSymbLeftLineEdit->setFont( mRefFont );
+    mDirectSymbRightLineEdit->setFont( mRefFont );
+  }
 
   blockFontChangeSignals( true );
   mFontFamilyCmbBx->setCurrentFont( mRefFont );


### PR DESCRIPTION
Also tested with linestring.

Fix #57336

I cannot say I really understand the deep reason of the issue, but this apparently fixes it. 
It actually makes sense because for non-linestring layers that part of the GUI is hidden.