### PR TITLE
Make 'Editable' field checkbox status consistent with read-only status

### DIFF
--- a/src/core/editform/qgseditformconfig.cpp
+++ b/src/core/editform/qgseditformconfig.cpp
@@ -238,6 +238,8 @@ bool QgsEditFormConfig::readOnly( int idx ) const
     if ( d->mFields.fieldOrigin( idx ) == Qgis::FieldOrigin::Join
          || d->mFields.fieldOrigin( idx ) == Qgis::FieldOrigin::Expression )
       return true;
+    if ( d->mFields.at( idx ).isReadOnly() )
+      return true;
     return !d->mFieldEditables.value( d->mFields.at( idx ).name(), true );
   }
   else

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -62,7 +62,8 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   connect( mWidgetTypeComboBox, static_cast< void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsAttributeTypeDialog::onCurrentWidgetChanged );
 
   if ( vl->fields().fieldOrigin( fieldIdx ) == Qgis::FieldOrigin::Join ||
-       vl->fields().fieldOrigin( fieldIdx ) == Qgis::FieldOrigin::Expression )
+       vl->fields().fieldOrigin( fieldIdx ) == Qgis::FieldOrigin::Expression ||
+       vl->fields().field( fieldIdx ).isReadOnly() )
   {
     isFieldEditableCheckBox->setEnabled( false );
   }

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1080,8 +1080,6 @@ QgsAttributesFormProperties::FieldConfig::FieldConfig( QgsVectorLayer *layer, in
   mDataDefinedProperties = layer->editFormConfig().dataDefinedFieldProperties( layer->fields().at( idx ).name() );
   mComment = layer->fields().at( idx ).comment();
   mEditable = !layer->editFormConfig().readOnly( idx );
-  mEditableEnabled = layer->fields().fieldOrigin( idx ) != Qgis::FieldOrigin::Join
-                     && layer->fields().fieldOrigin( idx ) != Qgis::FieldOrigin::Expression;
   mLabelOnTop = layer->editFormConfig().labelOnTop( idx );
   mReuseLastValues = layer->editFormConfig().reuseLastValue( idx );
   mFieldConstraints = layer->fields().at( idx ).constraints();

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -327,7 +327,6 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
       FieldConfig( QgsVectorLayer *layer, int idx );
 
       bool mEditable = true;
-      bool mEditableEnabled = true;
       bool mLabelOnTop = false;
       bool mReuseLastValues = false;
       QgsFieldConstraints mFieldConstraints;


### PR DESCRIPTION
In Layer Properties / Attributes Form, the "Editable" checkbox doesn't take into account the result of the QgsField::isReadOnly() method to decide whether to check or not the checkbox. It only takes into account the origin. So add a QgsFields::isFieldReadOnly() method that takes into accout both to decide both of the checked/unchecked status, as well as if the checkbox is enabled or not.

![image](https://github.com/qgis/QGIS/assets/1192433/f76e2599-c443-4001-a1ef-a4e5ce7f7444)
