### PR TITLE
Sensor things provider 3.38 improvement tweaks

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -176,6 +176,12 @@ Encapsulates information about how relationships in a SensorThings API service s
 Constructor for QgsSensorThingsExpansionDefinition, targeting the specified child entity type.
 %End
 
+    static QgsSensorThingsExpansionDefinition defaultDefinitionForEntity( Qgis::SensorThingsEntity entity );
+%Docstring
+Returns an expansion definition for the specified ``entity`` type, populated with reasonable
+defaults which make sense for that entity type.
+%End
+
     bool isValid() const;
 %Docstring
 Returns ``True`` if the definition is valid.

--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -170,7 +170,8 @@ Encapsulates information about how relationships in a SensorThings API service s
     QgsSensorThingsExpansionDefinition( Qgis::SensorThingsEntity childEntity = Qgis::SensorThingsEntity::Invalid,
                                         const QString &orderBy = QString(),
                                         Qt::SortOrder sortOrder = Qt::SortOrder::AscendingOrder,
-                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
+                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT,
+                                        const QString &filter = QString() );
 %Docstring
 Constructor for QgsSensorThingsExpansionDefinition, targeting the specified child entity type.
 %End
@@ -248,6 +249,20 @@ Set to -1 if no limit is desired.
 .. seealso:: :py:func:`limit`
 %End
 
+    QString filter() const;
+%Docstring
+Returns the the string filter to filter expanded child entities by.
+
+.. seealso:: :py:func:`setFilter`
+%End
+
+    void setFilter( const QString &filter );
+%Docstring
+Returns the the string ``filter`` to filter expanded child entities by.
+
+.. seealso:: :py:func:`filter`
+%End
+
     QString toString() const;
 %Docstring
 Returns a string encapsulation of the expansion definition.
@@ -293,6 +308,13 @@ Optionally a list of additional query options can be specified for the expansion
           innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
         else
           innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+      }
+      if ( !sipCpp->filter().isEmpty() )
+      {
+        if ( !innerDefinition.isEmpty() )
+          innerDefinition = QStringLiteral( "%1, filter '%2'" ).arg( innerDefinition ).arg( sipCpp->filter() );
+        else
+          innerDefinition = QStringLiteral( "filter '%1'" ).arg( sipCpp->filter() );
       }
 
       QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -176,6 +176,12 @@ Encapsulates information about how relationships in a SensorThings API service s
 Constructor for QgsSensorThingsExpansionDefinition, targeting the specified child entity type.
 %End
 
+    static QgsSensorThingsExpansionDefinition defaultDefinitionForEntity( Qgis::SensorThingsEntity entity );
+%Docstring
+Returns an expansion definition for the specified ``entity`` type, populated with reasonable
+defaults which make sense for that entity type.
+%End
+
     bool isValid() const;
 %Docstring
 Returns ``True`` if the definition is valid.

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -170,7 +170,8 @@ Encapsulates information about how relationships in a SensorThings API service s
     QgsSensorThingsExpansionDefinition( Qgis::SensorThingsEntity childEntity = Qgis::SensorThingsEntity::Invalid,
                                         const QString &orderBy = QString(),
                                         Qt::SortOrder sortOrder = Qt::SortOrder::AscendingOrder,
-                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
+                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT,
+                                        const QString &filter = QString() );
 %Docstring
 Constructor for QgsSensorThingsExpansionDefinition, targeting the specified child entity type.
 %End
@@ -248,6 +249,20 @@ Set to -1 if no limit is desired.
 .. seealso:: :py:func:`limit`
 %End
 
+    QString filter() const;
+%Docstring
+Returns the the string filter to filter expanded child entities by.
+
+.. seealso:: :py:func:`setFilter`
+%End
+
+    void setFilter( const QString &filter );
+%Docstring
+Returns the the string ``filter`` to filter expanded child entities by.
+
+.. seealso:: :py:func:`filter`
+%End
+
     QString toString() const;
 %Docstring
 Returns a string encapsulation of the expansion definition.
@@ -293,6 +308,13 @@ Optionally a list of additional query options can be specified for the expansion
           innerDefinition = QStringLiteral( "%1, limit %2" ).arg( innerDefinition ).arg( sipCpp->limit() );
         else
           innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
+      }
+      if ( !sipCpp->filter().isEmpty() )
+      {
+        if ( !innerDefinition.isEmpty() )
+          innerDefinition = QStringLiteral( "%1, filter '%2'" ).arg( innerDefinition ).arg( sipCpp->filter() );
+        else
+          innerDefinition = QStringLiteral( "filter '%1'" ).arg( sipCpp->filter() );
       }
 
       QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
@@ -319,6 +319,7 @@ QgsFeatureIds QgsSensorThingsSharedData::getFeatureIdsInExtent( const QgsRectang
   if ( hasCachedAllFeatures() || mCachedExtent.contains( extentGeom ) )
   {
     // all features cached locally, rely on local spatial index
+    nextPage.clear();
     return qgis::listToSet( mSpatialIndex.intersects( requestExtent ) );
   }
 

--- a/src/core/providers/sensorthings/qgssensorthingsutils.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.cpp
@@ -42,6 +42,42 @@ QgsSensorThingsExpansionDefinition::QgsSensorThingsExpansionDefinition( Qgis::Se
 
 }
 
+QgsSensorThingsExpansionDefinition QgsSensorThingsExpansionDefinition::defaultDefinitionForEntity( Qgis::SensorThingsEntity entity )
+{
+  switch ( entity )
+  {
+    case Qgis::SensorThingsEntity::Invalid:
+      return QgsSensorThingsExpansionDefinition();
+
+    case Qgis::SensorThingsEntity::Thing:
+    case Qgis::SensorThingsEntity::Location:
+    case Qgis::SensorThingsEntity::HistoricalLocation:
+    case Qgis::SensorThingsEntity::Sensor:
+    case Qgis::SensorThingsEntity::FeatureOfInterest:
+      // no special defaults for these entities
+      return QgsSensorThingsExpansionDefinition(
+               entity
+             );
+
+    case Qgis::SensorThingsEntity::Observation:
+      // default to descending sort by phenomenonTime
+      return QgsSensorThingsExpansionDefinition(
+               Qgis::SensorThingsEntity::Observation,
+               QStringLiteral( "phenomenonTime" ), Qt::SortOrder::DescendingOrder
+             );
+
+    case Qgis::SensorThingsEntity::Datastream:
+    case Qgis::SensorThingsEntity::MultiDatastream:
+    case Qgis::SensorThingsEntity::ObservedProperty:
+      // use smaller limit by default
+      return QgsSensorThingsExpansionDefinition(
+               entity,
+               QString(), Qt::SortOrder::AscendingOrder, 10
+             );
+  }
+  BUILTIN_UNREACHABLE
+}
+
 bool QgsSensorThingsExpansionDefinition::isValid() const
 {
   return mChildEntity != Qgis::SensorThingsEntity::Invalid;

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -192,7 +192,8 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
     QgsSensorThingsExpansionDefinition( Qgis::SensorThingsEntity childEntity = Qgis::SensorThingsEntity::Invalid,
                                         const QString &orderBy = QString(),
                                         Qt::SortOrder sortOrder = Qt::SortOrder::AscendingOrder,
-                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT );
+                                        int limit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT,
+                                        const QString &filter = QString() );
 
     /**
      * Returns TRUE if the definition is valid.
@@ -264,6 +265,20 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
     void setLimit( int limit );
 
     /**
+     * Returns the the string filter to filter expanded child entities by.
+     *
+     * \see setFilter()
+     */
+    QString filter() const;
+
+    /**
+     * Returns the the string \a filter to filter expanded child entities by.
+     *
+     * \see filter()
+     */
+    void setFilter( const QString &filter );
+
+    /**
      * Returns a string encapsulation of the expansion definition.
      *
      * \see fromString()
@@ -310,6 +325,13 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
         else
           innerDefinition = QStringLiteral( "limit %1" ).arg( sipCpp->limit() );
       }
+      if ( !sipCpp->filter().isEmpty() )
+      {
+        if ( !innerDefinition.isEmpty() )
+          innerDefinition = QStringLiteral( "%1, filter '%2'" ).arg( innerDefinition ).arg( sipCpp->filter() );
+        else
+          innerDefinition = QStringLiteral( "filter '%1'" ).arg( sipCpp->filter() );
+      }
 
       QString str = QStringLiteral( "<QgsSensorThingsExpansionDefinition: %1%2>" ).arg( qgsEnumValueToKey( sipCpp->childEntity() ), innerDefinition.isEmpty() ? QString() : ( QStringLiteral( " " ) + innerDefinition ) );
       sipRes = PyUnicode_FromString( str.toUtf8().constData() );
@@ -323,6 +345,8 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
     QString mOrderBy;
     Qt::SortOrder mSortOrder = Qt::SortOrder::AscendingOrder;
     int mLimit = QgsSensorThingsUtils::DEFAULT_EXPANSION_LIMIT;
+    QString mFilter;
+
 };
 Q_DECLARE_METATYPE( QgsSensorThingsExpansionDefinition )
 

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -196,6 +196,12 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
                                         const QString &filter = QString() );
 
     /**
+     * Returns an expansion definition for the specified \a entity type, populated with reasonable
+     * defaults which make sense for that entity type.
+     */
+    static QgsSensorThingsExpansionDefinition defaultDefinitionForEntity( Qgis::SensorThingsEntity entity );
+
+    /**
      * Returns TRUE if the definition is valid.
      */
     bool isValid() const;

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
@@ -650,6 +650,11 @@ bool QgsSensorThingsExpansionsModel::setData( const QModelIndex &index, const QV
           else
           {
             expansion.setChildEntity( value.value< Qgis::SensorThingsEntity >() );
+            if ( wasInvalid )
+            {
+              expansion = QgsSensorThingsExpansionDefinition::defaultDefinitionForEntity( expansion.childEntity() );
+              emit dataChanged( createIndex( index.row(), 0 ), createIndex( index.row(), columnCount() ) );
+            }
           }
           emit dataChanged( index, index, QVector<int>() << role );
           if ( wasInvalid )

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
@@ -46,7 +46,8 @@ class QgsSensorThingsExpansionsModel : public QAbstractItemModel
       Limit = 1,
       OrderBy = 2,
       SortOrder = 3,
-      Actions = 4,
+      Filter = 4,
+      Actions = 5,
     };
 
     QgsSensorThingsExpansionsModel( QObject *parent );
@@ -67,6 +68,29 @@ class QgsSensorThingsExpansionsModel : public QAbstractItemModel
   private:
 
     QList< QgsSensorThingsExpansionDefinition> mExpansions;
+};
+
+class QgsSensorThingsFilterWidget : public QWidget
+{
+    Q_OBJECT
+
+  public:
+    QgsSensorThingsFilterWidget( QWidget *parent, Qgis::SensorThingsEntity entity );
+    void setFilter( const QString &filter );
+    QString filter() const;
+
+  signals:
+    void filterChanged();
+
+  private slots:
+
+    void setQuery();
+
+  private:
+
+    QString mFilter;
+    Qgis::SensorThingsEntity mEntity = Qgis::SensorThingsEntity::Invalid;
+
 };
 
 

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
@@ -76,7 +76,8 @@ class QgsSensorThingsExpansionsDelegate : public QStyledItemDelegate
 
   public:
 
-    QgsSensorThingsExpansionsDelegate( QObject *parent, Qgis::SensorThingsEntity baseEntityType );
+    QgsSensorThingsExpansionsDelegate( QObject *parent );
+    void setBaseEntityType( Qgis::SensorThingsEntity type );
 
   protected:
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem & /*option*/, const QModelIndex &index ) const override;
@@ -105,24 +106,6 @@ class QgsSensorThingsRemoveExpansionDelegate : public QStyledItemDelegate SIP_SK
 };
 
 
-class QgsSensorThingsConfigureExpansionsDialog : public QDialog
-{
-    Q_OBJECT
-
-  public:
-
-    QgsSensorThingsConfigureExpansionsDialog( Qgis::SensorThingsEntity baseEntityType, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
-    void setExpansions( const QList< QgsSensorThingsExpansionDefinition> &expansions );
-    QList< QgsSensorThingsExpansionDefinition> expansions() const;
-
-  private:
-
-    Qgis::SensorThingsEntity mBaseEntityType = Qgis::SensorThingsEntity::Invalid;
-    QgsSensorThingsExpansionsModel *mModel = nullptr;
-    QTableView *mTable = nullptr;
-
-};
-
 class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui::QgsSensorThingsSourceWidgetBase
 {
     Q_OBJECT
@@ -150,14 +133,15 @@ class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui
     void validate();
     void retrieveTypes();
     void connectionPropertiesTaskCompleted();
-    void configureExpansions();
+
   private:
     void setCurrentEntityType( Qgis::SensorThingsEntity type );
     void setCurrentGeometryTypeFromString( const QString &geometryType );
 
     QgsExtentWidget *mExtentWidget = nullptr;
+    QgsSensorThingsExpansionsModel *mExpansionsModel = nullptr;
+    QgsSensorThingsExpansionsDelegate *mExpansionsTableDelegate = nullptr;
     QVariantMap mSourceParts;
-    QList< QgsSensorThingsExpansionDefinition> mExpansions;
     bool mIsValid = false;
     QPointer< QgsSensorThingsConnectionPropertiesTask > mPropertiesTask;
 };

--- a/src/gui/providers/sensorthings/qgssensorthingssubseteditor.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssubseteditor.cpp
@@ -85,6 +85,8 @@ QgsSensorThingsSubsetEditor::QgsSensorThingsSubsetEditor( QgsVectorLayer *layer,
   mButtonDiv->setProperty( "expression", " div " );
   mButtonMod->setToolTip( tr( "Modulo" ) );
   mButtonMod->setProperty( "expression", " mod " );
+  mButtonNow->setToolTip( tr( "Current datetime" ) );
+  mButtonNow->setProperty( "expression", " now() " );
 
   if ( mLayer )
     lblDataUri->setText( tr( "Set filter on %1" ).arg( mLayer->name() ) );
@@ -112,7 +114,8 @@ QgsSensorThingsSubsetEditor::QgsSensorThingsSubsetEditor( QgsVectorLayer *layer,
           mButtonSub,
           mButtonMul,
           mButtonDiv,
-          mButtonMod
+          mButtonMod,
+          mButtonNow
         } )
   {
     connect( button, &QPushButton::clicked, this, [this, button]

--- a/src/ui/qgssensorthingssourcewidgetbase.ui
+++ b/src/ui/qgssensorthingssourcewidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>537</width>
-    <height>198</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,45 +26,32 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="4" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
-     <property name="maximum">
-      <number>999999999</number>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Geometry type</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="2">
+   <item row="6" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Expansions</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QTableView" name="mExpansionsTable"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="mComboEntityType"/>
+   </item>
+   <item row="5" column="1" colspan="2">
     <widget class="QWidget" name="mExtentLimitFrame" native="true">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Feature limit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Page size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Extent limit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Entity type</string>
      </property>
     </widget>
    </item>
@@ -98,8 +85,12 @@
    <item row="1" column="1">
     <widget class="QComboBox" name="mComboGeometryType"/>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mComboEntityType"/>
+   <item row="4" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinFeatureLimit">
+     <property name="maximum">
+      <number>999999999</number>
+     </property>
+    </widget>
    </item>
    <item row="2" column="1" colspan="2">
     <widget class="QgsSpinBox" name="mSpinPageSize">
@@ -108,31 +99,31 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Geometry type</string>
+      <string>Page size</string>
      </property>
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label_8">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Expansions</string>
+      <string>Extent limit</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
-    <widget class="QToolButton" name="mConfigureExpansions">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>...</string>
+      <string>Feature limit</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QLabel" name="mExpansionsLabel">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string/>
+      <string>Entity type</string>
      </property>
     </widget>
    </item>
@@ -151,7 +142,6 @@
   <tabstop>mRetrieveTypesButton</tabstop>
   <tabstop>mSpinPageSize</tabstop>
   <tabstop>mSpinFeatureLimit</tabstop>
-  <tabstop>mConfigureExpansions</tabstop>
   <tabstop>mExtentLimitFrame</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgssensorthingssubseteditorbase.ui
+++ b/src/ui/qgssensorthingssubseteditorbase.ui
@@ -50,7 +50,7 @@
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox1">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -102,17 +102,17 @@ p, li { white-space: pre-wrap; }
       <property name="bottomMargin">
        <number>11</number>
       </property>
-      <item row="3" column="1">
-       <widget class="QPushButton" name="mButtonOr">
+      <item row="3" column="3">
+       <widget class="QPushButton" name="mButtonNow">
         <property name="text">
-         <string>or</string>
+         <string>now()</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="mButtonGt">
+      <item row="1" column="0">
+       <widget class="QPushButton" name="mButtonEq">
         <property name="text">
-         <string>gt</string>
+         <string>eq</string>
         </property>
        </widget>
       </item>
@@ -130,100 +130,10 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="mButtonEq">
+      <item row="2" column="3" colspan="3">
+       <widget class="QLabel" name="mLabelLogical_2">
         <property name="text">
-         <string>eq</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="mButtonNe">
-        <property name="text">
-         <string>ne</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QPushButton" name="mButtonNot">
-        <property name="text">
-         <string>not</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="6">
-       <widget class="QLabel" name="mLabelComparisons">
-        <property name="text">
-         <string>Comparisons</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QPushButton" name="mButtonAdd">
-        <property name="text">
-         <string>add</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QPushButton" name="mButtonGe">
-        <property name="text">
-         <string>ge</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <widget class="QPushButton" name="mButtonLt">
-        <property name="text">
-         <string>lt</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="6">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="4" column="0" colspan="6">
-       <widget class="QLabel" name="mLabelArithmetic">
-        <property name="text">
-         <string>Arithmetic</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QPushButton" name="mButtonSub">
-        <property name="text">
-         <string>sub</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2">
-       <widget class="QPushButton" name="mButtonMul">
-        <property name="text">
-         <string>mul</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="3">
-       <widget class="QPushButton" name="mButtonDiv">
-        <property name="text">
-         <string>div</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="4">
-       <widget class="QPushButton" name="mButtonMod">
-        <property name="text">
-         <string>mod</string>
+         <string>Date</string>
         </property>
        </widget>
       </item>
@@ -234,17 +144,94 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
-      <item row="2" column="3" colspan="3">
-       <widget class="QLabel" name="mLabelLogical_2">
+      <item row="5" column="0">
+       <widget class="QPushButton" name="mButtonAdd">
         <property name="text">
-         <string>Date</string>
+         <string>add</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
-       <widget class="QPushButton" name="mButtonNow">
+      <item row="1" column="2">
+       <widget class="QPushButton" name="mButtonGt">
         <property name="text">
-         <string>now()</string>
+         <string>gt</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QPushButton" name="mButtonGe">
+        <property name="text">
+         <string>ge</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="6">
+       <widget class="QLabel" name="mLabelArithmetic">
+        <property name="text">
+         <string>Arithmetic</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="3">
+       <widget class="QPushButton" name="mButtonDiv">
+        <property name="text">
+         <string>div</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QPushButton" name="mButtonLt">
+        <property name="text">
+         <string>lt</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QPushButton" name="mButtonSub">
+        <property name="text">
+         <string>sub</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="mButtonNot">
+        <property name="text">
+         <string>not</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="4">
+       <widget class="QPushButton" name="mButtonMod">
+        <property name="text">
+         <string>mod</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="6">
+       <widget class="QLabel" name="mLabelComparisons">
+        <property name="text">
+         <string>Comparisons</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QPushButton" name="mButtonMul">
+        <property name="text">
+         <string>mul</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="mButtonNe">
+        <property name="text">
+         <string>ne</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QPushButton" name="mButtonOr">
+        <property name="text">
+         <string>or</string>
         </property>
        </widget>
       </item>

--- a/src/ui/qgssensorthingssubseteditorbase.ui
+++ b/src/ui/qgssensorthingssubseteditorbase.ui
@@ -6,14 +6,40 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>816</width>
+    <width>852</width>
     <height>740</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>OGC SensorThings Data Filter</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,1,0">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0">
+   <item row="3" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="mEditorGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>OGC SensorThings Filter Expression</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="lblDataUri">
      <property name="text">
@@ -139,13 +165,6 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="6">
-       <widget class="QLabel" name="mLabelLogical">
-        <property name="text">
-         <string>Logical operators</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="3">
        <widget class="QPushButton" name="mButtonGe">
         <property name="text">
@@ -208,33 +227,28 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QLabel" name="mLabelLogical">
+        <property name="text">
+         <string>Logical operators</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3" colspan="3">
+       <widget class="QLabel" name="mLabelLogical_2">
+        <property name="text">
+         <string>Date</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QPushButton" name="mButtonNow">
+        <property name="text">
+         <string>now()</string>
+        </property>
+       </widget>
+      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QGroupBox" name="mEditorGroupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>OGC SensorThings Filter Expression</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Contains a couple of fixes/UI tweaks for the new SensorThings functionality introduced in 3.38:

- The expansions configuration widget has been moved to sit directly within the source widget, instead of being a separate dialog.
- Allow configuration of filters at each expansion level, instead of just at the root level. Filters must be configurable for each individual expansion level, as we can't achieve the same results by a single top-level filter. For instance, this prevents filtering children from the expansion to return just the most recent observation.
- Adds a quick shortcut button to insert "now()" into the query alongside the other shortcut buttons, as this function is commonly used to find the most recent observations.