### PR TITLE
[advanced digitizing] Implement visual construction guides

### DIFF
--- a/python/PyQt6/core/auto_generated/qgscadutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscadutils.sip.in
@@ -132,7 +132,6 @@ Returns the recent CAD point at the specified ``index`` (in map coordinates).
 
 .. versionadded:: 3.22
 %End
-
 %Property( name = cadPointList, get = _cadPointList, set = _setCadPointList )
         void _setCadPointList( const QList< QgsPointXY > &list );
         QList< QgsPointXY > _cadPointList() const;

--- a/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -277,7 +277,36 @@ Sets whether M is enabled
 
     bool constructionMode() const;
 %Docstring
-construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
+Returns whether the construction mode is activated. The construction mode is used to draw intermediate
+points that will not be part of a geometry being digitized.
+%End
+
+    QgsVectorLayer *constructionGuidesLayer() const;
+%Docstring
+Returns the vector layer within which construction guides are stored.
+
+.. versionadded:: 3.40
+%End
+
+    bool showConstructionGuides() const;
+%Docstring
+Returns whether the construction guides are visible.
+
+.. versionadded:: 3.40
+%End
+
+    bool snapToConstructionGuides() const;
+%Docstring
+Returns whether points should snap to construction guides.
+
+.. versionadded:: 3.40
+%End
+
+    bool recordConstructionGuides() const;
+%Docstring
+Returns whether construction guides are being recorded.
+
+.. versionadded:: 3.40
 %End
 
     Qgis::BetweenLineConstraint betweenLineConstraint() const;

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -132,7 +132,6 @@ Returns the recent CAD point at the specified ``index`` (in map coordinates).
 
 .. versionadded:: 3.22
 %End
-
 %Property( name = cadPointList, get = _cadPointList, set = _setCadPointList )
         void _setCadPointList( const QList< QgsPointXY > &list );
         QList< QgsPointXY > _cadPointList() const;

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -277,7 +277,36 @@ Sets whether M is enabled
 
     bool constructionMode() const;
 %Docstring
-construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
+Returns whether the construction mode is activated. The construction mode is used to draw intermediate
+points that will not be part of a geometry being digitized.
+%End
+
+    QgsVectorLayer *constructionGuidesLayer() const;
+%Docstring
+Returns the vector layer within which construction guides are stored.
+
+.. versionadded:: 3.40
+%End
+
+    bool showConstructionGuides() const;
+%Docstring
+Returns whether the construction guides are visible.
+
+.. versionadded:: 3.40
+%End
+
+    bool snapToConstructionGuides() const;
+%Docstring
+Returns whether points should snap to construction guides.
+
+.. versionadded:: 3.40
+%End
+
+    bool recordConstructionGuides() const;
+%Docstring
+Returns whether construction guides are being recorded.
+
+.. versionadded:: 3.40
 %End
 
     Qgis::BetweenLineConstraint betweenLineConstraint() const;

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -48,8 +48,8 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   res.softLockX = std::numeric_limits<double>::quiet_NaN();
   res.softLockY = std::numeric_limits<double>::quiet_NaN();
 
-  // try to snap to anything
-  const QgsPointLocator::Match snapMatch = ctx.snappingUtils->snapToMap( originalMapPoint, nullptr, true );
+  // try to snap to project layer(s) as well as visible construction guides
+  QgsPointLocator::Match snapMatch = ctx.snappingUtils->snapToMap( originalMapPoint, nullptr, true );
   res.snapMatch = snapMatch;
   QgsPointXY point = snapMatch.isValid() ? snapMatch.point() : originalMapPoint;
   QgsPointXY edgePt0, edgePt1;

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -195,7 +195,6 @@ class CORE_EXPORT QgsCadUtils
          */
         QQueue< QgsPointLocator::Match > lockedSnapVertices() const { return mLockedSnapVertices; } SIP_SKIP;
 
-
 #ifdef SIP_RUN
         SIP_PROPERTY( name = cadPointList, get = _cadPointList, set = _setCadPointList )
 #endif

--- a/src/gui/qgsadvanceddigitizingcanvasitem.h
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.h
@@ -60,6 +60,7 @@ class GUI_EXPORT QgsAdvancedDigitizingCanvasItem : public QgsMapCanvasItem
     QPen mSnapPen;
     QPen mSnapLinePen;
     QPen mCursorPen;
+    QPen mConstructionGuidesPen;
     QgsAdvancedDigitizingDockWidget *mAdvancedDigitizingDockWidget = nullptr;
 };
 


### PR DESCRIPTION
## Description

This PR adds visual construction guides to the advanced digitizing dock widget which builds on top of our preexisting CAD construction mode. 

UI wise, the functionality is exposed through a set of actions within a new drop-down menu attached to the construction activation toolbar button:

![image](https://github.com/qgis/QGIS/assets/1728657/84e3d6ee-0ca7-43f8-955c-915d6a7974c1)

When recording construction guides, QGIS will render all construction steps taken as dashed lines. Those lines will remain visible as long as advanced digitizing is enabled. The guides are snap-able, allowing for construction steps to begin mid-way into a previous set of steps too. 

In action:

https://github.com/qgis/QGIS/assets/1728657/db8bd954-f9c0-4ed2-a324-2805853c88d1

The construction guides are stored in a vector layer, which is exposed through the advanced digitizing dock widget, allowing for further customization of those guides via e.g. python plugins. 
