### PR TITLE
Fix python error when github gist creation fails (fix #57590)

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -318,7 +318,7 @@ class Editor(QgsCodeEditorPython):
             self.showMessage(msg)
         else:
             msg = QCoreApplication.translate('PythonConsole', 'Connection error: ')
-            self.showMessage(msg + request.erroMessage(),
+            self.showMessage(msg + request.errorMessage(),
                              level=Qgis.MessageLevel.Warning)
 
     def hideEditor(self):


### PR DESCRIPTION
## Fix python error on github gist publish fail 

PR to fix an error that occurred while trying to publish a new gist from python console editor with an invalid token.

```
AttributeError: 'QgsBlockingNetworkRequest' object has no attribute 'erroMessage' 
Traceback (most recent call last):
  File "/usr/share/qgis/python/console/console_editor.py", line 276, in shareOnGist
    self.parent.showMessage(msg + request.erroMessage(), Qgis.Warning, 5)
                                  ^^^^^^^^^^^^^^^^^^^
AttributeError: 'QgsBlockingNetworkRequest' object has no attribute 'erroMessage'
```

see #57590 for more details on bug.