### PR TITLE
Source-tree documentation improvements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1085,6 +1085,9 @@ CMake option:
 This will flood your terminal or system log with lots of useful output from
 QgsDebugMsg() calls in source code.
 
+Those lines can be reduced or augmented by setting the QGIS_DEBUG
+runtime environment variable between 0 (no messages) and 5 (all messages).
+
 If you would like to run the test suite, you will need to do so from the build
 directory, as it will not work with the installed/bundled app. First set the
 CMake option to enable tests:

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ There are several channels where you can find help and support for QGIS:
 - Using the [QGIS community site](https://qgis.org)
 - Joining the [qgis-users mailing list](https://lists.osgeo.org/mailman/listinfo/qgis-user)
 - Chatting with other users real-time. *Please wait around for a response to your question as many folks on the channel are doing other things and it may take a while for them to notice your question. The following paths all take you to the same chat room:*
-    - Using an IRC client and joining the [#qgis](https://webchat.freenode.net/?channels=#qgis) channel on irc.freenode.net.
-    - Using a Matrix client and joining the [#qgis:matrix.org](https://matrix.to/#/#qgis:matrix.org) room.
-    - Using [Gitter](https://gitter.im/qgis/QGIS) chat.
+    - Using an IRC client and joining the
+      [#qgis](https://web.libera.chat/?channels=#qgis) channel on irc.libera.chat.
+    - Using a Matrix client and joining the [#qgis:osgeo.org](https://matrix.to/#/#qgis:osgeo.org) room.
  - At the [GIS stackexchange](https://gis.stackexchange.com/) or [r/QGIS reddit](https://www.reddit.com/r/QGIS/), which are not maintained by the QGIS team, but where the QGIS and broader GIS community provides lots of advice
 - [Other support channels](https://qgis.org/en/site/forusers/support.html)
 


### PR DESCRIPTION
First commit is about the chat section in the local README to match what's on the website 
See https://qgis.org/en/site/forusers/support.html

Second commit is for the INSTALL file to mention QGIS_DEBUG environment variable
See https://lists.osgeo.org/pipermail/qgis-developer/2024-May/066821.html
