### PR TITLE
Prevent calling findLayers when there is no legend->rootGroup (fix #57595)

### DIFF
--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -1016,10 +1016,12 @@ void QgsLayoutItemLegend::updateFilterByMapAndRedraw()
 void QgsLayoutItemLegend::setModelStyleOverrides( const QMap<QString, QString> &overrides )
 {
   mLegendModel->setLayerStyleOverrides( overrides );
-  const QList< QgsLayerTreeLayer * > layers =  mLegendModel->rootGroup()->findLayers();
-  for ( QgsLayerTreeLayer *nodeLayer : layers )
-    mLegendModel->refreshLayerLegend( nodeLayer );
-
+  if ( QgsLayerTree *rootGroup = mLegendModel->rootGroup() )
+  {
+    const QList< QgsLayerTreeLayer * > layers =  rootGroup->findLayers();
+    for ( QgsLayerTreeLayer *nodeLayer : layers )
+      mLegendModel->refreshLayerLegend( nodeLayer );
+  }
 }
 
 void QgsLayoutItemLegend::clearLegendCachedData()

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -1019,7 +1019,7 @@ void QgsLayoutItemLegend::setModelStyleOverrides( const QMap<QString, QString> &
   if ( QgsLayerTree *rootGroup = mLegendModel->rootGroup() )
   {
     const QList< QgsLayerTreeLayer * > layers =  rootGroup->findLayers();
-    for ( QgsLayerTreeLayer *nodeLayer : layers )
+    for ( QgsLayerTreeLayer *nodeLayer : std::as_const( layers ) )
       mLegendModel->refreshLayerLegend( nodeLayer );
   }
 }


### PR DESCRIPTION
## Description

This PR adds a if condition to prevent a null pointer being used to call a method.

This prevents the crash mentioned in #57595.
