### PR TITLE
[ux][layouts] Fix legend item style mutex

### DIFF
--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -47,6 +47,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QInputDialog>
+#include <QActionGroup>
 
 ///@cond PRIVATE
 

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -1481,11 +1481,15 @@ QMenu *QgsLayoutLegendMenuProvider::createContextMenu()
 
   QgsLegendStyle::Style currentStyle = QgsLegendRenderer::nodeLegendStyle( mView->currentNode(), mView->layerTreeModel() );
 
+  QActionGroup *styleGroup = new QActionGroup{ mWidget };
+  styleGroup->setExclusive( true );
+
   QList<QgsLegendStyle::Style> lst;
   lst << QgsLegendStyle::Hidden << QgsLegendStyle::Group << QgsLegendStyle::Subgroup;
   for ( QgsLegendStyle::Style style : std::as_const( lst ) )
   {
     QAction *action = menu->addAction( QgsLegendStyle::styleLabel( style ), mWidget, &QgsLayoutLegendWidget::setCurrentNodeStyleFromAction );
+    action->setActionGroup( styleGroup );
     action->setCheckable( true );
     action->setChecked( currentStyle == style );
     action->setData( static_cast< int >( style ) );


### PR DESCRIPTION
The style was rendered as checkboxes actions while the correct UI for mutually exclusive options is a radio button.

## Before

![immagine](https://github.com/qgis/QGIS/assets/142164/faa9000a-327a-48b8-9652-d64ce56e2581)


## After

![immagine](https://github.com/qgis/QGIS/assets/142164/b039d120-cd7c-4f5b-b348-7d5517e49ee1)

