### PR TITLE
qgs3dmapsettings: Fix extent methods documention

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -48,18 +48,22 @@ Resolves references to other objects (map layers) after the call to :py:func:`~Q
 
     QgsRectangle extent() const;
 %Docstring
-Returns the 3D scene's 2D extent in project's CRS
+Returns the 3D scene's 2D extent in the 3D scene's CRS
+
+.. seealso:: :py:func:`crs`
 
 .. versionadded:: 3.30
 %End
 
     void setExtent( const QgsRectangle &extent );
 %Docstring
-Sets the 3D scene's 2D ``extent`` in project's CRS, while also setting the scene's origin to the extent's center
+Sets the 3D scene's 2D ``extent`` in the 3D scene's CRS, while also setting the scene's origin to the extent's center
 This needs to be called during initialization, as terrain will only be generated
 within this extent and layer 3D data will only be loaded within this extent too.
 
 .. seealso:: :py:func:`setOrigin`
+
+.. seealso:: :py:func:`setCrs`
 
 .. versionadded:: 3.30
 %End

--- a/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -48,18 +48,22 @@ Resolves references to other objects (map layers) after the call to :py:func:`~Q
 
     QgsRectangle extent() const;
 %Docstring
-Returns the 3D scene's 2D extent in project's CRS
+Returns the 3D scene's 2D extent in the 3D scene's CRS
+
+.. seealso:: :py:func:`crs`
 
 .. versionadded:: 3.30
 %End
 
     void setExtent( const QgsRectangle &extent );
 %Docstring
-Sets the 3D scene's 2D ``extent`` in project's CRS, while also setting the scene's origin to the extent's center
+Sets the 3D scene's 2D ``extent`` in the 3D scene's CRS, while also setting the scene's origin to the extent's center
 This needs to be called during initialization, as terrain will only be generated
 within this extent and layer 3D data will only be loaded within this extent too.
 
 .. seealso:: :py:func:`setOrigin`
+
+.. seealso:: :py:func:`setCrs`
 
 .. versionadded:: 3.30
 %End

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -68,17 +68,20 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     void resolveReferences( const QgsProject &project );
 
     /**
-     * Returns the 3D scene's 2D extent in project's CRS
+     * Returns the 3D scene's 2D extent in the 3D scene's CRS
+     *
+     * \see crs()
      * \since QGIS 3.30
      */
     QgsRectangle extent() const { return mExtent; }
 
     /**
-     * Sets the 3D scene's 2D \a extent in project's CRS, while also setting the scene's origin to the extent's center
+     * Sets the 3D scene's 2D \a extent in the 3D scene's CRS, while also setting the scene's origin to the extent's center
      * This needs to be called during initialization, as terrain will only be generated
      * within this extent and layer 3D data will only be loaded within this extent too.
      *
      * \see setOrigin()
+     * \see setCrs()
      * \since QGIS 3.30
      */
     void setExtent( const QgsRectangle &extent );


### PR DESCRIPTION
## Description

The 3D scene's CRS is not necessarily the same as the project's CRS. For example, it can be "EPSG:3857" if the project's CRS is geographic.

The stored extent in the settings is always the 3D scene's extent.

See:
https://github.com/qgis/qGIS/commit/b0d1a4f8b1cc244ccf2bc3b07798f9ee3540072f


