### PR TITLE
When field has no explicit type string set, use field type instead

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -111,6 +111,10 @@ QString QgsField::displayNameWithAlias() const
 QString QgsField::displayType( const bool showConstraints ) const
 {
   QString typeStr = typeName();
+  if ( typeStr.isEmpty() )
+  {
+    typeStr = QgsVariantUtils::typeToDisplayString( type(), subType() );
+  }
 
   if ( length() > 0 && precision() > 0 )
     typeStr += QStringLiteral( "(%1, %2)" ).arg( length() ).arg( precision() );

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -995,6 +995,14 @@ void TestQgsField::displayType()
   constraints.setConstraint( QgsFieldConstraints::ConstraintUnique );
   field.setConstraints( constraints );
   QCOMPARE( field.displayType( true ), QString( "numeric(20, 10) NULL UNIQUE" ) );
+
+  // test field without an explicit type name, we should use the field type
+  QgsField field2;
+  field2.setType( QMetaType::Type::QString );
+  QCOMPARE( field2.displayType( false ), QString( "Text (string)" ) );
+  QCOMPARE( field2.displayType( true ), QString( "Text (string) NULL" ) );
+  field2.setType( QMetaType::Type::Int );
+  QCOMPARE( field2.displayType( false ), QString( "Integer (32 bit)" ) );
 }
 
 void TestQgsField::friendlyTypeString()


### PR DESCRIPTION
Avoids missing field type information in eg the horizontal header tooltips in attribute table
