### PR TITLE
[qml] Add missing QgsProject's transactionMode property

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -1907,6 +1907,13 @@ Emitted when the project :py:func:`~QgsProject.transformContext` is changed.
 Emitted when datum transforms stored in the project are not available locally.
 %End
 
+    void transactionModeChanged();
+%Docstring
+Emitted when the transaction mode has changed.
+
+.. versionadded:: 3.38
+%End
+
     void transactionGroupsChanged();
 %Docstring
 Emitted whenever a new transaction group has been created or a

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1907,6 +1907,13 @@ Emitted when the project :py:func:`~QgsProject.transformContext` is changed.
 Emitted when datum transforms stored in the project are not available locally.
 %End
 
+    void transactionModeChanged();
+%Docstring
+Emitted when the transaction mode has changed.
+
+.. versionadded:: 3.38
+%End
+
     void transactionGroupsChanged();
 %Docstring
 Emitted whenever a new transaction group has been created or a

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -4439,9 +4439,9 @@ void QgsProject::setAutoTransaction( bool autoTransaction )
     return;
 
   if ( autoTransaction )
-    mTransactionMode = Qgis::TransactionMode::AutomaticGroups;
+    setTransactionMode( Qgis::TransactionMode::AutomaticGroups );
   else
-    mTransactionMode = Qgis::TransactionMode::Disabled;
+    setTransactionMode( Qgis::TransactionMode::Disabled );
 
   updateTransactionGroups();
 }
@@ -4473,6 +4473,7 @@ bool QgsProject::setTransactionMode( Qgis::TransactionMode transactionMode )
 
   mTransactionMode = transactionMode;
   updateTransactionGroups();
+  emit transactionModeChanged();
   return true;
 }
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -124,6 +124,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Q_PROPERTY( Qgis::DistanceUnit distanceUnits READ distanceUnits WRITE setDistanceUnits NOTIFY distanceUnitsChanged )
     Q_PROPERTY( Qgis::AreaUnit areaUnits READ areaUnits WRITE setAreaUnits NOTIFY areaUnitsChanged )
     Q_PROPERTY( QgsProjectDisplaySettings *displaySettings READ displaySettings CONSTANT )
+    Q_PROPERTY( Qgis::TransactionMode transactionMode READ transactionMode WRITE setTransactionMode NOTIFY transactionModeChanged )
 
   public:
 
@@ -1920,6 +1921,12 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * Emitted when datum transforms stored in the project are not available locally.
      */
     void missingDatumTransforms( const QStringList &missingTransforms );
+
+    /**
+     * Emitted when the transaction mode has changed.
+     * \since QGIS 3.38
+     */
+    void transactionModeChanged();
 
     /**
      * Emitted whenever a new transaction group has been created or a


### PR DESCRIPTION
## Description

QML API-only change to cover one more QgsProperty property.