### PR TITLE
Fix glitchy table layout + easy option to copy versions information

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5508,26 +5508,28 @@ void QgisApp::about()
   if ( !sAbt )
   {
     sAbt = new QgsAbout( this );
-    QString versionString = QStringLiteral( "<html><body><div align='center'><table width='100%'>" );
+    QString versionString = QStringLiteral( "<div align='center'><table width='100%'>" );
 
-    versionString += QStringLiteral( "<tr><td>%1</td><td>%2</td><td>" ).arg( tr( "QGIS version" ), Qgis::version() );
+    versionString += QStringLiteral( "<tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Libraries" ) );
+    versionString += QStringLiteral( "<tr><td>%1</td><td>%2</td>" ).arg( tr( "QGIS version" ), Qgis::version() );
 
     if ( QString( Qgis::devVersion() ) == QLatin1String( "exported" ) )
     {
       versionString += tr( "QGIS code branch" );
       if ( Qgis::version().endsWith( QLatin1String( "Master" ) ) )
       {
-        versionString += QLatin1String( "</td><td><a href=\"https://github.com/qgis/QGIS/tree/master\">master</a></td>" );
+        versionString += QLatin1String( "<td><a href=\"https://github.com/qgis/QGIS/tree/master\">master</a></td>" );
       }
       else
       {
-        versionString += QStringLiteral( "</td><td><a href=\"https://github.com/qgis/QGIS/tree/release-%1_%2\">Release %1.%2</a></td>" )
+        versionString += QStringLiteral( "<td><a href=\"https://github.com/qgis/QGIS/tree/release-%1_%2\">Release %1.%2</a></td>" )
                          .arg( Qgis::versionInt() / 10000 ).arg( Qgis::versionInt() / 100 % 100 );
       }
     }
     else
     {
-      versionString += QStringLiteral( "%1</td><td><a href=\"https://github.com/qgis/QGIS/commit/%2\">%2</a></td>" ).arg( tr( "QGIS code revision" ), Qgis::devVersion() );
+      versionString += QLatin1String( "</tr><tr>" );
+      versionString += QStringLiteral( "<td>%1</td><td><a href=\"https://github.com/qgis/QGIS/commit/%2\">%2</a></td>" ).arg( tr( "QGIS code revision" ), Qgis::devVersion() );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -5541,7 +5543,7 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "Qt version" ), qtVersionCompiled );
+      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Qt version" ), qtVersionCompiled );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -5556,7 +5558,7 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "Python version" ), PYTHON_VERSION );
+      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Python version" ), PYTHON_VERSION );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -5570,7 +5572,7 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "GDAL/OGR version" ), gdalVersionCompiled );
+      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GDAL/OGR version" ), gdalVersionCompiled );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -5585,12 +5587,12 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "PROJ version" ), projVersionCompiled );
+      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PROJ version" ), projVersionCompiled );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
     // CRS database versions
-    versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2 (%3)</td>" ).arg( tr( "EPSG Registry database version" ), QgsProjUtils::epsgRegistryVersion(), QgsProjUtils::epsgRegistryDate().toString( Qt::ISODate ) );
+    versionString += QStringLiteral( "<td>%1</td><td>%2 (%3)</td>" ).arg( tr( "EPSG Registry database version" ), QgsProjUtils::epsgRegistryVersion(), QgsProjUtils::epsgRegistryDate().toString( Qt::ISODate ) );
     versionString += QLatin1String( "</tr><tr>" );
 
     // GEOS version
@@ -5603,7 +5605,7 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "GEOS version" ), geosVersionCompiled );
+      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GEOS version" ), geosVersionCompiled );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -5617,7 +5619,7 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "SQLite version" ), sqliteVersionCompiled );
+      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "SQLite version" ), sqliteVersionCompiled );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -5639,13 +5641,13 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "PDAL version" ), pdalVersionCompiled );
+      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PDAL version" ), pdalVersionCompiled );
     }
     versionString += QLatin1String( "</tr><tr>" );
 #endif
 
     // postgres
-    versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">" ).arg( tr( "PostgreSQL client version" ) );
+    versionString += QStringLiteral( "<td>%1</td><td>" ).arg( tr( "PostgreSQL client version" ) );
 #ifdef HAVE_POSTGRESQL
     versionString += QStringLiteral( PG_VERSION );
 #else
@@ -5654,7 +5656,7 @@ void QgisApp::about()
     versionString += QLatin1String( "</td></tr><tr>" );
 
     // spatialite
-    versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">" ).arg( tr( "SpatiaLite version" ) );
+    versionString += QStringLiteral( "<td>%1</td><td>" ).arg( tr( "SpatiaLite version" ) );
 #ifdef HAVE_SPATIALITE
     versionString += QStringLiteral( "%1</td>" ).arg( spatialite_version() );
 #else
@@ -5663,37 +5665,37 @@ void QgisApp::about()
     versionString += QLatin1String( "</td></tr><tr>" );
 
     // QWT
-    versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "QWT version" ), QWT_VERSION_STR );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "QWT version" ), QWT_VERSION_STR );
     versionString += QLatin1String( "</tr><tr>" );
 
     // QScintilla
-    versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "QScintilla2 version" ), QSCINTILLA_VERSION_STR );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "QScintilla2 version" ), QSCINTILLA_VERSION_STR );
     versionString += QLatin1String( "</tr><tr>" );
 
     // Operating system
-    versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "OS version" ), QSysInfo::prettyProductName() );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "OS version" ), QSysInfo::prettyProductName() );
     versionString += QLatin1String( "</tr><tr>" );
 
 #ifdef QGISDEBUG
     versionString += QLatin1String( "</tr><tr>" );
-    versionString += QStringLiteral( "<td colspan=\"4\"><i>%1</i></td>" ).arg( tr( "This copy of QGIS writes debugging output." ) );
+    versionString += QStringLiteral( "<td colspan=\"2\"><i>%1</i></td>" ).arg( tr( "This copy of QGIS writes debugging output." ) );
     versionString += QLatin1String( "</tr><tr>" );
 #endif
 
 #ifdef WITH_BINDINGS
     if ( mPythonUtils && mPythonUtils->isEnabled() )
     {
-      versionString += QStringLiteral( "</tr><tr><td colspan=\"4\">%1</td>" ).arg( tr( "Active Python plugins" ) );
+      versionString += QStringLiteral( "</tr><tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Active Python plugins" ) );
       const QStringList activePlugins = mPythonUtils->listActivePlugins();
       for ( const QString &plugin : activePlugins )
       {
         const QString version = mPythonUtils->getPluginMetadata( plugin, QStringLiteral( "version" ) );
-        versionString += QStringLiteral( "</tr><tr><td>%1</td><td colspan=\"3\">%2</td>" ).arg( plugin, version );
+        versionString += QStringLiteral( "</tr><tr><td>%1</td><td>%2</td>" ).arg( plugin, version );
       }
     }
 #endif
 
-    versionString += QLatin1String( "</tr></table></div></body></html>" );
+    versionString += QLatin1String( "</tr></table></div>" );
 
     sAbt->setVersion( versionString );
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5508,200 +5508,204 @@ void QgisApp::about()
   if ( !sAbt )
   {
     sAbt = new QgsAbout( this );
-    QString versionString = QStringLiteral( "<div align='center'><table width='100%'>" );
-
-    versionString += QStringLiteral( "<tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Libraries" ) );
-    versionString += QStringLiteral( "<tr><td>%1</td><td>%2</td>" ).arg( tr( "QGIS version" ), Qgis::version() );
-
-    if ( QString( Qgis::devVersion() ) == QLatin1String( "exported" ) )
-    {
-      versionString += tr( "QGIS code branch" );
-      if ( Qgis::version().endsWith( QLatin1String( "Master" ) ) )
-      {
-        versionString += QLatin1String( "<td><a href=\"https://github.com/qgis/QGIS/tree/master\">master</a></td>" );
-      }
-      else
-      {
-        versionString += QStringLiteral( "<td><a href=\"https://github.com/qgis/QGIS/tree/release-%1_%2\">Release %1.%2</a></td>" )
-                         .arg( Qgis::versionInt() / 10000 ).arg( Qgis::versionInt() / 100 % 100 );
-      }
-    }
-    else
-    {
-      versionString += QLatin1String( "</tr><tr>" );
-      versionString += QStringLiteral( "<td>%1</td><td><a href=\"https://github.com/qgis/QGIS/commit/%2\">%2</a></td>" ).arg( tr( "QGIS code revision" ), Qgis::devVersion() );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // Qt version
-    const QString qtVersionCompiled{ QT_VERSION_STR };
-    const QString qtVersionRunning{ qVersion() };
-    if ( qtVersionCompiled != qtVersionRunning )
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against Qt" ), qtVersionCompiled );
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against Qt" ), qtVersionRunning );
-    }
-    else
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Qt version" ), qtVersionCompiled );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // Python version
-    QString pythonVersion;
-    QgsPythonRunner::run( QStringLiteral( "import platform" ) );
-    QgsPythonRunner::eval( QStringLiteral( "platform.python_version()" ), pythonVersion );
-    if ( pythonVersion != PYTHON_VERSION )
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against Python" ), PYTHON_VERSION );
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against Python" ), pythonVersion );
-    }
-    else
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Python version" ), PYTHON_VERSION );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // GDAL version
-    const QString gdalVersionCompiled { GDAL_RELEASE_NAME };
-    const QString gdalVersionRunning { GDALVersionInfo( "RELEASE_NAME" ) };
-    if ( gdalVersionCompiled != gdalVersionRunning )
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against GDAL/OGR" ), gdalVersionCompiled );
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against GDAL/OGR" ), gdalVersionRunning );
-    }
-    else
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GDAL/OGR version" ), gdalVersionCompiled );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // proj
-    PJ_INFO info = proj_info();
-    const QString projVersionCompiled { QStringLiteral( "%1.%2.%3" ).arg( PROJ_VERSION_MAJOR ).arg( PROJ_VERSION_MINOR ).arg( PROJ_VERSION_PATCH ) };
-    const QString projVersionRunning { info.version };
-    if ( projVersionCompiled != projVersionRunning )
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against PROJ" ), projVersionCompiled );
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against PROJ" ), projVersionRunning );
-    }
-    else
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PROJ version" ), projVersionCompiled );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // CRS database versions
-    versionString += QStringLiteral( "<td>%1</td><td>%2 (%3)</td>" ).arg( tr( "EPSG Registry database version" ), QgsProjUtils::epsgRegistryVersion(), QgsProjUtils::epsgRegistryDate().toString( Qt::ISODate ) );
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // GEOS version
-    const QString geosVersionCompiled { GEOS_CAPI_VERSION };
-    const QString geosVersionRunning { GEOSversion() };
-    if ( geosVersionCompiled != geosVersionRunning )
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against GEOS" ), geosVersionCompiled );
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against GEOS" ), geosVersionRunning );
-    }
-    else
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GEOS version" ), geosVersionCompiled );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // SQLite version
-    const QString sqliteVersionCompiled { SQLITE_VERSION };
-    const QString sqliteVersionRunning { sqlite3_libversion() };
-    if ( sqliteVersionCompiled != sqliteVersionRunning )
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against SQLite" ), sqliteVersionCompiled );
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against SQLite" ), sqliteVersionRunning );
-    }
-    else
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "SQLite version" ), sqliteVersionCompiled );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // PDAL
-#ifdef HAVE_PDAL_QGIS
-    const QString pdalVersionCompiled { PDAL_VERSION };
-#if PDAL_VERSION_MAJOR_INT > 1 || (PDAL_VERSION_MAJOR_INT == 1 && PDAL_VERSION_MINOR_INT >= 7)
-    const QString pdalVersionRunningRaw { QString::fromStdString( pdal::Config::fullVersionString() ) };
-#else
-    const QString pdalVersionRunningRaw { QString::fromStdString( pdal::GetFullVersionString() ) };
-#endif
-    const thread_local QRegularExpression pdalVersionRx { QStringLiteral( "(\\d+\\.\\d+\\.\\d+)" )};
-    const QRegularExpressionMatch pdalVersionMatch{ pdalVersionRx.match( pdalVersionRunningRaw ) };
-    const QString pdalVersionRunning{ pdalVersionMatch.hasMatch() ? pdalVersionMatch.captured( 1 ) : pdalVersionRunningRaw };
-    if ( pdalVersionCompiled != pdalVersionRunning )
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against PDAL" ), pdalVersionCompiled );
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against PDAL" ), pdalVersionRunning );
-    }
-    else
-    {
-      versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PDAL version" ), pdalVersionCompiled );
-    }
-    versionString += QLatin1String( "</tr><tr>" );
-#endif
-
-    // postgres
-    versionString += QStringLiteral( "<td>%1</td><td>" ).arg( tr( "PostgreSQL client version" ) );
-#ifdef HAVE_POSTGRESQL
-    versionString += QStringLiteral( PG_VERSION );
-#else
-    versionString += tr( "No support" );
-#endif
-    versionString += QLatin1String( "</td></tr><tr>" );
-
-    // spatialite
-    versionString += QStringLiteral( "<td>%1</td><td>" ).arg( tr( "SpatiaLite version" ) );
-#ifdef HAVE_SPATIALITE
-    versionString += QStringLiteral( "%1</td>" ).arg( spatialite_version() );
-#else
-    versionString += tr( "No support" );
-#endif
-    versionString += QLatin1String( "</td></tr><tr>" );
-
-    // QWT
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "QWT version" ), QWT_VERSION_STR );
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // QScintilla
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "QScintilla2 version" ), QSCINTILLA_VERSION_STR );
-    versionString += QLatin1String( "</tr><tr>" );
-
-    // Operating system
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "OS version" ), QSysInfo::prettyProductName() );
-    versionString += QLatin1String( "</tr><tr>" );
-
-#ifdef QGISDEBUG
-    versionString += QLatin1String( "</tr><tr>" );
-    versionString += QStringLiteral( "<td colspan=\"2\"><i>%1</i></td>" ).arg( tr( "This copy of QGIS writes debugging output." ) );
-    versionString += QLatin1String( "</tr><tr>" );
-#endif
-
-#ifdef WITH_BINDINGS
-    if ( mPythonUtils && mPythonUtils->isEnabled() )
-    {
-      versionString += QStringLiteral( "</tr><tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Active Python plugins" ) );
-      const QStringList activePlugins = mPythonUtils->listActivePlugins();
-      for ( const QString &plugin : activePlugins )
-      {
-        const QString version = mPythonUtils->getPluginMetadata( plugin, QStringLiteral( "version" ) );
-        versionString += QStringLiteral( "</tr><tr><td>%1</td><td>%2</td>" ).arg( plugin, version );
-      }
-    }
-#endif
-
-    versionString += QLatin1String( "</tr></table></div>" );
-
-    sAbt->setVersion( versionString );
+    sAbt->setVersion( QgisApp::getVersionString() );
   }
   sAbt->show();
   sAbt->raise();
   sAbt->activateWindow();
+}
+
+QString QgisApp::getVersionString()
+{
+  QString versionString = QStringLiteral( "<table width='100%' align='center'>" );
+
+  versionString += QStringLiteral( "<tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Libraries" ) );
+  versionString += QStringLiteral( "<tr><td>%1</td><td>%2</td>" ).arg( tr( "QGIS version" ), Qgis::version() );
+
+  if ( QString( Qgis::devVersion() ) == QLatin1String( "exported" ) )
+  {
+    versionString += tr( "QGIS code branch" );
+    if ( Qgis::version().endsWith( QLatin1String( "Master" ) ) )
+    {
+      versionString += QLatin1String( "<td><a href=\"https://github.com/qgis/QGIS/tree/master\">master</a></td>" );
+    }
+    else
+    {
+      versionString += QStringLiteral( "<td><a href=\"https://github.com/qgis/QGIS/tree/release-%1_%2\">Release %1.%2</a></td>" )
+                       .arg( Qgis::versionInt() / 10000 ).arg( Qgis::versionInt() / 100 % 100 );
+    }
+  }
+  else
+  {
+    versionString += QLatin1String( "</tr><tr>" );
+    versionString += QStringLiteral( "<td>%1</td><td><a href=\"https://github.com/qgis/QGIS/commit/%2\">%2</a></td>" ).arg( tr( "QGIS code revision" ), Qgis::devVersion() );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // Qt version
+  const QString qtVersionCompiled{ QT_VERSION_STR };
+  const QString qtVersionRunning{ qVersion() };
+  if ( qtVersionCompiled != qtVersionRunning )
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against Qt" ), qtVersionCompiled );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against Qt" ), qtVersionRunning );
+  }
+  else
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Qt version" ), qtVersionCompiled );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // Python version
+  QString pythonVersion;
+  QgsPythonRunner::run( QStringLiteral( "import platform" ) );
+  QgsPythonRunner::eval( QStringLiteral( "platform.python_version()" ), pythonVersion );
+  if ( pythonVersion != PYTHON_VERSION )
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against Python" ), PYTHON_VERSION );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against Python" ), pythonVersion );
+  }
+  else
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Python version" ), PYTHON_VERSION );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // GDAL version
+  const QString gdalVersionCompiled { GDAL_RELEASE_NAME };
+  const QString gdalVersionRunning { GDALVersionInfo( "RELEASE_NAME" ) };
+  if ( gdalVersionCompiled != gdalVersionRunning )
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against GDAL/OGR" ), gdalVersionCompiled );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against GDAL/OGR" ), gdalVersionRunning );
+  }
+  else
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GDAL/OGR version" ), gdalVersionCompiled );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // proj
+  PJ_INFO info = proj_info();
+  const QString projVersionCompiled { QStringLiteral( "%1.%2.%3" ).arg( PROJ_VERSION_MAJOR ).arg( PROJ_VERSION_MINOR ).arg( PROJ_VERSION_PATCH ) };
+  const QString projVersionRunning { info.version };
+  if ( projVersionCompiled != projVersionRunning )
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against PROJ" ), projVersionCompiled );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against PROJ" ), projVersionRunning );
+  }
+  else
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PROJ version" ), projVersionCompiled );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // CRS database versions
+  versionString += QStringLiteral( "<td>%1</td><td>%2 (%3)</td>" ).arg( tr( "EPSG Registry database version" ), QgsProjUtils::epsgRegistryVersion(), QgsProjUtils::epsgRegistryDate().toString( Qt::ISODate ) );
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // GEOS version
+  const QString geosVersionCompiled { GEOS_CAPI_VERSION };
+  const QString geosVersionRunning { GEOSversion() };
+  if ( geosVersionCompiled != geosVersionRunning )
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against GEOS" ), geosVersionCompiled );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against GEOS" ), geosVersionRunning );
+  }
+  else
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GEOS version" ), geosVersionCompiled );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // SQLite version
+  const QString sqliteVersionCompiled { SQLITE_VERSION };
+  const QString sqliteVersionRunning { sqlite3_libversion() };
+  if ( sqliteVersionCompiled != sqliteVersionRunning )
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against SQLite" ), sqliteVersionCompiled );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against SQLite" ), sqliteVersionRunning );
+  }
+  else
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "SQLite version" ), sqliteVersionCompiled );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // PDAL
+#ifdef HAVE_PDAL_QGIS
+  const QString pdalVersionCompiled { PDAL_VERSION };
+#if PDAL_VERSION_MAJOR_INT > 1 || (PDAL_VERSION_MAJOR_INT == 1 && PDAL_VERSION_MINOR_INT >= 7)
+  const QString pdalVersionRunningRaw { QString::fromStdString( pdal::Config::fullVersionString() ) };
+#else
+  const QString pdalVersionRunningRaw { QString::fromStdString( pdal::GetFullVersionString() ) };
+#endif
+  const thread_local QRegularExpression pdalVersionRx { QStringLiteral( "(\\d+\\.\\d+\\.\\d+)" )};
+  const QRegularExpressionMatch pdalVersionMatch{ pdalVersionRx.match( pdalVersionRunningRaw ) };
+  const QString pdalVersionRunning{ pdalVersionMatch.hasMatch() ? pdalVersionMatch.captured( 1 ) : pdalVersionRunningRaw };
+  if ( pdalVersionCompiled != pdalVersionRunning )
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against PDAL" ), pdalVersionCompiled );
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against PDAL" ), pdalVersionRunning );
+  }
+  else
+  {
+    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PDAL version" ), pdalVersionCompiled );
+  }
+  versionString += QLatin1String( "</tr><tr>" );
+#endif
+
+  // postgres
+  versionString += QStringLiteral( "<td>%1</td><td>" ).arg( tr( "PostgreSQL client version" ) );
+#ifdef HAVE_POSTGRESQL
+  versionString += QStringLiteral( PG_VERSION );
+#else
+  versionString += tr( "No support" );
+#endif
+  versionString += QLatin1String( "</td></tr><tr>" );
+
+  // spatialite
+  versionString += QStringLiteral( "<td>%1</td><td>" ).arg( tr( "SpatiaLite version" ) );
+#ifdef HAVE_SPATIALITE
+  versionString += QStringLiteral( "%1</td>" ).arg( spatialite_version() );
+#else
+  versionString += tr( "No support" );
+#endif
+  versionString += QLatin1String( "</td></tr><tr>" );
+
+  // QWT
+  versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "QWT version" ), QWT_VERSION_STR );
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // QScintilla
+  versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "QScintilla2 version" ), QSCINTILLA_VERSION_STR );
+  versionString += QLatin1String( "</tr><tr>" );
+
+  // Operating system
+  versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "OS version" ), QSysInfo::prettyProductName() );
+  versionString += QLatin1String( "</tr><tr>" );
+
+#ifdef QGISDEBUG
+  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QStringLiteral( "<td colspan=\"2\"><i>%1</i></td>" ).arg( tr( "This copy of QGIS writes debugging output." ) );
+  versionString += QLatin1String( "</tr><tr>" );
+#endif
+
+#ifdef WITH_BINDINGS
+  if ( mPythonUtils && mPythonUtils->isEnabled() )
+  {
+    versionString += QStringLiteral( "<td colspan=\"2\">&nbsp;</td></tr><tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Active Python plugins" ) );
+    const QStringList activePlugins = mPythonUtils->listActivePlugins();
+    for ( const QString &plugin : activePlugins )
+    {
+      const QString version = mPythonUtils->getPluginMetadata( plugin, QStringLiteral( "version" ) );
+      versionString += QStringLiteral( "</tr><tr><td>%1</td><td>%2</td>" ).arg( plugin, version );
+    }
+  }
+#endif
+
+  versionString += QLatin1String( "</tr></table>" );
+  return versionString;
 }
 
 QString QgisApp::crsAndFormatAdjustedLayerUri( const QString &uri, const QStringList &supportedCrs, const QStringList &supportedFormats ) const

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5519,6 +5519,9 @@ QString QgisApp::getVersionString()
 {
   QString versionString = QStringLiteral( "<table width='100%' align='center'>" );
 
+  const QString compLabel = tr( "Compiled" );
+  const QString runLabel = tr( "Running" );
+
   versionString += QStringLiteral( "<tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Libraries" ) );
   versionString += QStringLiteral( "<tr><td>%1</td><td>%2</td>" ).arg( tr( "QGIS version" ), Qgis::version() );
 
@@ -5545,60 +5548,44 @@ QString QgisApp::getVersionString()
   // Qt version
   const QString qtVersionCompiled{ QT_VERSION_STR };
   const QString qtVersionRunning{ qVersion() };
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "Qt version" ), qtVersionCompiled );
   if ( qtVersionCompiled != qtVersionRunning )
   {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against Qt" ), qtVersionCompiled );
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against Qt" ), qtVersionRunning );
+    versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, qtVersionRunning, runLabel );
   }
-  else
-  {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Qt version" ), qtVersionCompiled );
-  }
-  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QLatin1String( "</td></tr><tr>" );
 
   // Python version
   QString pythonVersion;
   QgsPythonRunner::run( QStringLiteral( "import platform" ) );
   QgsPythonRunner::eval( QStringLiteral( "platform.python_version()" ), pythonVersion );
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "Python version" ), PYTHON_VERSION );
   if ( pythonVersion != PYTHON_VERSION )
   {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against Python" ), PYTHON_VERSION );
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against Python" ), pythonVersion );
+    versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, pythonVersion, runLabel );
   }
-  else
-  {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Python version" ), PYTHON_VERSION );
-  }
-  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QLatin1String( "</td></tr><tr>" );
 
   // GDAL version
   const QString gdalVersionCompiled { GDAL_RELEASE_NAME };
   const QString gdalVersionRunning { GDALVersionInfo( "RELEASE_NAME" ) };
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "GDAL/OGR version" ), gdalVersionCompiled );
   if ( gdalVersionCompiled != gdalVersionRunning )
   {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against GDAL/OGR" ), gdalVersionCompiled );
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against GDAL/OGR" ), gdalVersionRunning );
+    versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, gdalVersionRunning, runLabel );
   }
-  else
-  {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GDAL/OGR version" ), gdalVersionCompiled );
-  }
-  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QLatin1String( "</td></tr><tr>" );
 
   // proj
   PJ_INFO info = proj_info();
   const QString projVersionCompiled { QStringLiteral( "%1.%2.%3" ).arg( PROJ_VERSION_MAJOR ).arg( PROJ_VERSION_MINOR ).arg( PROJ_VERSION_PATCH ) };
   const QString projVersionRunning { info.version };
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "PROJ version" ), projVersionCompiled );
   if ( projVersionCompiled != projVersionRunning )
   {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against PROJ" ), projVersionCompiled );
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against PROJ" ), projVersionRunning );
+    versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, projVersionRunning, runLabel );
   }
-  else
-  {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PROJ version" ), projVersionCompiled );
-  }
-  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QLatin1String( "</td></tr><tr>" );
 
   // CRS database versions
   versionString += QStringLiteral( "<td>%1</td><td>%2 (%3)</td>" ).arg( tr( "EPSG Registry database version" ), QgsProjUtils::epsgRegistryVersion(), QgsProjUtils::epsgRegistryDate().toString( Qt::ISODate ) );
@@ -5607,30 +5594,22 @@ QString QgisApp::getVersionString()
   // GEOS version
   const QString geosVersionCompiled { GEOS_CAPI_VERSION };
   const QString geosVersionRunning { GEOSversion() };
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "GEOS version" ), geosVersionCompiled );
   if ( geosVersionCompiled != geosVersionRunning )
   {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against GEOS" ), geosVersionCompiled );
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against GEOS" ), geosVersionRunning );
+    versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, geosVersionRunning, runLabel );
   }
-  else
-  {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "GEOS version" ), geosVersionCompiled );
-  }
-  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QLatin1String( "</td></tr><tr>" );
 
   // SQLite version
   const QString sqliteVersionCompiled { SQLITE_VERSION };
   const QString sqliteVersionRunning { sqlite3_libversion() };
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "SQLite version" ), sqliteVersionCompiled );
   if ( sqliteVersionCompiled != sqliteVersionRunning )
   {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against SQLite" ), sqliteVersionCompiled );
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against SQLite" ), sqliteVersionRunning );
+    versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, sqliteVersionRunning, runLabel );
   }
-  else
-  {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "SQLite version" ), sqliteVersionCompiled );
-  }
-  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QLatin1String( "</td></tr><tr>" );
 
   // PDAL
 #ifdef HAVE_PDAL_QGIS
@@ -5643,16 +5622,12 @@ QString QgisApp::getVersionString()
   const thread_local QRegularExpression pdalVersionRx { QStringLiteral( "(\\d+\\.\\d+\\.\\d+)" )};
   const QRegularExpressionMatch pdalVersionMatch{ pdalVersionRx.match( pdalVersionRunningRaw ) };
   const QString pdalVersionRunning{ pdalVersionMatch.hasMatch() ? pdalVersionMatch.captured( 1 ) : pdalVersionRunningRaw };
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "PDAL version" ), pdalVersionCompiled );
   if ( pdalVersionCompiled != pdalVersionRunning )
   {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Compiled against PDAL" ), pdalVersionCompiled );
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "Running against PDAL" ), pdalVersionRunning );
+    versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, pdalVersionRunning, runLabel );
   }
-  else
-  {
-    versionString += QStringLiteral( "<td>%1</td><td>%2</td>" ).arg( tr( "PDAL version" ), pdalVersionCompiled );
-  }
-  versionString += QLatin1String( "</tr><tr>" );
+  versionString += QLatin1String( "</td></tr><tr>" );
 #endif
 
   // postgres
@@ -5686,7 +5661,6 @@ QString QgisApp::getVersionString()
   versionString += QLatin1String( "</tr><tr>" );
 
 #ifdef QGISDEBUG
-  versionString += QLatin1String( "</tr><tr>" );
   versionString += QStringLiteral( "<td colspan=\"2\"><i>%1</i></td>" ).arg( tr( "This copy of QGIS writes debugging output." ) );
   versionString += QLatin1String( "</tr><tr>" );
 #endif

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -931,6 +931,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
                                        const QString &baseName,
                                        const QString &provider );
 
+    /**
+     * Returns the html formated string with current versions of the libraries and the active plugins
+     */
+    QString getVersionString();
+
   public slots:
     //! save current vector layer
     QString saveAsFile( QgsMapLayer *layer = nullptr, bool onlySelected = false, bool defaultToAddToMap = true );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -932,7 +932,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
                                        const QString &provider );
 
     /**
-     * Returns the html formated string with current versions of the libraries and the active plugins
+     * Returns the html formatted string with current versions of the libraries and the active plugins
      */
     QString getVersionString();
 

--- a/src/app/qgsabout.cpp
+++ b/src/app/qgsabout.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgisapp.h"
 #include "qgsabout.h"
 #include "qgsapplication.h"
 #include "qgsauthmethodregistry.h"
@@ -227,6 +226,7 @@ void QgsAbout::setVersion( const QString &v )
   txtVersion->setBackgroundRole( QPalette::NoRole );
   txtVersion->setAutoFillBackground( true );
   txtVersion->setHtml( v );
+  mVersionString = v;
 }
 
 void QgsAbout::setWhatsNew()
@@ -276,8 +276,7 @@ void QgsAbout::setPluginInfo()
 
 void QgsAbout::btnCopyToClipboard_clicked()
 {
-  const QString versionString = QgisApp::instance()->getVersionString();
-  QGuiApplication::clipboard()->setText( versionString );
+  QGuiApplication::clipboard()->setText( mVersionString );
 }
 
 void QgsAbout::btnQgisUser_clicked()

--- a/src/app/qgsabout.cpp
+++ b/src/app/qgsabout.cpp
@@ -20,6 +20,7 @@
 #include "qgsauthmethodregistry.h"
 #include "qgsproviderregistry.h"
 #include "qgslogger.h"
+#include <QClipboard>
 #include <QDesktopServices>
 #include <QFile>
 #include <QTextStream>
@@ -43,6 +44,7 @@ QgsAbout::QgsAbout( QWidget *parent )
   setupUi( this );
   connect( btnQgisUser, &QPushButton::clicked, this, &QgsAbout::btnQgisUser_clicked );
   connect( btnQgisHome, &QPushButton::clicked, this, &QgsAbout::btnQgisHome_clicked );
+  connect( btnCopyToClipboard, &QPushButton::clicked, this, &QgsAbout::btnCopyToClipboard_clicked );
   if constexpr( QSysInfo::WordSize != 64 )
   {
     // 64 bit is the current standard. Only specify word size if it is not 64.
@@ -269,6 +271,12 @@ void QgsAbout::setPluginInfo()
   txtProviders->clear();
   txtProviders->document()->setDefaultStyleSheet( myStyle );
   txtProviders->setText( myString );
+}
+
+void QgsAbout::btnCopyToClipboard_clicked()
+{
+  QString markdown = txtVersion->toHtml();
+  QGuiApplication::clipboard()->setText( markdown );
 }
 
 void QgsAbout::btnQgisUser_clicked()

--- a/src/app/qgsabout.cpp
+++ b/src/app/qgsabout.cpp
@@ -15,6 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgisapp.h"
 #include "qgsabout.h"
 #include "qgsapplication.h"
 #include "qgsauthmethodregistry.h"
@@ -275,8 +276,8 @@ void QgsAbout::setPluginInfo()
 
 void QgsAbout::btnCopyToClipboard_clicked()
 {
-  QString markdown = txtVersion->toHtml();
-  QGuiApplication::clipboard()->setText( markdown );
+  const QString versionString = QgisApp::instance()->getVersionString();
+  QGuiApplication::clipboard()->setText( versionString );
 }
 
 void QgsAbout::btnQgisUser_clicked()

--- a/src/app/qgsabout.h
+++ b/src/app/qgsabout.h
@@ -38,6 +38,7 @@ class APP_EXPORT QgsAbout : public QgsOptionsDialogBase, private Ui::QgsAbout
     void init();
 
   private slots:
+    void btnCopyToClipboard_clicked();
     void btnQgisUser_clicked();
     void btnQgisHome_clicked();
     void openUrl( const QUrl &url );

--- a/src/app/qgsabout.h
+++ b/src/app/qgsabout.h
@@ -36,6 +36,7 @@ class APP_EXPORT QgsAbout : public QgsOptionsDialogBase, private Ui::QgsAbout
     void setPluginInfo();
     void setDevelopersMap();
     void init();
+    QString mVersionString;
 
   private slots:
     void btnCopyToClipboard_clicked();

--- a/src/ui/qgsabout.ui
+++ b/src/ui/qgsabout.ui
@@ -223,6 +223,13 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="btnCopyToClipboard">
+             <property name="text">
+              <string>Copy to Clipboard</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QLabel" name="label_3">
              <property name="text">
               <string>QGIS is licensed under the GNU General Public License</string>


### PR DESCRIPTION
## Description

Fixes the glitchy table layout and adds a button in the about page to copy the version information more easily as suggested in https://github.com/qgis/QGIS/issues/43739#issuecomment-916951618. The version information in the clipboard is available in a Github-friendly format.

Fixes #49054 

Before and after PR:
![about-page](https://github.com/qgis/QGIS/assets/18557959/1a3f4b48-5958-440e-9914-4dff8bffb21c)
![github-page](https://github.com/qgis/QGIS/assets/18557959/f05f64fa-27ba-42c1-a3eb-a3cdeac756ee)

