### PR TITLE
Optimise QgsAbstractGeometry::snappedToGrid

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -604,7 +604,7 @@ E.g. :py:class:`QgsLineString` -> :py:class:`QgsCompoundCurve`, :py:class:`QgsPo
 :return: the converted geometry. Caller takes ownership
 %End
 
-    virtual QgsAbstractGeometry *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const = 0 /Factory/;
 %Docstring
 Makes a new geometry with all the points or vertices snapped to the closest point of the grid.
 Ownership is transferred to the caller.
@@ -626,6 +626,7 @@ In this case, it can be thought like rounding the x and y of all the points/vert
 :param vSpacing: Vertical spacing of the grid (y axis). 0 to disable.
 :param dSpacing: Depth spacing of the grid (z axis). 0 (default) to disable.
 :param mSpacing: Custom dimension spacing of the grid (m axis). 0 (default) to disable.
+:param removeRedundantPoints: if ``True``, then points which are redundant (e.g. they represent mid points on a straight line segment) will be skipped (since QGIS 3.38)
 %End
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false ) = 0;

--- a/python/PyQt6/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -151,7 +151,7 @@ Appends the contents of another circular ``string`` to the end of this circular 
 
     virtual QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const /Factory/;
 
-    virtual QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/PyQt6/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -81,7 +81,7 @@ of the curve.
 :param toleranceType: maximum segmentation angle or maximum difference between approximation and curve
 %End
 
-    virtual QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/PyQt6/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -68,7 +68,7 @@ Curve polygon geometry type
 
     virtual QgsAbstractGeometry *boundary() const /Factory/;
 
-    virtual QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -95,7 +95,7 @@ Returns a geometry from within the collection.
 
     virtual void clear();
 
-    virtual QgsGeometryCollection *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsGeometryCollection *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,7 +594,7 @@ segment in the line.
     int indexOf( const QgsPoint &point ) const final;
     virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
 
-    virtual QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/PyQt6/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgspoint.sip.in
@@ -355,7 +355,7 @@ Example
 
     virtual QgsPoint *clone() const /Factory/;
 
-    virtual QgsPoint *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsPoint *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -604,7 +604,7 @@ E.g. :py:class:`QgsLineString` -> :py:class:`QgsCompoundCurve`, :py:class:`QgsPo
 :return: the converted geometry. Caller takes ownership
 %End
 
-    virtual QgsAbstractGeometry *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const = 0 /Factory/;
 %Docstring
 Makes a new geometry with all the points or vertices snapped to the closest point of the grid.
 Ownership is transferred to the caller.
@@ -626,6 +626,7 @@ In this case, it can be thought like rounding the x and y of all the points/vert
 :param vSpacing: Vertical spacing of the grid (y axis). 0 to disable.
 :param dSpacing: Depth spacing of the grid (z axis). 0 (default) to disable.
 :param mSpacing: Custom dimension spacing of the grid (m axis). 0 (default) to disable.
+:param removeRedundantPoints: if ``True``, then points which are redundant (e.g. they represent mid points on a straight line segment) will be skipped (since QGIS 3.38)
 %End
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false ) = 0;

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -151,7 +151,7 @@ Appends the contents of another circular ``string`` to the end of this circular 
 
     virtual QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const /Factory/;
 
-    virtual QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -81,7 +81,7 @@ of the curve.
 :param toleranceType: maximum segmentation angle or maximum difference between approximation and curve
 %End
 
-    virtual QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -68,7 +68,7 @@ Curve polygon geometry type
 
     virtual QgsAbstractGeometry *boundary() const /Factory/;
 
-    virtual QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -95,7 +95,7 @@ Returns a geometry from within the collection.
 
     virtual void clear();
 
-    virtual QgsGeometryCollection *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsGeometryCollection *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,7 +594,7 @@ segment in the line.
     int indexOf( const QgsPoint &point ) const final;
     virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
 
-    virtual QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -355,7 +355,7 @@ Example
 
     virtual QgsPoint *clone() const /Factory/;
 
-    virtual QgsPoint *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
+    virtual QgsPoint *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -644,8 +644,9 @@ class CORE_EXPORT QgsAbstractGeometry
      * \param vSpacing Vertical spacing of the grid (y axis). 0 to disable.
      * \param dSpacing Depth spacing of the grid (z axis). 0 (default) to disable.
      * \param mSpacing Custom dimension spacing of the grid (m axis). 0 (default) to disable.
+     * \param removeRedundantPoints if TRUE, then points which are redundant (e.g. they represent mid points on a straight line segment) will be skipped (since QGIS 3.38)
      */
-    virtual QgsAbstractGeometry *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const = 0 SIP_FACTORY;
 
     /**
      * Removes duplicate nodes from the geometry, wherever removing the nodes does not result in a

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -624,7 +624,7 @@ QgsLineString *QgsCircularString::curveToLine( double tolerance, SegmentationTol
   return line;
 }
 
-QgsCircularString *QgsCircularString::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing ) const
+QgsCircularString *QgsCircularString::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing, bool ) const
 {
   // prepare result
   std::unique_ptr<QgsCircularString> result { createEmptyWithSameType() };

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -629,8 +629,9 @@ QgsCircularString *QgsCircularString::snappedToGrid( double hSpacing, double vSp
   // prepare result
   std::unique_ptr<QgsCircularString> result { createEmptyWithSameType() };
 
+  // remove redundant not supported for circular strings
   bool res = snapToGridPrivate( hSpacing, vSpacing, dSpacing, mSpacing, mX, mY, mZ, mM,
-                                result->mX, result->mY, result->mZ, result->mM );
+                                result->mX, result->mY, result->mZ, result->mM, false );
   if ( res )
     return result.release();
   else

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -259,7 +259,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     QgsPoint startPoint() const override SIP_HOLDGIL;
     QgsPoint endPoint() const override SIP_HOLDGIL;
     QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const override SIP_FACTORY;
-    QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
+    QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
 
     void draw( QPainter &p ) const override;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -465,13 +465,13 @@ QgsLineString *QgsCompoundCurve::curveToLine( double tolerance, SegmentationTole
   return line;
 }
 
-QgsCompoundCurve *QgsCompoundCurve::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing ) const
+QgsCompoundCurve *QgsCompoundCurve::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing, bool removeRedundantPoints ) const
 {
   std::unique_ptr<QgsCompoundCurve> result( createEmptyWithSameType() );
 
   for ( QgsCurve *curve : mCurves )
   {
-    std::unique_ptr<QgsCurve> gridified( static_cast< QgsCurve * >( curve->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing ) ) );
+    std::unique_ptr<QgsCurve> gridified( static_cast< QgsCurve * >( curve->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing, removeRedundantPoints ) ) );
     if ( gridified )
     {
       result->mCurves.append( gridified.release() );

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     */
     QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const override SIP_FACTORY;
 
-    QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
+    QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
     const QgsAbstractGeometry *simplifiedTypeRef() const override SIP_HOLDGIL;

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -316,91 +316,104 @@ QgsPoint QgsCurve::childPoint( int index ) const
 
 bool QgsCurve::snapToGridPrivate( double hSpacing, double vSpacing, double dSpacing, double mSpacing,
                                   const QVector<double> &srcX, const QVector<double> &srcY, const QVector<double> &srcZ, const QVector<double> &srcM,
-                                  QVector<double> &outX, QVector<double> &outY, QVector<double> &outZ, QVector<double> &outM ) const
+                                  QVector<double> &outX, QVector<double> &outY, QVector<double> &outZ, QVector<double> &outM, bool removeRedundantPoints ) const
 {
   const int length = numPoints();
-
-  if ( length <= 0 )
+  if ( length < 2 )
     return false;
 
   const bool hasZ = is3D();
   const bool hasM = isMeasure();
 
-  // helper functions
-  auto roundVertex = [hSpacing, vSpacing, dSpacing, mSpacing, hasZ, hasM, &srcX, &srcY, &srcZ, &srcM]( QgsPoint & out, int i )
+  outX.reserve( length );
+  outY.reserve( length );
+  if ( hasZ )
+    outZ.reserve( length );
+  if ( hasM )
+    outM.reserve( length );
+
+  const double *xIn = srcX.constData();
+  const double *yIn = srcY.constData();
+  const double *zIn = hasZ ? srcZ.constData() : nullptr;
+  const double *mIn = hasM ? srcM.constData() : nullptr;
+
+  double previousX = 0;
+  double previousY = 0;
+  double previousZ = 0;
+  double previousM = 0;
+  int outSize = 0;
+  for ( int i = 0; i < length; ++i )
   {
-    if ( hSpacing > 0 )
-      out.setX( std::round( srcX.at( i ) / hSpacing ) * hSpacing );
-    else
-      out.setX( srcX.at( i ) );
+    const double currentX = *xIn++;
+    const double currentY = *yIn++;
+    const double currentZ = zIn ? *zIn++ : 0;
+    const double currentM = mIn ? *mIn++ : 0;
 
-    if ( vSpacing > 0 )
-      out.setY( std::round( srcY.at( i ) / vSpacing ) * vSpacing );
-    else
-      out.setY( srcY.at( i ) );
+    const double roundedX = hSpacing > 0 ? ( std::round( currentX / hSpacing ) * hSpacing ) : currentX;
+    const double roundedY = vSpacing > 0 ? ( std::round( currentY / vSpacing ) * vSpacing ) : currentY;
+    const double roundedZ = hasZ && dSpacing > 0 ? ( std::round( currentZ / dSpacing ) * dSpacing ) : currentZ;
+    const double roundedM = hasM && mSpacing > 0 ? ( std::round( currentM / mSpacing ) * mSpacing ) : currentM;
 
-    if ( hasZ )
+    if ( i > 0 )
     {
-      if ( dSpacing > 0 )
-        out.setZ( std::round( srcZ.at( i ) / dSpacing ) * dSpacing );
+      const bool isPointEqual = qgsDoubleNear( roundedX, previousX )
+                                && qgsDoubleNear( roundedY, previousY )
+                                && ( !hasZ || dSpacing <= 0 || qgsDoubleNear( roundedZ, previousZ ) )
+                                && ( !hasM || mSpacing <= 0 || qgsDoubleNear( roundedM, previousM ) );
+      if ( isPointEqual )
+        continue;
+
+      // maybe previous point is redundant and is just a midpoint on a straight line -- let's check
+      bool previousPointRedundant = false;
+      if ( removeRedundantPoints && outSize > 1 && !hasZ && !hasM )
+      {
+        previousPointRedundant = QgsGeometryUtilsBase::leftOfLine( outX.at( outSize - 1 ),
+                                 outY.at( outSize - 1 ),
+                                 outX.at( outSize - 2 ),
+                                 outY.at( outSize - 2 ),
+                                 roundedX, roundedY ) == 0;
+      }
+      if ( previousPointRedundant )
+      {
+        outX[ outSize - 1 ] = roundedX;
+        outY[ outSize - 1 ] = roundedY;
+      }
       else
-        out.setZ( srcZ.at( i ) );
+      {
+        outX.append( roundedX );
+        outY.append( roundedY );
+        if ( hasZ )
+          outZ.append( roundedZ );
+        if ( hasM )
+          outM.append( roundedM );
+        outSize++;
+      }
     }
-
-    if ( hasM )
+    else
     {
-      if ( mSpacing > 0 )
-        out.setM( std::round( srcM.at( i ) / mSpacing ) * mSpacing );
-      else
-        out.setM( srcM.at( i ) );
+      outX.append( roundedX );
+      outY.append( roundedY );
+      if ( hasZ )
+        outZ.append( roundedZ );
+      if ( hasM )
+        outM.append( roundedM );
+      outSize++;
     }
-  };
 
-
-  auto append = [hasZ, hasM, &outX, &outY, &outM, &outZ]( QgsPoint const & point )
-  {
-    outX.append( point.x() );
-
-    outY.append( point.y() );
-
-    if ( hasZ )
-      outZ.append( point.z() );
-
-    if ( hasM )
-      outM.append( point.m() );
-  };
-
-  auto isPointEqual = [dSpacing, mSpacing, hasZ, hasM]( const QgsPoint & a, const QgsPoint & b )
-  {
-    return ( a.x() == b.x() )
-           && ( a.y() == b.y() )
-           && ( !hasZ || dSpacing <= 0 || a.z() == b.z() )
-           && ( !hasM || mSpacing <= 0 || a.m() == b.m() );
-  };
-
-  // temporary values
-  const Qgis::WkbType pointType = QgsWkbTypes::zmType( Qgis::WkbType::Point, hasZ, hasM );
-  QgsPoint last( pointType );
-  QgsPoint current( pointType );
-
-  // Actual code (what does all the work)
-  roundVertex( last, 0 );
-  append( last );
-
-  for ( int i = 1; i < length; ++i )
-  {
-    roundVertex( current, i );
-    if ( !isPointEqual( current, last ) )
-    {
-      append( current );
-      last = current;
-    }
+    previousX = roundedX;
+    previousY = roundedY;
+    previousZ = roundedZ;
+    previousM = roundedM;
   }
 
-  // if it's not closed, with 2 points you get a correct line
-  // if it is, you need at least 4 (3 + the vertex that closes)
-  if ( outX.length() < 2 || ( isClosed() && outX.length() < 4 ) )
-    return false;
+  // we previously reserved size based on a worst case scenario, let's free
+  // unnecessary memory reservation now
+  outX.squeeze();
+  outY.squeeze();
+  if ( hasZ )
+    outZ.squeeze();
+  if ( hasM )
+    outM.squeeze();
 
-  return true;
+  return outSize >= 4 || ( !isClosed() && outSize >= 2 );
 }

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -354,7 +354,17 @@ bool QgsCurve::snapToGridPrivate( double hSpacing, double vSpacing, double dSpac
     const double roundedZ = hasZ && dSpacing > 0 ? ( std::round( currentZ / dSpacing ) * dSpacing ) : currentZ;
     const double roundedM = hasM && mSpacing > 0 ? ( std::round( currentM / mSpacing ) * mSpacing ) : currentM;
 
-    if ( i > 0 )
+    if ( i == 0 )
+    {
+      outX.append( roundedX );
+      outY.append( roundedY );
+      if ( hasZ )
+        outZ.append( roundedZ );
+      if ( hasM )
+        outM.append( roundedM );
+      outSize++;
+    }
+    else
     {
       const bool isPointEqual = qgsDoubleNear( roundedX, previousX )
                                 && qgsDoubleNear( roundedY, previousY )
@@ -388,16 +398,6 @@ bool QgsCurve::snapToGridPrivate( double hSpacing, double vSpacing, double dSpac
           outM.append( roundedM );
         outSize++;
       }
-    }
-    else
-    {
-      outX.append( roundedX );
-      outY.append( roundedY );
-      if ( hasZ )
-        outZ.append( roundedZ );
-      if ( hasM )
-        outM.append( roundedM );
-      outSize++;
     }
 
     previousX = roundedX;

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -406,6 +406,23 @@ bool QgsCurve::snapToGridPrivate( double hSpacing, double vSpacing, double dSpac
     previousM = roundedM;
   }
 
+  if ( removeRedundantPoints && isClosed() && outSize > 4 && !hasZ && !hasM )
+  {
+    // maybe first/last vertex is redundant, let's try to remove that too
+    const bool firstVertexIsRedundant = QgsGeometryUtilsBase::leftOfLine( outX.at( 0 ),
+                                        outY.at( 0 ),
+                                        outX.at( outSize - 2 ),
+                                        outY.at( outSize - 2 ),
+                                        outX.at( 1 ), outY.at( 1 ) ) == 0;
+    if ( firstVertexIsRedundant )
+    {
+      outX.removeAt( 0 );
+      outY.removeAt( 0 );
+      outX[ outSize - 2 ] = outX.at( 0 );
+      outY[ outSize - 2 ] = outY.at( 0 );
+    }
+  }
+
   // we previously reserved size based on a worst case scenario, let's free
   // unnecessary memory reservation now
   outX.squeeze();

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -345,7 +345,8 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
      */
     bool snapToGridPrivate( double hSpacing, double vSpacing, double dSpacing, double mSpacing,
                             const QVector<double> &srcX, const QVector<double> &srcY, const QVector<double> &srcZ, const QVector<double> &srcM,
-                            QVector<double> &outX, QVector<double> &outY, QVector<double> &outZ, QVector<double> &outM ) const;
+                            QVector<double> &outX, QVector<double> &outY, QVector<double> &outZ, QVector<double> &outM,
+                            bool removeRedundantPoints ) const;
 #endif
 
     /**

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -551,7 +551,7 @@ QgsAbstractGeometry *QgsCurvePolygon::boundary() const
   }
 }
 
-QgsCurvePolygon *QgsCurvePolygon::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing ) const
+QgsCurvePolygon *QgsCurvePolygon::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing, bool removeRedundantPoints ) const
 {
   if ( !mExteriorRing )
     return nullptr;
@@ -560,7 +560,7 @@ QgsCurvePolygon *QgsCurvePolygon::snappedToGrid( double hSpacing, double vSpacin
   std::unique_ptr< QgsCurvePolygon > polygon( createEmptyWithSameType() );
 
   // exterior ring
-  auto exterior = std::unique_ptr<QgsCurve> { static_cast< QgsCurve *>( mExteriorRing->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing ) ) };
+  auto exterior = std::unique_ptr<QgsCurve> { static_cast< QgsCurve *>( mExteriorRing->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing, removeRedundantPoints ) ) };
 
   if ( !exterior )
     return nullptr;
@@ -573,7 +573,7 @@ QgsCurvePolygon *QgsCurvePolygon::snappedToGrid( double hSpacing, double vSpacin
     if ( !interior )
       continue;
 
-    QgsCurve *gridifiedInterior = static_cast< QgsCurve * >( interior->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing ) );
+    QgsCurve *gridifiedInterior = static_cast< QgsCurve * >( interior->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing, removeRedundantPoints ) );
 
     if ( !gridifiedInterior )
       continue;

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -137,7 +137,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     double perimeter() const override SIP_HOLDGIL;
     QgsPolygon *surfaceToPolygon() const override SIP_FACTORY;
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
-    QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
+    QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -947,7 +947,9 @@ Qgis::GeometryOperationResult QgsGeometry::addPart( const QVector<QgsPointXY> &p
 {
   QgsPointSequence l;
   convertPointList( points, l );
+  Q_NOWARN_DEPRECATED_PUSH
   return addPart( l, geomType );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 Qgis::GeometryOperationResult QgsGeometry::addPartV2( const QVector<QgsPointXY> &points, Qgis::WkbType wkbType )
@@ -970,7 +972,9 @@ Qgis::GeometryOperationResult QgsGeometry::addPart( const QgsPointSequence &poin
     ringLine->setPoints( points );
     partGeom = std::move( ringLine );
   }
+  Q_NOWARN_DEPRECATED_PUSH
   return addPart( partGeom.release(), geomType );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 Qgis::GeometryOperationResult QgsGeometry::addPartV2( const QgsPointSequence &points, Qgis::WkbType wkbType )

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -92,13 +92,13 @@ void QgsGeometryCollection::clear()
   clearCache(); //set bounding box invalid
 }
 
-QgsGeometryCollection *QgsGeometryCollection::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing ) const
+QgsGeometryCollection *QgsGeometryCollection::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing, bool removeRedundantPoints ) const
 {
   std::unique_ptr<QgsGeometryCollection> result;
 
   for ( auto geom : mGeometries )
   {
-    std::unique_ptr<QgsAbstractGeometry> gridified { geom->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing ) };
+    std::unique_ptr<QgsAbstractGeometry> gridified { geom->snappedToGrid( hSpacing, vSpacing, dSpacing, mSpacing, removeRedundantPoints ) };
     if ( gridified )
     {
       if ( !result )

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -184,7 +184,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     int dimension() const override SIP_HOLDGIL;
     QString geometryType() const override SIP_HOLDGIL;
     void clear() override;
-    QgsGeometryCollection *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
+    QgsGeometryCollection *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
     void adjacentVertices( QgsVertexId vertex, QgsVertexId &previousVertex SIP_OUT, QgsVertexId &nextVertex SIP_OUT ) const override;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -328,15 +328,72 @@ bool QgsLineString::isValid( QString &error, Qgis::GeometryValidityFlags flags )
 
 QgsLineString *QgsLineString::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing ) const
 {
-  // prepare result
-  std::unique_ptr<QgsLineString> result { createEmptyWithSameType() };
-
-  bool res = snapToGridPrivate( hSpacing, vSpacing, dSpacing, mSpacing, mX, mY, mZ, mM,
-                                result->mX, result->mY, result->mZ, result->mM );
-  if ( res )
-    return result.release();
-  else
+  const int length = numPoints();
+  if ( length < 2 )
     return nullptr;
+
+  const bool hasZ = is3D();
+  const bool hasM = isMeasure();
+
+  QVector< double > outX;
+  outX.reserve( length );
+  QVector< double > outY;
+  outY.reserve( length );
+  QVector< double > outZ;
+  if ( hasZ )
+    outZ.reserve( length );
+  QVector< double > outM;
+  if ( hasM )
+    outM.reserve( length );
+
+  const double *xIn = mX.constData();
+  const double *yIn = mY.constData();
+  const double *zIn = hasZ ? mZ.constData() : nullptr;
+  const double *mIn = hasM ? mM.constData() : nullptr;
+
+  double previousX = 0;
+  double previousY = 0;
+  double previousZ = 0;
+  double previousM = 0;
+  for ( int i = 0; i < length; ++i )
+  {
+    const double currentX = *xIn++;
+    const double currentY = *yIn++;
+    const double currentZ = zIn ? *zIn++ : 0;
+    const double currentM = mIn ? *mIn++ : 0;
+
+    const double roundedX = hSpacing > 0 ? ( std::round( currentX / hSpacing ) * hSpacing ) : currentX;
+    const double roundedY = vSpacing > 0 ? ( std::round( currentY / vSpacing ) * vSpacing ) : currentY;
+    const double roundedZ = hasZ && dSpacing > 0 ? ( std::round( currentZ / dSpacing ) * dSpacing ) : currentZ;
+    const double roundedM = hasM && mSpacing > 0 ? ( std::round( currentM / mSpacing ) * mSpacing ) : currentM;
+
+    if ( i > 0 )
+    {
+      const bool isPointEqual = qgsDoubleNear( roundedX, previousX )
+                                && qgsDoubleNear( roundedY, previousY )
+                                && ( !hasZ || dSpacing <= 0 || qgsDoubleNear( roundedZ, previousZ ) )
+                                && ( !hasM || mSpacing <= 0 || qgsDoubleNear( roundedM, previousM ) );
+      if ( isPointEqual )
+        continue;
+    }
+
+    outX.append( roundedX );
+    outY.append( roundedY );
+    if ( hasZ )
+      outZ.append( roundedZ );
+    if ( hasM )
+      outM.append( roundedM );
+
+    previousX = roundedX;
+    previousY = roundedY;
+    previousZ = roundedZ;
+    previousM = roundedM;
+  }
+
+  if ( outX.length() < 2 || ( isClosed() && outX.length() < 4 ) )
+    return nullptr;
+
+  return new QgsLineString( outX, outY, outZ, outM );
 }
 
 bool QgsLineString::removeDuplicateNodes( double epsilon, bool useZValues )

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -954,7 +954,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool isEmpty() const override SIP_HOLDGIL;
     int indexOf( const QgsPoint &point ) const final;
     bool isValid( QString &error SIP_OUT, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const override;
-    QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
+    QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool isClosed() const override SIP_HOLDGIL;
     bool isClosed2D() const override SIP_HOLDGIL;

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -107,7 +107,7 @@ QgsPoint *QgsPoint::clone() const
   return new QgsPoint( *this );
 }
 
-QgsPoint *QgsPoint::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing ) const
+QgsPoint *QgsPoint::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing, bool ) const
 {
   // helper function
   auto gridifyValue = []( double value, double spacing, bool extraCondition = true ) -> double

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -562,7 +562,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     QString geometryType() const override SIP_HOLDGIL;
     int dimension() const override SIP_HOLDGIL;
     QgsPoint *clone() const override SIP_FACTORY;
-    QgsPoint *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
+    QgsPoint *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0, bool removeRedundantPoints = false ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     void clear() override;
     bool fromWkb( QgsConstWkbPtr &wkb ) override;

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -2608,6 +2608,14 @@ void TestQgsGeometry::snappedToGrid()
     curve = curve.densifyByCount( 1000 );
     snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, true ) );
     QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (68 415, 68 505, 27 505)" ) );
+
+    // closed linestring, where the first vertex becomes redundant
+    curve = QgsGeometry::fromWkt( "LineString( 68.1 415.2, 90.1 415.2, 90.1 505.2, 27.1 505.2, 27.3 414.9, 68.1 415.2 )" );
+    snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, true ) );
+    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (90 415, 90 505, 27 505, 27 415, 90 415)" ) );
+    curve = curve.densifyByCount( 10 );
+    snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, true ) );
+    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (90 415, 90 505, 27 505, 27 415, 90 415)" ) );
   }
 
   //compound curve

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -2595,6 +2595,15 @@ void TestQgsGeometry::snappedToGrid()
     QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineStringZM (68 415 11 57, 27 505 24 49, 27 406 40 32)" ) );
     snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 10, 10 ) );
     QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineStringZM (68 415 10 60, 27 505 20 50, 27 406 40 30)" ) );
+
+    // with removal of redundant vertices
+    curve = QgsGeometry::fromWkt( "LineString( 68.1 415.2, 27.1 505.2, 27.1 406.2 )" );
+    curve.densifyByCount( 10 );
+    snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, true ) );
+    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (68 415, 27 505, 27 406)" ) );
+    curve.densifyByCount( 1000 );
+    snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, true ) );
+    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (68 415, 27 505, 27 406)" ) );
   }
 
   //compound curve

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -2597,13 +2597,17 @@ void TestQgsGeometry::snappedToGrid()
     QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineStringZM (68 415 10 60, 27 505 20 50, 27 406 40 30)" ) );
 
     // with removal of redundant vertices
-    curve = QgsGeometry::fromWkt( "LineString( 68.1 415.2, 27.1 505.2, 27.1 406.2 )" );
-    curve.densifyByCount( 10 );
+    curve = QgsGeometry::fromWkt( "LineString( 68.1 415.2, 68.1 505.2, 27.1 505.2 )" );
+    curve = curve.densifyByCount( 10 );
+    // no removal of redundant vertices
+    snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, false ) );
+    QCOMPARE( snapped->nCoordinates(), 23 );
+    // removal of redundant vertices
     snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, true ) );
-    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (68 415, 27 505, 27 406)" ) );
-    curve.densifyByCount( 1000 );
+    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (68 415, 68 505, 27 505)" ) );
+    curve = curve.densifyByCount( 1000 );
     snapped.reset( curve.constGet()->snappedToGrid( 1, 1, 0, 0, true ) );
-    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (68 415, 27 505, 27 406)" ) );
+    QCOMPARE( snapped->asWkt( 5 ), QStringLiteral( "LineString (68 415, 68 505, 27 505)" ) );
   }
 
   //compound curve


### PR DESCRIPTION
- Optimise QgsLineString::snappedToGrid: The old approach was quite inefficient and resulted in many reallocations and array resizing
- Add option to remove redundant vertices in QgsAbstractGeometry::snappedToGrid. If opted in, then vertices which form a midpoint of a straight line segment will be removed in the output. This can result in substantially smaller geometries, as the current behavior will leave these redundant vertices in place.

This is leading toward on-the-fly simplication of labeling masks, for https://github.com/qgis/QGIS/issues/54788 and https://github.com/qgis/QGIS/issues/50543