### PR TITLE
Add an option to autosize all columns by default when opening an attribute table

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -760,6 +760,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   cbxCheckVersion->setChecked( mSettings->value( QStringLiteral( "/qgis/checkVersion" ), true ).toBool() );
   cbxCheckVersion->setVisible( mSettings->value( QStringLiteral( "/qgis/allowVersionCheck" ), true ).toBool() );
   cbxAttributeTableDocked->setChecked( mSettings->value( QStringLiteral( "/qgis/dockAttributeTable" ), false ).toBool() );
+  cbxAutosizeAttributeTable->setChecked( mSettings->value( QStringLiteral( "/qgis/autosizeAttributeTable" ), false ).toBool() );
 
   mComboCopyFeatureFormat->addItem( tr( "Plain Text, No Geometry" ), QgsClipboard::AttributesOnly );
   mComboCopyFeatureFormat->addItem( tr( "Plain Text, WKT Geometry" ), QgsClipboard::AttributesWithWKT );
@@ -1619,6 +1620,8 @@ void QgsOptions::saveOptions()
 
   mSettings->setValue( QStringLiteral( "/qgis/checkVersion" ), cbxCheckVersion->isChecked() );
   mSettings->setValue( QStringLiteral( "/qgis/dockAttributeTable" ), cbxAttributeTableDocked->isChecked() );
+  mSettings->setValue( QStringLiteral( "/qgis/autosizeAttributeTable" ), cbxAutosizeAttributeTable->isChecked() );
+
   mSettings->setEnumValue( QStringLiteral( "/qgis/attributeTableBehavior" ), ( QgsAttributeTableFilterModel::FilterMode )cmbAttrTableBehavior->currentData().toInt() );
   mSettings->setValue( QStringLiteral( "/qgis/attributeTableView" ), mAttrTableViewComboBox->currentData() );
   mSettings->setValue( QStringLiteral( "/qgis/attributeTableRowCache" ), spinBoxAttrTableRowCache->value() );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -408,6 +408,12 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
     mMainView->setView( static_cast< QgsDualView::ViewMode >( initialView ) );
     mMainViewButtonGroup->button( initialView )->setChecked( true );
 
+    const bool autoSize = settings.value( QStringLiteral( "qgis/autosizeAttributeTable" ), false ).toBool();
+    if ( autoSize )
+    {
+      mMainView->tableView()->resizeColumnsToContents();
+    }
+
     connect( mActionToggleMultiEdit, &QAction::toggled, mMainView, &QgsDualView::setMultiEditEnabled );
     connect( mActionSearchForm, &QAction::toggled, mMainView, &QgsDualView::toggleSearchMode );
     updateMultiEditButtonState();

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -122,7 +122,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>8</number>
+          <number>4</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -152,7 +152,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>843</width>
-                <height>903</height>
+                <height>1009</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -968,8 +968,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>522</width>
-                <height>1054</height>
+                <width>843</width>
+                <height>1068</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1328,10 +1328,10 @@
                     <property name="title">
                      <string>Current environment variables (read-only - bold indicates modified at startup)</string>
                     </property>
-                    <property name="collapsed" stdset="0">
+                    <property name="collapsed">
                      <bool>false</bool>
                     </property>
-                    <property name="saveCollapsedState" stdset="0">
+                    <property name="saveCollapsedState">
                      <bool>true</bool>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1507,8 +1507,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>558</width>
-                <height>435</height>
+                <width>857</width>
+                <height>685</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1531,7 +1531,7 @@
                  </property>
                  <layout class="QGridLayout" name="gridLayout_14" columnstretch="0,1">
                   <item row="0" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs">
                     <property name="enabled">
                      <bool>true</bool>
                     </property>
@@ -1637,7 +1637,7 @@
                    </widget>
                   </item>
                   <item row="2" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="leProjectGlobalCrs" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="leProjectGlobalCrs">
                     <property name="minimumSize">
                      <size>
                       <width>0</width>
@@ -1751,8 +1751,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>533</width>
-                <height>99</height>
+                <width>596</width>
+                <height>105</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_47">
@@ -1835,7 +1835,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>843</width>
-                <height>715</height>
+                <height>743</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1857,14 +1857,7 @@
                   <string>Feature Attributes and Table</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_19">
-                  <item row="0" column="0" colspan="2">
-                   <widget class="QCheckBox" name="cbxAttributeTableDocked">
-                    <property name="text">
-                     <string>Open attribute table as docked window</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
+                  <item row="2" column="1">
                    <widget class="QComboBox" name="cmbAttrTableBehavior">
                     <item>
                      <property name="text">
@@ -1873,7 +1866,7 @@
                     </item>
                    </widget>
                   </item>
-                  <item row="3" column="0">
+                  <item row="2" column="0">
                    <widget class="QLabel" name="textLabel1_7">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1886,20 +1879,17 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="label_14">
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="mComboCopyFeatureFormat"/>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_46">
                     <property name="text">
-                     <string>Representation for NULL values</string>
+                     <string>Default view</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="1">
-                   <widget class="QComboBox" name="mAttrTableViewComboBox"/>
-                  </item>
-                  <item row="6" column="1">
-                   <widget class="QLineEdit" name="leNullValue"/>
-                  </item>
-                  <item row="5" column="0">
+                  <item row="4" column="0">
                    <widget class="QLabel" name="textLabel1_12">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1913,6 +1903,23 @@
                    </widget>
                   </item>
                   <item row="5" column="1">
+                   <widget class="QLineEdit" name="leNullValue"/>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_48">
+                    <property name="text">
+                     <string>Copy features as</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_14">
+                    <property name="text">
+                     <string>Representation for NULL values</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
                    <widget class="QgsSpinBox" name="spinBoxAttrTableRowCache">
                     <property name="minimum">
                      <number>0</number>
@@ -1928,20 +1935,20 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="1">
-                   <widget class="QComboBox" name="mComboCopyFeatureFormat"/>
+                  <item row="3" column="1">
+                   <widget class="QComboBox" name="mAttrTableViewComboBox"/>
                   </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="label_46">
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="cbxAttributeTableDocked">
                     <property name="text">
-                     <string>Default view</string>
+                     <string>Open attribute table as docked window</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_48">
+                  <item row="0" column="1">
+                   <widget class="QCheckBox" name="cbxAutosizeAttributeTable">
                     <property name="text">
-                     <string>Copy features as</string>
+                     <string>Autosize columns when opening attribute table</string>
                     </property>
                    </widget>
                   </item>
@@ -2216,8 +2223,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>415</width>
-                <height>403</height>
+                <width>857</width>
+                <height>685</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -2437,8 +2444,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>482</width>
-                <height>456</height>
+                <width>857</width>
+                <height>685</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -2573,6 +2580,9 @@
                   </item>
                   <item row="0" column="1">
                    <widget class="QComboBox" name="cmbLegendDoubleClickAction">
+                    <property name="sizeAdjustPolicy">
+                     <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                    </property>
                     <item>
                      <property name="text">
                       <string>Open layer properties</string>
@@ -2588,9 +2598,6 @@
                       <string>Open layer styling dock</string>
                      </property>
                     </item>
-                    <property name="sizeAdjustPolicy">
-                     <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-                    </property>
                    </widget>
                   </item>
                   <item row="1" column="0">
@@ -2604,7 +2611,7 @@
                    <widget class="QComboBox" name="mLayerTreeInsertionMethod">
                     <property name="sizeAdjustPolicy">
                      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-                    </property>                     
+                    </property>
                    </widget>
                   </item>
                   <item row="2" column="0" colspan="2">
@@ -2680,7 +2687,7 @@
                     <property name="value">
                      <double>0.100000000000000</double>
                     </property>
-                    <property name="showClearButton" stdset="0">
+                    <property name="showClearButton">
                      <bool>true</bool>
                     </property>
                    </widget>
@@ -2718,7 +2725,7 @@
                     <property name="value">
                      <double>20.000000000000000</double>
                     </property>
-                    <property name="showClearButton" stdset="0">
+                    <property name="showClearButton">
                      <bool>true</bool>
                     </property>
                    </widget>
@@ -2826,8 +2833,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>578</width>
-                <height>869</height>
+                <width>843</width>
+                <height>925</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3225,7 +3232,7 @@
                  <property name="title">
                   <string>Coordinate and Bearing Display</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_30" columnstretch="0,0,3,6">
@@ -3323,7 +3330,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     <property name="value">
                      <number>200</number>
                     </property>
-                    <property name="showClearButton" stdset="0">
+                    <property name="showClearButton">
                      <bool>true</bool>
                     </property>
                    </widget>
@@ -3489,9 +3496,9 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-256</y>
+                <y>0</y>
                 <width>843</width>
-                <height>971</height>
+                <height>1038</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4216,8 +4223,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>139</width>
-                <height>247</height>
+                <width>147</width>
+                <height>251</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -4396,8 +4403,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>448</width>
-                <height>520</height>
+                <width>476</width>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -4728,8 +4735,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>595</width>
-                <height>639</height>
+                <width>657</width>
+                <height>669</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -4946,10 +4953,10 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <property name="checkable">
                   <bool>true</bool>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_1">
@@ -5212,7 +5219,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
@@ -5606,6 +5613,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>mSearchLineEdit</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION

## Description
This PR adds an option via a checkbox in the Options Dialog to always resize columns to contents when opening an attribute table.
This extends #41276 and addresses a more recent request posted as a [comment](https://github.com/qgis/QGIS/issues/41108#issuecomment-2106695566) to the original [feature request](https://github.com/qgis/QGIS/issues/41108).

This was also discussed in [this question](https://gis.stackexchange.com/questions/481055/making-autosize-all-columns-the-default-view-every-time-attribute-tables-are-ope) on GIS Stack Exchange.

Screenshot of Options Dialog showing added checkbox at top right:

![Screenshot from 2024-06-03 19-52-27](https://github.com/qgis/QGIS/assets/47767794/ed2b6547-c2b7-41a8-af66-b5d1d1a440a0)

Quick screencast showing added default autosize behaviour with checkbox option checked.

![autosize-1](https://github.com/qgis/QGIS/assets/47767794/41ff878e-f536-4e93-9ffb-b467cfcc4794)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
