### PR TITLE
Actions Dialogue Duplicate Button

### DIFF
--- a/src/gui/vector/qgsattributeactiondialog.h
+++ b/src/gui/vector/qgsattributeactiondialog.h
@@ -81,6 +81,7 @@ class GUI_EXPORT QgsAttributeActionDialog: public QWidget, private Ui::QgsAttrib
     void moveDown();
     void remove();
     void insert();
+    void duplicate();
     void addDefaultActions();
     void itemDoubleClicked( QTableWidgetItem *item );
     void updateButtons();

--- a/src/ui/qgsattributeactiondialogbase.ui
+++ b/src/ui/qgsattributeactiondialogbase.ui
@@ -68,6 +68,19 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
       <item row="1" column="3">
        <widget class="QPushButton" name="mRemoveButton">
         <property name="sizePolicy">
@@ -88,7 +101,35 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="4">
+       <widget class="QPushButton" name="mAddButton">
+        <property name="toolTip">
+         <string>Add a new action</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="5">
+       <widget class="QPushButton" name="mDuplicateButton">
+        <property name="toolTip">
+         <string>Duplicate an action</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionDuplicateLayout.svg</normaloff>:/images/themes/default/mActionDuplicateLayout.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
        <spacer name="horizontalSpacer_4">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -101,7 +142,7 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="6">
+      <item row="1" column="7">
        <widget class="QPushButton" name="mAddDefaultActionsButton">
         <property name="text">
          <string>Create Default Actions</string>
@@ -128,7 +169,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="7">
+      <item row="0" column="0" colspan="8">
        <widget class="QTableWidget" name="mAttributeActionTable">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -193,33 +234,6 @@
         </column>
        </widget>
       </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer_5">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="4">
-       <widget class="QPushButton" name="mAddButton">
-        <property name="toolTip">
-         <string>Add a new action</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset resource="../../images/images.qrc">
-          <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
@@ -273,6 +287,7 @@
   <tabstop>mMoveDownButton</tabstop>
   <tabstop>mRemoveButton</tabstop>
   <tabstop>mAddButton</tabstop>
+  <tabstop>mDuplicateButton</tabstop>
   <tabstop>mAddDefaultActionsButton</tabstop>
   <tabstop>mShowInAttributeTable</tabstop>
   <tabstop>mAttributeTableWidgetType</tabstop>


### PR DESCRIPTION
## Description

Addresses this issue: https://github.com/qgis/QGIS/issues/57399

Before screenshot:
![image](https://github.com/qgis/QGIS/assets/35535932/1c0f8d3f-852d-46de-a505-0d75f25fb0c1)

After screenshot:
![image](https://github.com/qgis/QGIS/assets/35535932/7495b489-3bff-4274-9add-a35984af7c0c)

This adds a duplicate button to the layer properties actions dialogue. How it works: when a row is selected in the actions list, clicking the duplicate button will open a dialogue with all of the attributes of that row, allowing them to be edited. When clicking ok, it is submitted as a new row instead of editing the original.

Additionally, I edited the src/ui/qgsattributeactiondialogbase.ui file to put the components I was working with in order.