### PR TITLE
Reduce main thread blocking for `get_feature`

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
@@ -38,6 +38,12 @@ Constructor for QgsVectorLayerFeatureSource.
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() );
 
+%Docstring
+Gets an iterator for features matching the specified ``request``
+This function is thread-safe.
+
+:return: A feature iterator
+%End
 
 
     QgsFields fields() const;

--- a/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
@@ -38,6 +38,12 @@ Constructor for QgsVectorLayerFeatureSource.
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() );
 
+%Docstring
+Gets an iterator for features matching the specified ``request``
+This function is thread-safe.
+
+:return: A feature iterator
+%End
 
 
     QgsFields fields() const;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -264,11 +264,9 @@ bool QgsExpressionFunction::allParamsStatic( const QgsExpressionNodeFunction *no
 }
 
 /**
- *
- * @param layerNode
- * @param parent
- * @param context
- * @return
+ * Helper function to prepare layer nodes. If the node is static, we obtain a featureSource
+ * for the layer which can then be reused through the evaluation of this expression
+ * without blocking the main thread.
  */
 bool prepareLayerNode( QgsExpressionNode *layerNode, QgsExpression *parent, const QgsExpressionContext *context )
 {
@@ -8986,8 +8984,6 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 
     getFeatureFunc->setPrepareFunction( []( const QgsExpressionNodeFunction * node, QgsExpression * parent, const QgsExpressionContext * context )
     {
-      Q_UNUSED( context )
-
       if ( node->args()->count() > 0 )
       {
         prepareLayerNode( node->args()->at( 0 ), parent, context );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -275,9 +275,12 @@ bool prepareLayerNode( QgsExpressionNode *layerNode, QgsExpression *parent, cons
     QVariant layer = layerNode->eval( parent, context );
     bool foundLayer = false;
 
-    std::shared_ptr<QgsVectorLayerFeatureSource> featureSource = QgsExpressionUtils::getFeatureSource( layer, context, parent, foundLayer );
+    QgsVectorLayerFeatureSource *featureSource = QgsExpressionUtils::getFeatureSource( layer, context, parent, foundLayer );
 
-    layerNode->setCachedStaticValue( QVariant::fromValue( featureSource ) );
+    if ( featureSource )
+    {
+      context->setThreadLocalCachedValue( QStringLiteral( "featuresource/%1" ).arg( featureSource->id() ), QVariant::fromValue( featureSource ) );
+    }
 
     return featureSource && foundLayer;
   }
@@ -6303,7 +6306,7 @@ static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpre
 static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   bool foundLayer = false;
-  std::shared_ptr<QgsVectorLayerFeatureSource> featureSource = QgsExpressionUtils::getFeatureSource( values.at( 0 ), context, parent, foundLayer );
+  QgsVectorLayerFeatureSource *featureSource = QgsExpressionUtils::getFeatureSource( values.at( 0 ), context, parent, foundLayer );
 
   //no layer found
   if ( !featureSource || !foundLayer )
@@ -6334,7 +6337,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   //arguments: 1. layer id / name, 2. key attribute, 3. eq value
   bool foundLayer = false;
 
-  std::shared_ptr<QgsVectorLayerFeatureSource> featureSource = QgsExpressionUtils::getFeatureSource( values.at( 0 ), context, parent, foundLayer );
+  QgsVectorLayerFeatureSource *featureSource = QgsExpressionUtils::getFeatureSource( values.at( 0 ), context, parent, foundLayer );
 
   //no layer found
   if ( !featureSource || !foundLayer )

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -294,9 +294,9 @@ QVariant QgsExpressionUtils::runMapLayerFunctionThreadSafe( const QVariant &valu
   return res;
 }
 
-std::shared_ptr<QgsVectorLayerFeatureSource> QgsExpressionUtils::getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer )
+QgsVectorLayerFeatureSource *QgsExpressionUtils::getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer )
 {
-  std::shared_ptr<QgsVectorLayerFeatureSource> featureSource = value.value<std::shared_ptr<QgsVectorLayerFeatureSource>>();
+  QgsVectorLayerFeatureSource *featureSource = value.value<QgsVectorLayerFeatureSource*>();
 
   if ( featureSource )
   {
@@ -308,7 +308,7 @@ std::shared_ptr<QgsVectorLayerFeatureSource> QgsExpressionUtils::getFeatureSourc
   {
     if ( QgsVectorLayer *vl = qobject_cast< QgsVectorLayer *>( layer ) )
     {
-      featureSource = std::make_shared<QgsVectorLayerFeatureSource>( vl );
+      featureSource = new QgsVectorLayerFeatureSource( vl ); // TODO unique_ptr?
     }
   }, foundLayer );
 

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -376,7 +376,7 @@ class CORE_EXPORT QgsExpressionUtils
     /**
      * Gets a vector layer feature source for a \a value which corresponds to a vector layer, in a thread-safe way.
      */
-    static std::shared_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer );
+    static QgsVectorLayerFeatureSource *getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer );
 
     /**
      * \deprecated Not actually deprecated, but this method is not thread safe -- use with extreme caution only when the thread safety has already been taken care of by the caller!

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -376,7 +376,7 @@ class CORE_EXPORT QgsExpressionUtils
     /**
      * Gets a vector layer feature source for a \a value which corresponds to a vector layer, in a thread-safe way.
      */
-    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer );
+    static std::shared_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer );
 
     /**
      * \deprecated Not actually deprecated, but this method is not thread safe -- use with extreme caution only when the thread safety has already been taken care of by the caller!

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -730,6 +730,28 @@ void QgsExpressionContext::clearCachedValues() const
   mCachedValues.clear();
 }
 
+void QgsExpressionContext::setThreadLocalCachedValue(const QString &key, const QVariant &value) const
+{
+    QMap<QString, QVariant> localData = mThreadLocalCachedValues.localData();
+    localData.insert( key, value );
+    mThreadLocalCachedValues.setLocalData( localData );
+}
+
+bool QgsExpressionContext::hasThreadLocalCachedValue(const QString &key) const
+{
+  return mThreadLocalCachedValues.localData().contains( key );
+}
+
+QVariant QgsExpressionContext::threadLocalcachedValue(const QString &key) const
+{
+  return mThreadLocalCachedValues.localData().value( key );
+}
+
+void QgsExpressionContext::clearThreadLocalCachedValues() const
+{
+    mThreadLocalCachedValues.localData().clear();
+}
+
 QList<QgsMapLayerStore *> QgsExpressionContext::layerStores() const
 {
   //iterate through stack backwards, so that higher priority layer stores take precedence

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -23,6 +23,7 @@
 #include <QStringList>
 #include <QSet>
 #include <QPointer>
+#include <QThreadStorage>
 
 #include "qgsexpressionfunction.h"
 #include "qgsfeature.h"
@@ -829,6 +830,46 @@ class CORE_EXPORT QgsExpressionContext
     void clearCachedValues() const;
 
     /**
+     * Sets a value to cache within the expression context. This can be used to cache the results
+     * of expensive expression sub-calculations, to speed up future evaluations using the same
+     * expression context.
+     * \param key unique key for retrieving cached value
+     * \param value value to cache
+     * \see hasThreadLocalCachedValue()
+     * \see threadLocalcachedValue()
+     * \see clearThreadLocalCachedValues()
+     */
+    void setThreadLocalCachedValue( const QString &key, const QVariant &value ) const;
+
+    /**
+     * Returns TRUE if the expression context contains a cached value with a matching key.
+     * \param key unique key used to store cached value
+     * \see setThreadLocalCachedValue()
+     * \see threadLocalcachedValue()
+     * \see clearThreadLocalCachedValues()
+     */
+    bool hasThreadLocalCachedValue( const QString &key ) const;
+
+    /**
+     * Returns the matching cached value, if set. This can be used to retrieve the previously stored results
+     * of an expensive expression sub-calculation.
+     * \param key unique key used to store cached value
+     * \returns matching cached value, or invalid QVariant if not set
+     * \see setThreadLocalCachedValue()
+     * \see hasThreadLocalCachedValue()
+     * \see clearThreadLocalCachedValues()
+     */
+    QVariant threadLocalcachedValue( const QString &key ) const;
+
+    /**
+     * Clears all cached values from the context.
+     * \see setThreadLocalCachedValue()
+     * \see hasThreadLocalCachedValue()
+     * \see threadLocalCachedValue()
+     */
+    void clearThreadLocalCachedValues() const;
+
+    /**
      * Returns the list of layer stores associated with the context.
      *
      * \since QGIS 3.30
@@ -920,6 +961,7 @@ class CORE_EXPORT QgsExpressionContext
 
     // Cache is mutable because we want to be able to add cached values to const contexts
     mutable QMap< QString, QVariant > mCachedValues;
+    mutable QThreadStorage< QMap< QString, QVariant > > mThreadLocalCachedValues;
 
 };
 

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -114,6 +114,7 @@ QgsVectorLayerFeatureSource::~QgsVectorLayerFeatureSource() = default;
 
 QgsFeatureIterator QgsVectorLayerFeatureSource::getFeatures( const QgsFeatureRequest &request )
 {
+  QMutexLocker mutexLocker( &mGetFeatureMutex );
   // return feature iterator that does not own this source
   return QgsFeatureIterator( new QgsVectorLayerFeatureIterator( this, false, request ) );
 }

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -66,6 +66,11 @@ class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
 
     ~QgsVectorLayerFeatureSource() override;
 
+    /**
+     * Gets an iterator for features matching the specified \a request
+     * This function is thread-safe.
+     * \returns A feature iterator
+     */
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) override;
 
     friend class QgsVectorLayerFeatureIterator SIP_SKIP;
@@ -147,6 +152,7 @@ class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
 #ifdef SIP_RUN
     QgsVectorLayerFeatureSource( const QgsVectorLayerFeatureSource &other );
 #endif
+    QMutex mGetFeatureMutex;
 };
 
 /**

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -333,12 +333,13 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
   QString title;
   if ( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) && !( algorithm->flags() & Qgis::ProcessingAlgorithmFlag::DisplayNameIsLiteral ) )
   {
-    title = QgsStringUtils::capitalize( mAlgorithm->displayName(), Qgis::Capitalization::TitleCase );
+    title = QStringLiteral( "%1 - %2" ).arg( QgsStringUtils::capitalize( mAlgorithm->group(), Qgis::Capitalization::TitleCase ), QgsStringUtils::capitalize( mAlgorithm->displayName(), Qgis::Capitalization::TitleCase ) );
   }
   else
   {
-    title = mAlgorithm->displayName();
+    title = QStringLiteral( "%1 - %2" ).arg( mAlgorithm->group(), mAlgorithm->displayName() );
   }
+
   setWindowTitle( title );
 
   const QString algHelp = formatHelp( algorithm );


### PR DESCRIPTION
If a get_feature expression function is called in a background thread it no longer needs to block the main thread within each `eval` to get access to the vector layer in most cases. This has caused performance problems and even freeze/crash (through connection pool depletion).

If the `layer` parameter is static (e.g. by directly providing a layer name) it will now be resolved to a QgsVectorLayerFeatureSoruce in the expression preparation phase which is cheap and happens on the main thread already. Later on the thread can work with this source indepentently of the main thread.

Demonstration of the problem, the fields `T_basket`, `ZustandHalterungSignal` and `Reference` use `get_feature` in their display expression
![get_feature](https://github.com/qgis/QGIS/assets/588407/5c6f804e-83cd-4297-9479-7388a9987fde)

