### PR TITLE
HANA Provider: Add support for fast extent estimation

### DIFF
--- a/src/providers/hana/qgshanaconnection.cpp
+++ b/src/providers/hana/qgshanaconnection.cpp
@@ -509,6 +509,14 @@ const QString &QgsHanaConnection::getDatabaseVersion()
   return mDatabaseVersion;
 }
 
+const QString &QgsHanaConnection::getDatabaseCloudVersion()
+{
+  if ( mDatabaseCloudVersion.isEmpty() && QgsHanaUtils::toHANAVersion( getDatabaseVersion() ).majorVersion() >= 4 )
+    mDatabaseCloudVersion = executeScalar( QStringLiteral( "SELECT CLOUD_VERSION FROM SYS.M_DATABASE" ) ).toString();
+
+  return mDatabaseCloudVersion;
+}
+
 const QString &QgsHanaConnection::getUserName()
 {
   if ( mUserName.isEmpty() )

--- a/src/providers/hana/qgshanaconnection.h
+++ b/src/providers/hana/qgshanaconnection.h
@@ -72,6 +72,7 @@ class QgsHanaConnection : public QObject
 
     QList<QgsVectorDataProvider::NativeType> getNativeTypes();
     const QString &getDatabaseVersion();
+    const QString &getDatabaseCloudVersion();
     const QString &getUserName();
     QgsCoordinateReferenceSystem getCrs( int srid );
     QVector<QgsHanaLayerProperty> getLayers(
@@ -114,6 +115,7 @@ class QgsHanaConnection : public QObject
     NS_ODBC::ConnectionRef mConnection;
     const QgsDataSourceUri mUri;
     QString mDatabaseVersion;
+    QString mDatabaseCloudVersion;
     QString mUserName;
 };
 

--- a/src/providers/hana/qgshananewconnection.cpp
+++ b/src/providers/hana/qgshananewconnection.cpp
@@ -298,6 +298,7 @@ void QgsHanaNewConnection::readSettingsFromControls( QgsHanaSettings &settings )
   settings.setSavePassword( mAuthSettings->storePasswordIsChecked() );
   settings.setUserTablesOnly( chkUserTablesOnly->isChecked() );
   settings.setAllowGeometrylessTables( chkAllowGeometrylessTables->isChecked() );
+  settings.setUseEstimatedMetadata( chkUseEstimatedMetadata->isChecked() );
   settings.setEnableSsl( chkEnableSSL->isChecked() );
   settings.setSslCryptoProvider( cbxCryptoProvider->currentData().toString() );
   settings.setSslKeyStore( txtKeyStore->text() );
@@ -351,6 +352,7 @@ void QgsHanaNewConnection::updateControlsFromSettings( const QgsHanaSettings &se
   txtSchema->setText( settings.schema() );
   chkUserTablesOnly->setChecked( settings.userTablesOnly() );
   chkAllowGeometrylessTables->setChecked( settings.allowGeometrylessTables() );
+  chkUseEstimatedMetadata->setChecked( settings.useEstimatedMetadata() );
 
   if ( settings.saveUserName() )
   {

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -1336,7 +1336,7 @@ static bool checkHANAVersion( QgsHanaConnection &conn, const QVersionNumber &pre
     switch ( version.majorVersion() )
     {
       case 2: return version >= premise;
-      case 4: return QgsHanaUtils::toHANACloudVersion( conn.getDatabaseCloudVersion() ) >= cloud;
+      case 4: return QgsHanaUtils::toHANAVersion( conn.getDatabaseCloudVersion() ) >= cloud;
       default: return false;
     }
   }

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -1337,7 +1337,7 @@ QgsRectangle QgsHanaProvider::estimateExtent( bool useEstimatedMetadata ) const
   if ( conn.isNull() )
     return QgsRectangle();
 
-  if ( QgsHanaUtils::toHANAVersion(conn->getDatabaseVersion()).majorVersion() < 2 )
+  if ( QgsHanaUtils::toHANAVersion( conn->getDatabaseVersion() ).majorVersion() < 2 )
     useEstimatedMetadata = false;
 
   try
@@ -1349,10 +1349,11 @@ QgsRectangle QgsHanaProvider::estimateExtent( bool useEstimatedMetadata ) const
       sql = ::buildQuery(
               "SYS.M_ST_GEOMETRY_COLUMNS",
               "MIN_X,MIN_Y,MAX_X,MAX_Y",
-              QStringLiteral( "SCHEMA_NAME=%1 AND TABLE_NAME=%2" )
+              QStringLiteral( "SCHEMA_NAME=%1 AND TABLE_NAME=%2 AND COLUMN_NAME=%3" )
               .arg(
                 QgsHanaUtils::quotedString( mSchemaName ),
-                QgsHanaUtils::quotedString( mTableName ) ), QString(), 1 );
+                QgsHanaUtils::quotedString( mTableName ),
+                QgsHanaUtils::quotedString( mGeometryColumn ) ), QString(), 1 );
     }
     else
     {
@@ -1394,7 +1395,8 @@ QgsRectangle QgsHanaProvider::estimateExtent( bool useEstimatedMetadata ) const
   }
   catch ( const QgsHanaException &ex )
   {
-    if ( useEstimatedMetadata ) {
+    if ( useEstimatedMetadata )
+    {
       // Try again without fast extent estimation
       return estimateExtent( false );
     }

--- a/src/providers/hana/qgshanaprovider.h
+++ b/src/providers/hana/qgshanaprovider.h
@@ -110,7 +110,7 @@ class QgsHanaProvider final : public QgsVectorDataProvider
     QString buildQuery( const QString &columns, const QString &where ) const;
     QString buildQuery( const QString &columns ) const;
     bool checkPermissionsAndSetCapabilities( QgsHanaConnection &conn );
-    QgsRectangle estimateExtent() const;
+    QgsRectangle estimateExtent( bool useEstimatedMetadata ) const;
     void readAttributeFields( QgsHanaConnection &conn );
     void readGeometryType( QgsHanaConnection &conn );
     void readMetadata( QgsHanaConnection &conn );
@@ -130,6 +130,8 @@ class QgsHanaProvider final : public QgsVectorDataProvider
     int mSrid = -1;
     // Flag that shows the presence of a planar equivalent in a database
     bool mHasSrsPlanarEquivalent = false;
+    // Flag that shows whether estimated metadata should be used
+    bool mUseEstimatedMetadata = false;
     // Name of the table with no schema
     QString mTableName;
     // Name of the schema

--- a/src/providers/hana/qgshanaprovider.h
+++ b/src/providers/hana/qgshanaprovider.h
@@ -110,7 +110,6 @@ class QgsHanaProvider final : public QgsVectorDataProvider
     QString buildQuery( const QString &columns, const QString &where ) const;
     QString buildQuery( const QString &columns ) const;
     bool checkPermissionsAndSetCapabilities( QgsHanaConnection &conn );
-    bool checkHANAVersion( QgsHanaConnection &conn, const QVersionNumber &premise, const QVersionNumber &cloud ) const;
     QgsRectangle estimateExtent( bool useEstimatedMetadata ) const;
     void readAttributeFields( QgsHanaConnection &conn );
     void readGeometryType( QgsHanaConnection &conn );

--- a/src/providers/hana/qgshanaprovider.h
+++ b/src/providers/hana/qgshanaprovider.h
@@ -110,6 +110,7 @@ class QgsHanaProvider final : public QgsVectorDataProvider
     QString buildQuery( const QString &columns, const QString &where ) const;
     QString buildQuery( const QString &columns ) const;
     bool checkPermissionsAndSetCapabilities( QgsHanaConnection &conn );
+    bool checkHANAVersion( QgsHanaConnection &conn, const QVersionNumber &premise, const QVersionNumber &cloud ) const;
     QgsRectangle estimateExtent( bool useEstimatedMetadata ) const;
     void readAttributeFields( QgsHanaConnection &conn );
     void readGeometryType( QgsHanaConnection &conn );

--- a/src/providers/hana/qgshanasettings.cpp
+++ b/src/providers/hana/qgshanasettings.cpp
@@ -219,7 +219,7 @@ void QgsHanaSettings::load()
     mPassword = settings.value( key + "/password" ).toString();
   mUserTablesOnly = settings.value( key + "/userTablesOnly", true ).toBool();
   mAllowGeometrylessTables = settings.value( key + "/allowGeometrylessTables", false ).toBool();
-  mUseEstimatedMetadata = settings.value( key + "/estimatedmetadata", false ).toBool();
+  mUseEstimatedMetadata = settings.value( key + "/estimatedMetadata", false ).toBool();
 
   // SSL parameters
   mSslEnabled = settings.value( key + "/sslEnabled", false ).toBool();
@@ -289,7 +289,7 @@ void QgsHanaSettings::save()
   settings.setValue( key + "/password", mSavePassword ? mPassword : QString( ) );
   settings.setValue( key + "/userTablesOnly", mUserTablesOnly );
   settings.setValue( key + "/allowGeometrylessTables", mAllowGeometrylessTables );
-  settings.setValue( key + "/estimatedmetadata", mUseEstimatedMetadata );
+  settings.setValue( key + "/estimatedMetadata", mUseEstimatedMetadata );
   settings.setValue( key + "/sslEnabled", mSslEnabled );
   settings.setValue( key + "/sslCryptoProvider", mSslCryptoProvider );
   settings.setValue( key + "/sslKeyStore", mSslKeyStore );
@@ -339,7 +339,7 @@ void QgsHanaSettings::removeConnection( const QString &name )
   settings.remove( key + "/schema" );
   settings.remove( key + "/userTablesOnly" );
   settings.remove( key + "/allowGeometrylessTables" );
-  settings.remove( key + "/estimatedmetadata" );
+  settings.remove( key + "/estimatedMetadata" );
   settings.remove( key + "/username" );
   settings.remove( key + "/password" );
   settings.remove( key + "/saveUsername" );

--- a/src/providers/hana/qgshanasettings.cpp
+++ b/src/providers/hana/qgshanasettings.cpp
@@ -118,6 +118,7 @@ void QgsHanaSettings::setFromDataSourceUri( const QgsDataSourceUri &uri )
 
   mUserTablesOnly = true;
   mAllowGeometrylessTables = false;
+  mUseEstimatedMetadata = false;
   mSaveUserName = false;
   mSavePassword = false;
   mAuthcfg = QString();
@@ -126,6 +127,8 @@ void QgsHanaSettings::setFromDataSourceUri( const QgsDataSourceUri &uri )
     mUserTablesOnly = QVariant( uri.param( QStringLiteral( "userTablesOnly" ) ) ).toBool();
   if ( uri.hasParam( QStringLiteral( "allowGeometrylessTables" ) ) )
     mAllowGeometrylessTables = QVariant( uri.param( QStringLiteral( "allowGeometrylessTables" ) ) ).toBool();
+  if ( uri.hasParam( QStringLiteral( "estimatedmetadata" ) ) )
+    mUseEstimatedMetadata = QVariant( uri.param( QStringLiteral( "estimatedmetadata" ) ) ).toBool();
   if ( uri.hasParam( QStringLiteral( "saveUsername" ) ) )
     mSaveUserName = QVariant( uri.param( QStringLiteral( "saveUsername" ) ) ).toBool();
   if ( uri.hasParam( QStringLiteral( "savePassword" ) ) )
@@ -137,6 +140,7 @@ void QgsHanaSettings::setFromDataSourceUri( const QgsDataSourceUri &uri )
 QgsDataSourceUri QgsHanaSettings::toDataSourceUri() const
 {
   QgsDataSourceUri uri;
+  uri.setUseEstimatedMetadata( mUseEstimatedMetadata );
   uri.setParam( "connectionType", QString::number( static_cast<uint>( mConnectionType ) ) );
   switch ( mConnectionType )
   {
@@ -215,6 +219,7 @@ void QgsHanaSettings::load()
     mPassword = settings.value( key + "/password" ).toString();
   mUserTablesOnly = settings.value( key + "/userTablesOnly", true ).toBool();
   mAllowGeometrylessTables = settings.value( key + "/allowGeometrylessTables", false ).toBool();
+  mUseEstimatedMetadata = settings.value( key + "/estimatedmetadata", false ).toBool();
 
   // SSL parameters
   mSslEnabled = settings.value( key + "/sslEnabled", false ).toBool();
@@ -284,6 +289,7 @@ void QgsHanaSettings::save()
   settings.setValue( key + "/password", mSavePassword ? mPassword : QString( ) );
   settings.setValue( key + "/userTablesOnly", mUserTablesOnly );
   settings.setValue( key + "/allowGeometrylessTables", mAllowGeometrylessTables );
+  settings.setValue( key + "/estimatedmetadata", mUseEstimatedMetadata );
   settings.setValue( key + "/sslEnabled", mSslEnabled );
   settings.setValue( key + "/sslCryptoProvider", mSslCryptoProvider );
   settings.setValue( key + "/sslKeyStore", mSslKeyStore );
@@ -333,6 +339,7 @@ void QgsHanaSettings::removeConnection( const QString &name )
   settings.remove( key + "/schema" );
   settings.remove( key + "/userTablesOnly" );
   settings.remove( key + "/allowGeometrylessTables" );
+  settings.remove( key + "/estimatedmetadata" );
   settings.remove( key + "/username" );
   settings.remove( key + "/password" );
   settings.remove( key + "/saveUsername" );

--- a/src/providers/hana/qgshanasettings.h
+++ b/src/providers/hana/qgshanasettings.h
@@ -152,6 +152,15 @@ class QgsHanaSettings
     }
 
     /**
+     * Specifies whether estimated metadata from e.g. an index can be used or not.
+     */
+    bool useEstimatedMetadata() const { return mUseEstimatedMetadata; }
+    void setUseEstimatedMetadata( bool useEstimatedMetadata )
+    {
+      mUseEstimatedMetadata = useEstimatedMetadata;
+    }
+
+    /**
      * Enables or disables TLS 1.1 – TLS1.2 encryption.
      */
     bool enableSsl() const { return mSslEnabled; }
@@ -317,6 +326,7 @@ class QgsHanaSettings
     bool mSavePassword = false;
     bool mUserTablesOnly = true;
     bool mAllowGeometrylessTables = false;
+    bool mUseEstimatedMetadata = false;
     QMap<QString, QMap<QString, QStringList>> mKeyColumns;
     // SSL parameters
     bool mSslEnabled = false;

--- a/src/providers/hana/qgshanautils.cpp
+++ b/src/providers/hana/qgshanautils.cpp
@@ -417,6 +417,20 @@ QVersionNumber QgsHanaUtils::toHANAVersion( const QString &dbVersion )
   return QVersionNumber( maj, min, rev );
 }
 
+QVersionNumber QgsHanaUtils::toHANACloudVersion( const QString &dbCloudVersion )
+{
+  QString version = dbCloudVersion;
+  QStringList strs = version.replace( '-', '.' ).split( '.' );
+
+  if ( strs.length() < 3 )
+    return QVersionNumber( 0 );
+
+  const int maj = strs[0].toInt();
+  const int min = strs[1].toInt();
+  const int rev = strs[2].toInt();
+  return QVersionNumber( maj, min, rev );
+}
+
 constexpr int PLANAR_SRID_OFFSET = 1000000000;
 
 int QgsHanaUtils::toPlanarSRID( int srid )

--- a/src/providers/hana/qgshanautils.cpp
+++ b/src/providers/hana/qgshanautils.cpp
@@ -406,21 +406,7 @@ Qgis::WkbType QgsHanaUtils::toWkbType( const NS_ODBC::String &type, const NS_ODB
 QVersionNumber QgsHanaUtils::toHANAVersion( const QString &dbVersion )
 {
   QString version = dbVersion;
-  QStringList strs = version.replace( ' ', '.' ).split( '.' );
-
-  if ( strs.length() < 3 )
-    return QVersionNumber( 0 );
-
-  const int maj = strs[0].toInt();
-  const int min = strs[1].toInt();
-  const int rev = strs[2].toInt();
-  return QVersionNumber( maj, min, rev );
-}
-
-QVersionNumber QgsHanaUtils::toHANACloudVersion( const QString &dbCloudVersion )
-{
-  QString version = dbCloudVersion;
-  QStringList strs = version.replace( '-', '.' ).split( '.' );
+  QStringList strs = version.replace( '-', '.' ).replace( ' ', '.' ).split( '.' );
 
   if ( strs.length() < 3 )
     return QVersionNumber( 0 );

--- a/src/providers/hana/qgshanautils.h
+++ b/src/providers/hana/qgshanautils.h
@@ -65,6 +65,7 @@ class QgsHanaUtils
     static bool isGeometryTypeSupported( Qgis::WkbType wkbType );
     static Qgis::WkbType toWkbType( const NS_ODBC::String &type, const NS_ODBC::Int &hasZ, const NS_ODBC::Int &hasM );
     static QVersionNumber toHANAVersion( const QString &dbVersion );
+    static QVersionNumber toHANACloudVersion( const QString &dbCloudVersion );
     static int toPlanarSRID( int srid );
     static bool convertField( QgsField &field );
     static int countFieldsWithFirstLetterInUppercase( const QgsFields &fields );

--- a/src/providers/hana/qgshanautils.h
+++ b/src/providers/hana/qgshanautils.h
@@ -65,7 +65,6 @@ class QgsHanaUtils
     static bool isGeometryTypeSupported( Qgis::WkbType wkbType );
     static Qgis::WkbType toWkbType( const NS_ODBC::String &type, const NS_ODBC::Int &hasZ, const NS_ODBC::Int &hasM );
     static QVersionNumber toHANAVersion( const QString &dbVersion );
-    static QVersionNumber toHANACloudVersion( const QString &dbCloudVersion );
     static int toPlanarSRID( int srid );
     static bool convertField( QgsField &field );
     static int countFieldsWithFirstLetterInUppercase( const QgsFields &fields );

--- a/src/ui/qgshananewconnectionbase.ui
+++ b/src/ui/qgshananewconnectionbase.ui
@@ -893,7 +893,7 @@
       <item>
        <widget class="QCheckBox" name="chkUseEstimatedMetadata">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, estimated table metadata will be used if available. For large tables, this avoids slow table loads and potentially expensive computations, but may result in incorrect layer properties such as layer extent. The fast extent estimation is available on HANA Cloud since QRC1/2024 and will be available on HANA On-Premise with SP8 and above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, estimated table metadata will be used if available. For large tables, this avoids slow table loads and potentially expensive computations, but may result in incorrect layer properties such as layer extent. The fast extent estimation is available starting with QRC1/2024 and SP8 in HANA Cloud and HANA On-Premise respectively.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Use estimated table metadata</string>

--- a/src/ui/qgshananewconnectionbase.ui
+++ b/src/ui/qgshananewconnectionbase.ui
@@ -893,7 +893,7 @@
       <item>
        <widget class="QCheckBox" name="chkUseEstimatedMetadata">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, estimated table metadata will be used if available. For large tables, this avoids a slow table scans and potentially expensive computations, but may result in incorrect layer properties such as layer extent.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, estimated table metadata will be used if available. For large tables, this avoids slow table loads and potentially expensive computations, but may result in incorrect layer properties such as layer extent. The fast extent estimation is available on HANA Cloud since QRC1/2024 and will be available on HANA On-Premise with SP8 and above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Use estimated table metadata</string>

--- a/src/ui/qgshananewconnectionbase.ui
+++ b/src/ui/qgshananewconnectionbase.ui
@@ -891,6 +891,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="chkUseEstimatedMetadata">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, estimated table metadata will be used if available. For large tables, this avoids a slow table scans and potentially expensive computations, but may result in incorrect layer properties such as layer extent.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use estimated table metadata</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="chkAllowGeometrylessTables">
         <property name="text">
          <string>Also list tables with no geometry</string>
@@ -974,8 +984,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>322</x>
-     <y>611</y>
+     <x>331</x>
+     <y>841</y>
     </hint>
     <hint type="destinationlabel">
      <x>450</x>
@@ -990,8 +1000,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>404</x>
-     <y>611</y>
+     <x>413</x>
+     <y>841</y>
     </hint>
     <hint type="destinationlabel">
      <x>450</x>
@@ -1001,7 +1011,7 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/tests/src/python/test_provider_hana.py
+++ b/tests/src/python/test_provider_hana.py
@@ -543,17 +543,17 @@ class TestPyQgsHanaProvider(QgisTestCase, ProviderTestCase):
         create_sql = f'CREATE TABLE "{self.schemaName}"."test_extent" ( ' \
             'ID INTEGER NOT NULL PRIMARY KEY,' \
             'GEOM1 ST_GEOMETRY(0),' \
-            'GEOM2 ST_GEOMETRY(0))'
+            'GEOM2 ST_GEOMETRY(4326))'
         insert_sql = f'INSERT INTO "{self.schemaName}"."test_extent" (ID, GEOM1, GEOM2) ' \
-            f'VALUES (?, ST_GeomFromText(?), ST_GeomFromText(?)) '
-        insert_args = [[1, 'POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0))', 'POLYGON ((0 0, 40 0, 40 40, 0 40, 0 0))']]
+            f'VALUES (?, ST_GeomFromText(?), ST_GeomFromText(?, 4326)) '
+        insert_args = [[1, 'POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0))', 'POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0))']]
         self.prepareTestTable('test_extent', create_sql, insert_sql, insert_args)
 
         vl_geom1 = self.createVectorLayer(f'estimatedmetadata=true table="{self.schemaName}"."test_extent" (GEOM1) sql=', 'test_extent')
         vl_geom2 = self.createVectorLayer(f'estimatedmetadata=true table="{self.schemaName}"."test_extent" (GEOM2) sql=', 'test_extent')
 
         self.assertEqual(QgsRectangle(0, 0, 20, 20), vl_geom1.dataProvider().extent())
-        self.assertEqual(QgsRectangle(0, 0, 40, 40), vl_geom2.dataProvider().extent())
+        self.assertEqual(QgsRectangle(0, 0, 20, 20.283).toString(3), vl_geom2.dataProvider().extent().toString(3))
 
     def testEncodeDecodeUri(self):
         """Test HANA encode/decode URI"""

--- a/tests/src/python/test_provider_hana.py
+++ b/tests/src/python/test_provider_hana.py
@@ -553,7 +553,7 @@ class TestPyQgsHanaProvider(QgisTestCase, ProviderTestCase):
         vl_geom2 = self.createVectorLayer(f'estimatedmetadata=true table="{self.schemaName}"."test_extent" (GEOM2) sql=', 'test_extent')
 
         self.assertEqual(QgsRectangle(0, 0, 20, 20), vl_geom1.dataProvider().extent())
-        self.assertEqual(QgsRectangle(0, 0, 20, 20.283).toString(3), vl_geom2.dataProvider().extent().toString(3))
+        self.assertEqual(QgsRectangle(0, 0, 20, 20.284).toString(3), vl_geom2.dataProvider().extent().toString(3))
 
     def testEncodeDecodeUri(self):
         """Test HANA encode/decode URI"""

--- a/tests/src/python/test_provider_hana.py
+++ b/tests/src/python/test_provider_hana.py
@@ -542,10 +542,10 @@ class TestPyQgsHanaProvider(QgisTestCase, ProviderTestCase):
     def testExtentWithEstimatedMetadata(self):
         create_sql = f'CREATE TABLE "{self.schemaName}"."test_extent" ( ' \
             'ID INTEGER NOT NULL PRIMARY KEY,' \
-            'GEOM1 ST_GEOMETRY(4326),' \
-            'GEOM2 ST_GEOMETRY(4326))'
+            'GEOM1 ST_GEOMETRY(0),' \
+            'GEOM2 ST_GEOMETRY(0))'
         insert_sql = f'INSERT INTO "{self.schemaName}"."test_extent" (ID, GEOM1, GEOM2) ' \
-            f'VALUES (?, ST_GeomFromText(?, 4326), ST_GeomFromText(?, 4326)) '
+            f'VALUES (?, ST_GeomFromText(?), ST_GeomFromText(?)) '
         insert_args = [[1, 'POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0))', 'POLYGON ((0 0, 40 0, 40 40, 0 40, 0 0))']]
         self.prepareTestTable('test_extent', create_sql, insert_sql, insert_args)
 


### PR DESCRIPTION
## Description

With QRC/1 2024 a new and faster way to estimate extents of spatial column has been added to HANA.
More precisely, users can now use special columns in [this table](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-spatial-reference/spatial-extent-with-sys-m-st-geometry-columns?locale=en-US) to get an estimation of the extent of a spatial column.
Even though the stored extent is only an estimation, it is often _good enough_.
Especially for very large tables costly aggregation functions are avoided every time the extent is recomputed.
The extent information in the mentioned HANA table is only available after a delta-merge, so a fallback to the standard behaviour, i.e. via aggregation functions, was added in case the data is unavailable or has not yet been computed.

## Summary of changes:

1. Support for the mentioned fast extent estimation added
2. Fallback in case of unavailability added
3. Checkbox to enable behaviour added to HANA connection widget (see image down below, 'Use estimated table metadata')

![image](https://github.com/qgis/QGIS/assets/54998646/cf7661cd-7eb8-4930-a0f5-d38e95659e92)
