### PR TITLE
[ui] Fix unclickable labeling's position priority data-defined button

### DIFF
--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -4749,27 +4749,6 @@ font-style: italic;</string>
                               </property>
                              </widget>
                             </item>
-                            <item row="0" column="1" rowspan="2">
-                             <widget class="QFrame" name="mPlacementFixedQuadrantFrame_2">
-                              <layout class="QGridLayout" name="gridLayout_11">
-                               <property name="leftMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="topMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="rightMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="bottomMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="spacing">
-                                <number>2</number>
-                               </property>
-                              </layout>
-                             </widget>
-                            </item>
                            </layout>
                           </widget>
                          </item>


### PR DESCRIPTION
## Description

Over the course of development prior to 3.38, the following position priority data-defined button became unclickeable:

![image](https://github.com/qgis/QGIS/assets/1728657/880ec521-ab51-4d0e-b799-238448a2613a)

This PR fixes that.
