### PR TITLE
Fix broken prefetch capabilities for raster layers

### DIFF
--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -85,6 +85,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   , mLayerName( layer->name() )
   , mLayerOpacity( layer->opacity() )
   , mProviderCapabilities( layer->dataProvider()->providerCapabilities() )
+  , mInterfaceCapabilities( layer->dataProvider()->capabilities() )
   , mFeedback( new QgsRasterLayerRendererFeedback( this ) )
   , mEnableProfile( rendererContext.flags() & Qgis::RenderContextFlag::RecordProfile )
 {
@@ -450,7 +451,7 @@ bool QgsRasterLayerRenderer::render()
 
   // Skip rendering of out of view tiles (xyz)
   if ( !mRasterViewPort || ( renderContext()->testFlag( Qgis::RenderContextFlag::RenderPreviewJob ) &&
-                             !( mProviderCapabilities &
+                             !( mInterfaceCapabilities &
                                 QgsRasterInterface::Capability::Prefetch ) ) )
     return true;
 

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -84,6 +84,7 @@ class CORE_EXPORT QgsRasterLayerRenderer : public QgsMapLayerRenderer
     std::unique_ptr<QgsRasterPipe> mPipe;
 
     QgsRasterDataProvider::ProviderCapabilities mProviderCapabilities;
+    int mInterfaceCapabilities = 0;
 
     //! feedback class for cancellation and preview generation
     QgsRasterLayerRendererFeedback *mFeedback = nullptr;


### PR DESCRIPTION
We had a mismatch between QgsRasterDataProvider::providerCapabilities vs comparing to flags from QgsRasterInterface::capabilities.

This was allowed because both are old style int enums, and really need to be upgraded to enum classes!
