### PR TITLE
[3D] merge `Qgs3DWiredMesh` and `AABBMesh` classes

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -17,6 +17,7 @@ set(QGIS_3D_SRCS
   qgs3dmapcanvas.cpp
   qgs3dsceneexporter.cpp
   qgs3dutils.cpp
+  qgs3dwiredmesh_p.cpp
   qgscameracontroller.cpp
   qgscamerapose.cpp
   qgsfeature3dhandler_p.cpp
@@ -121,6 +122,7 @@ set(QGIS_3D_HDRS
   qgs3dtypes.h
   qgs3dutils.h
   qgs3dmapcanvas.h
+  qgs3dwiredmesh_p.h
   qgsaabb.h
   qgsabstract3dengine.h
   qgsabstractvectorlayer3drenderer.h

--- a/src/3d/chunks/qgschunkboundsentity_p.cpp
+++ b/src/3d/chunks/qgschunkboundsentity_p.cpp
@@ -15,84 +15,18 @@
 
 #include "qgschunkboundsentity_p.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <Qt3DRender/QBuffer>
-typedef Qt3DRender::QBuffer Qt3DQBuffer;
-#else
-#include <Qt3DCore/QBuffer>
-typedef Qt3DCore::QBuffer Qt3DQBuffer;
-#endif
 #include <Qt3DExtras/QPhongMaterial>
 
 #include "qgsaabb.h"
+#include "qgs3dwiredmesh_p.h"
 
 
 ///@cond PRIVATE
 
-LineMeshGeometry::LineMeshGeometry( Qt3DCore::QNode *parent )
-  : QGeometry( parent )
-  , mPositionAttribute( new Qt3DQAttribute( this ) )
-  , mVertexBuffer( new Qt3DQBuffer( this ) )
-{
-  mPositionAttribute->setAttributeType( Qt3DQAttribute::VertexAttribute );
-  mPositionAttribute->setBuffer( mVertexBuffer );
-  mPositionAttribute->setVertexBaseType( Qt3DQAttribute::Float );
-  mPositionAttribute->setVertexSize( 3 );
-  mPositionAttribute->setName( Qt3DQAttribute::defaultPositionAttributeName() );
-
-  addAttribute( mPositionAttribute );
-}
-
-void LineMeshGeometry::setVertices( const QList<QVector3D> &vertices )
-{
-  QByteArray vertexBufferData;
-  vertexBufferData.resize( vertices.size() * 3 * sizeof( float ) );
-  float *rawVertexArray = reinterpret_cast<float *>( vertexBufferData.data() );
-  int idx = 0;
-  for ( const auto &v : vertices )
-  {
-    rawVertexArray[idx++] = v.x();
-    rawVertexArray[idx++] = v.y();
-    rawVertexArray[idx++] = v.z();
-  }
-
-  mVertexCount = vertices.count();
-  mVertexBuffer->setData( vertexBufferData );
-}
-
-
-// ----------------
-
-
-AABBMesh::AABBMesh( Qt3DCore::QNode *parent )
-  : Qt3DRender::QGeometryRenderer( parent )
-{
-  setInstanceCount( 1 );
-  setIndexOffset( 0 );
-  setFirstInstance( 0 );
-  setPrimitiveType( Qt3DRender::QGeometryRenderer::Lines );
-
-  mLineMeshGeo = new LineMeshGeometry( this );
-  setGeometry( mLineMeshGeo );
-}
-
-void AABBMesh::setBoxes( const QList<QgsAABB> &bboxes )
-{
-  QList<QVector3D> vertices;
-  for ( const QgsAABB &bbox : bboxes )
-    vertices << bbox.verticesForLines();
-  mLineMeshGeo->setVertices( vertices );
-  setVertexCount( mLineMeshGeo->vertexCount() );
-}
-
-
-// ----------------
-
-
 QgsChunkBoundsEntity::QgsChunkBoundsEntity( Qt3DCore::QNode *parent )
   : Qt3DCore::QEntity( parent )
 {
-  mAabbMesh = new AABBMesh;
+  mAabbMesh = new Qgs3DWiredMesh;
   addComponent( mAabbMesh );
 
   Qt3DExtras::QPhongMaterial *bboxesMaterial = new Qt3DExtras::QPhongMaterial;
@@ -102,7 +36,7 @@ QgsChunkBoundsEntity::QgsChunkBoundsEntity( Qt3DCore::QNode *parent )
 
 void QgsChunkBoundsEntity::setBoxes( const QList<QgsAABB> &bboxes )
 {
-  mAabbMesh->setBoxes( bboxes );
+  mAabbMesh->setVertices( bboxes );
 }
 
 /// @endcond

--- a/src/3d/chunks/qgschunkboundsentity_p.h
+++ b/src/3d/chunks/qgschunkboundsentity_p.h
@@ -29,22 +29,8 @@
 
 #include <Qt3DCore/QEntity>
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <Qt3DRender/QAttribute>
-#include <Qt3DRender/QGeometry>
-typedef Qt3DRender::QAttribute Qt3DQAttribute;
-typedef Qt3DRender::QGeometry Qt3DQGeometry;
-#else
-#include <Qt3DCore/QAttribute>
-#include <Qt3DCore/QGeometry>
-typedef Qt3DCore::QAttribute Qt3DQAttribute;
-typedef Qt3DCore::QGeometry Qt3DQGeometry;
-#endif
-#include <QVector3D>
-#include <Qt3DRender/QGeometryRenderer>
-
 class QgsAABB;
-class AABBMesh;
+class Qgs3DWiredMesh;
 
 #define SIP_NO_FILE
 
@@ -66,48 +52,7 @@ class QgsChunkBoundsEntity : public Qt3DCore::QEntity
     void setBoxes( const QList<QgsAABB> &bboxes );
 
   private:
-    AABBMesh *mAabbMesh = nullptr;
-};
-
-
-class LineMeshGeometry : public Qt3DQGeometry
-{
-    Q_OBJECT
-
-  public:
-    LineMeshGeometry( Qt3DCore::QNode *parent = nullptr );
-
-    int vertexCount()
-    {
-      return mVertexCount;
-    }
-
-    void setVertices( const QList<QVector3D> &vertices );
-
-  private:
-    Qt3DQAttribute *mPositionAttribute = nullptr;
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    Qt3DRender::QBuffer *mVertexBuffer = nullptr;
-#else
-    Qt3DCore::QBuffer *mVertexBuffer = nullptr;
-#endif
-    int mVertexCount = 0;
-
-};
-
-
-//! Geometry renderer for axis aligned bounding boxes - draws a box edges as lines
-class AABBMesh : public Qt3DRender::QGeometryRenderer
-{
-    Q_OBJECT
-
-  public:
-    AABBMesh( Qt3DCore::QNode *parent = nullptr );
-
-    void setBoxes( const QList<QgsAABB> &bboxes );
-
-  private:
-    LineMeshGeometry *mLineMeshGeo = nullptr;
+    Qgs3DWiredMesh *mAabbMesh = nullptr;
 };
 
 /// @endcond

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -16,19 +16,6 @@
 #include "qgs3daxis.h"
 
 #include <Qt3DCore/QTransform>
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <Qt3DRender/QAttribute>
-#include <Qt3DRender/QGeometry>
-typedef Qt3DRender::QAttribute Qt3DQAttribute;
-typedef Qt3DRender::QGeometry Qt3DQGeometry;
-typedef Qt3DRender::QBuffer Qt3DQBuffer;
-#else
-#include <Qt3DCore/QAttribute>
-#include <Qt3DCore/QGeometry>
-typedef Qt3DCore::QAttribute Qt3DQAttribute;
-typedef Qt3DCore::QGeometry Qt3DQGeometry;
-typedef Qt3DCore::QBuffer Qt3DQBuffer;
-#endif
 #include <Qt3DExtras/QCylinderMesh>
 #include <Qt3DExtras/QPhongMaterial>
 #include <Qt3DExtras/QConeMesh>
@@ -54,6 +41,7 @@ typedef Qt3DCore::QBuffer Qt3DQBuffer;
 #include "qgscoordinatereferencesystem.h"
 #include "qgswindow3dengine.h"
 #include "qgsraycastingutils_p.h"
+#include "qgs3dwiredmesh_p.h"
 
 Qgs3DAxis::Qgs3DAxis( Qgs3DMapCanvas *canvas,
                       Qt3DCore::QEntity *parent3DScene,
@@ -1214,48 +1202,4 @@ void Qgs3DAxis::onTextZChanged( const QString &text )
   mTextZ->setFont( f );
   mTextZ->setWidth( mAxisScaleFactor * mFontSize * text.length() );
   mTextZ->setHeight( mAxisScaleFactor * mFontSize * 1.5f );
-}
-
-//
-// Qgs3DWiredMesh
-//
-
-Qgs3DWiredMesh::Qgs3DWiredMesh( Qt3DCore::QNode *parent )
-  : Qt3DRender::QGeometryRenderer( parent )
-  , mPositionAttribute( new Qt3DQAttribute( this ) )
-  , mVertexBuffer( new Qt3DQBuffer( this ) )
-{
-  mPositionAttribute->setAttributeType( Qt3DQAttribute::VertexAttribute );
-  mPositionAttribute->setBuffer( mVertexBuffer );
-  mPositionAttribute->setVertexBaseType( Qt3DQAttribute::Float );
-  mPositionAttribute->setVertexSize( 3 );
-  mPositionAttribute->setName( Qt3DQAttribute::defaultPositionAttributeName() );
-
-  mGeom = new Qt3DQGeometry( this );
-  mGeom->addAttribute( mPositionAttribute );
-
-  setInstanceCount( 1 );
-  setIndexOffset( 0 );
-  setFirstInstance( 0 );
-  setPrimitiveType( Qt3DRender::QGeometryRenderer::Lines );
-  setGeometry( mGeom );
-}
-
-Qgs3DWiredMesh::~Qgs3DWiredMesh() = default;
-
-void Qgs3DWiredMesh::setVertices( const QList<QVector3D> &vertices )
-{
-  QByteArray vertexBufferData;
-  vertexBufferData.resize( vertices.size() * 3 * sizeof( float ) );
-  float *rawVertexArray = reinterpret_cast<float *>( vertexBufferData.data() );
-  int idx = 0;
-  for ( const QVector3D &v : std::as_const( vertices ) )
-  {
-    rawVertexArray[idx++] = v.x();
-    rawVertexArray[idx++] = v.y();
-    rawVertexArray[idx++] = v.z();
-  }
-
-  mVertexBuffer->setData( vertexBufferData );
-  setVertexCount( vertices.count() );
 }

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -27,15 +27,8 @@
 #include <Qt3DRender/QPickEvent>
 #include <Qt3DRender/QScreenRayCaster>
 #include <QVector3D>
-#include <QVector2D>
 
 #include <Qt3DRender/QLayer>
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <Qt3DRender/QBuffer>
-#else
-#include <Qt3DCore/QBuffer>
-#endif
-#include <Qt3DRender/QGeometryRenderer>
 
 #include <QtWidgets/QMenu>
 #include "qgs3dmapsettings.h"
@@ -185,41 +178,6 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     QCursor mPreviousCursor = Qt::ArrowCursor;
     QMenu *mMenu = nullptr;
 
-};
-
-/**
- * \ingroup 3d
- * \brief Geometry renderer for lines, draws a wired mesh
- *
- * \since QGIS 3.26
- */
-class Qgs3DWiredMesh : public Qt3DRender::QGeometryRenderer
-{
-    Q_OBJECT
-
-  public:
-
-    /**
-     * \brief Default Qgs3DWiredMesh constructor
-     */
-    Qgs3DWiredMesh( Qt3DCore::QNode *parent = nullptr );
-    ~Qgs3DWiredMesh() override;
-
-    /**
-     * \brief add or replace mesh vertices coordinates
-     */
-    void setVertices( const QList<QVector3D> &vertices );
-
-  private:
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    Qt3DRender::QGeometry *mGeom = nullptr;
-    Qt3DRender::QAttribute *mPositionAttribute = nullptr;
-    Qt3DRender::QBuffer *mVertexBuffer = nullptr;
-#else
-    Qt3DCore::QGeometry *mGeom = nullptr;
-    Qt3DCore::QAttribute *mPositionAttribute = nullptr;
-    Qt3DCore::QBuffer *mVertexBuffer = nullptr;
-#endif
 };
 
 #endif // QGS3DAXIS_H

--- a/src/3d/qgs3dwiredmesh_p.cpp
+++ b/src/3d/qgs3dwiredmesh_p.cpp
@@ -29,6 +29,8 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 typedef Qt3DCore::QBuffer Qt3DQBuffer;
 #endif
 
+#include "qgsaabb.h"
+
 
 ///@cond PRIVATE
 
@@ -70,6 +72,15 @@ void Qgs3DWiredMesh::setVertices( const QList<QVector3D> &vertices )
 
   mVertexBuffer->setData( vertexBufferData );
   setVertexCount( vertices.count() );
+}
+
+void Qgs3DWiredMesh::setVertices( const QList<QgsAABB> &bboxes )
+{
+  QList<QVector3D> vertices;
+  for ( const QgsAABB &bbox : bboxes )
+    vertices << bbox.verticesForLines();
+
+  setVertices( vertices );
 }
 
 /// @endcond

--- a/src/3d/qgs3dwiredmesh_p.cpp
+++ b/src/3d/qgs3dwiredmesh_p.cpp
@@ -1,0 +1,75 @@
+/***************************************************************************
+  qgs3dwiredmesh_p.cpp
+  --------------------------------------
+  Date                 : March 2022
+  Copyright            : (C) 2022 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+  ***************************************************************************
+  *                                                                         *
+  *   This program is free software; you can redistribute it and/or modify  *
+  *   it under the terms of the GNU General Public License as published by  *
+  *   the Free Software Foundation; either version 2 of the License, or     *
+  *   (at your option) any later version.                                   *
+  *                                                                         *
+ ***************************************************************************/
+
+#include "qgs3dwiredmesh_p.h"
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QGeometry>
+typedef Qt3DRender::QAttribute Qt3DQAttribute;
+typedef Qt3DRender::QGeometry Qt3DQGeometry;
+typedef Qt3DRender::QBuffer Qt3DQBuffer;
+#else
+#include <Qt3DCore/QAttribute>
+#include <Qt3DCore/QGeometry>
+typedef Qt3DCore::QAttribute Qt3DQAttribute;
+typedef Qt3DCore::QGeometry Qt3DQGeometry;
+typedef Qt3DCore::QBuffer Qt3DQBuffer;
+#endif
+
+
+///@cond PRIVATE
+
+Qgs3DWiredMesh::Qgs3DWiredMesh( Qt3DCore::QNode *parent )
+  : Qt3DRender::QGeometryRenderer( parent )
+  , mPositionAttribute( new Qt3DQAttribute( this ) )
+  , mVertexBuffer( new Qt3DQBuffer( this ) )
+{
+  mPositionAttribute->setAttributeType( Qt3DQAttribute::VertexAttribute );
+  mPositionAttribute->setBuffer( mVertexBuffer );
+  mPositionAttribute->setVertexBaseType( Qt3DQAttribute::Float );
+  mPositionAttribute->setVertexSize( 3 );
+  mPositionAttribute->setName( Qt3DQAttribute::defaultPositionAttributeName() );
+
+  mGeom = new Qt3DQGeometry( this );
+  mGeom->addAttribute( mPositionAttribute );
+
+  setInstanceCount( 1 );
+  setIndexOffset( 0 );
+  setFirstInstance( 0 );
+  setPrimitiveType( Qt3DRender::QGeometryRenderer::Lines );
+  setGeometry( mGeom );
+}
+
+Qgs3DWiredMesh::~Qgs3DWiredMesh() = default;
+
+void Qgs3DWiredMesh::setVertices( const QList<QVector3D> &vertices )
+{
+  QByteArray vertexBufferData;
+  vertexBufferData.resize( static_cast<int>( static_cast<long>( vertices.size() ) * 3 * sizeof( float ) ) );
+  float *rawVertexArray = reinterpret_cast<float *>( vertexBufferData.data() );
+  int idx = 0;
+  for ( const QVector3D &v : std::as_const( vertices ) )
+  {
+    rawVertexArray[idx++] = v.x();
+    rawVertexArray[idx++] = v.y();
+    rawVertexArray[idx++] = v.z();
+  }
+
+  mVertexBuffer->setData( vertexBufferData );
+  setVertexCount( vertices.count() );
+}
+
+/// @endcond

--- a/src/3d/qgs3dwiredmesh_p.h
+++ b/src/3d/qgs3dwiredmesh_p.h
@@ -1,0 +1,78 @@
+/***************************************************************************
+  qgs3dwiredmesh_p.h
+  --------------------------------------
+  Date                 : March 2022
+  Copyright            : (C) 2022 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+  ***************************************************************************
+  *                                                                         *
+  *   This program is free software; you can redistribute it and/or modify  *
+  *   it under the terms of the GNU General Public License as published by  *
+  *   the Free Software Foundation; either version 2 of the License, or     *
+  *   (at your option) any later version.                                   *
+  *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGS3DWIREDMESH_P_H
+#define QGS3DWIREDMESH_P_H
+
+///@cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#include <QVector3D>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#include <Qt3DRender/QBuffer>
+#else
+#include <Qt3DCore/QBuffer>
+#endif
+#include <Qt3DRender/QGeometryRenderer>
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup 3d
+ * \brief Geometry renderer for lines, draws a wired mesh
+ *
+ * \since QGIS 3.26
+ */
+class Qgs3DWiredMesh : public Qt3DRender::QGeometryRenderer
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * \brief Default Qgs3DWiredMesh constructor
+     */
+    Qgs3DWiredMesh( Qt3DCore::QNode *parent = nullptr );
+    ~Qgs3DWiredMesh() override;
+
+    /**
+     * \brief add or replace mesh vertices coordinates
+     */
+    void setVertices( const QList<QVector3D> &vertices );
+
+  private:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    Qt3DRender::QGeometry *mGeom = nullptr;
+    Qt3DRender::QAttribute *mPositionAttribute = nullptr;
+    Qt3DRender::QBuffer *mVertexBuffer = nullptr;
+#else
+    Qt3DCore::QGeometry *mGeom = nullptr;
+    Qt3DCore::QAttribute *mPositionAttribute = nullptr;
+    Qt3DCore::QBuffer *mVertexBuffer = nullptr;
+#endif
+};
+
+/// @endcond
+
+#endif // QGS3DWIREDMESH_P_H

--- a/src/3d/qgs3dwiredmesh_p.h
+++ b/src/3d/qgs3dwiredmesh_p.h
@@ -36,6 +36,8 @@
 #endif
 #include <Qt3DRender/QGeometryRenderer>
 
+class QgsAABB;
+
 #define SIP_NO_FILE
 
 /**
@@ -60,6 +62,11 @@ class Qgs3DWiredMesh : public Qt3DRender::QGeometryRenderer
      * \brief add or replace mesh vertices coordinates
      */
     void setVertices( const QList<QVector3D> &vertices );
+
+    /**
+     * \brief add or replace mesh vertices coordinates from QgsAABB coordinates
+     */
+    void setVertices( const QList<QgsAABB> &bboxes );
 
   private:
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
## Description

```
`Qgs3DWiredMesh` and `AABBMesh` + `LineMeshGeometry` do exactly the same
thing. The only difference is that `AABBMesh` expects a `QgsABBB` to
describe the vertices while `Qgs3DWiredMesh` expects a list of
vertices. By adding a new method to `Qgs3DWiredMesh` which converts a
`QgsABBB` to a list of vertices, it is possible to directly use
Qgs3DWiredMesh for `QgsChunkBoundsEntity`.
```

cc @benoitdm-oslandia 