### PR TITLE
Fix port values range for OAuth2 UI

### DIFF
--- a/src/auth/oauth2/gui/qgsauthoauth2edit.ui
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.ui
@@ -476,7 +476,7 @@
                   <number>0</number>
                  </property>
                  <property name="maximum">
-                  <number>9999</number>
+                  <number>65535</number>
                  </property>
                  <property name="value">
                   <number>0</number>


### PR DESCRIPTION
## Description

When setting up OAuth2 authentication in QGIS Authentication manager, "Redirect URL" port is limited by 9999. This limitation is forced in [qgsauthoauth2edit.ui](https://github.com/qgis/QGIS/compare/master...eduard-kazakov:QGIS:oauth-port-range-patch#diff-36ce32a722ad9b1cb4e8d140a6279da536471f0ec9c8bc75af1d70f3cbf87dc4) with _maximum_ property.

![image](https://github.com/qgis/QGIS/assets/9954197/38b7b4cd-b758-42f7-84e9-1aec16b78ca9)

This limitation makes impossible OAuth2 authorization via services using port numbers > 9999.

This PR changes available port numbers range from 0 - 9999 to 0 - 65535 (real valid ports number range). QSpinBox which is used as UI-widget here allows such limit.