### PR TITLE
[SelectiveMasking] Fix masks UI update

### DIFF
--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -93,8 +93,8 @@ void QgsMaskingWidget::setLayer( QgsVectorLayer *layer )
 
 void QgsMaskingWidget::populate()
 {
-  mMaskSourcesWidget->blockSignals( true );
-  mMaskTargetsWidget->blockSignals( true );
+  const QSignalBlocker blockerSourceWidget( mMaskSourcesWidget );
+  const QSignalBlocker blockerTargetWidget( mMaskTargetsWidget );
 
   mMaskSourcesWidget->update();
   mMaskTargetsWidget->setLayer( mLayer );
@@ -155,9 +155,6 @@ void QgsMaskingWidget::populate()
 
   mMaskSourcesWidget->setSelection( maskSources );
   mMaskTargetsWidget->setSelection( maskedSymbolLayers );
-
-  mMaskSourcesWidget->blockSignals( false );
-  mMaskTargetsWidget->blockSignals( false );
 }
 
 void QgsMaskingWidget::apply()

--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -37,6 +37,9 @@ QgsMaskingWidget::QgsMaskingWidget( QWidget *parent ) :
   QgsPanelWidget( parent )
 {
   setupUi( this );
+
+  connect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
+  connect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
 }
 
 void QgsMaskingWidget::onSelectionChanged()
@@ -57,29 +60,6 @@ void QgsMaskingWidget::onSelectionChanged()
 
   emit widgetChanged();
 }
-
-void QgsMaskingWidget::showEvent( QShowEvent *event )
-{
-  Q_UNUSED( event );
-
-  // populate is quite long, so we delay it when the widget is first shown
-  if ( mMustPopulate )
-  {
-    disconnect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
-    disconnect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
-
-    mMustPopulate = false;
-    populate();
-
-    connect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
-    connect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
-
-    onSelectionChanged();
-  }
-}
-
-
-
 
 /**
  * Symbol layer masks collector. It is an enhanced version of QgsVectorLayerUtils::symbolLayerMasks.
@@ -107,15 +87,15 @@ QList<QPair<QString, QList<QgsSymbolLayerReference>>> symbolLayerMasks( const Qg
 
 void QgsMaskingWidget::setLayer( QgsVectorLayer *layer )
 {
-  if ( mLayer != layer )
-  {
-    mLayer = layer;
-    mMustPopulate = true;
-  }
+  mLayer = layer;
+  populate();
 }
 
 void QgsMaskingWidget::populate()
 {
+  mMaskSourcesWidget->blockSignals( true );
+  mMaskTargetsWidget->blockSignals( true );
+
   mMaskSourcesWidget->update();
   mMaskTargetsWidget->setLayer( mLayer );
 
@@ -175,6 +155,9 @@ void QgsMaskingWidget::populate()
 
   mMaskSourcesWidget->setSelection( maskSources );
   mMaskTargetsWidget->setSelection( maskedSymbolLayers );
+
+  mMaskSourcesWidget->blockSignals( false );
+  mMaskTargetsWidget->blockSignals( false );
 }
 
 void QgsMaskingWidget::apply()
@@ -274,11 +257,6 @@ void QgsMaskingWidget::apply()
     QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
     layer->triggerRepaint();
   }
-}
-
-bool QgsMaskingWidget::hasBeenPopulated()
-{
-  return !mMustPopulate;
 }
 
 SymbolLayerVisitor::SymbolLayerVisitor( SymbolLayerVisitor::SymbolLayerCallback callback ) :

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -71,6 +71,7 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
 
     QPointer<QgsMessageBarItem> mMessageBarItem;
     bool mMustPopulate = false;
+    friend class TestQgsMaskingWidget;
 };
 
 

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -50,13 +50,6 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     //! Applies the changes
     void apply();
 
-    //! Widget has been populated or not
-    bool hasBeenPopulated();
-
-  protected:
-
-    void showEvent( QShowEvent * ) override;
-
   private slots:
 
     /**
@@ -70,7 +63,7 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     void populate();
 
     QPointer<QgsMessageBarItem> mMessageBarItem;
-    bool mMustPopulate = false;
+
     friend class TestQgsMaskingWidget;
 };
 

--- a/src/gui/qgsmasksourceselectionwidget.h
+++ b/src/gui/qgsmasksourceselectionwidget.h
@@ -70,6 +70,8 @@ class GUI_EXPORT QgsMaskSourceSelectionWidget : public QWidget
   private:
     QTreeWidget *mTree;
     QHash<QgsSymbolLayerReference, QTreeWidgetItem *> mItems;
+
+    friend class TestQgsMaskingWidget;
 };
 
 #endif

--- a/src/gui/qgssymbollayerselectionwidget.h
+++ b/src/gui/qgssymbollayerselectionwidget.h
@@ -62,6 +62,8 @@ class GUI_EXPORT QgsSymbolLayerSelectionWidget : public QWidget
 
     // Mapping between symbol layer id and tree elements
     QHash<QString, QTreeWidgetItem *> mItems;
+
+    friend class TestQgsMaskingWidget;
 };
 
 #endif

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -759,7 +759,7 @@ void QgsVectorLayerProperties::apply()
   mMetadataFilled = false;
 
   // save masking settings
-  if ( mMaskingWidget && mMaskingWidget->hasBeenPopulated() )
+  if ( mMaskingWidget )
     mMaskingWidget->apply();
 
   // set up the scale based layer visibility stuff....

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -75,6 +75,7 @@ set(TESTS
   testqgsquerybuilder.cpp
   testqgsqueryresultwidget.cpp
   testqgscompoundcolorwidget.cpp
+  testqgsmaskingwidget.cpp
 )
 
 foreach(TESTSRC ${TESTS})

--- a/tests/src/gui/testqgsmaskingwidget.cpp
+++ b/tests/src/gui/testqgsmaskingwidget.cpp
@@ -1,0 +1,181 @@
+/***************************************************************************
+    testqgsmaskingwidget.cpp
+    ---------------------
+    begin                : 2024/06/05
+    copyright            : (C) 2024 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QTreeWidget>
+
+#include "qgscategorizedsymbolrenderer.h"
+#include "qgsmarkersymbol.h"
+#include "qgsmasksymbollayer.h"
+#include "qgsmaskingwidget.h"
+#include "qgsproject.h"
+#include "qgssinglesymbolrenderer.h"
+#include "qgstest.h"
+#include "qgsvectorlayer.h"
+
+#include <QElapsedTimer>
+
+class TestQgsMaskingWidget : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+
+    TestQgsMaskingWidget() : QgsTest( QStringLiteral( "Masking widget Tests" ) ) {}
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+
+    void testTreeWidget();
+};
+
+void TestQgsMaskingWidget::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsMaskingWidget::cleanupTestCase()
+{
+}
+
+void TestQgsMaskingWidget::init()
+{
+}
+
+void TestQgsMaskingWidget::cleanup()
+{
+}
+
+void TestQgsMaskingWidget::testTreeWidget()
+{
+  const QString projectFilePath = testDataPath( QStringLiteral( "selective_masking.qgs" ) );
+  QVERIFY( QgsProject::instance()->read( projectFilePath ) );
+
+  // get layers
+  QList<QgsMapLayer *> layers = QgsProject::instance()->mapLayersByName( "lines_with_labels" );
+  QCOMPARE( layers.count(), 1 );
+  QgsVectorLayer *linesWithLabels = qobject_cast<QgsVectorLayer *>( layers.at( 0 ) );
+  QVERIFY( linesWithLabels );
+
+  layers = QgsProject::instance()->mapLayersByName( "polys" );
+  QCOMPARE( layers.count(), 1 );
+  QgsVectorLayer *polys = qobject_cast<QgsVectorLayer *>( layers.at( 0 ) );
+  QVERIFY( polys );
+
+  layers = QgsProject::instance()->mapLayersByName( "points" );
+  QCOMPARE( layers.count(), 1 );
+  QgsVectorLayer *points = qobject_cast<QgsVectorLayer *>( layers.at( 0 ) );
+  QVERIFY( points );
+
+  // add masks on polys label and B52 points
+  QgsPalLayerSettings *labelSettings = new QgsPalLayerSettings( polys->labeling()->settings() );
+  QgsTextFormat format = labelSettings->format();
+  format.mask().setEnabled( true );
+  labelSettings->setFormat( format );
+  polys->labeling()->setSettings( labelSettings );
+
+  QgsMaskMarkerSymbolLayer *maskLayer = new QgsMaskMarkerSymbolLayer();
+  maskLayer->setSubSymbol( QgsMarkerSymbol::createSimple( { {QStringLiteral( "size" ), 6 } } ) );
+  QgsCategorizedSymbolRenderer *renderer = dynamic_cast<QgsCategorizedSymbolRenderer *>( points->renderer() );
+  QVERIFY( renderer );
+  const QgsCategoryList categories = renderer->categories();
+  QCOMPARE( categories.count(), 3 );
+  QCOMPARE( categories.at( 0 ).label(), QStringLiteral( "B52" ) );
+  QgsSymbol *symbol = categories.at( 0 ).symbol();
+  QVERIFY( symbol );
+  symbol->appendSymbolLayer( maskLayer );
+  QCOMPARE( maskLayer->masks().count(), 0 );
+
+  // update masking widget
+  std::unique_ptr<QgsMaskingWidget> mw = std::make_unique<QgsMaskingWidget>();
+  QElapsedTimer timer;
+  timer.start();
+  mw->setLayer( linesWithLabels );
+
+  mw->populate();
+
+  QVERIFY( mw->mMaskTargetsWidget );
+  QVERIFY( mw->mMaskSourcesWidget->mTree );
+  QCOMPARE( mw->mMaskSourcesWidget->mTree->topLevelItemCount(), 2 );
+
+  // check masking symbol, first branch : points > B52 > Mask symbol layer
+  QTreeWidgetItem *item = mw->mMaskSourcesWidget->mTree->topLevelItem( 0 );
+  QCOMPARE( item->text( 0 ), QStringLiteral( "points" ) );
+
+  QCOMPARE( item->childCount(), 1 );
+  item = item->child( 0 );
+  QCOMPARE( item->text( 0 ), QStringLiteral( "B52" ) );
+
+  QCOMPARE( item->childCount(), 1 );
+  item = item->child( 0 );
+  QCOMPARE( item->text( 0 ), QStringLiteral( "Mask symbol layer" ) );
+  QTreeWidgetItem *pointMaskItem = item;
+
+  // check masking symbol, second branch : polys > Label mask
+  item = mw->mMaskSourcesWidget->mTree->topLevelItem( 1 );
+  QCOMPARE( item->text( 0 ), QStringLiteral( "polys" ) );
+
+  QCOMPARE( item->childCount(), 1 );
+  item = item->child( 0 );
+  QCOMPARE( item->text( 0 ), QStringLiteral( "Label mask" ) );
+
+  // check masked symbol, one branch, 2 children
+  QVERIFY( mw->mMaskTargetsWidget->mTree );
+  QCOMPARE( mw->mMaskTargetsWidget->mTree->topLevelItemCount(), 1 );
+
+  item = mw->mMaskTargetsWidget->mTree->topLevelItem( 0 );
+  QCOMPARE( item->text( 0 ), QString() );
+  QCOMPARE( item->childCount(), 2 );
+  QTreeWidgetItem *blackLineItem = item->child( 0 );
+  QCOMPARE( blackLineItem->text( 0 ), QString() );
+  item = item->child( 1 );
+  QCOMPARE( item->text( 0 ), QString() );
+
+  // check 2 items
+  QVERIFY( mw->mMessageBar );
+  QVERIFY( !mw->mMessageBar->currentItem() );
+
+  blackLineItem->setCheckState( 0, Qt::Checked );
+  QVERIFY( mw->mMessageBar->currentItem() );
+
+  pointMaskItem->setCheckState( 0, Qt::Checked );
+  QVERIFY( !mw->mMessageBar->currentItem() );
+
+  mw->apply();
+
+  // check that mask have been set
+  const QList<QgsSymbolLayerReference> maskedSls = maskLayer->masks();
+  QCOMPARE( maskedSls.count(), 1 );
+  const QgsSymbolLayerReference maskedSl = maskedSls.at( 0 );
+  QCOMPARE( maskedSl.layerId(), linesWithLabels->id() );
+
+  const QgsSingleSymbolRenderer *lineRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( linesWithLabels->renderer() );
+  QVERIFY( lineRenderer );
+  const QgsSymbol *lineSymbol = lineRenderer->symbol();
+  QVERIFY( lineSymbol );
+  const QgsSymbolLayerList sls = lineSymbol->symbolLayers();
+  QCOMPARE( sls.count(), 2 );
+  QgsSymbolLayer *lineSl = sls.at( 0 );
+  QVERIFY( lineSl );
+
+  QCOMPARE( maskedSl.symbolLayerIdV2(), lineSl->id() );
+}
+
+
+QGSTEST_MAIN( TestQgsMaskingWidget )
+#include "testqgsmaskingwidget.moc"


### PR DESCRIPTION
Create a data structure on stack to avoid useless QTreeWidgetItem heap memory allocation which slows down considerably widget populate. That allows then to remove some flaky code used to avoid as much as possible masking widget update, causing refresh issues.

I tested it with the #34942 use case where masking widget populate was almost 3s. Since those modifications, populate is less than 50ms, so we can just update the masking widget every time it's useful.
