### PR TITLE
Fix python script editor "open in external editor" action

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -92,6 +92,15 @@ highlights from the widget scrollbars at the warning locations.
 .. seealso:: :py:func:`addWarning`
 %End
 
+    QString filePath() const;
+%Docstring
+Returns the widget's associated file path.
+
+.. seealso:: :py:func:`setFilePath`
+
+.. seealso:: :py:func:`filePathChanged`
+%End
+
   public slots:
 
     void showSearchBar();
@@ -138,11 +147,30 @@ This will automatically open the search bar and start a find operation using
 the default behavior, e.g. searching for any selected text in the code editor.
 %End
 
+    void setFilePath( const QString &path );
+%Docstring
+Sets the widget's associated file ``path``.
+
+.. seealso:: :py:func:`filePathChanged`
+
+.. seealso:: :py:func:`filePath`
+%End
+%End
+
   signals:
 
     void searchBarToggled( bool visible );
 %Docstring
 Emitted when the visibility of the search bar is changed.
+%End
+
+    void filePathChanged( const QString &path );
+%Docstring
+Emitted when the widget's associated file path is changed.
+
+.. seealso:: :py:func:`setFilePath`
+
+.. seealso:: :py:func:`filePath`
 %End
 
 };

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -155,6 +155,14 @@ Sets the widget's associated file ``path``.
 
 .. seealso:: :py:func:`filePath`
 %End
+
+    bool openInExternalEditor();
+%Docstring
+Attempts to opens the script from the editor in an external text editor.
+
+This requires that the widget has an associated :py:func:`~QgsCodeEditorWidget.filePath` set.
+
+:return: ``True`` if the file was opened successfully.
 %End
 
   signals:

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -588,23 +588,7 @@ class PythonConsoleWidget(QWidget):
 
     def openScriptFileExtEditor(self):
         tabWidget = self.tabEditorWidget.currentWidget()
-        path = tabWidget.file_path()
-
-        editor_command = os.environ.get('EDITOR')
-        if editor_command:
-            child = subprocess.Popen([os.environ['EDITOR'], path])
-            try:
-                # let's see if the EDITOR drops out immediately....
-                child.wait(0.01)
-                rc = child.poll()
-                if rc:
-                    # editor failed, use backup approach
-                    QDesktopServices.openUrl(QUrl.fromLocalFile(path))
-            except subprocess.TimeoutExpired:
-                # looks like EDITOR started up successfully, all is good
-                pass
-        else:
-            QDesktopServices.openUrl(QUrl.fromLocalFile(path))
+        tabWidget.open_in_external_editor()
 
     def openScriptFile(self):
         settings = QgsSettings()

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -588,7 +588,7 @@ class PythonConsoleWidget(QWidget):
 
     def openScriptFileExtEditor(self):
         tabWidget = self.tabEditorWidget.currentWidget()
-        path = tabWidget.path
+        path = tabWidget.file_path()
 
         editor_command = os.environ.get('EDITOR')
         if editor_command:
@@ -616,7 +616,7 @@ class PythonConsoleWidget(QWidget):
             for pyFile in fileList:
                 for i in range(self.tabEditorWidget.count()):
                     tabWidget = self.tabEditorWidget.widget(i)
-                    if tabWidget.path == pyFile:
+                    if tabWidget.file_path() == pyFile:
                         self.tabEditorWidget.setCurrentWidget(tabWidget)
                         break
                 else:
@@ -633,7 +633,7 @@ class PythonConsoleWidget(QWidget):
             tabWidget.save()
         except (IOError, OSError) as error:
             msgText = QCoreApplication.translate('PythonConsole',
-                                                 'The file <b>{0}</b> could not be saved. Error: {1}').format(tabWidget.path,
+                                                 'The file <b>{0}</b> could not be saved. Error: {1}').format(tabWidget.file_path(),
                                                                                                               error.strerror)
             self.callWidgetMessageBarEditor(msgText, Qgis.MessageLevel.Critical)
 
@@ -641,13 +641,13 @@ class PythonConsoleWidget(QWidget):
         tabWidget = self.tabEditorWidget.currentWidget()
         if not index:
             index = self.tabEditorWidget.currentIndex()
-        if not tabWidget.path:
+        if not tabWidget.file_path():
             fileName = self.tabEditorWidget.tabText(index).replace('*', '') + '.py'
             folder = QgsSettings().value("pythonConsole/lastDirPath", QDir.homePath())
             pathFileName = os.path.join(folder, fileName)
             fileNone = True
         else:
-            pathFileName = tabWidget.path
+            pathFileName = tabWidget.file_path()
             fileNone = False
         saveAsFileTr = QCoreApplication.translate("PythonConsole", "Save File As")
         filename, filter = QFileDialog.getSaveFileName(self,
@@ -660,13 +660,13 @@ class PythonConsoleWidget(QWidget):
                 tabWidget.save(filename)
             except (IOError, OSError) as error:
                 msgText = QCoreApplication.translate('PythonConsole',
-                                                     'The file <b>{0}</b> could not be saved. Error: {1}').format(tabWidget.path,
+                                                     'The file <b>{0}</b> could not be saved. Error: {1}').format(tabWidget.file_path(),
                                                                                                                   error.strerror)
                 self.callWidgetMessageBarEditor(msgText, Qgis.MessageLevel.Critical)
                 if fileNone:
-                    tabWidget.path = None
+                    tabWidget.set_file_path(None)
                 else:
-                    tabWidget.path = pathFileName
+                    tabWidget.set_file_path(pathFileName)
                 return
 
             if not fileNone:

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -568,6 +568,9 @@ class EditorTab(QWidget):
     def file_path(self) -> Optional[str]:
         return self._editor_code_widget.filePath()
 
+    def open_in_external_editor(self):
+        self._editor_code_widget.openInExternalEditor()
+
     def modified(self, modified):
         self.tab_widget.tabModified(self, modified)
 

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -292,7 +292,7 @@ class Editor(QgsCodeEditorPython):
 
         URL = "https://api.github.com/gists"
 
-        path = self.tab_widget.currentWidget().file_path()
+        path = self.code_editor_widget.filePath()
         filename = os.path.basename(path) if path else None
         filename = filename if filename else "pyqgis_snippet.py"
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -92,6 +92,15 @@ highlights from the widget scrollbars at the warning locations.
 .. seealso:: :py:func:`addWarning`
 %End
 
+    QString filePath() const;
+%Docstring
+Returns the widget's associated file path.
+
+.. seealso:: :py:func:`setFilePath`
+
+.. seealso:: :py:func:`filePathChanged`
+%End
+
   public slots:
 
     void showSearchBar();
@@ -138,11 +147,30 @@ This will automatically open the search bar and start a find operation using
 the default behavior, e.g. searching for any selected text in the code editor.
 %End
 
+    void setFilePath( const QString &path );
+%Docstring
+Sets the widget's associated file ``path``.
+
+.. seealso:: :py:func:`filePathChanged`
+
+.. seealso:: :py:func:`filePath`
+%End
+%End
+
   signals:
 
     void searchBarToggled( bool visible );
 %Docstring
 Emitted when the visibility of the search bar is changed.
+%End
+
+    void filePathChanged( const QString &path );
+%Docstring
+Emitted when the widget's associated file path is changed.
+
+.. seealso:: :py:func:`setFilePath`
+
+.. seealso:: :py:func:`filePath`
 %End
 
 };

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -155,6 +155,14 @@ Sets the widget's associated file ``path``.
 
 .. seealso:: :py:func:`filePath`
 %End
+
+    bool openInExternalEditor();
+%Docstring
+Attempts to opens the script from the editor in an external text editor.
+
+This requires that the widget has an associated :py:func:`~QgsCodeEditorWidget.filePath` set.
+
+:return: ``True`` if the file was opened successfully.
 %End
 
   signals:

--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -337,6 +337,15 @@ void QgsCodeEditorWidget::triggerFind()
   showSearchBar();
 }
 
+void QgsCodeEditorWidget::setFilePath( const QString &path )
+{
+  if ( mFilePath == path )
+    return;
+
+  mFilePath = path;
+  emit filePathChanged( mFilePath );
+}
+
 bool QgsCodeEditorWidget::findNext()
 {
   return findText( true, false );

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -106,6 +106,14 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      */
     void clearWarnings();
 
+    /**
+     * Returns the widget's associated file path.
+     *
+     * \see setFilePath()
+     * \see filePathChanged()
+     */
+    QString filePath() const { return mFilePath; }
+
   public slots:
 
     /**
@@ -148,12 +156,28 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      */
     void triggerFind();
 
+    /**
+     * Sets the widget's associated file \a path.
+     *
+     * \see filePathChanged()
+     * \see filePath()
+     */
+    void setFilePath( const QString &path );
+
   signals:
 
     /**
      * Emitted when the visibility of the search bar is changed.
      */
     void searchBarToggled( bool visible );
+
+    /**
+     * Emitted when the widget's associated file path is changed.
+     *
+     * \see setFilePath()
+     * \see filePath()
+     */
+    void filePathChanged( const QString &path );
 
   private slots:
 
@@ -196,6 +220,7 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
     int mBlockSearching = 0;
     QgsMessageBar *mMessageBar = nullptr;
     std::unique_ptr< QgsScrollBarHighlightController > mHighlightController;
+    QString mFilePath;
 };
 
 #endif // QGSCODEEDITORWIDGET_H

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -164,6 +164,15 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      */
     void setFilePath( const QString &path );
 
+    /**
+     * Attempts to opens the script from the editor in an external text editor.
+     *
+     * This requires that the widget has an associated filePath() set.
+     *
+     * \returns TRUE if the file was opened successfully.
+     */
+    bool openInExternalEditor();
+
   signals:
 
     /**


### PR DESCRIPTION
When a system has a EDITOR environment variable set to either an invalid editor, or an editor which requires a terminal (eg nano/vim), then fallback to the QDesktopServices approach to opening the script

Avoids this button doing nothing.
