### PR TITLE
Release GPS logging tables when connection is disconnected or logging is stopped

### DIFF
--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -222,8 +222,6 @@ void QgsAppGpsLogging::stopNmeaLogging()
 void QgsAppGpsLogging::createGpkgLogger()
 {
   mGpkgLogger.reset();
-  mGpkgPointsLayer.reset();
-  mGpkgTracksLayer.reset();
 
   mGpkgLogger = std::make_unique< QgsVectorLayerGpsLogger >( mConnection->connection() );
   mGpkgLogger->setTransformContext( QgsProject::instance()->transformContext() );

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -221,8 +221,6 @@ void QgsAppGpsLogging::stopNmeaLogging()
 
 void QgsAppGpsLogging::createGpkgLogger()
 {
-  mGpkgLogger.reset();
-
   mGpkgLogger = std::make_unique< QgsVectorLayerGpsLogger >( mConnection->connection() );
   mGpkgLogger->setTransformContext( QgsProject::instance()->transformContext() );
   mGpkgLogger->setEllipsoid( QgsProject::instance()->ellipsoid() );

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -155,9 +155,9 @@ void QgsAppGpsLogging::gpsConnected()
   {
     startNmeaLogging();
   }
-  if ( mGpkgLogger )
+  if ( !mGpkgLogFile.isEmpty() )
   {
-    mGpkgLogger->setConnection( mConnection->connection() );
+    setGpkgLogFile( mGpkgLogFile );
   }
 }
 
@@ -167,7 +167,9 @@ void QgsAppGpsLogging::gpsDisconnected()
   if ( mGpkgLogger )
   {
     mGpkgLogger->endCurrentTrack();
-    mGpkgLogger->setConnection( nullptr );
+    mGpkgLogger.reset();
+    mGpkgTracksLayer.reset();
+    mGpkgPointsLayer.reset();
   }
 }
 

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -133,6 +133,8 @@ void QgsAppGpsLogging::setGpkgLogFile( const QString &filename )
     {
       mGpkgLogger->endCurrentTrack();
       mGpkgLogger.reset();
+      mGpkgTracksLayer.reset();
+      mGpkgPointsLayer.reset();
 
       QgisApp::instance()->messageBar()->pushInfo( QString(), tr( "GPS logging stopped" ) );
     }
@@ -217,6 +219,10 @@ void QgsAppGpsLogging::stopNmeaLogging()
 
 void QgsAppGpsLogging::createGpkgLogger()
 {
+  mGpkgLogger.reset();
+  mGpkgPointsLayer.reset();
+  mGpkgTracksLayer.reset();
+
   mGpkgLogger = std::make_unique< QgsVectorLayerGpsLogger >( mConnection->connection() );
   mGpkgLogger->setTransformContext( QgsProject::instance()->transformContext() );
   mGpkgLogger->setEllipsoid( QgsProject::instance()->ellipsoid() );


### PR DESCRIPTION
Avoids holding on to an editable connection to the gpkg/spatialite for the duration of the QGIS session