### PR TITLE
Fix add feature dialog does not restore position when shown modally

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsattributedialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributedialog.sip.in
@@ -75,6 +75,9 @@ Intercept window activate/deactivate events to show/hide the highlighted feature
 :return: The same as the parent QDialog
 %End
 
+    virtual void showEvent( QShowEvent *event );
+
+
     void setExtraContextScope( QgsExpressionContextScope *extraScope /Transfer/ );
 %Docstring
 Sets ``extraScope`` as an additional expression context scope to be used

--- a/python/gui/auto_generated/qgsattributedialog.sip.in
+++ b/python/gui/auto_generated/qgsattributedialog.sip.in
@@ -75,6 +75,9 @@ Intercept window activate/deactivate events to show/hide the highlighted feature
 :return: The same as the parent QDialog
 %End
 
+    virtual void showEvent( QShowEvent *event );
+
+
     void setExtraContextScope( QgsExpressionContextScope *extraScope /Transfer/ );
 %Docstring
 Sets ``extraScope`` as an additional expression context scope to be used

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -88,6 +88,13 @@ void QgsAttributeDialog::show()
 {
   QDialog::show();
 
+  raise();
+  activateWindow();
+}
+
+void QgsAttributeDialog::showEvent( QShowEvent *event )
+{
+  QDialog::showEvent( event );
   // We cannot call restoreGeometry() in the constructor or init because the dialog is not yet visible
   // and the geometry restoration will not take the window decorations (frame) into account.
   if ( mFirstShow )
@@ -95,8 +102,6 @@ void QgsAttributeDialog::show()
     mFirstShow = false;
     restoreGeometry();
   }
-  raise();
-  activateWindow();
 }
 
 void QgsAttributeDialog::reject()

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -96,6 +96,8 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog, public QgsMapLayerActionCo
      */
     bool event( QEvent *e ) override;
 
+    void showEvent( QShowEvent *event ) override;
+
     /**
      * Sets \a extraScope as an additional expression context scope to be used
      * for calculations in this form.


### PR DESCRIPTION
The logic to restore the position was incorrectly placed in ::show(), which is not called when the dialog is being displayed modally via ::exec()
