### PR TITLE
Relation reference widget: connect changed signal from embeded attrib…

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -245,6 +245,13 @@ Set the limit of fetched features (0 means all features)
 .. versionadded:: 3.32
 %End
 
+    QgsAttributeForm *referencedAttributeForm();
+%Docstring
+Returns the referenced attribute form
+
+.. versionadded:: 3.38
+%End
+
 
   public slots:
     void openForm();

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -245,6 +245,13 @@ Set the limit of fetched features (0 means all features)
 .. versionadded:: 3.32
 %End
 
+    QgsAttributeForm *referencedAttributeForm();
+%Docstring
+Returns the referenced attribute form
+
+.. versionadded:: 3.38
+%End
+
 
   public slots:
     void openForm();

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -260,6 +260,12 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
      */
     void setFetchLimit( int fetchLimit ) {mFetchLimit = fetchLimit; }
 
+    /**
+     * Returns the referenced attribute form
+     * \since QGIS 3.38
+    */
+    QgsAttributeForm *referencedAttributeForm() { return mReferencedAttributeForm; }
+
 
   public slots:
     //! open the form of the related feature in a new dialog

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -108,6 +108,15 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   mWidget->setRelation( relation, config( QStringLiteral( "AllowNULL" ) ).toBool() );
 
   connect( mWidget, &QgsRelationReferenceWidget::foreignKeysChanged, this, &QgsRelationReferenceWidgetWrapper::foreignKeysChanged );
+  QgsAttributeForm *refForm = mWidget->referencedAttributeForm();
+  if ( refForm )
+  {
+    QgsVectorLayer *refFormLayer = refForm->layer();
+    if ( refFormLayer && refFormLayer->isEditable() )
+    {
+      connect( refForm, &QgsAttributeForm::widgetValueChanged, [ = ]( const QString & attribute, const QVariant & value, bool attributeChanged ) { if ( attributeChanged ) {refFormLayer->changeAttributeValue( refForm->currentFormFeature().id(), refFormLayer->fields().indexFromName( attribute ), value );} } );
+    }
+  }
 }
 
 QVariant QgsRelationReferenceWidgetWrapper::value() const

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -114,7 +114,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
     QgsVectorLayer *refFormLayer = refForm->layer();
     if ( refFormLayer && refFormLayer->isEditable() )
     {
-      connect( refForm, &QgsAttributeForm::widgetValueChanged, [ = ]( const QString & attribute, const QVariant & value, bool attributeChanged ) { if ( attributeChanged ) {refFormLayer->changeAttributeValue( refForm->currentFormFeature().id(), refFormLayer->fields().indexFromName( attribute ), value );} } );
+      connect( refForm, &QgsAttributeForm::widgetValueChanged, this, [ = ]( const QString & attribute, const QVariant & value, bool attributeChanged ) { if ( attributeChanged ) {refFormLayer->changeAttributeValue( refForm->currentFormFeature().id(), refFormLayer->fields().indexFromName( attribute ), value );} } );
     }
   }
 }


### PR DESCRIPTION
The relation reference widget can show an embedded form (mReferencedAttributeForm) and this form can be editable. Unfortunately, it seems that QGIS is not notified about the changes if editing only this form (it however works, if other attributes are edited as well). Therefore such edits are not written and if the dialog is closed and reopened, the old values are still there.

Connecting the signal widgetValueChanged of the form solves the problem for me. However I'm not very familiar with this part of the code, do you think this is a good change or are there side effects?