### PR TITLE
[forms] Validate value length for value maps

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -99,7 +99,7 @@ void QgsValueMapConfigDlg::setConfig( const QVariantMap &config )
   {
     for ( int i = 0, row = 0; i < valueList.count(); i++, row++ )
     {
-      orderedList.append( qMakePair( valueList[i].toMap().constBegin().key(), valueList[i].toMap().constBegin().value() ) );
+      orderedList.append( qMakePair( valueList[i].toMap().constBegin().value().toString(), valueList[i].toMap().constBegin().key() ) );
     }
   }
   else
@@ -111,7 +111,7 @@ void QgsValueMapConfigDlg::setConfig( const QVariantMap &config )
       if ( QgsVariantUtils::isNull( mit.value() ) )
         orderedList.append( qMakePair( mit.key(), QVariant() ) );
       else
-        orderedList.append( qMakePair( mit.key(), mit.value() ) );
+        orderedList.append( qMakePair( mit.value().toString(), mit.key() ) );
     }
   }
 

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -59,14 +59,6 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
     void updateMap( const QList<QPair<QString, QVariant>> &list, bool insertNull );
 
     /**
-     * Validates a value against the maximum allowed field length and trims it is necessary.
-     * \param value
-     * \return the validated field value trimmed if necessary
-     * \since QGIS 3.38
-     */
-    QString checkValueLength( const QString &value );
-
-    /**
      * Updates the displayed table with the values from a CSV file.
      * \param filePath the absolute file path of the CSV file.
      * \since QGIS 3.24
@@ -85,6 +77,14 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
 
   private:
     void setRow( int row, const QString &value, const QString &description );
+
+    /**
+     * Validates a value against the maximum allowed field length and trims it is necessary.
+     * \param value
+     * \return the validated field value trimmed if necessary
+     */
+    QString checkValueLength( const QString &value );
+
 
   private slots:
     void copySelectionToClipboard();

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -59,6 +59,14 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
     void updateMap( const QList<QPair<QString, QVariant>> &list, bool insertNull );
 
     /**
+     * Validates a value against the maximum allowed field length and trims it is necessary.
+     * \param value
+     * \return the validated field value trimmed if necessary
+     * \since QGIS 3.38
+     */
+    QString checkValueLength( const QString &value );
+
+    /**
      * Updates the displayed table with the values from a CSV file.
      * \param filePath the absolute file path of the CSV file.
      * \since QGIS 3.24

--- a/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
@@ -14,7 +14,7 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="5">
+   <item row="0" column="0" colspan="3">
     <widget class="QLabel" name="valueMapLabel">
      <property name="text">
       <string>Combo box with predefined items. Value is stored in the attribute, description is shown in the combo box.</string>
@@ -31,7 +31,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
+   <item row="1" column="1">
+    <widget class="QPushButton" name="loadFromCSVButton">
+     <property name="text">
+      <string>Load Data from CSV File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -44,53 +51,73 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0" colspan="5">
-    <widget class="QTableWidget" name="tableWidget">
-     <column>
-      <property name="text">
-       <string>Value</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Description</string>
-      </property>
-     </column>
-    </widget>
+   <item row="2" column="0" colspan="3">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QTableWidget" name="tableWidget">
+       <column>
+        <property name="text">
+         <string>Value</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Description</string>
+        </property>
+       </column>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="mValueMapErrorsLabel">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>100</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>No errors</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="3" column="3" colspan="2">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>518</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0">
-    <widget class="QPushButton" name="addNullButton">
-     <property name="text">
-      <string>Add &quot;NULL&quot; value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="removeSelectedButton">
-     <property name="text">
-      <string>Remove Selected</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="loadFromCSVButton">
-     <property name="text">
-      <string>Load Data from CSV File</string>
-     </property>
-    </widget>
+   <item row="3" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="addNullButton">
+       <property name="text">
+        <string>Add &quot;NULL&quot; value</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="removeSelectedButton">
+       <property name="text">
+        <string>Remove Selected</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>518</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Display errors and trim the values.

This also works when importing from CSV or from layer.

Fix #57634

![gh_57634_2](https://github.com/qgis/QGIS/assets/142164/8d77d62a-ce2e-40cd-ba45-84123517f767)
