### PR TITLE
Fix plugin manager background for dark themes

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -33,6 +33,7 @@
 #include <QRegularExpression>
 #include <QUrl>
 #include <QCheckBox>
+#include <QPalette>
 
 #include "qgsmessagelog.h"
 
@@ -699,7 +700,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
 
   QString html = "<style>"
                  "  body {"
-                 "    background-color:white;"
+                 "    color:" + QPalette().color( QPalette::ColorRole::Text ).name() + ";"
                  "  }"
                  "  body, table {"
                  "    padding:0px;"
@@ -1368,7 +1369,7 @@ void QgsPluginManager::setCurrentTab( int idx )
     {
       tabInfoHTML += "<style>"
                      "  body, p {"
-                     "      background-color: white;"
+                     "      color: " + QPalette().color( QPalette::ColorRole::Text ).name() + ";"
                      "      margin: 2px;"
                      "      font-family: Verdana, Sans-serif;"
                      "      font-size: 10pt;"


### PR DESCRIPTION
## Description

The explicitly set window color was making text unreadable when using the dark theme. Removing this styles allows the system to choose the appropriate color

### Before
![image](https://github.com/qgis/QGIS/assets/14816075/a7988867-a81f-46c3-a5a2-f638036827f4)

### After

![image](https://github.com/qgis/QGIS/assets/14816075/6e785f00-89d0-4096-9fbd-092064723f08)
![image](https://github.com/qgis/QGIS/assets/14816075/32ed1cfd-ca4e-46cf-94ca-ad9ada408c62)
