### PR TITLE
Replace processing default extension setting with string based setting

### DIFF
--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -57,8 +57,8 @@ class ProcessingConfig:
     SHOW_PROVIDERS_TOOLTIP = 'SHOW_PROVIDERS_TOOLTIP'
     SHOW_ALGORITHMS_KNOWN_ISSUES = 'SHOW_ALGORITHMS_KNOWN_ISSUES'
     MAX_THREADS = 'MAX_THREADS'
-    DEFAULT_OUTPUT_RASTER_LAYER_EXT = 'default-output-raster-layer-ext'
-    DEFAULT_OUTPUT_VECTOR_LAYER_EXT = 'default-output-vector-layer-ext'
+    DEFAULT_OUTPUT_RASTER_LAYER_EXT = 'default-output-raster-ext'
+    DEFAULT_OUTPUT_VECTOR_LAYER_EXT = 'default-output-vector-ext'
     TEMP_PATH = 'temp-path'
     RESULTS_GROUP_NAME = 'RESULTS_GROUP_NAME'
     VECTOR_FEATURE_COUNT = 'VECTOR_FEATURE_COUNT'
@@ -156,7 +156,7 @@ class ProcessingConfig:
             ProcessingConfig.DEFAULT_OUTPUT_VECTOR_LAYER_EXT,
             ProcessingConfig.tr('Default output vector layer extension'),
             QgsVectorFileWriter.supportedFormatExtensions()[0],
-            valuetype=Setting.SELECTION,
+            valuetype=Setting.SELECTION_STORE_STRING,
             options=extensions,
             hasSettingEntry=True))
 
@@ -166,7 +166,7 @@ class ProcessingConfig:
             ProcessingConfig.DEFAULT_OUTPUT_RASTER_LAYER_EXT,
             ProcessingConfig.tr('Default output raster layer extension'),
             'tif',
-            valuetype=Setting.SELECTION,
+            valuetype=Setting.SELECTION_STORE_STRING,
             options=extensions,
             hasSettingEntry=True))
 
@@ -273,6 +273,7 @@ class Setting:
     FLOAT = 4
     INT = 5
     MULTIPLE_FOLDERS = 6
+    SELECTION_STORE_STRING = 7
 
     def __init__(self, group, name, description, default, hidden=False, valuetype=None,
                  validator=None, options=None, placeholder="", hasSettingEntry=False):

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -370,6 +370,11 @@ class SettingDelegate(QStyledItemDelegate):
             combo = QComboBox(parent)
             combo.addItems(setting.options)
             return combo
+        elif setting.valuetype == Setting.SELECTION_STORE_STRING:
+            combo = QComboBox(parent)
+            for option in setting.options:
+                combo.addItem(option, option)
+            return combo
         elif setting.valuetype == Setting.MULTIPLE_FOLDERS:
             return MultipleDirectorySelector(parent, setting.placeholder)
         else:
@@ -393,6 +398,8 @@ class SettingDelegate(QStyledItemDelegate):
         setting = index.model().data(index, Qt.ItemDataRole.UserRole)
         if setting.valuetype == Setting.SELECTION:
             editor.setCurrentIndex(editor.findText(value))
+        elif setting.valuetype == Setting.SELECTION_STORE_STRING:
+            editor.setCurrentIndex(editor.findData(value))
         elif setting.valuetype in (Setting.FLOAT, Setting.INT):
             editor.setValue(value)
         else:
@@ -403,6 +410,8 @@ class SettingDelegate(QStyledItemDelegate):
         setting = index.model().data(index, Qt.ItemDataRole.UserRole)
         if setting.valuetype == Setting.SELECTION:
             model.setData(index, editor.currentText(), Qt.ItemDataRole.EditRole)
+        elif setting.valuetype == Setting.SELECTION_STORE_STRING:
+            model.setData(index, editor.currentData(), Qt.ItemDataRole.EditRole)
         else:
             if isinstance(value, str):
                 model.setData(index, editor.text(), Qt.ItemDataRole.EditRole)

--- a/src/core/processing/qgsprocessing.cpp
+++ b/src/core/processing/qgsprocessing.cpp
@@ -21,8 +21,8 @@ const QgsSettingsEntryBool *QgsProcessing::settingsPreferFilenameAsLayerName = n
 
 const QgsSettingsEntryString *QgsProcessing::settingsTempPath = new QgsSettingsEntryString( QStringLiteral( "temp-path" ), sTreeConfiguration, QString(), QObject::tr( "Override temporary output folder path" ) );
 
-const QgsSettingsEntryInteger *QgsProcessing::settingsDefaultOutputVectorLayerExt = new QgsSettingsEntryInteger( QStringLiteral( "default-output-vector-layer-ext" ), sTreeConfiguration, -1, QObject::tr( "Default output vector layer extension" ) );
+const QgsSettingsEntryString *QgsProcessing::settingsDefaultOutputVectorLayerExt = new QgsSettingsEntryString( QStringLiteral( "default-output-vector-ext" ), sTreeConfiguration, QString(), QObject::tr( "Default output vector layer extension" ) );
 
-const QgsSettingsEntryInteger *QgsProcessing::settingsDefaultOutputRasterLayerExt = new QgsSettingsEntryInteger( QStringLiteral( "default-output-raster-layer-ext" ), sTreeConfiguration, -1, QObject::tr( "Default output raster layer extension" ) );
+const QgsSettingsEntryString *QgsProcessing::settingsDefaultOutputRasterLayerExt = new QgsSettingsEntryString( QStringLiteral( "default-output-raster-ext" ), sTreeConfiguration, QString(), QObject::tr( "Default output raster layer extension" ) );
 
 const QString QgsProcessing::TEMPORARY_OUTPUT = QStringLiteral( "TEMPORARY_OUTPUT" );

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -117,9 +117,9 @@ class CORE_EXPORT QgsProcessing
     //! Settings entry temp path
     static const QgsSettingsEntryString *settingsTempPath;
     //! Settings entry default output vector layer ext
-    static const QgsSettingsEntryInteger *settingsDefaultOutputVectorLayerExt;
+    static const QgsSettingsEntryString *settingsDefaultOutputVectorLayerExt;
     //! Settings entry default output raster layer ext
-    static const QgsSettingsEntryInteger *settingsDefaultOutputRasterLayerExt;
+    static const QgsSettingsEntryString *settingsDefaultOutputRasterLayerExt;
 #endif
 };
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1540,18 +1540,34 @@ QgsFields QgsProcessingUtils::indicesToFields( const QList<int> &indices, const 
 
 QString QgsProcessingUtils::defaultVectorExtension()
 {
-  const int setting = QgsProcessing::settingsDefaultOutputVectorLayerExt->value();
-  if ( setting == -1 )
+  QString setting = QgsProcessing::settingsDefaultOutputVectorLayerExt->value().trimmed();
+  if ( setting.isEmpty() )
     return QStringLiteral( "gpkg" );
-  return QgsVectorFileWriter::supportedFormatExtensions().value( setting, QStringLiteral( "gpkg" ) );
+
+  if ( setting.startsWith( '.' ) )
+    setting = setting.mid( 1 );
+
+  const QStringList supportedFormats = QgsVectorFileWriter::supportedFormatExtensions();
+  if ( !supportedFormats.contains( setting, Qt::CaseInsensitive ) )
+    return QStringLiteral( "gpkg" );
+
+  return setting;
 }
 
 QString QgsProcessingUtils::defaultRasterExtension()
 {
-  const int setting = QgsProcessing::settingsDefaultOutputRasterLayerExt->value();
-  if ( setting == -1 )
+  QString setting = QgsProcessing::settingsDefaultOutputRasterLayerExt->value().trimmed();
+  if ( setting.isEmpty() )
     return QStringLiteral( "tif" );
-  return QgsRasterFileWriter::supportedFormatExtensions().value( setting, QStringLiteral( "tif" ) );
+
+  if ( setting.startsWith( '.' ) )
+    setting = setting.mid( 1 );
+
+  const QStringList supportedFormats = QgsRasterFileWriter::supportedFormatExtensions();
+  if ( !supportedFormats.contains( setting, Qt::CaseInsensitive ) )
+    return QStringLiteral( "tif" );
+
+  return setting;
 }
 
 QString QgsProcessingUtils::defaultPointCloudExtension()

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -142,8 +142,6 @@ void QgsSettingsRegistryCore::migrateOldSettings()
 
   QgsProcessing::settingsPreferFilenameAsLayerName->copyValueFromKey( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ) );
   QgsProcessing::settingsTempPath->copyValueFromKey( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) );
-  QgsProcessing::settingsDefaultOutputVectorLayerExt->copyValueFromKey( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->copyValueFromKey( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ) );
 
   QgsNetworkAccessManager::settingsNetworkTimeout->copyValueFromKey( QStringLiteral( "qgis/networkAndProxy/networkTimeout" ) );
 
@@ -397,8 +395,6 @@ void QgsSettingsRegistryCore::backwardCompatibility()
 
   QgsProcessing::settingsPreferFilenameAsLayerName->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ) );
   QgsProcessing::settingsTempPath->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) );
-  QgsProcessing::settingsDefaultOutputVectorLayerExt->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ) );
 
   QgsNetworkAccessManager::settingsNetworkTimeout->copyValueToKeyIfChanged( QStringLiteral( "qgis/networkAndProxy/networkTimeout" ) );
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -12811,8 +12811,8 @@ void TestQgsProcessing::defaultExtensionsForProvider()
   QCOMPARE( context.preferredRasterFormat(), QStringLiteral( "tif" ) );
 
   // unless the user has set a default format, which IS supported by that provider
-  QgsProcessing::settingsDefaultOutputVectorLayerExt->setValue( QgsVectorFileWriter::supportedFormatExtensions().indexOf( QLatin1String( "tab" ) ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->setValue( QgsRasterFileWriter::supportedFormatExtensions().indexOf( QLatin1String( "sdat" ) ) );
+  QgsProcessing::settingsDefaultOutputVectorLayerExt->setValue( QStringLiteral( "tab" ) );
+  QgsProcessing::settingsDefaultOutputRasterLayerExt->setValue( QStringLiteral( "sdat" ) );
 
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "tab" ) );
   QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "sdat" ) );
@@ -12823,8 +12823,8 @@ void TestQgsProcessing::defaultExtensionsForProvider()
   QCOMPARE( context2.preferredRasterFormat(), QStringLiteral( "sdat" ) );
 
   // but if default is not supported by provider, we use a supported format
-  QgsProcessing::settingsDefaultOutputVectorLayerExt->setValue( QgsVectorFileWriter::supportedFormatExtensions().indexOf( QLatin1String( "gpkg" ) ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->setValue( QgsRasterFileWriter::supportedFormatExtensions().indexOf( QLatin1String( "ecw" ) ) );
+  QgsProcessing::settingsDefaultOutputVectorLayerExt->setValue( QStringLiteral( "gpkg" ) );
+  QgsProcessing::settingsDefaultOutputRasterLayerExt->setValue( QStringLiteral( "ecw" ) );
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "mif" ) );
   QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "mig" ) );
 }


### PR DESCRIPTION
Change the setting key to force a reset for all users, and move to a stable string based setting instead of a fragile int index key

Fixes #57676

(already covered by existing tests)