### PR TITLE
Don't show invalid "Style not found in database" warning when adding vector tile layers

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -100,6 +100,14 @@ Qgis.LayerFilter.__doc__ = "Filter for layers\n\n.. versionadded:: 3.34.\n\n" + 
 Qgis.LayerFilters = lambda flags=0: Qgis.LayerFilter(flags)
 Qgis.LayerFilters.baseClass = Qgis
 LayerFilters = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.LoadStyleFlag.IgnoreMissingStyleErrors.__doc__ = "If the style is missing, then don't flag it as an error. This flag can be used when the caller is not certain that a style exists, and accordingly a failure to find the style does not indicate an issue with loading the style itself."
+Qgis.LoadStyleFlag.__doc__ = "Flags for loading layer styles.\n\n.. versionadded:: 3.38\n\n" + '* ``IgnoreMissingStyleErrors``: ' + Qgis.LoadStyleFlag.IgnoreMissingStyleErrors.__doc__
+# --
+Qgis.LoadStyleFlag.baseClass = Qgis
+Qgis.LoadStyleFlags = lambda flags=0: Qgis.LoadStyleFlag(flags)
+Qgis.LoadStyleFlags.baseClass = Qgis
+LoadStyleFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 QgsWkbTypes.Type = Qgis.WkbType
 # monkey patching scoped based enum
 QgsWkbTypes.Unknown = Qgis.WkbType.Unknown

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -109,6 +109,14 @@ The development version
     typedef QFlags<Qgis::LayerFilter> LayerFilters;
 
 
+    enum class LoadStyleFlag /BaseType=IntFlag/
+    {
+      IgnoreMissingStyleErrors,
+    };
+
+    typedef QFlags<Qgis::LoadStyleFlag> LoadStyleFlags;
+
+
     enum class WkbType /BaseType=IntEnum/
       {
       Unknown,
@@ -2971,6 +2979,8 @@ QFlags<Qgis::MapLayerActionTarget> operator|(Qgis::MapLayerActionTarget f1, QFla
 QFlags<Qgis::MapLayerProperty> operator|(Qgis::MapLayerProperty f1, QFlags<Qgis::MapLayerProperty> f2);
 
 QFlags<Qgis::MapLayerRendererFlag> operator|(Qgis::MapLayerRendererFlag f1, QFlags<Qgis::MapLayerRendererFlag> f2);
+
+QFlags<Qgis::LoadStyleFlag> operator|(Qgis::LoadStyleFlag f1, QFlags<Qgis::LoadStyleFlag> f2);
 
 QFlags<Qgis::MapSettingsFlag> operator|(Qgis::MapSettingsFlag f1, QFlags<Qgis::MapSettingsFlag> f2);
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -778,8 +778,11 @@ Saves named and sld style of the layer to the style table in the db.
    in your client code.
 %End
 
+
+
     virtual QString loadNamedStyle( const QString &theURI, bool &resultFlag /Out/, bool loadFromLocalDb,
-                                    QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+                                    QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories,
+                                    Qgis::LoadStyleFlags flags = Qgis::LoadStyleFlags() );
 %Docstring
 Loads a named style from file/local db/datasource db
 
@@ -787,6 +790,7 @@ Loads a named style from file/local db/datasource db
 :param resultFlag: will be set to ``True`` if a named style is correctly loaded
 :param loadFromLocalDb: if ``True`` forces to load from local db instead of datasource one
 :param categories: the style categories to be loaded.
+:param flags: flags controlling how the style should be loaded (since QGIS 3.38)
 %End
 
 
@@ -973,6 +977,7 @@ record in the users style table in their personal qgis.db)
 :return: a QString with any status messages
 %End
 
+
     virtual QString loadNamedMetadata( const QString &uri, bool &resultFlag /Out/ );
 %Docstring
 Retrieve a named metadata for this layer if one
@@ -988,6 +993,7 @@ record in the users style table in their personal qgis.db)
 :return: - a QString with any status messages
          - resultFlag: a reference to a flag that will be set to ``False`` if we did not manage to load the default metadata.
 %End
+
 
     virtual QString loadDefaultMetadata( bool &resultFlag );
 %Docstring
@@ -1035,6 +1041,7 @@ record in the users style table in their personal qgis.db)
 .. seealso:: :py:func:`saveNamedStyle`
 %End
 
+
     virtual QString loadDefaultStyle( bool &resultFlag /Out/ );
 %Docstring
 Retrieve the default style for this layer if one
@@ -1048,7 +1055,8 @@ record in the users style table in their personal qgis.db)
 .. seealso:: :py:func:`loadNamedStyle`
 %End
 
-    virtual QString loadNamedStyle( const QString &uri, bool &resultFlag /Out/, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+
+    virtual QString loadNamedStyle( const QString &uri, bool &resultFlag /Out/, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories, Qgis::LoadStyleFlags flags = Qgis::LoadStyleFlags() );
 %Docstring
 Retrieve a named style for this layer if one
 exists (either as a .qml file on disk or as a
@@ -1060,6 +1068,7 @@ record in the users style table in their personal qgis.db)
             table will be consulted to see if there is a style who's
             key matches the URI.
 :param categories: the style categories to be loaded.
+:param flags: flags controlling how the style should be loaded (since QGIS 3.38)
 
 :return: - a QString with any status messages
          - resultFlag: a reference to a flag that will be set to ``False`` if we did not manage to load the default style.

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -94,6 +94,13 @@ Qgis.LayerFilter.__doc__ = "Filter for layers\n\n.. versionadded:: 3.34.\n\n" + 
 # --
 Qgis.LayerFilters.baseClass = Qgis
 LayerFilters = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.LoadStyleFlag.IgnoreMissingStyleErrors.__doc__ = "If the style is missing, then don't flag it as an error. This flag can be used when the caller is not certain that a style exists, and accordingly a failure to find the style does not indicate an issue with loading the style itself."
+Qgis.LoadStyleFlag.__doc__ = "Flags for loading layer styles.\n\n.. versionadded:: 3.38\n\n" + '* ``IgnoreMissingStyleErrors``: ' + Qgis.LoadStyleFlag.IgnoreMissingStyleErrors.__doc__
+# --
+Qgis.LoadStyleFlag.baseClass = Qgis
+Qgis.LoadStyleFlags.baseClass = Qgis
+LoadStyleFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 QgsWkbTypes.Type = Qgis.WkbType
 # monkey patching scoped based enum
 QgsWkbTypes.Unknown = Qgis.WkbType.Unknown

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -109,6 +109,14 @@ The development version
     typedef QFlags<Qgis::LayerFilter> LayerFilters;
 
 
+    enum class LoadStyleFlag
+    {
+      IgnoreMissingStyleErrors,
+    };
+
+    typedef QFlags<Qgis::LoadStyleFlag> LoadStyleFlags;
+
+
     enum class WkbType
       {
       Unknown,
@@ -2971,6 +2979,8 @@ QFlags<Qgis::MapLayerActionTarget> operator|(Qgis::MapLayerActionTarget f1, QFla
 QFlags<Qgis::MapLayerProperty> operator|(Qgis::MapLayerProperty f1, QFlags<Qgis::MapLayerProperty> f2);
 
 QFlags<Qgis::MapLayerRendererFlag> operator|(Qgis::MapLayerRendererFlag f1, QFlags<Qgis::MapLayerRendererFlag> f2);
+
+QFlags<Qgis::LoadStyleFlag> operator|(Qgis::LoadStyleFlag f1, QFlags<Qgis::LoadStyleFlag> f2);
 
 QFlags<Qgis::MapSettingsFlag> operator|(Qgis::MapSettingsFlag f1, QFlags<Qgis::MapSettingsFlag> f2);
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -778,8 +778,11 @@ Saves named and sld style of the layer to the style table in the db.
    in your client code.
 %End
 
+
+
     virtual QString loadNamedStyle( const QString &theURI, bool &resultFlag /Out/, bool loadFromLocalDb,
-                                    QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+                                    QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories,
+                                    Qgis::LoadStyleFlags flags = Qgis::LoadStyleFlags() );
 %Docstring
 Loads a named style from file/local db/datasource db
 
@@ -787,6 +790,7 @@ Loads a named style from file/local db/datasource db
 :param resultFlag: will be set to ``True`` if a named style is correctly loaded
 :param loadFromLocalDb: if ``True`` forces to load from local db instead of datasource one
 :param categories: the style categories to be loaded.
+:param flags: flags controlling how the style should be loaded (since QGIS 3.38)
 %End
 
 
@@ -973,6 +977,7 @@ record in the users style table in their personal qgis.db)
 :return: a QString with any status messages
 %End
 
+
     virtual QString loadNamedMetadata( const QString &uri, bool &resultFlag /Out/ );
 %Docstring
 Retrieve a named metadata for this layer if one
@@ -988,6 +993,7 @@ record in the users style table in their personal qgis.db)
 :return: - a QString with any status messages
          - resultFlag: a reference to a flag that will be set to ``False`` if we did not manage to load the default metadata.
 %End
+
 
     virtual QString loadDefaultMetadata( bool &resultFlag );
 %Docstring
@@ -1035,6 +1041,7 @@ record in the users style table in their personal qgis.db)
 .. seealso:: :py:func:`saveNamedStyle`
 %End
 
+
     virtual QString loadDefaultStyle( bool &resultFlag /Out/ );
 %Docstring
 Retrieve the default style for this layer if one
@@ -1048,7 +1055,8 @@ record in the users style table in their personal qgis.db)
 .. seealso:: :py:func:`loadNamedStyle`
 %End
 
-    virtual QString loadNamedStyle( const QString &uri, bool &resultFlag /Out/, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+
+    virtual QString loadNamedStyle( const QString &uri, bool &resultFlag /Out/, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories, Qgis::LoadStyleFlags flags = Qgis::LoadStyleFlags() );
 %Docstring
 Retrieve a named style for this layer if one
 exists (either as a .qml file on disk or as a
@@ -1060,6 +1068,7 @@ record in the users style table in their personal qgis.db)
             table will be consulted to see if there is a style who's
             key matches the URI.
 :param categories: the style categories to be loaded.
+:param flags: flags controlling how the style should be loaded (since QGIS 3.38)
 
 :return: - a QString with any status messages
          - resultFlag: a reference to a flag that will be set to ``False`` if we did not manage to load the default style.

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -146,7 +146,7 @@ void QgsAppLayerHandling::postProcessAddedLayer( QgsMapLayer *layer )
     {
       bool ok = false;
       QString error = layer->loadDefaultStyle( ok );
-      if ( !ok && error != QObject::tr( "Style not found in database" ) )
+      if ( !ok && !error.isEmpty() )
         QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Error loading style" ), error, Qgis::MessageLevel::Warning );
       error = layer->loadDefaultMetadata( ok );
       if ( !ok )

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -146,7 +146,7 @@ void QgsAppLayerHandling::postProcessAddedLayer( QgsMapLayer *layer )
     {
       bool ok = false;
       QString error = layer->loadDefaultStyle( ok );
-      if ( !ok )
+      if ( !ok && error != QObject::tr( "Style not found in database" ) )
         QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Error loading style" ), error, Qgis::MessageLevel::Warning );
       error = layer->loadDefaultMetadata( ok );
       if ( !ok )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -152,6 +152,25 @@ class CORE_EXPORT Qgis
     Q_FLAG( LayerFilters )
 
     /**
+     * Flags for loading layer styles.
+     *
+     * \since QGIS 3.38
+     */
+    enum class LoadStyleFlag : int SIP_ENUM_BASETYPE( IntFlag )
+    {
+      IgnoreMissingStyleErrors = 1 << 0, //!< If the style is missing, then don't flag it as an error. This flag can be used when the caller is not certain that a style exists, and accordingly a failure to find the style does not indicate an issue with loading the style itself.
+    };
+    Q_ENUM( LoadStyleFlag )
+
+    /**
+     * Flags for loading layer styles.
+     *
+     * \since QGIS 3.38
+     */
+    Q_DECLARE_FLAGS( LoadStyleFlags, LoadStyleFlag )
+    Q_FLAG( LoadStyleFlags )
+
+    /**
      * The WKB type describes the number of dimensions a geometry has
      *
      * - Point
@@ -5219,6 +5238,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerActionFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerActionTargets )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerProperties )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerRendererFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::LoadStyleFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapSettingsFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MarkerLinePlacements )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::PlotToolFlags )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -772,15 +772,21 @@ class CORE_EXPORT QgsMapLayer : public QObject
                                       QString &msgError SIP_OUT,
                                       QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
 
+
+    // TODO QGIS 4.0 -- fix this. We incorrectly have a single boolean flag which in which false is used inconsistently for "a style WAS found but an error occurred loading it" vs "no style was found".
+    // The first (style found, error occurred loading it) should trigger a user-facing warning, whereas the second (no style found) isn't reflective of an error at all.
+
     /**
      * Loads a named style from file/local db/datasource db
      * \param theURI the URI of the style or the URI of the layer
      * \param resultFlag will be set to TRUE if a named style is correctly loaded
      * \param loadFromLocalDb if TRUE forces to load from local db instead of datasource one
      * \param categories the style categories to be loaded.
+     * \param flags flags controlling how the style should be loaded (since QGIS 3.38)
      */
     virtual QString loadNamedStyle( const QString &theURI, bool &resultFlag SIP_OUT, bool loadFromLocalDb,
-                                    QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+                                    QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories,
+                                    Qgis::LoadStyleFlags flags = Qgis::LoadStyleFlags() );
 
 #ifndef SIP_RUN
 
@@ -1106,6 +1112,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     QString saveNamedMetadata( const QString &uri, bool &resultFlag );
 
+    // TODO QGIS 4.0 -- fix this. We incorrectly have a single boolean flag which in which false is used inconsistently for "metadata WAS found but an error occurred loading it" vs "no metadata was found".
+    // The first (metadata found, error occurred loading it) should trigger a user-facing warning, whereas the second (no metadata found) isn't reflective of an error at all.
+
     /**
      * Retrieve a named metadata for this layer if one
      * exists (either as a .qmd file on disk or as a
@@ -1120,6 +1129,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \returns a QString with any status messages
      */
     virtual QString loadNamedMetadata( const QString &uri, bool &resultFlag SIP_OUT );
+
+    // TODO QGIS 4.0 -- fix this. We incorrectly have a single boolean flag which in which false is used inconsistently for "metadata WAS found but an error occurred loading it" vs "no metadata was found".
+    // The first (metadata found, error occurred loading it) should trigger a user-facing warning, whereas the second (no metadata found) isn't reflective of an error at all.
 
     /**
      * Retrieve the default metadata for this layer if one
@@ -1158,6 +1170,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     virtual QString styleURI() const;
 
+    // TODO QGIS 4.0 -- fix this. We incorrectly have a single boolean flag which in which false is used inconsistently for "a style WAS found but an error occurred loading it" vs "no style was found".
+    // The first (style found, error occurred loading it) should trigger a user-facing warning, whereas the second (no style found) isn't reflective of an error at all.
+
     /**
      * Retrieve the default style for this layer if one
      * exists (either as a .qml file on disk or as a
@@ -1168,6 +1183,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see loadNamedStyle()
      */
     virtual QString loadDefaultStyle( bool &resultFlag SIP_OUT );
+
+    // TODO QGIS 4.0 -- fix this. We incorrectly have a single boolean flag which in which false is used inconsistently for "a style WAS found but an error occurred loading it" vs "no style was found".
+    // The first (style found, error occurred loading it) should trigger a user-facing warning, whereas the second (no style found) isn't reflective of an error at all.
 
     /**
      * Retrieve a named style for this layer if one
@@ -1181,10 +1199,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \param resultFlag a reference to a flag that will be set to FALSE if
      * we did not manage to load the default style.
      * \param categories the style categories to be loaded.
+     * \param flags flags controlling how the style should be loaded (since QGIS 3.38)
      * \returns a QString with any status messages
      * \see loadDefaultStyle()
      */
-    virtual QString loadNamedStyle( const QString &uri, bool &resultFlag SIP_OUT, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+    virtual QString loadNamedStyle( const QString &uri, bool &resultFlag SIP_OUT, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories, Qgis::LoadStyleFlags flags = Qgis::LoadStyleFlags() );
 
     /**
      * Retrieve a named style for this layer from a sqlite database.
@@ -2344,7 +2363,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     QString saveNamedProperty( const QString &uri, QgsMapLayer::PropertyType type,
                                bool &resultFlag, StyleCategories categories = AllStyleCategories );
     QString loadNamedProperty( const QString &uri, QgsMapLayer::PropertyType type,
-                               bool &resultFlag, StyleCategories categories = AllStyleCategories );
+                               bool &namedPropertyExists, bool &propertySuccessfullyLoaded, StyleCategories categories = AllStyleCategories, Qgis::LoadStyleFlags flags = Qgis::LoadStyleFlags() );
     bool loadNamedPropertyFromDatabase( const QString &db, const QString &uri, QString &xml, QgsMapLayer::PropertyType type );
 
     // const method because extents are mutable


### PR DESCRIPTION
The API here is a mess -- since we use the same API for user-triggered intentional style loads and ALSO the attempt to sniff and see if a layer has a default style (when it may not), there's a mixup of whether or not we should report missing styles as an error or not.

This results in a misleading "style not found in database" error shown when adding vector tile layers. Other layer types just ignore the return code and don't show warnings, but for vector tiles the API returns valid warnings when loading styles which we DO want to be user visible.

Just hack around this by hiding the one particular unwanted warning for now.
