### PR TITLE
make Qgs3dMapScene really exportable

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -293,18 +293,6 @@ float Qgs3DMapScene::worldSpaceError( float epsilon, float distance ) const
   return err;
 }
 
-Qgs3DMapSceneEntity::SceneContext Qgs3DMapScene::buildSceneContext( ) const
-{
-  Qt3DRender::QCamera *camera = mEngine->camera();
-  Qgs3DMapSceneEntity::SceneContext sceneContext;
-  sceneContext.cameraFov = camera->fieldOfView();
-  sceneContext.cameraPos = camera->position();
-  const QSize size = mEngine->size();
-  sceneContext.screenSizePx = std::max( size.width(), size.height() ); // TODO: is this correct?
-  sceneContext.viewProjectionMatrix = camera->projectionMatrix() * camera->viewMatrix();
-  return sceneContext;
-}
-
 void Qgs3DMapScene::onCameraChanged()
 {
   if ( mMap.projectionType() == Qt3DRender::QCameraLens::OrthographicProjection )
@@ -337,7 +325,15 @@ void Qgs3DMapScene::updateScene( bool forceUpdate )
   if ( forceUpdate )
     QgsEventTracing::addEvent( QgsEventTracing::Instant, QStringLiteral( "3D" ), QStringLiteral( "Update Scene" ) );
 
-  Qgs3DMapSceneEntity::SceneContext sceneContext = buildSceneContext();
+  Qgs3DMapSceneEntity::SceneContext sceneContext;
+  Qt3DRender::QCamera *camera = mEngine->camera();
+  sceneContext.cameraFov = camera->fieldOfView();
+  sceneContext.cameraPos = camera->position();
+  const QSize size = mEngine->size();
+  sceneContext.screenSizePx = std::max( size.width(), size.height() ); // TODO: is this correct?
+  sceneContext.viewProjectionMatrix = camera->projectionMatrix() * camera->viewMatrix();
+
+
   for ( Qgs3DMapSceneEntity *entity : std::as_const( mSceneEntities ) )
   {
     if ( forceUpdate || ( entity->isEnabled() && entity->needsUpdate() ) )

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -22,7 +22,6 @@
 
 #include "qgsrectangle.h"
 #include "qgscameracontroller.h"
-#include "qgs3dmapsceneentity_p.h"
 
 #ifndef SIP_RUN
 namespace Qt3DRender
@@ -57,6 +56,7 @@ class Qgs3DMapExportSettings;
 class QgsPostprocessingEntity;
 class QgsChunkNode;
 class QgsDoubleRange;
+class Qgs3DMapSceneEntity;
 
 
 /**
@@ -277,7 +277,6 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     void updateScene( bool forceUpdate = false );
     void finalizeNewEntity( Qt3DCore::QEntity *newEntity );
     int maximumTextureSize() const;
-    Qgs3DMapSceneEntity::SceneContext buildSceneContext( ) const;
 
   private:
     Qgs3DMapSettings &mMap;


### PR DESCRIPTION
Header file contains reference to private header and can't be used externally.
This PR fixes this issue.

