### PR TITLE
qgsfeature3dhandler: Remove unused entityFromHandler Logic

### DIFF
--- a/src/3d/qgsfeature3dhandler_p.cpp
+++ b/src/3d/qgsfeature3dhandler_p.cpp
@@ -24,42 +24,6 @@
 
 /// @cond PRIVATE
 
-
-namespace Qgs3DSymbolImpl
-{
-
-  Qt3DCore::QEntity *entityFromHandler( QgsFeature3DHandler *handler, const Qgs3DMapSettings &map, QgsVectorLayer *layer )
-  {
-    Qgs3DRenderContext context( map );
-
-    QgsExpressionContext exprContext( Qgs3DUtils::globalProjectLayerExpressionContext( layer ) );
-    exprContext.setFields( layer->fields() );
-    context.setExpressionContext( exprContext );
-
-    QSet<QString> attributeNames;
-    if ( !handler->prepare( context, attributeNames ) )
-      return nullptr;
-
-    // build the feature request
-    QgsFeatureRequest req;
-    req.setDestinationCrs( map.crs(), map.transformContext() );
-    req.setSubsetOfAttributes( attributeNames, layer->fields() );
-
-    QgsFeature f;
-    QgsFeatureIterator fi = layer->getFeatures( req );
-    while ( fi.nextFeature( f ) )
-    {
-      context.expressionContext().setFeature( f );
-      handler->processFeature( f, context );
-    }
-
-    Qt3DCore::QEntity *entity = new Qt3DCore::QEntity;
-    handler->finalize( entity, context );
-    return entity;
-  }
-
-}
-
 void QgsFeature3DHandler::updateZRangeFromPositions( const QVector<QVector3D> &positions )
 {
   for ( const QVector3D &pos : positions )

--- a/src/3d/qgsfeature3dhandler_p.h
+++ b/src/3d/qgsfeature3dhandler_p.h
@@ -137,16 +137,6 @@ class QgsFeature3DHandler
 };
 
 
-class Qgs3DMapSettings;
-class QgsVectorLayer;
-
-namespace Qgs3DSymbolImpl
-{
-  //! generic method to iterate over a layer, handle features with handler and create an entity out of it
-  Qt3DCore::QEntity *entityFromHandler( QgsFeature3DHandler *handler, const Qgs3DMapSettings &map, QgsVectorLayer *layer );
-}
-
-
 /// @endcond
 
 #endif // QGSFEATURE3DHANDLER_P_H

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -404,14 +404,6 @@ namespace Qgs3DSymbolImpl
     else
       return new QgsBufferedLine3DSymbolHandler( lineSymbol, layer->selectedFeatureIds() );
   }
-
-  Qt3DCore::QEntity *entityForLine3DSymbol( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsLine3DSymbol &symbol )
-  {
-    QgsFeature3DHandler *handler = handlerForLine3DSymbol( layer, &symbol );
-    Qt3DCore::QEntity *e = entityFromHandler( handler, map, layer );
-    delete handler;
-    return e;
-  }
 }
 
 /// @endcond

--- a/src/3d/symbols/qgsline3dsymbol_p.h
+++ b/src/3d/symbols/qgsline3dsymbol_p.h
@@ -38,9 +38,6 @@ namespace Qgs3DSymbolImpl
 {
   //! factory method for QgsLine3DSymbol
   QgsFeature3DHandler *handlerForLine3DSymbol( QgsVectorLayer *layer, const QgsAbstract3DSymbol *symbol );
-
-  //! convenience function to create a complete entity from QgsPolygon3DSymbol (will run getFeatures() on the layer)
-  Qt3DCore::QEntity *entityForLine3DSymbol( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsLine3DSymbol &symbol );
 }
 
 /// @endcond

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -690,14 +690,6 @@ namespace Qgs3DSymbolImpl
     else
       return new QgsInstancedPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds() );
   }
-
-  Qt3DCore::QEntity *entityForPoint3DSymbol( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol )
-  {
-    QgsFeature3DHandler *handler = handlerForPoint3DSymbol( layer, &symbol );
-    Qt3DCore::QEntity *e = entityFromHandler( handler, map, layer );
-    delete handler;
-    return e;
-  }
 }
 
 /// @endcond

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -337,15 +337,6 @@ namespace Qgs3DSymbolImpl
 
     return new QgsPolygon3DSymbolHandler( polygonSymbol, layer->selectedFeatureIds() );
   }
-
-  Qt3DCore::QEntity *entityForPolygon3DSymbol( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPolygon3DSymbol &symbol )
-  {
-    QgsFeature3DHandler *handler = handlerForPolygon3DSymbol( layer, &symbol );
-    Qt3DCore::QEntity *e = entityFromHandler( handler, map, layer );
-    delete handler;
-    return e;
-  }
-
 }
 
 /// @endcond

--- a/src/3d/symbols/qgspolygon3dsymbol_p.h
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.h
@@ -38,9 +38,6 @@ namespace Qgs3DSymbolImpl
 {
   //! factory method for QgsPolygon3DSymbol
   QgsFeature3DHandler *handlerForPolygon3DSymbol( QgsVectorLayer *layer, const QgsAbstract3DSymbol *symbol );
-
-  //! convenience function to create a complete entity from QgsPolygon3DSymbol (will run getFeatures() on the layer)
-  Qt3DCore::QEntity *entityForPolygon3DSymbol( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPolygon3DSymbol &symbol );
 }
 
 /// @endcond


### PR DESCRIPTION
## Description

The `getFeatures()` logic is now implemented in `QgsVectorLayerChunkLoader`.

