### PR TITLE
Add feature tool: add topological point to each editable layer instead of only the snapped layer

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -133,6 +133,7 @@ void QgsMapToolAddFeature::featureDigitized( const QgsFeature &feature )
 
         layer->beginEditCommand( tr( "Topological points added by 'Add Feature'" ) );
 
+        int res;
         if ( layer->crs() != vlayer->crs() )
         {
           QgsGeometry transformedGeom = feature.geometry();
@@ -140,7 +141,7 @@ void QgsMapToolAddFeature::featureDigitized( const QgsFeature &feature )
           {
             // transform digitized geometry from vlayer crs to layer crs and add topological points
             transformedGeom.transform( QgsCoordinateTransform( vlayer->crs(), layer->crs(), layer->transformContext() ) );
-            layer->addTopologicalPoints( transformedGeom );
+            res = layer->addTopologicalPoints( transformedGeom );
           }
           catch ( QgsCsException &cse )
           {
@@ -152,10 +153,13 @@ void QgsMapToolAddFeature::featureDigitized( const QgsFeature &feature )
         }
         else
         {
-          layer->addTopologicalPoints( feature.geometry() );
+          res = layer->addTopologicalPoints( feature.geometry() );
         }
 
-        layer->endEditCommand();
+        if ( res == 0 ) // i.e. if any points were added
+          layer->endEditCommand();
+        else
+          layer->destroyEditCommand();
       }
       vlayer->addTopologicalPoints( feature.geometry() );
     }

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -146,6 +146,7 @@ void QgsMapToolAddFeature::featureDigitized( const QgsFeature &feature )
             try
             {
               topologicalPoint.transform( QgsCoordinateTransform( vlayer->crs(), layer->crs(), layer->transformContext() ) );
+              // the function adds a topological point if a segment overlaps it
               layer->addTopologicalPoints( topologicalPoint );
             }
             catch ( QgsCsException &cse )
@@ -156,6 +157,7 @@ void QgsMapToolAddFeature::featureDigitized( const QgsFeature &feature )
           }
           else
           {
+            // the function adds a topological point if a segment overlaps it
             layer->addTopologicalPoints( topologicalPoint );
           }
         }

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -131,6 +131,8 @@ void QgsMapToolAddFeature::featureDigitized( const QgsFeature &feature )
         if ( !( layer->geometryType() == Qgis::GeometryType::Polygon || layer->geometryType() == Qgis::GeometryType::Line ) )
           continue;
 
+        layer->beginEditCommand( tr( "Topological points added by 'Add Feature'" ) );
+
         if ( layer->crs() != vlayer->crs() )
         {
           QgsGeometry transformedGeom = feature.geometry();
@@ -144,12 +146,16 @@ void QgsMapToolAddFeature::featureDigitized( const QgsFeature &feature )
           {
             Q_UNUSED( cse )
             QgsDebugError( QStringLiteral( "transformation to layer coordinate failed" ) );
+            layer->destroyEditCommand();
+            continue;
           }
         }
         else
         {
           layer->addTopologicalPoints( feature.geometry() );
         }
+
+        layer->endEditCommand();
       }
       vlayer->addTopologicalPoints( feature.geometry() );
     }


### PR DESCRIPTION
## Description

Fixes #56689 (which is a duplicate of #37824). 

Instead of adding the topological point to the snapped layer in the QgsPointLocator::Match a topological point is added to each editable layer. This is done by iterating over editable layers in QgsMapToolAddFeature. One another way might've been to add a list of layers which have a segment that match the snap point to Match but that'd be a more substantial change to core so I've opted to handle all of it in the map tool itself.

**Funded by** the National Land Survey of Finland.