### PR TITLE
Optimise QgsFeature __getitem__

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -170,7 +170,7 @@ geometry and a list of field/values attributes.
 
     void __delitem__( int key ) /HoldGIL/;
 %MethodCode
-    if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
+    if ( a0 >= 0 && a0 < sipCpp->attributeCount() )
       sipCpp->deleteAttribute( a0 );
     else
     {
@@ -284,7 +284,7 @@ Returns the feature's attributes as a map of field name to value.
 %End
 %MethodCode
     const int fieldSize = sipCpp->fields().size();
-    const int attributeSize = sipCpp->attributes().size();
+    const int attributeSize = sipCpp->attributeCount();
     if ( fieldSize == 0 && attributeSize != 0 )
     {
       PyErr_SetString( PyExc_ValueError, QStringLiteral( "Field definition has not been set for feature" ).toUtf8().constData() );
@@ -478,7 +478,7 @@ Alternatively, in Python it is possible to directly `del` an attribute via its i
 .. seealso:: :py:func:`setAttribute`
 %End
 %MethodCode
-    if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
+    if ( a0 >= 0 && a0 < sipCpp->attributeCount() )
       sipCpp->deleteAttribute( a0 );
     else
     {
@@ -802,7 +802,7 @@ Alternatively, in Python it is possible to directly retrieve a field's value via
 %End
 %MethodCode
     {
-      if ( a0 < 0 || a0 >= sipCpp->attributes().count() )
+      if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
       {
         PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
         sipIsErr = 1;
@@ -829,7 +829,7 @@ Returns ``True`` if the attribute at the specified index is an unset value.
 %End
 %MethodCode
     {
-      if ( a0 < 0 || a0 >= sipCpp->attributes().count() )
+      if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
       {
         PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
         sipIsErr = 1;

--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -42,6 +42,7 @@ geometry and a list of field/values attributes.
     sipRes = PyObject_GetIter( attrs );
 %End
 
+
     SIP_PYOBJECT __getitem__( int key ) /HoldGIL/;
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
@@ -54,8 +55,8 @@ geometry and a list of field/values attributes.
       const QVariant v = sipCpp->attribute( a0 );
       if ( QgsVariantUtils::isNull( v, true ) )
       {
-        QVariant *newV = new QVariant( v );
-        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
       }
       else
       {
@@ -116,8 +117,8 @@ geometry and a list of field/values attributes.
       const QVariant v = sipCpp->attribute( fieldIdx );
       if ( QgsVariantUtils::isNull( v, true ) )
       {
-        QVariant *newV = new QVariant( v );
-        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
       }
       else
       {

--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -12,6 +12,7 @@
 
 
 
+
 class QgsFeature
 {
 %Docstring(signature="appended")
@@ -43,16 +44,62 @@ geometry and a list of field/values attributes.
 
     SIP_PYOBJECT __getitem__( int key ) /HoldGIL/;
 %MethodCode
-    QgsAttributes attrs = sipCpp->attributes();
-    if ( a0 < 0 || a0 >= attrs.count() )
+    if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
     {
       PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
       sipIsErr = 1;
     }
     else
     {
-      QVariant *v = new QVariant( attrs.at( a0 ) );
-      sipRes = sipConvertFromNewType( v, sipType_QVariant, Py_None );
+      const QVariant v = sipCpp->attribute( a0 );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        QVariant *newV = new QVariant( v );
+        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
     }
 %End
 
@@ -66,8 +113,55 @@ geometry and a list of field/values attributes.
     }
     else
     {
-      QVariant *v = new QVariant( sipCpp->attribute( fieldIdx ) );
-      sipRes = sipConvertFromNewType( v, sipType_QVariant, Py_None );
+      const QVariant v = sipCpp->attribute( fieldIdx );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        QVariant *newV = new QVariant( v );
+        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
     }
 %End
 

--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -53,7 +53,8 @@ geometry and a list of field/values attributes.
     else
     {
       const QVariant v = sipCpp->attribute( a0 );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         Py_INCREF( Py_None );
         sipRes = Py_None;
@@ -115,7 +116,8 @@ geometry and a list of field/values attributes.
     else
     {
       const QVariant v = sipCpp->attribute( fieldIdx );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         Py_INCREF( Py_None );
         sipRes = Py_None;

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -170,7 +170,7 @@ geometry and a list of field/values attributes.
 
     void __delitem__( int key ) /HoldGIL/;
 %MethodCode
-    if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
+    if ( a0 >= 0 && a0 < sipCpp->attributeCount() )
       sipCpp->deleteAttribute( a0 );
     else
     {
@@ -284,7 +284,7 @@ Returns the feature's attributes as a map of field name to value.
 %End
 %MethodCode
     const int fieldSize = sipCpp->fields().size();
-    const int attributeSize = sipCpp->attributes().size();
+    const int attributeSize = sipCpp->attributeCount();
     if ( fieldSize == 0 && attributeSize != 0 )
     {
       PyErr_SetString( PyExc_ValueError, QStringLiteral( "Field definition has not been set for feature" ).toUtf8().constData() );
@@ -478,7 +478,7 @@ Alternatively, in Python it is possible to directly `del` an attribute via its i
 .. seealso:: :py:func:`setAttribute`
 %End
 %MethodCode
-    if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
+    if ( a0 >= 0 && a0 < sipCpp->attributeCount() )
       sipCpp->deleteAttribute( a0 );
     else
     {
@@ -802,7 +802,7 @@ Alternatively, in Python it is possible to directly retrieve a field's value via
 %End
 %MethodCode
     {
-      if ( a0 < 0 || a0 >= sipCpp->attributes().count() )
+      if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
       {
         PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
         sipIsErr = 1;
@@ -829,7 +829,7 @@ Returns ``True`` if the attribute at the specified index is an unset value.
 %End
 %MethodCode
     {
-      if ( a0 < 0 || a0 >= sipCpp->attributes().count() )
+      if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
       {
         PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
         sipIsErr = 1;

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -52,7 +52,12 @@ geometry and a list of field/values attributes.
     else
     {
       const QVariant v = sipCpp->attribute( a0 );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      if ( !v.isValid() )
+      {
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
+      }
+      else if ( QgsVariantUtils::isNull( v, true ) )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );
@@ -118,7 +123,12 @@ geometry and a list of field/values attributes.
     else
     {
       const QVariant v = sipCpp->attribute( fieldIdx );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      if ( !v.isValid() )
+      {
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
+      }
+      else if ( QgsVariantUtils::isNull( v, true ) )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -12,6 +12,7 @@
 
 
 
+
 class QgsFeature
 {
 %Docstring(signature="appended")
@@ -43,16 +44,62 @@ geometry and a list of field/values attributes.
 
     SIP_PYOBJECT __getitem__( int key ) /HoldGIL/;
 %MethodCode
-    QgsAttributes attrs = sipCpp->attributes();
-    if ( a0 < 0 || a0 >= attrs.count() )
+    if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
     {
       PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
       sipIsErr = 1;
     }
     else
     {
-      QVariant *v = new QVariant( attrs.at( a0 ) );
-      sipRes = sipConvertFromNewType( v, sipType_QVariant, Py_None );
+      const QVariant v = sipCpp->attribute( a0 );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        QVariant *newV = new QVariant( v );
+        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
     }
 %End
 
@@ -66,8 +113,55 @@ geometry and a list of field/values attributes.
     }
     else
     {
-      QVariant *v = new QVariant( sipCpp->attribute( fieldIdx ) );
-      sipRes = sipConvertFromNewType( v, sipType_QVariant, Py_None );
+      const QVariant v = sipCpp->attribute( fieldIdx );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        QVariant *newV = new QVariant( v );
+        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
     }
 %End
 

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -57,7 +57,8 @@ geometry and a list of field/values attributes.
         Py_INCREF( Py_None );
         sipRes = Py_None;
       }
-      else if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      else if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );
@@ -128,7 +129,8 @@ geometry and a list of field/values attributes.
         Py_INCREF( Py_None );
         sipRes = Py_None;
       }
-      else if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      else if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -54,8 +54,12 @@ geometry and a list of field/values attributes.
       const QVariant v = sipCpp->attribute( a0 );
       if ( QgsVariantUtils::isNull( v, true ) )
       {
-        QVariant *newV = new QVariant( v );
-        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+        PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
+        PyObject *args = PyTuple_Pack( 1, vartype );
+        PyTypeObject *typeObj = sipTypeAsPyTypeObject( sipType_QVariant );
+        sipRes = PyObject_Call( ( PyObject * )typeObj, args, nullptr );
+        Py_DECREF( args );
+        Py_DECREF( vartype );
       }
       else
       {
@@ -116,8 +120,12 @@ geometry and a list of field/values attributes.
       const QVariant v = sipCpp->attribute( fieldIdx );
       if ( QgsVariantUtils::isNull( v, true ) )
       {
-        QVariant *newV = new QVariant( v );
-        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+        PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
+        PyObject *args = PyTuple_Pack( 1, vartype );
+        PyTypeObject *typeObj = sipTypeAsPyTypeObject( sipType_QVariant );
+        sipRes = PyObject_Call( ( PyObject * )typeObj, args, nullptr );
+        Py_DECREF( args );
+        Py_DECREF( vartype );
       }
       else
       {
@@ -164,6 +172,7 @@ geometry and a list of field/values attributes.
       }
     }
 %End
+
 
     void __setitem__( int key, SIP_PYOBJECT value /TypeHint="Optional[Union[bool, int, float, str, QVariant]]"/ ) /HoldGIL/;
 %MethodCode

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -1115,6 +1115,13 @@ while ($LINE_IDX < $LINE_COUNT){
             $LINE = read_line();
         }
     }
+    # skip PYQT6 code if we are in qt5
+    if ( !$is_qt6 && $LINE =~ m/^\s*#ifdef SIP_PYQT6_RUN/){
+        dbg_info("do not process PYQT6 code");
+        while ( $LINE !~ m/^#endif/ ){
+            $LINE = read_line();
+        }
+    }
 
     # do not process SIP code %XXXCode
     if ( $SIP_RUN == 1 && $LINE =~ m/^ *% *(VirtualErrorHandler|MappedType|Type(?:Header)?Code|Module(?:Header)?Code|Convert(?:From|To)(?:Type|SubClass)Code|MethodCode|Docstring)(.*)?$/ ){

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
@@ -199,7 +199,8 @@ QVariantMap QgsJoinByAttributeAlgorithm::processAlgorithm( const QVariantMap &pa
 
     // only keep selected attributes
     QgsAttributes attributes;
-    for ( int j = 0; j < feat.attributes().count(); ++j )
+    const int attributeCount = feat.attributeCount();
+    for ( int j = 0; j < attributeCount; ++j )
     {
       if ( ! fields2Indices.contains( j ) )
         continue;

--- a/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
@@ -209,7 +209,8 @@ QVariantMap QgsJoinByNearestAlgorithm::processAlgorithm( const QVariantMap &para
 
     // only keep selected attributes
     QgsAttributes attributes;
-    for ( int j = 0; j < f.attributes().count(); ++j )
+    const int attributeCount = f.attributeCount();
+    for ( int j = 0; j < attributeCount; ++j )
     {
       if ( ! fields2Indices.contains( j ) )
         continue;

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
@@ -259,7 +259,8 @@ QVariantMap QgsJoinWithLinesAlgorithm::processAlgorithm( const QVariantMap &para
 
     // only keep selected attributes
     QgsAttributes hubAttributes;
-    for ( int j = 0; j < hubFeature.attributes().count(); ++j )
+    const int attributeCount = hubFeature.attributeCount();
+    for ( int j = 0; j < attributeCount; ++j )
     {
       if ( !hubFieldIndices.contains( j ) )
         continue;
@@ -333,7 +334,8 @@ QVariantMap QgsJoinWithLinesAlgorithm::processAlgorithm( const QVariantMap &para
 
       // only keep selected attributes
       QgsAttributes spokeAttributes;
-      for ( int j = 0; j < spokeFeature.attributes().count(); ++j )
+      const int attributeCount = spokeFeature.attributeCount();
+      for ( int j = 0; j < attributeCount; ++j )
       {
         if ( !spokeFieldIndices.contains( j ) )
           continue;

--- a/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
@@ -136,7 +136,8 @@ void QgsVectorDataProviderFeaturePool::updateFeature( QgsFeature &feature )
   geometryMap.insert( feature.id(), feature.geometry() );
   QgsChangedAttributesMap changedAttributesMap;
   QgsAttributeMap attribMap;
-  for ( int i = 0, n = feature.attributes().size(); i < n; ++i )
+  const int attributeCount = feature.attributeCount();
+  for ( int i = 0, n = attributeCount; i < n; ++i )
   {
     attribMap.insert( i, feature.attributes().at( i ) );
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10372,7 +10372,8 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
       }
 
       QgsAttributeMap attrMap;
-      for ( int i = 0; i < feature.attributes().count(); i++ )
+      const int attributeCount = feature.attributeCount();
+      for ( int i = 0; i < attributeCount; i++ )
       {
         attrMap[i] = feature.attribute( i );
       }

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1012,7 +1012,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
   // add feature attributes
   if ( feature.isValid() )
   {
-    QgsDebugMsgLevel( QStringLiteral( "fields size = %1 attributes size = %2" ).arg( fields.size() ).arg( feature.attributes().size() ), 2 );
+    QgsDebugMsgLevel( QStringLiteral( "fields size = %1 attributes size = %2" ).arg( fields.size() ).arg( feature.attributeCount() ), 2 );
     const QgsAttributes attrs = feature.attributes();
     for ( int i = 0; i < attrs.count(); ++i )
     {

--- a/src/core/diagram/qgshistogramdiagram.cpp
+++ b/src/core/diagram/qgshistogramdiagram.cpp
@@ -36,7 +36,7 @@ QgsHistogramDiagram *QgsHistogramDiagram::clone() const
 QSizeF QgsHistogramDiagram::diagramSize( const QgsFeature &feature, const QgsRenderContext &c, const QgsDiagramSettings &s, const QgsDiagramInterpolationSettings &is )
 {
   QSizeF size;
-  if ( feature.attributes().isEmpty() )
+  if ( feature.attributeCount() == 0 )
   {
     return size; //zero size if no attributes
   }

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -433,21 +433,22 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags flags )
   {
     it->setId( mNextFeatureId );
     it->setValid( true );
-    if ( it->attributes().count() < fieldCount )
+    const int attributeCount = it->attributeCount();
+    if ( attributeCount < fieldCount )
     {
       // ensure features have the correct number of attributes by padding
       // them with null attributes for missing values
       QgsAttributes attributes = it->attributes();
-      for ( int i = it->attributes().count(); i < mFields.count(); ++i )
+      for ( int i = attributeCount; i < mFields.count(); ++i )
       {
         attributes.append( QgsVariantUtils::createNullVariant( mFields.at( i ).type() ) );
       }
       it->setAttributes( attributes );
     }
-    else if ( it->attributes().count() > fieldCount )
+    else if ( attributeCount > fieldCount )
     {
       // too many attributes
-      pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( fieldCount ).arg( it->attributes().count() ) );
+      pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( fieldCount ).arg( attributeCount ) );
       QgsAttributes attributes = it->attributes();
       attributes.resize( mFields.count() );
       it->setAttributes( attributes );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1679,7 +1679,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags, QgsFeatureId
     // don't try to set field from attribute map if it's not present in layer
     if ( ogrAttributeId >= featureDefinition.GetFieldCount() )
     {
-      pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( featureDefinition.GetFieldCount() ).arg( f.attributes().count() ) );
+      pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( featureDefinition.GetFieldCount() ).arg( f.attributeCount() ) );
       continue;
     }
 

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -77,7 +77,10 @@ class CORE_EXPORT QgsFeature
     PyObject *attrs = sipConvertFromType( &attributes, sipType_QgsAttributes, Py_None );
     sipRes = PyObject_GetIter( attrs );
     % End
+#endif
 
+#ifdef SIP_PYQT5_RUN
+#ifdef SIP_RUN
     SIP_PYOBJECT __getitem__( int key ) SIP_HOLDGIL;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
@@ -90,8 +93,12 @@ class CORE_EXPORT QgsFeature
       const QVariant v = sipCpp->attribute( a0 );
       if ( QgsVariantUtils::isNull( v, true ) )
       {
-        QVariant *newV = new QVariant( v );
-        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+        PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
+        PyObject *args = PyTuple_Pack( 1, vartype );
+        PyTypeObject *typeObj = sipTypeAsPyTypeObject( sipType_QVariant );
+        sipRes = PyObject_Call( ( PyObject * )typeObj, args, nullptr );
+        Py_DECREF( args );
+        Py_DECREF( vartype );
       }
       else
       {
@@ -152,8 +159,77 @@ class CORE_EXPORT QgsFeature
       const QVariant v = sipCpp->attribute( fieldIdx );
       if ( QgsVariantUtils::isNull( v, true ) )
       {
-        QVariant *newV = new QVariant( v );
-        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+        PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
+        PyObject *args = PyTuple_Pack( 1, vartype );
+        PyTypeObject *typeObj = sipTypeAsPyTypeObject( sipType_QVariant );
+        sipRes = PyObject_Call( ( PyObject * )typeObj, args, nullptr );
+        Py_DECREF( args );
+        Py_DECREF( vartype );
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
+    }
+    % End
+#endif
+#endif
+
+#ifdef SIP_PYQT6_RUN
+#ifdef SIP_RUN
+    SIP_PYOBJECT __getitem__( int key ) SIP_HOLDGIL;
+    % MethodCode
+    if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
+    {
+      PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const QVariant v = sipCpp->attribute( a0 );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
       }
       else
       {
@@ -201,6 +277,71 @@ class CORE_EXPORT QgsFeature
     }
     % End
 
+    SIP_PYOBJECT __getitem__( const QString &name ) SIP_HOLDGIL;
+    % MethodCode
+    int fieldIdx = sipCpp->fieldNameIndex( *a0 );
+    if ( fieldIdx == -1 )
+    {
+      PyErr_SetString( PyExc_KeyError, a0->toLatin1() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const QVariant v = sipCpp->attribute( fieldIdx );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
+    }
+    % End
+#endif
+#endif
+
+#ifdef SIP_RUN
     void __setitem__( int key, SIP_PYOBJECT value SIP_TYPEHINT( Optional[Union[bool, int, float, str, QVariant]] ) ) SIP_HOLDGIL;
     % MethodCode
     bool rv;

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -30,6 +30,8 @@ email                : sherman at mrcc.com
 #include "qgsattributes.h"
 #include "qgsfields.h"
 #include "qgsfeatureid.h"
+#include "qgsvariantutils.h"
+
 #include <memory>
 class QgsFeature;
 class QgsFeaturePrivate;
@@ -78,16 +80,62 @@ class CORE_EXPORT QgsFeature
 
     SIP_PYOBJECT __getitem__( int key ) SIP_HOLDGIL;
     % MethodCode
-    QgsAttributes attrs = sipCpp->attributes();
-    if ( a0 < 0 || a0 >= attrs.count() )
+    if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
     {
       PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
       sipIsErr = 1;
     }
     else
     {
-      QVariant *v = new QVariant( attrs.at( a0 ) );
-      sipRes = sipConvertFromNewType( v, sipType_QVariant, Py_None );
+      const QVariant v = sipCpp->attribute( a0 );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        QVariant *newV = new QVariant( v );
+        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
     }
     % End
 
@@ -101,8 +149,55 @@ class CORE_EXPORT QgsFeature
     }
     else
     {
-      QVariant *v = new QVariant( sipCpp->attribute( fieldIdx ) );
-      sipRes = sipConvertFromNewType( v, sipType_QVariant, Py_None );
+      const QVariant v = sipCpp->attribute( fieldIdx );
+      if ( QgsVariantUtils::isNull( v, true ) )
+      {
+        QVariant *newV = new QVariant( v );
+        sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+      }
+      else
+      {
+        switch ( v.userType() )
+        {
+          case QMetaType::Type::Int:
+            sipRes = PyLong_FromLong( v.toInt() );
+            break;
+
+          case QMetaType::Type::UInt:
+            sipRes = PyLong_FromUnsignedLong( v.toUInt() );
+            break;
+
+          case QMetaType::Type::Long:
+          case QMetaType::Type::LongLong:
+            sipRes = PyLong_FromLongLong( v.toLongLong() );
+            break;
+
+          case QMetaType::Type::ULong:
+          case QMetaType::Type::ULongLong:
+            sipRes = PyLong_FromUnsignedLongLong( v.toULongLong() );
+            break;
+
+          case QMetaType::Type::Bool:
+            sipRes = PyBool_FromLong( v.toBool() ? 1 : 0 );
+            break;
+
+          case QMetaType::Type::Float:
+          case QMetaType::Type::Double:
+            sipRes = PyFloat_FromDouble( v.toDouble() );
+            break;
+
+          case QMetaType::Type::QString:
+            sipRes = PyUnicode_FromString( v.toString().toUtf8().constData() );
+            break;
+
+          default:
+          {
+            QVariant *newV = new QVariant( v );
+            sipRes = sipConvertFromNewType( newV, sipType_QVariant, Py_None );
+            break;
+          }
+        }
+      }
     }
     % End
 

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -91,7 +91,12 @@ class CORE_EXPORT QgsFeature
     else
     {
       const QVariant v = sipCpp->attribute( a0 );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      if ( !v.isValid() )
+      {
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
+      }
+      else if ( QgsVariantUtils::isNull( v, true ) )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );
@@ -157,7 +162,12 @@ class CORE_EXPORT QgsFeature
     else
     {
       const QVariant v = sipCpp->attribute( fieldIdx );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      if ( !v.isValid() )
+      {
+        Py_INCREF( Py_None );
+        sipRes = Py_None;
+      }
+      else if ( QgsVariantUtils::isNull( v, true ) )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -96,7 +96,8 @@ class CORE_EXPORT QgsFeature
         Py_INCREF( Py_None );
         sipRes = Py_None;
       }
-      else if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      else if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );
@@ -167,7 +168,8 @@ class CORE_EXPORT QgsFeature
         Py_INCREF( Py_None );
         sipRes = Py_None;
       }
-      else if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      else if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         PyObject *vartype = sipConvertFromEnum( v.type(), sipType_QVariant_Type );
         PyObject *args = PyTuple_Pack( 1, vartype );
@@ -236,7 +238,8 @@ class CORE_EXPORT QgsFeature
     else
     {
       const QVariant v = sipCpp->attribute( a0 );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         Py_INCREF( Py_None );
         sipRes = Py_None;
@@ -298,7 +301,8 @@ class CORE_EXPORT QgsFeature
     else
     {
       const QVariant v = sipCpp->attribute( fieldIdx );
-      if ( QgsVariantUtils::isNull( v, true ) )
+      // QByteArray null handling is "special"! See null_from_qvariant_converter in conversions.sip
+      if ( QgsVariantUtils::isNull( v, true ) && v.userType() != QMetaType::Type::QByteArray )
       {
         Py_INCREF( Py_None );
         sipRes = Py_None;

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -205,7 +205,7 @@ class CORE_EXPORT QgsFeature
 
     void __delitem__( int key ) SIP_HOLDGIL;
     % MethodCode
-    if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
+    if ( a0 >= 0 && a0 < sipCpp->attributeCount() )
       sipCpp->deleteAttribute( a0 );
     else
     {
@@ -337,7 +337,7 @@ class CORE_EXPORT QgsFeature
     SIP_PYOBJECT attributeMap() const SIP_HOLDGIL SIP_TYPEHINT( Dict[str, Optional[object]] );
     % MethodCode
     const int fieldSize = sipCpp->fields().size();
-    const int attributeSize = sipCpp->attributes().size();
+    const int attributeSize = sipCpp->attributeCount();
     if ( fieldSize == 0 && attributeSize != 0 )
     {
       PyErr_SetString( PyExc_ValueError, QStringLiteral( "Field definition has not been set for feature" ).toUtf8().constData() );
@@ -545,7 +545,7 @@ class CORE_EXPORT QgsFeature
      */
     void deleteAttribute( int field ) SIP_HOLDGIL;
     % MethodCode
-    if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
+    if ( a0 >= 0 && a0 < sipCpp->attributeCount() )
       sipCpp->deleteAttribute( a0 );
     else
     {
@@ -906,7 +906,7 @@ class CORE_EXPORT QgsFeature
     SIP_PYOBJECT attribute( int fieldIdx ) const SIP_HOLDGIL;
     % MethodCode
     {
-      if ( a0 < 0 || a0 >= sipCpp->attributes().count() )
+      if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
       {
         PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
         sipIsErr = 1;
@@ -942,7 +942,7 @@ class CORE_EXPORT QgsFeature
     bool isUnsetValue( int fieldIdx ) const SIP_HOLDGIL;
     % MethodCode
     {
-      if ( a0 < 0 || a0 >= sipCpp->attributes().count() )
+      if ( a0 < 0 || a0 >= sipCpp->attributeCount() )
       {
         PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
         sipIsErr = 1;

--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -135,9 +135,9 @@ bool QgsVectorLayerEditBuffer::addFeature( QgsFeature &f )
   {
     return false;
   }
-  if ( L->mFields.count() != f.attributes().count() )
+  if ( L->mFields.count() != f.attributeCount() )
   {
-    QgsMessageLog::logMessage( tr( "cannot add feature, wrong field count: layer: %1 feature: %2:" ).arg( L->mFields.count() ).arg( f.attributes().count() ) );
+    QgsMessageLog::logMessage( tr( "cannot add feature, wrong field count: layer: %1 feature: %2:" ).arg( L->mFields.count() ).arg( f.attributeCount() ) );
     return false;
   }
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -743,7 +743,7 @@ void QgsVectorLayerUtils::matchAttributesToFields( QgsFeature &feature, const Qg
   else
   {
     // no field name mapping in feature, just use order
-    const int lengthDiff = feature.attributes().count() - fields.count();
+    const int lengthDiff = feature.attributeCount() - fields.count();
     if ( lengthDiff > 0 )
     {
       // truncate extra attributes
@@ -755,7 +755,8 @@ void QgsVectorLayerUtils::matchAttributesToFields( QgsFeature &feature, const Qg
       // add missing null attributes
       QgsAttributes attributes = feature.attributes();
       attributes.reserve( fields.count() );
-      for ( int i = feature.attributes().count(); i < fields.count(); ++i )
+      const int attributeCount = feature.attributeCount();
+      for ( int i = attributeCount; i < fields.count(); ++i )
       {
         attributes.append( QgsVariantUtils::createNullVariant( fields.at( i ).type() ) );
       }

--- a/src/providers/grass/qgis.v.in.cpp
+++ b/src/providers/grass/qgis.v.in.cpp
@@ -455,7 +455,7 @@ int main( int argc, char **argv )
     {
       QgsPointXY point = it.value().geometry().asPoint();
 
-      if ( it.value().attributes().size() > 0 )
+      if ( it.value().attributeCount() > 0 )
       {
         Vect_reset_cats( cats );
         const auto constAttributes = it.value().attributes();

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3774,7 +3774,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, Qgis:
           {
             QgsFeature *feature = featIt.value();
 
-            QgsDebugMsgLevel( QStringLiteral( "feature id = %1 : %2 attributes" ).arg( featIt.key() ).arg( feature->attributes().size() ), 2 );
+            QgsDebugMsgLevel( QStringLiteral( "feature id = %1 : %2 attributes" ).arg( featIt.key() ).arg( feature->attributeCount() ), 2 );
 
             if ( coordinateTransform.isValid() && feature->hasGeometry() )
             {


### PR DESCRIPTION
- Avoid calling expensive sipConvertFromNewType method when feature attribute is a trivial type
- Also avoid a copy of the feature attributes which we don't require