### PR TITLE
Add group name to processing algorithm dialog title

### DIFF
--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -333,12 +333,13 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
   QString title;
   if ( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) && !( algorithm->flags() & Qgis::ProcessingAlgorithmFlag::DisplayNameIsLiteral ) )
   {
-    title = QgsStringUtils::capitalize( mAlgorithm->displayName(), Qgis::Capitalization::TitleCase );
+    title = QStringLiteral( "%1 - %2" ).arg( QgsStringUtils::capitalize( mAlgorithm->group(), Qgis::Capitalization::TitleCase ), QgsStringUtils::capitalize( mAlgorithm->displayName(), Qgis::Capitalization::TitleCase ) );
   }
   else
   {
-    title = mAlgorithm->displayName();
+    title = QStringLiteral( "%1 - %2" ).arg( mAlgorithm->group(), mAlgorithm->displayName() );
   }
+
   setWindowTitle( title );
 
   const QString algHelp = formatHelp( algorithm );


### PR DESCRIPTION
## Description

This shows the group from which a processing algorithm originates in the dialog title. This makes it easier to understand for a user, from where an algorithm is coming.

Context: The current "unqualified" dialog title was leading to confusion in a course yesterday where some people where opening the "Point Cloud - Clip" algorithm whereas they meant to use "Vector Layer - Clip" algorithm.

New:

![image](https://github.com/qgis/QGIS/assets/588407/ae481173-88b2-4d45-a396-92a23b0a0cad)

Old:

![image](https://github.com/qgis/QGIS/assets/588407/3ec703b8-f95d-4136-b16e-5d0583664d66)
