### PR TITLE
Add (non-exposed) setting for the external Python editor

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -156,11 +156,17 @@ Sets the widget's associated file ``path``.
 .. seealso:: :py:func:`filePath`
 %End
 
-    bool openInExternalEditor();
+    bool openInExternalEditor( int line = -1, int column = -1 );
 %Docstring
 Attempts to opens the script from the editor in an external text editor.
 
 This requires that the widget has an associated :py:func:`~QgsCodeEditorWidget.filePath` set.
+
+Optionally a target ``line`` and ``column`` number can be specified to open the editor
+at the corresponding location. (Not all external editors support this.) Line/column
+numbers of -1 indicate that the current cursor position should be used. A ``line``
+number of 0 corresponds to the first line, and a column number of 0 corresponds to
+the first column.
 
 :return: ``True`` if the file was opened successfully.
 %End

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -156,11 +156,17 @@ Sets the widget's associated file ``path``.
 .. seealso:: :py:func:`filePath`
 %End
 
-    bool openInExternalEditor();
+    bool openInExternalEditor( int line = -1, int column = -1 );
 %Docstring
 Attempts to opens the script from the editor in an external text editor.
 
 This requires that the widget has an associated :py:func:`~QgsCodeEditorWidget.filePath` set.
+
+Optionally a target ``line`` and ``column`` number can be specified to open the editor
+at the corresponding location. (Not all external editors support this.) Line/column
+numbers of -1 indicate that the current cursor position should be used. A ``line``
+number of 0 corresponds to the first line, and a column number of 0 corresponds to
+the first column.
 
 :return: ``True`` if the file was opened successfully.
 %End

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -50,6 +50,7 @@ const QgsSettingsEntryInteger *QgsCodeEditorPython::settingMaxLineLength = new Q
 const QgsSettingsEntryBool *QgsCodeEditorPython::settingSortImports = new QgsSettingsEntryBool( QStringLiteral( "sort-imports" ), sTreePythonCodeEditor, true, QStringLiteral( "Whether imports should be sorted when auto-formatting code" ) );
 const QgsSettingsEntryInteger *QgsCodeEditorPython::settingAutopep8Level = new QgsSettingsEntryInteger( QStringLiteral( "autopep8-level" ), sTreePythonCodeEditor, 1, QStringLiteral( "Autopep8 aggressive level" ) );
 const QgsSettingsEntryBool *QgsCodeEditorPython::settingBlackNormalizeQuotes = new QgsSettingsEntryBool( QStringLiteral( "black-normalize-quotes" ), sTreePythonCodeEditor, true, QStringLiteral( "Whether quotes should be normalized when auto-formatting code using black" ) );
+const QgsSettingsEntryString *QgsCodeEditorPython::settingExternalPythonEditorCommand = new QgsSettingsEntryString( QStringLiteral( "external-editor" ), sTreePythonCodeEditor, QString(), QStringLiteral( "Command to launch an external Python code editor. Use the token <file> to insert the filename, <line> to insert line number, and <col> to insert the column number." ) );
 ///@endcond PRIVATE
 
 

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -61,6 +61,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
     static const QgsSettingsEntryBool *settingSortImports;
     static const QgsSettingsEntryInteger *settingAutopep8Level;
     static const QgsSettingsEntryBool *settingBlackNormalizeQuotes;
+    static const QgsSettingsEntryString *settingExternalPythonEditorCommand;
 ///@endcond PRIVATE
 #endif
 

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -169,9 +169,15 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      *
      * This requires that the widget has an associated filePath() set.
      *
+     * Optionally a target \a line and \a column number can be specified to open the editor
+     * at the corresponding location. (Not all external editors support this.) Line/column
+     * numbers of -1 indicate that the current cursor position should be used. A \a line
+     * number of 0 corresponds to the first line, and a column number of 0 corresponds to
+     * the first column.
+     *
      * \returns TRUE if the file was opened successfully.
      */
-    bool openInExternalEditor();
+    bool openInExternalEditor( int line = -1, int column = -1 );
 
   signals:
 


### PR DESCRIPTION
This isn't exposed in the GUI, but allows users to set a specific editor command to use when opening
Python files in the external editor.

Use the token <file> to insert the filename, <line> to insert line number, and <col> to insert the column number.

Eg:

    QgsSettings().setValue(
      'gui/code-editor/python/external-editor',
      'kate -l <line> -c <col> "<file>"')

This is considerably nicer than just assuming the system text editor is appropriate for Python files. (We can expose this as a user-facing setting in 3.40.)