### PR TITLE
Move console script editor external file watching logic to QgsCodeEditorWidget

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsCodeEditorWidget : QgsPanelWidget
 {
 %Docstring(signature="appended")
@@ -49,6 +50,8 @@ feedback, otherwise an integrated message bar will be used.
     virtual void resizeEvent( QResizeEvent *event );
 
     virtual void showEvent( QShowEvent *event );
+
+    virtual bool eventFilter( QObject *obj, QEvent *event );
 
 
     QgsCodeEditor *editor();

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -147,9 +147,21 @@ This will automatically open the search bar and start a find operation using
 the default behavior, e.g. searching for any selected text in the code editor.
 %End
 
+    bool loadFile( const QString &path );
+%Docstring
+Loads the file at the specified ``path`` into the widget, replacing the code editor's
+content with that from the file.
+
+This automatically sets the widget's :py:func:`~QgsCodeEditorWidget.filePath`
+
+Returns ``True`` if the file was loaded successfully.
+%End
+
     void setFilePath( const QString &path );
 %Docstring
 Sets the widget's associated file ``path``.
+
+.. seealso:: :py:func:`loadFile`
 
 .. seealso:: :py:func:`filePathChanged`
 
@@ -179,6 +191,12 @@ Emitted when the widget's associated file path is changed.
 .. seealso:: :py:func:`setFilePath`
 
 .. seealso:: :py:func:`filePath`
+%End
+
+    void loadedExternalChanges();
+%Docstring
+Emitted when the widget loads in text from the associated file to bring in
+changes made externally to the file.
 %End
 
 };

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -626,7 +626,9 @@ class PythonConsoleWidget(QWidget):
         if not index:
             index = self.tabEditorWidget.currentIndex()
         if not tabWidget.file_path():
-            fileName = self.tabEditorWidget.tabText(index).replace('*', '') + '.py'
+            fileName = self.tabEditorWidget.tabText(index).replace('*', '')
+            fileName = QgsFileUtils.ensureFileNameHasExtension(fileName,
+                                                               ['py'])
             folder = QgsSettings().value("pythonConsole/lastDirPath", QDir.homePath())
             pathFileName = os.path.join(folder, fileName)
             fileNone = True

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -424,14 +424,6 @@ class Editor(QgsCodeEditorPython):
                                              'The file <b>"{0}"</b> is read only, please save to different file first.').format(self.code_editor_widget.filePath())
         self.showMessage(msgText)
 
-    def loadFile(self, filename: str, read_only: bool = False):
-        self.lastModified = QFileInfo(filename).lastModified()
-        self.code_editor_widget.setFilePath(filename)
-        self.setText(Path(filename).read_text(encoding='utf-8'))
-        self.setReadOnly(read_only)
-        self.setModified(False)
-        self.recolor()
-
     def save(self, filename: Optional[str] = None):
         if self.isReadOnly():
             return
@@ -468,7 +460,6 @@ class Editor(QgsCodeEditorPython):
         self.tab_widget.setTabToolTip(index, self.code_editor_widget.filePath())
         self.setModified(False)
         self.console_widget.saveFileButton.setEnabled(False)
-        self.lastModified = QFileInfo(self.code_editor_widget.filePath()).lastModified()
         self.console_widget.updateTabListScript(self.code_editor_widget.filePath(), action='append')
         self.tab_widget.listObject(self.editor_tab)
         QgsSettings().setValue("pythonConsole/lastDirPath",
@@ -556,7 +547,9 @@ class EditorTab(QWidget):
 
         if filename:
             if QFileInfo(filename).exists():
-                self._editor.loadFile(filename, read_only)
+                self._editor_code_widget.loadFile(filename)
+                if read_only:
+                    self._editor.setReadOnly(True)
 
         self.tabLayout = QGridLayout(self)
         self.tabLayout.setContentsMargins(0, 0, 0, 0)

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -51,6 +51,8 @@ feedback, otherwise an integrated message bar will be used.
 
     virtual void showEvent( QShowEvent *event );
 
+    virtual bool eventFilter( QObject *obj, QEvent *event );
+
 
     QgsCodeEditor *editor();
 %Docstring

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsCodeEditorWidget : QgsPanelWidget
 {
 %Docstring(signature="appended")
@@ -147,9 +148,21 @@ This will automatically open the search bar and start a find operation using
 the default behavior, e.g. searching for any selected text in the code editor.
 %End
 
+    bool loadFile( const QString &path );
+%Docstring
+Loads the file at the specified ``path`` into the widget, replacing the code editor's
+content with that from the file.
+
+This automatically sets the widget's :py:func:`~QgsCodeEditorWidget.filePath`
+
+Returns ``True`` if the file was loaded successfully.
+%End
+
     void setFilePath( const QString &path );
 %Docstring
 Sets the widget's associated file ``path``.
+
+.. seealso:: :py:func:`loadFile`
 
 .. seealso:: :py:func:`filePathChanged`
 
@@ -179,6 +192,12 @@ Emitted when the widget's associated file path is changed.
 .. seealso:: :py:func:`setFilePath`
 
 .. seealso:: :py:func:`filePath`
+%End
+
+    void loadedExternalChanges();
+%Docstring
+Emitted when the widget loads in text from the associated file to bring in
+changes made externally to the file.
 %End
 
 };

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -149,7 +149,6 @@ class ScriptEditorDialog(BASE, WIDGET):
 
         self.run_dialog = None
 
-        self.filePath = None
         if filePath is not None:
             self._loadFile(filePath)
 
@@ -159,8 +158,10 @@ class ScriptEditorDialog(BASE, WIDGET):
         """
         Updates the script editor dialog title
         """
-        if self.filePath:
-            path, file_name = os.path.split(self.filePath)
+        if self.code_editor_widget.filePath():
+            path, file_name = os.path.split(
+                self.code_editor_widget.filePath()
+            )
         else:
             file_name = self.tr('Untitled Script')
 
@@ -219,7 +220,7 @@ class ScriptEditorDialog(BASE, WIDGET):
 
     def saveScript(self, saveAs):
         newPath = None
-        if self.filePath is None or saveAs:
+        if not self.code_editor_widget.filePath() or saveAs:
             scriptDir = ScriptUtils.scriptsFolders()[0]
             newPath, _ = QFileDialog.getSaveFileName(self,
                                                      self.tr("Save script"),
@@ -230,12 +231,13 @@ class ScriptEditorDialog(BASE, WIDGET):
                 if not newPath.lower().endswith(".py"):
                     newPath += ".py"
 
-                self.filePath = newPath
+                self.code_editor_widget.setFilePath(newPath)
 
-        if self.filePath:
+        if self.code_editor_widget.filePath():
             text = self.editor.text()
             try:
-                with codecs.open(self.filePath, "w", encoding="utf-8") as f:
+                with codecs.open(self.code_editor_widget.filePath(),
+                                 "w", encoding="utf-8") as f:
                     f.write(text)
             except OSError as e:
                 QMessageBox.warning(self,
@@ -307,13 +309,8 @@ class ScriptEditorDialog(BASE, WIDGET):
             canvas.setMapTool(prevMapTool)
 
     def _loadFile(self, filePath):
-        with codecs.open(filePath, "r", encoding="utf-8") as f:
-            txt = f.read()
 
-        self.editor.setText(txt)
+        self.code_editor_widget.loadFile(filePath)
         self.hasChanged = False
-        self.editor.setModified(False)
-        self.editor.recolor()
 
-        self.filePath = filePath
         self.update_dialog_title()

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -40,6 +40,7 @@ from qgis.gui import (
 )
 from qgis.core import (
     QgsApplication,
+    QgsFileUtils,
     QgsSettings,
     QgsError,
     QgsProcessingAlgorithm,
@@ -228,9 +229,7 @@ class ScriptEditorDialog(BASE, WIDGET):
                                                      self.tr("Processing scripts (*.py *.PY)"))
 
             if newPath:
-                if not newPath.lower().endswith(".py"):
-                    newPath += ".py"
-
+                newPath = QgsFileUtils.ensureFileNameHasExtension(newPath, ['py'])
                 self.code_editor_widget.setFilePath(newPath)
 
         if self.code_editor_widget.filePath():

--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -341,6 +341,25 @@ void QgsCodeEditorWidget::triggerFind()
   showSearchBar();
 }
 
+bool QgsCodeEditorWidget::loadFile( const QString &path )
+{
+  if ( !QFile::exists( path ) )
+    return false;
+
+  QFile file( path );
+  if ( file.open( QFile::ReadOnly ) )
+  {
+    const QString content = file.readAll();
+    mEditor->setText( content );
+    mEditor->setModified( false );
+    mEditor->recolor();
+    mLastModified = QFileInfo( path ).lastModified();
+    setFilePath( path );
+    return true;
+  }
+  return false;
+}
+
 void QgsCodeEditorWidget::setFilePath( const QString &path )
 {
   if ( mFilePath == path )

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -20,6 +20,8 @@
 #include "qgis_sip.h"
 #include "qgspanelwidget.h"
 
+#include <QDateTime>
+
 class QgsCodeEditor;
 class QgsFilterLineEdit;
 class QToolButton;
@@ -157,8 +159,19 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
     void triggerFind();
 
     /**
+     * Loads the file at the specified \a path into the widget, replacing the code editor's
+     * content with that from the file.
+     *
+     * This automatically sets the widget's filePath()
+     *
+     * Returns TRUE if the file was loaded successfully.
+     */
+    bool loadFile( const QString &path );
+
+    /**
      * Sets the widget's associated file \a path.
      *
+     * \see loadFile()
      * \see filePathChanged()
      * \see filePath()
      */
@@ -187,6 +200,12 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      * \see filePath()
      */
     void filePathChanged( const QString &path );
+
+    /**
+     * Emitted when the widget loads in text from the associated file to bring in
+     * changes made externally to the file.
+     */
+    void loadedExternalChanges();
 
   private slots:
 
@@ -230,6 +249,7 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
     QgsMessageBar *mMessageBar = nullptr;
     std::unique_ptr< QgsScrollBarHighlightController > mHighlightController;
     QString mFilePath;
+    QDateTime mLastModified;
 };
 
 #endif // QGSCODEEDITORWIDGET_H

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -66,6 +66,7 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
 
     void resizeEvent( QResizeEvent *event ) override;
     void showEvent( QShowEvent *event ) override;
+    bool eventFilter( QObject *obj, QEvent *event ) override;
 
     /**
      * Returns the wrapped code editor.


### PR DESCRIPTION
Ensures a consistent behavior between console script editor and eg processing script editor