### PR TITLE
Expose setting for external Python editor

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -91,7 +91,7 @@ def console_displayhook(obj):
 def init_options_widget():
     """ called from QGIS to add the console options widget """
     global _options_factory
-    _options_factory.setTitle(QCoreApplication.translate("PythonConsole", "Python Console"))
+    _options_factory.setTitle(QCoreApplication.translate("PythonConsole", "Python"))
     iface.registerOptionsWidgetFactory(_options_factory)
 
 

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -221,6 +221,8 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         pythonSettingsTreeNode.childSetting("autopep8-level").setValue(self.autopep8Level.value())
         pythonSettingsTreeNode.childSetting("black-normalize-quotes").setValue(self.blackNormalizeQuotes.isChecked())
         pythonSettingsTreeNode.childSetting("max-line-length").setValue(self.maxLineLength.value())
+        pythonSettingsTreeNode.childSetting('external-editor').setValue(
+            self.externalEditor.text())
 
     def restoreSettings(self):
         settings = QgsSettings()
@@ -262,6 +264,10 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
             self.autoCompFromAPI.setChecked(True)
         elif settings.value("pythonConsole/autoCompleteSource") == 'fromDocAPI':
             self.autoCompFromDocAPI.setChecked(True)
+
+        self.externalEditor.setText(
+            pythonSettingsTreeNode.childSetting('external-editor').value()
+        )
 
     def onFormatterChanged(self):
         """ Toggle formatter-specific options visibility when the formatter is changed """

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -52,9 +52,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>789</width>
-        <height>974</height>
+        <y>-192</y>
+        <width>775</width>
+        <height>1166</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -173,6 +173,20 @@
           <property name="verticalSpacing">
            <number>2</number>
           </property>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="sortImports">
+            <property name="text">
+             <string>Sort imports</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Maximum line length</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
            <widget class="QgsSpinBox" name="maxLineLength">
             <property name="minimum">
@@ -183,51 +197,6 @@
             </property>
             <property name="value">
              <number>80</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="formatOnSave">
-            <property name="text">
-             <string>Reformat on save</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="2">
-           <widget class="QCheckBox" name="blackNormalizeQuotes">
-            <property name="text">
-             <string>Normalize quotes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="formatter">
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QCheckBox" name="sortImports">
-            <property name="text">
-             <string>Sort imports</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="autopep8LevelLabel">
-            <property name="text">
-             <string>Autopep8 level</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Maximum line length</string>
             </property>
            </widget>
           </item>
@@ -248,6 +217,37 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="autopep8LevelLabel">
+            <property name="text">
+             <string>Autopep8 level</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QCheckBox" name="blackNormalizeQuotes">
+            <property name="text">
+             <string>Normalize quotes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="formatOnSave">
+            <property name="text">
+             <string>Reformat on save</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="formatter">
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="2">
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
@@ -265,7 +265,7 @@
         </widget>
        </item>
        <item row="6" column="0">
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QgsCollapsibleGroupBox" name="groupBox">
          <property name="title">
           <string>GitHub Access Token</string>
          </property>
@@ -321,6 +321,19 @@
           </item>
          </layout>
         </widget>
+       </item>
+       <item row="8" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item row="5" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBoxApi">
@@ -564,17 +577,33 @@
         </widget>
        </item>
        <item row="7" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+        <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>External Editor</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
+         <layout class="QGridLayout" name="gridLayout_8">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Command to launch an external Python code editor. If empty, the default system editor will be used.&lt;/p&gt;&lt;p&gt;Use the token &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;file&amp;gt;&lt;/span&gt; to insert the filename, &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;line&amp;gt;&lt;/span&gt; to insert line number, and &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;col&amp;gt;&lt;/span&gt; to insert the column number. For example:&lt;br/&gt;&lt;span style=&quot; font-family:'Noto Sans Mono';&quot;&gt;kate -l &amp;lt;line&amp;gt; -c &amp;lt;col&amp;gt; &amp;quot;&amp;lt;file&amp;gt;&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextBrowserInteraction</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QgsFilterLineEdit" name="externalEditor">
+            <property name="placeholderText">
+             <string>Default</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -592,6 +621,11 @@
   <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
    <header>qgis.gui</header>
   </customwidget>
  </customwidgets>

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>809</width>
-    <height>860</height>
+    <height>974</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -53,8 +53,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>775</width>
-        <height>879</height>
+        <width>789</width>
+        <height>974</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -70,6 +70,200 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
+       <item row="0" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
+         <property name="title">
+          <string>Autocompletion</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="saveCheckedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_36">
+            <property name="text">
+             <string>characters</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="autoCompThreshold">
+            <property name="maximum">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Autocompletion threshold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="3">
+           <layout class="QGridLayout" name="layoutRadioButton">
+            <item row="0" column="2">
+             <widget class="QRadioButton" name="autoCompFromDocAPI">
+              <property name="toolTip">
+               <string>Get autocompletion from current document and installed APIs</string>
+              </property>
+              <property name="text">
+               <string>From doc and APIs</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QRadioButton" name="autoCompFromAPI">
+              <property name="toolTip">
+               <string>Get autocompletion from installed APIs</string>
+              </property>
+              <property name="text">
+               <string>From API files</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="autoCompFromDoc">
+              <property name="toolTip">
+               <string>Get autocompletion from current document</string>
+              </property>
+              <property name="text">
+               <string>From document</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxFromatting">
+         <property name="title">
+          <string>Formatting</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
+          <item row="2" column="1">
+           <widget class="QgsSpinBox" name="maxLineLength">
+            <property name="minimum">
+             <number>60</number>
+            </property>
+            <property name="maximum">
+             <number>200</number>
+            </property>
+            <property name="value">
+             <number>80</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="formatOnSave">
+            <property name="text">
+             <string>Reformat on save</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QCheckBox" name="blackNormalizeQuotes">
+            <property name="text">
+             <string>Normalize quotes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="formatter">
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="sortImports">
+            <property name="text">
+             <string>Sort imports</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="autopep8LevelLabel">
+            <property name="text">
+             <string>Autopep8 level</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Maximum line length</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Formatter</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QgsSpinBox" name="autopep8Level">
+            <property name="maximum">
+             <number>3</number>
+            </property>
+            <property name="value">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item row="6" column="0">
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
@@ -87,6 +281,41 @@
            <widget class="QPushButton" name="generateToken">
             <property name="text">
              <string>Generate</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxRunDebugEditor">
+         <property name="title">
+          <string>Run and Debug</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_21">
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="autoSaveScript">
+            <property name="text">
+             <string>Auto-save script before running</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="enableObjectInspector">
+            <property name="text">
+             <string>Enable Object Inspector (switching between tabs may be slow)</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -334,234 +563,18 @@
          </layout>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBoxRunDebugEditor">
-         <property name="title">
-          <string>Run and Debug</string>
+       <item row="7" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="collapsed" stdset="0">
-          <bool>true</bool>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-         <property name="saveCollapsedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_21">
-          <property name="verticalSpacing">
-           <number>2</number>
-          </property>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="autoSaveScript">
-            <property name="text">
-             <string>Auto-save script before running</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="enableObjectInspector">
-            <property name="text">
-             <string>Enable Object Inspector (switching between tabs may be slow)</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
-         <property name="title">
-          <string>Autocompletion</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="saveCheckedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="saveCollapsedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <property name="verticalSpacing">
-           <number>2</number>
-          </property>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_36">
-            <property name="text">
-             <string>characters</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="autoCompThreshold">
-            <property name="maximum">
-             <number>10</number>
-            </property>
-            <property name="value">
-             <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Autocompletion threshold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="3">
-           <layout class="QGridLayout" name="layoutRadioButton">
-            <item row="0" column="2">
-             <widget class="QRadioButton" name="autoCompFromDocAPI">
-              <property name="toolTip">
-               <string>Get autocompletion from current document and installed APIs</string>
-              </property>
-              <property name="text">
-               <string>From doc and APIs</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QRadioButton" name="autoCompFromAPI">
-              <property name="toolTip">
-               <string>Get autocompletion from installed APIs</string>
-              </property>
-              <property name="text">
-               <string>From API files</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="autoCompFromDoc">
-              <property name="toolTip">
-               <string>Get autocompletion from current document</string>
-              </property>
-              <property name="text">
-               <string>From document</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBoxFromatting">
-         <property name="title">
-          <string>Formatting</string>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="saveCollapsedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_4">
-          <property name="verticalSpacing">
-           <number>2</number>
-          </property>
-          <item row="2" column="1">
-           <widget class="QgsSpinBox" name="maxLineLength">
-            <property name="minimum">
-             <number>60</number>
-            </property>
-            <property name="maximum">
-             <number>200</number>
-            </property>
-            <property name="value">
-             <number>80</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="formatOnSave">
-            <property name="text">
-             <string>Reformat on save</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="2">
-           <widget class="QCheckBox" name="blackNormalizeQuotes">
-            <property name="text">
-             <string>Normalize quotes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="formatter">
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QCheckBox" name="sortImports">
-            <property name="text">
-             <string>Sort imports</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="autopep8LevelLabel">
-            <property name="text">
-             <string>Autopep8 level</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Maximum line length</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Formatter</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QgsSpinBox" name="autopep8Level">
-            <property name="maximum">
-             <number>3</number>
-            </property>
-            <property name="value">
-             <number>1</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Adds user visible option to set the external Python code editor, from the Settings - Options - IDE - Python tab:

![image](https://github.com/qgis/QGIS/assets/1829991/926fffc9-a150-41b2-9134-251ffddb2b49)
