### PR TITLE
Tweak GRASS plugins metadata

### DIFF
--- a/python/plugins/grassprovider/metadata.txt
+++ b/python/plugins/grassprovider/metadata.txt
@@ -1,17 +1,16 @@
 [general]
-name=GRASS GIS provider
+name=GRASS GIS Processing Provider
 description=GRASS GIS Processing provider
-about=GRASS GIS Processing provider
+about=Exposes selected GRASS GIS algorithms and tools for use within the QGIS Processing framework.
 category=Analysis
 version=2.12.99
 qgisMinimumVersion=3.0
 supportsQt6=yes
-author=Victor Olaya
 
 icon=:/images/themes/default/providerGrass.svg
 
-homepage=https://qgis.org
+homepage=https://grass.osgeo.org
 tracker=https://github.com/qgis/QGIS/issues
-repository=https://github.com/qgis/QGIS
+repository=https://github.com/qgis/QGIS/tree/master/python/plugins/grassprovider
 
 hasProcessingProvider=yes

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -54,7 +54,7 @@ extern "C"
 #include <grass/version.h>
 }
 
-static const QString pluginName = QObject::tr( "GRASS %1" ).arg( GRASS_VERSION_MAJOR );
+static const QString pluginName = QObject::tr( "GRASS %1 (deprecated plugin)" ).arg( GRASS_VERSION_MAJOR );
 static const QString pluginDescription = QObject::tr( "GRASS %1 (Geographic Resources Analysis Support System)" ).arg( GRASS_VERSION_MAJOR );
 static const QString pluginCategory = QObject::tr( "Plugins" );
 static const QString pluginVersion = QObject::tr( "Version 2.0" );


### PR DESCRIPTION
Following recommendations from the GRASS developer meetup:

- Make it clear that the old c++ plugin is deprecated
- Change links for processing grass plugin to more relevant links
- Remove outdated information from processing provider metadata
