### PR TITLE
[relations] Fix problematic polymorphic relation's generated relation IDs

### DIFF
--- a/src/core/qgspolymorphicrelation.cpp
+++ b/src/core/qgspolymorphicrelation.cpp
@@ -385,9 +385,9 @@ QList<QgsRelation> QgsPolymorphicRelation::generateRelations() const
   for ( const QString &referencedLayerId : referencedLayerIds )
   {
     QgsRelation relation;
-    QString referencedLayerName = d->mReferencedLayersMap[referencedLayerId]->name();
+    const QString referencedLayerName = d->mReferencedLayersMap[referencedLayerId]->name();
 
-    relation.setId( QStringLiteral( "%1_%2" ).arg( d->mRelationId, referencedLayerName ) );
+    relation.setId( QStringLiteral( "%1_%2" ).arg( d->mRelationId, referencedLayerId ) );
     relation.setReferencedLayer( referencedLayerId );
     relation.setReferencingLayer( d->mReferencingLayerId );
     relation.setName( QStringLiteral( "Generated for \"%1\"" ).arg( referencedLayerName ) );
@@ -405,6 +405,24 @@ QList<QgsRelation> QgsPolymorphicRelation::generateRelations() const
   }
 
   return relations;
+}
+
+QString QgsPolymorphicRelation::upgradeGeneratedRelationId( const QString &oldRelationId ) const
+{
+  if ( !isValid() )
+    return QString();
+
+  const QStringList referencedLayerIds = d->mReferencedLayerIds;
+  for ( const QString &referencedLayerId : referencedLayerIds )
+  {
+    const QString referencedLayerName = d->mReferencedLayersMap[referencedLayerId]->name();
+    if ( oldRelationId == QStringLiteral( "%1_%2" ).arg( d->mRelationId, referencedLayerName ) )
+    {
+      return QStringLiteral( "%1_%2" ).arg( d->mRelationId, referencedLayerId );
+    }
+  }
+
+  return QString();
 }
 
 QString QgsPolymorphicRelation::layerRepresentation( const QgsVectorLayer *layer ) const

--- a/src/core/qgspolymorphicrelation.h
+++ b/src/core/qgspolymorphicrelation.h
@@ -285,6 +285,10 @@ class CORE_EXPORT QgsPolymorphicRelation
     void setRelationStrength( Qgis::RelationshipStrength relationStrength );
 
   private:
+    friend class QgsRelationManager;
+
+    //! Upgrades a relation ID to a stabler ID former if generated using QGIS < 3.38
+    QString upgradeGeneratedRelationId( const QString &oldRelationId ) const;
 
     QExplicitlySharedDataPointer<QgsPolymorphicRelationPrivate> d;
 

--- a/src/core/qgsrelationmanager.cpp
+++ b/src/core/qgsrelationmanager.cpp
@@ -93,6 +93,20 @@ void QgsRelationManager::removeRelation( const QgsRelation &relation )
 
 QgsRelation QgsRelationManager::relation( const QString &id ) const
 {
+  if ( !mRelations.contains( id ) )
+  {
+    // Check whether the provided ID refers to a polymorphic relation's generated ID
+    // from older versions of QGIS that used layer names instead of stable layer IDs.
+    const QList<QString> keys = mPolymorphicRelations.keys();
+    for ( const QString &key : keys )
+    {
+      if ( id.startsWith( key ) )
+      {
+        return mRelations.value( mPolymorphicRelations[key].upgradeGeneratedRelationId( id ) );
+      }
+    }
+  }
+
   return mRelations.value( id );
 }
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/47445 by insuring that polymorphic relations' generated relations rely on generated IDs that will remain valid if users change the referenced layer name.

~~To avoid breaking preexisting projects, relations using the weaker IDs (using layer name instead of layer ID) are also generated with a (deprecated) suffix added to their names. A //TODO is added to remove this whenever we hop onto QGIS 4 where we can break things ;)~~ The relation ID is automatically updated by the relation manager, insuring projects saved prior to this change don't break. 

I'd suggest backporting to LTR, IMHO a worthy fix. Among other things, it allows for polymorphic relationships to not go broken with translated projects.