### PR TITLE
Fix removal of multiple selected connections from browser

### DIFF
--- a/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
@@ -300,6 +300,7 @@ Sets the capabilities for the data item.
     static int findItem( QVector<QgsDataItem *> items, QgsDataItem *item );
 
 
+
     Qgis::BrowserItemType type() const;
 
     QgsDataItem *parent() const;

--- a/python/PyQt6/gui/auto_generated/qgsdataitemguiproviderutils.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsdataitemguiproviderutils.sip.in
@@ -1,0 +1,35 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdataitemguiproviderutils.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsDataItemGuiProviderUtils
+{
+%Docstring(signature="appended")
+
+Utility functions for :py:class:`QgsDataItemGuiProviders`.
+
+.. versionadded:: 3.38
+%End
+
+%TypeHeaderCode
+#include "qgsdataitemguiproviderutils.h"
+%End
+  public:
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdataitemguiproviderutils.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/PyQt6/gui/gui_auto.sip
+++ b/python/PyQt6/gui/gui_auto.sip
@@ -44,6 +44,7 @@
 %Include auto_generated/qgsdatabasetablecombobox.sip
 %Include auto_generated/qgsdataitemguiprovider.sip
 %Include auto_generated/qgsdataitemguiproviderregistry.sip
+%Include auto_generated/qgsdataitemguiproviderutils.sip
 %Include auto_generated/qgsdatasourceselectdialog.sip
 %Include auto_generated/qgsdbrelationshipwidget.sip
 %Include auto_generated/qgsdecoratedscrollbar.sip

--- a/python/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdataitem.sip.in
@@ -300,6 +300,7 @@ Sets the capabilities for the data item.
     static int findItem( QVector<QgsDataItem *> items, QgsDataItem *item );
 
 
+
     Qgis::BrowserItemType type() const;
 
     QgsDataItem *parent() const;

--- a/python/gui/auto_generated/qgsdataitemguiproviderutils.sip.in
+++ b/python/gui/auto_generated/qgsdataitemguiproviderutils.sip.in
@@ -1,0 +1,35 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdataitemguiproviderutils.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsDataItemGuiProviderUtils
+{
+%Docstring(signature="appended")
+
+Utility functions for :py:class:`QgsDataItemGuiProviders`.
+
+.. versionadded:: 3.38
+%End
+
+%TypeHeaderCode
+#include "qgsdataitemguiproviderutils.h"
+%End
+  public:
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdataitemguiproviderutils.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -44,6 +44,7 @@
 %Include auto_generated/qgsdatabasetablecombobox.sip
 %Include auto_generated/qgsdataitemguiprovider.sip
 %Include auto_generated/qgsdataitemguiproviderregistry.sip
+%Include auto_generated/qgsdataitemguiproviderutils.sip
 %Include auto_generated/qgsdatasourceselectdialog.sip
 %Include auto_generated/qgsdbrelationshipwidget.sip
 %Include auto_generated/qgsdecoratedscrollbar.sip

--- a/src/core/browser/qgsdataitem.h
+++ b/src/core/browser/qgsdataitem.h
@@ -313,6 +313,27 @@ class CORE_EXPORT QgsDataItem : public QObject
     // Find child index in vector of items using '==' operator
     static int findItem( QVector<QgsDataItem *> items, QgsDataItem *item );
 
+#ifndef SIP_RUN
+
+    /**
+     * Returns a filtered list of data \a items which match the template type.
+     *
+     * \since QGIS 3.38
+     */
+    template<class T>
+    static QList< T * > filteredItems( const QList< QgsDataItem * > &items )
+    {
+      QList< T * > result;
+      result.reserve( items.size() );
+      for ( QgsDataItem *item : items )
+      {
+        if ( T *matchedItem = qobject_cast< T * >( item ) )
+          result << matchedItem;
+      }
+      return result;
+    }
+#endif
+
     // members
 
     Qgis::BrowserItemType type() const { return mType; }

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -551,6 +551,7 @@ set(QGIS_GUI_SRCS
   qgsdatabasetablecombobox.cpp
   qgsdataitemguiprovider.cpp
   qgsdataitemguiproviderregistry.cpp
+  qgsdataitemguiproviderutils.cpp
   qgsdatasourceselectdialog.cpp
   qgsdbqueryhistoryprovider.cpp
   qgsdbrelationshipwidget.cpp
@@ -822,6 +823,7 @@ set(QGIS_GUI_HDRS
   qgsdatabasetablecombobox.h
   qgsdataitemguiprovider.h
   qgsdataitemguiproviderregistry.h
+  qgsdataitemguiproviderutils.h
   qgsdatasourcemanagerdialog.h
   qgsdatasourceselectdialog.h
   qgsdbqueryhistoryprovider.h

--- a/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.h
+++ b/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.h
@@ -34,7 +34,6 @@ class QgsSensorThingsDataItemGuiProvider : public QObject, public QgsDataItemGui
 
   private:
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/gui/qgsdataitemguiproviderutils.cpp
+++ b/src/gui/qgsdataitemguiproviderutils.cpp
@@ -1,0 +1,48 @@
+/***************************************************************************
+  qgsdataitemguiproviderutils.cpp
+  --------------------------------------
+  Date                 : June 2024
+  Copyright            : (C) 2024 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdataitemguiproviderutils.h"
+#include "qgsdataitem.h"
+#include "qgsdataitemguiprovider.h"
+
+#include <QPointer>
+#include <QMessageBox>
+
+void QgsDataItemGuiProviderUtils::deleteConnectionsPrivate( const QStringList &connectionNames, const std::function<void ( const QString & )> &deleteConnection, QPointer< QgsDataItem > firstParent )
+{
+  if ( connectionNames.size() > 1 )
+  {
+    if ( QMessageBox::question( nullptr,
+                                QObject::tr( "Remove Connections" ),
+                                QObject::tr( "Are you sure you want to remove all %1 selected connections?" ).arg( connectionNames.size() ),
+                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+      return;
+  }
+  else
+  {
+    if ( QMessageBox::question( nullptr, QObject::tr( "Remove Connection" ),
+                                QObject::tr( "Are you sure you want to remove the connection to “%1”?" ).arg( connectionNames.at( 0 ) ),
+                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+      return;
+  }
+
+  for ( const QString &connectionName : std::as_const( connectionNames ) )
+  {
+    deleteConnection( connectionName );
+  }
+
+  if ( firstParent )
+    firstParent->refreshConnections();
+}

--- a/src/gui/qgsdataitemguiproviderutils.h
+++ b/src/gui/qgsdataitemguiproviderutils.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+  qgsdataitemguiproviderutils.h
+  --------------------------------------
+  Date                 : June 2024
+  Copyright            : (C) 2024 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDATAITEMGUIPROVIDERUTILS_H
+#define QGSDATAITEMGUIPROVIDERUTILS_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgis.h"
+#include "qgsdataitem.h"
+#include "qgsdataitemguiprovider.h"
+#include <QPointer>
+#include <functional>
+
+class QgsDataItem;
+
+/**
+ * \class QgsDataItemGuiProviderUtils
+ * \ingroup gui
+ *
+ * \brief Utility functions for QgsDataItemGuiProviders.
+ *
+ * \since QGIS 3.38
+ */
+class GUI_EXPORT QgsDataItemGuiProviderUtils
+{
+  public:
+
+#ifndef SIP_RUN
+
+    /**
+     * Handles deletion of a list of connection \a items.
+     *
+     * \note Not available in Python bindings
+     */
+    template<class T>
+    static void deleteConnections( const QList< T * > &items, const std::function< void( const QString & ) > &deleteConnection, QgsDataItemGuiContext context )
+    {
+      ( void )context;
+      if ( items.empty() )
+        return;
+
+      QStringList connectionNames;
+      connectionNames.reserve( items.size() );
+      for ( T *item : items )
+      {
+        connectionNames << item->name();
+      }
+      QPointer< QgsDataItem > firstParent( items.at( 0 )->parent() );
+      deleteConnectionsPrivate( connectionNames, deleteConnection, firstParent );
+    }
+#endif
+
+  private:
+    static void deleteConnectionsPrivate( const QStringList &connectionNames, const std::function<void ( const QString & )> &deleteConnection, QPointer<QgsDataItem> firstParent );
+};
+
+#endif // QGSDATAITEMGUIPROVIDERUTILS_H

--- a/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
+++ b/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
@@ -18,13 +18,14 @@
 #include "qgstiledsceneconnection.h"
 #include "qgstiledsceneconnectiondialog.h"
 #include "qgsmanageconnectionsdialog.h"
+#include "qgsdataitemguiproviderutils.h"
 
 #include <QMessageBox>
 #include <QFileDialog>
 
 ///@cond PRIVATE
 
-void QgsTiledSceneDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
+void QgsTiledSceneDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &selection, QgsDataItemGuiContext context )
 {
   if ( QgsTiledSceneLayerItem *layerItem = qobject_cast< QgsTiledSceneLayerItem * >( item ) )
   {
@@ -32,8 +33,15 @@ void QgsTiledSceneDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     connect( actionEdit, &QAction::triggered, this, [layerItem] { editConnection( layerItem ); } );
     menu->addAction( actionEdit );
 
-    QAction *actionDelete = new QAction( tr( "Remove Connection" ), menu );
-    connect( actionDelete, &QAction::triggered, this, [layerItem] { deleteConnection( layerItem ); } );
+    const QList< QgsTiledSceneLayerItem * > sceneConnectionItems = QgsDataItem::filteredItems<QgsTiledSceneLayerItem>( selection );
+    QAction *actionDelete = new QAction( sceneConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
+    connect( actionDelete, &QAction::triggered, this, [sceneConnectionItems, context]
+    {
+      QgsDataItemGuiProviderUtils::deleteConnections( sceneConnectionItems, []( const QString & connectionName )
+      {
+        QgsTiledSceneProviderConnection( QString() ).remove( connectionName );
+      }, context );
+    } );
     menu->addAction( actionDelete );
   }
 
@@ -72,17 +80,6 @@ void QgsTiledSceneDataItemGuiProvider::editConnection( QgsDataItem *item )
   newConnection.provider = connection.provider;
 
   QgsTiledSceneProviderConnection::addConnection( dlg.connectionName(), newConnection );
-
-  item->parent()->refreshConnections();
-}
-
-void QgsTiledSceneDataItemGuiProvider::deleteConnection( QgsDataItem *item )
-{
-  if ( QMessageBox::question( nullptr, tr( "Remove Connection" ), tr( "Are you sure you want to remove the connection “%1”?" ).arg( item->name() ),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
-    return;
-
-  QgsTiledSceneProviderConnection( QString() ).remove( item->name() );
 
   item->parent()->refreshConnections();
 }

--- a/src/gui/tiledscene/qgstiledscenedataitemguiprovider.h
+++ b/src/gui/tiledscene/qgstiledscenedataitemguiprovider.h
@@ -34,7 +34,6 @@ class QgsTiledSceneDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
 
   private:
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void newCesium3dTilesConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
@@ -34,7 +34,6 @@ class QgsVectorTileDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
 
   private:
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void newArcGISConnection( QgsDataItem *item );
     static void saveXyzTilesServers();

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.h
@@ -39,7 +39,6 @@ class QgsArcGisRestDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -42,7 +42,6 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void createSchema( QgsDataItem *item, QgsDataItemGuiContext context );
     static void deleteSchema( QgsHanaSchemaItem *schemaItem, QgsDataItemGuiContext context );

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -39,7 +39,6 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void createSchema( QgsMssqlConnectionItem *connItem );
     static void truncateTable( QgsMssqlLayerItem *layerItem );
     static void saveConnections();

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -44,7 +44,6 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     static QString typeNameFromLayer( const QgsPostgresLayerProperty &layer );
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void createSchema( QgsDataItem *item, QgsDataItemGuiContext context );
     static void deleteSchema( QgsPGSchemaItem *schemaItem, QgsDataItemGuiContext context );

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
@@ -39,7 +39,6 @@ class QgsSpatiaLiteDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
   private:
     static void newConnection( QgsDataItem *item );
     static void createDatabase( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static bool handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction );
 };
 

--- a/src/providers/wcs/qgswcsdataitemguiprovider.h
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.h
@@ -31,7 +31,6 @@ class QgsWcsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/providers/wfs/qgswfsdataitemguiprovider.h
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.h
@@ -31,7 +31,6 @@ class QgsWfsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/providers/wms/qgswmsdataitemguiproviders.h
+++ b/src/providers/wms/qgswmsdataitemguiproviders.h
@@ -18,6 +18,9 @@
 
 #include "qgsdataitemguiprovider.h"
 
+class QgsWMSConnectionItem;
+class QgsXyzLayerItem;
+
 class QgsWmsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 {
     Q_OBJECT
@@ -33,7 +36,6 @@ class QgsWmsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void refreshConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
@@ -55,7 +57,6 @@ class QgsXyzDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 
   private:
     static void editConnection( QgsDataItem *item );
-    static void deleteConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void saveXyzTilesServers();
     static void loadXyzTilesServers( QgsDataItem *item );


### PR DESCRIPTION
Adds a new "QgsDataItemGuiProviderUtils" class, with a generic function for handling deletion of browser connection items.

Replace all the duplicate connection deletion logic from the different browser connection providers with calls to the generic function.

In addition to removing a lot of duplicate code, the new generic function correctly handles deletion of multiple selected connections (previously, only the first connection would actually be removed).

Fixes https://github.com/qgis/QGIS/issues/26276