### PR TITLE
[gdal] Allow storing credential key/value credential options in uris

### DIFF
--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -27,6 +27,7 @@
 #include "qgsgdalproviderbase.h"
 #include "qgsgdalutils.h"
 #include "qgssettings.h"
+#include "qgsmessagelog.h"
 
 #include <mutex>
 #include <QRegularExpression>
@@ -290,6 +291,31 @@ GDALDatasetH QgsGdalProviderBase::gdalOpen( const QString &uri, unsigned int nOp
                                      option.toUtf8().constData() );
   }
 
+  const QString vsiPrefix = parts.value( QStringLiteral( "vsiPrefix" ) ).toString();
+  const QString vsiSuffix = parts.value( QStringLiteral( "vsiSuffix" ) ).toString();
+
+  const QVariantMap credentialOptions = parts.value( QStringLiteral( "credentialOptions" ) ).toMap();
+  parts.remove( QStringLiteral( "credentialOptions" ) );
+  if ( !credentialOptions.isEmpty() && !vsiPrefix.isEmpty() )
+  {
+    const thread_local QRegularExpression bucketRx( QStringLiteral( "^(.*?)/" ) );
+    const QRegularExpressionMatch bucketMatch = bucketRx.match( parts.value( QStringLiteral( "path" ) ).toString() );
+    if ( bucketMatch.hasMatch() )
+    {
+      const QString bucket = vsiPrefix + bucketMatch.captured( 1 );
+      for ( auto it = credentialOptions.constBegin(); it != credentialOptions.constEnd(); ++it )
+      {
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 6, 0)
+        VSISetPathSpecificOption( bucket.toLocal8Bit().constData(), it.key().toLocal8Bit().constData(), it.value().toString().toLocal8Bit().constData() );
+#elif GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
+        VSISetCredential( bucket.toLocal8Bit().constData(), it.key().toLocal8Bit().constData(), it.value().toString().toLocal8Bit().constData() );
+#else
+        QgsMessageLog::logMessage( QObject::tr( "Cannot use VSI credential options on GDAL versions earlier than 3.5" ), QStringLiteral( "GDAL" ), Qgis::MessageLevel::Critical );
+#endif
+      }
+    }
+  }
+
   const bool modify_OGR_GPKG_FOREIGN_KEY_CHECK = !CPLGetConfigOption( "OGR_GPKG_FOREIGN_KEY_CHECK", nullptr );
   if ( modify_OGR_GPKG_FOREIGN_KEY_CHECK )
   {
@@ -301,8 +327,6 @@ GDALDatasetH QgsGdalProviderBase::gdalOpen( const QString &uri, unsigned int nOp
 
   if ( !hDS )
   {
-    const QString vsiPrefix = parts.value( QStringLiteral( "vsiPrefix" ) ).toString();
-    const QString vsiSuffix = parts.value( QStringLiteral( "vsiSuffix" ) ).toString();
     if ( vsiSuffix.isEmpty() && QgsGdalUtils::isVsiArchivePrefix( vsiPrefix ) )
     {
       // in the case that a direct path to a vsi supported archive was specified BUT
@@ -391,6 +415,7 @@ QVariantMap QgsGdalProviderBase::decodeGdalUri( const QString &uri )
   QString layerName;
   QString authcfg;
   QStringList openOptions;
+  QVariantMap credentialOptions;
 
   const thread_local QRegularExpression authcfgRegex( " authcfg='([^']+)'" );
   QRegularExpressionMatch match;
@@ -451,6 +476,30 @@ QVariantMap QgsGdalProviderBase::decodeGdalUri( const QString &uri )
         break;
       }
     }
+
+    const thread_local QRegularExpression credentialOptionRegex( QStringLiteral( "\\|credential:([^|]*)" ) );
+    const thread_local QRegularExpression credentialOptionKeyValueRegex( QStringLiteral( "(.*?)=(.*)" ) );
+    while ( true )
+    {
+      const QRegularExpressionMatch match = credentialOptionRegex.match( path );
+      if ( match.hasMatch() )
+      {
+        const QRegularExpressionMatch keyValueMatch = credentialOptionKeyValueRegex.match( match.captured( 1 ) );
+        if ( keyValueMatch.hasMatch() )
+        {
+          credentialOptions.insert( keyValueMatch.captured( 1 ), keyValueMatch.captured( 2 ) );
+        }
+        else
+        {
+          credentialOptions.insert( match.captured( 1 ), QString() );
+        }
+        path = path.remove( match.capturedStart( 0 ), match.capturedLength( 0 ) );
+      }
+      else
+      {
+        break;
+      }
+    }
   }
 
   QVariantMap uriComponents;
@@ -458,6 +507,8 @@ QVariantMap QgsGdalProviderBase::decodeGdalUri( const QString &uri )
   uriComponents.insert( QStringLiteral( "layerName" ), layerName );
   if ( !openOptions.isEmpty() )
     uriComponents.insert( QStringLiteral( "openOptions" ), openOptions );
+  if ( !credentialOptions.isEmpty() )
+    uriComponents.insert( QStringLiteral( "credentialOptions" ), credentialOptions );
   if ( !vsiPrefix.isEmpty() )
     uriComponents.insert( QStringLiteral( "vsiPrefix" ), vsiPrefix );
   if ( !vsiSuffix.isEmpty() )
@@ -492,6 +543,19 @@ QString QgsGdalProviderBase::encodeGdalUri( const QVariantMap &parts )
   {
     uri += QLatin1String( "|option:" );
     uri += openOption;
+  }
+
+  const QVariantMap credentialOptions = parts.value( QStringLiteral( "credentialOptions" ) ).toMap();
+  for ( auto it = credentialOptions.constBegin(); it != credentialOptions.constEnd(); ++it )
+  {
+    if ( !it.value().toString().isEmpty() )
+    {
+      uri += QStringLiteral( "|credential:%1=%2" ).arg( it.key(), it.value().toString() );
+    }
+    else
+    {
+      uri += QStringLiteral( "|credential:%1" ).arg( it.key() );
+    }
   }
 
   if ( !authcfg.isEmpty() )

--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -310,6 +310,7 @@ GDALDatasetH QgsGdalProviderBase::gdalOpen( const QString &uri, unsigned int nOp
 #elif GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
         VSISetCredential( bucket.toLocal8Bit().constData(), it.key().toLocal8Bit().constData(), it.value().toString().toLocal8Bit().constData() );
 #else
+        ( void )bucket;
         QgsMessageLog::logMessage( QObject::tr( "Cannot use VSI credential options on GDAL versions earlier than 3.5" ), QStringLiteral( "GDAL" ), Qgis::MessageLevel::Critical );
 #endif
       }

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -711,11 +711,10 @@ QString QgsGdalUtils::vsiPrefixForPath( const QString &path )
 {
   const QStringList vsiPrefixes = QgsGdalUtils::vsiArchivePrefixes();
 
-  for ( const QString &vsiPrefix : vsiPrefixes )
-  {
-    if ( path.startsWith( vsiPrefix, Qt::CaseInsensitive ) )
-      return vsiPrefix;
-  }
+  const thread_local QRegularExpression vsiRx( QStringLiteral( "^(/vsi.+?/)" ), QRegularExpression::PatternOption::CaseInsensitiveOption );
+  const QRegularExpressionMatch vsiMatch = vsiRx.match( path );
+  if ( vsiMatch.hasMatch() )
+    return vsiMatch.captured( 1 );
 
   if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) )
   {

--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -138,8 +138,15 @@ void TestQgsGdalProvider::decodeUri()
   // test authcfg with vsicurl URI
   uri = QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif authcfg='1234567'" );
   components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
-  QCOMPARE( components.value( QStringLiteral( "path" ) ).toString(), QString( "/vsicurl/https://www.qgis.org/dataset.tif" ) );
+  QCOMPARE( components.value( QStringLiteral( "path" ) ).toString(), QString( "https://www.qgis.org/dataset.tif" ) );
+  QCOMPARE( components.value( QStringLiteral( "vsiPrefix" ) ).toString(), QString( "/vsicurl/" ) );
   QCOMPARE( components.value( QStringLiteral( "authcfg" ) ).toString(), QString( "1234567" ) );
+
+  // vsis3
+  uri = QStringLiteral( "/vsis3/nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" );
+  components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
+  QCOMPARE( components.value( QStringLiteral( "path" ) ).toString(), QString( "nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" ) );
+  QCOMPARE( components.value( QStringLiteral( "vsiPrefix" ) ).toString(), QString( "/vsis3/" ) );
 }
 
 void TestQgsGdalProvider::encodeUri()
@@ -162,6 +169,17 @@ void TestQgsGdalProvider::encodeUri()
   parts.insert( QStringLiteral( "path" ), QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif" ) );
   parts.insert( QStringLiteral( "authcfg" ), QStringLiteral( "1234567" ) );
   QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif authcfg='1234567'" ) );
+  parts.clear();
+  parts.insert( QStringLiteral( "path" ), QStringLiteral( "https://www.qgis.org/dataset.tif" ) );
+  parts.insert( QStringLiteral( "vsiPrefix" ), QStringLiteral( "/vsicurl/" ) );
+  parts.insert( QStringLiteral( "authcfg" ), QStringLiteral( "1234567" ) );
+  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif authcfg='1234567'" ) );
+
+  // vsis3
+  parts.clear();
+  parts.insert( QStringLiteral( "vsiPrefix" ), QStringLiteral( "/vsis3/" ) );
+  parts.insert( QStringLiteral( "path" ), QStringLiteral( "nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" ) );
+  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/vsis3/nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" ) );
 }
 
 void TestQgsGdalProvider::scaleDataType()

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -113,6 +113,23 @@ class PyQgsGdalProvider(QgisTestCase):
         encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
         self.assertEqual(encodedUri, uri)
 
+    def testDecodeEncodeUriCredentialOptions(self):
+        """Test decodeUri/encodeUri credential options support"""
+
+        uri = '/my/raster.pdf|option:AN=OPTION|credential:ANOTHER|credential:SOMEKEY=AAAAA'
+        parts = QgsProviderRegistry.instance().decodeUri('gdal', uri)
+        self.assertEqual(parts, {
+            'path': '/my/raster.pdf',
+            'layerName': None,
+            'credentialOptions': {
+                'ANOTHER': None,
+                'SOMEKEY': 'AAAAA'
+            },
+            'openOptions': ['AN=OPTION']
+        })
+        encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
+        self.assertEqual(encodedUri, uri)
+
     def testDecodeEncodeUriVsizip(self):
         """Test decodeUri/encodeUri for /vsizip/ prefixed URIs"""
 


### PR DESCRIPTION
Extends decode/encodeUri to handle credential options. This is
modeled off the existing support for storing open options.

When credential options are found in a layer's URI, we use
GDAL's VSISetPathSpecificOption to set the credential option
for that VSI driver and bucket. This allows per-vsi driver & bucket
credentials for layers, whereas other approaches (like environment
variable setting) force a single set of credentials to be used
for an entire QGIS session.

Requires GDAL 3.5+

If this approach is acceptable, I'll implement for the OGR provider also.