### PR TITLE
qgsabstractmaterialsettings: Handle selection in addParametersToEffect

### DIFF
--- a/src/3d/materials/qgsabstractmaterialsettings.h
+++ b/src/3d/materials/qgsabstractmaterialsettings.h
@@ -189,7 +189,7 @@ class _3D_EXPORT QgsAbstractMaterialSettings SIP_ABSTRACT
     /**
      * Adds parameters from the material to a destination \a effect.
      */
-    virtual void addParametersToEffect( Qt3DRender::QEffect *effect ) const = 0;
+    virtual void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const = 0;
 
     // *INDENT-OFF*
     //! Data definable properties.

--- a/src/3d/materials/qgsgoochmaterialsettings.cpp
+++ b/src/3d/materials/qgsgoochmaterialsettings.cpp
@@ -141,7 +141,7 @@ Qt3DRender::QMaterial *QgsGoochMaterialSettings::toMaterial( QgsMaterialSettings
   return nullptr;
 }
 
-void QgsGoochMaterialSettings::addParametersToEffect( Qt3DRender::QEffect * ) const
+void QgsGoochMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *, const QgsMaterialContext & ) const
 {
 }
 

--- a/src/3d/materials/qgsgoochmaterialsettings.h
+++ b/src/3d/materials/qgsgoochmaterialsettings.h
@@ -100,7 +100,7 @@ class _3D_EXPORT QgsGoochMaterialSettings : public QgsAbstractMaterialSettings
 
 #ifndef SIP_RUN
     Qt3DRender::QMaterial *toMaterial( QgsMaterialSettingsRenderingTechnique technique, const QgsMaterialContext &context ) const override;
-    void addParametersToEffect( Qt3DRender::QEffect *effect ) const override;
+    void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const override;
 
     QByteArray dataDefinedVertexColorsAsByte( const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride() const override;

--- a/src/3d/materials/qgsmetalroughmaterialsettings.cpp
+++ b/src/3d/materials/qgsmetalroughmaterialsettings.cpp
@@ -98,8 +98,7 @@ QMap<QString, QString> QgsMetalRoughMaterialSettings::toExportParameters() const
   return parameters;
 }
 
-void QgsMetalRoughMaterialSettings::addParametersToEffect( Qt3DRender::QEffect * ) const
+void QgsMetalRoughMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *, const QgsMaterialContext & ) const
 {
 
 }
-

--- a/src/3d/materials/qgsmetalroughmaterialsettings.h
+++ b/src/3d/materials/qgsmetalroughmaterialsettings.h
@@ -104,7 +104,7 @@ class _3D_EXPORT QgsMetalRoughMaterialSettings : public QgsAbstractMaterialSetti
 
 #ifndef SIP_RUN
     Qt3DRender::QMaterial *toMaterial( QgsMaterialSettingsRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
-    void addParametersToEffect( Qt3DRender::QEffect *effect ) const override;
+    void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const override;
 #endif
 
     // TODO c++20 - replace with = default

--- a/src/3d/materials/qgsnullmaterialsettings.cpp
+++ b/src/3d/materials/qgsnullmaterialsettings.cpp
@@ -61,6 +61,6 @@ QMap<QString, QString> QgsNullMaterialSettings::toExportParameters() const
   return parameters;
 }
 
-void QgsNullMaterialSettings::addParametersToEffect( Qt3DRender::QEffect * ) const
+void QgsNullMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *, const QgsMaterialContext & ) const
 {
 }

--- a/src/3d/materials/qgsnullmaterialsettings.h
+++ b/src/3d/materials/qgsnullmaterialsettings.h
@@ -59,7 +59,7 @@ class _3D_EXPORT QgsNullMaterialSettings : public QgsAbstractMaterialSettings
     QMap<QString, QString> toExportParameters() const override;
 #ifndef SIP_RUN
     Qt3DRender::QMaterial *toMaterial( QgsMaterialSettingsRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
-    void addParametersToEffect( Qt3DRender::QEffect *effect ) const override;
+    void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const override;
 #endif
 
 };

--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -135,16 +135,19 @@ QMap<QString, QString> QgsPhongMaterialSettings::toExportParameters() const
   return parameters;
 }
 
-void QgsPhongMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect ) const
+void QgsPhongMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const
 {
+  const QColor ambient = materialContext.isSelected() ? materialContext.selectionColor().darker() : mAmbient;
+  const QColor diffuse = materialContext.isSelected() ? materialContext.selectionColor() : mDiffuse;
+
   Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ),
-      QColor::fromRgbF( mAmbient.redF() * mAmbientCoefficient,
-                        mAmbient.greenF() * mAmbientCoefficient,
-                        mAmbient.blueF() * mAmbientCoefficient ) );
+      QColor::fromRgbF( ambient.redF() * mAmbientCoefficient,
+                        ambient.greenF() * mAmbientCoefficient,
+                        ambient.blueF() * mAmbientCoefficient ) );
   Qt3DRender::QParameter *diffuseParameter = new Qt3DRender::QParameter( QStringLiteral( "diffuseColor" ),
-      QColor::fromRgbF( mDiffuse.redF() * mDiffuseCoefficient,
-                        mDiffuse.greenF() * mDiffuseCoefficient,
-                        mDiffuse.blueF() * mDiffuseCoefficient ) );
+      QColor::fromRgbF( diffuse.redF() * mDiffuseCoefficient,
+                        diffuse.greenF() * mDiffuseCoefficient,
+                        diffuse.blueF() * mDiffuseCoefficient ) );
   Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "specularColor" ),
       QColor::fromRgbF( mSpecular.redF() * mSpecularCoefficient,
                         mSpecular.greenF() * mSpecularCoefficient,

--- a/src/3d/materials/qgsphongmaterialsettings.h
+++ b/src/3d/materials/qgsphongmaterialsettings.h
@@ -158,7 +158,7 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
 
 #ifndef SIP_RUN
     Qt3DRender::QMaterial *toMaterial( QgsMaterialSettingsRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
-    void addParametersToEffect( Qt3DRender::QEffect *effect ) const override;
+    void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const override;
 
     QByteArray dataDefinedVertexColorsAsByte( const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride() const override;

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
@@ -196,9 +196,11 @@ QMap<QString, QString> QgsPhongTexturedMaterialSettings::toExportParameters() co
   return parameters;
 }
 
-void QgsPhongTexturedMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect ) const
+void QgsPhongTexturedMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const
 {
-  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), mAmbient );
+  const QColor ambientColor = materialContext.isSelected() ? materialContext.selectionColor().darker() : mAmbient;
+
+  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), ambientColor );
   Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), mSpecular );
   Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess );
 

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
@@ -198,13 +198,9 @@ QMap<QString, QString> QgsPhongTexturedMaterialSettings::toExportParameters() co
 
 void QgsPhongTexturedMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect ) const
 {
-  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), QColor::fromRgbF( 0.05f, 0.05f, 0.05f, 1.0f ) );
-  Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), QColor::fromRgbF( 0.01f, 0.01f, 0.01f, 1.0f ) );
-  Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), 150.0f );
-
-  ambientParameter->setValue( mAmbient );
-  specularParameter->setValue( mSpecular );
-  shininessParameter->setValue( mShininess );
+  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), mAmbient );
+  Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), mSpecular );
+  Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess );
 
   effect->addParameter( ambientParameter );
   effect->addParameter( specularParameter );

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.h
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.h
@@ -129,7 +129,7 @@ class _3D_EXPORT QgsPhongTexturedMaterialSettings : public QgsAbstractMaterialSe
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
 #ifndef SIP_RUN
     Qt3DRender::QMaterial *toMaterial( QgsMaterialSettingsRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
-    void addParametersToEffect( Qt3DRender::QEffect *effect ) const override;
+    void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const override;
 #endif
 
     // TODO c++20 - replace with = default

--- a/src/3d/materials/qgssimplelinematerialsettings.cpp
+++ b/src/3d/materials/qgssimplelinematerialsettings.cpp
@@ -126,9 +126,10 @@ QMap<QString, QString> QgsSimpleLineMaterialSettings::toExportParameters() const
   return parameters;
 }
 
-void QgsSimpleLineMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect ) const
+void QgsSimpleLineMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const
 {
-  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), mAmbient );
+  const QColor ambient = materialContext.isSelected() ? materialContext.selectionColor().darker() : mAmbient;
+  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), ambient );
   effect->addParameter( ambientParameter );
 }
 

--- a/src/3d/materials/qgssimplelinematerialsettings.cpp
+++ b/src/3d/materials/qgssimplelinematerialsettings.cpp
@@ -128,8 +128,7 @@ QMap<QString, QString> QgsSimpleLineMaterialSettings::toExportParameters() const
 
 void QgsSimpleLineMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect ) const
 {
-  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), QColor::fromRgbF( 0.05f, 0.05f, 0.05f, 1.0f ) );
-  ambientParameter->setValue( mAmbient );
+  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), mAmbient );
   effect->addParameter( ambientParameter );
 }
 

--- a/src/3d/materials/qgssimplelinematerialsettings.h
+++ b/src/3d/materials/qgssimplelinematerialsettings.h
@@ -75,7 +75,7 @@ class _3D_EXPORT QgsSimpleLineMaterialSettings : public QgsAbstractMaterialSetti
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
 #ifndef SIP_RUN
     Qt3DRender::QMaterial *toMaterial( QgsMaterialSettingsRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
-    void addParametersToEffect( Qt3DRender::QEffect *effect ) const override;
+    void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsMaterialContext &materialContext ) const override;
     QByteArray dataDefinedVertexColorsAsByte( const QgsExpressionContext &expressionContext ) const override;
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void applyDataDefinedToGeometry( Qt3DRender::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;

--- a/tests/src/3d/testqgsmaterialregistry.cpp
+++ b/tests/src/3d/testqgsmaterialregistry.cpp
@@ -33,7 +33,7 @@ class DummyMaterialSettings : public QgsAbstractMaterialSettings
     static bool supportsTechnique( QgsMaterialSettingsRenderingTechnique ) { return true; }
     void readXml( const QDomElement &, const QgsReadWriteContext & ) override { }
     void writeXml( QDomElement &, const QgsReadWriteContext & ) const override {}
-    void addParametersToEffect( Qt3DRender::QEffect * ) const override {}
+    void addParametersToEffect( Qt3DRender::QEffect *, const QgsMaterialContext & ) const override {}
     Qt3DRender::QMaterial *toMaterial( QgsMaterialSettingsRenderingTechnique, const QgsMaterialContext & ) const override { return nullptr; }
     QMap<QString, QString> toExportParameters() const override { return QMap<QString, QString>(); }
     QByteArray dataDefinedVertexColorsAsByte( const QgsExpressionContext & ) const override {return QByteArray();}


### PR DESCRIPTION
## Description

From the main commit: 

```
`addParametersToEffect()` method is used to set the material color
parameters if the material has been created without calling
`toMaterial()`. In pratice, this is only used by `QgsPoint3DSymbol`
for the Phong material.

This method does not handle the selection state of an entity. This
means that the color parameters of the material need to be changed
after `addParametersToEffect()` has been called. This is error prone.

This issue is fixed by adding a `QgsMaterialContext` to this
method. It allows to directly set the correct color parameters
according to the selection context.
```

cc @benoitdm-oslandia 
