### PR TITLE
Move "share on gist" logic to QgsCodeEditorWidget

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -186,6 +186,15 @@ the first column.
 :return: ``True`` if the file was opened successfully.
 %End
 
+    bool shareOnGist( bool isPublic );
+%Docstring
+Shares the contents of the code editor on GitHub Gist.
+
+Requires that the user has configured an API token with appropriate permission in advance.
+
+:return: ``False`` if the user has not configured a GitHub personal access token.
+%End
+
   signals:
 
     void searchBarToggled( bool visible );

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -285,43 +285,7 @@ class Editor(QgsCodeEditorPython):
             self.console_widget.objectListButton.setChecked(True)
 
     def shareOnGist(self, is_public):
-        ACCESS_TOKEN = QgsSettings().value("pythonConsole/accessTokenGithub", '', type=QByteArray)
-        if not ACCESS_TOKEN:
-            msg_text = QCoreApplication.translate(
-                'PythonConsole', 'GitHub personal access token must be generated (see Console Options)')
-            self.showMessage(msg_text,
-                             level=Qgis.MessageLevel.Warning)
-            return
-
-        URL = "https://api.github.com/gists"
-
-        path = self.code_editor_widget.filePath()
-        filename = os.path.basename(path) if path else None
-        filename = filename if filename else "pyqgis_snippet.py"
-
-        selected_text = self.selectedText()
-        data = {"description": "Gist created by PyQGIS Console",
-                "public": is_public,
-                "files": {filename: {"content": selected_text}}}
-
-        request = QgsBlockingNetworkRequest()
-        net_req = QNetworkRequest()
-        url = QUrl(URL)
-        net_req.setUrl(url)
-        net_req.setRawHeader(b"Authorization", b"token %s" % ACCESS_TOKEN)
-        err = request.post(net_req, QJsonDocument(data).toJson())
-        if not err:
-            response = request.reply().content()
-            json_doc = QJsonDocument()
-            _json = json_doc.fromJson(response)
-            link = _json.object()['html_url'].toString()
-            QApplication.clipboard().setText(link)
-            msg = QCoreApplication.translate('PythonConsole', 'URL copied to clipboard.')
-            self.showMessage(msg)
-        else:
-            msg = QCoreApplication.translate('PythonConsole', 'Connection error: ')
-            self.showMessage(msg + request.errorMessage(),
-                             level=Qgis.MessageLevel.Warning)
+        self.code_editor_widget.shareOnGist(is_public)
 
     def hideEditor(self):
         self.console_widget.splitterObj.hide()

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -247,7 +247,6 @@ class Editor(QgsCodeEditorPython):
         syntaxCheckAction.setEnabled(False)
         pasteAction.setEnabled(False)
         pyQGISHelpAction.setEnabled(False)
-        gist_menu.setEnabled(False)
         cutAction.setEnabled(False)
         runSelected.setEnabled(False)  # spellok
         copyAction.setEnabled(False)
@@ -259,7 +258,6 @@ class Editor(QgsCodeEditorPython):
             runSelected.setEnabled(True)  # spellok
             copyAction.setEnabled(True)
             cutAction.setEnabled(True)
-            gist_menu.setEnabled(True)
             pyQGISHelpAction.setEnabled(True)
         if not self.text() == '':
             selectAllAction.setEnabled(True)

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -94,14 +94,8 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.removeAPIpath.clicked.connect(self.removeAPI)
         self.compileAPIs.clicked.connect(self._prepareAPI)
 
-        self.generateToken.clicked.connect(self.generateGHToken)
         self.formatter.currentTextChanged.connect(self.onFormatterChanged)
         self.onFormatterChanged()
-
-    def generateGHToken(self):
-        description = self.tr("PyQGIS Console")
-        url = 'https://github.com/settings/tokens/new?description={}&scopes=gist'.format(description)
-        QDesktopServices.openUrl(QUrl(url))
 
     def initialCheck(self):
         if self.preloadAPI.isChecked():
@@ -188,8 +182,6 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/preloadAPI", self.preloadAPI.isChecked())
         settings.setValue("pythonConsole/autoSaveScript", self.autoSaveScript.isChecked())
 
-        settings.setValue("pythonConsole/accessTokenGithub", self.tokenGhLineEdit.text())
-
         for i in range(0, self.tableWidget.rowCount()):
             text = self.tableWidget.item(i, 1).text()
             self.listPath.append(text)
@@ -228,7 +220,6 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         settings = QgsSettings()
         self.preloadAPI.setChecked(settings.value("pythonConsole/preloadAPI", True, type=bool))
         self.lineEdit.setText(settings.value("pythonConsole/preparedAPIFile", "", type=str))
-        self.tokenGhLineEdit.setText(settings.value("pythonConsole/accessTokenGithub", "", type=str))
         itemTable = settings.value("pythonConsole/userAPI", [])
         if itemTable:
             self.tableWidget.setRowCount(0)

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -29,7 +29,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_16">
    <property name="leftMargin">
-    <number>20</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
     <number>0</number>
@@ -52,9 +52,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-133</y>
-        <width>775</width>
-        <height>1107</height>
+        <y>-115</y>
+        <width>795</width>
+        <height>1089</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -52,9 +52,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-192</y>
+        <y>-133</y>
         <width>775</width>
-        <height>1166</height>
+        <height>1107</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -70,94 +70,6 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item row="0" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
-         <property name="title">
-          <string>Autocompletion</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="saveCheckedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="saveCollapsedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <property name="verticalSpacing">
-           <number>2</number>
-          </property>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_36">
-            <property name="text">
-             <string>characters</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="autoCompThreshold">
-            <property name="maximum">
-             <number>10</number>
-            </property>
-            <property name="value">
-             <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Autocompletion threshold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="3">
-           <layout class="QGridLayout" name="layoutRadioButton">
-            <item row="0" column="2">
-             <widget class="QRadioButton" name="autoCompFromDocAPI">
-              <property name="toolTip">
-               <string>Get autocompletion from current document and installed APIs</string>
-              </property>
-              <property name="text">
-               <string>From doc and APIs</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QRadioButton" name="autoCompFromAPI">
-              <property name="toolTip">
-               <string>Get autocompletion from installed APIs</string>
-              </property>
-              <property name="text">
-               <string>From API files</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="autoCompFromDoc">
-              <property name="toolTip">
-               <string>Get autocompletion from current document</string>
-              </property>
-              <property name="text">
-               <string>From document</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="2" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBoxFromatting">
          <property name="title">
@@ -264,76 +176,93 @@
          </layout>
         </widget>
        </item>
-       <item row="6" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBox">
+       <item row="0" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
          <property name="title">
-          <string>GitHub Access Token</string>
+          <string>Autocompletion</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_6">
-          <item row="0" column="0">
-           <widget class="QLineEdit" name="tokenGhLineEdit">
-            <property name="placeholderText">
-             <string>&lt;PERSONAL_ACCESS_TOKEN&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QPushButton" name="generateToken">
-            <property name="text">
-             <string>Generate</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBoxRunDebugEditor">
-         <property name="title">
-          <string>Run and Debug</string>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
          <property name="collapsed" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="saveCheckedState" stdset="0">
           <bool>true</bool>
          </property>
          <property name="saveCollapsedState" stdset="0">
           <bool>true</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout_21">
+         <layout class="QGridLayout" name="gridLayout_5">
           <property name="verticalSpacing">
            <number>2</number>
           </property>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="autoSaveScript">
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_36">
             <property name="text">
-             <string>Auto-save script before running</string>
+             <string>characters</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="autoCompThreshold">
+            <property name="maximum">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>2</number>
             </property>
            </widget>
           </item>
           <item row="0" column="0">
-           <widget class="QCheckBox" name="enableObjectInspector">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Enable Object Inspector (switching between tabs may be slow)</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
+             <string>Autocompletion threshold</string>
             </property>
            </widget>
           </item>
+          <item row="1" column="0" colspan="3">
+           <layout class="QGridLayout" name="layoutRadioButton">
+            <item row="0" column="2">
+             <widget class="QRadioButton" name="autoCompFromDocAPI">
+              <property name="toolTip">
+               <string>Get autocompletion from current document and installed APIs</string>
+              </property>
+              <property name="text">
+               <string>From doc and APIs</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QRadioButton" name="autoCompFromAPI">
+              <property name="toolTip">
+               <string>Get autocompletion from installed APIs</string>
+              </property>
+              <property name="text">
+               <string>From API files</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="autoCompFromDoc">
+              <property name="toolTip">
+               <string>Get autocompletion from current document</string>
+              </property>
+              <property name="text">
+               <string>From document</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
-       </item>
-       <item row="8" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item row="5" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBoxApi">
@@ -537,6 +466,54 @@
          </layout>
         </widget>
        </item>
+       <item row="3" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxRunDebugEditor">
+         <property name="title">
+          <string>Run and Debug</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_21">
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="autoSaveScript">
+            <property name="text">
+             <string>Auto-save script before running</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="enableObjectInspector">
+            <property name="text">
+             <string>Enable Object Inspector (switching between tabs may be slow)</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
        <item row="1" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBoxTyping">
          <property name="title">
@@ -576,7 +553,7 @@
          </layout>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
          <property name="title">
           <string>External Editor</string>
@@ -654,8 +631,6 @@
   <tabstop>groupBoxPreparedAPI</tabstop>
   <tabstop>compileAPIs</tabstop>
   <tabstop>lineEdit</tabstop>
-  <tabstop>tokenGhLineEdit</tabstop>
-  <tabstop>generateToken</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -186,6 +186,15 @@ the first column.
 :return: ``True`` if the file was opened successfully.
 %End
 
+    bool shareOnGist( bool isPublic );
+%Docstring
+Shares the contents of the code editor on GitHub Gist.
+
+Requires that the user has configured an API token with appropriate permission in advance.
+
+:return: ``False`` if the user has not configured a GitHub personal access token.
+%End
+
   signals:
 
     void searchBarToggled( bool visible );

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -263,6 +263,7 @@ set(QGIS_APP_SRCS
   options/qgsfontoptions.cpp
   options/qgsgpsdeviceoptions.cpp
   options/qgsgpsoptions.cpp
+  options/qgsideoptions.cpp
   options/qgsoptions.cpp
   options/qgsoptionsutils.cpp
   options/qgsrasterrenderingoptions.cpp

--- a/src/app/options/qgsideoptions.cpp
+++ b/src/app/options/qgsideoptions.cpp
@@ -35,7 +35,7 @@ QgsIdeOptionsWidget::QgsIdeOptionsWidget( QWidget *parent )
   connect( mGenerateTokenButton, &QPushButton::clicked, this, &QgsIdeOptionsWidget::generateGitHubToken );
 
   QgsSettings settings;
-  mTokenLineEdit->setText(settings.value("pythonConsole/accessTokenGithub", QString() ).toString() );
+  mTokenLineEdit->setText( settings.value( "pythonConsole/accessTokenGithub", QString() ).toString() );
 }
 
 QgsIdeOptionsWidget::~QgsIdeOptionsWidget() = default;
@@ -47,20 +47,21 @@ QString QgsIdeOptionsWidget::helpKey() const
 
 void QgsIdeOptionsWidget::apply()
 {
-    QgsSettings settings;
-    settings.setValue("pythonConsole/accessTokenGithub", mTokenLineEdit->text() );
+  QgsSettings settings;
+  settings.setValue( "pythonConsole/accessTokenGithub", mTokenLineEdit->text() );
 }
 
 void QgsIdeOptionsWidget::generateGitHubToken()
 {
-  QDesktopServices::openUrl(QUrl(
-    QStringLiteral("https://github.com/settings/tokens/new?description=%1&scopes=gist").arg(tr("QGIS Code Editor"))
-  ));
+  QDesktopServices::openUrl( QUrl(
+                               QStringLiteral( "https://github.com/settings/tokens/new?description=%1&scopes=gist" ).arg( tr( "QGIS Code Editor" ) )
+                             ) );
 }
 
 //
 // QgsIdeOptionsFactory
 //
+
 QgsIdeOptionsFactory::QgsIdeOptionsFactory()
   : QgsOptionsWidgetFactory( tr( "IDE" ), QIcon(), QStringLiteral( "ide" ) )
 {
@@ -79,5 +80,5 @@ QgsOptionsPageWidget *QgsIdeOptionsFactory::createWidget( QWidget *parent ) cons
 
 QString QgsIdeOptionsFactory::pagePositionHint() const
 {
-    return QString();
+  return QString();
 }

--- a/src/app/options/qgsideoptions.cpp
+++ b/src/app/options/qgsideoptions.cpp
@@ -1,0 +1,83 @@
+/***************************************************************************
+    qgsideoptions.cpp
+    -------------------------
+    begin                : June 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsideoptions.h"
+#include "qgsapplication.h"
+#include "qgssettings.h"
+#include "qgis.h"
+
+#include <QDesktopServices>
+#include <QUrl>
+
+//
+// QgsIdeOptionsWidget
+//
+
+QgsIdeOptionsWidget::QgsIdeOptionsWidget( QWidget *parent )
+  : QgsOptionsPageWidget( parent )
+{
+  setupUi( this );
+
+  layout()->setContentsMargins( 0, 0, 0, 0 );
+
+  connect( mGenerateTokenButton, &QPushButton::clicked, this, &QgsIdeOptionsWidget::generateGitHubToken );
+
+  QgsSettings settings;
+  mTokenLineEdit->setText(settings.value("pythonConsole/accessTokenGithub", QString() ).toString() );
+}
+
+QgsIdeOptionsWidget::~QgsIdeOptionsWidget() = default;
+
+QString QgsIdeOptionsWidget::helpKey() const
+{
+  return QStringLiteral( "introduction/qgis_configuration.html#code-editor-options" );
+}
+
+void QgsIdeOptionsWidget::apply()
+{
+    QgsSettings settings;
+    settings.setValue("pythonConsole/accessTokenGithub", mTokenLineEdit->text() );
+}
+
+void QgsIdeOptionsWidget::generateGitHubToken()
+{
+  QDesktopServices::openUrl(QUrl(
+    QStringLiteral("https://github.com/settings/tokens/new?description=%1&scopes=gist").arg(tr("QGIS Code Editor"))
+  ));
+}
+
+//
+// QgsIdeOptionsFactory
+//
+QgsIdeOptionsFactory::QgsIdeOptionsFactory()
+  : QgsOptionsWidgetFactory( tr( "IDE" ), QIcon(), QStringLiteral( "ide" ) )
+{
+
+}
+
+QIcon QgsIdeOptionsFactory::icon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconCodeEditor.svg" ) );
+}
+
+QgsOptionsPageWidget *QgsIdeOptionsFactory::createWidget( QWidget *parent ) const
+{
+  return new QgsIdeOptionsWidget( parent );
+}
+
+QString QgsIdeOptionsFactory::pagePositionHint() const
+{
+    return QString();
+}

--- a/src/app/options/qgsideoptions.h
+++ b/src/app/options/qgsideoptions.h
@@ -39,7 +39,7 @@ class QgsIdeOptionsWidget : public QgsOptionsPageWidget, private Ui::QgsIdeOptio
 
     void apply() override;
 
-private slots:
+  private slots:
 
     void generateGitHubToken();
 
@@ -59,6 +59,5 @@ class QgsIdeOptionsFactory : public QgsOptionsWidgetFactory
     QString pagePositionHint() const override;
 
 };
-
 
 #endif // QGSIDEOPTIONS_H

--- a/src/app/options/qgsideoptions.h
+++ b/src/app/options/qgsideoptions.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+    qgsideoptions.h
+    -------------------------
+    begin                : June 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSIDEOPTIONS_H
+#define QGSIDEOPTIONS_H
+
+#include "ui_qgsideoptionswidgetbase.h"
+#include "qgsoptionswidgetfactory.h"
+
+/**
+ * \ingroup app
+ * \class QgsIdeOptionsWidget
+ * \brief An options widget showing IDE settings.
+ */
+class QgsIdeOptionsWidget : public QgsOptionsPageWidget, private Ui::QgsIdeOptionsWidgetBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsIdeOptionsWidget with the specified \a parent widget.
+     */
+    QgsIdeOptionsWidget( QWidget *parent );
+    ~QgsIdeOptionsWidget() override;
+
+    QString helpKey() const override;
+
+    void apply() override;
+
+private slots:
+
+    void generateGitHubToken();
+
+};
+
+
+class QgsIdeOptionsFactory : public QgsOptionsWidgetFactory
+{
+    Q_OBJECT
+
+  public:
+
+    QgsIdeOptionsFactory();
+
+    QIcon icon() const override;
+    QgsOptionsPageWidget *createWidget( QWidget *parent = nullptr ) const override;
+    QString pagePositionHint() const override;
+
+};
+
+
+#endif // QGSIDEOPTIONS_H

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -130,12 +130,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mTreeModel->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "Locator" ), tr( "Locator" ), QStringLiteral( "search.svg" ) ) );
   mTreeModel->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "Acceleration" ), tr( "GPU acceleration" ), QStringLiteral( "mIconGPU.svg" ) ) );
 
-  QStandardItem *ideGroup = new QStandardItem( QCoreApplication::translate( "QgsOptionsBase", "IDE" ) );
-  ideGroup->setData( QStringLiteral( "ide" ) );
-  ideGroup->setToolTip( tr( "Development and Scripting Settings" ) );
-  ideGroup->setSelectable( false );
-  mTreeModel->appendRow( ideGroup );
-
   mOptionsTreeView->setModel( mTreeModel );
 
   // stylesheet setup

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13085,6 +13085,24 @@ void QgisApp::unregisterMapLayerPropertiesFactory( QgsMapLayerConfigWidgetFactor
 
 void QgisApp::registerOptionsWidgetFactory( QgsOptionsWidgetFactory *factory )
 {
+  // make sure factories are inserted before others which create child pages for them
+  for ( auto it = mOptionsWidgetFactories.begin(); it != mOptionsWidgetFactories.end(); ++it )
+  {
+    const QgsOptionsWidgetFactory *other = ( *it ).data();
+    if ( !other )
+      continue;
+
+    const QStringList otherPath = other->path();
+    if ( otherPath.empty() )
+      continue;
+
+    if ( otherPath.at( 0 ) == factory->key() )
+    {
+      mOptionsWidgetFactories.insert( it, factory );
+      return;
+    }
+  }
+
   mOptionsWidgetFactories << factory;
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -112,6 +112,7 @@
 #include "options/qgsfontoptions.h"
 #include "options/qgsgpsdeviceoptions.h"
 #include "options/qgsgpsoptions.h"
+#include "options/qgsideoptions.h"
 #include "options/qgscustomprojectionoptions.h"
 #include "options/qgsrasterrenderingoptions.h"
 #include "options/qgsrenderingoptions.h"
@@ -1959,6 +1960,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
     mCentralContainer->setCurrentIndex( 0 );
   } );
 
+  mOptionWidgetFactories.emplace_back( QgsScopedOptionsWidgetFactory( std::make_unique< QgsIdeOptionsFactory >() ) );
   mOptionWidgetFactories.emplace_back( QgsScopedOptionsWidgetFactory( std::make_unique< QgsCodeEditorOptionsFactory >() ) );
   mOptionWidgetFactories.emplace_back( QgsScopedOptionsWidgetFactory( std::make_unique< QgsRenderingOptionsFactory >() ) );
   mOptionWidgetFactories.emplace_back( QgsScopedOptionsWidgetFactory( std::make_unique< QgsVectorRenderingOptionsFactory >() ) );

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -76,7 +76,6 @@ QMap< QgsCodeEditorColorScheme::ColorRole, QString > QgsCodeEditor::sColorRoleTo
   {QgsCodeEditorColorScheme::ColorRole::SearchMatchBackground, QStringLiteral( "searchMatchBackground" ) }
 };
 
-
 QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool folding, bool margin, QgsCodeEditor::Flags flags, QgsCodeEditor::Mode mode )
   : QsciScintilla( parent )
   , mWidgetTitle( title )

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -107,7 +107,6 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
 #ifndef SIP_RUN
 
     static inline QgsSettingsTreeNode *sTreeCodeEditor = QgsSettingsTree::sTreeGui->createChildNode( QStringLiteral( "code-editor" ) );
-
 #endif
 
     /**

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -193,6 +193,15 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      */
     bool openInExternalEditor( int line = -1, int column = -1 );
 
+    /**
+     * Shares the contents of the code editor on GitHub Gist.
+     *
+     * Requires that the user has configured an API token with appropriate permission in advance.
+     *
+     * \returns FALSE if the user has not configured a GitHub personal access token.
+     */
+    bool shareOnGist( bool isPublic );
+
   signals:
 
     /**

--- a/src/ui/qgsideoptionswidgetbase.ui
+++ b/src/ui/qgsideoptionswidgetbase.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsIdeOptionsWidgetBase</class>
+ <widget class="QWidget" name="QgsIdeOptionsWidgetBase">
+  <layout class="QGridLayout" name="gridLayout_16">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>500</width>
+        <height>432</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>GitHub Access Token</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_6">
+          <item row="0" column="0">
+           <widget class="QLineEdit" name="mTokenLineEdit">
+            <property name="placeholderText">
+             <string>&lt;PERSONAL_ACCESS_TOKEN&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QPushButton" name="mGenerateTokenButton">
+            <property name="text">
+             <string>Generate…</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>mTokenLineEdit</tabstop>
+  <tabstop>mGenerateTokenButton</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgsideoptionswidgetbase.ui
+++ b/src/ui/qgsideoptionswidgetbase.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>QgsIdeOptionsWidgetBase</class>
  <widget class="QWidget" name="QgsIdeOptionsWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>235</width>
+    <height>117</height>
+   </rect>
+  </property>
   <layout class="QGridLayout" name="gridLayout_16">
    <property name="leftMargin">
     <number>0</number>
@@ -16,7 +24,7 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -28,8 +36,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>500</width>
-        <height>432</height>
+        <width>235</width>
+        <height>117</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -87,6 +95,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>mTokenLineEdit</tabstop>


### PR DESCRIPTION
Allows this functionality to be used by other code editors, not just console script editor.

Accordingly I've also moved the Github token setting from the "Python Console" settings page up to the "IDE" settings page, as this setting applies to more than just the Python Console.