### PR TITLE
Allow setting VSI credentials when loading OGR/GDAL layers

### DIFF
--- a/python/PyQt6/gui/auto_generated/providers/gdal/qgsgdalcredentialoptionswidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/providers/gdal/qgsgdalcredentialoptionswidget.sip.in
@@ -1,0 +1,67 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsGdalCredentialOptionsWidget : QWidget
+{
+%Docstring(signature="appended")
+A widget for configuring GDAL credential options.
+
+.. versionadded:: 3.40
+%End
+
+%TypeHeaderCode
+#include "qgsgdalcredentialoptionswidget.h"
+%End
+  public:
+
+    QgsGdalCredentialOptionsWidget( QWidget *parent = 0 );
+%Docstring
+Constructor for QgsGdalCredentialOptionsWidget, with the specified ``parent`` widget.
+%End
+
+    void setDriver( const QString &driver );
+%Docstring
+Sets the corresponding ``driver``.
+
+This should match a GDAL VSI driver, eg "vsis3".
+%End
+
+    QVariantMap credentialOptions() const;
+%Docstring
+Returns the credential options configured in the widget.
+
+.. seealso:: :py:func:`setCredentialOptions`
+%End
+
+    void setCredentialOptions( const QVariantMap &options );
+%Docstring
+Sets the credential ``options`` to show in the widget.
+
+.. seealso:: :py:func:`credentialOptions`
+%End
+
+  signals:
+
+    void optionsChanged();
+%Docstring
+Emitted when the credential options are changed in the widget.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/PyQt6/gui/gui_auto.sip
+++ b/python/PyQt6/gui/gui_auto.sip
@@ -450,6 +450,7 @@
 %Include auto_generated/proj/qgsprojectionselectionwidget.sip
 %Include auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip
 %Include auto_generated/providers/qgsabstractdbsourceselect.sip
+%Include auto_generated/providers/gdal/qgsgdalcredentialoptionswidget.sip
 %Include auto_generated/raster/qgsrasterattributetablewidget.sip
 %Include auto_generated/raster/qgsrasterattributetabledialog.sip
 %Include auto_generated/raster/qgscolorrampshaderwidget.sip

--- a/python/gui/auto_generated/providers/gdal/qgsgdalcredentialoptionswidget.sip.in
+++ b/python/gui/auto_generated/providers/gdal/qgsgdalcredentialoptionswidget.sip.in
@@ -1,0 +1,67 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsGdalCredentialOptionsWidget : QWidget
+{
+%Docstring(signature="appended")
+A widget for configuring GDAL credential options.
+
+.. versionadded:: 3.40
+%End
+
+%TypeHeaderCode
+#include "qgsgdalcredentialoptionswidget.h"
+%End
+  public:
+
+    QgsGdalCredentialOptionsWidget( QWidget *parent = 0 );
+%Docstring
+Constructor for QgsGdalCredentialOptionsWidget, with the specified ``parent`` widget.
+%End
+
+    void setDriver( const QString &driver );
+%Docstring
+Sets the corresponding ``driver``.
+
+This should match a GDAL VSI driver, eg "vsis3".
+%End
+
+    QVariantMap credentialOptions() const;
+%Docstring
+Returns the credential options configured in the widget.
+
+.. seealso:: :py:func:`setCredentialOptions`
+%End
+
+    void setCredentialOptions( const QVariantMap &options );
+%Docstring
+Sets the credential ``options`` to show in the widget.
+
+.. seealso:: :py:func:`credentialOptions`
+%End
+
+  signals:
+
+    void optionsChanged();
+%Docstring
+Emitted when the credential options are changed in the widget.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -450,6 +450,7 @@
 %Include auto_generated/proj/qgsprojectionselectionwidget.sip
 %Include auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip
 %Include auto_generated/providers/qgsabstractdbsourceselect.sip
+%Include auto_generated/providers/gdal/qgsgdalcredentialoptionswidget.sip
 %Include auto_generated/raster/qgsrasterattributetablewidget.sip
 %Include auto_generated/raster/qgsrasterattributetabledialog.sip
 %Include auto_generated/raster/qgscolorrampshaderwidget.sip

--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -26,8 +26,6 @@
 #include "qgslogger.h"
 #include "qgsgdalproviderbase.h"
 #include "qgsgdalutils.h"
-#include "qgssettings.h"
-#include "qgsmessagelog.h"
 
 #include <mutex>
 #include <QRegularExpression>
@@ -302,18 +300,7 @@ GDALDatasetH QgsGdalProviderBase::gdalOpen( const QString &uri, unsigned int nOp
     const QRegularExpressionMatch bucketMatch = bucketRx.match( parts.value( QStringLiteral( "path" ) ).toString() );
     if ( bucketMatch.hasMatch() )
     {
-      const QString bucket = vsiPrefix + bucketMatch.captured( 1 );
-      for ( auto it = credentialOptions.constBegin(); it != credentialOptions.constEnd(); ++it )
-      {
-#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 6, 0)
-        VSISetPathSpecificOption( bucket.toUtf8().constData(), it.key().toUtf8().constData(), it.value().toString().toUtf8().constData() );
-#elif GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
-        VSISetCredential( bucket.toUtf8().constData(), it.key().toUtf8().constData(), it.value().toString().toUtf8().constData() );
-#else
-        ( void )bucket;
-        QgsMessageLog::logMessage( QObject::tr( "Cannot use VSI credential options on GDAL versions earlier than 3.5" ), QStringLiteral( "GDAL" ), Qgis::MessageLevel::Critical );
-#endif
-      }
+      QgsGdalUtils::applyVsiCredentialOptions( vsiPrefix, bucketMatch.captured( 1 ), credentialOptions );
     }
   }
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -441,18 +441,7 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
     const QRegularExpressionMatch bucketMatch = bucketRx.match( parts.value( QStringLiteral( "path" ) ).toString() );
     if ( bucketMatch.hasMatch() )
     {
-      const QString bucket = vsiPrefix + bucketMatch.captured( 1 );
-      for ( auto it = credentialOptions.constBegin(); it != credentialOptions.constEnd(); ++it )
-      {
-#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 6, 0)
-        VSISetPathSpecificOption( bucket.toUtf8().constData(), it.key().toUtf8().constData(), it.value().toString().toUtf8().constData() );
-#elif GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
-        VSISetCredential( bucket.toUtf8().constData(), it.key().toUtf8().constData(), it.value().toString().toUtf8().constData() );
-#else
-        ( void )bucket;
-        QgsMessageLog::logMessage( QObject::tr( "Cannot use VSI credential options on GDAL versions earlier than 3.5" ), QStringLiteral( "GDAL" ), Qgis::MessageLevel::Critical );
-#endif
-      }
+      QgsGdalUtils::applyVsiCredentialOptions( vsiPrefix, bucketMatch.captured( 1 ), credentialOptions );
     }
   }
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -4193,7 +4193,7 @@ void QgsOgrProvider::open( OpenMode mode )
   // Try to open using VSIFileHandler
   //   see http://trac.osgeo.org/gdal/wiki/UserDocs/ReadInZip
   const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( dataSourceUri( true ) );
-  if ( !vsiPrefix.isEmpty() || mFilePath.startsWith( QLatin1String( "/vsicurl/" ) ) )
+  if ( ( !vsiPrefix.isEmpty() && vsiPrefix != QStringLiteral( "/vsimem/" ) ) || mFilePath.startsWith( QLatin1String( "/vsicurl/" ) ) )
   {
     // GDAL>=1.8.0 has write support for zip, but read and write operations
     // cannot be interleaved, so for now just use read-only.

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -73,7 +73,7 @@ QString QgsOgrProviderUtils::analyzeURI( QString const &uri,
     QString &layerName,
     QString &subsetString,
     OGRwkbGeometryType &ogrGeometryTypeFilter,
-    QStringList &openOptions )
+    QStringList &openOptions, QVariantMap &credentialOptions )
 {
   isSubLayer = false;
   layerIndex = 0;
@@ -117,6 +117,8 @@ QString QgsOgrProviderUtils::analyzeURI( QString const &uri,
   {
     openOptions = parts.value( QStringLiteral( "openOptions" ) ).toStringList();
   }
+
+  credentialOptions = parts.value( QStringLiteral( "credentialOptions" ) ).toMap();
 
   const QString fullPath = parts.value( QStringLiteral( "vsiPrefix" ) ).toString()
                            + parts.value( QStringLiteral( "path" ) ).toString()
@@ -1449,6 +1451,7 @@ static GDALDatasetH OpenHelper( const QString &dsName,
     papszOpenOptions = CSLAddString( papszOpenOptions,
                                      option.toUtf8().constData() );
   }
+
   GDALDatasetH hDS = QgsOgrProviderUtils::GDALOpenWrapper(
                        QgsOgrProviderUtils::expandAuthConfig( dsName ).toUtf8().constData(), updateMode, papszOpenOptions, nullptr );
   CSLDestroy( papszOpenOptions );
@@ -3461,14 +3464,15 @@ bool QgsOgrProviderUtils::deleteLayer( const QString &uri, QString &errCause )
   QString subsetString;
   OGRwkbGeometryType ogrGeometryType;
   QStringList openOptions;
+  QVariantMap credentialOptions;
   QString filePath = analyzeURI( uri,
                                  isSubLayer,
                                  layerIndex,
                                  layerName,
                                  subsetString,
                                  ogrGeometryType,
-                                 openOptions );
-
+                                 openOptions,
+                                 credentialOptions );
 
   gdal::dataset_unique_ptr hDS( GDALOpenEx( filePath.toUtf8().constData(), GDAL_OF_RASTER | GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
   if ( hDS  && ( ! layerName.isEmpty() || layerIndex != -1 ) )

--- a/src/core/providers/ogr/qgsogrproviderutils.h
+++ b/src/core/providers/ogr/qgsogrproviderutils.h
@@ -250,7 +250,8 @@ class CORE_EXPORT QgsOgrProviderUtils
                                QString &layerName,
                                QString &subsetString,
                                OGRwkbGeometryType &ogrGeometryTypeFilter,
-                               QStringList &openOptions );
+                               QStringList &openOptions,
+                               QVariantMap &credentialOptions );
 
     //! Whether a driver can share the same dataset handle among different layers
     static bool canDriverShareSameDatasetAmongLayers( const QString &driverName );

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -965,6 +965,23 @@ bool QgsGdalUtils::isVsiArchiveFileExtension( const QString &extension )
   return vsiArchiveFileExtensions().contains( extWithDot.toLower() );
 }
 
+bool QgsGdalUtils::isProtocolCloudType( const QString &protocol )
+{
+  QString vsiPrefix = protocol;
+  if ( vsiPrefix.startsWith( '/' ) )
+    vsiPrefix = vsiPrefix.mid( 1 );
+  if ( vsiPrefix.endsWith( '/' ) )
+    vsiPrefix.chop( 1 );
+
+  return ( vsiPrefix == QLatin1String( "vsis3" ) ||
+           vsiPrefix == QLatin1String( "vsigs" ) ||
+           vsiPrefix == QLatin1String( "vsiaz" ) ||
+           vsiPrefix == QLatin1String( "vsiadls" ) ||
+           vsiPrefix == QLatin1String( "vsioss" ) ||
+           vsiPrefix == QLatin1String( "vsiswift" ) ||
+           vsiPrefix == QLatin1String( "vsihdfs" ) );
+}
+
 bool QgsGdalUtils::vrtMatchesLayerType( const QString &vrtPath, Qgis::LayerType type )
 {
   CPLPushErrorHandler( CPLQuietErrorHandler );

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -711,11 +711,10 @@ QString QgsGdalUtils::vsiPrefixForPath( const QString &path )
 {
   const QStringList vsiPrefixes = QgsGdalUtils::vsiArchivePrefixes();
 
-  for ( const QString &vsiPrefix : vsiPrefixes )
-  {
-    if ( path.startsWith( vsiPrefix, Qt::CaseInsensitive ) )
-      return vsiPrefix;
-  }
+  const thread_local QRegularExpression vsiRx( QStringLiteral( "^(/vsi.+?/)" ), QRegularExpression::PatternOption::CaseInsensitiveOption );
+  const QRegularExpressionMatch vsiMatch = vsiRx.match( path );
+  if ( vsiMatch.hasMatch() )
+    return vsiMatch.captured( 1 );
 
   if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) )
   {

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -32,7 +32,7 @@
 #include <mutex>
 
 
-QgsGdalOption QgsGdalOption::fromXmlNode( CPLXMLNode *node )
+QgsGdalOption QgsGdalOption::fromXmlNode( const CPLXMLNode *node )
 {
   if ( node->eType != CXT_Element || !EQUAL( node->pszValue, "Option" ) )
     return {};
@@ -45,6 +45,7 @@ QgsGdalOption QgsGdalOption::fromXmlNode( CPLXMLNode *node )
   option.name = optionName;
 
   option.description = QString( CPLGetXMLValue( node, "description", nullptr ) );
+  option.scope = QString( CPLGetXMLValue( node, "scope", nullptr ) );
 
   option.type = QgsGdalOption::Type::Text;
 
@@ -138,10 +139,10 @@ QgsGdalOption QgsGdalOption::fromXmlNode( CPLXMLNode *node )
   return {};
 }
 
-QList<QgsGdalOption> QgsGdalOption::optionsFromXml( CPLXMLNode *node )
+QList<QgsGdalOption> QgsGdalOption::optionsFromXml( const CPLXMLNode *node )
 {
   QList< QgsGdalOption > options;
-  for ( auto psItem = node->psChild; psItem != nullptr; psItem = node->psNext )
+  for ( auto psItem = node->psChild; psItem != nullptr; psItem = psItem->psNext )
   {
     const QgsGdalOption option = fromXmlNode( psItem );
     if ( option.type == QgsGdalOption::Type::Invalid )

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -26,6 +26,67 @@
 
 /**
  * \ingroup core
+ * \class QgsGdalOption
+ * \brief Encapsulates the definition of a GDAL configuration option.
+ *
+ * \note not available in Python bindings
+ * \since QGIS 3.40
+ */
+class CORE_EXPORT QgsGdalOption
+{
+  public:
+
+    /**
+     * Option types
+     */
+    enum class Type
+    {
+      Invalid, //!< Invalid option
+      Select, //!< Selection option
+      Boolean, //!< Boolean option
+      Text, //!< Text option
+      Int, //!< Integer option
+      Double, //!< Double option
+    };
+
+    //! Option name
+    QString name;
+
+    //! Option type
+    Type type = Type::Invalid;
+
+    //! Option description
+    QString description;
+
+    //! Available choices, for Select options
+    QStringList options;
+
+    //! Default value
+    QVariant defaultValue;
+
+    //! Minimum acceptable value
+    QVariant minimum;
+
+    //! Maximum acceptable value
+    QVariant maximum;
+
+    /**
+     * Creates a QgsGdalOption from an XML \a node.
+     *
+     * Returns an invalid option if the node could not be interpreted
+     * as a GDAL option.
+     */
+    static QgsGdalOption fromXmlNode( CPLXMLNode *node );
+
+    /**
+     * Returns a list of all GDAL options from an XML \a node.
+     */
+    static QList< QgsGdalOption > optionsFromXml( CPLXMLNode *node );
+};
+
+
+/**
+ * \ingroup core
  * \class QgsGdalUtils
  * \brief Utilities for working with GDAL
  *

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -342,6 +342,18 @@ class CORE_EXPORT QgsGdalUtils
     static bool isVsiArchiveFileExtension( const QString &extension );
 
     /**
+     * Attempts to apply VSI credential \a options.
+     *
+     * This method uses GDAL's VSISetPathSpecificOption, which will overrwrite any existing
+     * options for the same VSI \a prefix and \a path.
+     *
+     * Returns TRUE if the options could be applied.
+     *
+     * \since QGIS 3.40
+     */
+    static bool applyVsiCredentialOptions( const QString &prefix, const QString &path, const QVariantMap &options );
+
+    /**
      * Returns TRUE if the VRT file at the specified path is a VRT matching
      * the given layer \a type.
      *

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -70,18 +70,21 @@ class CORE_EXPORT QgsGdalOption
     //! Maximum acceptable value
     QVariant maximum;
 
+    //! Option scope
+    QString scope;
+
     /**
      * Creates a QgsGdalOption from an XML \a node.
      *
      * Returns an invalid option if the node could not be interpreted
      * as a GDAL option.
      */
-    static QgsGdalOption fromXmlNode( CPLXMLNode *node );
+    static QgsGdalOption fromXmlNode( const CPLXMLNode *node );
 
     /**
      * Returns a list of all GDAL options from an XML \a node.
      */
-    static QList< QgsGdalOption > optionsFromXml( CPLXMLNode *node );
+    static QList< QgsGdalOption > optionsFromXml( const CPLXMLNode *node );
 };
 
 

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -236,6 +236,27 @@ class CORE_EXPORT QgsGdalUtils
     static QStringList vsiArchivePrefixes();
 
     /**
+     * Encapsulates details for a GDAL VSI network file system.
+     *
+     * \since QGIS 3.40
+     */
+    struct VsiNetworkFileSystemDetails
+    {
+      //! VSI driver identifier, eg "vsis3"
+      QString identifier;
+
+      //! Translated, user-friendly name.
+      QString name;
+    };
+
+    /**
+     * Returns a list of available GDAL VSI network file systems.
+     *
+     * \since QGIS 3.40
+     */
+    static QList< VsiNetworkFileSystemDetails > vsiNetworkFileSystems();
+
+    /**
      * Returns TRUE if \a prefix is a supported archive style container prefix (e.g. "/vsizip/").
      *
      * \since QGIS 3.32

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -342,6 +342,13 @@ class CORE_EXPORT QgsGdalUtils
     static bool isVsiArchiveFileExtension( const QString &extension );
 
     /**
+     * Returns TRUE if \a protocol (eg "vsis3") is considered a cloud type.
+     *
+     * \since QGIS 3.40
+     */
+    static bool isProtocolCloudType( const QString &protocol );
+
+    /**
      * Attempts to apply VSI credential \a options.
      *
      * This method uses GDAL's VSISetPathSpecificOption, which will overrwrite any existing

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -443,6 +443,7 @@ set(QGIS_GUI_SRCS
   providers/qgspointcloudproviderguimetadata.cpp
   providers/qgspointcloudsourceselect.cpp
 
+  providers/gdal/qgsgdalcredentialoptionswidget.cpp
   providers/gdal/qgsgdalfilesourcewidget.cpp
   providers/gdal/qgsgdalsourceselect.cpp
   providers/gdal/qgsgdalguiprovider.cpp
@@ -1414,6 +1415,7 @@ set(QGIS_GUI_HDRS
   providers/qgspointcloudsourceselect.h
   providers/qgspointcloudproviderguimetadata.h
 
+  providers/gdal/qgsgdalcredentialoptionswidget.h
   providers/gdal/qgsgdalfilesourcewidget.h
   providers/gdal/qgsgdalguiprovider.h
   providers/gdal/qgsgdalsourceselect.h

--- a/src/gui/ogr/qgsnewogrconnection.cpp
+++ b/src/gui/ogr/qgsnewogrconnection.cpp
@@ -97,15 +97,14 @@ QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString &connTy
 
 void QgsNewOgrConnection::testConnection()
 {
-  QString uri;
-  uri = createDatabaseURI( cmbDatabaseTypes->currentText(),
-                           txtHost->text(),
-                           txtDatabase->text(),
-                           txtPort->text(),
-                           mAuthSettingsDatabase->configId(),
-                           mAuthSettingsDatabase->username(),
-                           mAuthSettingsDatabase->password(),
-                           true );
+  QString uri = QgsGdalGuiUtils::createDatabaseURI( cmbDatabaseTypes->currentText(),
+                txtHost->text(),
+                txtDatabase->text(),
+                txtPort->text(),
+                mAuthSettingsDatabase->configId(),
+                mAuthSettingsDatabase->username(),
+                mAuthSettingsDatabase->password(),
+                true );
   QgsDebugMsgLevel( "Connecting using uri = " + uri, 2 );
   OGRRegisterAll();
   OGRDataSourceH       poDS;

--- a/src/gui/ogr/qgsogrhelperfunctions.cpp
+++ b/src/gui/ogr/qgsogrhelperfunctions.cpp
@@ -290,17 +290,6 @@ QString QgsGdalGuiUtils::createProtocolURI( const QString &type, const QString &
   return uri;
 }
 
-bool QgsGdalGuiUtils::isProtocolCloudType( const QString &protocol )
-{
-  return ( protocol == QLatin1String( "vsis3" ) ||
-           protocol == QLatin1String( "vsigs" ) ||
-           protocol == QLatin1String( "vsiaz" ) ||
-           protocol == QLatin1String( "vsiadls" ) ||
-           protocol == QLatin1String( "vsioss" ) ||
-           protocol == QLatin1String( "vsiswift" ) ||
-           protocol == QLatin1String( "vsihdfs" ) );
-}
-
 QWidget *QgsGdalGuiUtils::createWidgetForOption( const QgsGdalOption &option, QWidget *parent, bool includeDefaultChoices )
 {
   switch ( option.type )

--- a/src/gui/ogr/qgsogrhelperfunctions.cpp
+++ b/src/gui/ogr/qgsogrhelperfunctions.cpp
@@ -27,7 +27,7 @@
 
 #include <QComboBox>
 
-QString createDatabaseURI( const QString &connectionType, const QString &host, const QString &database, QString port, const QString &configId, QString username,  QString password, bool expandAuthConfig )
+QString QgsGdalGuiUtils::createDatabaseURI( const QString &connectionType, const QString &host, const QString &database, QString port, const QString &configId, QString username,  QString password, bool expandAuthConfig )
 {
   QString uri;
 
@@ -223,7 +223,7 @@ QString createDatabaseURI( const QString &connectionType, const QString &host, c
 }
 
 
-QString createProtocolURI( const QString &type, const QString &url, const QString &configId, const QString &username, const QString &password, bool expandAuthConfig )
+QString QgsGdalGuiUtils::createProtocolURI( const QString &type, const QString &url, const QString &configId, const QString &username, const QString &password, bool expandAuthConfig )
 {
   QString uri;
   if ( type == QLatin1String( "vsicurl" ) )
@@ -290,7 +290,7 @@ QString createProtocolURI( const QString &type, const QString &url, const QStrin
   return uri;
 }
 
-bool isProtocolCloudType( const QString &protocol )
+bool QgsGdalGuiUtils::isProtocolCloudType( const QString &protocol )
 {
   return ( protocol == QLatin1String( "vsis3" ) ||
            protocol == QLatin1String( "vsigs" ) ||

--- a/src/gui/ogr/qgsogrhelperfunctions.cpp
+++ b/src/gui/ogr/qgsogrhelperfunctions.cpp
@@ -221,7 +221,7 @@ QString createDatabaseURI( const QString &connectionType, const QString &host, c
 QString createProtocolURI( const QString &type, const QString &url, const QString &configId, const QString &username, const QString &password, bool expandAuthConfig )
 {
   QString uri;
-  if ( type == QLatin1String( "HTTP/HTTPS/FTP" ) )
+  if ( type == QLatin1String( "vsicurl" ) )
   {
     uri = url;
     // If no protocol is provided in the URL, default to HTTP
@@ -231,35 +231,17 @@ QString createProtocolURI( const QString &type, const QString &url, const QStrin
     }
     uri.prepend( QStringLiteral( "/vsicurl/" ) );
   }
-  else if ( type == QLatin1String( "AWS S3" ) )
+  else if ( type == QLatin1String( "vsis3" )
+            || type == QLatin1String( "vsigs" )
+            || type == QLatin1String( "vsiaz" )
+            || type == QLatin1String( "vsiadls" )
+            || type == QLatin1String( "vsioss" )
+            || type == QLatin1String( "vsiswift" )
+            || type == QLatin1String( "vsihdfs" )
+          )
   {
     uri = url;
-    uri.prepend( QStringLiteral( "/vsis3/" ) );
-  }
-  else if ( type == QLatin1String( "Google Cloud Storage" ) )
-  {
-    uri = url;
-    uri.prepend( QStringLiteral( "/vsigs/" ) );
-  }
-  else if ( type == QLatin1String( "Microsoft Azure Blob" ) )
-  {
-    uri = url;
-    uri.prepend( QStringLiteral( "/vsiaz/" ) );
-  }
-  else if ( type == QLatin1String( "Microsoft Azure Data Lake Storage" ) )
-  {
-    uri = url;
-    uri.prepend( QStringLiteral( "/vsiadls/" ) );
-  }
-  else if ( type == QLatin1String( "Alibaba Cloud OSS" ) )
-  {
-    uri = url;
-    uri.prepend( QStringLiteral( "/vsioss/" ) );
-  }
-  else if ( type == QLatin1String( "OpenStack Swift Object Storage" ) )
-  {
-    uri = url;
-    uri.prepend( QStringLiteral( "/vsiswift/" ) );
+    uri.prepend( QStringLiteral( "/%1/" ).arg( type ) );
   }
   // catching both GeoJSON and GeoJSONSeq
   else if ( type.startsWith( QLatin1String( "GeoJSON" ) ) )
@@ -274,8 +256,7 @@ QString createProtocolURI( const QString &type, const QString &url, const QStrin
   {
     uri = QStringLiteral( "DODS:%1" ).arg( url );
   }
-  // Check beginning because of "experimental"
-  else if ( type.startsWith( QLatin1String( "WFS3" ) ) )
+  else if ( type == QLatin1String( "WFS3" ) )
   {
     uri = QStringLiteral( "WFS3:%1" ).arg( url );
   }
@@ -302,4 +283,15 @@ QString createProtocolURI( const QString &type, const QString &url, const QStrin
     uri.replace( QLatin1String( "://" ), QStringLiteral( "://%1:%2@" ).arg( username, password ) );
   }
   return uri;
+}
+
+bool isProtocolCloudType( const QString &protocol )
+{
+  return ( protocol == QLatin1String( "vsis3" ) ||
+           protocol == QLatin1String( "vsigs" ) ||
+           protocol == QLatin1String( "vsiaz" ) ||
+           protocol == QLatin1String( "vsiadls" ) ||
+           protocol == QLatin1String( "vsioss" ) ||
+           protocol == QLatin1String( "vsiswift" ) ||
+           protocol == QLatin1String( "vsihdfs" ) );
 }

--- a/src/gui/ogr/qgsogrhelperfunctions.cpp
+++ b/src/gui/ogr/qgsogrhelperfunctions.cpp
@@ -301,13 +301,17 @@ bool QgsGdalGuiUtils::isProtocolCloudType( const QString &protocol )
            protocol == QLatin1String( "vsihdfs" ) );
 }
 
-QWidget *QgsGdalGuiUtils::createWidgetForOption( const QgsGdalOption &option, QWidget *parent )
+QWidget *QgsGdalGuiUtils::createWidgetForOption( const QgsGdalOption &option, QWidget *parent, bool includeDefaultChoices )
 {
   switch ( option.type )
   {
     case QgsGdalOption::Type::Select:
     {
       QComboBox *cb = new QComboBox( parent );
+      if ( includeDefaultChoices )
+      {
+        cb->addItem( QObject::tr( "<Default>" ), QgsVariantUtils::createNullVariant( QMetaType::Type::QString ) );
+      }
       for ( const QString &val : std::as_const( option.options ) )
       {
         cb->addItem( val, val );
@@ -320,6 +324,10 @@ QWidget *QgsGdalGuiUtils::createWidgetForOption( const QgsGdalOption &option, QW
     case QgsGdalOption::Type::Boolean:
     {
       QComboBox *cb = new QComboBox( parent );
+      if ( includeDefaultChoices )
+      {
+        cb->addItem( QObject::tr( "<Default>" ), QgsVariantUtils::createNullVariant( QMetaType::Type::QString ) );
+      }
       cb->addItem( QObject::tr( "Yes" ), "YES" );
       cb->addItem( QObject::tr( "No" ), "NO" );
       cb->setCurrentIndex( 0 );
@@ -332,6 +340,10 @@ QWidget *QgsGdalGuiUtils::createWidgetForOption( const QgsGdalOption &option, QW
       QgsFilterLineEdit *res = new QgsFilterLineEdit( parent );
       res->setToolTip( option.description );
       res->setShowClearButton( true );
+      if ( includeDefaultChoices )
+      {
+        res->setPlaceholderText( QObject::tr( "Default" ) );
+      }
       return res;
     }
 
@@ -342,13 +354,22 @@ QWidget *QgsGdalGuiUtils::createWidgetForOption( const QgsGdalOption &option, QW
       if ( option.minimum.isValid() )
         res->setMinimum( option.minimum.toInt() );
       else
-        res->setMinimum( std::numeric_limits< int>::lowest() + 1 );
+        res->setMinimum( 0 );
       if ( option.maximum.isValid() )
         res->setMaximum( option.maximum.toInt() );
       else
         res->setMaximum( std::numeric_limits< int>::max() - 1 );
-      if ( option.defaultValue.isValid() )
+      if ( includeDefaultChoices )
+      {
+        res->setMinimum( res->minimum() - 1 );
+        res->setClearValueMode( QgsSpinBox::ClearValueMode::MinimumValue,
+                                QObject::tr( "Default" ) );
+      }
+      else if ( option.defaultValue.isValid() )
+      {
         res->setClearValue( option.defaultValue.toInt() );
+      }
+      res->clear();
       return res;
     }
 
@@ -359,13 +380,24 @@ QWidget *QgsGdalGuiUtils::createWidgetForOption( const QgsGdalOption &option, QW
       if ( option.minimum.isValid() )
         res->setMinimum( option.minimum.toDouble() );
       else
-        res->setMinimum( std::numeric_limits< double>::lowest() + 1 );
+        res->setMinimum( 0 );
       if ( option.maximum.isValid() )
         res->setMaximum( option.maximum.toDouble() );
       else
         res->setMaximum( std::numeric_limits< double>::max() - 1 );
       if ( option.defaultValue.isValid() )
         res->setClearValue( option.defaultValue.toDouble() );
+      if ( includeDefaultChoices )
+      {
+        res->setMinimum( res->minimum() - 1 );
+        res->setClearValueMode( QgsDoubleSpinBox::ClearValueMode::MinimumValue,
+                                QObject::tr( "Default" ) );
+      }
+      else if ( option.defaultValue.isValid() )
+      {
+        res->setClearValue( option.defaultValue.toDouble() );
+      }
+      res->clear();
       return res;
     }
 

--- a/src/gui/ogr/qgsogrhelperfunctions.h
+++ b/src/gui/ogr/qgsogrhelperfunctions.h
@@ -19,6 +19,9 @@
 #include <QString>
 #include "qgis_gui.h"
 
+class QWidget;
+class QgsGdalOption;
+
 #define SIP_NO_FILE
 
 /**
@@ -39,3 +42,23 @@ QString GUI_EXPORT createProtocolURI( const QString &type, const QString &url, c
  * Returns TRUE if \a protocol (eg "vsis3") is considered a cloud type.
  */
 bool GUI_EXPORT isProtocolCloudType( const QString &protocol );
+
+/**
+ * \ingroup core
+ * \class QgsGdalOption
+ * \brief Encapsulates the definition of a GDAL configuration option.
+ *
+ * \note not available in Python bindings
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsGdalGuiUtils
+{
+  public:
+
+    /**
+     * Creates a new widget for configuration a GDAL \a option.
+     */
+    static QWidget *createWidgetForOption( const QgsGdalOption &option, QWidget *parent = nullptr );
+
+};
+

--- a/src/gui/ogr/qgsogrhelperfunctions.h
+++ b/src/gui/ogr/qgsogrhelperfunctions.h
@@ -49,11 +49,6 @@ class GUI_EXPORT QgsGdalGuiUtils
     static QString createProtocolURI( const QString &type, const QString &url, const QString &configId, const QString &username, const QString &password, bool expandAuthConfig = false );
 
     /**
-     * Returns TRUE if \a protocol (eg "vsis3") is considered a cloud type.
-     */
-    static bool isProtocolCloudType( const QString &protocol );
-
-    /**
      * Creates a new widget for configuration a GDAL \a option.
      *
      * If \a includeDefaultChoices is TRUE then the widget will include an option

--- a/src/gui/ogr/qgsogrhelperfunctions.h
+++ b/src/gui/ogr/qgsogrhelperfunctions.h
@@ -34,3 +34,8 @@ QString GUI_EXPORT createDatabaseURI( const QString &connectionType, const QStri
  * \note not available in python bindings
  */
 QString GUI_EXPORT createProtocolURI( const QString &type, const QString &url, const QString &configId, const QString &username, const QString &password, bool expandAuthConfig = false );
+
+/**
+ * Returns TRUE if \a protocol (eg "vsis3") is considered a cloud type.
+ */
+bool GUI_EXPORT isProtocolCloudType( const QString &protocol );

--- a/src/gui/ogr/qgsogrhelperfunctions.h
+++ b/src/gui/ogr/qgsogrhelperfunctions.h
@@ -55,8 +55,11 @@ class GUI_EXPORT QgsGdalGuiUtils
 
     /**
      * Creates a new widget for configuration a GDAL \a option.
+     *
+     * If \a includeDefaultChoices is TRUE then the widget will include an option
+     * for the default value.
      */
-    static QWidget *createWidgetForOption( const QgsGdalOption &option, QWidget *parent = nullptr );
+    static QWidget *createWidgetForOption( const QgsGdalOption &option, QWidget *parent = nullptr, bool includeDefaultChoices = false );
 
 };
 

--- a/src/gui/ogr/qgsogrhelperfunctions.h
+++ b/src/gui/ogr/qgsogrhelperfunctions.h
@@ -25,28 +25,9 @@ class QgsGdalOption;
 #define SIP_NO_FILE
 
 /**
- * CreateDatabaseURI
- * \brief Create database uri from connection parameters
- * \note not available in python bindings
- */
-QString GUI_EXPORT createDatabaseURI( const QString &connectionType, const QString &host, const QString &database, QString port, const QString &configId, QString username, QString password, bool expandAuthConfig = false );
-
-/**
- * CreateProtocolURI
- * \brief Create protocol uri from connection parameters
- * \note not available in python bindings
- */
-QString GUI_EXPORT createProtocolURI( const QString &type, const QString &url, const QString &configId, const QString &username, const QString &password, bool expandAuthConfig = false );
-
-/**
- * Returns TRUE if \a protocol (eg "vsis3") is considered a cloud type.
- */
-bool GUI_EXPORT isProtocolCloudType( const QString &protocol );
-
-/**
- * \ingroup core
- * \class QgsGdalOption
- * \brief Encapsulates the definition of a GDAL configuration option.
+ * \ingroup gui
+ * \class QgsGdalGuiUtils
+ * \brief Utility functions for working with GDAL in GUI classes.
  *
  * \note not available in Python bindings
  * \since QGIS 3.40
@@ -54,6 +35,23 @@ bool GUI_EXPORT isProtocolCloudType( const QString &protocol );
 class GUI_EXPORT QgsGdalGuiUtils
 {
   public:
+
+    /**
+     * Create database uri from connection parameters
+     * \note not available in python bindings
+     */
+    static QString createDatabaseURI( const QString &connectionType, const QString &host, const QString &database, QString port, const QString &configId, QString username, QString password, bool expandAuthConfig = false );
+
+    /**
+     * Create protocol uri from connection parameters
+     * \note not available in python bindings
+     */
+    static QString createProtocolURI( const QString &type, const QString &url, const QString &configId, const QString &username, const QString &password, bool expandAuthConfig = false );
+
+    /**
+     * Returns TRUE if \a protocol (eg "vsis3") is considered a cloud type.
+     */
+    static bool isProtocolCloudType( const QString &protocol );
 
     /**
      * Creates a new widget for configuration a GDAL \a option.

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
@@ -20,7 +20,6 @@
 #include "ogr/qgsogrhelperfunctions.h"
 #include "qgsvariantutils.h"
 #include "qgsapplication.h"
-#include "qgslogger.h"
 #include "qgsspinbox.h"
 #include "qgsdoublespinbox.h"
 
@@ -347,72 +346,7 @@ QWidget *QgsGdalCredentialOptionsDelegate::createEditor( QWidget *parent, const 
         return nullptr;
 
       const QgsGdalOption option = model->option( key );
-      switch ( option.type )
-      {
-        case QgsGdalOption::Type::Select:
-        {
-          QComboBox *cb = new QComboBox( parent );
-          for ( const QString &val : std::as_const( option.options ) )
-          {
-            cb->addItem( val, val );
-          }
-          cb->setCurrentIndex( 0 );
-          cb->setToolTip( option.description );
-          return cb;
-        }
-
-        case QgsGdalOption::Type::Boolean:
-        {
-          QComboBox *cb = new QComboBox( parent );
-          cb->addItem( tr( "Yes" ), "YES" );
-          cb->addItem( tr( "No" ), "NO" );
-          cb->setCurrentIndex( 0 );
-          cb->setToolTip( option.description );
-          return cb;
-        }
-
-        case QgsGdalOption::Type::Text:
-        {
-          QLineEdit *res = new QLineEdit( parent );
-          res->setToolTip( option.description );
-          return res;
-        }
-
-        case QgsGdalOption::Type::Int:
-        {
-          QgsSpinBox *res = new QgsSpinBox( parent );
-          res->setToolTip( option.description );
-          if ( option.minimum.isValid() )
-            res->setMinimum( option.minimum.toInt() );
-          else
-            res->setMinimum( std::numeric_limits< int>::lowest() + 1 );
-          if ( option.maximum.isValid() )
-            res->setMaximum( option.maximum.toInt() );
-          else
-            res->setMaximum( std::numeric_limits< int>::max() - 1 );
-          if ( option.defaultValue.isValid() )
-            res->setClearValue( option.defaultValue.toInt() );
-          return res;
-        }
-
-        case QgsGdalOption::Type::Double:
-        {
-          QgsDoubleSpinBox *res = new QgsDoubleSpinBox( parent );
-          res->setToolTip( option.description );
-          if ( option.minimum.isValid() )
-            res->setMinimum( option.minimum.toDouble() );
-          else
-            res->setMinimum( std::numeric_limits< double>::lowest() + 1 );
-          if ( option.maximum.isValid() )
-            res->setMaximum( option.maximum.toDouble() );
-          else
-            res->setMaximum( std::numeric_limits< double>::max() - 1 );
-          if ( option.defaultValue.isValid() )
-            res->setClearValue( option.defaultValue.toDouble() );
-          return res;
-        }
-      }
-      return nullptr;
+      return QgsGdalGuiUtils::createWidgetForOption( option, parent );
     }
 
     default:

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
@@ -595,6 +595,7 @@ void QgsGdalCredentialOptionsWidget::setDriver( const QString &driver )
     option.type = GdalOption::Type::Text;
 
     const char *pszType = CPLGetXMLValue( psItem, "type", nullptr );
+    const char *pszDefault = CPLGetXMLValue( psItem, "default", nullptr );
     if ( pszType && EQUAL( pszType, "string-select" ) )
     {
       option.type = GdalOption::Type::Select;
@@ -608,12 +609,18 @@ void QgsGdalCredentialOptionsWidget::setDriver( const QString &driver )
         }
         option.options << psOption->psChild->pszValue;
       }
-      option.defaultValue = option.options.value( 0 );
+      option.defaultValue = pszDefault ? QString( pszDefault ) : option.options.value( 0 );
     }
     else if ( pszType && EQUAL( pszType, "boolean" ) )
     {
       option.type = GdalOption::Type::Boolean;
-      option.defaultValue = QStringLiteral( "YES" );
+      option.defaultValue = pszDefault ? QString( pszDefault ) : QStringLiteral( "YES" );
+    }
+    else if ( pszType && EQUAL( pszType, "string" ) )
+    {
+      option.type = GdalOption::Type::Text;
+      if ( pszDefault )
+        option.defaultValue = QString( pszDefault );
     }
 
     options << option;

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
@@ -1,0 +1,684 @@
+/***************************************************************************
+                          qgsgdalcredentialoptionswidget.h
+                             -------------------
+    begin                : June 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgdalcredentialoptionswidget.h"
+#include "ogr/qgsogrhelperfunctions.h"
+#include "qgsvariantutils.h"
+#include "qgsapplication.h"
+
+#include <gdal.h>
+#include <cpl_minixml.h>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QHoverEvent>
+
+
+//
+// QgsGdalCredentialOptionsModel
+//
+
+QgsGdalCredentialOptionsModel::QgsGdalCredentialOptionsModel( QObject *parent )
+  : QAbstractItemModel( parent )
+{
+
+}
+
+int QgsGdalCredentialOptionsModel::columnCount( const QModelIndex & ) const
+{
+  return 3;
+}
+
+int QgsGdalCredentialOptionsModel::rowCount( const QModelIndex &parent ) const
+{
+  if ( parent.isValid() )
+    return 0;
+  return mCredentialOptions.size();
+}
+
+QModelIndex QgsGdalCredentialOptionsModel::index( int row, int column, const QModelIndex &parent ) const
+{
+  if ( hasIndex( row, column, parent ) )
+  {
+    return createIndex( row, column, row );
+  }
+
+  return QModelIndex();
+}
+
+QModelIndex QgsGdalCredentialOptionsModel::parent( const QModelIndex &child ) const
+{
+  Q_UNUSED( child )
+  return QModelIndex();
+}
+
+Qt::ItemFlags QgsGdalCredentialOptionsModel::flags( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return Qt::ItemFlags();
+
+  if ( index.row() < 0 || index.row() >= mCredentialOptions.size() || index.column() < 0 || index.column() >= columnCount() )
+    return Qt::ItemFlags();
+
+  switch ( index.column() )
+  {
+    case Column::Key:
+    case Column::Value:
+      return Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsEditable | Qt::ItemFlag::ItemIsSelectable;
+    case Column::Actions:
+      return Qt::ItemFlag::ItemIsEnabled;
+    default:
+      break;
+  }
+
+  return Qt::ItemFlags();
+}
+
+QVariant QgsGdalCredentialOptionsModel::data( const QModelIndex &index, int role ) const
+{
+  if ( !index.isValid() )
+    return QVariant();
+
+  if ( index.row() < 0 || index.row() >= mCredentialOptions.size() || index.column() < 0 || index.column() >= columnCount() )
+    return QVariant();
+
+  const QPair< QString, QString > option = mCredentialOptions.at( index.row() );
+  const GdalOption gdalOption = QgsGdalCredentialOptionsModel::option( option.first );
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Key:
+          return option.first;
+
+        case Column::Value:
+          return gdalOption.type == GdalOption::Type::Boolean ? ( option.second == QStringLiteral( "YES" ) ? tr( "Yes" ) : option.second == QStringLiteral( "NO" ) ? tr( "No" ) : option.second )
+                 :  option.second;
+
+        default:
+          break;
+      }
+      break;
+    }
+
+    case Qt::EditRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Key:
+          return option.first;
+
+        case Column::Value:
+          return option.second;
+
+        default:
+          break;
+      }
+      break;
+    }
+
+    case Qt::ToolTipRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Key:
+        case Column::Value:
+          return mDescriptions.value( option.first, option.first );
+
+        case Column::Actions:
+          return tr( "Remove option" );
+
+        default:
+          break;
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+  return QVariant();
+}
+
+bool QgsGdalCredentialOptionsModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( !index.isValid() )
+    return false;
+
+  if ( index.row() > mCredentialOptions.size() || index.row() < 0 )
+    return false;
+
+  QPair< QString, QString > &option = mCredentialOptions[index.row()];
+
+  switch ( role )
+  {
+    case Qt::EditRole:
+    {
+      switch ( index.column() )
+      {
+        case Column::Key:
+        {
+          const bool wasInvalid = option.first.isEmpty();
+          if ( value.toString().isEmpty() )
+          {
+            if ( wasInvalid )
+              break;
+          }
+          else
+          {
+            if ( option.first != value.toString() )
+              option.second = QgsGdalCredentialOptionsModel::option( value.toString() ).defaultValue;
+
+            option.first = value.toString();
+            if ( wasInvalid )
+            {
+              emit dataChanged( createIndex( index.row(), 0 ), createIndex( index.row(), columnCount() ) );
+            }
+          }
+          emit dataChanged( createIndex( index.row(), 0 ), createIndex( index.row(), columnCount() ) );
+          if ( wasInvalid )
+          {
+            beginInsertRows( QModelIndex(), mCredentialOptions.size(), mCredentialOptions.size() );
+            mCredentialOptions.append( qMakePair( QString(), QString() ) );
+            endInsertRows();
+          }
+          emit optionsChanged();
+          break;
+        }
+
+        case Column::Value:
+        {
+          option.second = value.toString();
+          emit dataChanged( index, index, QVector<int>() << role );
+          emit optionsChanged();
+          break;
+        }
+
+        default:
+          break;
+      }
+      return true;
+    }
+
+    default:
+      break;
+  }
+
+  return false;
+}
+
+bool QgsGdalCredentialOptionsModel::insertRows( int position, int rows, const QModelIndex &parent )
+{
+  Q_UNUSED( parent )
+  beginInsertRows( QModelIndex(), position, position + rows - 1 );
+  for ( int i = 0; i < rows; ++i )
+  {
+    mCredentialOptions.insert( position, qMakePair( QString(), QString() ) );
+  }
+  endInsertRows();
+  emit optionsChanged();
+  return true;
+}
+
+bool QgsGdalCredentialOptionsModel::removeRows( int position, int rows, const QModelIndex &parent )
+{
+  Q_UNUSED( parent )
+  beginRemoveRows( QModelIndex(), position, position + rows - 1 );
+  for ( int i = 0; i < rows; ++i )
+    mCredentialOptions.removeAt( position );
+  endRemoveRows();
+
+  if ( mCredentialOptions.empty() || !mCredentialOptions.last().first.isEmpty() )
+  {
+    beginInsertRows( QModelIndex(), mCredentialOptions.size(), mCredentialOptions.size() );
+    mCredentialOptions.append( qMakePair( QString(), QString() ) );
+    endInsertRows();
+  }
+  emit optionsChanged();
+  return true;
+}
+
+void QgsGdalCredentialOptionsModel::setOptions( const QList< QPair< QString, QString > > &options )
+{
+  beginResetModel();
+  mCredentialOptions = options;
+  // last entry should always be a blank entry
+  if ( mCredentialOptions.isEmpty() || !mCredentialOptions.last().first.isEmpty() )
+    mCredentialOptions.append( qMakePair( QString(), QString() ) );
+  endResetModel();
+  emit optionsChanged();
+}
+
+void QgsGdalCredentialOptionsModel::setAvailableOptions( const QList<GdalOption> &options )
+{
+  mAvailableOptions = options;
+  mDescriptions.clear();
+  mAvailableKeys.clear();
+  for ( const GdalOption &option : options )
+  {
+    mAvailableKeys.append( option.name );
+    mDescriptions[option.name] = option.description;
+  }
+}
+
+GdalOption QgsGdalCredentialOptionsModel::option( const QString &key ) const
+{
+  for ( const GdalOption &option : mAvailableOptions )
+  {
+    if ( option.name == key )
+      return option;
+  }
+  return GdalOption();
+}
+
+void QgsGdalCredentialOptionsModel::setCredentialOptions( const QList<QPair<QString, QString> > &options )
+{
+  beginResetModel();
+  mCredentialOptions = options;
+
+  if ( mCredentialOptions.empty() || !mCredentialOptions.last().first.isEmpty() )
+  {
+    mCredentialOptions.append( qMakePair( QString(), QString() ) );
+  }
+
+  endResetModel();
+  emit optionsChanged();
+}
+
+
+//
+// QgsGdalCredentialOptionsDelegate
+//
+
+QgsGdalCredentialOptionsDelegate::QgsGdalCredentialOptionsDelegate( QObject *parent )
+  : QStyledItemDelegate( parent )
+{
+
+}
+
+QWidget *QgsGdalCredentialOptionsDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index ) const
+{
+  switch ( index.column() )
+  {
+    case QgsGdalCredentialOptionsModel::Column::Key:
+    {
+      const QgsGdalCredentialOptionsModel *model = qgis::down_cast< const QgsGdalCredentialOptionsModel * >( index.model() );
+      QComboBox *combo = new QComboBox( parent );
+      if ( !model->availableKeys().isEmpty() )
+      {
+        combo->addItems( model->availableKeys() );
+      }
+      return combo;
+    }
+
+    case QgsGdalCredentialOptionsModel::Column::Value:
+    {
+      // need to find out key for this row
+      const QgsGdalCredentialOptionsModel *model = qgis::down_cast< const QgsGdalCredentialOptionsModel * >( index.model() );
+      const QString key = index.model()->data( model->index( index.row(), QgsGdalCredentialOptionsModel::Column::Key ), Qt::EditRole ).toString();
+      if ( key.isEmpty() )
+        return nullptr;
+
+      const GdalOption option = model->option( key );
+      switch ( option.type )
+      {
+        case GdalOption::Type::Select:
+        {
+          QComboBox *cb = new QComboBox( parent );
+          for ( const QString &val : std::as_const( option.options ) )
+          {
+            cb->addItem( val, val );
+          }
+          cb->setCurrentIndex( 0 );
+          cb->setToolTip( option.description );
+          return cb;
+        }
+
+        case GdalOption::Type::Boolean:
+        {
+          QComboBox *cb = new QComboBox( parent );
+          cb->addItem( tr( "Yes" ), "YES" );
+          cb->addItem( tr( "No" ), "NO" );
+          cb->setCurrentIndex( 0 );
+          cb->setToolTip( option.description );
+          return cb;
+        }
+
+        case GdalOption::Type::Text:
+        {
+          QLineEdit *res = new QLineEdit( parent );
+          res->setToolTip( option.description );
+          return res;
+        }
+      }
+      return nullptr;
+    }
+
+    default:
+      break;
+  }
+  return nullptr;
+}
+
+void QgsGdalCredentialOptionsDelegate::setEditorData( QWidget *editor, const QModelIndex &index ) const
+{
+  switch ( index.column() )
+  {
+    case QgsGdalCredentialOptionsModel::Column::Key:
+    {
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        combo->setCurrentIndex( combo->findText( index.data( Qt::EditRole ).toString() ) );
+      }
+      return;
+    }
+
+    case QgsGdalCredentialOptionsModel::Column::Value:
+    {
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        combo->setCurrentIndex( combo->findData( index.data( Qt::EditRole ).toString() ) );
+        if ( combo->currentIndex() < 0 )
+          combo->setCurrentIndex( 0 );
+      }
+      else if ( QLineEdit *edit = qobject_cast< QLineEdit * >( editor ) )
+      {
+        edit->setText( index.data( Qt::EditRole ).toString() );
+      }
+      return;
+    }
+
+    default:
+      break;
+  }
+  QStyledItemDelegate::setEditorData( editor, index );
+}
+
+void QgsGdalCredentialOptionsDelegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
+{
+  switch ( index.column() )
+  {
+    case QgsGdalCredentialOptionsModel::Column::Key:
+    {
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        model->setData( index, combo->currentText() );
+      }
+      break;
+    }
+
+    case QgsGdalCredentialOptionsModel::Column::Value:
+    {
+      if ( QComboBox *combo = qobject_cast< QComboBox * >( editor ) )
+      {
+        model->setData( index, combo->currentData() );
+      }
+      else if ( QLineEdit *edit = qobject_cast< QLineEdit * >( editor ) )
+      {
+        model->setData( index, edit->text() );
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+
+//
+// QgsGdalCredentialOptionsRemoveOptionDelegate
+//
+
+QgsGdalCredentialOptionsRemoveOptionDelegate::QgsGdalCredentialOptionsRemoveOptionDelegate( QObject *parent )
+  : QStyledItemDelegate( parent )
+{
+
+}
+
+bool QgsGdalCredentialOptionsRemoveOptionDelegate::eventFilter( QObject *obj, QEvent *event )
+{
+  if ( event->type() == QEvent::HoverEnter || event->type() == QEvent::HoverMove )
+  {
+    QHoverEvent *hoverEvent = static_cast<QHoverEvent *>( event );
+    if ( QAbstractItemView *view = qobject_cast<QAbstractItemView *>( obj->parent() ) )
+    {
+      const QModelIndex indexUnderMouse = view->indexAt( hoverEvent->pos() );
+      setHoveredIndex( indexUnderMouse );
+      view->viewport()->update();
+    }
+  }
+  else if ( event->type() == QEvent::HoverLeave )
+  {
+    setHoveredIndex( QModelIndex() );
+    qobject_cast< QWidget * >( obj )->update();
+  }
+  return QStyledItemDelegate::eventFilter( obj, event );
+}
+
+void QgsGdalCredentialOptionsRemoveOptionDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+{
+  QStyledItemDelegate::paint( painter, option, index );
+
+  if ( index == mHoveredIndex )
+  {
+    QStyleOptionButton buttonOption;
+    buttonOption.initFrom( option.widget );
+    buttonOption.rect = option.rect;
+
+    option.widget->style()->drawControl( QStyle::CE_PushButton, &buttonOption, painter );
+  }
+
+  const QIcon icon = QgsApplication::getThemeIcon( "/mIconClearItem.svg" );
+  const QRect iconRect( option.rect.left() + ( option.rect.width() - 16 ) / 2,
+                        option.rect.top() + ( option.rect.height() - 16 ) / 2,
+                        16, 16 );
+
+  icon.paint( painter, iconRect );
+}
+
+void QgsGdalCredentialOptionsRemoveOptionDelegate::setHoveredIndex( const QModelIndex &index )
+{
+  mHoveredIndex = index;
+}
+
+
+
+//
+// QgsGdalCredentialOptionsWidget
+//
+
+QgsGdalCredentialOptionsWidget::QgsGdalCredentialOptionsWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  setupUi( this );
+
+  mLabelInfo->setText( tr( "Consult the <a href=\"%1\">GDAL documentation</a> for credential options." ).arg( QLatin1String( "https://gdal.org/user/virtual_file_systems.html#drivers-supporting-virtual-file-systems" ) ) );
+  mLabelInfo->setTextInteractionFlags( Qt::TextBrowserInteraction );
+  mLabelInfo->setOpenExternalLinks( true );
+
+  mLabelWarning->setText( tr( "Potentially sensitive credentials are configured! <b>These will be stored in plain text within the QGIS project</b>." ) );
+  mLabelWarning->setVisible( false );
+
+  mModel = new QgsGdalCredentialOptionsModel( this );
+  mTableView->setModel( mModel );
+
+  mTableView->horizontalHeader()->setVisible( false );
+  mTableView->verticalHeader()->setVisible( false );
+  mTableView->setEditTriggers( QAbstractItemView::AllEditTriggers );
+
+  mDelegate = new QgsGdalCredentialOptionsDelegate( mTableView );
+  mTableView->setItemDelegateForColumn( QgsGdalCredentialOptionsModel::Column::Key, mDelegate );
+  mTableView->setItemDelegateForColumn( QgsGdalCredentialOptionsModel::Column::Value, mDelegate );
+  mTableView->horizontalHeader()->resizeSection( QgsGdalCredentialOptionsModel::Column::Actions, QFontMetrics( mTableView->font() ).horizontalAdvance( '0' ) * 5 );
+  mTableView->horizontalHeader()->setSectionResizeMode( QgsGdalCredentialOptionsModel::Column::Value, QHeaderView::ResizeMode::Stretch );
+
+  QgsGdalCredentialOptionsRemoveOptionDelegate *removeDelegate = new QgsGdalCredentialOptionsRemoveOptionDelegate( mTableView );
+  mTableView->setItemDelegateForColumn( QgsGdalCredentialOptionsModel::Column::Actions, removeDelegate );
+  mTableView->viewport()->installEventFilter( removeDelegate );
+  connect( mTableView, &QTableView::clicked, this, [this]( const QModelIndex & index )
+  {
+    if ( index.column() == QgsGdalCredentialOptionsModel::Column::Actions )
+    {
+      mModel->removeRows( index.row(), 1 );
+    }
+  } );
+
+  mModel->setOptions( {} );
+
+  connect( mModel, &QgsGdalCredentialOptionsModel::optionsChanged, this, &QgsGdalCredentialOptionsWidget::modelOptionsChanged );
+}
+
+void QgsGdalCredentialOptionsWidget::setDriver( const QString &driver )
+{
+  if ( driver == mDriver )
+    return;
+
+  mDriver = driver;
+
+  if ( !isProtocolCloudType( mDriver ) )
+  {
+    mModel->setAvailableOptions( {} );
+    return;
+  }
+
+  const QString vsiPrefix = QStringLiteral( "/%1/" ).arg( mDriver );
+  const char *pszVsiOptions( VSIGetFileSystemOptions( vsiPrefix.toLocal8Bit().constData() ) );
+  if ( !pszVsiOptions )
+    return;
+
+  CPLXMLNode *psDoc = CPLParseXMLString( pszVsiOptions );
+  if ( !psDoc )
+    return;
+  CPLXMLNode *psOptionList = CPLGetXMLNode( psDoc, "=Options" );
+  if ( !psOptionList )
+  {
+    CPLDestroyXMLNode( psDoc );
+    return;
+  }
+
+  int maxKeyLength = 0;
+  QList< GdalOption > options;
+  for ( auto psItem = psOptionList->psChild; psItem != nullptr; psItem = psItem->psNext )
+  {
+    if ( psItem->eType != CXT_Element || !EQUAL( psItem->pszValue, "Option" ) )
+      continue;
+
+    const QString optionName( CPLGetXMLValue( psItem, "name", nullptr ) );
+    if ( optionName.isEmpty() )
+      continue;
+
+    GdalOption option;
+    option.name = optionName;
+    if ( optionName.length() > maxKeyLength )
+      maxKeyLength = optionName.length();
+
+    option.description = QString( CPLGetXMLValue( psItem, "description", nullptr ) );
+
+    option.type = GdalOption::Type::Text;
+
+    const char *pszType = CPLGetXMLValue( psItem, "type", nullptr );
+    if ( pszType && EQUAL( pszType, "string-select" ) )
+    {
+      option.type = GdalOption::Type::Select;
+      for ( auto psOption = psItem->psChild; psOption != nullptr; psOption = psOption->psNext )
+      {
+        if ( psOption->eType != CXT_Element ||
+             !EQUAL( psOption->pszValue, "Value" ) ||
+             psOption->psChild == nullptr )
+        {
+          continue;
+        }
+        option.options << psOption->psChild->pszValue;
+      }
+      option.defaultValue = option.options.value( 0 );
+    }
+    else if ( pszType && EQUAL( pszType, "boolean" ) )
+    {
+      option.type = GdalOption::Type::Boolean;
+      option.defaultValue = QStringLiteral( "YES" );
+    }
+
+    options << option;
+  }
+
+  CPLDestroyXMLNode( psDoc );
+
+  mTableView->setColumnWidth( QgsGdalCredentialOptionsModel::Column::Key, static_cast< int >( QFontMetrics( mTableView->font() ).horizontalAdvance( 'X' ) * maxKeyLength * 1.1 ) );
+
+  mModel->setAvailableOptions( options );
+}
+
+QVariantMap QgsGdalCredentialOptionsWidget::credentialOptions() const
+{
+  QVariantMap result;
+  const QList< QPair< QString, QString > > options = mModel->credentialOptions();
+  for ( const QPair< QString, QString> &option : options )
+  {
+    if ( option.first.isEmpty() )
+      continue;
+
+    result[option.first] = option.second;
+  }
+
+  return result;
+}
+
+void QgsGdalCredentialOptionsWidget::setCredentialOptions( const QVariantMap &options )
+{
+  QList< QPair< QString, QString > > modelOptions;
+  for ( auto it = options.constBegin(); it != options.constEnd(); ++it )
+  {
+    modelOptions.append( qMakePair( it.key(), it.value().toString() ) );
+  }
+  mModel->setCredentialOptions( modelOptions );
+}
+
+void QgsGdalCredentialOptionsWidget::modelOptionsChanged()
+{
+  bool needsSensitiveWarning = false;
+  const QVariantMap options = credentialOptions();
+  for ( const auto &key :
+        { "AWS_ACCESS_KEY_ID",
+          "AWS_SECRET_ACCESS_KEY",
+          "GS_SECRET_ACCESS_KEY",
+          "GS_ACCESS_KEY_ID",
+          "GS_OAUTH2_PRIVATE_KEY",
+          "GS_OAUTH2_CLIENT_SECRET",
+          "AZURE_STORAGE_CONNECTION_STRING",
+          "AZURE_STORAGE_ACCESS_TOKEN",
+          "AZURE_STORAGE_ACCESS_KEY",
+          "AZURE_STORAGE_SAS_TOKEN",
+          "OSS_SECRET_ACCESS_KEY",
+          "OSS_ACCESS_KEY_ID",
+          "SWIFT_AUTH_TOKEN",
+          "SWIFT_KEY"
+        } )
+  {
+    if ( !options.value( key ).toString().isEmpty() )
+    {
+      needsSensitiveWarning = true;
+      break;
+    }
+  }
+  mLabelWarning->setVisible( needsSensitiveWarning );
+
+  emit optionsChanged();
+}

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
@@ -324,9 +324,16 @@ QWidget *QgsGdalCredentialOptionsDelegate::createEditor( QWidget *parent, const 
     {
       const QgsGdalCredentialOptionsModel *model = qgis::down_cast< const QgsGdalCredentialOptionsModel * >( index.model() );
       QComboBox *combo = new QComboBox( parent );
-      if ( !model->availableKeys().isEmpty() )
+      const QStringList availableKeys = model->availableKeys();
+      for ( const QString &key : availableKeys )
       {
-        combo->addItems( model->availableKeys() );
+        if ( key == QLatin1String( "GDAL_HTTP_MAX_RETRY" ) && combo->count() > 0 )
+        {
+          // add separator before generic settings
+          combo->insertSeparator( combo->count() );
+        }
+
+        combo->addItem( key );
       }
       return combo;
     }

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
@@ -547,7 +547,7 @@ void QgsGdalCredentialOptionsWidget::setDriver( const QString &driver )
 
   mDriver = driver;
 
-  if ( !QgsGdalGuiUtils::isProtocolCloudType( mDriver ) )
+  if ( !QgsGdalUtils::isProtocolCloudType( mDriver ) )
   {
     mModel->setAvailableOptions( {} );
     return;

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.cpp
@@ -547,7 +547,7 @@ void QgsGdalCredentialOptionsWidget::setDriver( const QString &driver )
 
   mDriver = driver;
 
-  if ( !isProtocolCloudType( mDriver ) )
+  if ( !QgsGdalGuiUtils::isProtocolCloudType( mDriver ) )
   {
     mModel->setAvailableOptions( {} );
     return;

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h
@@ -20,32 +20,13 @@
 #include "ui_qgsgdalcredentialoptionswidgetbase.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
+#include "qgsgdalutils.h"
 
 #include <QAbstractItemModel>
 #include <QStyledItemDelegate>
 
 #ifndef SIP_RUN
 ///@cond PRIVATE
-
-struct GdalOption
-{
-  enum class Type
-  {
-    Select,
-    Boolean,
-    Text,
-    Int,
-    Double
-  };
-
-  QString name;
-  Type type = Type::Text;
-  QStringList options;
-  QString description;
-  QVariant defaultValue;
-  QVariant minimum;
-  QVariant maximum;
-};
 
 class QgsGdalCredentialOptionsModel : public QAbstractItemModel
 {
@@ -72,9 +53,9 @@ class QgsGdalCredentialOptionsModel : public QAbstractItemModel
     bool removeRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
 
     void setOptions( const QList< QPair< QString, QString > > &options );
-    void setAvailableOptions( const QList< GdalOption > &options );
+    void setAvailableOptions( const QList< QgsGdalOption > &options );
     QStringList availableKeys() const { return mAvailableKeys; }
-    GdalOption option( const QString &key ) const;
+    QgsGdalOption option( const QString &key ) const;
     QList< QPair< QString, QString > > credentialOptions() const { return mCredentialOptions; }
     void setCredentialOptions( const QList< QPair< QString, QString > > &options );
 
@@ -85,7 +66,7 @@ class QgsGdalCredentialOptionsModel : public QAbstractItemModel
   private:
 
     QList< QPair< QString, QString > > mCredentialOptions;
-    QList< GdalOption > mAvailableOptions;
+    QList< QgsGdalOption > mAvailableOptions;
     QStringList mAvailableKeys;
     QMap<QString, QString> mDescriptions;
 };

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h
@@ -1,0 +1,180 @@
+/***************************************************************************
+                          qgsgdalcredentialoptionswidget.h
+                             -------------------
+    begin                : June 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGGDALCREDENTIALOPTIONSWIDGET_H
+#define QGGDALCREDENTIALOPTIONSWIDGET_H
+
+#include "ui_qgsgdalcredentialoptionswidgetbase.h"
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+
+#include <QAbstractItemModel>
+#include <QStyledItemDelegate>
+
+#ifndef SIP_RUN
+///@cond PRIVATE
+
+struct GdalOption
+{
+  enum class Type
+  {
+    Select,
+    Boolean,
+    Text
+  };
+
+  QString name;
+  Type type = Type::Text;
+  QStringList options;
+  QString description;
+  QString defaultValue;
+};
+
+class QgsGdalCredentialOptionsModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+  public:
+
+    enum Column
+    {
+      Key = 0,
+      Value = 1,
+      Actions = 2
+    };
+
+    QgsGdalCredentialOptionsModel( QObject *parent );
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex parent( const QModelIndex &child ) const override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+    bool insertRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
+    bool removeRows( int position, int rows, const QModelIndex &parent = QModelIndex() ) override;
+
+    void setOptions( const QList< QPair< QString, QString > > &options );
+    void setAvailableOptions( const QList< GdalOption > &options );
+    QStringList availableKeys() const { return mAvailableKeys; }
+    GdalOption option( const QString &key ) const;
+    QList< QPair< QString, QString > > credentialOptions() const { return mCredentialOptions; }
+    void setCredentialOptions( const QList< QPair< QString, QString > > &options );
+
+  signals:
+
+    void optionsChanged();
+
+  private:
+
+    QList< QPair< QString, QString > > mCredentialOptions;
+    QList< GdalOption > mAvailableOptions;
+    QStringList mAvailableKeys;
+    QMap<QString, QString> mDescriptions;
+};
+
+
+class QgsGdalCredentialOptionsDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+
+    QgsGdalCredentialOptionsDelegate( QObject *parent );
+
+  protected:
+    QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem & /*option*/, const QModelIndex &index ) const override;
+    void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+    void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+};
+
+class QgsGdalCredentialOptionsRemoveOptionDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+    QgsGdalCredentialOptionsRemoveOptionDelegate( QObject *parent );
+    bool eventFilter( QObject *obj, QEvent *event ) override;
+  protected:
+    void paint( QPainter *painter,
+                const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+  private:
+    void setHoveredIndex( const QModelIndex &index );
+
+    QModelIndex mHoveredIndex;
+};
+
+///@endcond PRIVATE
+#endif
+
+/**
+ * \class QgsGdalCredentialOptionsWidget
+ * \brief A widget for configuring GDAL credential options.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsGdalCredentialOptionsWidget : public QWidget, private Ui::QgsGdalCredentialOptionsWidgetBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsGdalCredentialOptionsWidget, with the specified \a parent widget.
+     */
+    QgsGdalCredentialOptionsWidget( QWidget *parent = nullptr );
+
+    /**
+     * Sets the corresponding \a driver.
+     *
+     * This should match a GDAL VSI driver, eg "vsis3".
+     */
+    void setDriver( const QString &driver );
+
+    /**
+     * Returns the credential options configured in the widget.
+     *
+     * \see setCredentialOptions()
+     */
+    QVariantMap credentialOptions() const;
+
+    /**
+     * Sets the credential \a options to show in the widget.
+     *
+     * \see credentialOptions()
+     */
+    void setCredentialOptions( const QVariantMap &options );
+
+  signals:
+
+    /**
+     * Emitted when the credential options are changed in the widget.
+     */
+    void optionsChanged();
+
+  private slots:
+
+    void modelOptionsChanged();
+
+  private:
+
+    QString mDriver;
+    QgsGdalCredentialOptionsModel *mModel = nullptr;
+    QgsGdalCredentialOptionsDelegate *mDelegate = nullptr;
+
+};
+
+#endif // QGGDALCREDENTIALOPTIONSWIDGET_H

--- a/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h
+++ b/src/gui/providers/gdal/qgsgdalcredentialoptionswidget.h
@@ -33,14 +33,18 @@ struct GdalOption
   {
     Select,
     Boolean,
-    Text
+    Text,
+    Int,
+    Double
   };
 
   QString name;
   Type type = Type::Text;
   QStringList options;
   QString description;
-  QString defaultValue;
+  QVariant defaultValue;
+  QVariant minimum;
+  QVariant maximum;
 };
 
 class QgsGdalCredentialOptionsModel : public QAbstractItemModel

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -46,19 +46,10 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   whileBlocking( radioSrcFile )->setChecked( true );
   protocolGroupBox->hide();
 
-  for ( const auto &protocol :
-        {
-          std::make_pair( QStringLiteral( "HTTP/HTTPS/FTP" ), QStringLiteral( "vsicurl" ) ),
-          std::make_pair( QStringLiteral( "AWS S3" ), QStringLiteral( "vsis3" ) ),
-          std::make_pair( QObject::tr( "Google Cloud Storage" ), QStringLiteral( "vsigs" ) ),
-          std::make_pair( QObject::tr( "Microsoft Azure Blob" ), QStringLiteral( "vsiaz" ) ),
-          std::make_pair( QObject::tr( "Microsoft Azure Data Lake Storage" ), QStringLiteral( "vsiadls" ) ),
-          std::make_pair( QObject::tr( "Alibaba Cloud OSS" ), QStringLiteral( "vsioss" ) ),
-          std::make_pair( QObject::tr( "OpenStack Swift Object Storage" ), QStringLiteral( "vsiswift" ) ),
-          std::make_pair( QObject::tr( "Hadoop File System" ), QStringLiteral( "vsihdfs" ) ),
-        } )
+  const QList< QgsGdalUtils::VsiNetworkFileSystemDetails > vsiDetails = QgsGdalUtils::vsiNetworkFileSystems();
+  for ( const QgsGdalUtils::VsiNetworkFileSystemDetails &vsiDetail : vsiDetails )
   {
-    cmbProtocolTypes->addItem( protocol.first, protocol.second );
+    cmbProtocolTypes->addItem( vsiDetail.name, vsiDetail.identifier );
   }
 
   connect( protocolURI, &QLineEdit::textChanged, this, [ = ]( const QString & text )

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -99,7 +99,7 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
 
 void QgsGdalSourceSelect::setProtocolWidgetsVisibility()
 {
-  if ( isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
+  if ( QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
   {
     labelProtocolURI->hide();
     protocolURI->hide();
@@ -318,7 +318,7 @@ void QgsGdalSourceSelect::computeDataSources()
   }
   else if ( radioSrcProtocol->isChecked() )
   {
-    bool cloudType = isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
+    bool cloudType = QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
     if ( !cloudType && protocolURI->text().isEmpty() )
     {
       return;
@@ -344,11 +344,11 @@ void QgsGdalSourceSelect::computeDataSources()
     if ( !credentialOptions.isEmpty() )
       parts.insert( QStringLiteral( "credentialOptions" ), credentialOptions );
     parts.insert( QStringLiteral( "path" ),
-                  createProtocolURI( cmbProtocolTypes->currentData().toString(),
-                                     uri,
-                                     mAuthSettingsProtocol->configId(),
-                                     mAuthSettingsProtocol->username(),
-                                     mAuthSettingsProtocol->password() ) );
+                  QgsGdalGuiUtils::createProtocolURI( cmbProtocolTypes->currentData().toString(),
+                      uri,
+                      mAuthSettingsProtocol->configId(),
+                      mAuthSettingsProtocol->username(),
+                      mAuthSettingsProtocol->password() ) );
     mDataSources << QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts );
   }
 }
@@ -539,7 +539,7 @@ void QgsGdalSourceSelect::showHelp()
 void QgsGdalSourceSelect::updateProtocolOptions()
 {
   const QString currentProtocol = cmbProtocolTypes->currentData().toString();
-  if ( radioSrcProtocol->isChecked() && isProtocolCloudType( currentProtocol ) )
+  if ( radioSrcProtocol->isChecked() && QgsGdalGuiUtils::isProtocolCloudType( currentProtocol ) )
   {
     mCredentialsWidget->setDriver( currentProtocol );
     mCredentialOptionsGroupBox->setVisible( true );

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -48,8 +48,12 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   whileBlocking( radioSrcFile )->setChecked( true );
   protocolGroupBox->hide();
 
-  const QList< QgsGdalUtils::VsiNetworkFileSystemDetails > vsiDetails = QgsGdalUtils::vsiNetworkFileSystems();
-  for ( const QgsGdalUtils::VsiNetworkFileSystemDetails &vsiDetail : vsiDetails )
+  QList< QgsGdalUtils::VsiNetworkFileSystemDetails > vsiDetails = QgsGdalUtils::vsiNetworkFileSystems();
+  std::sort( vsiDetails.begin(), vsiDetails.end(), []( const QgsGdalUtils::VsiNetworkFileSystemDetails & a, const QgsGdalUtils::VsiNetworkFileSystemDetails & b )
+  {
+    return QString::localeAwareCompare( a.name, b.name ) < 0;
+  } );
+  for ( const QgsGdalUtils::VsiNetworkFileSystemDetails &vsiDetail : std::as_const( vsiDetails ) )
   {
     cmbProtocolTypes->addItem( vsiDetail.name, vsiDetail.identifier );
   }

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -432,18 +432,7 @@ void QgsGdalSourceSelect::fillOpenOptions()
     const QRegularExpressionMatch bucketMatch = bucketRx.match( parts.value( QStringLiteral( "path" ) ).toString() );
     if ( bucketMatch.hasMatch() )
     {
-      const QString bucket = vsiPrefix + bucketMatch.captured( 1 );
-      for ( auto it = credentialOptions.constBegin(); it != credentialOptions.constEnd(); ++it )
-      {
-#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 6, 0)
-        VSISetPathSpecificOption( bucket.toUtf8().constData(), it.key().toUtf8().constData(), it.value().toString().toUtf8().constData() );
-#elif GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
-        VSISetCredential( bucket.toUtf8().constData(), it.key().toUtf8().constData(), it.value().toString().toUtf8().constData() );
-#else
-        ( void )bucket;
-        QgsMessageLog::logMessage( QObject::tr( "Cannot use VSI credential options on GDAL versions earlier than 3.5" ), QStringLiteral( "GDAL" ), Qgis::MessageLevel::Critical );
-#endif
-      }
+      QgsGdalUtils::applyVsiCredentialOptions( vsiPrefix, bucketMatch.captured( 1 ), credentialOptions );
     }
   }
 

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -105,7 +105,7 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
 
 void QgsGdalSourceSelect::setProtocolWidgetsVisibility()
 {
-  if ( QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
+  if ( QgsGdalUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
   {
     labelProtocolURI->hide();
     protocolURI->hide();
@@ -360,7 +360,7 @@ void QgsGdalSourceSelect::computeDataSources()
   }
   else if ( radioSrcProtocol->isChecked() )
   {
-    bool cloudType = QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
+    bool cloudType = QgsGdalUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
     if ( !cloudType && protocolURI->text().isEmpty() )
     {
       return;
@@ -524,7 +524,7 @@ void QgsGdalSourceSelect::showHelp()
 void QgsGdalSourceSelect::updateProtocolOptions()
 {
   const QString currentProtocol = cmbProtocolTypes->currentData().toString();
-  if ( radioSrcProtocol->isChecked() && QgsGdalGuiUtils::isProtocolCloudType( currentProtocol ) )
+  if ( radioSrcProtocol->isChecked() && QgsGdalUtils::isProtocolCloudType( currentProtocol ) )
   {
     mCredentialsWidget->setDriver( currentProtocol );
     mCredentialOptionsGroupBox->setVisible( true );

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -37,9 +37,6 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
     //! Constructor
     QgsGdalSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
 
-    //! Returns whether the protocol is a cloud type
-    bool isProtocolCloudType();
-
   public slots:
     //! Determines the tables the user selected and closes the dialog
     void addButtonClicked() override;

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -25,6 +25,8 @@
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
+class QgsGdalCredentialOptionsWidget;
+
 /**
  * \class QgsGdalSourceSelect
  * \brief Dialog to select GDAL supported rasters
@@ -51,17 +53,23 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
 
   private slots:
     void showHelp();
+    void updateProtocolOptions();
+    void credentialOptionsChanged();
 
   private:
 
     void computeDataSources();
     void clearOpenOptions();
     void fillOpenOptions();
+
     std::vector<QWidget *> mOpenOptionsWidgets;
+    QgsGdalCredentialOptionsWidget *mCredentialsWidget = nullptr;
 
     QString mRasterPath;
     QStringList mDataSources;
     bool mIsOgcApi = false;
+    QVariantMap mCredentialOptions;
+
 };
 
 ///@endcond

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -385,13 +385,15 @@ bool QgsOgrDbSourceSelect::configureFromUri( const QString &uri )
   QString subsetString;
   OGRwkbGeometryType ogrGeometryType;
   QStringList openOptions;
+  QVariantMap credentialOptions;
   const QString filePath = QgsOgrProviderUtils::analyzeURI( uri,
                            isSubLayer,
                            layerIndex,
                            layerName,
                            subsetString,
                            ogrGeometryType,
-                           openOptions );
+                           openOptions,
+                           credentialOptions );
 
   QFileInfo pathInfo { filePath };
   const QString connectionName { pathInfo.fileName() };

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -99,8 +99,12 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   }
 
   //add protocol drivers
-  const QList< QgsGdalUtils::VsiNetworkFileSystemDetails > vsiDetails = QgsGdalUtils::vsiNetworkFileSystems();
-  for ( const QgsGdalUtils::VsiNetworkFileSystemDetails &vsiDetail : vsiDetails )
+  QList< QgsGdalUtils::VsiNetworkFileSystemDetails > vsiDetails = QgsGdalUtils::vsiNetworkFileSystems();
+  std::sort( vsiDetails.begin(), vsiDetails.end(), []( const QgsGdalUtils::VsiNetworkFileSystemDetails & a, const QgsGdalUtils::VsiNetworkFileSystemDetails & b )
+  {
+    return QString::localeAwareCompare( a.name, b.name ) < 0;
+  } );
+  for ( const QgsGdalUtils::VsiNetworkFileSystemDetails &vsiDetail : std::as_const( vsiDetails ) )
   {
     cmbProtocolTypes->addItem( vsiDetail.name, vsiDetail.identifier );
   }

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -284,7 +284,7 @@ void QgsOgrSourceSelect::setSelectedConnection()
 
 void QgsOgrSourceSelect::setProtocolWidgetsVisibility()
 {
-  if ( isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
+  if ( QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
   {
     labelProtocolURI->hide();
     protocolURI->hide();
@@ -376,7 +376,7 @@ void QgsOgrSourceSelect::computeDataSources( bool interactive )
       if ( !openOptions.isEmpty() )
         parts.insert( QStringLiteral( "openOptions" ), openOptions );
       parts.insert( QStringLiteral( "path" ),
-                    createDatabaseURI(
+                    QgsGdalGuiUtils::createDatabaseURI(
                       cmbDatabaseTypes->currentText(),
                       host,
                       database,
@@ -390,7 +390,7 @@ void QgsOgrSourceSelect::computeDataSources( bool interactive )
   }
   else if ( radioSrcProtocol->isChecked() )
   {
-    bool cloudType = isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
+    bool cloudType = QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
     if ( !cloudType && protocolURI->text().isEmpty() )
     {
       if ( interactive )
@@ -426,11 +426,11 @@ void QgsOgrSourceSelect::computeDataSources( bool interactive )
     if ( !openOptions.isEmpty() )
       parts.insert( QStringLiteral( "openOptions" ), openOptions );
     parts.insert( QStringLiteral( "path" ),
-                  createProtocolURI( cmbProtocolTypes->currentData().toString(),
-                                     uri,
-                                     mAuthSettingsProtocol->configId(),
-                                     mAuthSettingsProtocol->username(),
-                                     mAuthSettingsProtocol->password() ) );
+                  QgsGdalGuiUtils::createProtocolURI( cmbProtocolTypes->currentData().toString(),
+                      uri,
+                      mAuthSettingsProtocol->configId(),
+                      mAuthSettingsProtocol->username(),
+                      mAuthSettingsProtocol->password() ) );
     mDataSources << QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "ogr" ), parts );
   }
   else if ( radioSrcFile->isChecked() || radioSrcOgcApi->isChecked() )

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -32,6 +32,7 @@
 #include "ogr/qgsnewogrconnection.h"
 #include "ogr/qgsogrhelperfunctions.h"
 #include "qgsgui.h"
+#include "qgsgdalutils.h"
 
 #include <gdal.h>
 #include <cpl_minixml.h>
@@ -95,21 +96,13 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   }
 
   //add protocol drivers
-  for ( const auto &protocol :
-        {
-          std::make_pair( QStringLiteral( "HTTP/HTTPS/FTP" ), QStringLiteral( "vsicurl" ) ),
-          std::make_pair( QStringLiteral( "AWS S3" ), QStringLiteral( "vsis3" ) ),
-          std::make_pair( QObject::tr( "Google Cloud Storage" ), QStringLiteral( "vsigs" ) ),
-          std::make_pair( QObject::tr( "Microsoft Azure Blob" ), QStringLiteral( "vsiaz" ) ),
-          std::make_pair( QObject::tr( "Microsoft Azure Data Lake Storage" ), QStringLiteral( "vsiadls" ) ),
-          std::make_pair( QObject::tr( "Alibaba Cloud OSS" ), QStringLiteral( "vsioss" ) ),
-          std::make_pair( QObject::tr( "OpenStack Swift Object Storage" ), QStringLiteral( "vsiswift" ) ),
-          std::make_pair( QObject::tr( "Hadoop File System" ), QStringLiteral( "vsihdfs" ) ),
-          std::make_pair( QObject::tr( "WFS3 (Experimental)" ), QStringLiteral( "WFS3" ) ),
-        } )
+  const QList< QgsGdalUtils::VsiNetworkFileSystemDetails > vsiDetails = QgsGdalUtils::vsiNetworkFileSystems();
+  for ( const QgsGdalUtils::VsiNetworkFileSystemDetails &vsiDetail : vsiDetails )
   {
-    cmbProtocolTypes->addItem( protocol.first, protocol.second );
+    cmbProtocolTypes->addItem( vsiDetail.name, vsiDetail.identifier );
   }
+  cmbProtocolTypes->addItem( QObject::tr( "WFS3 (Experimental)" ), QStringLiteral( "WFS3" ) );
+
   cmbDatabaseTypes->blockSignals( false );
   cmbConnections->blockSignals( false );
 

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -295,7 +295,7 @@ void QgsOgrSourceSelect::setSelectedConnection()
 
 void QgsOgrSourceSelect::setProtocolWidgetsVisibility()
 {
-  if ( QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
+  if ( QgsGdalUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() ) )
   {
     labelProtocolURI->hide();
     protocolURI->hide();
@@ -415,7 +415,7 @@ void QgsOgrSourceSelect::computeDataSources( bool interactive )
   }
   else if ( radioSrcProtocol->isChecked() )
   {
-    bool cloudType = QgsGdalGuiUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
+    bool cloudType = QgsGdalUtils::isProtocolCloudType( cmbProtocolTypes->currentData().toString() );
     if ( !cloudType && protocolURI->text().isEmpty() )
     {
       if ( interactive )
@@ -739,7 +739,7 @@ bool QgsOgrSourceSelect::configureFromUri( const QString &uri )
 void QgsOgrSourceSelect::updateProtocolOptions()
 {
   const QString currentProtocol = cmbProtocolTypes->currentData().toString();
-  if ( radioSrcProtocol->isChecked() && QgsGdalGuiUtils::isProtocolCloudType( currentProtocol ) )
+  if ( radioSrcProtocol->isChecked() && QgsGdalUtils::isProtocolCloudType( currentProtocol ) )
   {
     mCredentialsWidget->setDriver( currentProtocol );
     mCredentialOptionsGroupBox->setVisible( true );

--- a/src/gui/providers/ogr/qgsogrsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrsourceselect.h
@@ -31,7 +31,6 @@
 #include <vector>
 
 #include "ui_qgsogrsourceselectbase.h"
-#include "qgshelp.h"
 #include "qgsproviderregistry.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
@@ -39,6 +38,8 @@
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
+
+class QgsGdalCredentialOptionsWidget;
 
 /**
  *  Class for a  dialog to select the type and source for ogr vectors, supports
@@ -110,6 +111,8 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     void cmbProtocolTypes_currentIndexChanged( const QString &text );
     void showHelp();
     bool configureFromUri( const QString &uri ) override;
+    void updateProtocolOptions();
+    void credentialOptionsChanged();
 
   private:
 
@@ -117,9 +120,10 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     void clearOpenOptions();
     void fillOpenOptions();
     std::vector<QWidget *> mOpenOptionsWidgets;
+    QgsGdalCredentialOptionsWidget *mCredentialsWidget = nullptr;
     bool mIsOgcApi = false;
+    QVariantMap mCredentialOptions;
     QString mVectorPath;
-
 
 };
 

--- a/src/gui/providers/ogr/qgsogrsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrsourceselect.h
@@ -61,8 +61,6 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     QString encoding();
     //! Returns the connection type
     QString dataSourceType();
-    //! Returns whether the protocol is a cloud type
-    bool isProtocolCloudType();
 
   private:
     //! Stores the file vector filters

--- a/src/ui/qgsgdalcredentialoptionswidgetbase.ui
+++ b/src/ui/qgsgdalcredentialoptionswidgetbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Credentials</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">

--- a/src/ui/qgsgdalcredentialoptionswidgetbase.ui
+++ b/src/ui/qgsgdalcredentialoptionswidgetbase.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsGdalCredentialOptionsWidgetBase</class>
+ <widget class="QWidget" name="QgsGdalCredentialOptionsWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>705</width>
+    <height>446</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="2" column="0">
+    <widget class="QTableView" name="mTableView"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mLabelWarning">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mLabelInfo">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>355</width>
-    <height>501</height>
+    <width>878</width>
+    <height>921</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -179,19 +179,6 @@
         <item row="3" column="1">
          <widget class="QLineEdit" name="mKey"/>
         </item>
-        <item row="4" column="0" colspan="2">
-         <widget class="QLabel" name="mAuthWarning">
-          <property name="text">
-           <string>…</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item row="5" column="0" colspan="2">
          <widget class="QGroupBox" name="mAuthGroupBox">
           <property name="title">
@@ -227,6 +214,18 @@
       </widget>
      </item>
      <item>
+      <widget class="QgsCollapsibleGroupBox" name="mCredentialOptionsGroupBox" native="true">
+       <property name="title" stdset="0">
+        <string>Credential Options</string>
+       </property>
+       <layout class="QVBoxLayout" name="openOptionsVBoxLayout_2" stretch="1">
+        <item>
+         <layout class="QFormLayout" name="mCredentialOptionsLayout"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QgsScrollArea" name="scrollArea">
        <property name="frameShape">
         <enum>QFrame::NoFrame</enum>
@@ -239,8 +238,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>353</width>
-          <height>68</height>
+          <width>876</width>
+          <height>246</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_5">

--- a/src/ui/qgsogrsourceselectbase.ui
+++ b/src/ui/qgsogrsourceselectbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>522</width>
+    <width>545</width>
     <height>786</height>
    </rect>
   </property>
@@ -141,23 +141,19 @@
         <string>Protocol</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
+        <item row="3" column="1">
+         <widget class="QLineEdit" name="mKey"/>
+        </item>
         <item row="0" column="1">
          <widget class="QComboBox" name="cmbProtocolTypes"/>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_2">
+        <item row="3" column="0">
+         <widget class="QLabel" name="labelKey">
           <property name="text">
-           <string>Type</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="labelProtocolURI">
-          <property name="text">
-           <string>&amp;URI</string>
+           <string>Object key</string>
           </property>
           <property name="buddy">
-           <cstring>protocolURI</cstring>
+           <cstring>mKey</cstring>
           </property>
          </widget>
         </item>
@@ -177,33 +173,7 @@
         <item row="2" column="1">
          <widget class="QLineEdit" name="mBucket"/>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="labelKey">
-          <property name="text">
-           <string>Object key</string>
-          </property>
-          <property name="buddy">
-           <cstring>mKey</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="mKey"/>
-        </item>
         <item row="4" column="0" colspan="2">
-         <widget class="QLabel" name="mAuthWarning">
-          <property name="text">
-           <string>…</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0" colspan="2">
          <widget class="QGroupBox" name="mAuthGroupBox">
           <property name="title">
            <string>Authentication</string>
@@ -232,6 +202,23 @@
             </widget>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelProtocolURI">
+          <property name="text">
+           <string>&amp;URI</string>
+          </property>
+          <property name="buddy">
+           <cstring>protocolURI</cstring>
+          </property>
          </widget>
         </item>
        </layout>
@@ -366,6 +353,18 @@
       </widget>
      </item>
      <item>
+      <widget class="QgsCollapsibleGroupBox" name="mCredentialOptionsGroupBox">
+       <property name="title">
+        <string>Credential Options</string>
+       </property>
+       <layout class="QVBoxLayout" name="openOptionsVBoxLayout_2" stretch="1">
+        <item>
+         <layout class="QFormLayout" name="mCredentialOptionsLayout"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QgsScrollArea" name="scrollArea">
        <property name="frameShape">
         <enum>QFrame::NoFrame</enum>
@@ -390,8 +389,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>506</width>
-          <height>78</height>
+          <width>529</width>
+          <height>77</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -408,8 +407,8 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QgsCollapsibleGroupBox" name="mOpenOptionsGroupBox" native="true">
-           <property name="title" stdset="0">
+          <widget class="QgsCollapsibleGroupBox" name="mOpenOptionsGroupBox">
+           <property name="title">
             <string>Options</string>
            </property>
            <layout class="QVBoxLayout" name="openOptionsVBoxLayout">
@@ -461,6 +460,18 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
@@ -470,18 +481,6 @@
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>qgsauthsettingswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QWidget</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -138,8 +138,15 @@ void TestQgsGdalProvider::decodeUri()
   // test authcfg with vsicurl URI
   uri = QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif authcfg='1234567'" );
   components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
-  QCOMPARE( components.value( QStringLiteral( "path" ) ).toString(), QString( "/vsicurl/https://www.qgis.org/dataset.tif" ) );
+  QCOMPARE( components.value( QStringLiteral( "path" ) ).toString(), QString( "https://www.qgis.org/dataset.tif" ) );
+  QCOMPARE( components.value( QStringLiteral( "vsiPrefix" ) ).toString(), QString( "/vsicurl/" ) );
   QCOMPARE( components.value( QStringLiteral( "authcfg" ) ).toString(), QString( "1234567" ) );
+
+  // vsis3
+  uri = QStringLiteral( "/vsis3/nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" );
+  components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
+  QCOMPARE( components.value( QStringLiteral( "path" ) ).toString(), QString( "nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" ) );
+  QCOMPARE( components.value( QStringLiteral( "vsiPrefix" ) ).toString(), QString( "/vsis3/" ) );
 }
 
 void TestQgsGdalProvider::encodeUri()
@@ -162,6 +169,17 @@ void TestQgsGdalProvider::encodeUri()
   parts.insert( QStringLiteral( "path" ), QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif" ) );
   parts.insert( QStringLiteral( "authcfg" ), QStringLiteral( "1234567" ) );
   QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif authcfg='1234567'" ) );
+  parts.clear();
+  parts.insert( QStringLiteral( "path" ), QStringLiteral( "https://www.qgis.org/dataset.tif" ) );
+  parts.insert( QStringLiteral( "vsiPrefix" ), QStringLiteral( "/vsicurl/" ) );
+  parts.insert( QStringLiteral( "authcfg" ), QStringLiteral( "1234567" ) );
+  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/vsicurl/https://www.qgis.org/dataset.tif authcfg='1234567'" ) );
+
+  // vsis3
+  parts.clear();
+  parts.insert( QStringLiteral( "vsiPrefix" ), QStringLiteral( "/vsis3/" ) );
+  parts.insert( QStringLiteral( "path" ), QStringLiteral( "nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" ) );
+  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/vsis3/nz-elevation/auckland/auckland-north_2016-2018/dem_1m/2193/AY30_10000_0405.tiff" ) );
 }
 
 void TestQgsGdalProvider::scaleDataType()

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -113,6 +113,23 @@ class PyQgsGdalProvider(QgisTestCase):
         encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
         self.assertEqual(encodedUri, uri)
 
+    def testDecodeEncodeUriCredentialOptions(self):
+        """Test decodeUri/encodeUri credential options support"""
+
+        uri = '/my/raster.pdf|option:AN=OPTION|credential:ANOTHER=BBB|credential:SOMEKEY=AAAAA'
+        parts = QgsProviderRegistry.instance().decodeUri('gdal', uri)
+        self.assertEqual(parts, {
+            'path': '/my/raster.pdf',
+            'layerName': None,
+            'credentialOptions': {
+                'ANOTHER': 'BBB',
+                'SOMEKEY': 'AAAAA'
+            },
+            'openOptions': ['AN=OPTION']
+        })
+        encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
+        self.assertEqual(encodedUri, uri)
+
     def testDecodeEncodeUriVsizip(self):
         """Test decodeUri/encodeUri for /vsizip/ prefixed URIs"""
 

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -1626,6 +1626,24 @@ class PyQgsOGRProvider(QgisTestCase):
         encodedUri = QgsProviderRegistry.instance().encodeUri('ogr', parts)
         self.assertEqual(encodedUri, uri)
 
+    def testDecodeEncodeUriCredentialOptions(self):
+        """Test decodeUri/encodeUri credential options support"""
+
+        uri = '/my/vector.shp|option:AN=OPTION|credential:ANOTHER=BBB|credential:SOMEKEY=AAAAA'
+        parts = QgsProviderRegistry.instance().decodeUri('ogr', uri)
+        self.assertEqual(parts, {
+            'path': '/my/vector.shp',
+            'layerId': None,
+            'layerName': None,
+            'credentialOptions': {
+                'ANOTHER': 'BBB',
+                'SOMEKEY': 'AAAAA'
+            },
+            'openOptions': ['AN=OPTION']
+        })
+        encodedUri = QgsProviderRegistry.instance().encodeUri('ogr', parts)
+        self.assertEqual(encodedUri, uri)
+
     @unittest.skipIf(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(3, 3, 0), "GDAL 3.3 required")
     def testFieldDomains(self):
         """


### PR DESCRIPTION
This PR exposes the VSI credential options for user control when adding OGR vector/GDAL raster layers from the Data Source Manager, eg:

![image](https://github.com/qgis/QGIS/assets/1829991/5ffcdfee-6869-4018-9460-e81f3e8e41fb)

The underlying provider changes were discussed in https://github.com/qgis/QGIS/pull/57801. When credential options are found in a layer's URI, we use GDAL's VSISetPathSpecificOption to set the credential option for that VSI driver and bucket. 

This allows per-vsi driver & bucket credentials for layers, whereas other approaches (like environment variable setting) force a single set of credentials to be used for an entire QGIS session. (And are difficult for users to set)

I've also taken the opportunity to cleanup a bunch of code relating to how VSI protocols are exposed in GUI, and how GUIs for GDAL configuration options are dynamically created.

Requires GDAL 3.5+