### PR TITLE
[api][processing] QgsProcessingAlgorithm's supportsInPlace function should be public

### DIFF
--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -450,6 +450,16 @@ Returns a JSON serializable variant map containing the specified ``parameters`` 
 Associates this algorithm with its provider. No transfer of ownership is involved.
 %End
 
+    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
+%Docstring
+Checks whether this algorithm supports in-place editing on the given ``layer``
+Default implementation returns ``False``.
+
+:return: ``True`` if the algorithm supports in-place editing
+
+.. versionadded:: 3.4
+%End
+
   protected:
 
     virtual QgsProcessingAlgorithm *createInstance() const = 0 /Factory,VirtualErrorHandler=processing_exception_handler/;
@@ -1099,16 +1109,6 @@ should correspond to the sink parameter name.
 .. versionadded:: 3.22
 %End
 
-    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
-%Docstring
-Checks whether this algorithm supports in-place editing on the given ``layer``
-Default implementation returns ``False``.
-
-:return: ``True`` if the algorithm supports in-place editing
-
-.. versionadded:: 3.4
-%End
-
   private:
     QgsProcessingAlgorithm( const QgsProcessingAlgorithm &other );
 };
@@ -1172,6 +1172,18 @@ Algorithms can throw a :py:class:`QgsProcessingException` if a fatal error occur
 prevent the algorithm execution from continuing. This can be annoying for users though as it
 can break valid model execution - so use with extreme caution, and consider using
 ``feedback`` to instead report non-fatal processing failures for features instead.
+%End
+
+    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
+
+%Docstring
+Checks whether this algorithm supports in-place editing on the given ``layer``
+Default implementation for feature based algorithms run some basic compatibility
+checks based on the geometry type of the layer.
+
+:return: ``True`` if the algorithm supports in-place editing
+
+.. versionadded:: 3.4
 %End
 
   protected:
@@ -1281,18 +1293,6 @@ called from a subclasses' :py:func:`~QgsProcessingFeatureBasedAlgorithm.processF
 %Docstring
 Returns the feature request used for fetching features to process from the
 source layer. The default implementation requests all attributes and geometry.
-%End
-
-    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
-
-%Docstring
-Checks whether this algorithm supports in-place editing on the given ``layer``
-Default implementation for feature based algorithms run some basic compatibility
-checks based on the geometry type of the layer.
-
-:return: ``True`` if the algorithm supports in-place editing
-
-.. versionadded:: 3.4
 %End
 
     void prepareSource( const QVariantMap &parameters, QgsProcessingContext &context );

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -1186,11 +1186,6 @@ checks based on the geometry type of the layer.
 .. versionadded:: 3.4
 %End
 
-  protected:
-
-    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );
-
-
     virtual QString inputParameterName() const /HoldGIL/;
 %Docstring
 Returns the name of the parameter corresponding to the input layer.
@@ -1208,6 +1203,11 @@ By default this is a translated "Input layer" string.
 
 .. versionadded:: 3.12
 %End
+
+  protected:
+
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );
+
 
     virtual QString outputName() const = 0 /HoldGIL/;
 %Docstring

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -450,6 +450,16 @@ Returns a JSON serializable variant map containing the specified ``parameters`` 
 Associates this algorithm with its provider. No transfer of ownership is involved.
 %End
 
+    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
+%Docstring
+Checks whether this algorithm supports in-place editing on the given ``layer``
+Default implementation returns ``False``.
+
+:return: ``True`` if the algorithm supports in-place editing
+
+.. versionadded:: 3.4
+%End
+
   protected:
 
     virtual QgsProcessingAlgorithm *createInstance() const = 0 /Factory,VirtualErrorHandler=processing_exception_handler/;
@@ -1099,16 +1109,6 @@ should correspond to the sink parameter name.
 .. versionadded:: 3.22
 %End
 
-    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
-%Docstring
-Checks whether this algorithm supports in-place editing on the given ``layer``
-Default implementation returns ``False``.
-
-:return: ``True`` if the algorithm supports in-place editing
-
-.. versionadded:: 3.4
-%End
-
   private:
     QgsProcessingAlgorithm( const QgsProcessingAlgorithm &other );
 };
@@ -1172,6 +1172,18 @@ Algorithms can throw a :py:class:`QgsProcessingException` if a fatal error occur
 prevent the algorithm execution from continuing. This can be annoying for users though as it
 can break valid model execution - so use with extreme caution, and consider using
 ``feedback`` to instead report non-fatal processing failures for features instead.
+%End
+
+    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
+
+%Docstring
+Checks whether this algorithm supports in-place editing on the given ``layer``
+Default implementation for feature based algorithms run some basic compatibility
+checks based on the geometry type of the layer.
+
+:return: ``True`` if the algorithm supports in-place editing
+
+.. versionadded:: 3.4
 %End
 
   protected:
@@ -1281,18 +1293,6 @@ called from a subclasses' :py:func:`~QgsProcessingFeatureBasedAlgorithm.processF
 %Docstring
 Returns the feature request used for fetching features to process from the
 source layer. The default implementation requests all attributes and geometry.
-%End
-
-    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
-
-%Docstring
-Checks whether this algorithm supports in-place editing on the given ``layer``
-Default implementation for feature based algorithms run some basic compatibility
-checks based on the geometry type of the layer.
-
-:return: ``True`` if the algorithm supports in-place editing
-
-.. versionadded:: 3.4
 %End
 
     void prepareSource( const QVariantMap &parameters, QgsProcessingContext &context );

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -1186,11 +1186,6 @@ checks based on the geometry type of the layer.
 .. versionadded:: 3.4
 %End
 
-  protected:
-
-    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );
-
-
     virtual QString inputParameterName() const /HoldGIL/;
 %Docstring
 Returns the name of the parameter corresponding to the input layer.
@@ -1208,6 +1203,11 @@ By default this is a translated "Input layer" string.
 
 .. versionadded:: 3.12
 %End
+
+  protected:
+
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );
+
 
     virtual QString outputName() const = 0 /HoldGIL/;
 %Docstring

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.h
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.h
@@ -42,6 +42,7 @@ class QgsAddIncrementalFieldAlgorithm : public QgsProcessingFeatureBasedAlgorith
     QString shortHelpString() const override;
     QList<int> inputLayerTypes() const override;
     QgsAddIncrementalFieldAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -53,7 +54,6 @@ class QgsAddIncrementalFieldAlgorithm : public QgsProcessingFeatureBasedAlgorith
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureRequest request() const override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmaddtablefield.h
+++ b/src/analysis/processing/qgsalgorithmaddtablefield.h
@@ -42,6 +42,7 @@ class QgsAddTableFieldAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortHelpString() const override;
     QList<int> inputLayerTypes() const override;
     QgsAddTableFieldAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -52,7 +53,6 @@ class QgsAddTableFieldAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmaddxyfields.h
+++ b/src/analysis/processing/qgsalgorithmaddxyfields.h
@@ -43,6 +43,7 @@ class QgsAddXYFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortDescription() const override;
     QList<int> inputLayerTypes() const override;
     QgsAddXYFieldsAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -54,7 +55,6 @@ class QgsAddXYFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmaggregate.h
+++ b/src/analysis/processing/qgsalgorithmaggregate.h
@@ -41,6 +41,7 @@ class QgsAggregateAlgorithm : public QgsProcessingAlgorithm
     QString group() const override;
     QString groupId() const override;
     QString shortHelpString() const override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
     QgsAggregateAlgorithm *createInstance() const override SIP_FACTORY;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
 
@@ -48,8 +49,6 @@ class QgsAggregateAlgorithm : public QgsProcessingAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmdropfields.h
+++ b/src/analysis/processing/qgsalgorithmdropfields.h
@@ -44,6 +44,7 @@ class QgsDropTableFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortDescription() const override;
     QList<int> inputLayerTypes() const override;
     QgsDropTableFieldsAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -54,7 +55,6 @@ class QgsDropTableFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmextractzmvalues.h
+++ b/src/analysis/processing/qgsalgorithmextractzmvalues.h
@@ -39,6 +39,7 @@ class QgsExtractZMValuesAlgorithmBase : public QgsProcessingFeatureBasedAlgorith
     QString group() const override;
     QString groupId() const override;
     QList<int> inputLayerTypes() const override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -49,7 +50,6 @@ class QgsExtractZMValuesAlgorithmBase : public QgsProcessingFeatureBasedAlgorith
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.h
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.h
@@ -44,6 +44,7 @@ class QgsFieldCalculatorAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortHelpString() const override;
     QList<int> inputLayerTypes() const override;
     QgsFieldCalculatorAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
     void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
@@ -53,7 +54,6 @@ class QgsFieldCalculatorAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
     QgsFields mFields;

--- a/src/analysis/processing/qgsalgorithmpointsinpolygon.h
+++ b/src/analysis/processing/qgsalgorithmpointsinpolygon.h
@@ -48,6 +48,7 @@ class QgsPointsInPolygonAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QList<int> inputLayerTypes() const override;
     Qgis::ProcessingSourceType outputLayerType() const override;
     QgsCoordinateReferenceSystem outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
 
   protected:
@@ -57,7 +58,6 @@ class QgsPointsInPolygonAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFields outputFields( const QgsFields &inputFields ) const override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
     bool mIsInPlace = false;

--- a/src/analysis/processing/qgsalgorithmrefactorfields.h
+++ b/src/analysis/processing/qgsalgorithmrefactorfields.h
@@ -43,6 +43,7 @@ class QgsRefactorFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortHelpString() const override;
     QList<int> inputLayerTypes() const override;
     QgsRefactorFieldsAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -53,7 +54,6 @@ class QgsRefactorFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmrenametablefield.h
+++ b/src/analysis/processing/qgsalgorithmrenametablefield.h
@@ -43,6 +43,7 @@ class QgsRenameTableFieldAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortDescription() const override;
     QList<int> inputLayerTypes() const override;
     QgsRenameTableFieldAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -53,7 +54,6 @@ class QgsRenameTableFieldAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmsetmvalue.h
+++ b/src/analysis/processing/qgsalgorithmsetmvalue.h
@@ -41,6 +41,7 @@ class QgsSetMValueAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString groupId() const override;
     QString shortHelpString() const override;
     QgsSetMValueAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *l ) const override;
 
   protected:
 
@@ -48,7 +49,6 @@ class QgsSetMValueAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     Qgis::WkbType outputWkbType( Qgis::WkbType inputWkbType ) const override;
     Qgis::ProcessingFeatureSourceFlags sourceFlags() const override;
-    bool supportInPlaceEdit( const QgsMapLayer *l ) const override;
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;

--- a/src/analysis/processing/qgsalgorithmsetzvalue.h
+++ b/src/analysis/processing/qgsalgorithmsetzvalue.h
@@ -41,6 +41,7 @@ class QgsSetZValueAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString groupId() const override;
     QString shortHelpString() const override;
     QgsSetZValueAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *l ) const override;
 
   protected:
 
@@ -48,7 +49,6 @@ class QgsSetZValueAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     Qgis::WkbType outputWkbType( Qgis::WkbType inputWkbType ) const override;
     Qgis::ProcessingFeatureSourceFlags sourceFlags() const override;
-    bool supportInPlaceEdit( const QgsMapLayer *l ) const override;
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;

--- a/src/analysis/processing/qgsalgorithmsumlinelength.h
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.h
@@ -47,7 +47,7 @@ class QgsSumLineLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QList<int> inputLayerTypes() const override;
     Qgis::ProcessingSourceType outputLayerType() const override;
     QgsCoordinateReferenceSystem outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const override;
-
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
     QString inputParameterName() const override;
@@ -56,7 +56,6 @@ class QgsSumLineLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFields outputFields( const QgsFields &inputFields ) const override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
     bool mIsInPlace = false;

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.h
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.h
@@ -41,7 +41,7 @@ class QgsZonalStatisticsFeatureBasedAlgorithm : public QgsProcessingFeatureBased
     QString groupId() const override;
     QString shortHelpString() const override;
     QList<int> inputLayerTypes() const override;
-
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
     QgsZonalStatisticsFeatureBasedAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
@@ -52,7 +52,6 @@ class QgsZonalStatisticsFeatureBasedAlgorithm : public QgsProcessingFeatureBased
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
     std::unique_ptr< QgsRasterInterface > mRaster;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -461,6 +461,15 @@ class CORE_EXPORT QgsProcessingAlgorithm
      */
     void setProvider( QgsProcessingProvider *provider ) SIP_HOLDGIL;
 
+    /**
+     * Checks whether this algorithm supports in-place editing on the given \a layer
+     * Default implementation returns FALSE.
+     *
+     * \return TRUE if the algorithm supports in-place editing
+     * \since QGIS 3.4
+     */
+    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
+
   protected:
 
     /**
@@ -1082,15 +1091,6 @@ class CORE_EXPORT QgsProcessingAlgorithm
      */
     static QString writeFeatureError( QgsFeatureSink *sink, const QVariantMap &parameters, const QString &name );
 
-    /**
-     * Checks whether this algorithm supports in-place editing on the given \a layer
-     * Default implementation returns FALSE.
-     *
-     * \return TRUE if the algorithm supports in-place editing
-     * \since QGIS 3.4
-     */
-    virtual bool supportInPlaceEdit( const QgsMapLayer *layer ) const;
-
   private:
 
     QgsProcessingProvider *mProvider = nullptr;
@@ -1174,6 +1174,16 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
      * \a feedback to instead report non-fatal processing failures for features instead.
      */
     virtual QgsFeatureList processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) SIP_THROW( QgsProcessingException ) = 0 SIP_VIRTUALERRORHANDLER( processing_exception_handler );
+
+    /**
+     * Checks whether this algorithm supports in-place editing on the given \a layer
+     * Default implementation for feature based algorithms run some basic compatibility
+     * checks based on the geometry type of the layer.
+     *
+     * \return TRUE if the algorithm supports in-place editing
+     * \since QGIS 3.4
+     */
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -1281,16 +1291,6 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
      * source layer. The default implementation requests all attributes and geometry.
      */
     virtual QgsFeatureRequest request() const;
-
-    /**
-     * Checks whether this algorithm supports in-place editing on the given \a layer
-     * Default implementation for feature based algorithms run some basic compatibility
-     * checks based on the geometry type of the layer.
-     *
-     * \return TRUE if the algorithm supports in-place editing
-     * \since QGIS 3.4
-     */
-    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
     /**
      * Read the source from \a parameters and \a context and set it

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -1185,10 +1185,6 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
      */
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
-  protected:
-
-    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
-
     /**
      * Returns the name of the parameter corresponding to the input layer.
      *
@@ -1206,6 +1202,10 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
      * \since QGIS 3.12
      */
     virtual QString inputParameterDescription() const SIP_HOLDGIL;
+
+  protected:
+
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
 
     /**
      * Returns the translated, user visible name for any layers created by this algorithm.


### PR DESCRIPTION
## Description

To be able to check whether a given algorithm is compatible with an in-place editing run with a given vector layer, we need the supportsInPlace( layer ) function to be public (instead of protected).

Funnily enough, half of the native algorithms overriding this function were already putting the function in public: -- that's how natural this felt like :wink: 