### PR TITLE
Provide a sourceable shell script setting up test environment

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,11 @@ if (ENABLE_TESTS)
   endif()
 
   add_subdirectory(code_layout)
+
+  configure_file(
+    "${CMAKE_SOURCE_DIR}/tests/env.sh.in"
+    "${CMAKE_BINARY_DIR}/tests/env.sh"
+    IMMEDIATE @ONLY)
 endif()
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -130,6 +130,16 @@ with something like this (tweak $builddir and $srcdir as appropriate)
    TestQgsVectorLayer.testOverwriteLayer
 ```
 
+A convenient way to set all the variables used in the above snippet
+automatically is by sourcing the tests/env.sh script in build dir,
+for example:
+
+```
+source build/tests/env.sh
+python ${srcdir}/tests/src/python/test_provider_postgres.py \
+  TestPyQgsPostgresProvider.testExtent
+````
+
 #### Running python tests in GDB
 
 First find out the required environment variables by running the test outside

--- a/tests/env.sh.in
+++ b/tests/env.sh.in
@@ -1,0 +1,21 @@
+# Source this to configure environment in a way to make
+# it easy to run python tests manually.
+#
+# See tests/README.md in source dir
+#
+
+_srcdir=@CMAKE_SOURCE_DIR@
+_builddir=@CMAKE_BINARY_DIR@
+
+if expr "${_builddir}" : "@" > /dev/null || test -z "${_builddir}" ||
+   expr "${_srcdir}" : "@" > /dev/null || test -z "${_srcdir}"
+then
+  echo "This File, it wasn't generated properly." >&2
+  return 1
+fi
+
+export srcdir=${_srcdir}
+export builddir=${_builddir}
+
+export QGIS_PREFIX_PATH=${builddir}/output
+export PYTHONPATH=${builddir}/output/python:$PYTHONPATH


### PR DESCRIPTION
Testing locally becomes as simple as (from build dir):

  . tests/env.sh
  python ${srcdir}/tests/src/python/test_provider_postgres.py
