### PR TITLE
Set minimum bison version according to INSTALL.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,7 +342,7 @@ if(WITH_CORE)
   endif()
 
   find_package(FLEX 2.6 REQUIRED)
-  find_package(BISON REQUIRED)
+  find_package(BISON 2.4 REQUIRED)
 
   #############################################################
   # search for dependencies


### PR DESCRIPTION
I can confirm at least 2.3 doesn't work. According to INSTALL.md it's 2.4, let's stick to this until we know better.