### PR TITLE
[sensorthings] Always be tolerant when reading datetime ranges

### DIFF
--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
@@ -581,7 +581,7 @@ bool QgsSensorThingsSharedData::processFeatureRequest( QString &nextPage, QgsFee
                 return QVariant();
               };
 
-              auto getDateTimeRange = []( const basic_json<> &json, const char *tag, bool allowInstant = false ) -> std::pair< QVariant, QVariant >
+              auto getDateTimeRange = []( const basic_json<> &json, const char *tag ) -> std::pair< QVariant, QVariant >
               {
                 if ( !json.contains( tag ) )
                   return { QVariant(), QVariant() };
@@ -599,10 +599,11 @@ bool QgsSensorThingsSharedData::processFeatureRequest( QString &nextPage, QgsFee
                       QDateTime::fromString( rangeParts.at( 1 ), Qt::ISODateWithMs )
                     };
                   }
-                  else if ( allowInstant )
+                  else
                   {
                     const QDateTime instant = QDateTime::fromString( rangeString, Qt::ISODateWithMs );
-                    return { instant, instant };
+                    if ( instant.isValid() )
+                      return { instant, instant };
                   }
                 }
 
@@ -676,7 +677,7 @@ bool QgsSensorThingsSharedData::processFeatureRequest( QString &nextPage, QgsFee
 
                   case Qgis::SensorThingsEntity::Datastream:
                   {
-                    std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( entityData, "phenomenonTime", true );
+                    std::pair< QVariant, QVariant > phenomenonTime = getDateTimeRange( entityData, "phenomenonTime" );
                     std::pair< QVariant, QVariant > resultTime = getDateTimeRange( entityData, "resultTime" );
                     attributes
                         << iotId


### PR DESCRIPTION
And always handle single datetime values as a time instant when we are expecting a range value. Seems many SensorThings servers deliver instant ranges as a single value instead of a range of the same datetime value.

Fixes #57815
