### PR TITLE
qgs3daxis: Fix cube face picking

### DIFF
--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -29,6 +29,7 @@
 #include <QVector3D>
 
 #include <Qt3DRender/QLayer>
+#include <Qt3DRender/QRenderSettings>
 
 #include <QtWidgets/QMenu>
 #include "qgs3dmapsettings.h"
@@ -176,6 +177,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     QPoint mLastClickedPos;
     Qt::MouseButton mLastClickedButton;
     QCursor mPreviousCursor = Qt::ArrowCursor;
+    Qt3DRender::QPickingSettings::PickMethod mDefaultPickingMethod;
     QMenu *mMenu = nullptr;
 
 };


### PR DESCRIPTION
## Description

When clicking on a face of the cube, the view is rotated according to the clicked face. However, this needs `TrianglePicking` to be enabled to properly detect the face because it needs the `primitiveIndex` of the hit. `TrianglePicking` was activated by default up to commit b371267fbe117ecf54f56dd8c9948db0d89dfdd1 which restored it to the default picking method: `BoundingVolumePicking`.

This issue is fixed by enabling `TrianglePicking` when entering the viewport if the cube is visible. `TrianglePicking` is then deactivated when leaving the viewport.

Fixes: commit b371267fbe117ecf54f56dd8c9948db0d89dfdd1
