### PR TITLE
[3D] 3daxis cleanup

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -76,6 +76,21 @@ Qgs3DAxis::~Qgs3DAxis()
 {
   delete mMenu;
   mMenu = nullptr;
+
+  // If a root entity is not enabled, it means that it does not have a parent.
+  // In that case, it will never be automatically deleted. Therefore, it needs to be manually deleted.
+  // See setEnableCube() and setEnableAxis().
+  if ( !mCubeRoot->isEnabled() )
+  {
+    delete mCubeRoot;
+    mCubeRoot = nullptr;
+  }
+
+  if ( !mAxisRoot->isEnabled() )
+  {
+    delete mAxisRoot;
+    mAxisRoot = nullptr;
+  }
 }
 
 void Qgs3DAxis::init3DObjectPicking( )

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -813,9 +813,9 @@ void Qgs3DAxis::createCube( )
   int fontSize = 0.75 * mFontSize;
   float textHeight = fontSize * 1.5f;
   float textWidth;
-  QFont f = QFontDatabase::systemFont( QFontDatabase::FixedFont );
-  f.setPointSize( fontSize );
-  f.setWeight( QFont::Weight::Black );
+  QFont font = QFontDatabase::systemFont( QFontDatabase::FixedFont );
+  font.setPointSize( fontSize );
+  font.setWeight( QFont::Weight::Black );
 
   {
     text = QStringLiteral( "top" );
@@ -825,7 +825,7 @@ void Qgs3DAxis::createCube( )
                               mCylinderLength * 0.5f - textHeight / 2.0f,
                               mCylinderLength * 1.01f );
     QMatrix4x4 rotation;
-    mCubeLabels << addCubeText( text, textHeight, textWidth, f, rotation, translation );
+    mCubeLabels << addCubeText( text, textHeight, textWidth, font, rotation, translation );
   }
 
   {
@@ -837,7 +837,7 @@ void Qgs3DAxis::createCube( )
                               -mCylinderLength * 0.01f );
     QMatrix4x4 rotation;
     rotation.rotate( 180.0f, QVector3D( 1.0f, 0.0f, 0.0f ).normalized() );
-    mCubeLabels << addCubeText( text, textHeight, textWidth, f, rotation, translation );
+    mCubeLabels << addCubeText( text, textHeight, textWidth, font, rotation, translation );
   }
 
   {
@@ -850,7 +850,7 @@ void Qgs3DAxis::createCube( )
     QMatrix4x4 rotation;
     rotation.rotate( 90.0f, QVector3D( 0.0f, -1.0f, 0.0f ).normalized() );
     rotation.rotate( 90.0f, QVector3D( 0.0f, 0.0f, -1.0f ).normalized() );
-    mCubeLabels << addCubeText( text, textHeight, textWidth, f, rotation, translation );
+    mCubeLabels << addCubeText( text, textHeight, textWidth, font, rotation, translation );
   }
 
   {
@@ -863,7 +863,7 @@ void Qgs3DAxis::createCube( )
     QMatrix4x4 rotation;
     rotation.rotate( 90.0f, QVector3D( 0.0f, 1.0f, 0.0f ).normalized() );
     rotation.rotate( 90.0f, QVector3D( 0.0f, 0.0f, 1.0f ).normalized() );
-    mCubeLabels << addCubeText( text, textHeight, textWidth, f, rotation, translation );
+    mCubeLabels << addCubeText( text, textHeight, textWidth, font, rotation, translation );
   }
 
   {
@@ -875,7 +875,7 @@ void Qgs3DAxis::createCube( )
                               mCylinderLength * 0.5f - textHeight / 2.0f );
     QMatrix4x4 rotation;
     rotation.rotate( 90.0f, QVector3D( 1.0f, 0.0f, 0.0f ).normalized() );
-    mCubeLabels << addCubeText( text, textHeight, textWidth, f, rotation, translation );
+    mCubeLabels << addCubeText( text, textHeight, textWidth, font, rotation, translation );
   }
 
   {
@@ -888,7 +888,7 @@ void Qgs3DAxis::createCube( )
     QMatrix4x4 rotation;
     rotation.rotate( 90.0f, QVector3D( -1.0f, 0.0f, 0.0f ).normalized() );
     rotation.rotate( 180.0f, QVector3D( 0.0f, 0.0f, 1.0f ).normalized() );
-    mCubeLabels << addCubeText( text, textHeight, textWidth, f, rotation, translation );
+    mCubeLabels << addCubeText( text, textHeight, textWidth, font, rotation, translation );
   }
 
   for ( Qt3DExtras::QText2DEntity *l : std::as_const( mCubeLabels ) )
@@ -897,11 +897,11 @@ void Qgs3DAxis::createCube( )
   }
 }
 
-Qt3DExtras::QText2DEntity *Qgs3DAxis::addCubeText( const QString &text, float textHeight, float textWidth, const QFont &f, const QMatrix4x4 &rotation, const QVector3D &translation )
+Qt3DExtras::QText2DEntity *Qgs3DAxis::addCubeText( const QString &text, float textHeight, float textWidth, const QFont &font, const QMatrix4x4 &rotation, const QVector3D &translation )
 {
   Qt3DExtras::QText2DEntity *textEntity = new Qt3DExtras::QText2DEntity;
   textEntity->setObjectName( "3DAxis_cube_label_" + text );
-  textEntity->setFont( f );
+  textEntity->setFont( font );
   textEntity->setHeight( textHeight );
   textEntity->setWidth( textWidth );
   textEntity->setColor( QColor( 192, 192, 192 ) );

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -810,16 +810,14 @@ void Qgs3DAxis::createCube( )
 
   // text
   QString text;
-  int fontSize = 0.75 * mFontSize;
-  float textHeight = fontSize * 1.5f;
+  const int fontSize = static_cast<int>( std::round( 0.75f * static_cast<float>( mFontSize ) ) );
+  const float textHeight = static_cast<float>( fontSize ) * 1.5f;
   float textWidth;
-  QFont font = QFontDatabase::systemFont( QFontDatabase::FixedFont );
-  font.setPointSize( fontSize );
-  font.setWeight( QFont::Weight::Black );
+  const QFont font = createFont( fontSize );
 
   {
     text = QStringLiteral( "top" );
-    textWidth = text.length() * fontSize * 0.75f;
+    textWidth = static_cast<float>( text.length() * fontSize ) * 0.75f;
     QVector3D translation = minPos + QVector3D(
                               mCylinderLength * 0.5f - textWidth / 2.0f,
                               mCylinderLength * 0.5f - textHeight / 2.0f,
@@ -830,7 +828,7 @@ void Qgs3DAxis::createCube( )
 
   {
     text = QStringLiteral( "btm" );
-    textWidth = text.length() * fontSize * 0.75f;
+    textWidth = static_cast<float>( text.length() * fontSize ) * 0.75f;
     QVector3D translation = minPos + QVector3D(
                               mCylinderLength * 0.5f - textWidth / 2.0f,
                               mCylinderLength * 0.5f + textHeight / 2.0f,
@@ -842,7 +840,7 @@ void Qgs3DAxis::createCube( )
 
   {
     text = QStringLiteral( "west" );
-    textWidth = text.length() * fontSize * 0.75f;
+    textWidth = static_cast<float>( text.length() * fontSize ) * 0.75f;
     QVector3D translation = minPos + QVector3D(
                               - mCylinderLength * 0.01f,
                               mCylinderLength * 0.5f + textWidth / 2.0f,
@@ -855,7 +853,7 @@ void Qgs3DAxis::createCube( )
 
   {
     text = QStringLiteral( "east" );
-    textWidth = text.length() * fontSize * 0.75f;
+    textWidth = static_cast<float>( text.length() * fontSize ) * 0.75f;
     QVector3D translation = minPos + QVector3D(
                               mCylinderLength * 1.01f,
                               mCylinderLength * 0.5f - textWidth / 2.0f,
@@ -868,7 +866,7 @@ void Qgs3DAxis::createCube( )
 
   {
     text = QStringLiteral( "south" );
-    textWidth = text.length() * fontSize * 0.75f;
+    textWidth = static_cast<float>( text.length() * fontSize ) * 0.75f;
     QVector3D translation = minPos + QVector3D(
                               mCylinderLength * 0.5f - textWidth / 2.0f,
                               - mCylinderLength * 0.01f,
@@ -880,7 +878,7 @@ void Qgs3DAxis::createCube( )
 
   {
     text = QStringLiteral( "north" );
-    textWidth = text.length() * fontSize * 0.75f;
+    textWidth = static_cast<float>( text.length() * fontSize ) * 0.75f;
     QVector3D translation = minPos + QVector3D(
                               mCylinderLength * 0.5f + textWidth / 2.0f,
                               mCylinderLength * 1.01f,
@@ -1203,11 +1201,18 @@ void Qgs3DAxis::updateAxisLabelPosition()
 
 void Qgs3DAxis::updateAxisLabelText( Qt3DExtras::QText2DEntity *textEntity, const QString &text )
 {
-  QFont font = QFont( "monospace", mAxisScaleFactor *  mFontSize ); // TODO: should use outlined font
-  font.setWeight( QFont::Weight::Black );
-  font.setStyleStrategy( QFont::StyleStrategy::ForceOutline );
-  textEntity->setFont( font );
   const float scaledFontSize = static_cast<float>( mAxisScaleFactor ) * static_cast<float>( mFontSize );
+  const QFont font = createFont( static_cast<int>( std::round( scaledFontSize ) ) );
+  textEntity->setFont( font );
   textEntity->setWidth( scaledFontSize * static_cast<float>( text.length() ) );
   textEntity->setHeight( 1.5f * scaledFontSize );
+}
+
+QFont Qgs3DAxis::createFont( int pointSize )
+{
+  QFont font = QFontDatabase::systemFont( QFontDatabase::FixedFont );
+  font.setPointSize( pointSize );
+  font.setWeight( QFont::Weight::Black );
+  font.setStyleStrategy( QFont::StyleStrategy::ForceOutline );
+  return font;
 }

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -933,7 +933,10 @@ void Qgs3DAxis::createAxis( Qt::Axis axisType )
     case Qt::Axis::XAxis:
       mTextX = new Qt3DExtras::QText2DEntity( );  // object initialization in two step:
       mTextX->setParent( mTwoDLabelSceneEntity ); // see https://bugreports.qt.io/browse/QTBUG-77139
-      connect( mTextX, &Qt3DExtras::QText2DEntity::textChanged, this, &Qgs3DAxis::onTextXChanged );
+      connect( mTextX, &Qt3DExtras::QText2DEntity::textChanged, this, [this]( const QString & text )
+      {
+        updateAxisLabelText( mTextX, text );
+      } );
       mTextTransformX = new Qt3DCore::QTransform();
       mTextCoordX = QVector3D( mCylinderLength + coneLength / 2.0f, 0.0f, 0.0f );
 
@@ -947,7 +950,10 @@ void Qgs3DAxis::createAxis( Qt::Axis axisType )
     case Qt::Axis::YAxis:
       mTextY = new Qt3DExtras::QText2DEntity( );  // object initialization in two step:
       mTextY->setParent( mTwoDLabelSceneEntity ); // see https://bugreports.qt.io/browse/QTBUG-77139
-      connect( mTextY, &Qt3DExtras::QText2DEntity::textChanged, this, &Qgs3DAxis::onTextYChanged );
+      connect( mTextY, &Qt3DExtras::QText2DEntity::textChanged, this, [this]( const QString & text )
+      {
+        updateAxisLabelText( mTextY, text );
+      } );
       mTextTransformY = new Qt3DCore::QTransform();
       mTextCoordY = QVector3D( 0.0f, mCylinderLength + coneLength / 2.0f, 0.0f );
 
@@ -961,7 +967,10 @@ void Qgs3DAxis::createAxis( Qt::Axis axisType )
     case Qt::Axis::ZAxis:
       mTextZ = new Qt3DExtras::QText2DEntity( );  // object initialization in two step:
       mTextZ->setParent( mTwoDLabelSceneEntity ); // see https://bugreports.qt.io/browse/QTBUG-77139
-      connect( mTextZ, &Qt3DExtras::QText2DEntity::textChanged, this, &Qgs3DAxis::onTextZChanged );
+      connect( mTextZ, &Qt3DExtras::QText2DEntity::textChanged, this, [this]( const QString & text )
+      {
+        updateAxisLabelText( mTextZ, text );
+      } );
       mTextTransformZ = new Qt3DCore::QTransform();
       mTextCoordZ = QVector3D( 0.0f, 0.0f, mCylinderLength + coneLength / 2.0f );
 
@@ -1178,46 +1187,27 @@ void Qgs3DAxis::updateAxisLabelPosition()
     mTextTransformX->setTranslation( from3DTo2DLabelPosition( mTextCoordX * mAxisScaleFactor, mAxisCamera,
                                      mAxisViewport, mTwoDLabelCamera, mTwoDLabelViewport,
                                      mCanvas->size() ) );
-    onTextXChanged( mTextX->text() );
+    updateAxisLabelText( mTextX, mTextX->text() );
 
     mTextTransformY->setTranslation( from3DTo2DLabelPosition( mTextCoordY * mAxisScaleFactor, mAxisCamera,
                                      mAxisViewport, mTwoDLabelCamera, mTwoDLabelViewport,
                                      mCanvas->size() ) );
-    onTextYChanged( mTextY->text() );
+    updateAxisLabelText( mTextY, mTextY->text() );
 
     mTextTransformZ->setTranslation( from3DTo2DLabelPosition( mTextCoordZ * mAxisScaleFactor, mAxisCamera,
                                      mAxisViewport, mTwoDLabelCamera, mTwoDLabelViewport,
                                      mCanvas->size() ) );
-    onTextZChanged( mTextZ->text() );
+    updateAxisLabelText( mTextZ, mTextZ->text() );
   }
 }
 
-void Qgs3DAxis::onTextXChanged( const QString &text )
+void Qgs3DAxis::updateAxisLabelText( Qt3DExtras::QText2DEntity *textEntity, const QString &text )
 {
-  QFont f = QFont( "monospace", mAxisScaleFactor *  mFontSize ); // TODO: should use outlined font
-  f.setWeight( QFont::Weight::Black );
-  f.setStyleStrategy( QFont::StyleStrategy::ForceOutline );
-  mTextX->setFont( f );
-  mTextX->setWidth( mAxisScaleFactor * mFontSize * text.length() );
-  mTextX->setHeight( mAxisScaleFactor * mFontSize * 1.5f );
-}
-
-void Qgs3DAxis::onTextYChanged( const QString &text )
-{
-  QFont f = QFont( "monospace", mAxisScaleFactor *  mFontSize ); // TODO: should use outlined font
-  f.setWeight( QFont::Weight::Black );
-  f.setStyleStrategy( QFont::StyleStrategy::ForceOutline );
-  mTextY->setFont( f );
-  mTextY->setWidth( mAxisScaleFactor * mFontSize * text.length() );
-  mTextY->setHeight( mAxisScaleFactor * mFontSize * 1.5f );
-}
-
-void Qgs3DAxis::onTextZChanged( const QString &text )
-{
-  QFont f = QFont( "monospace", mAxisScaleFactor *  mFontSize ); // TODO: should use outlined font
-  f.setWeight( QFont::Weight::Black );
-  f.setStyleStrategy( QFont::StyleStrategy::ForceOutline );
-  mTextZ->setFont( f );
-  mTextZ->setWidth( mAxisScaleFactor * mFontSize * text.length() );
-  mTextZ->setHeight( mAxisScaleFactor * mFontSize * 1.5f );
+  QFont font = QFont( "monospace", mAxisScaleFactor *  mFontSize ); // TODO: should use outlined font
+  font.setWeight( QFont::Weight::Black );
+  font.setStyleStrategy( QFont::StyleStrategy::ForceOutline );
+  textEntity->setFont( font );
+  const float scaledFontSize = static_cast<float>( mAxisScaleFactor ) * static_cast<float>( mFontSize );
+  textEntity->setWidth( scaledFontSize * static_cast<float>( text.length() ) );
+  textEntity->setHeight( 1.5f * scaledFontSize );
 }

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -1168,7 +1168,7 @@ void Qgs3DAxis::onCameraUpdate( )
     }
     else
     {
-      mAxisCamera->setPosition( mainCameraShift * mCylinderLength * 10.0 );
+      mAxisCamera->setPosition( mainCameraShift * mCylinderLength * 9.0 );
     }
 
     if ( mAxisRoot->isEnabled() )

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -355,6 +355,7 @@ Qt3DRender::QViewport *Qgs3DAxis::constructLabelViewport( Qt3DCore::QEntity *par
   mTwoDLabelCamera->setPosition( QVector3D( 0.0f, 0.0f, 100.0f ) );
 
   Qt3DRender::QLayer *twoDLayer = new Qt3DRender::QLayer;
+  twoDLayer->setObjectName( "3DAxis_LabelsLayer" );
   twoDLayer->setRecursive( true );
   mTwoDLabelSceneEntity->addComponent( twoDLayer );
 

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -88,7 +88,7 @@ void Qgs3DAxis::init3DObjectPicking( )
   //   2- connect screencaster results to onTouchedByRay
   //   3- screencaster will be triggered by EventFilter
   mScreenRayCaster = new Qt3DRender::QScreenRayCaster( mAxisSceneEntity );
-  mScreenRayCaster->addLayer( mAxisSceneLayer ); // to only filter on axis objects
+  mScreenRayCaster->addLayer( mAxisObjectLayer ); // to only filter on axis objects
   mScreenRayCaster->setFilterMode( Qt3DRender::QScreenRayCaster::AcceptAllMatchingLayers );
   mScreenRayCaster->setRunMode( Qt3DRender::QAbstractRayCaster::SingleShot );
 
@@ -296,10 +296,10 @@ Qt3DRender::QViewport *Qgs3DAxis::constructAxisViewport( Qt3DCore::QEntity *pare
   mAxisSceneEntity->setParent( parent3DScene );
   mAxisSceneEntity->setObjectName( "3DAxis_SceneEntity" );
 
-  mAxisSceneLayer = new Qt3DRender::QLayer;
-  mAxisSceneLayer->setObjectName( "3DAxis_SceneLayer" );
-  mAxisSceneLayer->setParent( mAxisSceneEntity );
-  mAxisSceneLayer->setRecursive( true );
+  mAxisObjectLayer = new Qt3DRender::QLayer;
+  mAxisObjectLayer->setObjectName( "3DAxis_ObjectLayer" );
+  mAxisObjectLayer->setParent( mAxisSceneEntity );
+  mAxisObjectLayer->setRecursive( true );
 
   mAxisCamera = new Qt3DRender::QCamera;
   mAxisCamera->setParent( mAxisSceneEntity );
@@ -310,12 +310,8 @@ Qt3DRender::QViewport *Qgs3DAxis::constructAxisViewport( Qt3DCore::QEntity *pare
   mAxisCamera->setViewCenter( QVector3D( 0.0f, 0.0f, 0.0f ) );
   // position will be set later
 
-  Qt3DRender::QLayer *axisLayer = new Qt3DRender::QLayer;
-  axisLayer->setRecursive( true );
-  mAxisSceneEntity->addComponent( axisLayer );
-
   Qt3DRender::QLayerFilter *axisLayerFilter = new Qt3DRender::QLayerFilter( axisViewport );
-  axisLayerFilter->addLayer( axisLayer );
+  axisLayerFilter->addLayer( mAxisObjectLayer );
 
   Qt3DRender::QCameraSelector *axisCameraSelector = new Qt3DRender::QCameraSelector;
   axisCameraSelector->setParent( axisLayerFilter );
@@ -453,7 +449,7 @@ void Qgs3DAxis::createAxisScene()
     mAxisRoot = new Qt3DCore::QEntity;
     mAxisRoot->setParent( mAxisSceneEntity );
     mAxisRoot->setObjectName( "3DAxis_AxisRoot" );
-    mAxisRoot->addComponent( mAxisSceneLayer ); // raycaster will filter object containing this layer
+    mAxisRoot->addComponent( mAxisObjectLayer ); // raycaster will filter object containing this layer
 
     createAxis( Qt::Axis::XAxis );
     createAxis( Qt::Axis::YAxis );
@@ -462,7 +458,7 @@ void Qgs3DAxis::createAxisScene()
     mCubeRoot = new Qt3DCore::QEntity;
     mCubeRoot->setParent( mAxisSceneEntity );
     mCubeRoot->setObjectName( "3DAxis_CubeRoot" );
-    mCubeRoot->addComponent( mAxisSceneLayer ); // raycaster will filter object containing this layer
+    mCubeRoot->addComponent( mAxisObjectLayer ); // raycaster will filter object containing this layer
 
     createCube( );
   }

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -135,8 +135,8 @@ bool Qgs3DAxis::eventFilter( QObject *watched, QEvent *event )
     else if ( ! mIsDragging )
     {
       // limit ray caster usage to the axis viewport
-      QPointF normalizedPos( static_cast<float>( mouseEvent->pos().x() ) / mCanvas->width(),
-                             ( float )mouseEvent->pos().y() / mCanvas->height() );
+      QPointF normalizedPos( static_cast<float>( mouseEvent->pos().x() ) / static_cast<float>( mCanvas->width() ),
+                             static_cast<float>( mouseEvent->pos().y() ) / static_cast<float>( mCanvas->height() ) );
 
       if ( 2 <= QgsLogger::debugLevel() && event->type() == QEvent::MouseButtonRelease )
       {
@@ -1090,16 +1090,16 @@ void Qgs3DAxis::onAxisViewportSizeUpdate( int )
     if ( settings.horizontalPosition() == Qt::AnchorPoint::AnchorLeft )
       xRatio = 0.0f;
     else if ( settings.horizontalPosition() == Qt::AnchorPoint::AnchorHorizontalCenter )
-      xRatio = 0.5f - widthRatio / 2.0f;
+      xRatio = 0.5f - static_cast<float>( widthRatio ) / 2.0f;
     else
-      xRatio = 1.0f - widthRatio;
+      xRatio = 1.0f - static_cast<float>( widthRatio );
 
     if ( settings.verticalPosition() == Qt::AnchorPoint::AnchorTop )
       yRatio = 0.0f;
     else if ( settings.verticalPosition() == Qt::AnchorPoint::AnchorVerticalCenter )
-      yRatio = 0.5f - heightRatio / 2.0f;
+      yRatio = 0.5f - static_cast<float>( heightRatio ) / 2.0f;
     else
-      yRatio = 1.0f - heightRatio;
+      yRatio = 1.0f - static_cast<float>( heightRatio );
 
     QgsDebugMsgLevel( QString( "Qgs3DAxis: update viewport: %1 x %2 x %3 x %4" ).arg( xRatio ).arg( yRatio ).arg( widthRatio ).arg( heightRatio ), 2 );
     mViewport->setNormalizedRect( QRectF( xRatio, yRatio, widthRatio, heightRatio ) );

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -145,7 +145,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     int mFontSize = 10;
 
     Qt3DCore::QEntity *mAxisSceneEntity = nullptr;
-    Qt3DRender::QLayer *mAxisSceneLayer = nullptr;
+    Qt3DRender::QLayer *mAxisObjectLayer = nullptr;
     Qt3DRender::QCamera *mAxisCamera = nullptr;
     Qt3DRender::QViewport *mAxisViewport = nullptr;
 

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -119,6 +119,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     void setEnableAxis( bool show );
     void updateAxisLabelPosition();
     void updateAxisLabelText( Qt3DExtras::QText2DEntity *textEntity, const QString &text );
+    QFont createFont( int pointSize );
 
     Qt3DRender::QViewport *constructAxisViewport( Qt3DCore::QEntity *parent3DScene );
     Qt3DRender::QViewport *constructLabelViewport( Qt3DCore::QEntity *parent3DScene, const QRectF &parentViewportSize );

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -140,7 +140,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     QgsCameraController *mCameraController = nullptr;
 
     float mCylinderLength = 40.0f;
-    int mFontSize = 10;
+    int mFontSize = 12;
 
     Qt3DCore::QEntity *mAxisSceneEntity = nullptr;
     Qt3DRender::QLayer *mAxisObjectLayer = nullptr;

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -69,20 +69,15 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     ~Qgs3DAxis() override;
 
     /**
-     * \brief project a 3D position from sourceCamera (in sourceViewport) to a 2D position for destCamera (in destViewport). destCamera and the destViewport act as a billboarding layer. The labels displayed by this process will always face the camera.
+     * \brief project a 3D position from sourceCamera to a 2D position for destCamera. destCamera acts as a billboarding layer. The labels displayed by this process will always face the camera.
      *
      * \param sourcePos 3D label coordinates
      * @param sourceCamera main view camera
-     * @param sourceViewport main viewport
      * @param destCamera billboarding camera
-     * @param destViewport billboarding viewport
-     * @param destSize main qt3d window size
      * @return
      */
-    QVector3D from3DTo2DLabelPosition( const QVector3D &sourcePos,
-                                       Qt3DRender::QCamera *sourceCamera, Qt3DRender::QViewport *sourceViewport,
-                                       Qt3DRender::QCamera *destCamera, Qt3DRender::QViewport *destViewport,
-                                       const QSize &destSize );
+    QVector3D from3DTo2DLabelPosition( const QVector3D &sourcePos, Qt3DRender::QCamera *sourceCamera, Qt3DRender::QCamera *destCamera );
+
 
   public slots:
 
@@ -121,8 +116,8 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     void updateAxisLabelText( Qt3DExtras::QText2DEntity *textEntity, const QString &text );
     QFont createFont( int pointSize );
 
-    Qt3DRender::QViewport *constructAxisViewport( Qt3DCore::QEntity *parent3DScene );
-    Qt3DRender::QViewport *constructLabelViewport( Qt3DCore::QEntity *parent3DScene, const QRectF &parentViewportSize );
+    Qt3DRender::QViewport *constructAxisScene( Qt3DCore::QEntity *parent3DScene );
+    void constructLabelsScene( Qt3DCore::QEntity *parent3DScene );
 
     Qt3DExtras::QText2DEntity *addCubeText( const QString &text, float textHeight, float textWidth, const QFont &font, const QMatrix4x4 &rotation, const QVector3D &translation );
 
@@ -142,10 +137,11 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     float mCylinderLength = 40.0f;
     int mFontSize = 12;
 
+    Qt3DRender::QViewport *mViewport = nullptr;
+
     Qt3DCore::QEntity *mAxisSceneEntity = nullptr;
     Qt3DRender::QLayer *mAxisObjectLayer = nullptr;
     Qt3DRender::QCamera *mAxisCamera = nullptr;
-    Qt3DRender::QViewport *mAxisViewport = nullptr;
 
     Qt3DCore::QEntity *mAxisRoot = nullptr;
     Qt3DCore::QEntity *mCubeRoot = nullptr;
@@ -166,7 +162,6 @@ class _3D_EXPORT Qgs3DAxis : public QObject
 
     Qt3DRender::QCamera *mTwoDLabelCamera  = nullptr;
     Qt3DCore::QEntity *mTwoDLabelSceneEntity = nullptr;
-    Qt3DRender::QViewport *mTwoDLabelViewport = nullptr;
 
     // axis picking and menu
     Qt3DRender::QScreenRayCaster *mScreenRayCaster = nullptr;

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -110,10 +110,6 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     void onCameraViewChangeWest() { onCameraViewChange( 90.0f, -90.0f ); }
     void onCameraViewChangeBottom() { onCameraViewChange( 180.0f, 0.0f ); }
 
-    void onTextXChanged( const QString &text );
-    void onTextYChanged( const QString &text );
-    void onTextZChanged( const QString &text );
-
   private:
 
     void createAxisScene();
@@ -122,6 +118,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     void setEnableCube( bool show );
     void setEnableAxis( bool show );
     void updateAxisLabelPosition();
+    void updateAxisLabelText( Qt3DExtras::QText2DEntity *textEntity, const QString &text );
 
     Qt3DRender::QViewport *constructAxisViewport( Qt3DCore::QEntity *parent3DScene );
     Qt3DRender::QViewport *constructLabelViewport( Qt3DCore::QEntity *parent3DScene, const QRectF &parentViewportSize );

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -123,7 +123,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     Qt3DRender::QViewport *constructAxisViewport( Qt3DCore::QEntity *parent3DScene );
     Qt3DRender::QViewport *constructLabelViewport( Qt3DCore::QEntity *parent3DScene, const QRectF &parentViewportSize );
 
-    Qt3DExtras::QText2DEntity *addCubeText( const QString &text, float textHeight, float textWidth, const QFont &f, const QMatrix4x4 &rotation, const QVector3D &translation );
+    Qt3DExtras::QText2DEntity *addCubeText( const QString &text, float textHeight, float textWidth, const QFont &font, const QMatrix4x4 &rotation, const QVector3D &translation );
 
     // axis picking and menu
     void init3DObjectPicking( );


### PR DESCRIPTION
## Description

This PR mostly does some minor cleanups. It also improves the framegraph of the 3D axis: 

```
The axis framegraph has two distinct branches : one for the main
object (the axis or the cube) and one for the axis labels. Each of
those branches have a dedicated viewport. However, only one viewport
is needed since the two branches need the same part of the
window.

With this change, the first node of the axis' framegraph is now the
viewport (mViewport) and the two branches inherit from it:

- viewport
  <-- object branch -->
  - layerfilter (axisLayerFilter)
  - cameraselector
  - sortPolicy
  - clearBuffers

  <-- labels branch -->
  - layerfilter (twoDLayerFilter)
  - cameraselector
  - sortPolicy
  - clearBuffers

`from3DTo2DLabelPosition()` is also simplified to compute the
billboard position of the axis labels. Indeed, the viewport of the
labels had the dimensions of the main window (0, 0, 1, 1) while the
objects viewport has only the dimensions the relevant part of the
window. Therefore, `from3DTo2DLabelPosition()` needed to take into
this into account and recenter the computer coordinates. This is not
needed anymore. 
```