### PR TITLE
Add metadata setting to override widget wrapper used for a parameter

### DIFF
--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -154,7 +154,9 @@ QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingGuiRegistry::createPar
   if ( !parameter )
     return nullptr;
 
-  const QString parameterType = parameter->type();
+  const QVariantMap metadata = parameter->metadata();
+  const QString widgetType = metadata.value( QStringLiteral( "widget_wrapper" ) ).toMap().value( QStringLiteral( "widget_type" ) ).toString();
+  const QString parameterType = !widgetType.isEmpty() ? widgetType : parameter->type();
   if ( !mParameterWidgetFactories.contains( parameterType ) )
     return nullptr;
 

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -524,6 +524,21 @@ void TestProcessingGui::testWrapperFactoryRegistry()
   QCOMPARE( wrapper->parameterDefinition()->type(), QStringLiteral( "num" ) );
   delete wrapper;
 
+  // creating wrapper using metadata
+  TestParamType customParam( QStringLiteral( "custom" ), QStringLiteral( "custom" ) );
+  wrapper = registry.createParameterWidgetWrapper( &customParam, QgsProcessingGui::Standard );
+  QVERIFY( !wrapper );
+  customParam.setMetadata( {{
+      QStringLiteral( "widget_wrapper" ), QVariantMap(
+      {{QStringLiteral( "widget_type" ), QStringLiteral( "str" ) }}
+      )
+    }
+  } );
+  wrapper = registry.createParameterWidgetWrapper( &customParam, QgsProcessingGui::Standard );
+  QVERIFY( wrapper );
+  QCOMPARE( wrapper->parameterDefinition()->type(), QStringLiteral( "custom" ) );
+  delete wrapper;
+
   // removing
   registry.removeParameterWidgetFactory( nullptr );
   TestWidgetFactory *factory4 = new TestWidgetFactory( QStringLiteral( "xxxx" ) );


### PR DESCRIPTION
## Description

While it is possible to add new widget wrappers for Processing parameters there is no way to override standard widget wrappers defined for each parameter type. This was possible using old API and added a lot of flexibility in different use cases.

This PR adds support for a new parameter metadata setting "widget_type" which allows to allows to override standard widget wrapper for a parameter. 

```
param.setMetadata( {'widget_wrapper': { 'widget_type': 'my_widget' }} )
```