### PR TITLE
[attribute form] Fix addition of features from a child feature dialog being added

### DIFF
--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -289,7 +289,7 @@ QgsFeatureIds QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &ge
 
     QgsVectorLayerToolsContext context;
     context.setParentWidget( this );
-    context.setShowModal( true );
+    context.setShowModal( false );
     context.setHideParent( true );
     std::unique_ptr<QgsExpressionContextScope> scope( QgsExpressionContextUtils::parentFormScope( mFeatureList.first(), mEditorContext.attributeFormModeString() ) );
     context.setAdditionalExpressionContextScope( scope.get() );


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/57474 . The regression was caused by this commit (https://github.com/qgis/QGIS/commit/5ac470cb6d9d759f5fd32ca52495b254ac04c0a7) merged back in July 2023.

@troopa81 , @Djedouas , I couldn't find an issue tied to the commit pushed back then, is it safe to revert? The change would need to be reviewed in any case as it triggers the above-mentioned regression whereas making the child feature attribute form modal prevents that form from creating other features (e.g. from an [+] add new feature button within the referenced relation editor widget).