### PR TITLE
Allow to create an empty GeoPackage from the context menu of the top-level GeoPackage node (fix #25116)

### DIFF
--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -358,7 +358,7 @@ void QgsGeoPackageItemGuiProvider::createDatabase( const QPointer< QgsGeoPackage
 {
   if ( item )
   {
-    const QgsSettings settings;
+    QgsSettings settings;
     const QString lastUsedDir = settings.value( QStringLiteral( "UI/lastGeoPackageDir" ), QDir::homePath() ).toString();
 
     QString filename = QFileDialog::getSaveFileName( nullptr, tr( "New GeoPackage" ),
@@ -371,18 +371,20 @@ void QgsGeoPackageItemGuiProvider::createDatabase( const QPointer< QgsGeoPackage
 
     filename = QgsFileUtils::ensureFileNameHasExtension( filename, QStringList() << QStringLiteral( "gpkg" ) );
 
-    QString errorMsg;
+    const QFileInfo fileInfo( filename );
+    settings.setValue( QStringLiteral( "UI/lastGeoPackageDir" ), fileInfo.absoluteDir().absolutePath() );
+
     if ( QgsProviderMetadata *ogrMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) )
     {
       QString error;
-      if ( ! ogrMetadata->createDatabase( filename, errorMsg ) )
+      if ( ! ogrMetadata->createDatabase( filename, error ) )
       {
-        QMessageBox::critical( nullptr, tr( "New GeoPackage" ), errorMsg );
+        QMessageBox::critical( nullptr, tr( "New GeoPackage" ), error );
         return;
       }
 
       // Call QFileInfo to normalize paths, see: https://github.com/qgis/QGIS/issues/36832
-      if ( QgsOgrProviderUtils::saveConnection( QFileInfo( filename ).filePath(), QStringLiteral( "GPKG" ) ) )
+      if ( QgsOgrProviderUtils::saveConnection( fileInfo.filePath(), QStringLiteral( "GPKG" ) ) )
       {
         item->refreshConnections();
       }

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -359,9 +359,9 @@ void QgsGeoPackageItemGuiProvider::createDatabase( const QPointer< QgsGeoPackage
   if ( item )
   {
     const QgsSettings settings;
-    const QString lastUsedDir = settings.value( QStringLiteral( "UI/lastGeoPackageeDir" ), QDir::homePath() ).toString();
+    const QString lastUsedDir = settings.value( QStringLiteral( "UI/lastGeoPackageDir" ), QDir::homePath() ).toString();
 
-    QString filename = QFileDialog::getSaveFileName( nullptr, tr( "New GeoPackage Database File" ),
+    QString filename = QFileDialog::getSaveFileName( nullptr, tr( "New GeoPackage" ),
                        lastUsedDir,
                        tr( "GeoPackage" ) + " (*.gpkg *.GPKG)" );
     if ( filename.isEmpty() )
@@ -377,7 +377,7 @@ void QgsGeoPackageItemGuiProvider::createDatabase( const QPointer< QgsGeoPackage
       QString error;
       if ( ! ogrMetadata->createDatabase( filename, errorMsg ) )
       {
-        QMessageBox::critical( nullptr, tr( "New GeoPackage Database" ), errorMsg );
+        QMessageBox::critical( nullptr, tr( "New GeoPackage" ), errorMsg );
         return;
       }
 

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
@@ -54,6 +54,7 @@ class QgsGeoPackageItemGuiProvider : public QObject, public QgsDataItemGuiProvid
     //! Compacts (VACUUM) a geopackage database
     void vacuumGeoPackageDbAction( const QString &path, const QString &name, QgsDataItemGuiContext context );
     void createDatabase( const QPointer< QgsGeoPackageRootItem > &item );
+    void createDatabaseAndLayer( const QPointer< QgsGeoPackageRootItem > &item );
 
   protected slots:
     void renameVectorLayer( const QString &uri, const QString &key, const QStringList &tableNames,


### PR DESCRIPTION
## Description

There an inconsistency in behavior of the "Create Database" context menu item for SpatiaLite and GeoPackage nodes in the Browser. In case of SpatiaLite this action creates an empty database and adds a new connection while the same action for GeoPackage creates a new GeoPackage file **with a layer** and adds a new connection.

This is not only confusing but also not very convinient in some use cases when user needs an empty GeoPackage. Of course, it is possible to create an empty GeoPackage from the context menu of the directory nodes, but this again is  not very intuitive and many users are not aware about this option.

This PR renames existing "Create Database" action to "Create Database and Layer" action and adds a new context menu action "Create Database" which creates an empty GeoPackage.

![image](https://github.com/qgis/QGIS/assets/776954/3a2742c7-de80-40b3-847d-b8bec464132c)

Fixes #25116.

Funded by [NaturalGIS](https://www.naturalgis.pt/).