### PR TITLE
appdata: be mindful of the xml elements depth when translating

### DIFF
--- a/scripts/ts2appinfo.py.in
+++ b/scripts/ts2appinfo.py.in
@@ -29,8 +29,9 @@ strings = {}
 d = et.parse('linux/org.qgis.qgis.appdata.xml.in')
 
 r = d.getroot()
-for elem in ['name', 'summary', 'description']:
-    for c in r.iter(elem):
+valuesNeeded = ['name', 'summary', 'description']
+for c in r:
+    if c.tag in valuesNeeded:
         if not c.attrib:
             l = list(c)
             t = c.text if not l else "".join([et.tostring(x).decode("utf-8") for x in l])
@@ -68,8 +69,9 @@ for qm in sorted(glob(sys.argv[1] + "/output/i18n/qgis_*.qm")):
             continue
         strings[s][lang] = translation
 
-for elem in ['name', 'summary']:
-    for c in r.iter(elem):
+valuesOffered = ['name', 'summary']
+for c in r:
+    if c.tag in valuesOffered:
         if c.attrib:
             continue
 
@@ -77,7 +79,7 @@ for elem in ['name', 'summary']:
         s = c.text if not l else "".join([et.tostring(x).decode("utf-8") for x in l])
 
         for lang in strings[s]:
-            e = et.Element(elem, attrib={"xml:lang": lang})
+            e = et.Element(c.tag, attrib={"xml:lang": lang})
             e.text = strings[s][lang]
             e.tail = c.tail
             r.append(e)


### PR DESCRIPTION
## Description

We were doing a deep search for "name" which happened for the component name _and_ and the developer name, which is in a deeper tag. Instead of doing a deep search, just look for the elements we care about among the component element's children.

Fixes this error from appstreamcli:
org.qgis.qgis.metainfo.xml
  E: org.qgis.qgis.desktop:88: tag-duplicated name (lang=de)
  E: org.qgis.qgis.desktop:88: tag-duplicated name (lang=hu)
  E: org.qgis.qgis.desktop:88: tag-duplicated name (lang=lt)
  E: org.qgis.qgis.desktop:88: tag-duplicated name (lang=nb)
  E: org.qgis.qgis.desktop:88: tag-duplicated name (lang=zh-Hans)

To verify the fix, run "appstreamcli validate org.qgis.qgis.appdata.xml".

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
