### PR TITLE
[processing] Support drag and drop for multi-layer parameters

### DIFF
--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -464,6 +464,8 @@ QStringList QgsProcessingMultipleInputPanelWidget::compatibleUrisFromMimeData( c
     if ( skipUrlData.contains( u.data() ) )
       continue;
 
+    // clang analyzer is not happy because of the multiple duplicate return branches, but it makes the code more readable
+    // NOLINTBEGIN(bugprone-branch-clone)
     if ( ( mParameter->layerType() == Qgis::ProcessingSourceType::MapLayer
            || mParameter->layerType() == Qgis::ProcessingSourceType::Vector
            || mParameter->layerType() == Qgis::ProcessingSourceType::VectorAnyGeometry
@@ -514,6 +516,7 @@ QStringList QgsProcessingMultipleInputPanelWidget::compatibleUrisFromMimeData( c
     else if ( ( mParameter->layerType()  == Qgis::ProcessingSourceType::MapLayer || mParameter->layerType() == Qgis::ProcessingSourceType::VectorTile )
               && u.layerType == QLatin1String( "vector-tile" ) )
       res.append( u.uri );
+    // NOLINTEND(bugprone-branch-clone)
   }
   if ( !uriList.isEmpty() )
     return res;

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.h
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.h
@@ -20,6 +20,7 @@
 #include "qgis_gui.h"
 #include "ui_qgsprocessingmultipleselectiondialogbase.h"
 #include "qgsprocessingparameters.h"
+#include "qgsmimedatautils.h"
 #include <QDialog>
 
 class QStandardItemModel;
@@ -265,7 +266,8 @@ class GUI_EXPORT QgsProcessingMultipleInputPanelWidget : public QgsProcessingMul
      * Returns a map layer, compatible with the filters set for the combo box, from
      * the specified mime \a data (if possible!).
      */
-    QList<int> existingMapLayerFromMimeData( const QMimeData *data ) const;
+    QList<int> existingMapLayerFromMimeData( const QMimeData *data, QgsMimeDataUtils::UriList &handledUrls ) const;
+    QStringList compatibleUrisFromMimeData( const QMimeData *data, const QgsMimeDataUtils::UriList &skipUrls ) const;
     void populateFromProject( QgsProject *project );
 
     const QgsProcessingParameterMultipleLayers *mParameter = nullptr;


### PR DESCRIPTION
Allows dragging and dropping layers from either the QGIS browser or file explorer onto any multiple-layer parameter panel. Handy when you have to add many layers and it's simpler to make a selection outside of the processing dialog.
