### PR TITLE
[tests][auth] Fix unreported issue with auth tests skipped

### DIFF
--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -49,7 +49,7 @@ init initialize QCA, prioritize qca-ossl plugin and optionally set up the authen
 .. seealso:: :py:func:`QgsApplication.qgisAuthDatabaseFilePath`
 
 .. deprecated:: QGIS 3.36
-  use :py:func:`~QgsAuthManager.setup` instead.
+  use :py:func:`~QgsAuthManager.setup` or :py:func:`~QgsAuthManager.ensureInitialized` instead.
 %End
 
     void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
@@ -61,6 +61,18 @@ to lazy-initialize when required.
 
 :param pluginPath: the plugin path
 :param authDatabasePath: the authentication DB path
+
+.. seealso:: :py:func:`ensureInitialized`
+%End
+
+    bool ensureInitialized() const;
+%Docstring
+Performs lazy initialization of the authentication framework, if it has
+not already been done.
+
+.. versionadded:: 3.40
+
+.. seealso:: :py:func:`setup`
 %End
 
     ~QgsAuthManager();

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -87,7 +87,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * \return TRUE on success
      * \see QgsApplication::pluginPath
      * \see QgsApplication::qgisAuthDatabaseFilePath
-     * \deprecated Since QGIS 3.36, use setup() instead.
+     * \deprecated Since QGIS 3.36, use setup() or ensureInitialized() instead.
      */
     Q_DECL_DEPRECATED bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) SIP_DEPRECATED;
 
@@ -99,8 +99,18 @@ class CORE_EXPORT QgsAuthManager : public QObject
      *
      * \param pluginPath the plugin path
      * \param authDatabasePath the authentication DB path
+     * \see ensureInitialized()
      */
     void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
+
+    /**
+     * Performs lazy initialization of the authentication framework, if it has
+     * not already been done.
+     *
+     * \since QGIS 3.40
+     * \see setup()
+     */
+    bool ensureInitialized() const;
 
     ~QgsAuthManager() override;
 
@@ -786,12 +796,6 @@ class CORE_EXPORT QgsAuthManager : public QObject
 #endif
 
   private:
-
-    /**
-     * Performs lazy initialization of the authentication framework, if it has
-     * not already been done.
-     */
-    bool ensureInitialized() const;
 
     bool initPrivate( const QString &pluginPath,  const QString &authDatabasePath );
 

--- a/tests/src/core/testqgsauthcertutils.cpp
+++ b/tests/src/core/testqgsauthcertutils.cpp
@@ -14,16 +14,16 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsauthmanager.h"
 #include "qgstest.h"
+#include "qgsapplication.h"
+#include "qgsauthcrypto.h"
+#include "qgsauthcertutils.h"
+
 #include <QObject>
 #include <QSslKey>
 #include <QString>
 #include <QStringList>
-
-#include "qgsapplication.h"
-#include "qgsauthcrypto.h"
-#include "qgsauthcertutils.h"
-#include "qgslogger.h"
 
 /**
  * \ingroup UnitTests
@@ -52,6 +52,7 @@ void TestQgsAuthCertUtils::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsApplication::authManager()->ensureInitialized();
   if ( QgsAuthCrypto::isDisabled() )
     QSKIP( "QCA's qca-ossl plugin is missing, skipping test case", SkipAll );
 }

--- a/tests/src/core/testqgsauthconfig.cpp
+++ b/tests/src/core/testqgsauthconfig.cpp
@@ -13,14 +13,15 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#include "qgsauthmanager.h"
 #include "qgstest.h"
-#include <QObject>
-#include <QString>
-#include <QStringList>
-
 #include "qgsapplication.h"
 #include "qgsauthcrypto.h"
 #include "qgsauthconfig.h"
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
 
 /**
  * \ingroup UnitTests
@@ -52,6 +53,7 @@ void TestQgsAuthConfig::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsApplication::authManager()->ensureInitialized();
   if ( QgsAuthCrypto::isDisabled() )
     QSKIP( "QCA's qca-ossl plugin is missing, skipping test case", SkipAll );
 }

--- a/tests/src/core/testqgsauthcrypto.cpp
+++ b/tests/src/core/testqgsauthcrypto.cpp
@@ -14,12 +14,13 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgstest.h"
+#include "qgsauthmanager.h"
+#include "qgsapplication.h"
+#include "qgsauthcrypto.h"
+
 #include <QObject>
 #include <QString>
 #include <QStringList>
-
-#include "qgsapplication.h"
-#include "qgsauthcrypto.h"
 
 /**
  * \ingroup UnitTests
@@ -83,6 +84,7 @@ void TestQgsAuthCrypto::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsApplication::authManager()->ensureInitialized();
   if ( QgsAuthCrypto::isDisabled() )
     QSKIP( "QCA's qca-ossl plugin is missing, skipping test case", SkipAll );
 }


### PR DESCRIPTION
Test were silently skipped since 5ac17746de (lazy init of auth manager).

The error message was also misleading:
"QCA's qca-ossl plugin is missing, skipping test case" because the plugin was actually installed but the auth system wasn't initialized.
