### PR TITLE
Don't go to massive negative numbers when incrementing a NULL spin box

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
@@ -135,6 +135,8 @@ is equal to :py:func:`~QgsDoubleSpinBox.minimum`. Typical use is to indicate tha
 
     virtual void paintEvent( QPaintEvent *e );
 
+    virtual void stepBy( int steps );
+
 
   protected:
     virtual void changeEvent( QEvent *event );

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
@@ -133,6 +133,8 @@ is equal to :py:func:`~QgsSpinBox.minimum`. Typical use is to indicate that this
 
     virtual QValidator::State validate( QString &input, int &pos ) const;
 
+    virtual void stepBy( int steps );
+
 
   protected:
 

--- a/python/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
@@ -135,6 +135,8 @@ is equal to :py:func:`~QgsDoubleSpinBox.minimum`. Typical use is to indicate tha
 
     virtual void paintEvent( QPaintEvent *e );
 
+    virtual void stepBy( int steps );
+
 
   protected:
     virtual void changeEvent( QEvent *event );

--- a/python/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
@@ -133,6 +133,8 @@ is equal to :py:func:`~QgsSpinBox.minimum`. Typical use is to indicate that this
 
     virtual QValidator::State validate( QString &input, int &pos ) const;
 
+    virtual void stepBy( int steps );
+
 
   protected:
 

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -114,6 +114,20 @@ void QgsDoubleSpinBox::paintEvent( QPaintEvent *event )
   QDoubleSpinBox::paintEvent( event );
 }
 
+void QgsDoubleSpinBox::stepBy( int steps )
+{
+  const bool wasNull = mShowClearButton && value() == clearValue();
+  if ( wasNull && minimum() < 0 && maximum() > 0 )
+  {
+    // value is currently null, and range allows both positive and negative numbers
+    // in this case we DON'T do the default step, as that would add one step to the NULL value,
+    // which is usually the minimum acceptable value... so the user will get a very large negative number!
+    // Instead, treat the initial value as 0 instead, and then perform the step.
+    whileBlocking( this )->setValue( 0 );
+  }
+  QDoubleSpinBox::stepBy( steps );
+}
+
 void QgsDoubleSpinBox::changed( double value )
 {
   mLineEdit->setShowClearButton( shouldShowClearForValue( value ) );

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -140,6 +140,7 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
     double valueFromText( const QString &text ) const override;
     QValidator::State validate( QString &input, int &pos ) const override;
     void paintEvent( QPaintEvent *e ) override;
+    void stepBy( int steps ) override;
 
   protected:
     void changeEvent( QEvent *event ) override;

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -216,6 +216,20 @@ QValidator::State QgsSpinBox::validate( QString &input, int &pos ) const
   return QValidator::Acceptable;
 }
 
+void QgsSpinBox::stepBy( int steps )
+{
+  const bool wasNull = mShowClearButton && value() == clearValue();
+  if ( wasNull && minimum() < 0 && maximum() > 0 )
+  {
+    // value is currently null, and range allows both positive and negative numbers
+    // in this case we DON'T do the default step, as that would add one step to the NULL value,
+    // which is usually the minimum acceptable value... so the user will get a very large negative number!
+    // Instead, treat the initial value as 0 instead, and then perform the step.
+    whileBlocking( this )->setValue( 0 );
+  }
+  QSpinBox::stepBy( steps );
+}
+
 int QgsSpinBox::frameWidth() const
 {
   return style()->pixelMetric( QStyle::PM_DefaultFrameWidth );

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -139,6 +139,7 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
 
     int valueFromText( const QString &text ) const override;
     QValidator::State validate( QString &input, int &pos ) const override;
+    void stepBy( int steps ) override;
 
   protected:
 

--- a/tests/src/gui/testqgsdoublespinbox.cpp
+++ b/tests/src/gui/testqgsdoublespinbox.cpp
@@ -29,6 +29,7 @@ class TestQgsDoubleSpinBox: public QObject
 
     void clear();
     void expression();
+    void step();
 
   private:
 
@@ -142,6 +143,44 @@ void TestQgsDoubleSpinBox::expression()
   QCOMPARE( spinBox->valueFromText( QString( "mm5/ll" ) ), 4.0 ); //invalid expression should reset to previous value
 
   delete spinBox;
+}
+
+void TestQgsDoubleSpinBox::step()
+{
+  // test step logic
+
+  QgsDoubleSpinBox spin;
+  spin.setMinimum( -1000 );
+  spin.setMaximum( 1000 );
+  spin.setSingleStep( 1 );
+
+  // no clear value
+  spin.setValue( 0 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), 0 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
+
+  // with clear value
+  spin.setClearValue( -1000, QStringLiteral( "NULL" ) );
+  spin.setValue( 0 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), 0 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  // when cleared, a step should NOT go to -999 (which is annoying for users), but rather pretend that the initial value was 0, not NULL
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
 }
 
 QGSTEST_MAIN( TestQgsDoubleSpinBox )

--- a/tests/src/gui/testqgsspinbox.cpp
+++ b/tests/src/gui/testqgsspinbox.cpp
@@ -29,6 +29,7 @@ class TestQgsSpinBox: public QObject
 
     void clear();
     void expression();
+    void step();
 
   private:
 
@@ -142,6 +143,44 @@ void TestQgsSpinBox::expression()
   QCOMPARE( spinBox->valueFromText( QString( "mm5/ll" ) ), 4 ); //invalid expression should reset to previous value
 
   delete spinBox;
+}
+
+void TestQgsSpinBox::step()
+{
+  // test step logic
+
+  QgsSpinBox spin;
+  spin.setMinimum( -1000 );
+  spin.setMaximum( 1000 );
+  spin.setSingleStep( 1 );
+
+  // no clear value
+  spin.setValue( 0 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), 0 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
+
+  // with clear value
+  spin.setClearValue( -1000, QStringLiteral( "NULL" ) );
+  spin.setValue( 0 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), 0 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  // when cleared, a step should NOT go to -999 (which is annoying for users), but rather pretend that the initial value was 0, not NULL
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
 }
 
 QGSTEST_MAIN( TestQgsSpinBox )


### PR DESCRIPTION
When a spin box is showing a NULL value, we DON'T do the default step behavior, as that would add one step to the NULL value, which is usually a very large negative value... so the user will get a very large negative number!

Instead, treat the initial value as 0 instead, and then perform the step.

Before: (also note how the increment is broken with the cleared double spin box, because it's trying to add 1 to the lowest double value, which results in the lowest double value... :rofl: )

![Peek 2024-06-27 11-27](https://github.com/qgis/QGIS/assets/1829991/e4a485e7-e1ae-4eee-aaad-fe7f52fd06e9)

After:

![Peek 2024-06-27 11-28](https://github.com/qgis/QGIS/assets/1829991/97ae569d-a45d-4b90-929a-bd5e2dfaa61d)

