### PR TITLE
[3.34 backport] qgs3daxis: Fix object root memory leak

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -89,6 +89,21 @@ Qgs3DAxis::~Qgs3DAxis()
 {
   delete mMenu;
   mMenu = nullptr;
+
+  // If a root entity is not enabled, it means that it does not have a parent.
+  // In that case, it will never be automatically deleted. Therefore, it needs to be manually deleted.
+  // See setEnableCube() and setEnableAxis().
+  if ( !mCubeRoot->isEnabled() )
+  {
+    delete mCubeRoot;
+    mCubeRoot = nullptr;
+  }
+
+  if ( !mAxisRoot->isEnabled() )
+  {
+    delete mAxisRoot;
+    mAxisRoot = nullptr;
+  }
 }
 
 void Qgs3DAxis::init3DObjectPicking( )


### PR DESCRIPTION
## Description

This is a manual backport of a memoy leak fix introduced in https://github.com/qgis/QGIS/pull/57849


If an object root entity (`mCubeRoot` or `mAxisRoot`) is not enabled, it means that it does not have a parent because of the `setEnableCube()` and `setEnableAxis()` logic. In that case, it will never be automatically deleted by Qt. Therefore, it creates a memory leak.

This issue is fixed by adding a check in the destructor. If an object is not enabled, then it is disabled.

