### PR TITLE
qgs3daxis: Correctly delete axis or cube in the destructor

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -77,19 +77,25 @@ Qgs3DAxis::~Qgs3DAxis()
   delete mMenu;
   mMenu = nullptr;
 
-  // If a root entity is not enabled, it means that it does not have a parent.
+  // When an object (axis or cube) is not enabled. It is still present but it does not have a parent.
   // In that case, it will never be automatically deleted. Therefore, it needs to be manually deleted.
   // See setEnableCube() and setEnableAxis().
-  if ( !mCubeRoot->isEnabled() )
+  switch ( mMapSettings->get3DAxisSettings().mode() )
   {
-    delete mCubeRoot;
-    mCubeRoot = nullptr;
-  }
-
-  if ( !mAxisRoot->isEnabled() )
-  {
-    delete mAxisRoot;
-    mAxisRoot = nullptr;
+    case Qgs3DAxisSettings::Mode::Crs:
+      delete mCubeRoot;
+      mCubeRoot = nullptr;
+      break;
+    case Qgs3DAxisSettings::Mode::Cube:
+      delete mAxisRoot;
+      mAxisRoot = nullptr;
+      break;
+    case Qgs3DAxisSettings::Mode::Off:
+      delete mAxisRoot;
+      mAxisRoot = nullptr;
+      delete mCubeRoot;
+      mCubeRoot = nullptr;
+      break;
   }
 }
 


### PR DESCRIPTION
## Description

In the desctrutor, `mAxisRoot` or `mCubeRoot` may have already been freed by Qt. In that case, a `isEnabled()` call will create a segmentation fault. By checking the axis mode, this allows to properly know which objects needs to be deleted.

Fixes commit b578f1ea82ba9bd091198c1673583dadf21aa495

@nyalldawson I was a bit optimistic with my memory leak fix. It can cause a segmentation fault un some cases. This is a proper fix.