### PR TITLE
Externalize nlohmann

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,8 @@ if(WITH_CORE)
   find_package(EXPAT REQUIRED)
   find_package(Spatialindex REQUIRED)
   find_package(LibZip REQUIRED)
+  set (WITH_INTERNAL_NLOHMANN_JSON ON CACHE BOOL "Determines whether the vendored copy of nlohmann-json should be used")
+  find_package(nlohmann_json REQUIRED)
 
   find_package(Sqlite3)
   if (NOT SQLITE3_FOUND)

--- a/cmake/Findnlohmann_json.cmake
+++ b/cmake/Findnlohmann_json.cmake
@@ -1,0 +1,12 @@
+if(WITH_INTERNAL_NLOHMANN_JSON)
+  # Create imported target nlohmann_json::nlohmann_json
+  add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)
+  
+  set_target_properties(nlohmann_json::nlohmann_json PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "\$<\$<NOT:\$<BOOL:ON>>:JSON_USE_GLOBAL_UDLS=0>;\$<\$<NOT:\$<BOOL:ON>>:JSON_USE_IMPLICIT_CONVERSIONS=0>;\$<\$<BOOL:OFF>:JSON_DISABLE_ENUM_SERIALIZATION=1>;\$<\$<BOOL:OFF>:JSON_DIAGNOSTICS=1>;\$<\$<BOOL:OFF>:JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=1>"
+    INTERFACE_COMPILE_FEATURES "cxx_std_11"
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/external/nlohmann/"
+  )
+else()
+  find_package(nlohmann_json CONFIG REQUIRED)
+endif()

--- a/external/tinygltf/tiny_gltf.h
+++ b/external/tinygltf/tiny_gltf.h
@@ -1703,7 +1703,7 @@ class TinyGLTF {
 
 #ifndef TINYGLTF_NO_INCLUDE_JSON
 #ifndef TINYGLTF_USE_RAPIDJSON
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #else
 #ifndef TINYGLTF_NO_INCLUDE_RAPIDJSON
 #include "document.h"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1064,8 +1064,6 @@ else()
 endif()
 
 set(QGIS_CORE_HDRS
-  ${CMAKE_SOURCE_DIR}/external/nlohmann/json_fwd.hpp
-
   ${CMAKE_BINARY_DIR}/qgsconfig.h
 
   ../plugins/qgisplugin.h
@@ -2371,7 +2369,6 @@ target_include_directories(qgis_core PUBLIC
   web
   ${CMAKE_SOURCE_DIR}/external
   ${CMAKE_SOURCE_DIR}/external/delaunator-cpp
-  ${CMAKE_SOURCE_DIR}/external/nlohmann
   ${CMAKE_SOURCE_DIR}/external/kdbush/include
   ${CMAKE_SOURCE_DIR}/external/nmea
   ${CMAKE_SOURCE_DIR}/external/rtree/include
@@ -2485,6 +2482,7 @@ target_link_libraries(qgis_core
   ${ZLIB_LIBRARIES}
   ${EXIV2_LIBRARY}
   PROJ::proj
+  nlohmann_json::nlohmann_json
 )
 
 if(BUILD_WITH_QT6)

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -27,7 +27,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgswkbptr.h"
 
 #ifndef SIP_RUN
-#include "json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 using namespace nlohmann;
 #endif
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -38,7 +38,7 @@ email                : morb at ozemail dot com dot au
 #include "qgsvertexid.h"
 
 #ifndef SIP_RUN
-#include "json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 using namespace nlohmann;
 #endif
 

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -33,7 +33,7 @@
 #include <string>
 
 #ifndef SIP_RUN
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #endif
 
 class QgsCoordinateReferenceSystem;

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -26,7 +26,7 @@
 #include <QJsonObject>
 
 #ifndef SIP_RUN
-#include "json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 using namespace nlohmann;
 #endif
 

--- a/src/core/tiledscene/qgscesiumutils.h
+++ b/src/core/tiledscene/qgscesiumutils.h
@@ -23,7 +23,7 @@
 #include "qgsbox3d.h"
 #include "qgsvector3d.h"
 #include "qgis_sip.h"
-#include "nlohmann/json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 
 #ifndef SIP_RUN
 using namespace nlohmann;

--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -4,7 +4,6 @@
 set(QGIS_PROCESS_SRCS
   main.cpp
   qgsprocess.cpp
-  ${CMAKE_SOURCE_DIR}/external/nlohmann/json_fwd.hpp
 )
 
 if (UNIX AND NOT ANDROID)

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -50,7 +50,7 @@
 #include <ogr_api.h>
 #include <gdal_version.h>
 #include <proj.h>
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 
 ConsoleFeedback::ConsoleFeedback( bool useJson )
   : mUseJson( useJson )

--- a/src/providers/mdal/CMakeLists.txt
+++ b/src/providers/mdal/CMakeLists.txt
@@ -72,7 +72,6 @@ if (WITH_INTERNAL_MDAL)
     ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty/libplyxx.h
     ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty/libplyxx/libplyxx_internal.h
     ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty/textio.h
-    ${CMAKE_SOURCE_DIR}/external/nlohmann/json.hpp
   )
 
   if(HDF5_FOUND)

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -21,7 +21,7 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgsjsonutils.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "qgspdalindexingtask.h"
 #include "qgseptpointcloudindex.h"
 #include "qgstaskmanager.h"

--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -3,7 +3,6 @@
 # Files
 
 set(WFS_SRCS
-  ${CMAKE_SOURCE_DIR}/external/nlohmann/json.hpp
   qgswfsprovider.cpp
   qgswfsprovidermetadata.cpp
   qgswfscapabilities.cpp

--- a/src/server/qgsserverapiutils.h
+++ b/src/server/qgsserverapiutils.h
@@ -41,7 +41,7 @@ class QgsCoordinateReferenceSystem;
 class QgsVectorLayer;
 
 #ifndef SIP_RUN
-#include "nlohmann/json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 using namespace nlohmann;
 #endif
 

--- a/src/server/qgsserverogcapihandler.h
+++ b/src/server/qgsserverogcapihandler.h
@@ -20,7 +20,7 @@
 #include "qgis_server.h"
 #include "qgsserverquerystringparameter.h"
 #include "qgsserverogcapi.h"
-#include "nlohmann/json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 #include "inja/inja.hpp"
 
 #ifndef SIP_RUN

--- a/src/server/qgsserverquerystringparameter.h
+++ b/src/server/qgsserverquerystringparameter.h
@@ -24,7 +24,7 @@
 #include <QObject>
 
 
-#include "nlohmann/json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 
 #ifndef SIP_RUN
 using namespace nlohmann;

--- a/src/server/services/landingpage/CMakeLists.txt
+++ b/src/server/services/landingpage/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Files
 
 set (LANDINGPAGE_SRCS
-  ${CMAKE_SOURCE_DIR}/external/nlohmann/json.hpp
   ${CMAKE_SOURCE_DIR}/external/inja/inja.hpp
   qgslandingpage.cpp
   qgslandingpageutils.cpp

--- a/src/server/services/landingpage/qgslandingpageutils.h
+++ b/src/server/services/landingpage/qgslandingpageutils.h
@@ -20,7 +20,7 @@
 #include <QStringList>
 #include <QRegularExpression>
 
-#include "nlohmann/json_fwd.hpp"
+#include <nlohmann/json_fwd.hpp>
 #include "qgsserversettings.h"
 #include "qgsserverrequest.h"
 

--- a/src/server/services/wfs3/CMakeLists.txt
+++ b/src/server/services/wfs3/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Files
 
 set (WFS3_SRCS
-  ${CMAKE_SOURCE_DIR}/external/nlohmann/json.hpp
   ${CMAKE_SOURCE_DIR}/external/inja/inja.hpp
   qgswfs3.cpp
   qgswfs3handlers.cpp

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -56,7 +56,7 @@
 #include "qgspointcloudlayer.h"
 #include "qgsannotationlayer.h"
 #include "qgsjsonutils.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "qgsspatialindex.h"
 #include "qgstiledscenelayer.h"
 #include "qgsalignrasterdata.h"


### PR DESCRIPTION
nlohmann_json is used in many different styles throughout the codebase. This cleans things up and makes it possible to use a system provided copy.

Adds a new cmake flag `WITH_INTERNAL_NLOHMANN_JSON` which is enabled by default for backwards compatibility.