### PR TITLE
Browser: Fix untranslatable provider names

### DIFF
--- a/src/core/vectortile/qgsvectortiledataitems.cpp
+++ b/src/core/vectortile/qgsvectortiledataitems.cpp
@@ -70,7 +70,7 @@ Qgis::DataItemProviderCapabilities QgsVectorTileDataItemProvider::capabilities()
 QgsDataItem *QgsVectorTileDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
 {
   if ( path.isEmpty() )
-    return new QgsVectorTileRootItem( parentItem, QStringLiteral( "Vector Tiles" ), QStringLiteral( "vectortile:" ) );
+    return new QgsVectorTileRootItem( parentItem, QObject::tr( "Vector Tiles" ), QStringLiteral( "vectortile:" ) );
   return nullptr;
 }
 

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -211,7 +211,7 @@ QgsDataItem *QgsWfsDataItemProvider::createDataItem( const QString &path, QgsDat
   QgsDebugMsgLevel( "WFS path = " + path, 4 );
   if ( path.isEmpty() )
   {
-    return new QgsWfsRootItem( parentItem, QStringLiteral( "WFS / OGC API - Features" ), QStringLiteral( "wfs:" ) );
+    return new QgsWfsRootItem( parentItem, QObject::tr( "WFS / OGC API - Features" ), QStringLiteral( "wfs:" ) );
   }
 
   // path schema: wfs:/connection name (used by OWS)

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -769,7 +769,7 @@ Qgis::DataItemProviderCapabilities QgsXyzTileDataItemProvider::capabilities() co
 QgsDataItem *QgsXyzTileDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
 {
   if ( path.isEmpty() )
-    return new QgsXyzTileRootItem( parentItem, QStringLiteral( "XYZ Tiles" ), QStringLiteral( "xyz:" ) );
+    return new QgsXyzTileRootItem( parentItem, QObject::tr( "XYZ Tiles" ), QStringLiteral( "xyz:" ) );
   return nullptr;
 }
 


### PR DESCRIPTION
## Description

Some of the provider's QgsDataItem texts are not included to the i18n, making them untranslatable:

![image](https://github.com/qgis/QGIS/assets/1000043/59a1ee16-3feb-446d-bd61-5ec044bb6a85)

This simple PR fixes `Vector Tiles`, `XYZ Tiles` and `WFS / OGC API - Features`.

Note there are 6 more (`GeoPackage`, `WMS/WMTS`, `SAP HANA`, `SpatiaLite`, `WCS`, `Oracle`) left, but they are proper names, so I don't expect anyone would want to translate them. I can, however, add them as well, in the sake of consistency.