### PR TITLE
Respect Exiv2::Value type (Exiv2::unsignedRational) in readRational of QgsExifTools (fixes #57942)

### DIFF
--- a/src/core/raster/qgsexiftools.cpp
+++ b/src/core/raster/qgsexiftools.cpp
@@ -165,9 +165,10 @@ QVariant decodeExifData( const QString &key, Exiv2::ExifData::const_iterator &it
     const QStringList parts = QString::fromStdString( it->toString() ).split( QRegularExpression( QStringLiteral( "\\s+" ) ) );
     if ( parts.size() == 3 )
     {
-      const int hour = readRational( it->value(), 0 );
-      const int minute = readRational( it->value(), 1 );
-      const int second = readRational( it->value(), 2 );
+      const int hour = std::max( 0, std::min( 23, static_cast< int >( readRational( it->value(), 0 ) ) ) );
+      const int minute = std::max( 0, std::min( 59, static_cast< int >( readRational( it->value(), 1 ) ) ) );
+      const int second = std::max( 0, std::min( 59, static_cast< int >( readRational( it->value(), 2 ) ) ) );
+
       val = QVariant::fromValue( QTime::fromString( QStringLiteral( "%1:%2:%3" )
                                  .arg( QString::number( hour ).rightJustified( 2, '0' ) )
                                  .arg( QString::number( minute ).rightJustified( 2, '0' ) )

--- a/src/core/raster/qgsexiftools.cpp
+++ b/src/core/raster/qgsexiftools.cpp
@@ -23,10 +23,21 @@
 #include <QFileInfo>
 #include <QTime>
 
-double readRationale( const Exiv2::Value &value, long n = 0 )
+double readRational( const Exiv2::Value &value, long n = 0 )
 {
   const Exiv2::Rational rational = value.toRational( n );
-  return static_cast< double >( rational.first ) / rational.second;
+  const auto numerator = rational.first;
+  const auto denominator = rational.second;
+  double res = 0;
+  if ( value.typeId() == Exiv2::unsignedRational )
+  {
+    res = static_cast< double >( static_cast<uint32_t>( numerator ) ) / static_cast<uint32_t>( denominator );
+  }
+  else
+  {
+    res = static_cast< double >( numerator ) / denominator;
+  }
+  return res;
 };
 
 double readCoordinate( const Exiv2::Value &value )
@@ -35,7 +46,7 @@ double readCoordinate( const Exiv2::Value &value )
   double div = 1;
   for ( int i = 0; i < 3; i++ )
   {
-    res += readRationale( value, i ) / div;
+    res += readRational( value, i ) / div;
     div *= 60;
   }
   return res;
@@ -114,7 +125,7 @@ QVariant decodeXmpData( const QString &key, Exiv2::XmpData::const_iterator &it )
       {
         if ( it->count() == 1 )
         {
-          val = QVariant::fromValue( readRationale( it->value() ) );
+          val = QVariant::fromValue( readRational( it->value() ) );
         }
         else
         {
@@ -154,9 +165,9 @@ QVariant decodeExifData( const QString &key, Exiv2::ExifData::const_iterator &it
     const QStringList parts = QString::fromStdString( it->toString() ).split( QRegularExpression( QStringLiteral( "\\s+" ) ) );
     if ( parts.size() == 3 )
     {
-      const int hour = readRationale( it->value(), 0 );
-      const int minute = readRationale( it->value(), 1 );
-      const int second = readRationale( it->value(), 2 );
+      const int hour = readRational( it->value(), 0 );
+      const int minute = readRational( it->value(), 1 );
+      const int second = readRational( it->value(), 2 );
       val = QVariant::fromValue( QTime::fromString( QStringLiteral( "%1:%2:%3" )
                                  .arg( QString::number( hour ).rightJustified( 2, '0' ) )
                                  .arg( QString::number( minute ).rightJustified( 2, '0' ) )
@@ -238,7 +249,7 @@ QVariant decodeExifData( const QString &key, Exiv2::ExifData::const_iterator &it
       {
         if ( it->count() == 1 )
         {
-          val = QVariant::fromValue( readRationale( it->value() ) );
+          val = QVariant::fromValue( readRational( it->value() ) );
         }
         else
         {
@@ -408,7 +419,7 @@ QgsPoint QgsExifTools::getGeoTag( const QString &imagePath, bool &ok )
     const Exiv2::ExifData::iterator itElevRefVal = exifData.findKey( Exiv2::ExifKey( "Exif.GPSInfo.GPSAltitudeRef" ) );
     if ( itElevVal != exifData.end() )
     {
-      double elev = readRationale( itElevVal->value() );
+      double elev = readRational( itElevVal->value() );
       if ( itElevRefVal != exifData.end() )
       {
         const QString elevRef = QString::fromStdString( itElevRefVal->value().toString() );


### PR DESCRIPTION
## Description

GPSLatitude/GPSLongitude are stored as [rational64u[3]](https://exiftool.org/TagNames/GPS.html), with a rational for degrees, minutes and seconds. If the numerator or denominator of such a rational is bigger then `2^32/2` (`2147483648`), the `int32_t` will turn negative and lead to a wrong result while parsing the x/y value to a double in the **QgsExifTools**

This PR adresses this by using `uint32_t` on `Exiv2::unsignedRational`

- Fixes #57942 
- Also rename `readRationale` to `readRational`
- Explicitly cast the Exif `GPSTimeStamp` from `double` to `int` and min/max `hh:mm:ss` values