### PR TITLE
Update r.param.scale.txt - correct stated maximum "size"

### DIFF
--- a/python/plugins/grassprovider/description/r.param.scale.txt
+++ b/python/plugins/grassprovider/description/r.param.scale.txt
@@ -4,7 +4,7 @@ Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterNumber|slope_tolerance|Slope tolerance that defines a 'flat' surface (degrees)|QgsProcessingParameterNumber.Double|1.0|True|None|None
 QgsProcessingParameterNumber|curvature_tolerance|Curvature tolerance that defines 'planar' surface|QgsProcessingParameterNumber.Double|0.0001|True|None|None
-QgsProcessingParameterNumber|size|Size of processing window (odd number only, max: 69)|QgsProcessingParameterNumber.Integer|3|True|3|499
+QgsProcessingParameterNumber|size|Size of processing window (odd number only, max: 499)|QgsProcessingParameterNumber.Integer|3|True|3|499
 QgsProcessingParameterEnum|method|Morphometric parameter in 'size' window to calculate|elev;slope;aspect;profc;planc;longc;crosc;minic;maxic;feature|False|0|True
 QgsProcessingParameterNumber|exponent|Exponent for distance weighting (0.0-4.0)|QgsProcessingParameterNumber.Double|0.0|True|0.0|4.0
 QgsProcessingParameterNumber|zscale|Vertical scaling factor|QgsProcessingParameterNumber.Double|1.0|True|None|None


### PR DESCRIPTION
Correct stated maximum value for "size" parameter. Don't know why it would have been 69 - maybe someone intended to make that the default value?