### PR TITLE
Allow postgresraster layers as gdal processing tools input

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -472,6 +472,29 @@ class GdalUtils:
                     open_options=parts.get('openOptions', None),
                     credential_options=parts.get('credentialOptions', None)
                 )
+        elif provider == 'postgresraster':
+            gdal_source = ''
+            uri = layer.dataProvider().uri()
+            gdal_source = f"PG: {uri.connectionInfo()}"
+            schema = uri.schema()
+            if schema:
+                gdal_source += f" schema='{schema}'"
+            table = uri.table()
+            gdal_source += f" table='{table}'"
+            column = uri.param('column') or uri.geometryColumn()
+            if column:
+                gdal_source += f" column='{column}'"
+            is_tiled = any([layer.dataProvider().xSize() != layer.dataProvider().xBlockSize(),
+                            layer.dataProvider().ySize() != layer.dataProvider().yBlockSize()])
+            gdal_source += f" mode={2 if is_tiled else 1}"
+            where = layer.dataProvider().subsetString()
+            if where:
+                gdal_source += f" where='{where}'"
+
+            return GdalConnectionDetails(
+                connection_string=gdal_source,
+                format='"PostGISRaster"'
+            )
 
         ogrstr = str(layer.source()).split("|")[0]
         path, ext = os.path.splitext(ogrstr)

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -2439,26 +2439,12 @@ Qgis::DataType QgsPostgresRasterProvider::sourceDataType( int bandNo ) const
 
 int QgsPostgresRasterProvider::xBlockSize() const
 {
-  if ( mInput )
-  {
-    return mInput->xBlockSize();
-  }
-  else
-  {
-    return static_cast<int>( mWidth );
-  }
+  return mTileWidth;
 }
 
 int QgsPostgresRasterProvider::yBlockSize() const
 {
-  if ( mInput )
-  {
-    return mInput->yBlockSize();
-  }
-  else
-  {
-    return static_cast<int>( mHeight );
-  }
+  return mTileHeight;
 }
 
 QgsRasterBandStats QgsPostgresRasterProvider::bandStatistics( int bandNo, Qgis::RasterBandStatistics stats, const QgsRectangle &extent, int sampleSize, QgsRasterBlockFeedback *feedback )

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -388,6 +388,7 @@ ADD_PYTHON_TEST(PyQgsSelectiveMasking test_selective_masking.py)
 ADD_PYTHON_TEST(PyQgsAttributeEditorAction test_qgsattributeeditoraction.py)
 ADD_PYTHON_TEST(PyQgsVectorTile test_qgsvectortile.py)
 ADD_PYTHON_TEST(PyQgsVtpk test_qgsvtpk.py)
+ADD_PYTHON_TEST(PyQgsProcessingAlgsGdalGdalUtils test_processing_algs_gdal_gdalutils.py)
 
 if (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_processing_algs_gdal_gdalutils.py
+++ b/tests/src/python/test_processing_algs_gdal_gdalutils.py
@@ -1,0 +1,82 @@
+"""QGIS Unit tests for GdalUtils class
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Stefanos Natsis'
+__date__ = '03/07/2024'
+__copyright__ = 'Copyright 2024, The QGIS Project'
+
+
+import unittest
+from qgis.testing import start_app, QgisTestCase
+from qgis.core import QgsApplication, QgsRasterLayer, QgsDataSourceUri, QgsAuthMethodConfig
+from processing.algs.gdal.GdalUtils import (
+    GdalUtils,
+    GdalConnectionDetails
+)
+
+start_app()
+
+
+class TestProcessingAlgsGdalGdalUtils(QgisTestCase):
+
+    def test_gdal_connection_details_from_layer_postgresraster(self):
+        """
+        Test GdalUtils.gdal_connection_details_from_layer
+        """
+
+        rl = QgsRasterLayer(
+            "dbname='mydb' host=localhost port=5432 user='asdf' password='42'"
+            " sslmode=disable table=some_table schema=some_schema column=rast sql=pk = 2",
+            'pg_layer', 'postgresraster')
+
+        self.assertEqual(rl.providerType(), 'postgresraster')
+
+        connection_details = GdalUtils.gdal_connection_details_from_layer(rl)
+        s = connection_details.connection_string
+
+        self.assertTrue(s.lower().startswith('pg:'))
+        self.assertTrue("schema='some_schema'" in s)
+        self.assertTrue("password='42'" in s)
+        self.assertTrue("column='rast'" in s)
+        self.assertTrue("mode=1" in s)
+        self.assertTrue("where='pk = 2'" in s)
+        self.assertEqual(connection_details.format, '"PostGISRaster"')
+
+        # test different uri:
+        # - authcfg is expanded
+        # - column is parsed
+        # - where is skipped
+        authm = QgsApplication.authManager()
+        self.assertTrue(authm.setMasterPassword('masterpassword', True))
+        config = QgsAuthMethodConfig()
+        config.setName('Basic')
+        config.setMethod('Basic')
+        config.setConfig('username', 'asdf')
+        config.setConfig('password', '42')
+        self.assertTrue(authm.storeAuthenticationConfig(config, True))
+
+        rl = QgsRasterLayer(
+            f"dbname='mydb' host=localhost port=5432 authcfg={config.id()}"
+            f" sslmode=disable table=\"some_schema\".\"some_table\" (rast)",
+            'pg_layer', 'postgresraster')
+
+        self.assertEqual(rl.providerType(), 'postgresraster')
+
+        connection_details = GdalUtils.gdal_connection_details_from_layer(rl)
+        s = connection_details.connection_string
+
+        self.assertTrue(s.lower().startswith('pg:'))
+        self.assertTrue("schema='some_schema'" in s)
+        self.assertTrue("user='asdf'" in s)
+        self.assertTrue("password='42'" in s)
+        self.assertTrue("column='rast'" in s)
+        self.assertTrue("mode=1" in s)
+        self.assertFalse("where=" in s)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/src/python/test_processing_algs_gdal_gdalutils.py
+++ b/tests/src/python/test_processing_algs_gdal_gdalutils.py
@@ -10,6 +10,10 @@ __date__ = '03/07/2024'
 __copyright__ = 'Copyright 2024, The QGIS Project'
 
 
+import os
+import tempfile
+from shutil import rmtree
+
 import unittest
 from qgis.testing import start_app, QgisTestCase
 from qgis.core import QgsApplication, QgsRasterLayer, QgsDataSourceUri, QgsAuthMethodConfig
@@ -18,10 +22,20 @@ from processing.algs.gdal.GdalUtils import (
     GdalConnectionDetails
 )
 
+QGIS_AUTH_DB_DIR_PATH = tempfile.mkdtemp()
+os.environ['QGIS_AUTH_DB_DIR_PATH'] = QGIS_AUTH_DB_DIR_PATH
+
 start_app()
 
 
 class TestProcessingAlgsGdalGdalUtils(QgisTestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests"""
+        rmtree(QGIS_AUTH_DB_DIR_PATH)
+        del os.environ['QGIS_AUTH_DB_DIR_PATH']
+        super().tearDownClass()
 
     def test_gdal_connection_details_from_layer_postgresraster(self):
         """

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -664,6 +664,37 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
         self.assertTrue(b.isNoData(0, 0))
         self.assertTrue(b.isNoData(0, 1))
 
+    def testBlockSize(self):
+        """Check that tiled raster returns correct block size"""
+
+        # untiled have blocksize == size
+        rl = QgsRasterLayer(
+            self.dbconn + " sslmode=disable table={table} schema={schema} sql=\"pk\" = 2".format(
+                table='raster_3035_untiled_multiple_rows', schema='public'), 'pg_layer', 'postgresraster')
+
+        self.assertTrue(rl.isValid())
+
+        dp = rl.dataProvider()
+
+        self.assertEqual(dp.xSize(), 2)
+        self.assertEqual(dp.ySize(), 2)
+        self.assertEqual(dp.xBlockSize(), 2)
+        self.assertEqual(dp.yBlockSize(), 2)
+
+        # tiled have blocksize != size
+        rl = QgsRasterLayer(
+            self.dbconn + " srid=3035 sslmode=disable table={table} schema={schema}".format(
+                table='raster_3035_tiled_no_overviews', schema='public'), 'pg_layer', 'postgresraster')
+
+        self.assertTrue(rl.isValid())
+
+        dp = rl.dataProvider()
+
+        self.assertEqual(dp.xSize(), 6)
+        self.assertEqual(dp.ySize(), 5)
+        self.assertEqual(dp.xBlockSize(), 2)
+        self.assertEqual(dp.yBlockSize(), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Allow postgresraster layers as gdal processing tools input.

In order to decide if `mode=1` or `mode=2` will be used, the `QgsPostgresRasterProvider` was fixed to return correct values for `xBlockSize()` and `yBlockSize()`

Fixes #43030 regression
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
