### PR TITLE
[processing][feature] Enhance the GDAL "Vector information" alg and add a new GDAL "Vector information (JSON)" alg

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -82,7 +82,7 @@ from .Dissolve import Dissolve
 from .ExecuteSql import ExecuteSql
 from .OffsetCurve import OffsetCurve
 from .ogr2ogr import ogr2ogr
-from .ogrinfo import ogrinfo
+from .ogrinfo import ogrinfo, ogrinfojson
 from .OgrToPostGis import OgrToPostGis
 from .ogr2ogrtopostgislist import Ogr2OgrToPostGisList
 from .OneSideBuffer import OneSideBuffer
@@ -204,6 +204,9 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
 
         if int(gdal.VersionInfo()) > 3010000:
             self.algs.append(viewshed())
+
+        if int(gdal.VersionInfo()) >= 3070000:
+            self.algs.append(ogrinfojson())
 
         for a in self.algs:
             self.addAlgorithm(a)

--- a/python/plugins/processing/algs/gdal/ogrinfo.py
+++ b/python/plugins/processing/algs/gdal/ogrinfo.py
@@ -22,6 +22,8 @@ __copyright__ = '(C) 2012, Victor Olaya'
 from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterBoolean,
+                       QgsProcessingParameterDefinition,
+                       QgsProcessingParameterString,
                        QgsProcessingParameterFileDestination)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
@@ -29,8 +31,10 @@ from processing.algs.gdal.GdalUtils import GdalUtils
 
 class ogrinfo(GdalAlgorithm):
     INPUT = 'INPUT'
+    ALL_LAYERS = 'ALL_LAYERS'
     SUMMARY_ONLY = 'SUMMARY_ONLY'
     NO_METADATA = 'NO_METADATA'
+    EXTRA = 'EXTRA'
     OUTPUT = 'OUTPUT'
 
     def __init__(self):
@@ -39,16 +43,37 @@ class ogrinfo(GdalAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT,
                                                             self.tr('Input layer')))
-        self.addParameter(QgsProcessingParameterBoolean(self.SUMMARY_ONLY,
-                                                        self.tr('Summary output only'),
-                                                        defaultValue=True))
+        self.addParameter(QgsProcessingParameterBoolean(self.ALL_LAYERS,
+                                                        self.tr('Enable listing of all layers in the dataset'),
+                                                        defaultValue=False))
+        if self.name() == 'ogrinfo':
+            self.addParameter(QgsProcessingParameterBoolean(self.SUMMARY_ONLY,
+                                                            self.tr('Summary output only'),
+                                                            defaultValue=True))
+        else:
+            self.addParameter(QgsProcessingParameterBoolean(self.FEATURES,
+                                                            self.tr('Enable listing of features'),
+                                                            defaultValue=False))
+
         self.addParameter(QgsProcessingParameterBoolean(self.NO_METADATA,
                                                         self.tr('Suppress metadata info'),
                                                         defaultValue=False))
 
-        self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT,
-                                                                self.tr('Layer information'),
-                                                                self.tr('HTML files (*.html)')))
+        extra_param = QgsProcessingParameterString(self.EXTRA,
+                                                   self.tr('Additional command-line parameters'),
+                                                   defaultValue=None,
+                                                   optional=True)
+        extra_param.setFlags(extra_param.flags() | QgsProcessingParameterDefinition.Flag.FlagAdvanced)
+        self.addParameter(extra_param)
+
+        if self.name() == 'ogrinfo':
+            self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT,
+                                                                    self.tr('Layer information'),
+                                                                    self.tr('HTML files (*.html)')))
+        else:
+            self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT,
+                                                                    self.tr('Layer information'),
+                                                                    self.tr('JSON files (*.json)')))
 
     def name(self):
         return 'ogrinfo'
@@ -66,12 +91,24 @@ class ogrinfo(GdalAlgorithm):
         return 'ogrinfo'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
-        arguments = ['-al']
+        if self.name() == 'ogrinfo':
+            arguments = ['-al']
+        else:
+            arguments = ['-json']
 
-        if self.parameterAsBoolean(parameters, self.SUMMARY_ONLY, context):
-            arguments.append('-so')
+        if self.name() == 'ogrinfo':
+            if self.parameterAsBoolean(parameters, self.SUMMARY_ONLY, context):
+                arguments.append('-so')
+        else:
+            if self.parameterAsBoolean(parameters, self.FEATURES, context):
+                arguments.append('-features')
+
         if self.parameterAsBoolean(parameters, self.NO_METADATA, context):
             arguments.append('-nomd')
+
+        if self.EXTRA in parameters and parameters[self.EXTRA] not in (None, ''):
+            extra = self.parameterAsString(parameters, self.EXTRA, context)
+            arguments.append(extra)
 
         inLayer = self.parameterAsVectorLayer(parameters, self.INPUT, context)
         if inLayer is None:
@@ -79,7 +116,8 @@ class ogrinfo(GdalAlgorithm):
 
         input_details = self.getOgrCompatibleSource(self.INPUT, parameters, context, feedback, executing)
         arguments.append(input_details.connection_string)
-        arguments.append(input_details.layer_name)
+        if not self.parameterAsBoolean(parameters, self.ALL_LAYERS, context):
+            arguments.append(input_details.layer_name)
 
         if input_details.open_options:
             arguments.extend(input_details.open_options_as_arguments())
@@ -97,5 +135,24 @@ class ogrinfo(GdalAlgorithm):
             for s in console_output[1:]:
                 f.write(str(s))
             f.write('</pre>')
+
+        return {self.OUTPUT: output}
+
+
+class ogrinfojson(ogrinfo):
+    FEATURES = 'FEATURES'
+
+    def name(self):
+        return 'ogrinfojson'
+
+    def displayName(self):
+        return self.tr('Vector information (JSON)')
+
+    def processAlgorithm(self, parameters, context, feedback):
+        console_output = GdalUtils.runGdal(self.getConsoleCommands(parameters, context, feedback))
+        output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
+        with open(output, 'w', newline='') as f:
+            for s in console_output[1:]:
+                f.write(str(s))
 
         return {self.OUTPUT: output}

--- a/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
@@ -34,7 +34,7 @@ from qgis.testing import (QgisTestCase,
 
 import AlgorithmsTestBase
 from processing.algs.gdal.ogr2ogr import ogr2ogr
-from processing.algs.gdal.ogrinfo import ogrinfo
+from processing.algs.gdal.ogrinfo import ogrinfo, ogrinfojson
 from processing.algs.gdal.Buffer import Buffer
 from processing.algs.gdal.Dissolve import Dissolve
 from processing.algs.gdal.OffsetCurve import OffsetCurve
@@ -146,6 +146,27 @@ class TestGdalVectorAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
              '-al -so ' +
              source + ' polys2'])
 
+        source = os.path.join(testDataPath, 'polys.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'ALL_LAYERS': True,
+                                    'SUMMARY_ONLY': True,
+                                    'NO_METADATA': False}, context, feedback),
+            ['ogrinfo',
+             '-al -so ' +
+             source])
+
+        source = os.path.join(testDataPath, 'polys.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'ALL_LAYERS': True,
+                                    'SUMMARY_ONLY': True,
+                                    'EXTRA': '-nocount',
+                                    'NO_METADATA': False}, context, feedback),
+            ['ogrinfo',
+             '-al -so -nocount ' +
+             source])
+
         source = os.path.join(testDataPath, 'filename with spaces.gml')
         self.assertEqual(
             alg.getConsoleCommands({'INPUT': source,
@@ -189,6 +210,87 @@ class TestGdalVectorAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'NO_METADATA': True}, context, feedback),
             ['ogrinfo',
              '-al -so -nomd "' +
+             source + '" filename_with_spaces --config X Y --config Z A'])
+
+    def testOgrInfoJson(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'polys.gml')
+        alg = ogrinfojson()
+        alg.initAlgorithm()
+
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'FEATURES': True,
+                                    'NO_METADATA': False}, context, feedback),
+            ['ogrinfo',
+             '-json -features ' +
+             source + ' polys2'])
+
+        source = os.path.join(testDataPath, 'polys.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'ALL_LAYERS': True,
+                                    'FEATURES': True,
+                                    'NO_METADATA': False}, context, feedback),
+            ['ogrinfo',
+             '-json -features ' +
+             source])
+
+        source = os.path.join(testDataPath, 'polys.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'ALL_LAYERS': True,
+                                    'FEATURES': True,
+                                    'EXTRA': '-nocount',
+                                    'NO_METADATA': False}, context, feedback),
+            ['ogrinfo',
+             '-json -features -nocount ' +
+             source])
+
+        source = os.path.join(testDataPath, 'filename with spaces.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'FEATURES': True,
+                                    'NO_METADATA': False}, context, feedback),
+            ['ogrinfo',
+             '-json -features "' +
+             source + '" filename_with_spaces'])
+
+        source = os.path.join(testDataPath, 'filename with spaces.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'FEATURES': False,
+                                    'NO_METADATA': False}, context, feedback),
+            ['ogrinfo',
+             '-json "' +
+             source + '" filename_with_spaces'])
+
+        source = os.path.join(testDataPath, 'filename with spaces.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'FEATURES': True,
+                                    'NO_METADATA': True}, context, feedback),
+            ['ogrinfo',
+             '-json -features -nomd "' +
+             source + '" filename_with_spaces'])
+
+        source = os.path.join(testDataPath, 'filename with spaces.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source + '|option:X_POSSIBLE_NAMES=geom_x|option:Y_POSSIBLE_NAMES=geom_y',
+                                    'FEATURES': True,
+                                    'NO_METADATA': True}, context, feedback),
+            ['ogrinfo',
+             '-json -features -nomd "' +
+             source + '" filename_with_spaces -oo X_POSSIBLE_NAMES=geom_x -oo Y_POSSIBLE_NAMES=geom_y'])
+
+        source = os.path.join(testDataPath, 'filename with spaces.gml')
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source + '|credential:X=Y|credential:Z=A',
+                                    'FEATURES': True,
+                                    'NO_METADATA': True}, context, feedback),
+            ['ogrinfo',
+             '-json -features -nomd "' +
              source + '" filename_with_spaces --config X Y --config Z A'])
 
     def testBuffer(self):

--- a/python/plugins/processing/tests/testdata/expected/gdal/vector_info.json
+++ b/python/plugins/processing/tests/testdata/expected/gdal/vector_info.json
@@ -1,0 +1,143 @@
+{
+  "description":"C:/OSGeo4W/apps/qgis-dev/python/plugins/processing/tests/testdata/lines.gml",
+  "driverShortName":"GML",
+  "driverLongName":"Geography Markup Language (GML)",
+  "layers":[
+    {
+      "name":"lines",
+      "metadata":{
+      },
+      "geometryFields":[
+        {
+          "name":"",
+          "type":"LineString",
+          "nullable":true,
+          "extent":[
+            -1.0,
+            -3.0,
+            11.0,
+            5.0
+          ],
+          "coordinateSystem":{
+            "wkt":"GEOGCRS[\"WGS 84\",\n    ENSEMBLE[\"World Geodetic System 1984 ensemble\",\n        MEMBER[\"World Geodetic System 1984 (Transit)\"],\n        MEMBER[\"World Geodetic System 1984 (G730)\"],\n        MEMBER[\"World Geodetic System 1984 (G873)\"],\n        MEMBER[\"World Geodetic System 1984 (G1150)\"],\n        MEMBER[\"World Geodetic System 1984 (G1674)\"],\n        MEMBER[\"World Geodetic System 1984 (G1762)\"],\n        MEMBER[\"World Geodetic System 1984 (G2139)\"],\n        ELLIPSOID[\"WGS 84\",6378137,298.257223563,\n            LENGTHUNIT[\"metre\",1]],\n        ENSEMBLEACCURACY[2.0]],\n    PRIMEM[\"Greenwich\",0,\n        ANGLEUNIT[\"degree\",0.0174532925199433]],\n    CS[ellipsoidal,2],\n        AXIS[\"geodetic latitude (Lat)\",north,\n            ORDER[1],\n            ANGLEUNIT[\"degree\",0.0174532925199433]],\n        AXIS[\"geodetic longitude (Lon)\",east,\n            ORDER[2],\n            ANGLEUNIT[\"degree\",0.0174532925199433]],\n    USAGE[\n        SCOPE[\"Horizontal component of 3D system.\"],\n        AREA[\"World.\"],\n        BBOX[-90,-180,90,180]],\n    ID[\"EPSG\",4326]]",
+            "projjson":{
+              "$schema":"https://proj.org/schemas/v0.7/projjson.schema.json",
+              "type":"GeographicCRS",
+              "name":"WGS 84",
+              "datum_ensemble":{
+                "name":"World Geodetic System 1984 ensemble",
+                "members":[
+                  {
+                    "name":"World Geodetic System 1984 (Transit)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1166
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G730)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1152
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G873)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1153
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1150)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1154
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1674)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1155
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1762)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1156
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G2139)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1309
+                    }
+                  }
+                ],
+                "ellipsoid":{
+                  "name":"WGS 84",
+                  "semi_major_axis":6378137,
+                  "inverse_flattening":298.257223563
+                },
+                "accuracy":"2.0",
+                "id":{
+                  "authority":"EPSG",
+                  "code":6326
+                }
+              },
+              "coordinate_system":{
+                "subtype":"ellipsoidal",
+                "axis":[
+                  {
+                    "name":"Geodetic latitude",
+                    "abbreviation":"Lat",
+                    "direction":"north",
+                    "unit":"degree"
+                  },
+                  {
+                    "name":"Geodetic longitude",
+                    "abbreviation":"Lon",
+                    "direction":"east",
+                    "unit":"degree"
+                  }
+                ]
+              },
+              "scope":"Horizontal component of 3D system.",
+              "area":"World.",
+              "bbox":{
+                "south_latitude":-90,
+                "west_longitude":-180,
+                "north_latitude":90,
+                "east_longitude":180
+              },
+              "id":{
+                "authority":"EPSG",
+                "code":4326
+              }
+            },
+            "dataAxisToSRSAxisMapping":[
+              2,
+              1
+            ]
+          }
+        }
+      ],
+      "featureCount":6,
+      "fields":[
+        {
+          "name":"fid",
+          "type":"String",
+          "nullable":false,
+          "uniqueConstraint":false
+        }
+      ]
+    }
+  ],
+  "metadata":{
+  },
+  "domains":{
+  }
+}

--- a/python/plugins/processing/tests/testdata/expected/gdal/vector_info_2.html
+++ b/python/plugins/processing/tests/testdata/expected/gdal/vector_info_2.html
@@ -1,0 +1,74 @@
+<pre>INFO: Open of `C:/OSGeo4W/apps/qgis-dev/python/plugins/processing/tests/testdata/points_lines.gpkg'
+      using driver `GPKG' successful.
+
+Layer name: points
+Geometry: Point
+Feature Count: 9
+Extent: (0.000000, -5.000000) - (8.000000, 3.000000)
+Layer SRS WKT:
+GEOGCRS["WGS 84",
+    ENSEMBLE["World Geodetic System 1984 ensemble",
+        MEMBER["World Geodetic System 1984 (Transit)"],
+        MEMBER["World Geodetic System 1984 (G730)"],
+        MEMBER["World Geodetic System 1984 (G873)"],
+        MEMBER["World Geodetic System 1984 (G1150)"],
+        MEMBER["World Geodetic System 1984 (G1674)"],
+        MEMBER["World Geodetic System 1984 (G1762)"],
+        MEMBER["World Geodetic System 1984 (G2139)"],
+        ELLIPSOID["WGS 84",6378137,298.257223563,
+            LENGTHUNIT["metre",1]],
+        ENSEMBLEACCURACY[2.0]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433]],
+    CS[ellipsoidal,2],
+        AXIS["geodetic latitude (Lat)",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433]],
+        AXIS["geodetic longitude (Lon)",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433]],
+    USAGE[
+        SCOPE["Horizontal component of 3D system."],
+        AREA["World."],
+        BBOX[-90,-180,90,180]],
+    ID["EPSG",4326]]
+Data axis to CRS axis mapping: 2,1
+FID Column = fid
+Geometry Column = geom
+id: Integer (0.0)
+id2: Integer (0.0)
+
+Layer name: lines
+Geometry: Line String
+Feature Count: 7
+Extent: (-1.000000, -3.000000) - (11.000000, 5.000000)
+Layer SRS WKT:
+GEOGCRS["WGS 84",
+    ENSEMBLE["World Geodetic System 1984 ensemble",
+        MEMBER["World Geodetic System 1984 (Transit)"],
+        MEMBER["World Geodetic System 1984 (G730)"],
+        MEMBER["World Geodetic System 1984 (G873)"],
+        MEMBER["World Geodetic System 1984 (G1150)"],
+        MEMBER["World Geodetic System 1984 (G1674)"],
+        MEMBER["World Geodetic System 1984 (G1762)"],
+        MEMBER["World Geodetic System 1984 (G2139)"],
+        ELLIPSOID["WGS 84",6378137,298.257223563,
+            LENGTHUNIT["metre",1]],
+        ENSEMBLEACCURACY[2.0]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433]],
+    CS[ellipsoidal,2],
+        AXIS["geodetic latitude (Lat)",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433]],
+        AXIS["geodetic longitude (Lon)",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433]],
+    USAGE[
+        SCOPE["Horizontal component of 3D system."],
+        AREA["World."],
+        BBOX[-90,-180,90,180]],
+    ID["EPSG",4326]]
+Data axis to CRS axis mapping: 2,1
+FID Column = fid
+Geometry Column = geom</pre>

--- a/python/plugins/processing/tests/testdata/expected/gdal/vector_info_2.json
+++ b/python/plugins/processing/tests/testdata/expected/gdal/vector_info_2.json
@@ -1,0 +1,279 @@
+{
+  "description":"C:/OSGeo4W/apps/qgis-dev/python/plugins/processing/tests/testdata/points_lines.gpkg",
+  "driverShortName":"GPKG",
+  "driverLongName":"GeoPackage",
+  "layers":[
+    {
+      "name":"points",
+      "metadata":{
+      },
+      "geometryFields":[
+        {
+          "name":"geom",
+          "type":"Point",
+          "nullable":true,
+          "extent":[
+            0.0,
+            -5.0,
+            8.0,
+            3.0
+          ],
+          "coordinateSystem":{
+            "wkt":"GEOGCRS[\"WGS 84\",\n    ENSEMBLE[\"World Geodetic System 1984 ensemble\",\n        MEMBER[\"World Geodetic System 1984 (Transit)\"],\n        MEMBER[\"World Geodetic System 1984 (G730)\"],\n        MEMBER[\"World Geodetic System 1984 (G873)\"],\n        MEMBER[\"World Geodetic System 1984 (G1150)\"],\n        MEMBER[\"World Geodetic System 1984 (G1674)\"],\n        MEMBER[\"World Geodetic System 1984 (G1762)\"],\n        MEMBER[\"World Geodetic System 1984 (G2139)\"],\n        ELLIPSOID[\"WGS 84\",6378137,298.257223563,\n            LENGTHUNIT[\"metre\",1]],\n        ENSEMBLEACCURACY[2.0]],\n    PRIMEM[\"Greenwich\",0,\n        ANGLEUNIT[\"degree\",0.0174532925199433]],\n    CS[ellipsoidal,2],\n        AXIS[\"geodetic latitude (Lat)\",north,\n            ORDER[1],\n            ANGLEUNIT[\"degree\",0.0174532925199433]],\n        AXIS[\"geodetic longitude (Lon)\",east,\n            ORDER[2],\n            ANGLEUNIT[\"degree\",0.0174532925199433]],\n    USAGE[\n        SCOPE[\"Horizontal component of 3D system.\"],\n        AREA[\"World.\"],\n        BBOX[-90,-180,90,180]],\n    ID[\"EPSG\",4326]]",
+            "projjson":{
+              "$schema":"https://proj.org/schemas/v0.7/projjson.schema.json",
+              "type":"GeographicCRS",
+              "name":"WGS 84",
+              "datum_ensemble":{
+                "name":"World Geodetic System 1984 ensemble",
+                "members":[
+                  {
+                    "name":"World Geodetic System 1984 (Transit)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1166
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G730)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1152
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G873)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1153
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1150)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1154
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1674)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1155
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1762)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1156
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G2139)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1309
+                    }
+                  }
+                ],
+                "ellipsoid":{
+                  "name":"WGS 84",
+                  "semi_major_axis":6378137,
+                  "inverse_flattening":298.257223563
+                },
+                "accuracy":"2.0",
+                "id":{
+                  "authority":"EPSG",
+                  "code":6326
+                }
+              },
+              "coordinate_system":{
+                "subtype":"ellipsoidal",
+                "axis":[
+                  {
+                    "name":"Geodetic latitude",
+                    "abbreviation":"Lat",
+                    "direction":"north",
+                    "unit":"degree"
+                  },
+                  {
+                    "name":"Geodetic longitude",
+                    "abbreviation":"Lon",
+                    "direction":"east",
+                    "unit":"degree"
+                  }
+                ]
+              },
+              "scope":"Horizontal component of 3D system.",
+              "area":"World.",
+              "bbox":{
+                "south_latitude":-90,
+                "west_longitude":-180,
+                "north_latitude":90,
+                "east_longitude":180
+              },
+              "id":{
+                "authority":"EPSG",
+                "code":4326
+              }
+            },
+            "dataAxisToSRSAxisMapping":[
+              2,
+              1
+            ]
+          }
+        }
+      ],
+      "featureCount":9,
+      "fidColumnName":"fid",
+      "fields":[
+        {
+          "name":"id",
+          "type":"Integer",
+          "nullable":true,
+          "uniqueConstraint":false
+        },
+        {
+          "name":"id2",
+          "type":"Integer",
+          "nullable":true,
+          "uniqueConstraint":false
+        }
+      ]
+    },
+    {
+      "name":"lines",
+      "metadata":{
+      },
+      "geometryFields":[
+        {
+          "name":"geom",
+          "type":"LineString",
+          "nullable":true,
+          "extent":[
+            -1.0,
+            -3.0,
+            11.0,
+            5.0
+          ],
+          "coordinateSystem":{
+            "wkt":"GEOGCRS[\"WGS 84\",\n    ENSEMBLE[\"World Geodetic System 1984 ensemble\",\n        MEMBER[\"World Geodetic System 1984 (Transit)\"],\n        MEMBER[\"World Geodetic System 1984 (G730)\"],\n        MEMBER[\"World Geodetic System 1984 (G873)\"],\n        MEMBER[\"World Geodetic System 1984 (G1150)\"],\n        MEMBER[\"World Geodetic System 1984 (G1674)\"],\n        MEMBER[\"World Geodetic System 1984 (G1762)\"],\n        MEMBER[\"World Geodetic System 1984 (G2139)\"],\n        ELLIPSOID[\"WGS 84\",6378137,298.257223563,\n            LENGTHUNIT[\"metre\",1]],\n        ENSEMBLEACCURACY[2.0]],\n    PRIMEM[\"Greenwich\",0,\n        ANGLEUNIT[\"degree\",0.0174532925199433]],\n    CS[ellipsoidal,2],\n        AXIS[\"geodetic latitude (Lat)\",north,\n            ORDER[1],\n            ANGLEUNIT[\"degree\",0.0174532925199433]],\n        AXIS[\"geodetic longitude (Lon)\",east,\n            ORDER[2],\n            ANGLEUNIT[\"degree\",0.0174532925199433]],\n    USAGE[\n        SCOPE[\"Horizontal component of 3D system.\"],\n        AREA[\"World.\"],\n        BBOX[-90,-180,90,180]],\n    ID[\"EPSG\",4326]]",
+            "projjson":{
+              "$schema":"https://proj.org/schemas/v0.7/projjson.schema.json",
+              "type":"GeographicCRS",
+              "name":"WGS 84",
+              "datum_ensemble":{
+                "name":"World Geodetic System 1984 ensemble",
+                "members":[
+                  {
+                    "name":"World Geodetic System 1984 (Transit)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1166
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G730)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1152
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G873)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1153
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1150)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1154
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1674)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1155
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G1762)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1156
+                    }
+                  },
+                  {
+                    "name":"World Geodetic System 1984 (G2139)",
+                    "id":{
+                      "authority":"EPSG",
+                      "code":1309
+                    }
+                  }
+                ],
+                "ellipsoid":{
+                  "name":"WGS 84",
+                  "semi_major_axis":6378137,
+                  "inverse_flattening":298.257223563
+                },
+                "accuracy":"2.0",
+                "id":{
+                  "authority":"EPSG",
+                  "code":6326
+                }
+              },
+              "coordinate_system":{
+                "subtype":"ellipsoidal",
+                "axis":[
+                  {
+                    "name":"Geodetic latitude",
+                    "abbreviation":"Lat",
+                    "direction":"north",
+                    "unit":"degree"
+                  },
+                  {
+                    "name":"Geodetic longitude",
+                    "abbreviation":"Lon",
+                    "direction":"east",
+                    "unit":"degree"
+                  }
+                ]
+              },
+              "scope":"Horizontal component of 3D system.",
+              "area":"World.",
+              "bbox":{
+                "south_latitude":-90,
+                "west_longitude":-180,
+                "north_latitude":90,
+                "east_longitude":180
+              },
+              "id":{
+                "authority":"EPSG",
+                "code":4326
+              }
+            },
+            "dataAxisToSRSAxisMapping":[
+              2,
+              1
+            ]
+          }
+        }
+      ],
+      "featureCount":7,
+      "fidColumnName":"fid",
+      "fields":[
+      ]
+    }
+  ],
+  "metadata":{
+  },
+  "domains":{
+  },
+  "relationships":{
+  }
+}

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_vector_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_vector_tests.yaml
@@ -242,6 +242,69 @@ tests:
           - 'Geometry: Line String'
           - 'Feature Count: [6|7]' # On some platforms returns 6 instead of 7...
 
+  - algorithm: gdal:ogrinfo
+    name: ogrinfo all layers
+    params:
+      INPUT:
+        name: points_lines.gpkg
+        type: vector
+      SUMMARY_ONLY: 'True'
+      ALL_LAYERS: 'True'
+    results:
+      OUTPUT:
+        name: expected/gdal/vector_info_2.html
+        type: regex
+        rules:
+          - 'Layer name: points'
+          - 'Geometry: Point'
+          - 'Feature Count: 9'
+          - 'Extent: \(0.000000, -5.000000\) - \(8.000000, 3.000000\)'
+          - 'Layer name: lines'
+          - 'Geometry: Line String'
+          - 'Feature Count: 7'
+          - 'Extent: \(-1.000000, -3.000000\) - \(11.000000, 5.000000\)'
+
+  - algorithm: gdal:ogrinfojson
+    name: ogrinfo (json)
+    condition:
+      gdal:
+        at_least: 3070000
+    params:
+      INPUT:
+        name: lines.gml
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/gdal/vector_info.json
+        type: regex
+        rules:
+          - '"extent":\[\n\s*-1.0,\s*-3.0,\n\s*11.0,\n\s*5.0\n\s*\],'
+          - '"type":"LineString",'
+          - '"featureCount":[6|7],' # On some platforms returns 6 instead of 7...
+
+  - algorithm: gdal:ogrinfojson
+    name: ogrinfo (json) all layers
+    condition:
+      gdal:
+        at_least: 3070000
+    params:
+      INPUT:
+        name: points_lines.gpkg
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/gdal/vector_info_2.json
+        type: regex
+        rules:
+          - '"name":"points",'
+          - '"type":"Point",'
+          - '"extent":\[\n\s*0.0,\s*-5.0,\n\s*8.0,\n\s*3.0\n\s*\],'
+          - '"featureCount":9,'
+          - '"name":"lines",'
+          - '"type":"LineString",'
+          - '"extent":\[\n\s*-1.0,\s*-3.0,\n\s*11.0,\n\s*5.0\n\s*\],'
+          - '"featureCount":7,'
+
   - algorithm: gdal:onesidebuffer
     name: One-sided buffer (left-handed)
     params:


### PR DESCRIPTION
## Description

- Enhancements of the "**[Vector information](https://docs.qgis.org/testing/en/docs/user_manual/processing_algs/gdal/vectormiscellaneous.html#vector-information)**" (`gdal:ogrinfo`) GDAL processing algorithm:
  The checkbox parameter `ALL_LAYERS` "Enable listing of all layer information", `False` by default, is added in order for the layer name to not be added to the `ogrinfo` command-line so it will output the info of all the layers in the dataset (see also https://github.com/qgis/QGIS/pull/45955).
  The advanced parameter `EXTRA` "Additional command-line parameters" (optional) is added in order to provide additional command-line options to the `ogrinfo` command (to be consistent with the "[Raster information](https://docs.qgis.org/3.34/en/docs/user_manual/processing_algs/gdal/rastermiscellaneous.html#raster-information)" (`gdal:gdalinfo`) GDAL processing algorithm (see also https://github.com/qgis/QGIS/pull/30377).

  ![image](https://github.com/qgis/QGIS/assets/16253859/ffc75034-fa05-4b5e-8874-c9be91951cac)


- New "**Vector information (JSON)**" (`gdal:ogrinfojson`) GDAL processing algorithm (only available with GDAL >= 3.7):
  This algorithm will use the [`-json`](https://gdal.org/programs/ogrinfo.html#cmdoption-ogrinfo-json) option of ogrinfo in order to create a JSON file containing the layer or dataset information.
  It has the same parameters as "Vector information" (`gdal:ogrinfo`), except for the parameter `SUMMARY_ONLY` "Summary output only" ([`-so`](https://gdal.org/programs/ogrinfo.html#cmdoption-ogrinfo-so) option), which is replaced by `FEATURES` "Enable listing of features" ([`-features`](https://gdal.org/programs/ogrinfo.html#cmdoption-ogrinfo-features) option), `False` by default.
  The algorithm output is a JSON file.
  I think this new algorithm fixes https://github.com/qgis/QGIS/issues/57945.

  ![image](https://github.com/qgis/QGIS/assets/16253859/98259ef2-d191-4b2d-8e5f-acd5f6d56e7a)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
