### PR TITLE
[tests][auth] Fix unreported issue with auth tests skipped, fix storage of ssl protocol

### DIFF
--- a/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -49,7 +49,7 @@ init initialize QCA, prioritize qca-ossl plugin and optionally set up the authen
 .. seealso:: :py:func:`QgsApplication.qgisAuthDatabaseFilePath`
 
 .. deprecated:: QGIS 3.36
-  use :py:func:`~QgsAuthManager.setup` instead.
+  use :py:func:`~QgsAuthManager.setup` or :py:func:`~QgsAuthManager.ensureInitialized` instead.
 %End
 
     void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
@@ -61,6 +61,18 @@ to lazy-initialize when required.
 
 :param pluginPath: the plugin path
 :param authDatabasePath: the authentication DB path
+
+.. seealso:: :py:func:`ensureInitialized`
+%End
+
+    bool ensureInitialized() const;
+%Docstring
+Performs lazy initialization of the authentication framework, if it has
+not already been done.
+
+.. seealso:: :py:func:`setup`
+
+.. versionadded:: 3.40
 %End
 
     ~QgsAuthManager();

--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -70,9 +70,9 @@ to lazy-initialize when required.
 Performs lazy initialization of the authentication framework, if it has
 not already been done.
 
-.. versionadded:: 3.40
-
 .. seealso:: :py:func:`setup`
+
+.. versionadded:: 3.40
 %End
 
     ~QgsAuthManager();

--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -49,7 +49,7 @@ init initialize QCA, prioritize qca-ossl plugin and optionally set up the authen
 .. seealso:: :py:func:`QgsApplication.qgisAuthDatabaseFilePath`
 
 .. deprecated:: QGIS 3.36
-  use :py:func:`~QgsAuthManager.setup` instead.
+  use :py:func:`~QgsAuthManager.setup` or :py:func:`~QgsAuthManager.ensureInitialized` instead.
 %End
 
     void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
@@ -61,6 +61,18 @@ to lazy-initialize when required.
 
 :param pluginPath: the plugin path
 :param authDatabasePath: the authentication DB path
+
+.. seealso:: :py:func:`ensureInitialized`
+%End
+
+    bool ensureInitialized() const;
+%Docstring
+Performs lazy initialization of the authentication framework, if it has
+not already been done.
+
+.. versionadded:: 3.40
+
+.. seealso:: :py:func:`setup`
 %End
 
     ~QgsAuthManager();

--- a/src/core/auth/qgsauthconfig.h
+++ b/src/core/auth/qgsauthconfig.h
@@ -457,6 +457,9 @@ class CORE_EXPORT QgsAuthConfigSslServer
     QString mSslHostPort;
     QSslCertificate mSslCert;
 
+    static QSsl::SslProtocol decodeSslProtocol( const QString &protocol );
+    static QString encodeSslProtocol( QSsl::SslProtocol protocol );
+
     QSsl::SslProtocol mSslProtocol;
     int mQtVersion;
     QList<QSslError::SslError> mSslIgnoredErrors;

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -87,7 +87,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * \return TRUE on success
      * \see QgsApplication::pluginPath
      * \see QgsApplication::qgisAuthDatabaseFilePath
-     * \deprecated Since QGIS 3.36, use setup() instead.
+     * \deprecated Since QGIS 3.36, use setup() or ensureInitialized() instead.
      */
     Q_DECL_DEPRECATED bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) SIP_DEPRECATED;
 
@@ -99,8 +99,18 @@ class CORE_EXPORT QgsAuthManager : public QObject
      *
      * \param pluginPath the plugin path
      * \param authDatabasePath the authentication DB path
+     * \see ensureInitialized()
      */
     void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
+
+    /**
+     * Performs lazy initialization of the authentication framework, if it has
+     * not already been done.
+     *
+     * \since QGIS 3.40
+     * \see setup()
+     */
+    bool ensureInitialized() const;
 
     ~QgsAuthManager() override;
 
@@ -786,12 +796,6 @@ class CORE_EXPORT QgsAuthManager : public QObject
 #endif
 
   private:
-
-    /**
-     * Performs lazy initialization of the authentication framework, if it has
-     * not already been done.
-     */
-    bool ensureInitialized() const;
 
     bool initPrivate( const QString &pluginPath,  const QString &authDatabasePath );
 

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -107,8 +107,8 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Performs lazy initialization of the authentication framework, if it has
      * not already been done.
      *
-     * \since QGIS 3.40
      * \see setup()
+     * \since QGIS 3.40
      */
     bool ensureInitialized() const;
 

--- a/tests/src/core/testqgsauthcertutils.cpp
+++ b/tests/src/core/testqgsauthcertutils.cpp
@@ -14,16 +14,16 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsauthmanager.h"
 #include "qgstest.h"
+#include "qgsapplication.h"
+#include "qgsauthcrypto.h"
+#include "qgsauthcertutils.h"
+
 #include <QObject>
 #include <QSslKey>
 #include <QString>
 #include <QStringList>
-
-#include "qgsapplication.h"
-#include "qgsauthcrypto.h"
-#include "qgsauthcertutils.h"
-#include "qgslogger.h"
 
 /**
  * \ingroup UnitTests
@@ -52,6 +52,7 @@ void TestQgsAuthCertUtils::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsApplication::authManager()->ensureInitialized();
   if ( QgsAuthCrypto::isDisabled() )
     QSKIP( "QCA's qca-ossl plugin is missing, skipping test case", SkipAll );
 }

--- a/tests/src/core/testqgsauthconfig.cpp
+++ b/tests/src/core/testqgsauthconfig.cpp
@@ -203,7 +203,6 @@ void TestQgsAuthConfig::testPkiConfigBundle()
 void TestQgsAuthConfig::testConfigSslServer()
 {
   const QString hostport( QStringLiteral( "localhost:443" ) );
-  const QString confstr( QStringLiteral( "2|||470|||2|||10~~19|||0~~2" ) );
   const QSslCertificate sslcert( QSslCertificate::fromPath( sPkiData + "/localhost_ssl_cert.pem" ).at( 0 ) );
 
   QgsAuthConfigSslServer sslconfig;
@@ -224,7 +223,7 @@ void TestQgsAuthConfig::testConfigSslServer()
   sslconfig.setSslIgnoredErrorEnums( sslerrenums );
   QVERIFY( !sslconfig.isNull() );
 
-  QCOMPARE( sslconfig.configString(), confstr );
+  QCOMPARE( sslconfig.configString(), QStringLiteral( "2|||470|||TlsV1_0|||10~~19|||0~~2" ) );
   QCOMPARE( sslconfig.sslHostPort(), hostport );
   QCOMPARE( sslconfig.sslCertificate(), sslcert );
   QCOMPARE( sslconfig.sslProtocol(), QSsl::TlsV1_0 );
@@ -235,14 +234,35 @@ void TestQgsAuthConfig::testConfigSslServer()
   QCOMPARE( sslconfig.sslIgnoredErrorEnums(), sslerrenums );
 
   QgsAuthConfigSslServer sslconfig2;
-  sslconfig2.loadConfigString( confstr );
+  // try loading the older format strings, used in QGIS < 3.40
+  sslconfig2.loadConfigString( QStringLiteral( "2|||470|||2|||10~~19|||0~~2" ) );
   QCOMPARE( sslconfig2.sslProtocol(), QSsl::TlsV1_0 );
   QCOMPARE( sslconfig2.version(), 2 );
   QCOMPARE( sslconfig2.qtVersion(), 470 );
   QCOMPARE( sslconfig2.sslPeerVerifyMode(), QSslSocket::VerifyNone );
   QCOMPARE( sslconfig2.sslPeerVerifyDepth(), 2 );
   QCOMPARE( sslconfig2.sslIgnoredErrorEnums(), sslerrenums );
-  QCOMPARE( sslconfig2.configString(), confstr );
+  QCOMPARE( sslconfig2.configString(), QStringLiteral( "2|||470|||TlsV1_0|||10~~19|||0~~2" ) );
+
+  sslconfig2.loadConfigString( QStringLiteral( "2|||470|||3|||10~~19|||0~~2" ) );
+  QCOMPARE( sslconfig2.sslProtocol(), QSsl::TlsV1_1 );
+  QCOMPARE( sslconfig2.version(), 2 );
+  QCOMPARE( sslconfig2.qtVersion(), 470 );
+  QCOMPARE( sslconfig2.sslPeerVerifyMode(), QSslSocket::VerifyNone );
+  QCOMPARE( sslconfig2.sslPeerVerifyDepth(), 2 );
+  QCOMPARE( sslconfig2.sslIgnoredErrorEnums(), sslerrenums );
+  QCOMPARE( sslconfig2.configString(), QStringLiteral( "2|||470|||TlsV1_1|||10~~19|||0~~2" ) );
+
+  QgsAuthConfigSslServer sslconfig3;
+  // try loading the newer format string, used in QGIS >= 3.40
+  sslconfig2.loadConfigString( QStringLiteral( "2|||470|||TlsV1_3|||10~~19|||0~~2" ) );
+  QCOMPARE( sslconfig2.sslProtocol(), QSsl::TlsV1_3 );
+  QCOMPARE( sslconfig2.version(), 2 );
+  QCOMPARE( sslconfig2.qtVersion(), 470 );
+  QCOMPARE( sslconfig2.sslPeerVerifyMode(), QSslSocket::VerifyNone );
+  QCOMPARE( sslconfig2.sslPeerVerifyDepth(), 2 );
+  QCOMPARE( sslconfig2.sslIgnoredErrorEnums(), sslerrenums );
+  QCOMPARE( sslconfig2.configString(), QStringLiteral( "2|||470|||TlsV1_3|||10~~19|||0~~2" ) );
 }
 
 QGSTEST_MAIN( TestQgsAuthConfig )

--- a/tests/src/core/testqgsauthconfig.cpp
+++ b/tests/src/core/testqgsauthconfig.cpp
@@ -13,14 +13,15 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#include "qgsauthmanager.h"
 #include "qgstest.h"
-#include <QObject>
-#include <QString>
-#include <QStringList>
-
 #include "qgsapplication.h"
 #include "qgsauthcrypto.h"
 #include "qgsauthconfig.h"
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
 
 /**
  * \ingroup UnitTests
@@ -52,6 +53,7 @@ void TestQgsAuthConfig::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsApplication::authManager()->ensureInitialized();
   if ( QgsAuthCrypto::isDisabled() )
     QSKIP( "QCA's qca-ossl plugin is missing, skipping test case", SkipAll );
 }

--- a/tests/src/core/testqgsauthcrypto.cpp
+++ b/tests/src/core/testqgsauthcrypto.cpp
@@ -14,12 +14,13 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgstest.h"
+#include "qgsauthmanager.h"
+#include "qgsapplication.h"
+#include "qgsauthcrypto.h"
+
 #include <QObject>
 #include <QString>
 #include <QStringList>
-
-#include "qgsapplication.h"
-#include "qgsauthcrypto.h"
 
 /**
  * \ingroup UnitTests
@@ -83,6 +84,7 @@ void TestQgsAuthCrypto::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsApplication::authManager()->ensureInitialized();
   if ( QgsAuthCrypto::isDisabled() )
     QSKIP( "QCA's qca-ossl plugin is missing, skipping test case", SkipAll );
 }


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/57890, adding the required changes to fix the tests on Qt 6 builds.

The old approach (casting Qt enums to int and storing) is not stable, and breaks with the Qt 6 builds were the raw SSL protocol
enums have changed values (due to removed deprecated protocols).

Replace this with a stable string encoding/decoding approach, with compatibility for upgrading older configus, and add additional tests.

(Note that auth configuration created in Qt 5 builds which use the deprecated protocols cannot be loaded in Qt 6 builds, since
those protocols are no longer supported.)