### PR TITLE
Ignore custom developer configuration/settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 .pydevproject
 .venv
 .vscode
+.vs
+.devcontainer
+CMakePresets.json
 /CMakeLists.txt.user
 /CMakeLists.txt.user.*
 /build*


### PR DESCRIPTION
Added a few extra files to .gitignore.

These are some files I am currently using in my build environment.

.vs: is an automatically generated configuration folder created by visual studio.
.devcontainer: Can be created to manage one or multiple developer containers.
CMakePresets.json: Can be created to manage different CMake configuration builds.

These files are definitely helpful when switching from development with qt5 and qt6. And also different OSs.