### PR TITLE
Georeferencer preview point fixes

### DIFF
--- a/src/app/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/app/georeferencer/qgsgcpcanvasitem.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsgcpcanvasitem.h"
+#include "qgsmapcanvas.h"
 #include "qgsgeorefdatapoint.h"
 #include "qgsproject.h"
 #include "qgsrasterlayer.h"

--- a/src/app/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/app/georeferencer/qgsgcpcanvasitem.cpp
@@ -25,7 +25,7 @@
 QgsGCPCanvasItem::QgsGCPCanvasItem( QgsMapCanvas *mapCanvas, QgsGeorefDataPoint *dataPoint, bool isGCPSource )
   : QgsMapCanvasItem( mapCanvas )
   , mDataPoint( dataPoint )
-  , mPointBrush( Qt::red )
+  , mPointBrush( mDataPoint && mDataPoint->id() < 0 ? QColor( 0, 200, 0 ) : Qt::red )
   , mLabelBrush( Qt::yellow )
   , mIsGCPSource( isGCPSource )
 {
@@ -63,6 +63,10 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   p->setPen( Qt::black );
   p->setBrush( mPointBrush );
   p->drawEllipse( -2, -2, 5, 5 );
+
+  // Don't draw point tip for temporary points
+  if ( id < 0 )
+    return;
 
   const QgsSettings s;
   const bool showIDs = s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowId" ) ).toBool();

--- a/src/app/georeferencer/qgsgcpcanvasitem.h
+++ b/src/app/georeferencer/qgsgcpcanvasitem.h
@@ -16,9 +16,12 @@
 #ifndef QGSGCPCANVASITEM_H
 #define QGSGCPCANVASITEM_H
 
-#include "qgsmapcanvas.h"
+#include <QBrush>
+#include <QPen>
+
 #include "qgsmapcanvasitem.h"
 
+class QgsMapCanvas;
 class QgsGeorefDataPoint;
 
 class QgsGCPCanvasItem : public QgsMapCanvasItem

--- a/src/app/georeferencer/qgsgcpcanvasitem.h
+++ b/src/app/georeferencer/qgsgcpcanvasitem.h
@@ -24,7 +24,7 @@
 class QgsMapCanvas;
 class QgsGeorefDataPoint;
 
-class QgsGCPCanvasItem : public QgsMapCanvasItem
+class QgsGCPCanvasItem final: public QgsMapCanvasItem
 {
   public:
     QgsGCPCanvasItem( QgsMapCanvas *mapCanvas, QgsGeorefDataPoint *dataPoint, bool isGCPSource/* = true*/ );

--- a/src/app/georeferencer/qgsgeorefdatapoint.cpp
+++ b/src/app/georeferencer/qgsgeorefdatapoint.cpp
@@ -92,13 +92,18 @@ void QgsGeorefDataPoint::setEnabled( bool enabled )
 
 void QgsGeorefDataPoint::setId( int id )
 {
+  const bool noLongerTemporary = mId < 0 && id >= 0;
   mId = id;
   if ( mGCPSourceItem )
   {
+    if ( noLongerTemporary )
+      mGCPSourceItem->setPointColor( Qt::red );
     mGCPSourceItem->update();
   }
   if ( mGCPDestinationItem )
   {
+    if ( noLongerTemporary )
+      mGCPDestinationItem->setPointColor( Qt::red );
     mGCPDestinationItem->update();
   }
 }

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -744,6 +744,7 @@ void QgsGeoreferencerMainWindow::movePoint( QPoint canvasPixels )
   if ( mvPoint )
   {
     mvPoint->moveTo( canvasPixels, pointType );
+    mGCPListWidget->updateResiduals();
   }
 }
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -55,7 +55,6 @@
 #include "qgsgeoreftooladdpoint.h"
 #include "qgsgeoreftooldeletepoint.h"
 #include "qgsgeoreftoolmovepoint.h"
-#include "qgsgcpcanvasitem.h"
 #include "qgscoordinateutils.h"
 
 #include "qgsgcplistwidget.h"

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -285,10 +285,9 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     QgsGeorefToolMovePoint *mToolMovePoint = nullptr;
     QgsGeorefToolMovePoint *mToolMovePointQgis = nullptr;
 
-    QgsGCPCanvasItem *mNewlyAddedPointItem = nullptr;
-
     QgsGeorefDataPoint *mMovingPoint = nullptr;
     QgsGeorefDataPoint *mMovingPointQgis = nullptr;
+    QgsGeorefDataPoint *mNewlyAddedPoint = nullptr;
     QPointer<QgsMapCoordsDialog> mMapCoordsDialog;
 
     bool mUseZeroForTrans = false;

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -45,7 +45,6 @@ class QgsGeorefToolAddPoint;
 class QgsGeorefToolDeletePoint;
 class QgsGeorefToolMovePoint;
 class QgsGeorefToolMovePoint;
-class QgsGCPCanvasItem;
 class QgsGcpPoint;
 class QgsMapLayer;
 class QgsScreenHelper;

--- a/src/app/georeferencer/qgsmapcoordsdialog.cpp
+++ b/src/app/georeferencer/qgsmapcoordsdialog.cpp
@@ -24,13 +24,13 @@
 #include "qgsapplication.h"
 #include "qgsprojectionselectionwidget.h"
 #include "qgsproject.h"
-#include "qgsgcpcanvasitem.h"
+#include "qgsgeorefdatapoint.h""
 
-QgsMapCoordsDialog::QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, const QgsPointXY &sourceLayerCoordinates, QgsCoordinateReferenceSystem &rasterCrs, QWidget *parent )
+QgsMapCoordsDialog::QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, QgsGeorefDataPoint *georefDataPoint, QgsCoordinateReferenceSystem &rasterCrs, QWidget *parent )
   : QDialog( parent, Qt::Dialog )
   , mQgisCanvas( qgisCanvas )
   , mRasterCrs( rasterCrs )
-  , mSourceLayerCoordinates( sourceLayerCoordinates )
+  , mNewlyAddedPoint( georefDataPoint )
 {
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
@@ -73,9 +73,6 @@ QgsMapCoordsDialog::~QgsMapCoordsDialog()
 {
   delete mToolEmitPoint;
 
-  delete mNewlyAddedPointItem;
-  mNewlyAddedPointItem = nullptr;
-
   QgsSettings settings;
   settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/Config/Minimize" ), mMinimizeWindowCheckBox->isChecked() );
 }
@@ -103,7 +100,7 @@ void QgsMapCoordsDialog::buttonBox_accepted()
   if ( !ok )
     y = dmsToDD( leYCoord->text() );
 
-  emit pointAdded( mSourceLayerCoordinates, QgsPointXY( x, y ), mProjectionSelector->crs().isValid() ? mProjectionSelector->crs() : mRasterCrs );
+  emit pointAdded( mNewlyAddedPoint->sourcePoint(), QgsPointXY( x, y ), mProjectionSelector->crs().isValid() ? mProjectionSelector->crs() : mRasterCrs );
   close();
 }
 
@@ -119,13 +116,7 @@ void QgsMapCoordsDialog::maybeSetXY( const QgsPointXY &xy, Qt::MouseButton butto
     leXCoord->setText( qgsDoubleToString( mapCoordPoint.x() ) );
     leYCoord->setText( qgsDoubleToString( mapCoordPoint.y() ) );
 
-    delete mNewlyAddedPointItem;
-    mNewlyAddedPointItem = nullptr;
-
-    // show a temporary marker at the clicked source point
-    mNewlyAddedPointItem = new QgsGCPCanvasItem( mQgisCanvas, nullptr, true );
-    mNewlyAddedPointItem->setPointColor( QColor( 0, 200, 0 ) );
-    mNewlyAddedPointItem->setPos( mNewlyAddedPointItem->toCanvasCoordinates( mapCoordPoint ) );
+    mNewlyAddedPoint->setDestinationPoint( mapCoordPoint );
   }
 
   // only restore window if it was minimized
@@ -184,6 +175,12 @@ double QgsMapCoordsDialog::dmsToDD( const QString &dms )
   else
     return res;
 }
+
+void QgsMapCoordsDialog::updateSourceCoordinates( const QgsPointXY &sourceCoordinates )
+{
+  mNewlyAddedPoint->setSourcePoint( sourceCoordinates );
+}
+
 
 QgsGeorefMapToolEmitPoint::QgsGeorefMapToolEmitPoint( QgsMapCanvas *canvas )
   : QgsMapTool( canvas )

--- a/src/app/georeferencer/qgsmapcoordsdialog.cpp
+++ b/src/app/georeferencer/qgsmapcoordsdialog.cpp
@@ -23,8 +23,7 @@
 #include "qgsgui.h"
 #include "qgsapplication.h"
 #include "qgsprojectionselectionwidget.h"
-#include "qgsproject.h"
-#include "qgsgeorefdatapoint.h""
+#include "qgsgeorefdatapoint.h"
 
 QgsMapCoordsDialog::QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, QgsGeorefDataPoint *georefDataPoint, QgsCoordinateReferenceSystem &rasterCrs, QWidget *parent )
   : QDialog( parent, Qt::Dialog )

--- a/src/app/georeferencer/qgsmapcoordsdialog.h
+++ b/src/app/georeferencer/qgsmapcoordsdialog.h
@@ -25,7 +25,7 @@
 
 #include "ui_qgsmapcoordsdialogbase.h"
 
-class QgsGCPCanvasItem;
+class QgsGeorefDataPoint;
 
 class QPushButton;
 
@@ -64,12 +64,15 @@ class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase
     /**
      * Constructor for QgsMapCoordsDialog.
      * \param qgisCanvas
-     * \param sourceCoordinates must be in source layer coordinates, NOT pixels (unless source image is completely non-referenced)!
+     * \param georefDataPoint Temporary data point used for preview on source and destination canvases while dialog is visible
      * \param rasterCrs
      * \param parent
      */
-    QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, const QgsPointXY &sourceCoordinates, QgsCoordinateReferenceSystem &rasterCrs, QWidget *parent = nullptr );
+    QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, QgsGeorefDataPoint *georefDataPoint, QgsCoordinateReferenceSystem &rasterCrs, QWidget *parent = nullptr );
     ~QgsMapCoordsDialog() override;
+
+    //! Update the source coordinates of the newly added
+    void updateSourceCoordinates( const QgsPointXY &sourceCoordinates );
 
   private slots:
     void buttonBox_accepted();
@@ -101,12 +104,10 @@ class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase
     QgsMapTool *mPrevMapTool = nullptr;
     QgsMapCanvas *mQgisCanvas = nullptr;
 
-    QgsGCPCanvasItem *mNewlyAddedPointItem = nullptr;
-
     QgsCoordinateReferenceSystem mRasterCrs;
 
-    //! Source layer coordinates -- must be in source layer coordinates, not pixels (unless source image is completely non-referenced)
-    QgsPointXY mSourceLayerCoordinates;
+    //! Used for point preview. Holds the source layer coordinates -- must be in source layer coordinates, not pixels (unless source image is completely non-referenced)
+    QgsGeorefDataPoint *mNewlyAddedPoint = nullptr;
 };
 
 #endif


### PR DESCRIPTION
## Description
- Preview points cannot be added before a layer is loaded
- Preview points do not display a point tip
- Preview points are correctly displayed when zooming/panning the canvases
- Last clicked preview point is actually used if georef canvas is clicked again while coords dialog is open

Fixes #44986
Fixes #44987
Fixes #44988

Also fixes old unreported regression: residual bars are now updated while moving GCPs

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
