### PR TITLE
Add option to set GeoPDF group name for items

### DIFF
--- a/python/PyQt6/core/auto_additions/qgslayoutitem.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutitem.py
@@ -21,6 +21,7 @@ QgsLayoutItem.UndoMarginBottom = QgsLayoutItem.UndoCommand.UndoMarginBottom
 QgsLayoutItem.UndoMarginRight = QgsLayoutItem.UndoCommand.UndoMarginRight
 QgsLayoutItem.UndoSetId = QgsLayoutItem.UndoCommand.UndoSetId
 QgsLayoutItem.UndoRotation = QgsLayoutItem.UndoCommand.UndoRotation
+QgsLayoutItem.UndoExportLayerName = QgsLayoutItem.UndoCommand.UndoExportLayerName
 QgsLayoutItem.UndoShapeStyle = QgsLayoutItem.UndoCommand.UndoShapeStyle
 QgsLayoutItem.UndoShapeCornerRadius = QgsLayoutItem.UndoCommand.UndoShapeCornerRadius
 QgsLayoutItem.UndoNodeMove = QgsLayoutItem.UndoCommand.UndoNodeMove

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -444,40 +444,6 @@ Returns the behavior of this item during exporting to layered exports (e.g. SVG 
 .. versionadded:: 3.10
 %End
 
-    QString exportLayerName() const;
-%Docstring
-Returns the name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
-
-By default this is an empty string, which indicates that the item does not need to be placed in any specific
-layer and will automatically be grouped with other items where possible.
-
-If the layer name is non-empty, then the item will be placed in a group with the corresponding name
-during layered exports.
-
-.. seealso:: :py:func:`setExportLayerName`
-
-.. seealso:: :py:func:`exportLayerBehavior`
-
-.. versionadded:: 3.40
-%End
-
-    void setExportLayerName( const QString &name );
-%Docstring
-Sets the ``name`` for this item during exporting to layered exports (e.g. SVG or GeoPDF).
-
-If ``name`` is an empty string then the item does not need to be placed in any specific
-layer and will automatically be grouped with other items where possible.
-
-If the layer ``name`` is non-empty, then the item will be placed in a group with the corresponding name
-during layered exports.
-
-.. seealso:: :py:func:`exportLayerName`
-
-.. seealso:: :py:func:`exportLayerBehavior`
-
-.. versionadded:: 3.40
-%End
-
  virtual int numberExportLayers() const /Deprecated/;
 %Docstring
 Returns the number of layers that this item requires for exporting during layered exports (e.g. SVG).

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -182,6 +182,7 @@ Base class for graphical items within a :py:class:`QgsLayout`.
       UndoMarginRight,
       UndoSetId,
       UndoRotation,
+      UndoExportLayerName,
       UndoShapeStyle,
       UndoShapeCornerRadius,
       UndoNodeMove,
@@ -432,13 +433,49 @@ Sets the item's parent ``group``.
 
     virtual ExportLayerBehavior exportLayerBehavior() const;
 %Docstring
-Returns the behavior of this item during exporting to layered exports (e.g. SVG).
+Returns the behavior of this item during exporting to layered exports (e.g. SVG or GeoPDF).
 
 .. seealso:: :py:func:`numberExportLayers`
 
 .. seealso:: :py:func:`exportLayerDetails`
 
+.. seealso:: :py:func:`exportLayerName`
+
 .. versionadded:: 3.10
+%End
+
+    QString exportLayerName() const;
+%Docstring
+Returns the name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
+
+By default this is an empty string, which indicates that the item does not need to be placed in any specific
+layer and will automatically be grouped with other items where possible.
+
+If the layer name is non-empty, then the item will be placed in a group with the corresponding name
+during layered exports.
+
+.. seealso:: :py:func:`setExportLayerName`
+
+.. seealso:: :py:func:`exportLayerBehavior`
+
+.. versionadded:: 3.40
+%End
+
+    void setExportLayerName( const QString &name );
+%Docstring
+Sets the ``name`` for this item during exporting to layered exports (e.g. SVG or GeoPDF).
+
+If ``name`` is an empty string then the item does not need to be placed in any specific
+layer and will automatically be grouped with other items where possible.
+
+If the layer ``name`` is non-empty, then the item will be placed in a group with the corresponding name
+during layered exports.
+
+.. seealso:: :py:func:`exportLayerName`
+
+.. seealso:: :py:func:`exportLayerBehavior`
+
+.. versionadded:: 3.40
 %End
 
  virtual int numberExportLayers() const /Deprecated/;
@@ -502,6 +539,8 @@ Moves to the next export part for a multi-layered export item, during a multi-la
       double opacity;
 
       QString mapTheme;
+
+      QString groupName;
     };
 
     virtual QgsLayoutItem::ExportLayerDetail exportLayerDetails() const;

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -439,8 +439,6 @@ Returns the behavior of this item during exporting to layered exports (e.g. SVG 
 
 .. seealso:: :py:func:`exportLayerDetails`
 
-.. seealso:: :py:func:`exportLayerName`
-
 .. versionadded:: 3.10
 %End
 

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -444,40 +444,6 @@ Returns the behavior of this item during exporting to layered exports (e.g. SVG 
 .. versionadded:: 3.10
 %End
 
-    QString exportLayerName() const;
-%Docstring
-Returns the name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
-
-By default this is an empty string, which indicates that the item does not need to be placed in any specific
-layer and will automatically be grouped with other items where possible.
-
-If the layer name is non-empty, then the item will be placed in a group with the corresponding name
-during layered exports.
-
-.. seealso:: :py:func:`setExportLayerName`
-
-.. seealso:: :py:func:`exportLayerBehavior`
-
-.. versionadded:: 3.40
-%End
-
-    void setExportLayerName( const QString &name );
-%Docstring
-Sets the ``name`` for this item during exporting to layered exports (e.g. SVG or GeoPDF).
-
-If ``name`` is an empty string then the item does not need to be placed in any specific
-layer and will automatically be grouped with other items where possible.
-
-If the layer ``name`` is non-empty, then the item will be placed in a group with the corresponding name
-during layered exports.
-
-.. seealso:: :py:func:`exportLayerName`
-
-.. seealso:: :py:func:`exportLayerBehavior`
-
-.. versionadded:: 3.40
-%End
-
  virtual int numberExportLayers() const /Deprecated/;
 %Docstring
 Returns the number of layers that this item requires for exporting during layered exports (e.g. SVG).

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -182,6 +182,7 @@ Base class for graphical items within a :py:class:`QgsLayout`.
       UndoMarginRight,
       UndoSetId,
       UndoRotation,
+      UndoExportLayerName,
       UndoShapeStyle,
       UndoShapeCornerRadius,
       UndoNodeMove,
@@ -432,13 +433,49 @@ Sets the item's parent ``group``.
 
     virtual ExportLayerBehavior exportLayerBehavior() const;
 %Docstring
-Returns the behavior of this item during exporting to layered exports (e.g. SVG).
+Returns the behavior of this item during exporting to layered exports (e.g. SVG or GeoPDF).
 
 .. seealso:: :py:func:`numberExportLayers`
 
 .. seealso:: :py:func:`exportLayerDetails`
 
+.. seealso:: :py:func:`exportLayerName`
+
 .. versionadded:: 3.10
+%End
+
+    QString exportLayerName() const;
+%Docstring
+Returns the name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
+
+By default this is an empty string, which indicates that the item does not need to be placed in any specific
+layer and will automatically be grouped with other items where possible.
+
+If the layer name is non-empty, then the item will be placed in a group with the corresponding name
+during layered exports.
+
+.. seealso:: :py:func:`setExportLayerName`
+
+.. seealso:: :py:func:`exportLayerBehavior`
+
+.. versionadded:: 3.40
+%End
+
+    void setExportLayerName( const QString &name );
+%Docstring
+Sets the ``name`` for this item during exporting to layered exports (e.g. SVG or GeoPDF).
+
+If ``name`` is an empty string then the item does not need to be placed in any specific
+layer and will automatically be grouped with other items where possible.
+
+If the layer ``name`` is non-empty, then the item will be placed in a group with the corresponding name
+during layered exports.
+
+.. seealso:: :py:func:`exportLayerName`
+
+.. seealso:: :py:func:`exportLayerBehavior`
+
+.. versionadded:: 3.40
 %End
 
  virtual int numberExportLayers() const /Deprecated/;
@@ -502,6 +539,8 @@ Moves to the next export part for a multi-layered export item, during a multi-la
       double opacity;
 
       QString mapTheme;
+
+      QString groupName;
     };
 
     virtual QgsLayoutItem::ExportLayerDetail exportLayerDetails() const;

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -439,8 +439,6 @@ Returns the behavior of this item during exporting to layered exports (e.g. SVG 
 
 .. seealso:: :py:func:`exportLayerDetails`
 
-.. seealso:: :py:func:`exportLayerName`
-
 .. versionadded:: 3.10
 %End
 

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -776,7 +776,10 @@ class CORE_EXPORT QgsLayoutExporter
     bool georeferenceOutputPrivate( const QString &file, QgsLayoutItemMap *referenceMap = nullptr,
                                     const QRectF &exportRegion = QRectF(), double dpi = -1, bool includeGeoreference = true, bool includeMetadata = false ) const;
 
-    ExportResult handleLayeredExport( const QList<QGraphicsItem *> &items, const std::function<QgsLayoutExporter::ExportResult( unsigned int layerId, const QgsLayoutItem::ExportLayerDetail &layerDetails )> &exportFunc );
+    ExportResult handleLayeredExport( const QList<QGraphicsItem *> &items,
+                                      const std::function<QgsLayoutExporter::ExportResult( unsigned int layerId, const QgsLayoutItem::ExportLayerDetail &layerDetails )> &exportFunc,
+                                      const std::function<QString( QgsLayoutItem *item )> &getItemExportGroupFunc
+                                    );
 
     static QgsVectorSimplifyMethod createExportSimplifyMethod();
     static QgsMaskRenderSettings createExportMaskSettings();

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -243,16 +243,6 @@ QgsLayoutItem::ExportLayerBehavior QgsLayoutItem::exportLayerBehavior() const
   return CanGroupWithAnyOtherItem;
 }
 
-QString QgsLayoutItem::exportLayerName() const
-{
-  return mExportLayerName;
-}
-
-void QgsLayoutItem::setExportLayerName( const QString &name )
-{
-  mExportLayerName = name;
-}
-
 int QgsLayoutItem::numberExportLayers() const
 {
   return 0;
@@ -643,7 +633,6 @@ bool QgsLayoutItem::writeXml( QDomElement &parentElement, QDomDocument &doc, con
   element.setAttribute( QStringLiteral( "size" ), mItemSize.encodeSize() );
   element.setAttribute( QStringLiteral( "itemRotation" ), QString::number( mItemRotation ) );
   element.setAttribute( QStringLiteral( "groupUuid" ), mParentGroupUuid );
-  element.setAttribute( QStringLiteral( "exportLayer" ), mExportLayerName );
 
   element.setAttribute( QStringLiteral( "zValue" ), QString::number( zValue() ) );
   element.setAttribute( QStringLiteral( "visibility" ), isVisible() );
@@ -834,7 +823,6 @@ bool QgsLayoutItem::readXml( const QDomElement &element, const QDomDocument &doc
 
   mExcludeFromExports = element.attribute( QStringLiteral( "excludeFromExports" ), QStringLiteral( "0" ) ).toInt();
   mEvaluatedExcludeFromExports = mExcludeFromExports;
-  mExportLayerName = element.attribute( QStringLiteral( "exportLayer" ) );
 
   const bool result = readPropertiesFromElement( element, doc, context );
 

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -243,6 +243,16 @@ QgsLayoutItem::ExportLayerBehavior QgsLayoutItem::exportLayerBehavior() const
   return CanGroupWithAnyOtherItem;
 }
 
+QString QgsLayoutItem::exportLayerName() const
+{
+  return mExportLayerName;
+}
+
+void QgsLayoutItem::setExportLayerName( const QString &name )
+{
+  mExportLayerName = name;
+}
+
 int QgsLayoutItem::numberExportLayers() const
 {
   return 0;
@@ -633,6 +643,7 @@ bool QgsLayoutItem::writeXml( QDomElement &parentElement, QDomDocument &doc, con
   element.setAttribute( QStringLiteral( "size" ), mItemSize.encodeSize() );
   element.setAttribute( QStringLiteral( "itemRotation" ), QString::number( mItemRotation ) );
   element.setAttribute( QStringLiteral( "groupUuid" ), mParentGroupUuid );
+  element.setAttribute( QStringLiteral( "exportLayer" ), mExportLayerName );
 
   element.setAttribute( QStringLiteral( "zValue" ), QString::number( zValue() ) );
   element.setAttribute( QStringLiteral( "visibility" ), isVisible() );
@@ -823,6 +834,7 @@ bool QgsLayoutItem::readXml( const QDomElement &element, const QDomDocument &doc
 
   mExcludeFromExports = element.attribute( QStringLiteral( "excludeFromExports" ), QStringLiteral( "0" ) ).toInt();
   mEvaluatedExcludeFromExports = mExcludeFromExports;
+  mExportLayerName = element.attribute( QStringLiteral( "exportLayer" ) );
 
   const bool result = readPropertiesFromElement( element, doc, context );
 

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -476,36 +476,6 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     virtual ExportLayerBehavior exportLayerBehavior() const;
 
     /**
-     * Returns the name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
-     *
-     * By default this is an empty string, which indicates that the item does not need to be placed in any specific
-     * layer and will automatically be grouped with other items where possible.
-     *
-     * If the layer name is non-empty, then the item will be placed in a group with the corresponding name
-     * during layered exports.
-     *
-     * \see setExportLayerName()
-     * \see exportLayerBehavior()
-     * \since QGIS 3.40
-     */
-    QString exportLayerName() const;
-
-    /**
-     * Sets the \a name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
-     *
-     * If \a name is an empty string then the item does not need to be placed in any specific
-     * layer and will automatically be grouped with other items where possible.
-     *
-     * If the layer \a name is non-empty, then the item will be placed in a group with the corresponding name
-     * during layered exports.
-     *
-     * \see exportLayerName()
-     * \see exportLayerBehavior()
-     * \since QGIS 3.40
-     */
-    void setExportLayerName( const QString &name );
-
-    /**
      * Returns the number of layers that this item requires for exporting during layered exports (e.g. SVG).
      * Returns 0 if this item is to be placed on the same layer as the previous item,
      * 1 if it should be placed on its own layer, and >1 if it requires multiple export layers.
@@ -1347,8 +1317,6 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
 
     //! Whether item should be excluded in exports
     bool mExcludeFromExports = false;
-
-    QString mExportLayerName;
 
     /**
      * Temporary evaluated item exclusion. Data defined properties may mean

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -469,7 +469,6 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
      *
      * \see numberExportLayers()
      * \see exportLayerDetails()
-     * \see exportLayerName()
      *
      * \since QGIS 3.10
      */

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -234,6 +234,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
       UndoMarginRight, //!< Right margin (since QGIS 3.30)
       UndoSetId, //!< Change item ID
       UndoRotation, //!< Rotation adjustment
+      UndoExportLayerName, //!< Export layer name (since QGIS 3.40)
       UndoShapeStyle, //!< Shape symbol style
       UndoShapeCornerRadius, //!< Shape corner radius
       UndoNodeMove, //!< Node move
@@ -464,12 +465,45 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     };
 
     /**
-     * Returns the behavior of this item during exporting to layered exports (e.g. SVG).
+     * Returns the behavior of this item during exporting to layered exports (e.g. SVG or GeoPDF).
+     *
      * \see numberExportLayers()
      * \see exportLayerDetails()
+     * \see exportLayerName()
+     *
      * \since QGIS 3.10
      */
     virtual ExportLayerBehavior exportLayerBehavior() const;
+
+    /**
+     * Returns the name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
+     *
+     * By default this is an empty string, which indicates that the item does not need to be placed in any specific
+     * layer and will automatically be grouped with other items where possible.
+     *
+     * If the layer name is non-empty, then the item will be placed in a group with the corresponding name
+     * during layered exports.
+     *
+     * \see setExportLayerName()
+     * \see exportLayerBehavior()
+     * \since QGIS 3.40
+     */
+    QString exportLayerName() const;
+
+    /**
+     * Sets the \a name for this item during exporting to layered exports (e.g. SVG or GeoPDF).
+     *
+     * If \a name is an empty string then the item does not need to be placed in any specific
+     * layer and will automatically be grouped with other items where possible.
+     *
+     * If the layer \a name is non-empty, then the item will be placed in a group with the corresponding name
+     * during layered exports.
+     *
+     * \see exportLayerName()
+     * \see exportLayerBehavior()
+     * \since QGIS 3.40
+     */
+    void setExportLayerName( const QString &name );
 
     /**
      * Returns the number of layers that this item requires for exporting during layered exports (e.g. SVG).
@@ -540,6 +574,13 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
 
       //! Associated map theme, or an empty string if this export layer does not need to be associated with a map theme
       QString mapTheme;
+
+      /**
+       * Associated group name, if this layer is associated with an export group.
+       *
+       * \since QGIS 3.40
+       */
+      QString groupName;
     };
 
     /**
@@ -1306,6 +1347,8 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
 
     //! Whether item should be excluded in exports
     bool mExcludeFromExports = false;
+
+    QString mExportLayerName;
 
     /**
      * Temporary evaluated item exclusion. Data defined properties may mean

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -302,6 +302,13 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
        */
       QStringList layerTreeGroupOrder;
 
+      /**
+       * Contains a list of group names which should be considered as mutually exclusive.
+       *
+       * \since QGIS 3.40
+       */
+      QSet< QString > mutuallyExclusiveGroups;
+
     };
 
     /**

--- a/src/gui/layout/qgslayoutitemwidget.cpp
+++ b/src/gui/layout/qgslayoutitemwidget.cpp
@@ -789,7 +789,7 @@ void QgsLayoutItemPropertiesWidget::setValuesForGuiElements()
 
   if ( QgsLayout *layout = mItem->layout() )
   {
-    // collect export groups from layout, so that we can offer auto completion in the PDF export group drop down
+    // collect export groups from layout, so that we can offer auto completion in the PDF export group combo
     QList< QgsLayoutItem * > items;
     layout->layoutItems( items );
     QStringList existingGroups;

--- a/src/gui/layout/qgslayoutitemwidget.cpp
+++ b/src/gui/layout/qgslayoutitemwidget.cpp
@@ -747,7 +747,7 @@ void QgsLayoutItemPropertiesWidget::setValuesForGuiNonPositionElements()
   whileBlocking( mOpacityWidget )->setOpacity( mItem->itemOpacity() );
   whileBlocking( mItemRotationSpinBox )->setValue( mItem->itemRotation() );
   whileBlocking( mExcludeFromPrintsCheckBox )->setChecked( mItem->excludeFromExports() );
-  whileBlocking( mExportGroupNameCombo )->setCurrentText( mItem->exportLayerName() );
+  whileBlocking( mExportGroupNameCombo )->setCurrentText( mItem->customProperty( QStringLiteral( "pdfExportGroup" ) ).toString() );
 }
 
 void QgsLayoutItemPropertiesWidget::initializeDataDefinedButtons()
@@ -795,8 +795,9 @@ void QgsLayoutItemPropertiesWidget::setValuesForGuiElements()
     QStringList existingGroups;
     for ( const QgsLayoutItem *item : std::as_const( items ) )
     {
-      if ( !item->exportLayerName().isEmpty() && !existingGroups.contains( item->exportLayerName() ) )
-        existingGroups.append( item->exportLayerName() );
+      const QString groupName = item->customProperty( QStringLiteral( "pdfExportGroup" ) ).toString();
+      if ( !groupName.isEmpty() && !existingGroups.contains( groupName ) )
+        existingGroups.append( groupName );
     }
 
     std::sort( existingGroups.begin(), existingGroups.end(), [ = ]( const QString & a, const QString & b ) -> bool
@@ -852,7 +853,7 @@ void QgsLayoutItemPropertiesWidget::exportGroupNameEditingFinished()
   if ( mItem )
   {
     mItem->layout()->undoStack()->beginCommand( mItem, tr( "Change Export Group Name" ), QgsLayoutItem::UndoExportLayerName );
-    mItem->setExportLayerName( mExportGroupNameCombo->currentText() );
+    mItem->setCustomProperty( QStringLiteral( "pdfExportGroup" ), mExportGroupNameCombo->currentText() );
     mItem->layout()->undoStack()->endCommand();
   }
 }

--- a/src/gui/layout/qgslayoutitemwidget.h
+++ b/src/gui/layout/qgslayoutitemwidget.h
@@ -272,6 +272,7 @@ class GUI_EXPORT QgsLayoutItemPropertiesWidget: public QWidget, private Ui::QgsL
     void mFrameJoinStyleCombo_currentIndexChanged( int index );
     void mBackgroundGroupBox_toggled( bool state );
     void mItemIdLineEdit_editingFinished();
+    void exportGroupNameEditingFinished();
 
     //adjust coordinates in line edits
     void mPageSpinBox_valueChanged( int );

--- a/src/ui/layout/qgslayoutitemwidgetbase.ui
+++ b/src/ui/layout/qgslayoutitemwidgetbase.ui
@@ -685,24 +685,13 @@
       <string notr="true">composeritem</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,1">
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelBlendMode">
-        <property name="text">
-         <string>Blending mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
-          <property name="focusPolicy">
-           <enum>Qt::StrongFocus</enum>
-          </property>
-         </widget>
+         <widget class="QgsBlendModeComboBox" name="mBlendModeCombo"/>
         </item>
         <item>
-         <widget class="QgsPropertyOverrideButton" name="mOpacityDDBtn">
+         <widget class="QgsPropertyOverrideButton" name="mBlendModeDDBtn">
           <property name="text">
            <string>…</string>
           </property>
@@ -728,6 +717,13 @@
         </item>
        </layout>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelBlendMode">
+        <property name="text">
+         <string>Blending mode</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="labelTransparency">
         <property name="text">
@@ -735,19 +731,37 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QgsBlendModeComboBox" name="mBlendModeCombo"/>
+         <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
+         </widget>
         </item>
         <item>
-         <widget class="QgsPropertyOverrideButton" name="mBlendModeDDBtn">
+         <widget class="QgsPropertyOverrideButton" name="mOpacityDDBtn">
           <property name="text">
            <string>…</string>
           </property>
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>GeoPDF group</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="mExportGroupNameCombo">
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -791,10 +805,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPropertyOverrideButton</class>
@@ -802,25 +815,26 @@
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsPenJoinStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>

--- a/tests/src/core/testqgslayoutexporter.cpp
+++ b/tests/src/core/testqgslayoutexporter.cpp
@@ -40,6 +40,7 @@ class TestQgsLayoutExporter: public QgsTest
     void init();
     void cleanup();
     void testHandleLayeredExport();
+    void testHandleLayeredExportCustomGroups();
 
 };
 
@@ -258,6 +259,254 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
   QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() << QString() << linesLayer->id() << QString() << QString() << QString() << QString() );
   layerIds.clear();
   layerNames.clear();
+  mapLayerIds.clear();
+
+  qDeleteAll( items );
+}
+
+
+void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
+{
+  QgsProject p;
+  QgsLayout l( &p );
+  QgsLayoutExporter exporter( &l );
+
+  QList< unsigned int > layerIds;
+  QStringList layerNames;
+  QStringList mapLayerIds;
+  QStringList groupNames;
+  QgsLayout *layout = &l;
+  auto exportFunc = [&layerIds, &layerNames, &mapLayerIds, &groupNames, layout]( unsigned int layerId, const QgsLayoutItem::ExportLayerDetail & layerDetail )->QgsLayoutExporter::ExportResult
+  {
+    layerIds << layerId;
+    layerNames << layerDetail.name;
+    mapLayerIds << layerDetail.mapLayerId;
+    groupNames << layerDetail.groupName;
+    QImage im( 512, 512, QImage::Format_ARGB32_Premultiplied );
+    QPainter p( &im );
+    layout->render( &p );
+    p.end();
+
+    return QgsLayoutExporter::Success;
+  };
+
+  QList< QGraphicsItem * > items;
+  QStringList expectedGroupNames;
+  QgsLayoutExporter::ExportResult res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QVERIFY( layerIds.isEmpty() );
+  QVERIFY( layerNames.isEmpty() );
+  QVERIFY( groupNames.isEmpty() );
+  QVERIFY( mapLayerIds.isEmpty() );
+
+  // add two pages to a layout
+  QgsLayoutItemPage *page1 = new QgsLayoutItemPage( &l );
+  items << page1;
+  expectedGroupNames << QString();
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Page" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
+  items << page2;
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemLabel *label = new QgsLayoutItemLabel( &l );
+  items << label;
+  expectedGroupNames << QString();
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemShape *shape = new QgsLayoutItemShape( &l );
+  items << shape;
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemLabel *label2 = new QgsLayoutItemLabel( &l );
+  label2->setExportLayerName( QStringLiteral( "first group" ) );
+  expectedGroupNames << QStringLiteral( "first group" );
+  items << label2;
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  // add an item which can only be used with other similar items, should break the next label into a different layer
+  QgsLayoutItemScaleBar *scaleBar = new QgsLayoutItemScaleBar( &l );
+  scaleBar->setExportLayerName( QStringLiteral( "first group" ) );
+  expectedGroupNames << QStringLiteral( "first group" );
+  items << scaleBar;
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemLabel *label3 = new QgsLayoutItemLabel( &l );
+  items << label3;
+  expectedGroupNames << QString();
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemScaleBar *scaleBar2 = new QgsLayoutItemScaleBar( &l );
+  scaleBar2->setExportLayerName( QStringLiteral( "scales" ) );
+  items << scaleBar2;
+  expectedGroupNames << QStringLiteral( "scales" );
+  QgsLayoutItemScaleBar *scaleBar3 = new QgsLayoutItemScaleBar( &l );
+  scaleBar3->setExportLayerName( QStringLiteral( "scales" ) );
+  items << scaleBar3;
+  expectedGroupNames << QStringLiteral( "scales" );
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  // with an item which has sublayers
+  QgsVectorLayer *linesLayer = new QgsVectorLayer( TEST_DATA_DIR + QStringLiteral( "/lines.shp" ),
+      QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
+  QVERIFY( linesLayer->isValid() );
+
+  p.addMapLayer( linesLayer );
+
+  QgsLayoutItemMap *map = new QgsLayoutItemMap( &l );
+  map->attemptSetSceneRect( QRectF( 20, 20, 200, 100 ) );
+  map->setFrameEnabled( false );
+  map->setBackgroundEnabled( false );
+  map->setCrs( linesLayer->crs() );
+  map->zoomToExtent( linesLayer->extent() );
+  map->setLayers( QList<QgsMapLayer *>() << linesLayer );
+
+  items << map;
+  expectedGroupNames << QString();
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: lines" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << linesLayer->id() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  map->setFrameEnabled( true );
+  map->setBackgroundEnabled( true );
+  res = exporter.handleLayeredExport( items, exportFunc );
+  expectedGroupNames << QString() << QString();
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << linesLayer->id() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  // add two legends -- legends are complex and must be placed in an isolated layer
+  QgsLayoutItemLegend *legend = new QgsLayoutItemLegend( &l );
+  legend->setId( QStringLiteral( "my legend" ) );
+  legend->setExportLayerName( QStringLiteral( "second group" ) );
+  QgsLayoutItemLegend *legend2 = new QgsLayoutItemLegend( &l );
+  legend2->setId( QStringLiteral( "my legend 2" ) );
+  legend2->setExportLayerName( QStringLiteral( "second group" ) );
+  items << legend << legend2;
+  expectedGroupNames << QStringLiteral( "second group" ) << QStringLiteral( "second group" );
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << linesLayer->id() << QString() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemLabel *label4 = new QgsLayoutItemLabel( &l );
+  items << label4;
+  label4->setExportLayerName( QStringLiteral( "more labels" ) );
+  expectedGroupNames << QStringLiteral( "more labels" );
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 << 13 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) << QStringLiteral( "Label" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << linesLayer->id() << QString() << QString() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+
+  QgsLayoutItemLabel *label5 = new QgsLayoutItemLabel( &l );
+  items << label5;
+  label5->setExportLayerName( QStringLiteral( "more labels 2" ) );
+  expectedGroupNames << QStringLiteral( "more labels 2" );
+  res = exporter.handleLayeredExport( items, exportFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 << 13 << 14 );
+  QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) << QStringLiteral( "Label" ) << QStringLiteral( "Label" ) );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << QString() << linesLayer->id() << QString() << QString() << QString() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
   mapLayerIds.clear();
 
   qDeleteAll( items );

--- a/tests/src/core/testqgslayoutexporter.cpp
+++ b/tests/src/core/testqgslayoutexporter.cpp
@@ -88,8 +88,13 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
     return QgsLayoutExporter::Success;
   };
 
+  auto getExportGroupNameFunc = []( QgsLayoutItem * )->QString
+  {
+    return QString();
+  };
+
   QList< QGraphicsItem * > items;
-  QgsLayoutExporter::ExportResult res = exporter.handleLayeredExport( items, exportFunc );
+  QgsLayoutExporter::ExportResult res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QVERIFY( layerIds.isEmpty() );
   QVERIFY( layerNames.isEmpty() );
@@ -98,7 +103,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
   // add two pages to a layout
   QgsLayoutItemPage *page1 = new QgsLayoutItemPage( &l );
   items << page1;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Page" ) );
@@ -109,7 +114,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
   items << page2;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) );
@@ -120,7 +125,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   QgsLayoutItemLabel *label = new QgsLayoutItemLabel( &l );
   items << label;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label" ) );
@@ -131,7 +136,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   QgsLayoutItemShape *shape = new QgsLayoutItemShape( &l );
   items << shape;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) );
@@ -142,7 +147,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   QgsLayoutItemLabel *label2 = new QgsLayoutItemLabel( &l );
   items << label2;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) );
@@ -154,7 +159,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
   // add an item which can only be used with other similar items, should break the next label into a different layer
   QgsLayoutItemScaleBar *scaleBar = new QgsLayoutItemScaleBar( &l );
   items << scaleBar;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) );
@@ -165,7 +170,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   QgsLayoutItemLabel *label3 = new QgsLayoutItemLabel( &l );
   items << label3;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) );
@@ -179,7 +184,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
   items << scaleBar2;
   QgsLayoutItemScaleBar *scaleBar3 = new QgsLayoutItemScaleBar( &l );
   items << scaleBar3;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebars" ) );
@@ -204,7 +209,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
   map->setLayers( QList<QgsMapLayer *>() << linesLayer );
 
   items << map;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebars" ) << QStringLiteral( "Map 1: lines" ) );
@@ -215,7 +220,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   map->setFrameEnabled( true );
   map->setBackgroundEnabled( true );
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebars" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) );
@@ -230,7 +235,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
   QgsLayoutItemLegend *legend2 = new QgsLayoutItemLegend( &l );
   legend2->setId( QStringLiteral( "my legend 2" ) );
   items << legend << legend2;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebars" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) );
@@ -241,7 +246,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   QgsLayoutItemLabel *label4 = new QgsLayoutItemLabel( &l );
   items << label4;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebars" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) << QStringLiteral( "Label" ) );
@@ -252,7 +257,7 @@ void TestQgsLayoutExporter::testHandleLayeredExport()
 
   QgsLayoutItemLabel *label5 = new QgsLayoutItemLabel( &l );
   items << label5;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Labels, Shape" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebars" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) << QStringLiteral( "Labels" ) );
@@ -289,10 +294,14 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
     return QgsLayoutExporter::Success;
   };
+  auto getExportGroupNameFunc = []( QgsLayoutItem * item )->QString
+  {
+    return item->customProperty( QStringLiteral( "pdfExportGroup" ) ).toString();
+  };
 
   QList< QGraphicsItem * > items;
   QStringList expectedGroupNames;
-  QgsLayoutExporter::ExportResult res = exporter.handleLayeredExport( items, exportFunc );
+  QgsLayoutExporter::ExportResult res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QVERIFY( layerIds.isEmpty() );
   QVERIFY( layerNames.isEmpty() );
@@ -303,7 +312,7 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
   QgsLayoutItemPage *page1 = new QgsLayoutItemPage( &l );
   items << page1;
   expectedGroupNames << QString();
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Page" ) );
@@ -316,7 +325,7 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
   items << page2;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) );
@@ -330,7 +339,7 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
   QgsLayoutItemLabel *label = new QgsLayoutItemLabel( &l );
   items << label;
   expectedGroupNames << QString();
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label" ) );
@@ -343,7 +352,7 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   QgsLayoutItemShape *shape = new QgsLayoutItemShape( &l );
   items << shape;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) );
@@ -355,10 +364,10 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
   mapLayerIds.clear();
 
   QgsLayoutItemLabel *label2 = new QgsLayoutItemLabel( &l );
-  label2->setExportLayerName( QStringLiteral( "first group" ) );
+  label2->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "first group" ) );
   expectedGroupNames << QStringLiteral( "first group" );
   items << label2;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) );
@@ -370,10 +379,10 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   // add an item which can only be used with other similar items, should break the next label into a different layer
   QgsLayoutItemScaleBar *scaleBar = new QgsLayoutItemScaleBar( &l );
-  scaleBar->setExportLayerName( QStringLiteral( "first group" ) );
+  scaleBar->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "first group" ) );
   expectedGroupNames << QStringLiteral( "first group" );
   items << scaleBar;
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) );
@@ -387,7 +396,7 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
   QgsLayoutItemLabel *label3 = new QgsLayoutItemLabel( &l );
   items << label3;
   expectedGroupNames << QString();
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) );
@@ -399,14 +408,14 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
   mapLayerIds.clear();
 
   QgsLayoutItemScaleBar *scaleBar2 = new QgsLayoutItemScaleBar( &l );
-  scaleBar2->setExportLayerName( QStringLiteral( "scales" ) );
+  scaleBar2->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "scales" ) );
   items << scaleBar2;
   expectedGroupNames << QStringLiteral( "scales" );
   QgsLayoutItemScaleBar *scaleBar3 = new QgsLayoutItemScaleBar( &l );
-  scaleBar3->setExportLayerName( QStringLiteral( "scales" ) );
+  scaleBar3->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "scales" ) );
   items << scaleBar3;
   expectedGroupNames << QStringLiteral( "scales" );
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) );
@@ -434,7 +443,7 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   items << map;
   expectedGroupNames << QString();
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: lines" ) );
@@ -447,7 +456,7 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   map->setFrameEnabled( true );
   map->setBackgroundEnabled( true );
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   expectedGroupNames << QString() << QString();
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 );
@@ -462,13 +471,13 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
   // add two legends -- legends are complex and must be placed in an isolated layer
   QgsLayoutItemLegend *legend = new QgsLayoutItemLegend( &l );
   legend->setId( QStringLiteral( "my legend" ) );
-  legend->setExportLayerName( QStringLiteral( "second group" ) );
+  legend->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "second group" ) );
   QgsLayoutItemLegend *legend2 = new QgsLayoutItemLegend( &l );
   legend2->setId( QStringLiteral( "my legend 2" ) );
-  legend2->setExportLayerName( QStringLiteral( "second group" ) );
+  legend2->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "second group" ) );
   items << legend << legend2;
   expectedGroupNames << QStringLiteral( "second group" ) << QStringLiteral( "second group" );
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) );
@@ -481,9 +490,9 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   QgsLayoutItemLabel *label4 = new QgsLayoutItemLabel( &l );
   items << label4;
-  label4->setExportLayerName( QStringLiteral( "more labels" ) );
+  label4->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "more labels" ) );
   expectedGroupNames << QStringLiteral( "more labels" );
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 << 13 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) << QStringLiteral( "Label" ) );
@@ -496,9 +505,9 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   QgsLayoutItemLabel *label5 = new QgsLayoutItemLabel( &l );
   items << label5;
-  label5->setExportLayerName( QStringLiteral( "more labels 2" ) );
+  label5->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "more labels 2" ) );
   expectedGroupNames << QStringLiteral( "more labels 2" );
-  res = exporter.handleLayeredExport( items, exportFunc );
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
   QCOMPARE( res, QgsLayoutExporter::Success );
   QCOMPARE( layerIds, QList< unsigned int >() << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 << 13 << 14 );
   QCOMPARE( layerNames, QStringList() << QStringLiteral( "Pages" ) << QStringLiteral( "Label, Shape" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Label" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Scalebar" ) << QStringLiteral( "Map 1: Background" ) << QStringLiteral( "Map 1: lines" ) << QStringLiteral( "Map 1: Frame" ) << QStringLiteral( "my legend" ) << QStringLiteral( "my legend 2" ) << QStringLiteral( "Label" ) << QStringLiteral( "Label" ) );

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -170,6 +170,7 @@ class TestQgsLayoutItem: public QgsTest
     void blendMode();
     void opacity();
     void excludeFromExports();
+    void exportName();
     void setSceneRect();
     void page();
     void itemVariablesFunction();
@@ -1743,6 +1744,7 @@ void TestQgsLayoutItem::writeReadXmlProperties()
   original->setBlendMode( QPainter::CompositionMode_Darken );
   original->setExcludeFromExports( true );
   original->setItemOpacity( 0.75 );
+  original->setExportLayerName( QStringLiteral( "_export_layer_" ) );
 
   std::unique_ptr< QgsLayoutItem > copy = createCopyViaXml( &l, original );
 
@@ -1772,6 +1774,7 @@ void TestQgsLayoutItem::writeReadXmlProperties()
   QCOMPARE( copy->blendMode(), QPainter::CompositionMode_Darken );
   QVERIFY( copy->excludeFromExports( ) );
   QCOMPARE( copy->itemOpacity(), 0.75 );
+  QCOMPARE( copy->exportLayerName(), QStringLiteral( "_export_layer_" ) );
   delete original;
 }
 
@@ -2094,6 +2097,18 @@ void TestQgsLayoutItem::excludeFromExports()
 
   mControlPathPrefix = QStringLiteral( "layouts" );
   QGSVERIFYLAYOUTCHECK( QStringLiteral( "layoutitem_excluded" ), &l, 0, 0, QSize( 400, 400 ) );
+}
+
+void TestQgsLayoutItem::exportName()
+{
+  QgsProject proj;
+  QgsLayout l( &proj );
+  QgsLayoutItemShape *item = new QgsLayoutItemShape( &l );
+  l.addLayoutItem( item );
+
+  QCOMPARE( item->exportLayerName(), QString() );
+  item->setExportLayerName( QStringLiteral( "my export group" ) );
+  QCOMPARE( item->exportLayerName(), QStringLiteral( "my export group" ) );
 }
 
 std::unique_ptr<QgsLayoutItem> TestQgsLayoutItem::createCopyViaXml( QgsLayout *layout, QgsLayoutItem *original )

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -170,7 +170,6 @@ class TestQgsLayoutItem: public QgsTest
     void blendMode();
     void opacity();
     void excludeFromExports();
-    void exportName();
     void setSceneRect();
     void page();
     void itemVariablesFunction();
@@ -1744,7 +1743,7 @@ void TestQgsLayoutItem::writeReadXmlProperties()
   original->setBlendMode( QPainter::CompositionMode_Darken );
   original->setExcludeFromExports( true );
   original->setItemOpacity( 0.75 );
-  original->setExportLayerName( QStringLiteral( "_export_layer_" ) );
+  original->setCustomProperty( QStringLiteral( "pdfExportGroup" ), QStringLiteral( "_export_layer_" ) );
 
   std::unique_ptr< QgsLayoutItem > copy = createCopyViaXml( &l, original );
 
@@ -1774,7 +1773,7 @@ void TestQgsLayoutItem::writeReadXmlProperties()
   QCOMPARE( copy->blendMode(), QPainter::CompositionMode_Darken );
   QVERIFY( copy->excludeFromExports( ) );
   QCOMPARE( copy->itemOpacity(), 0.75 );
-  QCOMPARE( copy->exportLayerName(), QStringLiteral( "_export_layer_" ) );
+  QCOMPARE( copy->customProperty( QStringLiteral( "pdfExportGroup" ) ).toString(), QStringLiteral( "_export_layer_" ) );
   delete original;
 }
 
@@ -2097,18 +2096,6 @@ void TestQgsLayoutItem::excludeFromExports()
 
   mControlPathPrefix = QStringLiteral( "layouts" );
   QGSVERIFYLAYOUTCHECK( QStringLiteral( "layoutitem_excluded" ), &l, 0, 0, QSize( 400, 400 ) );
-}
-
-void TestQgsLayoutItem::exportName()
-{
-  QgsProject proj;
-  QgsLayout l( &proj );
-  QgsLayoutItemShape *item = new QgsLayoutItemShape( &l );
-  l.addLayoutItem( item );
-
-  QCOMPARE( item->exportLayerName(), QString() );
-  item->setExportLayerName( QStringLiteral( "my export group" ) );
-  QCOMPARE( item->exportLayerName(), QStringLiteral( "my export group" ) );
 }
 
 std::unique_ptr<QgsLayoutItem> TestQgsLayoutItem::createCopyViaXml( QgsLayout *layout, QgsLayoutItem *original )


### PR DESCRIPTION
This new setting, located in the layout item "Rendering" section, allows users to set an optional "group name" for use in GeoPDF
exports. When set, a matching layer tree group will be created in the exported GeoPDF and the item will only be visible when
this group is checked.

This allows content to be selectively displayed as a group by viewers of the GeoPDF. Eg, it can allow extra layout content
such as descriptive labels or legends to only be shown when layers from the group are visible, making GeoPDF export much
more flexible.

![image](https://github.com/qgis/QGIS/assets/1829991/6a2239af-5c9a-4dc8-881b-29871e6d363e)


Sponsored by Rubicon Concierge Real Estate Services
