### PR TITLE
Use qMetaTypeId<T>() instead of QMetaType::type( T )

### DIFF
--- a/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
@@ -145,7 +145,7 @@ QgsFeatureList QgsGeometryByExpressionAlgorithm::processFeature( const QgsFeatur
   }
   else
   {
-    if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+    if ( value.userType() == qMetaTypeId< QgsGeometry>() )
     {
       const QgsGeometry geom = value.value<QgsGeometry>();
       feature.setGeometry( geom );

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -828,7 +828,7 @@ bool QgsMapToolLabel::currentLabelDataDefinedPosition( double &x, bool &xSuccess
            && !QgsVariantUtils::isNull( attributes.at( pointCol ) ) )
       {
         QVariant pointAsVariant = attributes.at( pointCol );
-        if ( pointAsVariant.userType() == QMetaType::type( "QgsGeometry" ) )
+        if ( pointAsVariant.userType() == qMetaTypeId< QgsGeometry>() )
         {
           const  QgsGeometry geometry = pointAsVariant.value<QgsGeometry>();
           if ( const QgsPoint *point  = ( geometry.constGet() ? qgsgeometry_cast<const QgsPoint *>( geometry.constGet()->simplifiedTypeRef() ) : nullptr ) )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -26,6 +26,7 @@
 #include "qgsexpression_p.h"
 #include "qgsvariantutils.h"
 #include "qgsunittypes.h"
+#include "qgscolorrampimpl.h"
 
 #include <QRegularExpression>
 
@@ -1016,7 +1017,7 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   const QString startToken = htmlOutput ? QStringLiteral( "<i>&lt;" ) : QStringLiteral( "<" );
   const QString endToken = htmlOutput ? QStringLiteral( "&gt;</i>" ) : QStringLiteral( ">" );
 
-  if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( value.userType() == qMetaTypeId< QgsGeometry>() )
   {
     //result is a geometry
     QgsGeometry geom = value.value<QgsGeometry>();
@@ -1034,13 +1035,13 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   {
     return htmlOutput ? tr( "<i>NULL</i>" ) : QString();
   }
-  else if ( value.userType() == QMetaType::type( "QgsFeature" ) )
+  else if ( value.userType() == qMetaTypeId< QgsFeature>() )
   {
     //result is a feature
     QgsFeature feat = value.value<QgsFeature>();
     return startToken + tr( "feature: %1" ).arg( feat.id() ) + endToken;
   }
-  else if ( value.userType() == QMetaType::type( "QgsInterval" ) )
+  else if ( value.userType() == qMetaTypeId< QgsInterval>() )
   {
     QgsInterval interval = value.value<QgsInterval>();
     if ( interval.days() > 1 )
@@ -1060,7 +1061,7 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
       return startToken + tr( "interval: %1 seconds" ).arg( interval.seconds() ) + endToken;
     }
   }
-  else if ( value.userType() == QMetaType::type( "QgsGradientColorRamp" ) )
+  else if ( value.userType() == qMetaTypeId< QgsGradientColorRamp>() )
   {
     return startToken + tr( "gradient ramp" ) + endToken;
   }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1478,7 +1478,7 @@ static QVariant fcnWordwrap( const QVariantList &values, const QgsExpressionCont
 static QVariant fcnLength( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // two variants, one for geometry, one for string
-  if ( values.at( 0 ).userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( values.at( 0 ).userType() == qMetaTypeId< QgsGeometry>() )
   {
     //geometry variant
     QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
@@ -3684,7 +3684,7 @@ static QVariant fcnCollectGeometries( const QVariantList &values, const QgsExpre
   parts.reserve( list.size() );
   for ( const QVariant &value : std::as_const( list ) )
   {
-    if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+    if ( value.userType() == qMetaTypeId< QgsGeometry>() )
     {
       parts << value.value<QgsGeometry>();
     }
@@ -5926,7 +5926,7 @@ QVariant fcnRampColor( const QVariantList &values, const QgsExpressionContext *,
 {
   QgsGradientColorRamp expRamp;
   const QgsColorRamp *ramp = nullptr;
-  if ( values.at( 0 ).userType() == QMetaType::type( "QgsGradientColorRamp" ) )
+  if ( values.at( 0 ).userType() == qMetaTypeId< QgsGradientColorRamp>() )
   {
     expRamp = QgsExpressionUtils::getRamp( values.at( 0 ), parent );
     ramp = &expRamp;

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -484,7 +484,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
       }
 
       // warning - QgsExpression::isIntervalSafe is VERY expensive and should not be used here
-      else if ( vL.userType() == QMetaType::type( "QgsInterval" ) && vR.userType() == QMetaType::type( "QgsInterval" ) )
+      else if ( vL.userType() == qMetaTypeId< QgsInterval>() && vR.userType() == qMetaTypeId< QgsInterval>() )
       {
         double fL = QgsExpressionUtils::getInterval( vL, parent ).seconds();
         ENSURE_NO_EVAL_ERROR

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -42,7 +42,7 @@ QgsExpressionUtils::TVL QgsExpressionUtils::NOT[3] = { True, False, Unknown };
 
 QgsGradientColorRamp QgsExpressionUtils::getRamp( const QVariant &value, QgsExpression *parent, bool report_error )
 {
-  if ( value.userType() == QMetaType::type( "QgsGradientColorRamp" ) )
+  if ( value.userType() == qMetaTypeId<QgsGradientColorRamp>() )
     return value.value<QgsGradientColorRamp>();
 
   // If we get here then we can't convert so we just error and return invalid.

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -96,13 +96,13 @@ class CORE_EXPORT QgsExpressionUtils
       //handle some special cases
       if ( value.type() == QVariant::UserType )
       {
-        if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+        if ( value.userType() == qMetaTypeId< QgsGeometry>() )
         {
           //geom is false if empty
           const QgsGeometry geom = value.value<QgsGeometry>();
           return geom.isNull() ? False : True;
         }
-        else if ( value.userType() == QMetaType::type( "QgsFeature" ) )
+        else if ( value.userType() == qMetaTypeId<QgsFeature>() )
         {
           //feat is false if non-valid
           const QgsFeature feat = value.value<QgsFeature>();
@@ -176,7 +176,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static inline bool isIntervalSafe( const QVariant &v )
     {
-      if ( v.userType() == QMetaType::type( "QgsInterval" ) )
+      if ( v.userType() == qMetaTypeId<QgsInterval>() )
       {
         return true;
       }
@@ -313,7 +313,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static QgsInterval getInterval( const QVariant &value, QgsExpression *parent, bool report_error = false )
     {
-      if ( value.userType() == QMetaType::type( "QgsInterval" ) )
+      if ( value.userType() == qMetaTypeId<QgsInterval>() )
         return value.value<QgsInterval>();
 
       QgsInterval inter = QgsInterval::fromString( value.toString() );
@@ -332,7 +332,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static QgsGeometry getGeometry( const QVariant &value, QgsExpression *parent )
     {
-      if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+      if ( value.userType() == qMetaTypeId< QgsGeometry>() )
         return value.value<QgsGeometry>();
 
       parent->setEvalErrorString( QStringLiteral( "Cannot convert to geometry" ) );
@@ -341,7 +341,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static QgsFeature getFeature( const QVariant &value, QgsExpression *parent )
     {
-      if ( value.userType() == QMetaType::type( "QgsFeature" ) )
+      if ( value.userType() == qMetaTypeId<QgsFeature>() )
         return value.value<QgsFeature>();
 
       parent->setEvalErrorString( QStringLiteral( "Cannot convert to feature" ) );

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2594,7 +2594,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
         ddPosition = true;
 
         QgsPoint point;
-        if ( pointPosProperty.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+        if ( pointPosProperty.userType() == qMetaTypeId<QgsReferencedGeometry>() )
         {
           QgsReferencedGeometry referencedGeometryPoint = pointPosProperty.value<QgsReferencedGeometry>();
           point = QgsPoint( referencedGeometryPoint.asPoint() );
@@ -2603,7 +2603,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
                && ct.sourceCrs() != referencedGeometryPoint.crs() )
             QgsMessageLog::logMessage( QObject::tr( "Label position geometry is not in layer coordinates reference system. Layer CRS: '%1', Geometry CRS: '%2'" ).arg( ct.sourceCrs().userFriendlyIdentifier(), referencedGeometryPoint.crs().userFriendlyIdentifier() ), QObject::tr( "Labeling" ), Qgis::Warning );
         }
-        else if ( pointPosProperty.userType() == QMetaType::type( "QgsGeometry" ) )
+        else if ( pointPosProperty.userType() == qMetaTypeId< QgsGeometry>() )
         {
           point = QgsPoint( pointPosProperty.value<QgsGeometry>().asPoint() );
         }

--- a/src/core/layout/qgslayoutitemmanualtable.cpp
+++ b/src/core/layout/qgslayoutitemmanualtable.cpp
@@ -77,7 +77,7 @@ bool QgsLayoutItemManualTable::getTableContents( QgsLayoutTableContents &content
       {
         QVariant cellContent = row.at( columnNumber ).content();
 
-        if ( cellContent.userType() == QMetaType::type( "QgsProperty" ) )
+        if ( cellContent.userType() == qMetaTypeId<QgsProperty>() )
         {
           // expression based cell content, evaluate now
           QgsExpressionContextScopePopper popper( context, scopeForCell( rowNumber, columnNumber ) );

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -203,7 +203,7 @@ QVariantMap QgsProcessingModelAlgorithm::parametersForChildAlgorithm( const QgsP
 
           if ( foundParam )
           {
-            if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+            if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
             {
               // make sure layer output name is correctly set
               QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
@@ -1185,11 +1185,11 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
 
     }
 
-    if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+    if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
       value = fromVar.sink;
-      if ( value.userType() == QMetaType::type( "QgsProperty" ) && context )
+      if ( value.userType() == qMetaTypeId<QgsProperty>() && context )
       {
         value = value.value< QgsProperty >().valueAsString( context->expressionContext() );
       }
@@ -1249,16 +1249,16 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
     }
 
     QgsFeatureSource *featureSource = nullptr;
-    if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+    if ( value.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
     {
       QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( value );
       value = fromVar.source;
     }
-    else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+    else if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
       value = fromVar.sink;
-      if ( context && value.userType() == QMetaType::type( "QgsProperty" ) )
+      if ( context && value.userType() == qMetaTypeId<QgsProperty>() )
       {
         value = value.value< QgsProperty >().valueAsString( context->expressionContext() );
       }
@@ -2003,7 +2003,7 @@ void QgsProcessingModelAlgorithm::changeParameterName( const QString &oldName, c
 
           case Qgis::ProcessingModelChildParameterSource::StaticValue:
           {
-            if ( valueIt->staticValue().userType() == QMetaType::type( "QgsProperty" ) )
+            if ( valueIt->staticValue().userType() == qMetaTypeId<QgsProperty>() )
             {
               QgsProperty property = valueIt->staticValue().value< QgsProperty >();
               if ( property.propertyType() == Qgis::PropertyType::Expression )

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -34,7 +34,7 @@ QVariant QgsProcessingModelOutput::toVariant() const
   QVariantMap map;
   map.insert( QStringLiteral( "name" ), mName );
 
-  if ( mDefaultValue.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( mDefaultValue.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     QVariantMap defaultMap = mDefaultValue.value<QgsProcessingOutputLayerDefinition>().toVariant().toMap();
     defaultMap.insert( QStringLiteral( "class" ), QStringLiteral( "QgsProcessingOutputLayerDefinition" ) );

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -925,17 +925,17 @@ QString QgsProcessingAlgorithm::invalidSourceError( const QVariantMap &parameter
   else
   {
     QVariant var = parameters.value( name );
-    if ( var.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+    if ( var.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
     {
       QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( var );
       var = fromVar.source;
     }
-    else if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+    else if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
       var = fromVar.sink;
     }
-    if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( var.userType() == qMetaTypeId<QgsProperty>() )
     {
       QgsProperty p = var.value< QgsProperty >();
       if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -957,7 +957,7 @@ QString QgsProcessingAlgorithm::invalidRasterError( const QVariantMap &parameter
   else
   {
     QVariant var = parameters.value( name );
-    if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( var.userType() == qMetaTypeId<QgsProperty>() )
     {
       QgsProperty p = var.value< QgsProperty >();
       if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -979,12 +979,12 @@ QString QgsProcessingAlgorithm::invalidSinkError( const QVariantMap &parameters,
   else
   {
     QVariant var = parameters.value( name );
-    if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+    if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
       var = fromVar.sink;
     }
-    if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( var.userType() == qMetaTypeId<QgsProperty>() )
     {
       QgsProperty p = var.value< QgsProperty >();
       if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -1006,7 +1006,7 @@ QString QgsProcessingAlgorithm::invalidPointCloudError( const QVariantMap &param
   else
   {
     QVariant var = parameters.value( name );
-    if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( var.userType() == qMetaTypeId<QgsProperty>() )
     {
       QgsProperty p = var.value< QgsProperty >();
       if ( p.propertyType() == Qgis::PropertyType::Static )

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -117,7 +117,7 @@ bool QgsProcessingOutputLayerDefinition::operator!=( const QgsProcessingOutputLa
 bool QgsProcessingParameters::isDynamic( const QVariantMap &parameters, const QString &name )
 {
   const QVariant val = parameters.value( name );
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return val.value< QgsProperty >().propertyType() != Qgis::PropertyType::Static;
   else
     return false;
@@ -137,7 +137,7 @@ QString QgsProcessingParameters::parameterAsString( const QgsProcessingParameter
     return QString();
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
 
   if ( !val.isValid() )
@@ -169,7 +169,7 @@ QString QgsProcessingParameters::parameterAsExpression( const QgsProcessingParam
     return QString();
 
   const QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
 
   if ( val.isValid() && !val.toString().isEmpty() )
@@ -197,7 +197,7 @@ double QgsProcessingParameters::parameterAsDouble( const QgsProcessingParameterD
     return 0;
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return val.value< QgsProperty >().valueAsDouble( context.expressionContext(), definition->defaultValue().toDouble() );
 
   bool ok = false;
@@ -224,7 +224,7 @@ int QgsProcessingParameters::parameterAsInt( const QgsProcessingParameterDefinit
     return 0;
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return val.value< QgsProperty >().valueAsInt( context.expressionContext(), definition->defaultValue().toInt() );
 
   bool ok = false;
@@ -269,7 +269,7 @@ QList< int > QgsProcessingParameters::parameterAsInts( const QgsProcessingParame
   const QVariant val = value;
   if ( val.isValid() )
   {
-    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( val.userType() == qMetaTypeId<QgsProperty>() )
       resultList << val.value< QgsProperty >().valueAsInt( context.expressionContext(), definition->defaultValue().toInt() );
     else if ( val.userType() == QMetaType::Type::QVariantList )
     {
@@ -322,7 +322,7 @@ QDateTime QgsProcessingParameters::parameterAsDateTime( const QgsProcessingParam
     return QDateTime();
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
 
   QDateTime d = val.toDateTime();
@@ -359,7 +359,7 @@ QDate QgsProcessingParameters::parameterAsDate( const QgsProcessingParameterDefi
     return QDate();
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
 
   QDate d = val.toDate();
@@ -396,7 +396,7 @@ QTime QgsProcessingParameters::parameterAsTime( const QgsProcessingParameterDefi
     return QTime();
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
 
   QTime d;
@@ -462,7 +462,7 @@ QList<int> QgsProcessingParameters::parameterAsEnums( const QgsProcessingParamet
 
   QVariantList resultList;
   const QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     resultList << val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else if ( val.userType() == QMetaType::Type::QVariantList )
   {
@@ -573,7 +573,7 @@ QStringList QgsProcessingParameters::parameterAsEnumStrings( const QgsProcessing
         processVariant( s );
       }
     }
-    else if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+    else if ( var.userType() == qMetaTypeId<QgsProperty>() )
       processVariant( var.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
     else
     {
@@ -628,7 +628,7 @@ bool QgsProcessingParameters::parameterAsBool( const QgsProcessingParameterDefin
   const QVariant def = definition->defaultValue();
 
   const QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return val.value< QgsProperty >().valueAsBool( context.expressionContext(), def.toBool() );
   else if ( val.isValid() )
     return val.toBool();
@@ -644,7 +644,7 @@ bool QgsProcessingParameters::parameterAsBoolean( const QgsProcessingParameterDe
   const QVariant def = definition->defaultValue();
 
   const QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return val.value< QgsProperty >().valueAsBool( context.expressionContext(), def.toBool() );
   else if ( val.isValid() )
     return val.toBool();
@@ -675,7 +675,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   QString destName;
   QgsRemappingSinkDefinition remapDefinition;
   bool useRemapDefinition = false;
-  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -692,7 +692,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   }
 
   QString dest;
-  if ( definition && val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( definition && val.userType() == qMetaTypeId<QgsProperty>() )
   {
     dest = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -767,7 +767,7 @@ QString parameterAsCompatibleSourceLayerPathInternal( const QgsProcessingParamet
   bool selectedFeaturesOnly = false;
   long long featureLimit = -1;
   QString filterExpression;
-  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
@@ -776,14 +776,14 @@ QString parameterAsCompatibleSourceLayerPathInternal( const QgsProcessingParamet
     filterExpression = fromVar.filterExpression;
     val = fromVar.source;
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
   {
     val = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -794,7 +794,7 @@ QString parameterAsCompatibleSourceLayerPathInternal( const QgsProcessingParamet
   if ( !vl )
   {
     QString layerRef;
-    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( val.userType() == qMetaTypeId<QgsProperty>() )
     {
       layerRef = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
     }
@@ -864,7 +864,7 @@ QgsMapLayer *QgsProcessingParameters::parameterAsLayer( const QgsProcessingParam
     return nullptr;
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
   {
     val = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -874,14 +874,14 @@ QgsMapLayer *QgsProcessingParameters::parameterAsLayer( const QgsProcessingParam
     return layer;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -943,7 +943,7 @@ QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingPara
 
   QgsProject *destinationProject = nullptr;
   QString destName;
-  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -953,7 +953,7 @@ QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingPara
   }
 
   QString dest;
-  if ( definition && val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( definition && val.userType() == qMetaTypeId<QgsProperty>() )
   {
     dest = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -1013,7 +1013,7 @@ QString QgsProcessingParameters::parameterAsFileOutput( const QgsProcessingParam
 {
   QVariant val = value;
 
-  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -1021,7 +1021,7 @@ QString QgsProcessingParameters::parameterAsFileOutput( const QgsProcessingParam
   }
 
   QString dest;
-  if ( definition && val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( definition && val.userType() == qMetaTypeId<QgsProperty>() )
   {
     dest = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -1084,17 +1084,17 @@ QgsRectangle QgsProcessingParameters::parameterAsExtent( const QgsProcessingPara
 
   QVariant val = value;
 
-  if ( val.userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( val.userType() == qMetaTypeId<QgsRectangle>() )
   {
     return val.value<QgsRectangle>();
   }
-  if ( val.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( val.userType() == qMetaTypeId< QgsGeometry>() )
   {
     const QgsGeometry geom = val.value<QgsGeometry>();
     if ( !geom.isNull() )
       return geom.boundingBox();
   }
-  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( val.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     if ( crs.isValid() && rr.crs().isValid() && crs != rr.crs() )
@@ -1113,20 +1113,20 @@ QgsRectangle QgsProcessingParameters::parameterAsExtent( const QgsProcessingPara
     return rr;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -1135,7 +1135,7 @@ QgsRectangle QgsProcessingParameters::parameterAsExtent( const QgsProcessingPara
   QgsMapLayer *layer = qobject_cast< QgsMapLayer * >( qvariant_cast<QObject *>( val ) );
 
   QString rectText;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     rectText = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else
     rectText = val.toString();
@@ -1208,7 +1208,7 @@ QgsGeometry QgsProcessingParameters::parameterAsExtentGeometry( const QgsProcess
 
   QVariant val = parameters.value( definition->name() );
 
-  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( val.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     QgsGeometry g = QgsGeometry::fromRect( rr );
@@ -1228,26 +1228,26 @@ QgsGeometry QgsProcessingParameters::parameterAsExtentGeometry( const QgsProcess
     }
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
   {
     val = val.value< QgsProperty >().staticValue();
   }
 
   QString rectText;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     rectText = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else
     rectText = val.toString();
@@ -1328,7 +1328,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( cons
 QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context )
 {
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( val.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     if ( rr.crs().isValid() )
@@ -1337,26 +1337,26 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( cons
     }
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
   {
     val = val.value< QgsProperty >().staticValue();
   }
 
   QString valueAsString;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     valueAsString = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else
     valueAsString = val.toString();
@@ -1371,20 +1371,20 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( cons
       return crs;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -1415,17 +1415,17 @@ QgsPointXY QgsProcessingParameters::parameterAsPoint( const QgsProcessingParamet
     return QgsPointXY();
 
   const QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsPointXY" ) )
+  if ( val.userType() == qMetaTypeId<QgsPointXY>() )
   {
     return val.value<QgsPointXY>();
   }
-  if ( val.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( val.userType() == qMetaTypeId< QgsGeometry>() )
   {
     const QgsGeometry geom = val.value<QgsGeometry>();
     if ( !geom.isNull() )
       return geom.centroid().asPoint();
   }
-  if ( val.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  if ( val.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     const QgsReferencedPointXY rp = val.value<QgsReferencedPointXY>();
     if ( crs.isValid() && rp.crs().isValid() && crs != rp.crs() )
@@ -1493,7 +1493,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsPointCrs( const
 
 QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsPointCrs( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context )
 {
-  if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  if ( value.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     const QgsReferencedPointXY rr = value.value<QgsReferencedPointXY>();
     if ( rr.crs().isValid() )
@@ -1533,22 +1533,22 @@ QgsGeometry QgsProcessingParameters::parameterAsGeometry( const QgsProcessingPar
     return QgsGeometry();
 
   const QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( val.userType() == qMetaTypeId< QgsGeometry>() )
   {
     return val.value<QgsGeometry>();
   }
 
-  if ( val.userType() == QMetaType::type( "QgsPointXY" ) )
+  if ( val.userType() == qMetaTypeId<QgsPointXY>() )
   {
     return QgsGeometry::fromPointXY( val.value<QgsPointXY>() );
   }
 
-  if ( val.userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( val.userType() == qMetaTypeId<QgsRectangle>() )
   {
     return QgsGeometry::fromRect( val.value<QgsRectangle>() );
   }
 
-  if ( val.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  if ( val.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     const QgsReferencedPointXY rp = val.value<QgsReferencedPointXY>();
     if ( crs.isValid() && rp.crs().isValid() && crs != rp.crs() )
@@ -1566,7 +1566,7 @@ QgsGeometry QgsProcessingParameters::parameterAsGeometry( const QgsProcessingPar
     return QgsGeometry::fromPointXY( rp );
   }
 
-  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( val.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     QgsGeometry g = QgsGeometry::fromRect( rr );
@@ -1586,7 +1586,7 @@ QgsGeometry QgsProcessingParameters::parameterAsGeometry( const QgsProcessingPar
     return g;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  if ( val.userType() == qMetaTypeId<QgsReferencedGeometry>() )
   {
     QgsReferencedGeometry rg = val.value<QgsReferencedGeometry>();
     if ( crs.isValid() && rg.crs().isValid() && crs != rg.crs() )
@@ -1647,7 +1647,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( co
 
 QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context )
 {
-  if ( value.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  if ( value.userType() == qMetaTypeId<QgsReferencedGeometry>() )
   {
     const QgsReferencedGeometry rg = value.value<QgsReferencedGeometry>();
     if ( rg.crs().isValid() )
@@ -1656,7 +1656,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( co
     }
   }
 
-  if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  if ( value.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     const QgsReferencedPointXY rp = value.value<QgsReferencedPointXY>();
     if ( rp.crs().isValid() )
@@ -1665,7 +1665,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( co
     }
   }
 
-  if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( value.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle rr = value.value<QgsReferencedRectangle>();
     if ( rr.crs().isValid() )
@@ -1729,7 +1729,7 @@ QVariantList QgsProcessingParameters::parameterAsMatrix( const QgsProcessingPara
 
   QString resultString;
   const QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     resultString = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else if ( val.userType() == QMetaType::Type::QVariantList )
     return val.toList();
@@ -1798,14 +1798,14 @@ QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsPro
         processVariant( s );
       }
     }
-    else if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+    else if ( var.userType() == qMetaTypeId<QgsProperty>() )
       processVariant( var.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
-    else if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+    else if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
     {
       // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
       const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
       const QVariant sink = fromVar.sink;
-      if ( sink.userType() == QMetaType::type( "QgsProperty" ) )
+      if ( sink.userType() == qMetaTypeId<QgsProperty>() )
       {
         processVariant( sink.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
       }
@@ -1881,7 +1881,7 @@ QStringList QgsProcessingParameters::parameterAsFileList( const QgsProcessingPar
         processVariant( s );
       }
     }
-    else if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+    else if ( var.userType() == qMetaTypeId<QgsProperty>() )
       processVariant( var.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
     else
     {
@@ -1923,7 +1923,7 @@ QList<double> QgsProcessingParameters::parameterAsRange( const QgsProcessingPara
   QStringList resultStringList;
   const QVariant val = value;
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     resultStringList << val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else if ( val.userType() == QMetaType::Type::QVariantList )
   {
@@ -2003,7 +2003,7 @@ QStringList QgsProcessingParameters::parameterAsStrings( const QgsProcessingPara
   const QVariant val = value;
   if ( val.isValid() )
   {
-    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( val.userType() == qMetaTypeId<QgsProperty>() )
       resultStringList << val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
     else if ( val.userType() == QMetaType::Type::QVariantList )
     {
@@ -2107,7 +2107,7 @@ QColor QgsProcessingParameters::parameterAsColor( const QgsProcessingParameterDe
     return QColor();
 
   QVariant val = value;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
   {
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
   }
@@ -2505,7 +2505,7 @@ QString QgsProcessingParameterDefinition::valueAsPythonString( const QVariant &v
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -2564,7 +2564,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
         break;
     }
 
-    if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( value.userType() == qMetaTypeId<QgsProperty>() )
     {
       const QgsProperty prop = value.value< QgsProperty >();
       switch ( prop.propertyType() )
@@ -2581,7 +2581,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
     }
 
     // value may be a CRS
-    if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+    if ( value.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
     {
       const QgsCoordinateReferenceSystem crs = value.value< QgsCoordinateReferenceSystem >();
       if ( !crs.isValid() )
@@ -2591,7 +2591,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
       else
         return crs.toWkt( Qgis::CrsWktVariant::Preferred );
     }
-    else if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
+    else if ( value.userType() == qMetaTypeId<QgsRectangle>() )
     {
       const QgsRectangle r = value.value<QgsRectangle>();
       return QStringLiteral( "%1, %3, %2, %4" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -2599,7 +2599,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
              qgsDoubleToString( r.xMaximum() ),
              qgsDoubleToString( r.yMaximum() ) );
     }
-    else if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+    else if ( value.userType() == qMetaTypeId<QgsReferencedRectangle>() )
     {
       const QgsReferencedRectangle r = value.value<QgsReferencedRectangle>();
       return QStringLiteral( "%1, %3, %2, %4 [%5]" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -2608,7 +2608,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
              qgsDoubleToString( r.yMaximum() ),
              r.crs().authid() );
     }
-    else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+    else if ( value.userType() == qMetaTypeId< QgsGeometry>() )
     {
       const QgsGeometry g = value.value<QgsGeometry>();
       if ( !g.isNull() )
@@ -2620,7 +2620,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
         return QString();
       }
     }
-    else if ( value.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+    else if ( value.userType() == qMetaTypeId<QgsReferencedGeometry>() )
     {
       const QgsReferencedGeometry g = value.value<QgsReferencedGeometry>();
       if ( !g.isNull() )
@@ -2635,32 +2635,32 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
         return QString();
       }
     }
-    else if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
+    else if ( value.userType() == qMetaTypeId<QgsPointXY>() )
     {
       const QgsPointXY r = value.value<QgsPointXY>();
       return QStringLiteral( "%1,%2" ).arg( qgsDoubleToString( r.x() ),
                                             qgsDoubleToString( r.y() ) );
     }
-    else if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+    else if ( value.userType() == qMetaTypeId<QgsReferencedPointXY>() )
     {
       const QgsReferencedPointXY r = value.value<QgsReferencedPointXY>();
       return QStringLiteral( "%1,%2 [%3]" ).arg( qgsDoubleToString( r.x() ),
              qgsDoubleToString( r.y() ),
              r.crs().authid() );
     }
-    else if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+    else if ( value.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
     {
       const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( value );
 
       // TODO -- we could consider also serializating the additional properties like invalid feature handling, limits, etc
       return valueAsJsonObject( fromVar.source, context );
     }
-    else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+    else if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
     {
       const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
       return valueAsJsonObject( fromVar.sink, context );
     }
-    else if ( value.userType() == QMetaType::type( "QColor" ) )
+    else if ( value.userType() == qMetaTypeId<QColor>() )
     {
       const QColor fromVar = value.value< QColor >();
       if ( !fromVar.isValid() )
@@ -2668,7 +2668,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
 
       return QStringLiteral( "rgba( %1, %2, %3, %4 )" ).arg( fromVar.red() ).arg( fromVar.green() ).arg( fromVar.blue() ).arg( QString::number( fromVar.alphaF(), 'f', 2 ) );
     }
-    else if ( value.userType() == QMetaType::type( "QDateTime" ) )
+    else if ( value.userType() == qMetaTypeId<QDateTime>() )
     {
       const QDateTime fromVar = value.toDateTime();
       if ( !fromVar.isValid() )
@@ -2676,7 +2676,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
 
       return fromVar.toString( Qt::ISODate );
     }
-    else if ( value.userType() == QMetaType::type( "QDate" ) )
+    else if ( value.userType() == qMetaTypeId<QDate>() )
     {
       const QDate fromVar = value.toDate();
       if ( !fromVar.isValid() )
@@ -2684,7 +2684,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
 
       return fromVar.toString( Qt::ISODate );
     }
-    else if ( value.userType() == QMetaType::type( "QTime" ) )
+    else if ( value.userType() == qMetaTypeId<QTime>() )
     {
       const QTime fromVar = value.toTime();
       if ( !fromVar.isValid() )
@@ -2745,7 +2745,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
       break;
   }
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty prop = value.value< QgsProperty >();
     switch ( prop.propertyType() )
@@ -2762,7 +2762,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
   }
 
   // value may be a CRS
-  if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+  if ( value.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
   {
     const QgsCoordinateReferenceSystem crs = value.value< QgsCoordinateReferenceSystem >();
     if ( !crs.isValid() )
@@ -2772,7 +2772,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
     else
       return crs.toWkt( Qgis::CrsWktVariant::Preferred );
   }
-  else if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
+  else if ( value.userType() == qMetaTypeId<QgsRectangle>() )
   {
     const QgsRectangle r = value.value<QgsRectangle>();
     return QStringLiteral( "%1, %3, %2, %4" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -2780,7 +2780,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ) );
   }
-  else if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  else if ( value.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle r = value.value<QgsReferencedRectangle>();
     return QStringLiteral( "%1, %3, %2, %4 [%5]" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -2788,7 +2788,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ), r.crs().authid() );
   }
-  else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+  else if ( value.userType() == qMetaTypeId< QgsGeometry>() )
   {
     const QgsGeometry g = value.value<QgsGeometry>();
     if ( !g.isNull() )
@@ -2800,7 +2800,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
       return QString();
     }
   }
-  else if ( value.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  else if ( value.userType() == qMetaTypeId<QgsReferencedGeometry>() )
   {
     const QgsReferencedGeometry g = value.value<QgsReferencedGeometry>();
     if ( !g.isNull() )
@@ -2815,30 +2815,30 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
       return QString();
     }
   }
-  else if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
+  else if ( value.userType() == qMetaTypeId<QgsPointXY>() )
   {
     const QgsPointXY r = value.value<QgsPointXY>();
     return QStringLiteral( "%1,%2" ).arg( qgsDoubleToString( r.x() ),
                                           qgsDoubleToString( r.y() ) );
   }
-  else if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  else if ( value.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     const QgsReferencedPointXY r = value.value<QgsReferencedPointXY>();
     return QStringLiteral( "%1,%2 [%3]" ).arg( qgsDoubleToString( r.x() ),
            qgsDoubleToString( r.y() ),
            r.crs().authid() );
   }
-  else if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  else if ( value.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( value );
     return valueAsString( fromVar.source, context, ok );
   }
-  else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     return valueAsString( fromVar.sink, context, ok );
   }
-  else if ( value.userType() == QMetaType::type( "QColor" ) )
+  else if ( value.userType() == qMetaTypeId<QColor>() )
   {
     const QColor fromVar = value.value< QColor >();
     if ( !fromVar.isValid() )
@@ -2846,7 +2846,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
 
     return QStringLiteral( "rgba( %1, %2, %3, %4 )" ).arg( fromVar.red() ).arg( fromVar.green() ).arg( fromVar.blue() ).arg( QString::number( fromVar.alphaF(), 'f', 2 ) );
   }
-  else if ( value.userType() == QMetaType::type( "QDateTime" ) )
+  else if ( value.userType() == qMetaTypeId<QDateTime>() )
   {
     const QDateTime fromVar = value.toDateTime();
     if ( !fromVar.isValid() )
@@ -2854,7 +2854,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
 
     return fromVar.toString( Qt::ISODate );
   }
-  else if ( value.userType() == QMetaType::type( "QDate" ) )
+  else if ( value.userType() == qMetaTypeId<QDate>() )
   {
     const QDate fromVar = value.toDate();
     if ( !fromVar.isValid() )
@@ -2862,7 +2862,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
 
     return fromVar.toString( Qt::ISODate );
   }
-  else if ( value.userType() == QMetaType::type( "QTime" ) )
+  else if ( value.userType() == qMetaTypeId<QTime>() )
   {
     const QTime fromVar = value.toTime();
     if ( !fromVar.isValid() )
@@ -3018,7 +3018,7 @@ QString QgsProcessingParameterBoolean::valueAsPythonString( const QVariant &val,
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
   return val.toBool() ? QStringLiteral( "True" ) : QStringLiteral( "False" );
 }
@@ -3060,20 +3060,20 @@ bool QgsProcessingParameterCrs::checkValueIsAcceptable( const QVariant &v, QgsPr
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+  if ( input.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
   {
     return true;
   }
-  else if ( input.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  else if ( input.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     return true;
   }
-  else if ( input.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( input.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     return true;
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -3104,7 +3104,7 @@ QString QgsProcessingParameterCrs::valueAsPythonString( const QVariant &value, Q
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+  if ( value.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
   {
     if ( !value.value< QgsCoordinateReferenceSystem >().isValid() )
       return QStringLiteral( "QgsCoordinateReferenceSystem()" );
@@ -3112,7 +3112,7 @@ QString QgsProcessingParameterCrs::valueAsPythonString( const QVariant &value, Q
       return QStringLiteral( "QgsCoordinateReferenceSystem('%1')" ).arg( value.value< QgsCoordinateReferenceSystem >().authid() );
   }
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.type() == QVariant::String )
@@ -3196,7 +3196,7 @@ bool QgsProcessingParameterMapLayer::checkValueIsAcceptable( const QVariant &v, 
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -3227,7 +3227,7 @@ QString QgsProcessingParameterMapLayer::valueAsPythonString( const QVariant &val
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -3480,30 +3480,30 @@ bool QgsProcessingParameterExtent::checkValueIsAcceptable( const QVariant &v, Qg
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( input.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     return true;
   }
-  else if ( input.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
-  {
-    return true;
-  }
-
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  else if ( input.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     return true;
   }
 
-  if ( input.userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
+  {
+    return true;
+  }
+
+  if ( input.userType() == qMetaTypeId<QgsRectangle>() )
   {
     const QgsRectangle r = input.value<QgsRectangle>();
     return !r.isNull();
   }
-  if ( input.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( input.userType() == qMetaTypeId< QgsGeometry>() )
   {
     return true;
   }
-  if ( input.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( input.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle r = input.value<QgsReferencedRectangle>();
     return !r.isNull();
@@ -3557,10 +3557,10 @@ QString QgsProcessingParameterExtent::valueAsPythonString( const QVariant &value
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( value.userType() == qMetaTypeId<QgsRectangle>() )
   {
     const QgsRectangle r = value.value<QgsRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -3568,7 +3568,7 @@ QString QgsProcessingParameterExtent::valueAsPythonString( const QVariant &value
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ) );
   }
-  else if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  else if ( value.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedRectangle r = value.value<QgsReferencedRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4 [%5]'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -3576,7 +3576,7 @@ QString QgsProcessingParameterExtent::valueAsPythonString( const QVariant &value
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ),                                                                                                                             r.crs().authid() );
   }
-  else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+  else if ( value.userType() == qMetaTypeId< QgsGeometry>() )
   {
     const QgsGeometry g = value.value<QgsGeometry>();
     if ( !g.isNull() )
@@ -3646,20 +3646,20 @@ bool QgsProcessingParameterPoint::checkValueIsAcceptable( const QVariant &v, Qgs
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
 
-  if ( input.userType() == QMetaType::type( "QgsPointXY" ) )
+  if ( input.userType() == qMetaTypeId<QgsPointXY>() )
   {
     return true;
   }
-  if ( input.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  if ( input.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     return true;
   }
-  if ( input.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( input.userType() == qMetaTypeId< QgsGeometry>() )
   {
     return true;
   }
@@ -3690,23 +3690,23 @@ QString QgsProcessingParameterPoint::valueAsPythonString( const QVariant &value,
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
+  if ( value.userType() == qMetaTypeId<QgsPointXY>() )
   {
     const QgsPointXY r = value.value<QgsPointXY>();
     return QStringLiteral( "'%1,%2'" ).arg( qgsDoubleToString( r.x() ),
                                             qgsDoubleToString( r.y() ) );
   }
-  else if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  else if ( value.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     const QgsReferencedPointXY r = value.value<QgsReferencedPointXY>();
     return QStringLiteral( "'%1,%2 [%3]'" ).arg( qgsDoubleToString( r.x() ),
            qgsDoubleToString( r.y() ),
            r.crs().authid() );
   }
-  else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+  else if ( value.userType() == qMetaTypeId< QgsGeometry>() )
   {
     const QgsGeometry g = value.value<QgsGeometry>();
     if ( !g.isNull() )
@@ -3749,41 +3749,41 @@ bool QgsProcessingParameterGeometry::checkValueIsAcceptable( const QVariant &v, 
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
 
   const bool anyTypeAllowed = mGeomTypes.isEmpty() || mGeomTypes.contains( static_cast< int >( Qgis::GeometryType::Unknown ) );
 
-  if ( input.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( input.userType() == qMetaTypeId< QgsGeometry>() )
   {
     return ( anyTypeAllowed || mGeomTypes.contains( static_cast< int >( input.value<QgsGeometry>().type() ) ) ) &&
            ( mAllowMultipart || !input.value<QgsGeometry>().isMultipart() );
   }
 
-  if ( input.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  if ( input.userType() == qMetaTypeId<QgsReferencedGeometry>() )
   {
     return ( anyTypeAllowed || mGeomTypes.contains( static_cast<int>( input.value<QgsReferencedGeometry>().type() ) ) ) &&
            ( mAllowMultipart || !input.value<QgsReferencedGeometry>().isMultipart() );
   }
 
-  if ( input.userType() == QMetaType::type( "QgsPointXY" ) )
+  if ( input.userType() == qMetaTypeId<QgsPointXY>() )
   {
     return anyTypeAllowed || mGeomTypes.contains( static_cast< int >( Qgis::GeometryType::Point ) );
   }
 
-  if ( input.userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( input.userType() == qMetaTypeId<QgsRectangle>() )
   {
     return anyTypeAllowed || mGeomTypes.contains( static_cast< int >( Qgis::GeometryType::Polygon ) );
   }
 
-  if ( input.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  if ( input.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     return anyTypeAllowed || mGeomTypes.contains( static_cast< int >( Qgis::GeometryType::Point ) );
   }
 
-  if ( input.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( input.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     return anyTypeAllowed || mGeomTypes.contains( static_cast< int >( Qgis::GeometryType::Polygon ) );
   }
@@ -3826,45 +3826,45 @@ QString QgsProcessingParameterGeometry::valueAsPythonString( const QVariant &val
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression(%1)" ).arg( QgsProcessingUtils::stringToPythonLiteral( value.value< QgsProperty >().asExpression() ) );
 
-  if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+  if ( value.userType() == qMetaTypeId< QgsGeometry>() )
   {
     const QgsGeometry g = value.value<QgsGeometry>();
     if ( !g.isNull() )
       return asPythonString( g );
   }
 
-  if ( value.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  if ( value.userType() == qMetaTypeId<QgsReferencedGeometry>() )
   {
     const QgsReferencedGeometry g = value.value<QgsReferencedGeometry>();
     if ( !g.isNull() )
       return asPythonString( g, g.crs() );
   }
 
-  if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
+  if ( value.userType() == qMetaTypeId<QgsPointXY>() )
   {
     const QgsGeometry g = QgsGeometry::fromPointXY( value.value<QgsPointXY>() );
     if ( !g.isNull() )
       return asPythonString( g );
   }
 
-  if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  if ( value.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     const QgsReferencedGeometry g = QgsReferencedGeometry::fromReferencedPointXY( value.value<QgsReferencedPointXY>() );
     if ( !g.isNull() )
       return asPythonString( g, g.crs() );
   }
 
-  if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( value.userType() == qMetaTypeId<QgsRectangle>() )
   {
     const QgsGeometry g = QgsGeometry::fromRect( value.value<QgsRectangle>() );
     if ( !g.isNull() )
       return asPythonString( g );
   }
 
-  if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  if ( value.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     const QgsReferencedGeometry g = QgsReferencedGeometry::fromReferencedRect( value.value<QgsReferencedRectangle>() );
     if ( !g.isNull() )
@@ -4020,7 +4020,7 @@ bool QgsProcessingParameterFile::checkValueIsAcceptable( const QVariant &v, QgsP
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -4198,7 +4198,7 @@ QString QgsProcessingParameterMatrix::valueAsPythonString( const QVariant &value
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -4390,7 +4390,7 @@ QString QgsProcessingParameterMultipleLayers::valueAsPythonString( const QVarian
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( mLayerType == Qgis::ProcessingSourceType::File )
@@ -4624,7 +4624,7 @@ bool QgsProcessingParameterNumber::checkValueIsAcceptable( const QVariant &value
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -4642,7 +4642,7 @@ QString QgsProcessingParameterNumber::valueAsPythonString( const QVariant &value
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return value.toString();
@@ -4766,7 +4766,7 @@ bool QgsProcessingParameterRange::checkValueIsAcceptable( const QVariant &v, Qgs
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -4806,7 +4806,7 @@ QString QgsProcessingParameterRange::valueAsPythonString( const QVariant &value,
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -4895,7 +4895,7 @@ bool QgsProcessingParameterRasterLayer::checkValueIsAcceptable( const QVariant &
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -4924,7 +4924,7 @@ QString QgsProcessingParameterRasterLayer::valueAsPythonString( const QVariant &
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -4979,7 +4979,7 @@ bool QgsProcessingParameterEnum::checkValueIsAcceptable( const QVariant &value, 
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -5098,7 +5098,7 @@ QString QgsProcessingParameterEnum::valueAsPythonString( const QVariant &value, 
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( mUsesStaticStrings )
@@ -5159,7 +5159,7 @@ QString QgsProcessingParameterEnum::valueAsPythonComment( const QVariant &value,
   if ( !value.isValid() )
     return QString();
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QString();
 
   if ( mUsesStaticStrings )
@@ -5345,7 +5345,7 @@ QString QgsProcessingParameterString::valueAsPythonString( const QVariant &value
   if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -5506,7 +5506,7 @@ QString QgsProcessingParameterExpression::valueAsPythonString( const QVariant &v
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -5621,7 +5621,7 @@ bool QgsProcessingParameterVectorLayer::checkValueIsAcceptable( const QVariant &
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -5658,7 +5658,7 @@ QString QgsProcessingParameterVectorLayer::valueAsPythonString( const QVariant &
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -5773,7 +5773,7 @@ bool QgsProcessingParameterMeshLayer::checkValueIsAcceptable( const QVariant &v,
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -5810,7 +5810,7 @@ QString QgsProcessingParameterMeshLayer::valueAsPythonString( const QVariant &va
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -5867,7 +5867,7 @@ bool QgsProcessingParameterField::checkValueIsAcceptable( const QVariant &v, Qgs
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -5902,7 +5902,7 @@ QString QgsProcessingParameterField::valueAsPythonString( const QVariant &value,
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.userType() == QMetaType::Type::QVariantList )
@@ -6183,19 +6183,19 @@ bool QgsProcessingParameterFeatureSource::checkValueIsAcceptable( const QVariant
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( var.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( var );
     var = fromVar.source;
   }
-  else if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -6233,10 +6233,10 @@ QString QgsProcessingParameterFeatureSource::valueAsPythonString( const QVariant
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression(%1)" ).arg( QgsProcessingUtils::stringToPythonLiteral( value.value< QgsProperty >().asExpression() ) );
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( value );
     QString geometryCheckString;
@@ -6475,13 +6475,13 @@ bool QgsProcessingParameterFeatureSink::checkValueIsAcceptable( const QVariant &
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -6508,10 +6508,10 @@ QString QgsProcessingParameterFeatureSink::valueAsPythonString( const QVariant &
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == Qgis::PropertyType::Static )
@@ -6764,13 +6764,13 @@ bool QgsProcessingParameterRasterDestination::checkValueIsAcceptable( const QVar
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -6797,10 +6797,10 @@ QString QgsProcessingParameterRasterDestination::valueAsPythonString( const QVar
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == Qgis::PropertyType::Static )
@@ -6893,13 +6893,13 @@ bool QgsProcessingParameterFileDestination::checkValueIsAcceptable( const QVaria
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -6928,10 +6928,10 @@ QString QgsProcessingParameterFileDestination::valueAsPythonString( const QVaria
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == Qgis::PropertyType::Static )
@@ -7051,7 +7051,7 @@ bool QgsProcessingParameterFolderDestination::checkValueIsAcceptable( const QVar
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -7204,13 +7204,13 @@ bool QgsProcessingParameterVectorDestination::checkValueIsAcceptable( const QVar
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -7237,10 +7237,10 @@ QString QgsProcessingParameterVectorDestination::valueAsPythonString( const QVar
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == Qgis::PropertyType::Static )
@@ -7464,7 +7464,7 @@ bool QgsProcessingParameterBand::checkValueIsAcceptable( const QVariant &value, 
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -7503,7 +7503,7 @@ QString QgsProcessingParameterBand::valueAsPythonString( const QVariant &value, 
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.userType() == QMetaType::Type::QVariantList )
@@ -7831,7 +7831,7 @@ QString QgsProcessingParameterLayout::valueAsPythonString( const QVariant &value
   if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -7906,7 +7906,7 @@ QString QgsProcessingParameterLayoutItem::valueAsPythonString( const QVariant &v
   if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -8039,7 +8039,7 @@ QString QgsProcessingParameterColor::valueAsPythonString( const QVariant &value,
   if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.canConvert< QColor >() && !value.value< QColor >().isValid() )
@@ -8105,7 +8105,7 @@ bool QgsProcessingParameterColor::checkValueIsAcceptable( const QVariant &input,
   {
     return true;
   }
-  else if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  else if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -8192,7 +8192,7 @@ QString QgsProcessingParameterCoordinateOperation::valueAsPythonStringPrivate( c
   if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
-  if ( allowNonStringValues && value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+  if ( allowNonStringValues && value.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
   {
     if ( !value.value< QgsCoordinateReferenceSystem >().isValid() )
       return QStringLiteral( "QgsCoordinateReferenceSystem()" );
@@ -8200,7 +8200,7 @@ QString QgsProcessingParameterCoordinateOperation::valueAsPythonStringPrivate( c
       return QStringLiteral( "QgsCoordinateReferenceSystem('%1')" ).arg( value.value< QgsCoordinateReferenceSystem >().authid() );
   }
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( allowNonStringValues )
@@ -8343,7 +8343,7 @@ QString QgsProcessingParameterMapTheme::valueAsPythonString( const QVariant &val
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -8441,7 +8441,7 @@ bool QgsProcessingParameterDateTime::checkValueIsAcceptable( const QVariant &val
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -8485,7 +8485,7 @@ QString QgsProcessingParameterDateTime::valueAsPythonString( const QVariant &val
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.userType() == QMetaType::Type::QDateTime )
@@ -8659,7 +8659,7 @@ QString QgsProcessingParameterProviderConnection::valueAsPythonString( const QVa
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -8774,7 +8774,7 @@ QString QgsProcessingParameterDatabaseSchema::valueAsPythonString( const QVarian
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -8908,7 +8908,7 @@ QString QgsProcessingParameterDatabaseTable::valueAsPythonString( const QVariant
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -9062,7 +9062,7 @@ bool QgsProcessingParameterPointCloudLayer::checkValueIsAcceptable( const QVaria
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -9099,7 +9099,7 @@ QString QgsProcessingParameterPointCloudLayer::valueAsPythonString( const QVaria
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -9155,7 +9155,7 @@ bool QgsProcessingParameterAnnotationLayer::checkValueIsAcceptable( const QVaria
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -9192,7 +9192,7 @@ QString QgsProcessingParameterAnnotationLayer::valueAsPythonString( const QVaria
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -9238,13 +9238,13 @@ bool QgsProcessingParameterPointCloudDestination::checkValueIsAcceptable( const 
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -9271,10 +9271,10 @@ QString QgsProcessingParameterPointCloudDestination::valueAsPythonString( const 
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == Qgis::PropertyType::Static )
@@ -9372,7 +9372,7 @@ bool QgsProcessingParameterPointCloudAttribute::checkValueIsAcceptable( const QV
     input = defaultValue();
   }
 
-  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     return true;
   }
@@ -9407,7 +9407,7 @@ QString QgsProcessingParameterPointCloudAttribute::valueAsPythonString( const QV
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.userType() == QMetaType::Type::QVariantList )
@@ -9596,13 +9596,13 @@ bool QgsProcessingParameterVectorTileDestination::checkValueIsAcceptable( const 
     var = defaultValue();
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( var.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( var.userType() == qMetaTypeId<QgsProperty>() )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == Qgis::PropertyType::Static )
@@ -9629,10 +9629,10 @@ QString QgsProcessingParameterVectorTileDestination::valueAsPythonString( const 
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == Qgis::PropertyType::Static )

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -553,7 +553,7 @@ QgsProcessingFeatureSource *QgsProcessingUtils::variantToSource( const QVariant 
   QString filterExpression;
   bool overrideGeometryCheck = false;
   Qgis::InvalidGeometryCheck geometryCheck = Qgis::InvalidGeometryCheck::AbortOnInvalid;
-  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
@@ -564,7 +564,7 @@ QgsProcessingFeatureSource *QgsProcessingUtils::variantToSource( const QVariant 
     overrideGeometryCheck = fromVar.flags & Qgis::ProcessingFeatureSourceDefinitionFlag::OverrideDefaultGeometryCheck;
     geometryCheck = fromVar.geometryCheck;
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition (e.g. an output from earlier in a model) - get extra properties from it
     QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -580,7 +580,7 @@ QgsProcessingFeatureSource *QgsProcessingUtils::variantToSource( const QVariant 
   }
 
   QString layerRef;
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
   {
     layerRef = val.value< QgsProperty >().valueAsString( context.expressionContext(), fallbackValue.toString() );
   }
@@ -628,25 +628,25 @@ QgsCoordinateReferenceSystem QgsProcessingUtils::variantToCrs( const QVariant &v
 {
   QVariant val = value;
 
-  if ( val.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+  if ( val.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
   {
     // input is a QgsCoordinateReferenceSystem - done!
     return val.value< QgsCoordinateReferenceSystem >();
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  else if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() && val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -655,7 +655,7 @@ QgsCoordinateReferenceSystem QgsProcessingUtils::variantToCrs( const QVariant &v
   if ( QgsMapLayer *layer = qobject_cast< QgsMapLayer * >( qvariant_cast<QObject *>( val ) ) )
     return layer->crs();
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
     val = val.value< QgsProperty >().valueAsString( context.expressionContext(), fallbackValue.toString() );
 
   if ( !val.isValid() )
@@ -768,16 +768,16 @@ QString QgsProcessingUtils::variantToPythonLiteral( const QVariant &value )
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( value.userType() == qMetaTypeId<QgsProperty>() )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
-  else if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+  else if ( value.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
   {
     if ( !value.value< QgsCoordinateReferenceSystem >().isValid() )
       return QStringLiteral( "QgsCoordinateReferenceSystem()" );
     else
       return QStringLiteral( "QgsCoordinateReferenceSystem('%1')" ).arg( value.value< QgsCoordinateReferenceSystem >().authid() );
   }
-  else if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
+  else if ( value.userType() == qMetaTypeId<QgsRectangle>() )
   {
     QgsRectangle r = value.value<QgsRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -785,7 +785,7 @@ QString QgsProcessingUtils::variantToPythonLiteral( const QVariant &value )
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ) );
   }
-  else if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
+  else if ( value.userType() == qMetaTypeId<QgsReferencedRectangle>() )
   {
     QgsReferencedRectangle r = value.value<QgsReferencedRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4 [%5]'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -793,13 +793,13 @@ QString QgsProcessingUtils::variantToPythonLiteral( const QVariant &value )
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ),                                                                                                                             r.crs().authid() );
   }
-  else if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
+  else if ( value.userType() == qMetaTypeId<QgsPointXY>() )
   {
     QgsPointXY r = value.value<QgsPointXY>();
     return QStringLiteral( "'%1,%2'" ).arg( qgsDoubleToString( r.x() ),
                                             qgsDoubleToString( r.y() ) );
   }
-  else if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
+  else if ( value.userType() == qMetaTypeId<QgsReferencedPointXY>() )
   {
     QgsReferencedPointXY r = value.value<QgsReferencedPointXY>();
     return QStringLiteral( "'%1,%2 [%3]'" ).arg( qgsDoubleToString( r.x() ),
@@ -1206,14 +1206,14 @@ QVariant QgsProcessingUtils::generateIteratingDestination( const QVariant &input
   if ( !input.isValid() )
     return QStringLiteral( "memory:%1" ).arg( id.toString() );
 
-  if ( input.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+  if ( input.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
   {
     QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( input );
     QVariant newSink = generateIteratingDestination( fromVar.sink, id, context );
     fromVar.sink = QgsProperty::fromValue( newSink );
     return fromVar;
   }
-  else if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  else if ( input.userType() == qMetaTypeId<QgsProperty>() )
   {
     QString res = input.value< QgsProperty>().valueAsString( context.expressionContext() );
     return generateIteratingDestination( res, id, context );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1464,7 +1464,7 @@ bool QgsOgrProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::C
     // stricter check
     return mDefaultValues.contains( fieldIndex ) && !QgsVariantUtils::isNull( value ) && (
              mDefaultValues.value( fieldIndex ) == value.toString()
-             || value.userType() == QMetaType::type( "QgsUnsetAttributeValue" ) );
+             || value.userType() == qMetaTypeId<QgsUnsetAttributeValue>() );
   }
 }
 

--- a/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
@@ -534,7 +534,7 @@ QString QgsSensorThingsProviderMetadata::encodeUri( const QVariantMap &parts ) c
     dsUri.setWkbType( Qgis::WkbType::MultiPolygonZ );
   }
 
-  if ( parts.contains( QStringLiteral( "bounds" ) ) && parts.value( QStringLiteral( "bounds" ) ).userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( parts.contains( QStringLiteral( "bounds" ) ) && parts.value( QStringLiteral( "bounds" ) ).userType() == qMetaTypeId<QgsRectangle>() )
   {
     const QgsRectangle bBox = parts.value( QStringLiteral( "bounds" ) ).value< QgsRectangle >();
     dsUri.setParam( QStringLiteral( "bbox" ), QStringLiteral( "%1,%2,%3,%4" ).arg( bBox.xMinimum() ).arg( bBox.yMinimum() ).arg( bBox.xMaximum() ).arg( bBox.yMaximum() ) );

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -874,7 +874,7 @@ QVariant QgsAggregateCalculator::calculateGeometryAggregate( QgsFeatureIterator 
     Q_ASSERT( context );
     context->setFeature( f );
     const QVariant v = expression->evaluate( context );
-    if ( v.userType() == QMetaType::type( "QgsGeometry" ) )
+    if ( v.userType() == qMetaTypeId< QgsGeometry>() )
     {
       geometries << v.value<QgsGeometry>();
     }

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -31,6 +31,7 @@
 
 
 #include "qgsfields.h"
+#include "qgsunsetattributevalue.h"
 #include "qgsvariantutils.h"
 
 
@@ -131,7 +132,7 @@ class QgsAttributes : public QVector<QVariant>
       if ( index < 0 || index >= size() )
         return false;
 
-      return at( index ).userType() == QMetaType::type( "QgsUnsetAttributeValue" );
+      return at( index ).userType() == qMetaTypeId<QgsUnsetAttributeValue>();
     }
 
     inline bool operator!=( const QgsAttributes &v ) const { return !( *this == v ); }

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -315,7 +315,7 @@ bool QgsFeature::isUnsetValue( int fieldIdx ) const
   if ( fieldIdx < 0 || fieldIdx >= d->attributes.count() )
     return false;
 
-  return d->attributes.at( fieldIdx ).userType() == QMetaType::type( "QgsUnsetAttributeValue" );
+  return d->attributes.at( fieldIdx ).userType() == qMetaTypeId<QgsUnsetAttributeValue>();
 }
 
 const QgsSymbol *QgsFeature::embeddedSymbol() const

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -320,7 +320,7 @@ QString QgsField::displayString( const QVariant &v ) const
     return QgsApplication::nullRepresentation();
   }
 
-  if ( v.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  if ( v.userType() == qMetaTypeId<QgsReferencedGeometry>() )
   {
     QgsReferencedGeometry geom = qvariant_cast<QgsReferencedGeometry>( v );
     if ( geom.isNull() )
@@ -662,7 +662,7 @@ bool QgsField::convertCompatible( QVariant &v, QString *errorMessage ) const
   }
 
   // Handle referenced geometries (e.g. from additional geometry fields)
-  if ( d->type == QMetaType::Type::QString && v.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  if ( d->type == QMetaType::Type::QString && v.userType() == qMetaTypeId<QgsReferencedGeometry>() )
   {
     const QgsReferencedGeometry geom { v.value<QgsReferencedGeometry>( ) };
     if ( geom.isNull() )
@@ -677,7 +677,7 @@ bool QgsField::convertCompatible( QVariant &v, QString *errorMessage ) const
   }
   else if ( d->type == QMetaType::Type::User && d->typeName.compare( QLatin1String( "geometry" ), Qt::CaseInsensitive ) == 0 )
   {
-    if ( v.userType() == QMetaType::type( "QgsReferencedGeometry" ) || v.userType() == QMetaType::type( "QgsGeometry" ) )
+    if ( v.userType() == qMetaTypeId<QgsReferencedGeometry>() || v.userType() == qMetaTypeId< QgsGeometry>() )
     {
       return true;
     }

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2452,7 +2452,7 @@ QDomElement QgsOgcUtilsExprToFilter::expressionFunctionToOgcFilter( const QgsExp
       const QDomNode geomNode = mDoc.importNode( geomDoc.documentElement(), true );
       otherGeomElem = geomNode.toElement();
     }
-    else if ( otherNode->hasCachedStaticValue() && otherNode->cachedStaticValue().userType() == QMetaType::type( "QgsGeometry" ) )
+    else if ( otherNode->hasCachedStaticValue() && otherNode->cachedStaticValue().userType() == qMetaTypeId< QgsGeometry>() )
     {
       QgsGeometry geom = otherNode->cachedStaticValue().value<QgsGeometry>();
       otherGeomElem = QgsOgcUtils::geometryToGML( geom, mDoc, mGMLVersion, mSrsName, mInvertAxisOrientation,

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -232,42 +232,42 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
 
     default:
 
-      if ( value.userType() == QMetaType::type( "QgsProperty" ) )
+      if ( value.userType() == qMetaTypeId<QgsProperty>() )
       {
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProperty" ) );
         const QDomElement propertyElem = QgsXmlUtils::writeVariant( value.value< QgsProperty >().toVariant(), doc );
         element.appendChild( propertyElem );
         break;
       }
-      else if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
+      else if ( value.userType() == qMetaTypeId<QgsCoordinateReferenceSystem>() )
       {
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsCoordinateReferenceSystem" ) );
         const QgsCoordinateReferenceSystem crs = value.value< QgsCoordinateReferenceSystem >();
         crs.writeXml( element, doc );
         break;
       }
-      else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+      else if ( value.userType() == qMetaTypeId< QgsGeometry>() )
       {
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsGeometry" ) );
         const QgsGeometry geom = value.value< QgsGeometry >();
         element.setAttribute( QStringLiteral( "value" ), geom.asWkt() );
         break;
       }
-      else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+      else if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
       {
         const QDomElement valueElement = writeVariant( value.value< QgsProcessingOutputLayerDefinition >().toVariant(), doc );
         element.appendChild( valueElement );
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProcessingOutputLayerDefinition" ) );
         break;
       }
-      else if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+      else if ( value.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
       {
         const QDomElement valueElement = writeVariant( value.value< QgsProcessingFeatureSourceDefinition >().toVariant(), doc );
         element.appendChild( valueElement );
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProcessingFeatureSourceDefinition" ) );
         break;
       }
-      else if ( value.userType() == QMetaType::type( "QgsRemappingSinkDefinition" ) )
+      else if ( value.userType() == qMetaTypeId<QgsRemappingSinkDefinition>() )
       {
         const QDomElement valueElement = writeVariant( value.value< QgsRemappingSinkDefinition >().toVariant(), doc );
         element.appendChild( valueElement );

--- a/src/gui/editorwidgets/qgsgeometrywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsgeometrywidgetwrapper.cpp
@@ -78,11 +78,11 @@ void QgsGeometryWidgetWrapper::updateValues( const QVariant &value, const QVaria
   QgsReferencedGeometry geom;
   if ( !QgsVariantUtils::isNull( value ) )
   {
-    if ( value.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+    if ( value.userType() == qMetaTypeId<QgsReferencedGeometry>() )
     {
       geom = value.value< QgsReferencedGeometry >();
     }
-    else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+    else if ( value.userType() == qMetaTypeId< QgsGeometry>() )
     {
       geom = QgsReferencedGeometry( value.value< QgsGeometry >(), QgsCoordinateReferenceSystem() );
     }

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -397,7 +397,7 @@ QList<QgsModelGraphicsScene::LinkSource> QgsModelGraphicsScene::linkSourcesForPa
     for ( const QString &v : list )
       res.append( linkSourcesForParameterValue( model, v, childId, context ) );
   }
-  else if ( value.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
+  else if ( value.userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>() )
   {
     const QgsProcessingModelChildParameterSource source = value.value< QgsProcessingModelChildParameterSource >();
     switch ( source.source() )

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -249,7 +249,7 @@ void QgsProcessingMapLayerComboBox::setValue( const QVariant &value, QgsProcessi
   bool found = false;
   bool selectedOnly = false;
   bool iterate = false;
-  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
@@ -268,7 +268,7 @@ void QgsProcessingMapLayerComboBox::setValue( const QVariant &value, QgsProcessi
     mGeometryCheck = Qgis::InvalidGeometryCheck::AbortOnInvalid;
   }
 
-  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( val.userType() == qMetaTypeId<QgsProperty>() )
   {
     if ( val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
     {

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -220,7 +220,7 @@ QVariant QgsProcessingModelerParameterWidget::value() const
         const QVariantList vList = v.toList();
         if ( std::all_of( vList.begin(), vList.end(), []( const QVariant & val )
       {
-        return val.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" );
+        return val.userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>();
         } ) )
         {
           return v;

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -44,7 +44,7 @@ QgsProcessingMultipleSelectionPanelWidget::QgsProcessingMultipleSelectionPanelWi
   : QgsPanelWidget( parent )
   , mValueFormatter( []( const QVariant & v )->QString
 {
-  if ( v.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
+  if ( v.userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>() )
     return v.value< QgsProcessingModelChildParameterSource >().staticValue().toString();
   else
     return v.toString();
@@ -108,7 +108,7 @@ QVariantList QgsProcessingMultipleSelectionPanelWidget::selectedOptions() const
     {
       const QVariant option = item->data( Qt::UserRole );
 
-      if ( option.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
+      if ( option.userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>() )
         hasModelSources = true;
 
       options << option;
@@ -122,7 +122,7 @@ QVariantList QgsProcessingMultipleSelectionPanelWidget::selectedOptions() const
     options.clear();
     for ( const QVariant &option : originalOptions )
     {
-      if ( option.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
+      if ( option.userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>() )
         options << option;
       else
         options << QVariant::fromValue( QgsProcessingModelChildParameterSource::fromStaticValue( option ) );
@@ -263,8 +263,8 @@ void QgsProcessingMultipleSelectionPanelWidget::addOption( const QVariant &value
   for ( int i = 0; i < mModel->rowCount(); ++i )
   {
     if ( mModel->item( i )->data( Qt::UserRole ) == value ||
-         ( mModel->item( i )->data( Qt::UserRole ).userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) &&
-           value.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) &&
+         ( mModel->item( i )->data( Qt::UserRole ).userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>() &&
+           value.userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>() &&
            mModel->item( i )->data( Qt::UserRole ).value< QgsProcessingModelChildParameterSource >() ==
            value.value< QgsProcessingModelChildParameterSource >() )
        )

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -97,7 +97,7 @@ void QgsProcessingLayerOutputDestinationWidget::setValue( const QVariant &value 
     {
       saveToTemporary();
     }
-    else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
+    else if ( value.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
     {
       const QgsProcessingOutputLayerDefinition def = value.value< QgsProcessingOutputLayerDefinition >();
       if ( def.sink.staticValue().toString() == QLatin1String( "memory:" ) || def.sink.staticValue().toString() == QgsProcessing::TEMPORARY_OUTPUT || def.sink.staticValue().toString().isEmpty() )
@@ -133,7 +133,7 @@ void QgsProcessingLayerOutputDestinationWidget::setValue( const QVariant &value 
       }
       else
       {
-        if ( prev.userType() != QMetaType::type( "QgsProcessingOutputLayerDefinition" ) ||
+        if ( prev.userType() != qMetaTypeId<QgsProcessingOutputLayerDefinition>() ||
              !( prev.value< QgsProcessingOutputLayerDefinition >() == QgsProcessingLayerOutputDestinationWidget::value().value< QgsProcessingOutputLayerDefinition >() ) )
           emit destinationChanged();
       }

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -184,7 +184,7 @@ const QgsProcessingParameterDefinition *QgsAbstractProcessingParameterWidgetWrap
 
 void QgsAbstractProcessingParameterWidgetWrapper::setParameterValue( const QVariant &value, QgsProcessingContext &context )
 {
-  if ( mPropertyButton && value.userType() == QMetaType::type( "QgsProperty" ) )
+  if ( mPropertyButton && value.userType() == qMetaTypeId<QgsProperty>() )
   {
     mPropertyButton->setToProperty( value.value< QgsProperty >() );
   }
@@ -332,7 +332,7 @@ void QgsAbstractProcessingParameterWidgetWrapper::setDynamicParentLayerParameter
     }
 
     QVariant val = parentWrapper->parameterValue();
-    if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+    if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
     {
       // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
       const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2409,7 +2409,7 @@ void QgsProcessingExpressionWidgetWrapper::setParentLayerWrapperValue( const Qgs
   {
     case Qgis::ExpressionType::Qgis:
     {
-      if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+      if ( val.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
       {
         // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
         QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
@@ -4733,7 +4733,7 @@ void QgsProcessingFieldWidgetWrapper::setParentLayerWrapperValue( const QgsAbstr
 
   QVariant value = parentWrapper->parameterValue();
 
-  if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
+  if ( value.userType() == qMetaTypeId<QgsProcessingFeatureSourceDefinition>() )
   {
     // input is a QgsProcessingFeatureSourceDefinition - source from it.
     // this is normally discouraged, and algorithms should NEVER do this -- but in this case we can make
@@ -7514,7 +7514,7 @@ void QgsProcessingMultipleLayerWidgetWrapper::setWidgetValue( const QVariant &va
 
     for ( const QVariant &v : value.toList() )
     {
-      if ( v.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
+      if ( v.userType() == qMetaTypeId<QgsProcessingModelChildParameterSource>() )
       {
         const QgsProcessingModelChildParameterSource source = v.value< QgsProcessingModelChildParameterSource >();
         opts << QVariant::fromValue( source );
@@ -7743,7 +7743,7 @@ void QgsProcessingAnnotationLayerWidgetWrapper::setWidgetValue( const QVariant &
     }
 
     QVariant val = value;
-    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
+    if ( val.userType() == qMetaTypeId<QgsProperty>() )
     {
       if ( val.value< QgsProperty >().propertyType() == Qgis::PropertyType::Static )
       {

--- a/src/gui/qgsdetaileditemdelegate.cpp
+++ b/src/gui/qgsdetaileditemdelegate.cpp
@@ -50,7 +50,7 @@ void QgsDetailedItemDelegate::paint( QPainter *thepPainter,
 {
   // After painting we need to restore the painter to its original state
   const QgsScopedQPainterState painterState( thepPainter );
-  if ( index.data( Qt::UserRole ).userType() == QMetaType::type( "QgsDetailedItemData" ) )
+  if ( index.data( Qt::UserRole ).userType() == qMetaTypeId<QgsDetailedItemData>() )
   {
     const QgsDetailedItemData myData =
       index.data( Qt::UserRole ).value<QgsDetailedItemData>();
@@ -71,7 +71,7 @@ QSize QgsDetailedItemDelegate::sizeHint(
   const QStyleOptionViewItem &option,
   const QModelIndex &index ) const
 {
-  if ( index.data( Qt::UserRole ).userType() == QMetaType::type( "QgsDetailedItemData" ) )
+  if ( index.data( Qt::UserRole ).userType() == qMetaTypeId<QgsDetailedItemData>() )
   {
     const QgsDetailedItemData myData =
       index.data( Qt::UserRole ).value<QgsDetailedItemData>();

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -313,7 +313,7 @@ void QgsFieldCalculator::accept()
       }
       else if ( updatingGeom )
       {
-        if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
+        if ( value.userType() == qMetaTypeId< QgsGeometry>() )
         {
           QgsGeometry geom = value.value< QgsGeometry >();
           mVectorLayer->changeGeometry( feature.id(), geom );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -797,7 +797,7 @@ QString QgsAfsProviderMetadata::encodeUri( const QVariantMap &parts ) const
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "url" ), parts.value( QStringLiteral( "url" ) ).toString() );
 
-  if ( parts.contains( QStringLiteral( "bounds" ) ) && parts.value( QStringLiteral( "bounds" ) ).userType() == QMetaType::type( "QgsRectangle" ) )
+  if ( parts.contains( QStringLiteral( "bounds" ) ) && parts.value( QStringLiteral( "bounds" ) ).userType() == qMetaTypeId<QgsRectangle>() )
   {
     const QgsRectangle bBox = parts.value( QStringLiteral( "bounds" ) ).value< QgsRectangle >();
     dsUri.setParam( QStringLiteral( "bbox" ), QStringLiteral( "%1,%2,%3,%4" ).arg( bBox.xMinimum() ).arg( bBox.yMinimum() ).arg( bBox.xMaximum() ).arg( bBox.yMaximum() ) );

--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -833,14 +833,14 @@ void qgisFunctionWrapper( sqlite3_context *ctxt, int nArgs, sqlite3_value **args
     }
     case QMetaType::Type::User:
     {
-      if ( ret.userType() == QMetaType::type( "QgsGeometry" ) )
+      if ( ret.userType() == qMetaTypeId< QgsGeometry>() )
       {
         char *blob = nullptr;
         int size = 0;
         qgsGeometryToSpatialiteBlob( ret.value<QgsGeometry>(), /*srid*/0, blob, size );
         sqlite3_result_blob( ctxt, blob, size, deleteGeometryBlob );
       }
-      else if ( ret.userType() == QMetaType::type( "QgsInterval" ) )
+      else if ( ret.userType() == qMetaTypeId<QgsInterval>() )
       {
         sqlite3_result_double( ctxt, ret.value<QgsInterval>().seconds() );
       }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -12199,14 +12199,14 @@ void TestQgsProcessing::generateIteratingDestination()
   def.sink = QgsProperty::fromValue( "ape.shp" );
   def.destinationProject = &p;
   QVariant res = QgsProcessingUtils::generateIteratingDestination( def, 2, context );
-  QCOMPARE( res.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( res.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( res );
   QCOMPARE( fromVar.sink.staticValue().toString(), QStringLiteral( "ape_2.shp" ) );
   QCOMPARE( fromVar.destinationProject, &p );
 
   def.sink = QgsProperty::fromExpression( "'ape' || '.shp'" );
   res = QgsProcessingUtils::generateIteratingDestination( def, 2, context );
-  QCOMPARE( res.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( res.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( res );
   QCOMPARE( fromVar.sink.staticValue().toString(), QStringLiteral( "ape_2.shp" ) );
   QCOMPARE( fromVar.destinationProject, &p );
@@ -12215,7 +12215,7 @@ void TestQgsProcessing::generateIteratingDestination()
   def2.sink = QgsProperty::fromValue( QgsProcessing::TEMPORARY_OUTPUT );
   def2.destinationProject = &p;
   res = QgsProcessingUtils::generateIteratingDestination( def2, 2, context );
-  QCOMPARE( res.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( res.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( res );
   QCOMPARE( fromVar.sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QCOMPARE( fromVar.destinationProject, &p );

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -504,7 +504,7 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   QCOMPARE( map["default_value"].toMap()["create_options"].toMap()[QStringLiteral( "fileEncoding" )].toString(), QStringLiteral( "my_encoding" ) );
   QgsProcessingModelOutput out;
   out.loadVariant( map );
-  QCOMPARE( out.defaultValue().userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( out.defaultValue().userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   layerDef = out.defaultValue().value<QgsProcessingOutputLayerDefinition>();
   QCOMPARE( layerDef.sink.staticValue().toString(), QStringLiteral( "my_path" ) );
   QCOMPARE( layerDef.createOptions[QStringLiteral( "fileEncoding" )].toString(), QStringLiteral( "my_encoding" ) );
@@ -1042,7 +1042,7 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 3 ).source(), Qgis::ProcessingModelChildParameterSource::Expression );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 3 ).expression(), QStringLiteral( "1+2" ) );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).source(), Qgis::ProcessingModelChildParameterSource::StaticValue );
-  QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().userType(), QMetaType::type( "QgsProperty" ) );
+  QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().userType(), qMetaTypeId<QgsProperty>() );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().value< QgsProperty >().expressionString(), QStringLiteral( "1+8" ) );
 
   QCOMPARE( alg6c1.modelOutputs().count(), 1 );
@@ -1334,7 +1334,7 @@ void TestQgsProcessingModelAlgorithm::modelExecution()
   QVERIFY( error.isEmpty() );
   QCOMPARE( params.value( "INPUT" ).toString(), QStringLiteral( "dest.shp" ) );
   QCOMPARE( params.value( "EXPRESSION" ).toString(), QStringLiteral( "true" ) );
-  QCOMPARE( params.value( "OUTPUT" ).userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( params.value( "OUTPUT" ).userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   const QgsProcessingOutputLayerDefinition outDef = qvariant_cast<QgsProcessingOutputLayerDefinition>( params.value( "OUTPUT" ) );
   QCOMPARE( outDef.destinationName, QStringLiteral( "MY_OUT" ) );
   QCOMPARE( outDef.sink.staticValue().toString(), QStringLiteral( "memory:" ) );
@@ -1347,7 +1347,7 @@ void TestQgsProcessingModelAlgorithm::modelExecution()
   QVERIFY( error.isEmpty() );
   QCOMPARE( params.value( "INPUT" ).toString(), QStringLiteral( "dest.shp" ) );
   QCOMPARE( params.value( "EXPRESSION" ).toString(), QStringLiteral( "true" ) );
-  QCOMPARE( params.value( "OUTPUT" ).userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( params.value( "OUTPUT" ).userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   const QgsProcessingOutputLayerDefinition outDef2 = qvariant_cast<QgsProcessingOutputLayerDefinition>( params.value( "OUTPUT" ) );
   QCOMPARE( outDef2.destinationName, QStringLiteral( "MY_OUT" ) );
   QCOMPARE( outDef2.sink.staticValue().toString(), QStringLiteral( "memory:" ) );

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -395,7 +395,7 @@ void TestQgsGeometry::asVariant()
   //convert to and from a QVariant
   QVariant var = QVariant::fromValue( original );
   QVERIFY( var.isValid() );
-  QCOMPARE( var.userType(), QMetaType::type( "QgsGeometry" ) );
+  QCOMPARE( var.userType(), qMetaTypeId< QgsGeometry>() );
 
   QgsGeometry fromVar = qvariant_cast<QgsGeometry>( var );
   QCOMPARE( fromVar.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ).x(), 1.0 );
@@ -427,7 +427,7 @@ void TestQgsGeometry::referenced()
   QVariant var = QVariant::fromValue( geom1 );
   QVERIFY( var.isValid() );
 
-  QCOMPARE( var.userType(), QMetaType::type( "QgsReferencedGeometry" ) );
+  QCOMPARE( var.userType(), qMetaTypeId<QgsReferencedGeometry>() );
 
   QgsReferencedGeometry geom2 = qvariant_cast<QgsReferencedGeometry>( var );
   QCOMPARE( geom2.asWkt(), geom1.asWkt() );

--- a/tests/src/core/geometry/testqgspointxy.cpp
+++ b/tests/src/core/geometry/testqgspointxy.cpp
@@ -325,7 +325,7 @@ void TestQgsPointXY::asVariant()
   //convert to and from a QVariant
   const QVariant var = QVariant::fromValue( p1 );
   QVERIFY( var.isValid() );
-  QCOMPARE( var.userType(), QMetaType::type( "QgsPointXY" ) );
+  QCOMPARE( var.userType(), qMetaTypeId<QgsPointXY>() );
 
   const QgsPointXY p2 = qvariant_cast<QgsPointXY>( var );
   QCOMPARE( p2.x(), p1.x() );
@@ -346,7 +346,7 @@ void TestQgsPointXY::referenced()
   // not great - we'd ideally like this to pass, but it doesn't:
   // QVERIFY( !var.canConvert< QgsPointXY >() );
 
-  QCOMPARE( var.userType(), QMetaType::type( "QgsReferencedPointXY" ) );
+  QCOMPARE( var.userType(), qMetaTypeId<QgsReferencedPointXY>() );
 
   const QgsReferencedPointXY p2 = qvariant_cast<QgsReferencedPointXY>( var );
   QCOMPARE( p2.x(), p1.x() );

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -330,7 +330,7 @@ void TestQgsRectangle::asVariant()
   //convert to and from a QVariant
   const QVariant var = QVariant::fromValue( rect1 );
   QVERIFY( var.isValid() );
-  QCOMPARE( var.userType(), QMetaType::type( "QgsRectangle" ) );
+  QCOMPARE( var.userType(), qMetaTypeId<QgsRectangle>() );
   QVERIFY( !var.canConvert< QgsReferencedRectangle >() );
 
   const QgsRectangle rect2 = qvariant_cast<QgsRectangle>( var );
@@ -354,7 +354,7 @@ void TestQgsRectangle::referenced()
   // not great - we'd ideally like this to pass, but it doesn't:
   // QVERIFY( !var.canConvert< QgsRectangle >() );
 
-  QCOMPARE( var.userType(), QMetaType::type( "QgsReferencedRectangle" ) );
+  QCOMPARE( var.userType(), qMetaTypeId<QgsReferencedRectangle>() );
 
   const QgsReferencedRectangle rect2 = qvariant_cast<QgsReferencedRectangle>( var );
   QCOMPARE( rect2.xMinimum(), rect1.xMinimum() );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2572,7 +2572,7 @@ class TestQgsExpression: public QObject
         qDebug() << exp.evalErrorString();
 
       QCOMPARE( exp.hasEvalError(), false );
-      QCOMPARE( res.userType() == QMetaType::type( "QgsFeature" ), featureMatched );
+      QCOMPARE( res.userType() == qMetaTypeId<QgsFeature>(), featureMatched );
       if ( featureMatched )
       {
         QgsFeature feat = res.value<QgsFeature>();
@@ -3872,7 +3872,7 @@ class TestQgsExpression: public QObject
       QVariant out = exp.evaluate( &context );
       QCOMPARE( exp.hasEvalError(), evalError );
 
-      QCOMPARE( out.userType() == QMetaType::type( "QgsGeometry" ), true );
+      QCOMPARE( out.userType() == qMetaTypeId< QgsGeometry>(), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       QCOMPARE( geom.equals( outGeom ), true );
     }
@@ -3933,7 +3933,7 @@ class TestQgsExpression: public QObject
       QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, QgsFields() );
       QVariant out = exp.evaluate( &context );
       QCOMPARE( exp.hasEvalError(), evalError );
-      QCOMPARE( out.userType() == QMetaType::type( "QgsGeometry" ), true );
+      QCOMPARE( out.userType() == qMetaTypeId< QgsGeometry>(), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       QCOMPARE( geom.equals( outGeom ), true );
     }
@@ -4076,7 +4076,7 @@ class TestQgsExpression: public QObject
       QVariant out = exp.evaluate( &context );
       QCOMPARE( exp.hasEvalError(), evalError );
 
-      QCOMPARE( out.userType() == QMetaType::type( "QgsGeometry" ), true );
+      QCOMPARE( out.userType() == qMetaTypeId< QgsGeometry>(), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       outGeom.normalize();
       result.normalize();

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -911,15 +911,15 @@ void TestQgsField::convertCompatible()
   QVERIFY( geometryValue.isNull() );
   geometryValue = QVariant::fromValue( QgsGeometry::fromWkt( QStringLiteral( "Point( 1 2 )" ) ) );
   QVERIFY( geometryField.convertCompatible( geometryValue ) );
-  QCOMPARE( geometryValue.userType(), QMetaType::type( "QgsGeometry" ) );
+  QCOMPARE( geometryValue.userType(), qMetaTypeId< QgsGeometry>() );
 
   geometryValue = QVariant::fromValue( QgsReferencedGeometry( QgsGeometry::fromWkt( QStringLiteral( "Point( 1 2 )" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ) ) );
   QVERIFY( geometryField.convertCompatible( geometryValue ) );
-  QCOMPARE( geometryValue.userType(), QMetaType::type( "QgsReferencedGeometry" ) );
+  QCOMPARE( geometryValue.userType(), qMetaTypeId<QgsReferencedGeometry>() );
 
   geometryValue = QStringLiteral( "LineString( 1 2, 3 4 )" );
   QVERIFY( geometryField.convertCompatible( geometryValue ) );
-  QCOMPARE( geometryValue.userType(), QMetaType::type( "QgsGeometry" ) );
+  QCOMPARE( geometryValue.userType(), qMetaTypeId< QgsGeometry>() );
 }
 
 void TestQgsField::dataStream()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -6153,7 +6153,7 @@ void TestProcessingGui::mapLayerComboBox()
   // now make a selection in the layer, and repeat
   vl2->selectAll();
   combo->setValue( sourceDef, context );
-  QCOMPARE( combo->value().userType(), QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) );
+  QCOMPARE( combo->value().userType(), qMetaTypeId<QgsProcessingFeatureSourceDefinition>() );
   QCOMPARE( combo->value().value< QgsProcessingFeatureSourceDefinition >().source.staticValue().toString(), vl2->id() );
   QVERIFY( combo->value().value< QgsProcessingFeatureSourceDefinition >().selectedFeaturesOnly );
   QVERIFY( combo->currentText().startsWith( vl2->name() ) );
@@ -6168,7 +6168,7 @@ void TestProcessingGui::mapLayerComboBox()
   // phew, nearly there. Let's check another variation
   vl2->selectAll();
   combo->setValue( sourceDef, context );
-  QCOMPARE( combo->value().userType(), QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) );
+  QCOMPARE( combo->value().userType(), qMetaTypeId<QgsProcessingFeatureSourceDefinition>() );
   QCOMPARE( spy.count(), 10 );
   combo->setValue( QVariant::fromValue( vl ), context );
   QCOMPARE( combo->value().toString(), vl->id() );
@@ -6183,7 +6183,7 @@ void TestProcessingGui::mapLayerComboBox()
   sourceDef = QgsProcessingFeatureSourceDefinition( vl->id(), true );
   combo->setValue( sourceDef, context );
   // expect "selected only" state to remain
-  QCOMPARE( combo->value().userType(), QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) );
+  QCOMPARE( combo->value().userType(), qMetaTypeId<QgsProcessingFeatureSourceDefinition>() );
   QCOMPARE( combo->value().value< QgsProcessingFeatureSourceDefinition >().source.staticValue().toString(), vl->id() );
   QVERIFY( combo->value().value< QgsProcessingFeatureSourceDefinition >().selectedFeaturesOnly );
   QVERIFY( combo->currentText().startsWith( vl->name() ) );
@@ -8766,13 +8766,13 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8789,13 +8789,13 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 0 );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
 
   panel.setValue( QStringLiteral( "memory:" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8810,7 +8810,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 0 );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
 
@@ -8818,7 +8818,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8828,7 +8828,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel.setValue( QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8840,7 +8840,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel.setValue( QStringLiteral( "/home/me/test.shp" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.shp" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8857,7 +8857,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.shp" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.shp" ) ) );
 
@@ -8870,13 +8870,13 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -8908,7 +8908,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
@@ -8939,7 +8939,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel3.setValue( def );
   v = panel3.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QVERIFY( v.value< QgsProcessingOutputLayerDefinition>().useRemapping() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().remappingDefinition().fieldMap().size(), 2 );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().remappingDefinition().fieldMap().value( QStringLiteral( "field1" ) ), QgsProperty::fromField( QStringLiteral( "source1" ) ) );
@@ -8947,7 +8947,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel3.setValue( QStringLiteral( "other.shp" ) );
   v = panel3.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QVERIFY( !v.value< QgsProcessingOutputLayerDefinition>().useRemapping() );
 }
 
@@ -8960,13 +8960,13 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8978,7 +8978,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel.setValue( QStringLiteral( "memory:" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8993,7 +8993,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9003,7 +9003,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel.setValue( QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9015,7 +9015,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel.setValue( QStringLiteral( "/home/me/test.shp" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.shp" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9032,7 +9032,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.shp" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.shp" ) ) );
 
@@ -9045,13 +9045,13 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -9083,7 +9083,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
@@ -9113,13 +9113,13 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9133,7 +9133,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.tif" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9145,7 +9145,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.tif" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.tif" ) ) );
 
@@ -9158,13 +9158,13 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -9196,7 +9196,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
@@ -9226,13 +9226,13 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9246,7 +9246,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.las" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9258,7 +9258,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.las" ) );
   v = panel.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.las" ) ) );
 
@@ -9271,13 +9271,13 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -9309,7 +9309,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
+  QCOMPARE( v.userType(), qMetaTypeId<QgsProcessingOutputLayerDefinition>() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );

--- a/tests/src/gui/testqgstableeditor.cpp
+++ b/tests/src/gui/testqgstableeditor.cpp
@@ -963,20 +963,20 @@ void TestQgsTableEditor::properties()
   QCOMPARE( w.tableContents().size(), 1 );
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
-  QVERIFY( w.tableContents().at( 0 ).at( 0 ).content().userType() != QMetaType::type( "QgsProperty" ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().userType(), QMetaType::type( "QgsProperty" ) );
+  QVERIFY( w.tableContents().at( 0 ).at( 0 ).content().userType() != qMetaTypeId<QgsProperty>() );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().userType(), qMetaTypeId<QgsProperty>() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().value< QgsProperty >().asExpression(), QStringLiteral( "1+2" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
-  QVERIFY( w.tableContents().at( 0 ).at( 2 ).content().userType() != QMetaType::type( "QgsProperty" ) );
+  QVERIFY( w.tableContents().at( 0 ).at( 2 ).content().userType() != qMetaTypeId<QgsProperty>() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
-  QVERIFY( w.tableContents().at( 0 ).at( 3 ).content().userType() != QMetaType::type( "QgsProperty" ) );
+  QVERIFY( w.tableContents().at( 0 ).at( 3 ).content().userType() != qMetaTypeId<QgsProperty>() );
 
   w.selectionModel()->clearSelection();
   w.setSelectionCellProperty( QgsProperty::fromExpression( QStringLiteral( "2+3" ) ) );
   QCOMPARE( spy.count(), 1 );
 
   w.selectionModel()->select( w.model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect );
-  QVERIFY( w.tableContents().at( 0 ).at( 0 ).content().userType() != QMetaType::type( "QgsProperty" ) );
+  QVERIFY( w.tableContents().at( 0 ).at( 0 ).content().userType() != qMetaTypeId<QgsProperty>() );
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::Select );
   QVERIFY( !w.selectionCellProperty().isActive() );
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::ClearAndSelect );
@@ -988,14 +988,14 @@ void TestQgsTableEditor::properties()
   QCOMPARE( spy.count(), 2 );
   QVERIFY( w.selectionCellProperty().isActive() );
   QCOMPARE( w.selectionCellProperty().asExpression(), QStringLiteral( "3+4" ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().userType(), QMetaType::type( "QgsProperty" ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().userType(), qMetaTypeId<QgsProperty>() );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().value< QgsProperty >().asExpression(), QStringLiteral( "3+4" ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().userType(), QMetaType::type( "QgsProperty" ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().userType(), qMetaTypeId<QgsProperty>() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().value< QgsProperty >().asExpression(), QStringLiteral( "3+4" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
-  QVERIFY( w.tableContents().at( 0 ).at( 2 ).content().userType() != QMetaType::type( "QgsProperty" ) );
+  QVERIFY( w.tableContents().at( 0 ).at( 2 ).content().userType() != qMetaTypeId<QgsProperty>() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
-  QVERIFY( w.tableContents().at( 0 ).at( 3 ).content().userType() != QMetaType::type( "QgsProperty" ) );
+  QVERIFY( w.tableContents().at( 0 ).at( 3 ).content().userType() != qMetaTypeId<QgsProperty>() );
   w.selectionModel()->select( w.model()->index( 0, 3 ), QItemSelectionModel::Select );
   QVERIFY( !w.selectionCellProperty().isActive() );
 }


### PR DESCRIPTION
According to the Qt docs this is faster, and also gives us the stability of compile-time assurances that T is correctly registered as a metatype (and doesn't have typos!)
