### PR TITLE
[attribute form] Properly handle default value using current_parent_* variable/function when in editing state

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -3280,12 +3280,17 @@ void QgsAttributeForm::updateRelatedLayerFieldsDependencies( QgsEditorWidgetWrap
 
 void QgsAttributeForm::updateFieldDependenciesParent( QgsEditorWidgetWrapper *eww )
 {
-  if ( eww )
+  if ( eww && !eww->field().defaultValueDefinition().expression().isEmpty() )
   {
-    QString expression = eww->field().defaultValueDefinition().expression();
-    if ( expression.contains( QStringLiteral( "current_parent" ) ) )
+    const QgsExpression expression( eww->field().defaultValueDefinition().expression() );
+    const QSet< QString > referencedVariablesAndFunctions = expression.referencedVariables() + expression.referencedFunctions();
+    for ( const QString &referenced : referencedVariablesAndFunctions )
     {
-      mParentDependencies.insert( eww );
+      if ( referenced.startsWith( QStringLiteral( "current_parent" ) ) )
+      {
+        mParentDependencies.insert( eww );
+        break;
+      }
     }
   }
 }

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -387,6 +387,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateFieldDependenciesDefaultValue( QgsEditorWidgetWrapper *eww );
     void updateFieldDependenciesVirtualFields( QgsEditorWidgetWrapper *eww );
     void updateRelatedLayerFieldsDependencies( QgsEditorWidgetWrapper *eww = nullptr );
+    void updateFieldDependenciesParent( QgsEditorWidgetWrapper *eww );
 
     void setMultiEditFeatureIdsRelations( const QgsFeatureIds &fids );
 
@@ -422,6 +423,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateValuesDependencies( const int originIdx );
     void updateValuesDependenciesDefaultValues( const int originIdx );
     void updateValuesDependenciesVirtualFields( const int originIdx );
+    void updateValuesDependenciesParent();
     void updateRelatedLayerFields();
 
     void clearMultiEditMessages();
@@ -554,6 +556,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      * Dependency list for values depending on related layers.
      */
     QSet<QgsEditorWidgetWrapper *> mRelatedLayerFieldsDependencies;
+
+    QSet<QgsEditorWidgetWrapper *> mParentDependencies;
 
     //! List of updated fields to avoid recursion on the setting of defaultValues
     QList<int> mAlreadyUpdatedFields;

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -1120,14 +1120,14 @@ void TestQgsAttributeForm::testParentFeatureUpdate()
   layer->setDefaultValueDefinition( 0, QgsDefaultValue( QStringLiteral( "current_parent_value('colZero\')" ), true ) );
   layer->startEditing();
 
-  // initalize parent feature
+  // initialize parent feature
   QgsFields parentFields;
   parentFields.append( QgsField( QStringLiteral( "colZero" ), QMetaType::Type::Int ) );
 
   QgsFeature parentFeature( parentFields, 1 );
   parentFeature.setAttribute( QStringLiteral( "colZero" ), 10 );
 
-  // initalize child feature
+  // initialize child feature
   QgsFeature feature( layer->dataProvider()->fields(), 1 );
 
   // build a form


### PR DESCRIPTION
## Description

This PR addresses https://github.com/qgis/QGIS/issues/57957 by ensuring that changes to a parent feature triggers default value updates when the expression relies on a current_parent variable or expression when in editing mode (i.e. when the child feature has been created already).