### PR TITLE
[map canvas] Fix annotations not drawn onto preview renders

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -3573,6 +3573,10 @@ void QgsMapCanvas::startPreviewJob( int number )
 
     previewLayers << layer;
   }
+  if ( QgsProject::instance()->mainAnnotationLayer()->dataProvider()->renderInPreview( context ) )
+  {
+    previewLayers.insert( 0, QgsProject::instance()->mainAnnotationLayer() );
+  }
   jobSettings.setLayers( previewLayers );
 
   QgsMapRendererQImageJob *job = new QgsMapRendererSequentialJob( jobSettings );


### PR DESCRIPTION
## Description

This PR fixes project's (main) annotations layer not drawn onto the map canvas' preview renders. 