### PR TITLE
Allow running processing tools on grass vector layers

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -84,7 +84,7 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
             parameters = {parameter_name: parameters[parameter_name].source}
 
         input_layer = self.parameterAsVectorLayer(parameters, parameter_name, context)
-        if input_layer is None or input_layer.providerType() == 'memory':
+        if input_layer is None or input_layer.providerType() in ('memory', 'grass'):
             if executing:
                 # parameter is not a vector layer - try to convert to a source compatible with OGR
                 # and extract selection if required

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -188,8 +188,6 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   if ( filters )
     mCombo->setFilters( filters );
 
-  mCombo->setExcludedProviders( QStringList() << QStringLiteral( "grass" ) ); // not sure if this is still required...
-
   // Check compatibility with virtualraster data provider
   // see https://github.com/qgis/QGIS/issues/55890
   if ( mayBeRaster &&


### PR DESCRIPTION
Remove an outdated constraint preventing processing tools from operating on GRASS provider vector layers. These native QGIS
algorithms "just work" with GRASS provider vectors, so there's no reason to explicitly block them anymore...