### PR TITLE
[processing] Gracefully handle FID constraints when writing layers to temporary provider-compatible formats

### DIFF
--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -12672,11 +12672,18 @@ void TestQgsProcessing::convertCompatibleDuplicateFids()
   QVariantMap params;
   params.insert( QStringLiteral( "source" ), QgsProcessingFeatureSourceDefinition( layer->id(), false ) );
 
-  QgsProcessingParameters::parameterAsCompatibleSourceLayerPath( def.get(), params, context, QStringList() << "gpkg", QString( "gpkg" ), &feedback );
+  const QString temporaryFile = QgsProcessingParameters::parameterAsCompatibleSourceLayerPath( def.get(), params, context, QStringList() << "gpkg", QString( "gpkg" ), &feedback );
   const QStringList logs( feedback.textLog().split( '\n', Qt::SplitBehaviorFlags::SkipEmptyParts ) );
-  QCOMPARE( logs.size(), 11 );
-  QVERIFY( logs.first().startsWith( QLatin1String( "Error writing feature # 2" ) ) );
-  QVERIFY( logs.last().startsWith( QLatin1String( "There were 11 errors writing features" ) ) );
+  QCOMPARE( logs.size(), 1 );
+  QCOMPARE( logs.at( 0 ), QStringLiteral( "Cannot store existing FID values in temporary GeoPackage layer, these will be moved to \"OLD_FID\" instead." ) );
+
+  QgsVectorLayer vl( temporaryFile );
+  QVERIFY( vl.isValid() );
+
+  QCOMPARE( vl.featureCount(), 12 );
+  QCOMPARE( vl.fields().at( 0 ).name(), QStringLiteral( "fid" ) );
+  QCOMPARE( vl.fields().at( 1 ).name(), QStringLiteral( "OLD_FID" ) );
+  QCOMPARE( vl.fields().at( 2 ).name(), QStringLiteral( "name" ) );
 }
 
 void TestQgsProcessing::create()


### PR DESCRIPTION
When writing a layer to a temporary GPKG file for compatibilty with provider's supported formats, rename the existing FID column if we can't write the FID values into the GPKG

Eg when the source layer has string/duplicate fids, we warn the user and then automatically move the existing fids to a "OLD_FID" field
