### PR TITLE
Fix PDF export size of elevation plots

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -768,7 +768,7 @@ void QgsElevationProfileWidget::exportAsPdf()
   pageLayout.setMode( QPageLayout::FullPageMode );
   pdfWriter.setPageLayout( pageLayout );
   pdfWriter.setPageMargins( QMarginsF( 0, 0, 0, 0 ) );
-  pdfWriter.setResolution( 300 );
+  pdfWriter.setResolution( 1200 );
 
   QPainter p;
   if ( !p.begin( &pdfWriter ) )


### PR DESCRIPTION
QPdfWriter doesn't return the output resolution as the device physicalDpiX(?!), so let's hack around this by just setting the output resolution to match the value reported by physicalDpiX...

Fixes #57880
