### PR TITLE
Remove geometry validity checks from some algorithms

### DIFF
--- a/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
@@ -89,7 +89,7 @@ QVariantMap QgsDeleteDuplicateGeometriesAlgorithm::processAlgorithm( const QVari
   if ( !sink )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
 
-  QgsFeatureIterator it = mSource->getFeatures( QgsFeatureRequest().setSubsetOfAttributes( QgsAttributeList() ) );
+  QgsFeatureIterator it = mSource->getFeatures( QgsFeatureRequest().setSubsetOfAttributes( QgsAttributeList() ), Qgis::ProcessingFeatureSourceFlag::SkipGeometryValidityChecks );
 
   double step = mSource->featureCount() > 0 ? 100.0 / mSource->featureCount() : 0;
   QHash< QgsFeatureId, QgsGeometry > geometries;
@@ -170,7 +170,7 @@ QVariantMap QgsDeleteDuplicateGeometriesAlgorithm::processAlgorithm( const QVari
   step = outputFeatureIds.empty() ? 1 : 100.0 / outputFeatureIds.size();
 
   const QgsFeatureRequest request = QgsFeatureRequest().setFilterFids( outputFeatureIds ).setFlags( Qgis::FeatureRequestFlag::NoGeometry );
-  it = mSource->getFeatures( request );
+  it = mSource->getFeatures( request, Qgis::ProcessingFeatureSourceFlag::SkipGeometryValidityChecks );
   current = 0;
   while ( it.nextFeature( f ) )
   {

--- a/src/analysis/processing/qgsalgorithmexplode.cpp
+++ b/src/analysis/processing/qgsalgorithmexplode.cpp
@@ -105,6 +105,11 @@ QgsFeatureList QgsExplodeAlgorithm::processFeature( const QgsFeature &f, QgsProc
   }
 }
 
+Qgis::ProcessingFeatureSourceFlags QgsExplodeAlgorithm::sourceFlags() const
+{
+  return Qgis::ProcessingFeatureSourceFlag::SkipGeometryValidityChecks;
+}
+
 QgsFeatureSink::SinkFlags QgsExplodeAlgorithm::sinkFlags() const
 {
   return QgsFeatureSink::RegeneratePrimaryKey;

--- a/src/analysis/processing/qgsalgorithmexplode.h
+++ b/src/analysis/processing/qgsalgorithmexplode.h
@@ -48,6 +48,7 @@ class QgsExplodeAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     Qgis::WkbType outputWkbType( Qgis::WkbType inputWkbType ) const override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    Qgis::ProcessingFeatureSourceFlags sourceFlags() const override;
     QgsFeatureSink::SinkFlags sinkFlags() const override;
 
     std::vector< QgsGeometry > extractAsParts( const QgsGeometry &geometry ) const;


### PR DESCRIPTION
Remove validity requirement for "Delete Duplicate Geometries" and "Explode Lines" algorithms. In both cases validity is not required and get constraint gets in the way when these tools are used as a data cleaning step prior to fixing geometries.