### PR TITLE
Fix settings CRS for new GRASS mapsets

### DIFF
--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -384,7 +384,7 @@ void QgsGrassNewMapset::setGrassProjection()
 {
   setError( mProjErrorLabel );
 
-  QString proj4 = mProjectionSelector->crs().toProj();
+  const QgsCoordinateReferenceSystem crs = mProjectionSelector->crs();
 
   // Not defined
   if ( mNoProjRadioButton->isChecked() )
@@ -399,64 +399,29 @@ void QgsGrassNewMapset::setGrassProjection()
   }
 
   // Define projection
-  if ( !proj4.isEmpty() )
+  if ( crs.isValid() )
   {
-    QgsDebugMsgLevel( QString( "proj4 = %1" ).arg( proj4.toLocal8Bit().constData() ), 3 );
+    const QString wkt = crs.toWkt( Qgis::CrsWktVariant::Preferred );
+    QgsDebugMsgLevel( QStringLiteral( "wkt = %1" ).arg( crs.toWkt( Qgis::CrsWktVariant::Preferred ) ), 3 );
 
-    OGRSpatialReferenceH hCRS = nullptr;
-    hCRS = OSRNewSpatialReference( nullptr );
-    int errcode;
+    // Note: GPJ_osr_to_grass() defaults in PROJECTION_XY if projection
+    //       cannot be set
 
+    G_TRY
     {
-      QgsLocaleNumC l;
-      errcode = OSRImportFromProj4( hCRS, proj4.toUtf8() );
+      // There was a bug in GRASS, it is present in 6.0.x line
+      int ret = GPJ_wkt_to_grass( &mCellHead, &mProjInfo, &mProjUnits, wkt.toUtf8().constData(), 0 );
+      // Note: It seems that GPJ_osr_to_grass()returns always 1,
+      //   -> test if mProjInfo was set
+
+      Q_UNUSED( ret )
+      QgsDebugMsgLevel( QString( "ret = %1" ).arg( ret ), 2 );
+      QgsDebugMsgLevel( QString( "mProjInfo = %1" ).arg( QString::number( ( qulonglong )mProjInfo, 16 ).toLocal8Bit().constData() ), 2 );
     }
-
-    if ( errcode != OGRERR_NONE )
+    G_CATCH( QgsGrass::Exception & e )
     {
-      QgsDebugMsgLevel( QString( "OGR can't parse PROJ-style parameter string:\n%1\nOGR Error code was %2" ).arg( proj4 ).arg( errcode ), 2 );
-
-      mCellHead.proj = PROJECTION_XY;
-      mCellHead.zone = 0;
-      mProjInfo = nullptr;
-      mProjUnits = nullptr;
-    }
-    else
-    {
-      char *wkt = nullptr;
-
-      QgsDebugMsgLevel( QString( "OSRIsGeographic = %1" ).arg( OSRIsGeographic( hCRS ) ), 2 );
-      QgsDebugMsgLevel( QString( "OSRIsProjected = %1" ).arg( OSRIsProjected( hCRS ) ), 2 );
-
-      if ( ( errcode = OSRExportToWkt( hCRS, &wkt ) ) != OGRERR_NONE )
-      {
-        QgsDebugMsgLevel( QString( "OGR can't get Wkt-style parameter string\nOGR Error code was %1" ).arg( errcode ), 2 );
-      }
-      else
-      {
-        QgsDebugMsgLevel( QString( "wkt = %1" ).arg( wkt ), 2 );
-      }
-
-      // Note: GPJ_osr_to_grass() defaults in PROJECTION_XY if projection
-      //       cannot be set
-
-      G_TRY
-      {
-        // There was a bug in GRASS, it is present in 6.0.x line
-        int ret = GPJ_wkt_to_grass( &mCellHead, &mProjInfo, &mProjUnits, wkt, 0 );
-        // Note: It seems that GPJ_osr_to_grass()returns always 1,
-        //   -> test if mProjInfo was set
-
-        Q_UNUSED( ret )
-        QgsDebugMsgLevel( QString( "ret = %1" ).arg( ret ), 2 );
-        QgsDebugMsgLevel( QString( "mProjInfo = %1" ).arg( QString::number( ( qulonglong )mProjInfo, 16 ).toLocal8Bit().constData() ), 2 );
-        CPLFree( wkt );
-      }
-      G_CATCH( QgsGrass::Exception & e )
-      {
-        QgsGrass::warning( tr( "Cannot set projection: %1" ).arg( e.what() ) );
-        return;
-      }
+      QgsGrass::warning( tr( "Cannot set projection: %1" ).arg( e.what() ) );
+      return;
     }
 
     if ( !mProjInfo || !mProjUnits )

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -416,7 +416,7 @@ void QgsGrassNewMapset::setGrassProjection()
 
       Q_UNUSED( ret )
       QgsDebugMsgLevel( QString( "ret = %1" ).arg( ret ), 2 );
-      QgsDebugMsgLevel( QString( "mProjInfo = %1" ).arg( QString::number( ( qulonglong )mProjInfo, 16 ).toLocal8Bit().constData() ), 2 );
+      QgsDebugMsgLevel( QString( "mProjInfo = %1" ).arg( QString::number( static_cast<qulonglong>( mProjInfo ), 16 ).toLocal8Bit().constData() ), 2 );
     }
     G_CATCH( QgsGrass::Exception & e )
     {

--- a/src/providers/grass/qgis.g.info.c
+++ b/src/providers/grass/qgis.g.info.c
@@ -57,39 +57,48 @@ int main( int argc, char **argv )
 
   rast_opt = G_define_standard_option( G_OPT_R_INPUT );
   rast_opt->key = "rast";
+  rast_opt->description = "rast";
   rast_opt->required = NO;
 
   vect_opt = G_define_standard_option( G_OPT_V_INPUT );
   vect_opt->key = "vect";
+  vect_opt->description = "vect";
   vect_opt->required = NO;
 
   coor_opt = G_define_option();
   coor_opt->key = "coor";
+  coor_opt->description = "coor";
   coor_opt->type = TYPE_DOUBLE;
   coor_opt->multiple = YES;
 
   north_opt = G_define_option();
   north_opt->key = "north";
+  north_opt->description = "north";
   north_opt->type = TYPE_STRING;
 
   south_opt = G_define_option();
   south_opt->key = "south";
+  south_opt->description = "south";
   south_opt->type = TYPE_STRING;
 
   east_opt = G_define_option();
   east_opt->key = "east";
+  east_opt->description = "east";
   east_opt->type = TYPE_STRING;
 
   west_opt = G_define_option();
   west_opt->key = "west";
+  west_opt->description = "west";
   west_opt->type = TYPE_STRING;
 
   rows_opt = G_define_option();
   rows_opt->key = "rows";
+  rows_opt->description = "rows";
   rows_opt->type = TYPE_INTEGER;
 
   cols_opt = G_define_option();
   cols_opt->key = "cols";
+  cols_opt->description = "cols";
   cols_opt->type = TYPE_INTEGER;
 
   if ( G_parser( argc, argv ) )


### PR DESCRIPTION
Don't force the selected CRS to a (lossy) proj string, just use the CRS's WKT directly

This avoids losing projection information from some selected projections when creating a new GRASS mapset (eg EPSG:3111)