### PR TITLE
Create converter for ArcGis FeatureServer type classBreaks

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1016,7 +1016,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       }
 
       const QVariantList visualVariablesData = rendererData.value( QStringLiteral( "visualVariables" ) ).toList();
-      double lastValue = 0;
+      double lastValue = rendererData.value( QStringLiteral( "minValue" ) ).toDouble();
       for ( const QVariant& visualVariable : visualVariablesData )
       {
           const QVariantList stops = visualVariable.toMap().value( QStringLiteral( "stops" ) ).toList();
@@ -1047,7 +1047,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
               }
           }
       }
-      lastValue = 0;
+      lastValue = rendererData.value( QStringLiteral( "minValue" ) ).toDouble();
       for ( const QVariant& classBreakInfo : classBreakInfos )
       {
           const QVariantMap symbolData = classBreakInfo.toMap().value( QStringLiteral( "symbol" ) ).toMap();

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -953,7 +953,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
   else if ( type == QLatin1String( "classBreaks" ) )
   {
     const QString attrName = rendererData.value( QStringLiteral( "field" ) ).toString();
-    QgsGraduatedSymbolRenderer *graduatedRenderer = new QgsGraduatedSymbolRenderer( attrName );
+    std::unique_ptr< QgsGraduatedSymbolRenderer > graduatedRenderer = std::make_unique< QgsGraduatedSymbolRenderer >( attrName );
 
     const QVariantList classBreakInfos = rendererData.value( QStringLiteral( "classBreakInfos" ) ).toList();
     const QVariantMap authoringInfo = rendererData.value( QStringLiteral( "authoringInfo" ) ).toMap();
@@ -964,7 +964,6 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
     {
       esriMode = rendererData.value( QStringLiteral( "classificationMethod" ) ).toString();
     }
-
 
     if ( esriMode == QLatin1String( "esriClassifyDefinedInterval" ) )
     {
@@ -1073,8 +1072,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       graduatedRenderer->addClass( range );
     }
 
-
-    return graduatedRenderer;
+    return graduatedRenderer.release();
   }
   else if ( type == QLatin1String( "heatmap" ) )
   {

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -961,7 +961,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
 
       const QString esriMode = rendererData.value( QStringLiteral( "authoringInfo" ) ).toString();
       if (esriMode.isEmpty()){
-          const QString esriMode = rendererData.value( QStringLiteral( "classificationMethod" ) ).toString();
+          esriMode = rendererData.value( QStringLiteral( "classificationMethod" ) ).toString();
       }
 
 

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -965,31 +965,31 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       }
 
 
-      if (esriMode == QString("esriClassifyDefinedInterval")){
+      if (esriMode == QLatin1String("esriClassifyDefinedInterval")){
           QgsClassificationFixedInterval* method = new QgsClassificationFixedInterval();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QString("esriClassifyEqualInterval")){
+      if (esriMode == QLatin1String("esriClassifyEqualInterval")){
           QgsClassificationEqualInterval* method = new QgsClassificationEqualInterval();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QString("esriClassifyGeometricalInterval")){
+      if (esriMode == QLatin1String("esriClassifyGeometricalInterval")){
           QgsClassificationCustom* method = new QgsClassificationCustom();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QString("esriClassifyManual")){
+      if (esriMode == QLatin1String("esriClassifyManual")){
           QgsClassificationCustom* method = new QgsClassificationCustom();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QString("esriClassifyNaturalBreaks")){
+      if (esriMode == QLatin1String("esriClassifyNaturalBreaks")){
           QgsClassificationJenks* method = new QgsClassificationJenks();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QString("esriClassifyQuantile")){
+      if (esriMode == QLatin1String("esriClassifyQuantile")){
           QgsClassificationQuantile* method = new QgsClassificationQuantile();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QString("esriClassifyStandardDeviation")){
+      if (esriMode == QLatin1String("esriClassifyStandardDeviation")){
           QgsClassificationStandardDeviation* method = new QgsClassificationStandardDeviation();
           graduatedRenderer->setClassificationMethod(method);
       }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -993,6 +993,10 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
           QgsClassificationStandardDeviation* method = new QgsClassificationStandardDeviation();
           graduatedRenderer->setClassificationMethod(method);
       }
+      else
+      {
+         QgsDebugError( QStringLiteral( "ESRI classification mode %1 is not currently supported" ).arg( esriMode ) );
+      }
 
 
       if ( !classBreakInfos.isEmpty() )

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -959,7 +959,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
     const QVariantMap authoringInfo = rendererData.value( QStringLiteral( "authoringInfo" ) ).toMap();
     QVariantMap symbolData;
 
-    QString esriMode = rendererData.value( QStringLiteral( "authoringInfo" ) ).toMap().value( QStringLiteral( "classificationMethod" ) ).toString();
+    QString esriMode = authoringInfo.value( QStringLiteral( "classificationMethod" ) ).toString();
     if ( esriMode.isEmpty() )
     {
       esriMode = rendererData.value( QStringLiteral( "classificationMethod" ) ).toString();

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -45,14 +45,13 @@
 
 #include <QRegularExpression>
 #include <QUrl>
-#include <qgsapplication.h>
-#include <qgsclassificationcustom.h>
-#include <qgsclassificationequalinterval.h>
-#include <qgsclassificationfixedinterval.h>
-#include <qgsclassificationjenks.h>
-#include <qgsclassificationquantile.h>
-#include <qgsclassificationstandarddeviation.h>
-#include <qgsgraduatedsymbolrenderer.h>
+#include "qgsclassificationcustom.h"
+#include "qgsclassificationequalinterval.h"
+#include "qgsclassificationfixedinterval.h"
+#include "qgsclassificationjenks.h"
+#include "qgsclassificationquantile.h"
+#include "qgsclassificationstandarddeviation.h"
+#include "qgsgraduatedsymbolrenderer.h"
 
 QMetaType::Type QgsArcGisRestUtils::convertFieldType( const QString &esriFieldType )
 {

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -959,7 +959,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       const QVariantMap authoringInfo = rendererData.value( QStringLiteral( "authoringInfo" ) ).toMap();
       QVariantMap symbolData;
 
-      const QString esriMode = rendererData.value( QStringLiteral( "authoringInfo" ) ).toString();
+      QString esriMode = rendererData.value( QStringLiteral( "authoringInfo" ) ).toString();
       if (esriMode.isEmpty()){
           esriMode = rendererData.value( QStringLiteral( "classificationMethod" ) ).toString();
       }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1052,7 +1052,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       {
           const QVariantMap symbolData = classBreakInfo.toMap().value( QStringLiteral( "symbol" ) ).toMap();
           std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( symbolData ) );
-          double classMaxValue = classBreakInfo.toMap().value( QStringLiteral( "classMaxValue" ) ).toFloat();
+          double classMaxValue = classBreakInfo.toMap().value( QStringLiteral( "classMaxValue" ) ).toDouble();
           const QString label = classBreakInfo.toMap().value( QStringLiteral( "label" ) ).toString();
 
           QgsRendererRange range;

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -969,27 +969,27 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
           QgsClassificationFixedInterval* method = new QgsClassificationFixedInterval();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QLatin1String("esriClassifyEqualInterval")){
+      else if (esriMode == QLatin1String("esriClassifyEqualInterval")){
           QgsClassificationEqualInterval* method = new QgsClassificationEqualInterval();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QLatin1String("esriClassifyGeometricalInterval")){
+      else if (esriMode == QLatin1String("esriClassifyGeometricalInterval")){
           QgsClassificationCustom* method = new QgsClassificationCustom();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QLatin1String("esriClassifyManual")){
+      else if (esriMode == QLatin1String("esriClassifyManual")){
           QgsClassificationCustom* method = new QgsClassificationCustom();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QLatin1String("esriClassifyNaturalBreaks")){
+      else if (esriMode == QLatin1String("esriClassifyNaturalBreaks")){
           QgsClassificationJenks* method = new QgsClassificationJenks();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QLatin1String("esriClassifyQuantile")){
+      else if (esriMode == QLatin1String("esriClassifyQuantile")){
           QgsClassificationQuantile* method = new QgsClassificationQuantile();
           graduatedRenderer->setClassificationMethod(method);
       }
-      if (esriMode == QLatin1String("esriClassifyStandardDeviation")){
+      else if (esriMode == QLatin1String("esriClassifyStandardDeviation")){
           QgsClassificationStandardDeviation* method = new QgsClassificationStandardDeviation();
           graduatedRenderer->setClassificationMethod(method);
       }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1026,7 +1026,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
           {
               const QVariantMap stopData = stop.toMap();
               const QString label = stopData.value( QStringLiteral( "label" ) ).toString();
-              const double breakpoint = stopData.value( QStringLiteral( "value" ) ).toFloat();
+              const double breakpoint = stopData.value( QStringLiteral( "value" ) ).toDouble();
               std::unique_ptr< QgsSymbol > symbolForStop( graduatedRenderer->sourceSymbol()->clone() );
 
               if ( visualVariable.toMap().value( QStringLiteral( "type" ) ).toString() == QStringLiteral( "colorInfo" ) )

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -959,7 +959,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       const QVariantMap authoringInfo = rendererData.value( QStringLiteral( "authoringInfo" ) ).toMap();
       QVariantMap symbolData;
 
-      QString esriMode = rendererData.value( QStringLiteral( "authoringInfo" ) ).toString();
+      QString esriMode = rendererData.value( QStringLiteral( "authoringInfo" ) ).toMap().value( QStringLiteral( "classificationMethod" ) ).toString();
       if (esriMode.isEmpty()){
           esriMode = rendererData.value( QStringLiteral( "classificationMethod" ) ).toString();
       }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1020,7 +1020,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       for ( const QVariant& visualVariable : visualVariablesData )
       {
           const QVariantList stops = visualVariable.toMap().value( QStringLiteral( "stops" ) ).toList();
-          QString lastLabel = nullptr;
+          QString lastLabel;
 
           for ( const QVariant &stop : stops )
           {

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1029,8 +1029,6 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
     for ( const QVariant &visualVariable : visualVariablesData )
     {
       const QVariantList stops = visualVariable.toMap().value( QStringLiteral( "stops" ) ).toList();
-      QString lastLabel;
-
       for ( const QVariant &stop : stops )
       {
         const QVariantMap stopData = stop.toMap();

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1022,9 +1022,8 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
           const QVariantList stops = visualVariable.toMap().value( QStringLiteral( "stops" ) ).toList();
           QString lastLabel = nullptr;
 
-          for (int i = 0; i < stops.size(); ++i)
+          for ( const QVariant &stop : stops )
           {
-              const QVariant& stop = stops.at(i);
               const QVariantMap stopData = stop.toMap();
               const QString label = stopData.value( QStringLiteral( "label" ) ).toString();
               const double breakpoint = stopData.value( QStringLiteral( "value" ) ).toFloat();

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1004,7 +1004,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
           symbolData = classBreakInfos.at( 0 ).toMap().value( QStringLiteral( "symbol" ) ).toMap();
       }
       std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( symbolData ) );
-      double transparency = rendererData.value( QStringLiteral( "transparency" ) ).toFloat();
+      double transparency = rendererData.value( QStringLiteral( "transparency" ) ).toDouble();
 
       double opacity = (100.0 - transparency) / 100.0;
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -313,6 +313,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   // renderer
   mRendererDataMap = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "renderer" ) ).toMap();
   mLabelingDataList = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "labelingInfo" ) ).toList();
+  const double transparency = layerData.value(QStringLiteral("drawingInfo")).toMap().value(QStringLiteral("transparency")).toFloat();
+  mRendererDataMap.insert(QStringLiteral("transparency"), QVariant(transparency));
 
   mValid = true;
 }

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -313,7 +313,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   // renderer
   mRendererDataMap = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "renderer" ) ).toMap();
   mLabelingDataList = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "labelingInfo" ) ).toList();
-  const double transparency = layerData.value(QStringLiteral("drawingInfo")).toMap().value(QStringLiteral("transparency")).toFloat();
+  const double transparency = layerData.value(QStringLiteral("drawingInfo")).toMap().value(QStringLiteral("transparency")).toDouble();
   mRendererDataMap.insert(QStringLiteral("transparency"), QVariant(transparency));
 
   mValid = true;

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -313,8 +313,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   // renderer
   mRendererDataMap = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "renderer" ) ).toMap();
   mLabelingDataList = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "labelingInfo" ) ).toList();
-  const double transparency = layerData.value(QStringLiteral("drawingInfo")).toMap().value(QStringLiteral("transparency")).toDouble();
-  mRendererDataMap.insert(QStringLiteral("transparency"), QVariant(transparency));
+  const double transparency = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "transparency" ) ).toDouble();
+  mRendererDataMap.insert( QStringLiteral( "transparency" ), QVariant( transparency ) );
 
   mValid = true;
 }

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -313,8 +313,11 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   // renderer
   mRendererDataMap = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "renderer" ) ).toMap();
   mLabelingDataList = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "labelingInfo" ) ).toList();
-  const double transparency = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "transparency" ) ).toDouble();
-  mRendererDataMap.insert( QStringLiteral( "transparency" ), QVariant( transparency ) );
+  const QVariant transparency = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "transparency" ) );
+  if ( transparency.isValid() )
+  {
+    mRendererDataMap.insert( QStringLiteral( "transparency" ), transparency );
+  }
 
   mValid = true;
 }

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -1402,7 +1402,6 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         self.assertEqual(vl.renderer().ranges()[0][0], -9007199254740991)
         self.assertEqual(vl.renderer().ranges()[-1][1], 9007199254740991)
 
-
     def testBboxRestriction(self):
         """
         Test limiting provider to features within a preset bounding box

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -41,6 +41,7 @@ from qgis.core import (
     QgsWkbTypes,
     QgsGraduatedSymbolRenderer,
     QgsSymbol,
+    QgsRendererRange,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -1396,6 +1397,10 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         self.assertIsNotNone(vl.dataProvider().createRenderer())
         self.assertIsInstance(vl.renderer(), QgsGraduatedSymbolRenderer)
         self.assertIsInstance(vl.renderer().sourceSymbol(), QgsSymbol)
+        self.assertIsInstance(vl.renderer().ranges()[0], QgsRendererRange)
+        self.assertEqual(len(vl.renderer().ranges()), 6)
+        self.assertEqual(vl.renderer().ranges()[0][0], -9007199254740991)
+        self.assertEqual(vl.renderer().ranges()[-1][1], 9007199254740991)
 
 
     def testBboxRestriction(self):

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -1335,6 +1335,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
             }
           ],
           "authoringInfo": {
+            "classificationMethod": "esriClassifyEqualInterval",
             "visualVariables": [
               {
                 "type": "colorInfo",

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -1229,7 +1229,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
     def testGraduatedRenderer(self):
         """ Test that the graduated renderer is correctly acquired from provider """
 
-        endpoint = self.basetestpath + '/renderer_fake_qgis_http_endpoint'
+        endpoint = self.basetestpath + '/class_breaks_renderer_fake_qgis_http_endpoint'
         with open(sanitize(endpoint, '?f=json'), 'wb') as f:
             f.write(b"""{
       "currentVersion": 11.2,


### PR DESCRIPTION
## Description

The file qgsarcgisrestutils.cpp is currently not supporting "classBreaks" type ArcGis-FeatureServers. This pull request adds functionality for QGIS to automatically convert classBreaks FeatureServer into a QgsGraduatedSymbolRenderer. Symbology will be loaded automatically now. 

![image](https://github.com/qgis/QGIS/assets/81414045/47a2e49a-96ba-45db-8129-65832fbaf522)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
