### PR TITLE
Fix WMS layer access control check

### DIFF
--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -47,10 +47,20 @@ void QgsWmsRenderContext::setParameters( const QgsWmsParameters &parameters )
 
   searchLayersToRender();
   removeUnwantedLayers();
-  checkLayerReadPermissions();
 
   std::reverse( mLayersToRender.begin(), mLayersToRender.end() );
 }
+
+bool QgsWmsRenderContext::addLayerToRender( QgsMapLayer *layer )
+{
+  bool allowed = checkLayerReadPermissions( layer );
+  if ( allowed )
+  {
+    mLayersToRender.append( layer );
+  }
+  return allowed;
+}
+
 
 void QgsWmsRenderContext::setFlag( const Flag flag, const bool on )
 {
@@ -186,6 +196,7 @@ qreal QgsWmsRenderContext::dotsPerMm() const
 
 QStringList QgsWmsRenderContext::flattenedQueryLayers( const QStringList &layerNames ) const
 {
+
   QStringList result;
   std::function <QStringList( const QString &name )> findLeaves = [ & ]( const QString & name ) -> QStringList
   {
@@ -335,7 +346,7 @@ void QgsWmsRenderContext::initLayerGroupsRecursive( const QgsLayerTreeGroup *gro
 {
   if ( !groupName.isEmpty() )
   {
-    mLayerGroups[groupName] = QList<QgsMapLayer *>();
+    QList<QgsMapLayer *> layerGroup;
     const auto projectLayerTreeRoot { mProject->layerTreeRoot() };
     const auto treeGroupLayers { group->findLayers() };
     // Fast track if there is no custom layer order,
@@ -344,7 +355,11 @@ void QgsWmsRenderContext::initLayerGroupsRecursive( const QgsLayerTreeGroup *gro
     {
       for ( const auto &tl : treeGroupLayers )
       {
-        mLayerGroups[groupName].push_back( tl->layer() );
+        auto layer = tl->layer();
+        if ( checkLayerReadPermissions( layer ) )
+        {
+          layerGroup.push_back( layer );
+        }
       }
     }
     else
@@ -354,15 +369,24 @@ void QgsWmsRenderContext::initLayerGroupsRecursive( const QgsLayerTreeGroup *gro
       QList<QgsMapLayer *> groupLayersList;
       for ( const auto &tl : treeGroupLayers )
       {
-        groupLayersList << tl->layer();
+        auto layer = tl->layer();
+        if ( checkLayerReadPermissions( layer ) )
+        {
+          groupLayersList << layer;
+        }
       }
       for ( const auto &l : projectLayerOrder )
       {
         if ( groupLayersList.contains( l ) )
         {
-          mLayerGroups[groupName].push_back( l );
+          layerGroup.push_back( l );
         }
       }
+    }
+
+    if ( !layerGroup.empty() )
+    {
+      mLayerGroups[groupName] = layerGroup;
     }
   }
 
@@ -442,10 +466,16 @@ void QgsWmsRenderContext::searchLayersToRender()
     {
       const QList<QgsMapLayer *> layers = mNicknameLayers.values( layerName );
       for ( QgsMapLayer *lyr : layers )
+      {
         if ( !mLayersToRender.contains( lyr ) )
         {
-          mLayersToRender.append( lyr );
+          if ( !addLayerToRender( lyr ) )
+          {
+            throw QgsSecurityException( QStringLiteral( "Your are not allowed to access the layer %1" ).arg( lyr->name() ) );
+
+          }
         }
+      }
     }
   }
 
@@ -456,10 +486,16 @@ void QgsWmsRenderContext::searchLayersToRender()
     {
       const QList<QgsMapLayer *> layers = mNicknameLayers.values( layerName );
       for ( QgsMapLayer *lyr : layers )
+      {
         if ( !mLayersToRender.contains( lyr ) )
         {
-          mLayersToRender.append( lyr );
+          if ( !addLayerToRender( lyr ) )
+          {
+            throw QgsSecurityException( QStringLiteral( "Your are not allowed to access the layer %1" ).arg( lyr->name() ) );
+
+          }
         }
+      }
     }
   }
 }
@@ -495,7 +531,13 @@ void QgsWmsRenderContext::searchLayersToRenderSld()
       if ( mNicknameLayers.contains( lname ) )
       {
         mSlds[lname] = namedElem;
-        mLayersToRender.append( mNicknameLayers.values( lname ) );
+        for ( const auto layer : mNicknameLayers.values( lname ) )
+        {
+          if ( !addLayerToRender( layer ) )
+          {
+            throw QgsSecurityException( QStringLiteral( "Your are not allowed to access the layer %1" ).arg( layer->name() ) );
+          }
+        }
       }
       else if ( mLayerGroups.contains( lname ) )
       {
@@ -540,7 +582,12 @@ void QgsWmsRenderContext::searchLayersToRenderStyle()
       {
         // to delete later
         mExternalLayers.append( layer.release() );
-        mLayersToRender.append( mExternalLayers.last() );
+        auto lyr = mExternalLayers.last();
+        if ( !addLayerToRender( lyr ) )
+        {
+          throw QgsSecurityException( QStringLiteral( "Your are not allowed to access the layer %1" ).arg( lyr->name() ) );
+
+        }
       }
     }
     else if ( mNicknameLayers.contains( nickname ) )
@@ -550,7 +597,13 @@ void QgsWmsRenderContext::searchLayersToRenderStyle()
         mStyles[nickname] = style;
       }
 
-      mLayersToRender.append( mNicknameLayers.values( nickname ) );
+      for ( const auto layer : mNicknameLayers.values( nickname ) )
+      {
+        if ( !addLayerToRender( layer ) )
+        {
+          throw QgsSecurityException( QStringLiteral( "Your are not allowed to access the layer %1" ).arg( layer->name() ) );
+        }
+      }
     }
     else if ( mLayerGroups.contains( nickname ) )
     {
@@ -575,7 +628,10 @@ void QgsWmsRenderContext::searchLayersToRenderStyle()
 
       for ( const auto &name : layersFromGroup )
       {
-        mLayersToRender.append( mNicknameLayers.values( name ) );
+        for ( const auto layer : mNicknameLayers.values( name ) )
+        {
+          addLayerToRender( layer );
+        }
       }
     }
     else
@@ -852,17 +908,17 @@ bool QgsWmsRenderContext::isExternalLayer( const QString &name ) const
   return false;
 }
 
-void QgsWmsRenderContext::checkLayerReadPermissions()
+bool QgsWmsRenderContext::checkLayerReadPermissions( QgsMapLayer *layer )
 {
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-  for ( const auto layer : mLayersToRender )
+  if ( !accessControl()->layerReadPermission( layer ) )
   {
-    if ( !accessControl()->layerReadPermission( layer ) )
-    {
-      throw QgsSecurityException( QStringLiteral( "You are not allowed to access to the layer: %1" ).arg( layer->name() ) );
-    }
+    QString msg = QStringLiteral( "Checking forbidden access for layer: %1" ).arg( layer->name() );
+    QgsMessageLog::logMessage( msg, "Server", Qgis::MessageLevel::Info );
+    return false;
   }
 #endif
+  return true;
 }
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -292,7 +292,17 @@ namespace QgsWms
       void searchLayersToRenderStyle();
       void removeUnwantedLayers();
 
-      void checkLayerReadPermissions();
+      /**
+       * Adds the layer to the list of layers to be rendered if the layer is readable
+       * Returns true if the layer is readable, false otherwise
+       */
+      bool addLayerToRender( QgsMapLayer *layer );
+
+      /**
+       * Check layer read permissions
+       * Returns true if the layer is readable, false otherwise
+       */
+      bool checkLayerReadPermissions( QgsMapLayer *layer );
 
       bool layerScaleVisibility( const QString &name ) const;
 

--- a/tests/src/python/test_qgsserver_accesscontrol_wms.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wms.py
@@ -276,9 +276,30 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
             headers.get("Content-Type"), "text/xml; charset=utf-8",
             f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
-            str(response).find('<ServiceException code="Security">') != -1,
+            str(response).find('<ServiceException code="LayerNotDefined">') != -1,
             "Not allowed do a GetMap on Country_grp"
         )
+
+        # Check group ACL.
+        # The whole group should not fail since it contains
+        # allowed layers.
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetMap",
+            "LAYERS": "project_grp",
+            "STYLES": "",
+            "FORMAT": "image/png",
+            "BBOX": "-16817707,-6318936.5,5696513,16195283.5",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "SRS": "EPSG:3857"
+        }.items())])
+        response, headers = self._get_restricted(query_string)
+        self.assertEqual(
+            headers.get("Content-Type"), "image/png",
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
 
     def test_wms_getfeatureinfo_hello(self):
         query_string = "&".join(["%s=%s" % i for i in list({

--- a/tests/src/python/test_qgsserver_accesscontrol_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wms_getlegendgraphic.py
@@ -98,7 +98,7 @@ class TestQgsServerAccessControlWMSGetlegendgraphic(TestQgsServerAccessControl):
             headers.get("Content-Type"), "text/xml; charset=utf-8",
             f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
-            str(response).find('<ServiceException code="Security">') != -1,
+            str(response).find('<ServiceException code="LayerNotDefined">') != -1,
             "Not allowed GetLegendGraphic"
         )
 

--- a/tests/testdata/qgis_server_accesscontrol/project_grp.qgs
+++ b/tests/testdata/qgis_server_accesscontrol/project_grp.qgs
@@ -3742,7 +3742,7 @@ def my_form_open(dialog, layer, feature):
     <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
     <WMSRestrictedComposers type="QStringList"/>
     <WMSRestrictedLayers type="QStringList"/>
-    <WMSRootName type="QString"></WMSRootName>
+    <WMSRootName type="QString">project_grp</WMSRootName>
     <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
     <WMSServiceAbstract type="QString">Simple test app.</WMSServiceAbstract>
     <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>


### PR DESCRIPTION
## Description

Fix access control when requesting layer's group with mixed allowed and forbidden layers from WMS requests.

Actual behavior: raise a security exception

Proposed behavior: consider only allowed layers in group.

The behavior for layers submitted to access control is now the following:

* Requesting a forbidden layer explicitely raise a security exception (unchanged behavior)
* Requesting a layer group that contain allowed layers and forbidden layers returns allowed layers and does not raise an exception anymore (changed behavior)
* Requesting a layer group that does not contains allowed layers is now a considered as non-existant group and returns error accordingly - which is consistent with the previous behavior (changed behavior)
* If no layers are requested explicitely, forbidden layers are discarded from the rendering list (unchanged behavior)

Implementation details:

Adding a layer to the rendering list is done by calling the `addLayerToRender` method with a boolean `queryLayer` context variable if the layer is added explicitely or not. If the layer is added explicetely, then a security exception is raised otherwie the layer is discarded from the rendering list.