### PR TITLE
Vertical transformation of features in iterators

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -138,6 +138,9 @@ Copy constructor
 
     ~QgsCoordinateTransform();
 
+    bool operator==( const QgsCoordinateTransform &other ) const;
+    bool operator!=( const QgsCoordinateTransform &other ) const;
+
     static bool isTransformationPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
 %Docstring
 Returns ``True`` if it is theoretically possible to transform between ``source`` and ``destination`` CRSes.

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -351,6 +351,14 @@ otherwise points are transformed from destination to source CRS.
 Returns ``True`` if the transform short circuits because the source and destination are equivalent.
 %End
 
+    bool hasVerticalComponent() const;
+%Docstring
+Returns ``True`` if the transform includes a vertical component, i.e. if both the :py:func:`~QgsCoordinateTransform.sourceCrs`
+and :py:func:`~QgsCoordinateTransform.destinationCrs` have a vertical axis.
+
+.. versionadded:: 3.40
+%End
+
     QString coordinateOperation() const;
 %Docstring
 Returns a Proj string representing the coordinate operation which will be used to transform

--- a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
@@ -758,6 +758,17 @@ and reprojection is required
 .. seealso:: :py:func:`destinationCrs`
 %End
 
+    QgsCoordinateTransform calculateTransform( const QgsCoordinateReferenceSystem &sourceCrs ) const;
+%Docstring
+Calculates the coordinate transform to use to transform geometries
+when they are originally in ``sourceCrs``.
+
+This method will return :py:func:`~QgsFeatureRequest.coordinateTransform` if it is set (ignoring ``sourceCrs``), otherwise
+it will calculate an appriopriate transform from ``sourceCrs`` to :py:func:`~QgsFeatureRequest.destinationCrs`.
+
+.. versionadded:: 3.40
+%End
+
     QgsFeatureRequest &setCoordinateTransform( const QgsCoordinateTransform &transform );
 %Docstring
 Sets the coordinate ``transform`` which will be used to transform

--- a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
@@ -8,7 +8,6 @@
 
 
 
-
 class QgsFeatureRequest
 {
 %Docstring(signature="appended")
@@ -716,11 +715,33 @@ Returns the simplification method for geometries that will be fetched.
 .. seealso:: :py:func:`setSimplifyMethod`
 %End
 
+    QgsCoordinateTransform coordinateTransform() const;
+%Docstring
+Returns the coordinate transform which will be used to transform
+the feature's geometries.
+
+If this transform is valid  then it will always be used to transform
+features, regardless of the :py:func:`~QgsFeatureRequest.destinationCrs` setting or the underlying
+feature source's actual CRS.
+
+.. seealso:: :py:func:`setCoordinateTransform`
+
+.. versionadded:: 3.40
+%End
+
     QgsCoordinateReferenceSystem destinationCrs() const;
 %Docstring
 Returns the destination coordinate reference system for feature's geometries,
 or an invalid :py:class:`QgsCoordinateReferenceSystem` if no reprojection will be done
 and all features will be left with their original geometry.
+
+.. warning::
+
+   if :py:func:`~QgsFeatureRequest.coordinateTransform` returns a valid transform then the
+   :py:func:`~QgsFeatureRequest.destinationCrs` will have no effect, and the :py:func:`~QgsFeatureRequest.coordinateTransform` will
+   always be used to transform features.
+
+.. seealso:: :py:func:`calculateTransform`
 
 .. seealso:: :py:func:`setDestinationCrs`
 
@@ -735,6 +756,41 @@ and reprojection is required
 .. seealso:: :py:func:`setDestinationCrs`
 
 .. seealso:: :py:func:`destinationCrs`
+%End
+
+    QgsFeatureRequest &setCoordinateTransform( const QgsCoordinateTransform &transform );
+%Docstring
+Sets the coordinate ``transform`` which will be used to transform
+the feature's geometries.
+
+If this transform is valid then it will always be used to transform
+features, regardless of the :py:func:`~QgsFeatureRequest.destinationCrs` setting or the underlying
+feature source's actual CRS.
+
+When a ``transform`` is set using :py:func:`~QgsFeatureRequest.setCoordinateTransform`, then any :py:func:`~QgsFeatureRequest.filterRect`
+or :py:func:`~QgsFeatureRequest.referenceGeometry` set on the request is expected to be in the
+same CRS as the destination CRS for the ``transform``.
+
+The feature geometry transformation is performed
+after all filter expressions are tested and any virtual fields are
+calculated. Accordingly, any geometric expressions used in
+:py:func:`~QgsFeatureRequest.filterExpression` will be performed in the original
+source CRS. This ensures consistent results are returned regardless of the
+destination CRS. Similarly, virtual field values will be calculated using the
+original geometry in the source CRS, so these values are not affected by
+any destination CRS transform present in the feature request.
+
+.. warning::
+
+   This method should be used with caution, and it is recommended
+   to use the high-level :py:func:`~QgsFeatureRequest.setDestinationCrs` method instead. Setting a specific
+   transform should only be done when there is a requirement to use a particular
+   transform.
+
+.. seealso:: :py:func:`coordinateTransform`
+
+
+.. versionadded:: 3.40
 %End
 
     QgsFeatureRequest &setDestinationCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
@@ -757,6 +813,12 @@ source CRS. This ensures consistent results are returned regardless of the
 destination CRS. Similarly, virtual field values will be calculated using the
 original geometry in the source CRS, so these values are not affected by
 any destination CRS transform present in the feature request.
+
+.. warning::
+
+   if :py:func:`~QgsFeatureRequest.coordinateTransform` returns a valid transform then the
+   :py:func:`~QgsFeatureRequest.destinationCrs` will have no effect, and the :py:func:`~QgsFeatureRequest.coordinateTransform` will
+   always be used to transform features.
 
 .. seealso:: :py:func:`destinationCrs`
 %End

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -138,6 +138,9 @@ Copy constructor
 
     ~QgsCoordinateTransform();
 
+    bool operator==( const QgsCoordinateTransform &other ) const;
+    bool operator!=( const QgsCoordinateTransform &other ) const;
+
     static bool isTransformationPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
 %Docstring
 Returns ``True`` if it is theoretically possible to transform between ``source`` and ``destination`` CRSes.

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -351,6 +351,14 @@ otherwise points are transformed from destination to source CRS.
 Returns ``True`` if the transform short circuits because the source and destination are equivalent.
 %End
 
+    bool hasVerticalComponent() const;
+%Docstring
+Returns ``True`` if the transform includes a vertical component, i.e. if both the :py:func:`~QgsCoordinateTransform.sourceCrs`
+and :py:func:`~QgsCoordinateTransform.destinationCrs` have a vertical axis.
+
+.. versionadded:: 3.40
+%End
+
     QString coordinateOperation() const;
 %Docstring
 Returns a Proj string representing the coordinate operation which will be used to transform

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -758,6 +758,17 @@ and reprojection is required
 .. seealso:: :py:func:`destinationCrs`
 %End
 
+    QgsCoordinateTransform calculateTransform( const QgsCoordinateReferenceSystem &sourceCrs ) const;
+%Docstring
+Calculates the coordinate transform to use to transform geometries
+when they are originally in ``sourceCrs``.
+
+This method will return :py:func:`~QgsFeatureRequest.coordinateTransform` if it is set (ignoring ``sourceCrs``), otherwise
+it will calculate an appriopriate transform from ``sourceCrs`` to :py:func:`~QgsFeatureRequest.destinationCrs`.
+
+.. versionadded:: 3.40
+%End
+
     QgsFeatureRequest &setCoordinateTransform( const QgsCoordinateTransform &transform );
 %Docstring
 Sets the coordinate ``transform`` which will be used to transform

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -8,7 +8,6 @@
 
 
 
-
 class QgsFeatureRequest
 {
 %Docstring(signature="appended")
@@ -716,11 +715,33 @@ Returns the simplification method for geometries that will be fetched.
 .. seealso:: :py:func:`setSimplifyMethod`
 %End
 
+    QgsCoordinateTransform coordinateTransform() const;
+%Docstring
+Returns the coordinate transform which will be used to transform
+the feature's geometries.
+
+If this transform is valid  then it will always be used to transform
+features, regardless of the :py:func:`~QgsFeatureRequest.destinationCrs` setting or the underlying
+feature source's actual CRS.
+
+.. seealso:: :py:func:`setCoordinateTransform`
+
+.. versionadded:: 3.40
+%End
+
     QgsCoordinateReferenceSystem destinationCrs() const;
 %Docstring
 Returns the destination coordinate reference system for feature's geometries,
 or an invalid :py:class:`QgsCoordinateReferenceSystem` if no reprojection will be done
 and all features will be left with their original geometry.
+
+.. warning::
+
+   if :py:func:`~QgsFeatureRequest.coordinateTransform` returns a valid transform then the
+   :py:func:`~QgsFeatureRequest.destinationCrs` will have no effect, and the :py:func:`~QgsFeatureRequest.coordinateTransform` will
+   always be used to transform features.
+
+.. seealso:: :py:func:`calculateTransform`
 
 .. seealso:: :py:func:`setDestinationCrs`
 
@@ -735,6 +756,41 @@ and reprojection is required
 .. seealso:: :py:func:`setDestinationCrs`
 
 .. seealso:: :py:func:`destinationCrs`
+%End
+
+    QgsFeatureRequest &setCoordinateTransform( const QgsCoordinateTransform &transform );
+%Docstring
+Sets the coordinate ``transform`` which will be used to transform
+the feature's geometries.
+
+If this transform is valid then it will always be used to transform
+features, regardless of the :py:func:`~QgsFeatureRequest.destinationCrs` setting or the underlying
+feature source's actual CRS.
+
+When a ``transform`` is set using :py:func:`~QgsFeatureRequest.setCoordinateTransform`, then any :py:func:`~QgsFeatureRequest.filterRect`
+or :py:func:`~QgsFeatureRequest.referenceGeometry` set on the request is expected to be in the
+same CRS as the destination CRS for the ``transform``.
+
+The feature geometry transformation is performed
+after all filter expressions are tested and any virtual fields are
+calculated. Accordingly, any geometric expressions used in
+:py:func:`~QgsFeatureRequest.filterExpression` will be performed in the original
+source CRS. This ensures consistent results are returned regardless of the
+destination CRS. Similarly, virtual field values will be calculated using the
+original geometry in the source CRS, so these values are not affected by
+any destination CRS transform present in the feature request.
+
+.. warning::
+
+   This method should be used with caution, and it is recommended
+   to use the high-level :py:func:`~QgsFeatureRequest.setDestinationCrs` method instead. Setting a specific
+   transform should only be done when there is a requirement to use a particular
+   transform.
+
+.. seealso:: :py:func:`coordinateTransform`
+
+
+.. versionadded:: 3.40
 %End
 
     QgsFeatureRequest &setDestinationCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
@@ -757,6 +813,12 @@ source CRS. This ensures consistent results are returned regardless of the
 destination CRS. Similarly, virtual field values will be calculated using the
 original geometry in the source CRS, so these values are not affected by
 any destination CRS transform present in the feature request.
+
+.. warning::
+
+   if :py:func:`~QgsFeatureRequest.coordinateTransform` returns a valid transform then the
+   :py:func:`~QgsFeatureRequest.destinationCrs` will have no effect, and the :py:func:`~QgsFeatureRequest.coordinateTransform` will
+   always be used to transform features.
 
 .. seealso:: :py:func:`destinationCrs`
 %End

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -174,6 +174,20 @@ QgsCoordinateTransform &QgsCoordinateTransform::operator=( const QgsCoordinateTr
 
 QgsCoordinateTransform::~QgsCoordinateTransform() {} //NOLINT
 
+bool QgsCoordinateTransform::operator==( const QgsCoordinateTransform &other ) const
+{
+  return d->mSourceCRS == other.d->mSourceCRS
+         && d->mDestCRS == other.d->mDestCRS
+         && mBallparkTransformsAreAppropriate == other.mBallparkTransformsAreAppropriate
+         && d->mProjCoordinateOperation == other.d->mProjCoordinateOperation
+         && instantiatedCoordinateOperationDetails().proj == other.instantiatedCoordinateOperationDetails().proj;
+}
+
+bool QgsCoordinateTransform::operator!=( const QgsCoordinateTransform &other ) const
+{
+  return !( *this == other );
+}
+
 bool QgsCoordinateTransform::isTransformationPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
 {
   if ( !source.isValid() || !destination.isValid() )

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -935,6 +935,11 @@ bool QgsCoordinateTransform::isShortCircuited() const
   return !d->mIsValid || d->mShortCircuit;
 }
 
+bool QgsCoordinateTransform::hasVerticalComponent() const
+{
+  return d->mIsValid && d->mHasVerticalComponent;
+}
+
 QString QgsCoordinateTransform::coordinateOperation() const
 {
   return d->mProjCoordinateOperation;

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -382,6 +382,14 @@ class CORE_EXPORT QgsCoordinateTransform
     bool isShortCircuited() const;
 
     /**
+     * Returns TRUE if the transform includes a vertical component, i.e. if both the sourceCrs()
+     * and destinationCrs() have a vertical axis.
+     *
+     * \since QGIS 3.40
+     */
+    bool hasVerticalComponent() const;
+
+    /**
      * Returns a Proj string representing the coordinate operation which will be used to transform
      * coordinates.
      *

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -147,6 +147,9 @@ class CORE_EXPORT QgsCoordinateTransform
 
     ~QgsCoordinateTransform();
 
+    bool operator==( const QgsCoordinateTransform &other ) const;
+    bool operator!=( const QgsCoordinateTransform &other ) const;
+
     /**
      * Returns TRUE if it is theoretically possible to transform between \a source and \a destination CRSes.
      *

--- a/src/core/proj/qgscoordinatetransform_p.cpp
+++ b/src/core/proj/qgscoordinatetransform_p.cpp
@@ -84,6 +84,7 @@ QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate( const QgsCoordinat
   , mIsValid( other.mIsValid )
   , mShortCircuit( other.mShortCircuit )
   , mGeographicToWebMercator( other.mGeographicToWebMercator )
+  , mHasVerticalComponent( other.mHasVerticalComponent )
   , mSourceCRS( other.mSourceCRS )
   , mDestCRS( other.mDestCRS )
   , mSourceDatumTransform( other.mSourceDatumTransform )
@@ -162,6 +163,8 @@ bool QgsCoordinateTransformPrivate::initialize()
   mGeographicToWebMercator =
     mSourceCRS.isGeographic() &&
     mDestCRS.authid() == QLatin1String( "EPSG:3857" );
+
+  mHasVerticalComponent = mSourceCRS.hasVerticalAxis() && mDestCRS.hasVerticalAxis();
 
   mSourceIsDynamic = mSourceCRS.isDynamic();
   mSourceCoordinateEpoch = mSourceCRS.coordinateEpoch();

--- a/src/core/proj/qgscoordinatetransform_p.h
+++ b/src/core/proj/qgscoordinatetransform_p.h
@@ -91,6 +91,9 @@ class QgsCoordinateTransformPrivate : public QSharedData
     //! Flag to indicate EPSG:4326 to EPSG:3857 reprojection
     bool mGeographicToWebMercator = false;
 
+    //! Flag to indicate whether the transform has a vertical component
+    bool mHasVerticalComponent = false;
+
     //! QgsCoordinateReferenceSystem of the source (layer) coordinate system
     QgsCoordinateReferenceSystem mSourceCRS;
 

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -28,10 +28,8 @@
 QgsMemoryFeatureIterator::QgsMemoryFeatureIterator( QgsMemoryFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsMemoryFeatureSource>( source, ownSource, request )
 {
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
+
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -123,10 +123,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   }
   QMutexLocker locker( mSharedDS ? &mSharedDS->mutex() : nullptr );
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/core/providers/sensorthings/qgssensorthingsfeatureiterator.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsfeatureiterator.cpp
@@ -48,10 +48,7 @@ QgsSensorThingsFeatureIterator::QgsSensorThingsFeatureIterator( QgsSensorThingsF
   : QgsAbstractFeatureIteratorFromSource<QgsSensorThingsFeatureSource>( source, ownSource, request )
   , mInterruptionChecker( request.feedback() )
 {
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->sharedData()->crs() )
-  {
-    mTransform = QgsCoordinateTransform( mSource->sharedData()->crs(), mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->sharedData()->crs() );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -23,10 +23,7 @@ QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache
   : QgsAbstractFeatureIterator( featureRequest )
   , mVectorLayerCache( vlCache )
 {
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mVectorLayerCache->sourceCrs() )
-  {
-    mTransform = QgsCoordinateTransform( mVectorLayerCache->sourceCrs(), mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mVectorLayerCache->sourceCrs() );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );
@@ -143,10 +140,7 @@ QgsCachedFeatureWriterIterator::QgsCachedFeatureWriterIterator( QgsVectorLayerCa
   : QgsAbstractFeatureIterator( featureRequest )
   , mVectorLayerCache( vlCache )
 {
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mVectorLayerCache->sourceCrs() )
-  {
-    mTransform = QgsCoordinateTransform( mVectorLayerCache->sourceCrs(), mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mVectorLayerCache->sourceCrs() );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -102,7 +102,7 @@ void QgsAbstractFeatureIterator::geometryToDestinationCrs( QgsFeature &feature, 
     try
     {
       QgsGeometry g = feature.geometry();
-      g.transform( transform );
+      g.transform( transform, Qgis::TransformDirection::Forward, transform.hasVerticalComponent() );
       feature.setGeometry( g );
     }
     catch ( QgsCsException & )

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -89,6 +89,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mSimplifyMethod = rh.mSimplifyMethod;
   mLimit = rh.mLimit;
   mOrderBy = rh.mOrderBy;
+  mTransform = rh.mTransform;
   mCrs = rh.mCrs;
   mTransformContext = rh.mTransformContext;
   mTransformErrorCallback = rh.mTransformErrorCallback;
@@ -118,11 +119,11 @@ bool QgsFeatureRequest::compare( const QgsFeatureRequest &rh ) const
          mSimplifyMethod == rh.mSimplifyMethod &&
          mLimit == rh.mLimit &&
          mOrderBy == rh.mOrderBy &&
+         mTransform == rh.mTransform &&
          mCrs == rh.mCrs &&
          mTransformContext == rh.mTransformContext &&
          mTimeout == rh.mTimeout &&
          mRequestMayBeNested == rh.mRequestMayBeNested;
-
 }
 
 
@@ -315,6 +316,10 @@ QgsFeatureRequest &QgsFeatureRequest::setSimplifyMethod( const QgsSimplifyMethod
   return *this;
 }
 
+QgsCoordinateTransform QgsFeatureRequest::coordinateTransform() const
+{
+  return mTransform;
+}
 
 QgsCoordinateReferenceSystem QgsFeatureRequest::destinationCrs() const
 {
@@ -324,6 +329,12 @@ QgsCoordinateReferenceSystem QgsFeatureRequest::destinationCrs() const
 QgsCoordinateTransformContext QgsFeatureRequest::transformContext() const
 {
   return mTransformContext;
+}
+
+QgsFeatureRequest &QgsFeatureRequest::setCoordinateTransform( const QgsCoordinateTransform &transform )
+{
+  mTransform = transform;
+  return *this;
 }
 
 QgsFeatureRequest &QgsFeatureRequest::setDestinationCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context )

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -331,6 +331,19 @@ QgsCoordinateTransformContext QgsFeatureRequest::transformContext() const
   return mTransformContext;
 }
 
+QgsCoordinateTransform QgsFeatureRequest::calculateTransform( const QgsCoordinateReferenceSystem &sourceCrs ) const
+{
+  if ( mTransform.isValid() )
+  {
+    return mTransform;
+  }
+  else if ( sourceCrs.isValid() && mCrs != sourceCrs )
+  {
+    return QgsCoordinateTransform( sourceCrs, mCrs, mTransformContext );
+  }
+  return QgsCoordinateTransform();
+}
+
 QgsFeatureRequest &QgsFeatureRequest::setCoordinateTransform( const QgsCoordinateTransform &transform )
 {
   mTransform = transform;

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -761,6 +761,17 @@ class CORE_EXPORT QgsFeatureRequest
     QgsCoordinateTransformContext transformContext() const;
 
     /**
+     * Calculates the coordinate transform to use to transform geometries
+     * when they are originally in \a sourceCrs.
+     *
+     * This method will return coordinateTransform() if it is set (ignoring \a sourceCrs), otherwise
+     * it will calculate an appriopriate transform from \a sourceCrs to destinationCrs().
+     *
+     * \since QGIS 3.40
+     */
+    QgsCoordinateTransform calculateTransform( const QgsCoordinateReferenceSystem &sourceCrs ) const;
+
+    /**
      * Sets the coordinate \a transform which will be used to transform
      * the feature's geometries.
      *

--- a/src/core/qgsfeaturesource.cpp
+++ b/src/core/qgsfeaturesource.cpp
@@ -137,7 +137,8 @@ QgsFeatureIds QgsFeatureSource::allFeatureIds() const
 QgsVectorLayer *QgsFeatureSource::materialize( const QgsFeatureRequest &request, QgsFeedback *feedback )
 {
   const Qgis::WkbType outWkbType = ( request.flags() & Qgis::FeatureRequestFlag::NoGeometry ) ? Qgis::WkbType::NoGeometry : wkbType();
-  const QgsCoordinateReferenceSystem crs = request.destinationCrs().isValid() ? request.destinationCrs() : sourceCrs();
+  const QgsCoordinateReferenceSystem crs = request.coordinateTransform().isValid() ? request.coordinateTransform().destinationCrs()
+      : request.destinationCrs().isValid() ? request.destinationCrs() : sourceCrs();
 
   const QgsAttributeList requestedAttrs = request.subsetOfAttributes();
 

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -138,11 +138,8 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
   : QgsAbstractFeatureIteratorFromSource<QgsVectorLayerFeatureSource>( source, ownSource, request )
   , mFetchedFid( false )
 {
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-    mHasValidTransform = mTransform.isValid();
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
+  mHasValidTransform = mTransform.isValid();
 
   // prepare spatial filter geometries for optimal speed
   // since the mDistanceWithin* constraint member variables are all in the DESTINATION CRS,
@@ -238,8 +235,9 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
   // but we remove any destination CRS parameter - that is handled in QgsVectorLayerFeatureIterator,
   // not at the provider level. Otherwise virtual fields depending on geometry would have incorrect
   // values
-  if ( mRequest.destinationCrs().isValid() )
+  if ( mRequest.coordinateTransform().isValid() || mRequest.destinationCrs().isValid() )
   {
+    mProviderRequest.setCoordinateTransform( QgsCoordinateTransform() );
     mProviderRequest.setDestinationCrs( QgsCoordinateReferenceSystem(), mRequest.transformContext() );
   }
 

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -41,10 +41,7 @@ QgsAfsSharedData *QgsAfsFeatureSource::sharedData() const
 QgsAfsFeatureIterator::QgsAfsFeatureIterator( QgsAfsFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsAfsFeatureSource>( source, ownSource, request )
 {
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->sharedData()->crs() )
-  {
-    mTransform = QgsCoordinateTransform( mSource->sharedData()->crs(), mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->sharedData()->crs() );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -41,10 +41,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   // load it.
   const bool hasGeometry = mSource->mGeomRep != QgsDelimitedTextProvider::GeomNone;
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/gpx/qgsgpxfeatureiterator.cpp
+++ b/src/providers/gpx/qgsgpxfeatureiterator.cpp
@@ -35,10 +35,7 @@ QgsGPXFeatureIterator::QgsGPXFeatureIterator( QgsGPXFeatureSource *source, bool 
     return;
   }
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/hana/qgshanafeatureiterator.cpp
+++ b/src/providers/hana/qgshanafeatureiterator.cpp
@@ -85,8 +85,7 @@ QgsHanaFeatureIterator::QgsHanaFeatureIterator(
     return;
   }
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
 
   try
   {

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -39,10 +39,7 @@ QgsMssqlFeatureIterator::QgsMssqlFeatureIterator( QgsMssqlFeatureSource *source,
 
   mParser.mIsGeography = mSource->mIsGeography;
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -48,10 +48,7 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
     return;
   }
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -57,10 +57,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
     return;
   }
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -51,10 +51,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
   QString fallbackWhereClause;
   QString whereClause;
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -43,10 +43,7 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
     return;
   }
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
-  {
-    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mSource->mCrs );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
@@ -294,10 +294,7 @@ QgsBackgroundCachedFeatureIterator::QgsBackgroundCachedFeatureIterator(
     }
   }
 
-  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mShared->sourceCrs() )
-  {
-    mTransform = QgsCoordinateTransform( mShared->sourceCrs(), mRequest.destinationCrs(), mRequest.transformContext() );
-  }
+  mTransform = mRequest.calculateTransform( mShared->sourceCrs() );
   try
   {
     mFilterRect = filterRectToSourceCrs( mTransform );

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -34,6 +34,7 @@ class TestQgsCoordinateTransform: public QObject
     void transformBoundingBox();
     void copy();
     void assignment();
+    void equality();
     void isValid();
     void isShortCircuited();
     void contextShared();
@@ -123,6 +124,66 @@ void TestQgsCoordinateTransform::assignment()
   copy = uninitialized;
   QVERIFY( !copy.isValid() );
   QVERIFY( original.isValid() );
+}
+
+void TestQgsCoordinateTransform::equality()
+{
+  QgsCoordinateTransform t1;
+  QgsCoordinateTransform t2;
+  QVERIFY( t1 == t2 );
+
+  t1 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext() );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+  // same source and destination
+  t2 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext() );
+  QVERIFY( t1 == t2 );
+  QVERIFY( t2 == t1 );
+  // different source
+  t2 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3113" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext() );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+  // different destination
+  t2 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateTransformContext() );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+  // different source and destination
+  t2 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3113" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateTransformContext() );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+  // source/destination swapped
+  t2 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ), QgsCoordinateTransformContext() );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+
+  // same source and dest, different settings
+  t2 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext() );
+  t1.setBallparkTransformsAreAppropriate( true );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+  t2.setBallparkTransformsAreAppropriate( true );
+  QVERIFY( t1 == t2 );
+
+  // explicit coordinate operation
+  t1 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext() );
+  t1.setCoordinateOperation( QStringLiteral( "+proj=pipeline +step +inv +proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +step +proj=hgridshift +grids=au_icsm_GDA94_GDA2020_conformal_and_distortion.tif +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84" ) );
+  t2 = QgsCoordinateTransform( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext() );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+  t2.setCoordinateOperation( QStringLiteral( "+proj=pipeline +step +inv +proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84" ) );
+  QVERIFY( t1 != t2 );
+  QVERIFY( t2 != t1 );
+  t2.setCoordinateOperation( t1.coordinateOperation() );
+  QVERIFY( t1 == t2 );
 }
 
 void TestQgsCoordinateTransform::isValid()

--- a/tests/src/python/provider_python.py
+++ b/tests/src/python/provider_python.py
@@ -43,9 +43,7 @@ class PyFeatureIterator(QgsAbstractFeatureIterator):
         self._request = request if request is not None else QgsFeatureRequest()
         self._source = source
         self._index = 0
-        self._transform = QgsCoordinateTransform()
-        if self._request.destinationCrs().isValid() and self._request.destinationCrs() != self._source._provider.crs():
-            self._transform = QgsCoordinateTransform(self._source._provider.crs(), self._request.destinationCrs(), self._request.transformContext())
+        self._transform = request.calculateTransform(self._source._provider.crs())
         try:
             self._filter_rect = self.filterRectToSourceCrs(self._transform)
         except QgsCsException as e:

--- a/tests/src/python/test_provider_gpx.py
+++ b/tests/src/python/test_provider_gpx.py
@@ -64,6 +64,10 @@ class TestPyQgsGpxProvider(QgisTestCase, ProviderTestCase):
         pass
 
     @unittest.skip('Base provider test is not suitable for GPX provider')
+    def testGetFeaturesCoordinateTransform(self):
+        pass
+
+    @unittest.skip('Base provider test is not suitable for GPX provider')
     def testGetFeaturesLimit(self):
         pass
 

--- a/tests/src/python/test_qgscoordinatetransform.py
+++ b/tests/src/python/test_qgscoordinatetransform.py
@@ -161,6 +161,53 @@ class TestQgsCoordinateTransform(QgisTestCase):
         self.assertAlmostEqual(transformedExtent.xMaximum(), 20037508.343, delta=1e-3)
         self.assertAlmostEqual(transformedExtent.yMaximum(), 44927335.427, delta=1e-3)
 
+    def test_has_vertical_component(self):
+        transform = QgsCoordinateTransform()
+        self.assertFalse(transform.hasVerticalComponent())
+
+        # 2d to 2d
+        transform = QgsCoordinateTransform(
+            QgsCoordinateReferenceSystem('EPSG:4326'),
+            QgsCoordinateReferenceSystem('EPSG:3857'),
+            QgsCoordinateTransformContext()
+        )
+        self.assertFalse(transform.hasVerticalComponent())
+
+        # 2d to 3d
+        transform = QgsCoordinateTransform(
+            QgsCoordinateReferenceSystem('EPSG:4326'),
+            QgsCoordinateReferenceSystem('EPSG:7843'),
+            QgsCoordinateTransformContext()
+        )
+        self.assertFalse(transform.hasVerticalComponent())
+
+        # 3d to 2d
+        transform = QgsCoordinateTransform(
+            QgsCoordinateReferenceSystem('EPSG:7843'),
+            QgsCoordinateReferenceSystem('EPSG:4326'),
+            QgsCoordinateTransformContext()
+        )
+        self.assertFalse(transform.hasVerticalComponent())
+
+        # 3d to 3d
+        transform = QgsCoordinateTransform(
+            QgsCoordinateReferenceSystem('EPSG:7843'),
+            QgsCoordinateReferenceSystem.createCompoundCrs(
+                QgsCoordinateReferenceSystem('EPSG:7844'),
+                QgsCoordinateReferenceSystem('EPSG:9458'))[0],
+            QgsCoordinateTransformContext()
+        )
+        self.assertTrue(transform.hasVerticalComponent())
+
+        transform = QgsCoordinateTransform(
+            QgsCoordinateReferenceSystem.createCompoundCrs(
+                QgsCoordinateReferenceSystem('EPSG:7844'),
+                QgsCoordinateReferenceSystem('EPSG:5711'))[0],
+            QgsCoordinateReferenceSystem('EPSG:7843'),
+            QgsCoordinateTransformContext()
+        )
+        self.assertTrue(transform.hasVerticalComponent())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsfeatureiterator.py
+++ b/tests/src/python/test_qgsfeatureiterator.py
@@ -23,6 +23,10 @@ from qgis.core import (
     QgsPropertyDefinition,
     QgsVectorLayer,
     QgsVectorLayerJoinInfo,
+    QgsPoint,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsCoordinateTransformContext,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -532,6 +536,196 @@ class TestQgsFeatureIterator(QgisTestCase):
                layer.getFeatures(QgsFeatureRequest().setInvalidGeometryCheck(QgsFeatureRequest.InvalidGeometryCheck.GeometryAbortOnInvalid))]
         self.assertEqual(res, ['a', 'b'])
         layer.rollBack()
+
+    def test_vertical_transformation_gda2020_to_AVWS(self):
+        """
+        Test vertical transformations are correctly handled during iteration
+
+        GDA2020 to AVWS
+        """
+
+        # GDA2020 vertical CRS
+        vl = QgsVectorLayer('PointZ?crs=EPSG:7843', 'gda2020points', 'memory')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.crs().authid(), 'EPSG:7843')
+
+        self.assertEqual(vl.crs3D().horizontalCrs().authid(), 'EPSG:7843')
+
+        f = QgsFeature()
+        f.setGeometry(QgsPoint(134.445567853,
+                               -23.445567853,
+                               5543.325))
+        self.assertTrue(vl.dataProvider().addFeature(f))
+
+        # AVWS
+        dest_crs, msg = QgsCoordinateReferenceSystem.createCompoundCrs(
+            QgsCoordinateReferenceSystem('EPSG:7844'),
+            QgsCoordinateReferenceSystem('EPSG:9458'))
+        self.assertFalse(msg)
+        self.assertTrue(dest_crs.isValid())
+        self.assertEqual(dest_crs.horizontalCrs().authid(), 'EPSG:7844')
+        self.assertEqual(dest_crs.verticalCrs().authid(), 'EPSG:9458')
+
+        transform = QgsCoordinateTransform(
+            vl.crs3D(),
+            dest_crs,
+            QgsCoordinateTransformContext()
+        )
+        # for debugging
+        # self.assertEqual(transform.instantiatedCoordinateOperationDetails().proj, '+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +inv +proj=vgridshift +grids=au_ga_AGQG_20201120.tif +multiplier=1 +step +proj=unitconvert +xy_in=rad +xy_out=deg')
+
+        request = QgsFeatureRequest().setCoordinateTransform(
+            transform)
+
+        transformed_features = list(vl.getFeatures(request))
+        self.assertEqual(len(transformed_features), 1)
+        geom = transformed_features[0].geometry()
+        self.assertAlmostEqual(geom.constGet().x(), 134.445567853, 6)
+        self.assertAlmostEqual(geom.constGet().y(), -23.445567853, 6)
+        # comparing against results from https://geodesyapps.ga.gov.au/avws
+        self.assertAlmostEqual(geom.constGet().z(), 5524.13969, 3)
+
+    def test_vertical_transformation_AVWS_to_gda2020(self):
+        """
+        Test vertical transformations are correctly handled during iteration
+
+        AVWS to GDA2020
+        """
+
+        # GDA2020 vertical CRS
+        vl = QgsVectorLayer('PointZ?crs=EPSG:7844', 'gda2020points', 'memory')
+        self.assertTrue(vl.isValid())
+
+        f = QgsFeature()
+        f.setGeometry(QgsPoint(134.445567853,
+                               -23.445567853,
+                               5524.13969))
+        self.assertTrue(vl.dataProvider().addFeature(f))
+
+        # AVWS
+        source_crs, msg = QgsCoordinateReferenceSystem.createCompoundCrs(
+            QgsCoordinateReferenceSystem('EPSG:7844'),
+            QgsCoordinateReferenceSystem('EPSG:9458'))
+        self.assertFalse(msg)
+        self.assertTrue(source_crs.isValid())
+        self.assertEqual(source_crs.horizontalCrs().authid(), 'EPSG:7844')
+        self.assertEqual(source_crs.verticalCrs().authid(), 'EPSG:9458')
+
+        # dest CRS is GDA2020
+
+        transform = QgsCoordinateTransform(
+            source_crs,
+            QgsCoordinateReferenceSystem('EPSG:7843'),
+            QgsCoordinateTransformContext()
+        )
+        # for debugging
+        # self.assertEqual(transform.instantiatedCoordinateOperationDetails().proj, '+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +inv +proj=vgridshift +grids=au_ga_AGQG_20201120.tif +multiplier=1 +step +proj=unitconvert +xy_in=rad +xy_out=deg')
+
+        request = QgsFeatureRequest().setCoordinateTransform(
+            transform)
+
+        transformed_features = list(vl.getFeatures(request))
+        self.assertEqual(len(transformed_features), 1)
+        geom = transformed_features[0].geometry()
+        self.assertAlmostEqual(geom.constGet().x(), 134.445567853, 6)
+        self.assertAlmostEqual(geom.constGet().y(), -23.445567853, 6)
+        # comparing against results from https://geodesyapps.ga.gov.au/avws
+        self.assertAlmostEqual(geom.constGet().z(), 5543.325, 3)
+
+    def test_vertical_transformation_gda2020_to_AHD(self):
+        """
+        Test vertical transformations are correctly handled during iteration
+
+        GDA2020 to AHD
+        """
+
+        # GDA2020 vertical CRS
+        vl = QgsVectorLayer('PointZ?crs=EPSG:7843', 'gda2020points', 'memory')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.crs().authid(), 'EPSG:7843')
+
+        self.assertEqual(vl.crs3D().horizontalCrs().authid(), 'EPSG:7843')
+
+        f = QgsFeature()
+        f.setGeometry(QgsPoint(134.445567853,
+                               -23.445567853,
+                               5543.325))
+        self.assertTrue(vl.dataProvider().addFeature(f))
+
+        # AHD
+        dest_crs, msg = QgsCoordinateReferenceSystem.createCompoundCrs(
+            QgsCoordinateReferenceSystem('EPSG:7844'),
+            QgsCoordinateReferenceSystem('EPSG:5711'))
+        self.assertFalse(msg)
+        self.assertTrue(dest_crs.isValid())
+        self.assertEqual(dest_crs.horizontalCrs().authid(), 'EPSG:7844')
+        self.assertEqual(dest_crs.verticalCrs().authid(), 'EPSG:5711')
+
+        transform = QgsCoordinateTransform(
+            vl.crs3D(),
+            dest_crs,
+            QgsCoordinateTransformContext()
+        )
+        # for debugging
+        # self.assertEqual(transform.instantiatedCoordinateOperationDetails().proj, '+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +inv +proj=vgridshift +grids=au_ga_AGQG_20201120.tif +multiplier=1 +step +proj=unitconvert +xy_in=rad +xy_out=deg')
+
+        request = QgsFeatureRequest().setCoordinateTransform(
+            transform)
+
+        transformed_features = list(vl.getFeatures(request))
+        self.assertEqual(len(transformed_features), 1)
+        geom = transformed_features[0].geometry()
+        self.assertAlmostEqual(geom.constGet().x(), 134.445567853, 6)
+        self.assertAlmostEqual(geom.constGet().y(), -23.445567853, 6)
+        # comparing against results from https://geodesyapps.ga.gov.au/ausgeoid2020
+        self.assertAlmostEqual(geom.constGet().z(), 5523.598, 3)
+
+    def test_vertical_transformation_AHD_to_gda2020(self):
+        """
+        Test vertical transformations are correctly handled during iteration
+
+        AHD to GDA2020
+        """
+
+        # GDA2020 vertical CRS
+        vl = QgsVectorLayer('PointZ?crs=EPSG:7844', 'gda2020points', 'memory')
+        self.assertTrue(vl.isValid())
+
+        f = QgsFeature()
+        f.setGeometry(QgsPoint(134.445567853,
+                               -23.445567853,
+                               5523.598))
+        self.assertTrue(vl.dataProvider().addFeature(f))
+
+        # AHD
+        source_crs, msg = QgsCoordinateReferenceSystem.createCompoundCrs(
+            QgsCoordinateReferenceSystem('EPSG:7844'),
+            QgsCoordinateReferenceSystem('EPSG:5711'))
+        self.assertFalse(msg)
+        self.assertTrue(source_crs.isValid())
+        self.assertEqual(source_crs.horizontalCrs().authid(), 'EPSG:7844')
+        self.assertEqual(source_crs.verticalCrs().authid(), 'EPSG:5711')
+
+        # dest CRS is GDA2020
+
+        transform = QgsCoordinateTransform(
+            source_crs,
+            QgsCoordinateReferenceSystem('EPSG:7843'),
+            QgsCoordinateTransformContext()
+        )
+        # for debugging
+        # self.assertEqual(transform.instantiatedCoordinateOperationDetails().proj, '+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +inv +proj=vgridshift +grids=au_ga_AGQG_20201120.tif +multiplier=1 +step +proj=unitconvert +xy_in=rad +xy_out=deg')
+
+        request = QgsFeatureRequest().setCoordinateTransform(
+            transform)
+
+        transformed_features = list(vl.getFeatures(request))
+        self.assertEqual(len(transformed_features), 1)
+        geom = transformed_features[0].geometry()
+        self.assertAlmostEqual(geom.constGet().x(), 134.445567853, 6)
+        self.assertAlmostEqual(geom.constGet().y(), -23.445567853, 6)
+        # comparing against results from https://geodesyapps.ga.gov.au/avws
+        self.assertAlmostEqual(geom.constGet().z(), 5543.325, 3)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfeatureiterator.py
+++ b/tests/src/python/test_qgsfeatureiterator.py
@@ -27,6 +27,7 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
     QgsCoordinateTransformContext,
+    QgsDatumTransform,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -566,6 +567,12 @@ class TestQgsFeatureIterator(QgisTestCase):
         self.assertEqual(dest_crs.horizontalCrs().authid(), 'EPSG:7844')
         self.assertEqual(dest_crs.verticalCrs().authid(), 'EPSG:9458')
 
+        available_operations = QgsDatumTransform.operations(vl.crs3D(), dest_crs)
+        self.assertEqual(len(available_operations[0].grids), 1)
+        self.assertEqual(available_operations[0].grids[0].shortName, 'au_ga_AGQG_20201120.tif')
+        if not available_operations[0].isAvailable:
+            self.skipTest(f'Required grid {available_operations[0].grids[0].shortName} not available on system')
+
         transform = QgsCoordinateTransform(
             vl.crs3D(),
             dest_crs,
@@ -610,6 +617,13 @@ class TestQgsFeatureIterator(QgisTestCase):
         self.assertTrue(source_crs.isValid())
         self.assertEqual(source_crs.horizontalCrs().authid(), 'EPSG:7844')
         self.assertEqual(source_crs.verticalCrs().authid(), 'EPSG:9458')
+
+        available_operations = QgsDatumTransform.operations(source_crs,
+                                                            QgsCoordinateReferenceSystem('EPSG:7843'))
+        self.assertEqual(len(available_operations[0].grids), 1)
+        self.assertEqual(available_operations[0].grids[0].shortName, 'au_ga_AGQG_20201120.tif')
+        if not available_operations[0].isAvailable:
+            self.skipTest(f'Required grid {available_operations[0].grids[0].shortName} not available on system')
 
         # dest CRS is GDA2020
 
@@ -661,6 +675,13 @@ class TestQgsFeatureIterator(QgisTestCase):
         self.assertEqual(dest_crs.horizontalCrs().authid(), 'EPSG:7844')
         self.assertEqual(dest_crs.verticalCrs().authid(), 'EPSG:5711')
 
+        available_operations = QgsDatumTransform.operations(vl.crs3D(),
+                                                            dest_crs)
+        self.assertEqual(len(available_operations[0].grids), 1)
+        self.assertEqual(available_operations[0].grids[0].shortName, 'au_ga_AUSGeoid2020_20180201.tif')
+        if not available_operations[0].isAvailable:
+            self.skipTest(f'Required grid {available_operations[0].grids[0].shortName} not available on system')
+
         transform = QgsCoordinateTransform(
             vl.crs3D(),
             dest_crs,
@@ -707,6 +728,13 @@ class TestQgsFeatureIterator(QgisTestCase):
         self.assertEqual(source_crs.verticalCrs().authid(), 'EPSG:5711')
 
         # dest CRS is GDA2020
+
+        available_operations = QgsDatumTransform.operations(source_crs,
+                                                            QgsCoordinateReferenceSystem('EPSG:7843'))
+        self.assertEqual(len(available_operations[0].grids), 1)
+        self.assertEqual(available_operations[0].grids[0].shortName, 'au_ga_AUSGeoid2020_20180201.tif')
+        if not available_operations[0].isAvailable:
+            self.skipTest(f'Required grid {available_operations[0].grids[0].shortName} not available on system')
 
         transform = QgsCoordinateTransform(
             source_crs,

--- a/tests/src/python/test_qgsfeaturerequest.py
+++ b/tests/src/python/test_qgsfeaturerequest.py
@@ -381,7 +381,7 @@ class TestQgsFeatureRequest(QgisTestCase):
             QgsCoordinateTransform(
                 QgsCoordinateReferenceSystem('EPSG:3111'),
                 QgsCoordinateReferenceSystem('EPSG:3857'),
-            QgsCoordinateTransformContext()
+                QgsCoordinateTransformContext()
             )
         )
         self.assertTrue(req.coordinateTransform().isValid())
@@ -405,7 +405,7 @@ class TestQgsFeatureRequest(QgisTestCase):
             QgsCoordinateTransform(
                 QgsCoordinateReferenceSystem('EPSG:3111'),
                 QgsCoordinateReferenceSystem('EPSG:3857'),
-            QgsCoordinateTransformContext()
+                QgsCoordinateTransformContext()
             )
         )
 
@@ -501,7 +501,7 @@ class TestQgsFeatureRequest(QgisTestCase):
             QgsCoordinateTransform(
                 QgsCoordinateReferenceSystem('EPSG:3111'),
                 QgsCoordinateReferenceSystem('EPSG:3857'),
-            QgsCoordinateTransformContext()
+                QgsCoordinateTransformContext()
             )
         )
         self.assertFalse(req3.compare(req2))
@@ -527,6 +527,37 @@ class TestQgsFeatureRequest(QgisTestCase):
         self.assertFalse(order1 == order2)
         order2 = QgsFeatureRequest.OrderBy([orderClause1, orderClause2])
         self.assertFalse(order1 == order2)
+
+    def test_calculate_transform(self):
+        """
+        Test transform calculation
+        """
+        req = QgsFeatureRequest()
+        # no transformation
+        transform = req.calculateTransform(QgsCoordinateReferenceSystem('EPSG:4326'))
+        self.assertFalse(transform.isValid())
+
+        # transform using destination crs
+        req.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:3857'),
+                              QgsCoordinateTransformContext())
+        transform = req.calculateTransform(QgsCoordinateReferenceSystem('EPSG:4326'))
+        self.assertTrue(transform.isValid())
+        self.assertEqual(transform.sourceCrs().authid(), 'EPSG:4326')
+        self.assertEqual(transform.destinationCrs().authid(), 'EPSG:3857')
+
+        # transform using a specific coordinate transform, must take precedence
+        req.setCoordinateTransform(
+            QgsCoordinateTransform(
+                QgsCoordinateReferenceSystem('EPSG:3111'),
+                QgsCoordinateReferenceSystem('EPSG:3857'),
+                QgsCoordinateTransformContext()
+            )
+        )
+        # source crs is ignored
+        transform = req.calculateTransform(QgsCoordinateReferenceSystem('EPSG:4326'))
+        self.assertTrue(transform.isValid())
+        self.assertEqual(transform.sourceCrs().authid(), 'EPSG:3111')
+        self.assertEqual(transform.destinationCrs().authid(), 'EPSG:3857')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds API to ensure that z values in features are correctly transformed by iterators when a coordinate transform involving vertical components is in effect.