### PR TITLE
Update qgslayoutscalebarwidgetbase.ui

### DIFF
--- a/src/ui/layout/qgslayoutscalebarwidgetbase.ui
+++ b/src/ui/layout/qgslayoutscalebarwidgetbase.ui
@@ -529,7 +529,7 @@
           <enum>Qt::StrongFocus</enum>
          </property>
          <property name="title">
-          <string>Display</string>
+          <string>Appearance</string>
          </property>
          <property name="syncGroup" stdset="0">
           <string notr="true">composeritem</string>


### PR DESCRIPTION
Make it the same appropriate label as other widgets like qgslayoutlabelwidgetbase, qgslayoutattributetablewidgetbase, etc.

The Screenshots are shown below.

New:
![new_](https://github.com/user-attachments/assets/355064c5-e550-42df-b12f-501a81889f73)

Old:
![old_](https://github.com/user-attachments/assets/8d8f56bf-2fc6-45f0-a638-1177fd770119)

qgslayoutlabelwidgetbase:
![label](https://github.com/user-attachments/assets/1f53729a-d811-43c8-82ba-bb317bd31df1)

qgslayoutattributetablewidgetbase:
![attrtable](https://github.com/user-attachments/assets/df012dd2-093f-4631-82e8-7f7a4e20bb32)