### PR TITLE
Fix use-after-free in QgsVectorLayerCache iterators

### DIFF
--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -93,7 +93,7 @@ bool QgsCachedFeatureIterator::fetchFeature( QgsFeature &f )
 {
   f.setValid( false );
 
-  if ( mClosed )
+  if ( mClosed || !mVectorLayerCache )
     return false;
 
   while ( mFeatureIdIterator != mFeatureIds.constEnd() )
@@ -168,7 +168,7 @@ QgsCachedFeatureWriterIterator::QgsCachedFeatureWriterIterator( QgsVectorLayerCa
 
 bool QgsCachedFeatureWriterIterator::fetchFeature( QgsFeature &f )
 {
-  if ( mClosed )
+  if ( mClosed || !mVectorLayerCache )
   {
     f.setValid( false );
     return false;

--- a/src/core/qgscachedfeatureiterator.h
+++ b/src/core/qgscachedfeatureiterator.h
@@ -20,6 +20,8 @@
 #include "qgsfeature.h"
 #include "qgsfeatureiterator.h"
 #include "qgscoordinatetransform.h"
+#include "qgsvectorlayercache.h"
+#include <QPointer>
 
 class QgsVectorLayerCache;
 
@@ -84,7 +86,7 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
 #endif
 
     QList< QgsFeatureId > mFeatureIds;
-    QgsVectorLayerCache *mVectorLayerCache = nullptr;
+    QPointer< QgsVectorLayerCache > mVectorLayerCache = nullptr;
     QList< QgsFeatureId >::ConstIterator mFeatureIdIterator;
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
@@ -140,7 +142,7 @@ class CORE_EXPORT QgsCachedFeatureWriterIterator : public QgsAbstractFeatureIter
 
   private:
     QgsFeatureIterator mFeatIt;
-    QgsVectorLayerCache *mVectorLayerCache = nullptr;
+    QPointer< QgsVectorLayerCache > mVectorLayerCache;
     QgsFeatureIds mFids;
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;

--- a/tests/src/python/test_qgsvectorlayercache.py
+++ b/tests/src/python/test_qgsvectorlayercache.py
@@ -96,6 +96,12 @@ class TestQgsVectorLayerCache(QgisTestCase, FeatureSourceTestCase):
         """
         pass
 
+    def testOpenIteratorAfterSourceRemoval(self):
+        """
+        Skip this test -- the iterators from the cache CANNOT be used after the cache is deleted
+        """
+        pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We need to gracefully handle the situation where the cache is deleted before the iterator, as these iterators require the cache object

