### PR TITLE
Ensure QgsPropertyOverrideButtons always look correct

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -1181,17 +1181,6 @@ QgsMessageBar QScrollBar::down-arrow:vertical {
     image: url(@theme_path/icons/arrow-down.svg);
 }
 
-QgsPropertyOverrideButton, QgsPropertyOverrideButton:hover, QgsPropertyOverrideButton:pressed {
-    background: none;
-    border: 1px solid rgba(0, 0, 0, 0%);
-    padding: 0px;
-}
-
-QgsPropertyOverrideButton:focus {
-    border:1px solid @focusdark;
-    border-radius: 0.2em;
-}
-
 QListWidget#mOptionsListWidget {
     background-color: @itemdarkbackground;
     color: @itembackground;

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1252,16 +1252,6 @@ QgsMessageBar QScrollBar::down-arrow:vertical {
     image: url(@theme_path/icons/arrow-down.svg);
 }
 
-QgsPropertyOverrideButton, QgsPropertyOverrideButton:hover, QgsPropertyOverrideButton:pressed {
-    background: none;
-    border: 1px solid rgba(0, 0, 0, 0%);
-    padding: 0px;
-}
-
-QgsPropertyOverrideButton:focus {
-    border:1px solid @focusdark;
-}
-
 QListWidget#mOptionsListWidget {
     background-color: @itembackground;
     color: @text;

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -171,11 +171,6 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
                    "}" )
           .arg( palette.highlight().color().name(),
                 palette.highlightedText().color().name() );
-
-    ss += QLatin1String( "QgsPropertyOverrideButton { background: none; border: 1px solid rgba(0, 0, 0, 0%); } QgsPropertyOverrideButton:focus { border: 1px solid palette(highlight); }" );
-#ifdef Q_OS_MACX
-    ss += QLatin1String( "QgsPropertyOverrideButton::menu-indicator { width: 5px; }" );
-#endif
   }
 
   QgsDebugMsgLevel( QStringLiteral( "Stylesheet built: %1" ).arg( ss ), 2 );

--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -42,6 +42,12 @@ QgsPropertyOverrideButton::QgsPropertyOverrideButton( QWidget *parent,
 {
   setFocusPolicy( Qt::StrongFocus );
 
+  QString ss = QStringLiteral( "QgsPropertyOverrideButton { background: none; border: 1px solid rgba(0, 0, 0, 0%); } QgsPropertyOverrideButton:focus { border: 1px solid palette(highlight); }" );
+#ifdef Q_OS_MACX
+  ss += QLatin1String( "QgsPropertyOverrideButton::menu-indicator { width: 5px; }" );
+#endif
+  setStyleSheet( ss );
+
   int iconSize = QgsGuiUtils::scaleIconSize( 24 );
 
   // button width is 1.25 * icon size, height 1.1 * icon size. But we round to ensure even pixel sizes for equal margins


### PR DESCRIPTION
We shouldn't require the main window stylesheet to be applied for these buttons to look right
