### PR TITLE
Make visible layer ids accessible via a custom QgsRenderContext property

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrendercontext.sip.in
@@ -855,7 +855,7 @@ in a mask painter, which is not meant to be visible, by definition.
 .. versionadded:: 3.12
 %End
 
-    QVariantMap customRenderingFlags() const;
+ QVariantMap customRenderingFlags() const /Deprecated/;
 %Docstring
 Gets custom rendering flags. Layers might honour these to alter their rendering.
 
@@ -863,10 +863,22 @@ Gets custom rendering flags. Layers might honour these to alter their rendering.
 
 .. seealso:: :py:func:`setCustomRenderingFlag`
 
-.. versionadded:: 3.12
+.. deprecated::
+   QGIS 3.40 Use :py:func:`~QgsRenderContext.customProperties` instead.
 %End
 
-    void setCustomRenderingFlag( const QString &flag, const QVariant &value );
+    QVariantMap customProperties() const;
+%Docstring
+Returns custom rendering properties.
+
+Objects might honour these to alter their rendering.
+
+.. seealso:: :py:func:`setCustomProperty`
+
+.. versionadded:: 3.40
+%End
+
+ void setCustomRenderingFlag( const QString &flag, const QVariant &value ) /Deprecated/;
 %Docstring
 Sets a custom rendering flag. Layers might honour these to alter their rendering.
 
@@ -875,10 +887,22 @@ Sets a custom rendering flag. Layers might honour these to alter their rendering
 
 .. seealso:: :py:func:`customRenderingFlags`
 
-.. versionadded:: 3.12
+.. deprecated::
+   QGIS 3.40 Use :py:func:`~QgsRenderContext.setCustomProperty` instead.
 %End
 
-    void clearCustomRenderingFlag( const QString &flag );
+    void setCustomProperty( const QString &property, const QVariant &value );
+%Docstring
+Sets a custom rendering property.
+
+Objects might honour these to alter their rendering.
+
+.. seealso:: :py:func:`customProperties`
+
+.. versionadded:: 3.40
+%End
+
+ void clearCustomRenderingFlag( const QString &flag ) /Deprecated/;
 %Docstring
 Clears the specified custom rendering flag.
 
@@ -886,7 +910,17 @@ Clears the specified custom rendering flag.
 
 .. seealso:: :py:func:`setCustomRenderingFlag`
 
-.. versionadded:: 3.12
+.. deprecated::
+   QGIS 3.40 Use :py:func:`~QgsRenderContext.clearCustomProperty` instead.
+%End
+
+    void clearCustomProperty( const QString &property );
+%Docstring
+Clears the specified custom rendering property.
+
+.. seealso:: :py:func:`setCustomProperty`
+
+.. versionadded:: 3.40
 %End
 
     QList< QgsMapClippingRegion > clippingRegions() const;

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -855,7 +855,7 @@ in a mask painter, which is not meant to be visible, by definition.
 .. versionadded:: 3.12
 %End
 
-    QVariantMap customRenderingFlags() const;
+ QVariantMap customRenderingFlags() const /Deprecated/;
 %Docstring
 Gets custom rendering flags. Layers might honour these to alter their rendering.
 
@@ -863,10 +863,22 @@ Gets custom rendering flags. Layers might honour these to alter their rendering.
 
 .. seealso:: :py:func:`setCustomRenderingFlag`
 
-.. versionadded:: 3.12
+.. deprecated::
+   QGIS 3.40 Use :py:func:`~QgsRenderContext.customProperties` instead.
 %End
 
-    void setCustomRenderingFlag( const QString &flag, const QVariant &value );
+    QVariantMap customProperties() const;
+%Docstring
+Returns custom rendering properties.
+
+Objects might honour these to alter their rendering.
+
+.. seealso:: :py:func:`setCustomProperty`
+
+.. versionadded:: 3.40
+%End
+
+ void setCustomRenderingFlag( const QString &flag, const QVariant &value ) /Deprecated/;
 %Docstring
 Sets a custom rendering flag. Layers might honour these to alter their rendering.
 
@@ -875,10 +887,22 @@ Sets a custom rendering flag. Layers might honour these to alter their rendering
 
 .. seealso:: :py:func:`customRenderingFlags`
 
-.. versionadded:: 3.12
+.. deprecated::
+   QGIS 3.40 Use :py:func:`~QgsRenderContext.setCustomProperty` instead.
 %End
 
-    void clearCustomRenderingFlag( const QString &flag );
+    void setCustomProperty( const QString &property, const QVariant &value );
+%Docstring
+Sets a custom rendering property.
+
+Objects might honour these to alter their rendering.
+
+.. seealso:: :py:func:`customProperties`
+
+.. versionadded:: 3.40
+%End
+
+ void clearCustomRenderingFlag( const QString &flag ) /Deprecated/;
 %Docstring
 Clears the specified custom rendering flag.
 
@@ -886,7 +910,17 @@ Clears the specified custom rendering flag.
 
 .. seealso:: :py:func:`setCustomRenderingFlag`
 
-.. versionadded:: 3.12
+.. deprecated::
+   QGIS 3.40 Use :py:func:`~QgsRenderContext.clearCustomProperty` instead.
+%End
+
+    void clearCustomProperty( const QString &property );
+%Docstring
+Clears the specified custom rendering property.
+
+.. seealso:: :py:func:`setCustomProperty`
+
+.. versionadded:: 3.40
 %End
 
     QList< QgsMapClippingRegion > clippingRegions() const;

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -71,7 +71,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mTextRenderFormat( rh.mTextRenderFormat )
   , mRenderedFeatureHandlers( rh.mRenderedFeatureHandlers )
   , mHasRenderedFeatureHandlers( rh.mHasRenderedFeatureHandlers )
-  , mCustomRenderingFlags( rh.mCustomRenderingFlags )
+  , mCustomProperties( rh.mCustomProperties )
   , mDisabledSymbolLayers()
   , mClippingRegions( rh.mClippingRegions )
   , mFeatureClipGeometry( rh.mFeatureClipGeometry )
@@ -123,7 +123,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mTextRenderFormat = rh.mTextRenderFormat;
   mRenderedFeatureHandlers = rh.mRenderedFeatureHandlers;
   mHasRenderedFeatureHandlers = rh.mHasRenderedFeatureHandlers;
-  mCustomRenderingFlags = rh.mCustomRenderingFlags;
+  mCustomProperties = rh.mCustomProperties;
   mClippingRegions = rh.mClippingRegions;
   mFeatureClipGeometry = rh.mFeatureClipGeometry;
   mTextureOrigin = rh.mTextureOrigin;
@@ -277,7 +277,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   //this flag is only for stopping during the current rendering progress,
   //so must be false at every new render operation
   ctx.setRenderingStopped( false );
-  ctx.mCustomRenderingFlags = mapSettings.customRenderingFlags();
+  ctx.mCustomProperties = mapSettings.customRenderingFlags();
   ctx.setIsTemporal( mapSettings.isTemporal() );
   if ( ctx.isTemporal() )
     ctx.setTemporalRange( mapSettings.temporalRange() );
@@ -297,7 +297,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
 
   const QStringList layerIds = mapSettings.layerIds( true );
   if ( !layerIds.empty() )
-    ctx.setCustomRenderingFlag( QStringLiteral( "visible_layer_ids" ), layerIds );
+    ctx.setCustomProperty( QStringLiteral( "visible_layer_ids" ), layerIds );
 
   return ctx;
 }

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -295,6 +295,10 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.mFrameRate = mapSettings.frameRate();
   ctx.mCurrentFrame = mapSettings.currentFrame();
 
+  const QStringList layerIds = mapSettings.layerIds( true );
+  if ( !layerIds.empty() )
+    ctx.setCustomRenderingFlag( QStringLiteral( "visible_layer_ids" ), layerIds );
+
   return ctx;
 }
 

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -855,26 +855,54 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      * Gets custom rendering flags. Layers might honour these to alter their rendering.
      * \returns a map of custom flags
      * \see setCustomRenderingFlag()
-     * \since QGIS 3.12
+     * \deprecated QGIS 3.40 Use customProperties() instead.
      */
-    QVariantMap customRenderingFlags() const { return mCustomRenderingFlags; }
+    Q_DECL_DEPRECATED QVariantMap customRenderingFlags() const SIP_DEPRECATED { return mCustomProperties; }
+
+    /**
+     * Returns custom rendering properties.
+     *
+     * Objects might honour these to alter their rendering.
+     *
+     * \see setCustomProperty()
+     * \since QGIS 3.40
+     */
+    QVariantMap customProperties() const { return mCustomProperties; }
 
     /**
      * Sets a custom rendering flag. Layers might honour these to alter their rendering.
      * \param flag the flag name
      * \param value the flag value
      * \see customRenderingFlags()
-     * \since QGIS 3.12
+     * \deprecated QGIS 3.40 Use setCustomProperty() instead.
      */
-    void setCustomRenderingFlag( const QString &flag, const QVariant &value ) { mCustomRenderingFlags[flag] = value; }
+    Q_DECL_DEPRECATED void setCustomRenderingFlag( const QString &flag, const QVariant &value ) SIP_DEPRECATED { mCustomProperties[flag] = value; }
+
+    /**
+     * Sets a custom rendering property.
+     *
+     * Objects might honour these to alter their rendering.
+     *
+     * \see customProperties()
+     * \since QGIS 3.40
+     */
+    void setCustomProperty( const QString &property, const QVariant &value ) { mCustomProperties[property] = value; }
 
     /**
      * Clears the specified custom rendering flag.
      * \param flag the flag name
      * \see setCustomRenderingFlag()
-     * \since QGIS 3.12
+     * \deprecated QGIS 3.40 Use clearCustomProperty() instead.
      */
-    void clearCustomRenderingFlag( const QString &flag ) { mCustomRenderingFlags.remove( flag ); }
+    Q_DECL_DEPRECATED void clearCustomRenderingFlag( const QString &flag ) SIP_DEPRECATED { mCustomProperties.remove( flag ); }
+
+    /**
+     * Clears the specified custom rendering property.
+     *
+     * \see setCustomProperty()
+     * \since QGIS 3.40
+     */
+    void clearCustomProperty( const QString &property ) { mCustomProperties.remove( property ); }
 
     /**
      * Returns the list of clipping regions to apply during the render.
@@ -1261,7 +1289,7 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
     Qgis::TextRenderFormat mTextRenderFormat = Qgis::TextRenderFormat::AlwaysOutlines;
     QList< QgsRenderedFeatureHandlerInterface * > mRenderedFeatureHandlers;
     bool mHasRenderedFeatureHandlers = false;
-    QVariantMap mCustomRenderingFlags;
+    QVariantMap mCustomProperties;
 
     QSet<QString> mDisabledSymbolLayers;
 

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -206,7 +206,7 @@ class TestQgsRenderContext(QgisTestCase):
         self.assertEqual(rc.imageFormat(), QImage.Format.Format_Alpha8)
         self.assertEqual(rc.frameRate(), 30)
         self.assertEqual(rc.currentFrame(), 6)
-        self.assertEqual(rc.customRenderingFlags()['visible_layer_ids'], [layer1.id(), layer2.id(), layer3.id()])
+        self.assertEqual(rc.customProperties()['visible_layer_ids'], [layer1.id(), layer2.id(), layer3.id()])
 
         # should have an valid mapToPixel
         self.assertTrue(rc.mapToPixel().isValid())

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -28,6 +28,7 @@ from qgis.core import (
     QgsRenderedFeatureHandlerInterface,
     QgsUnitTypes,
     QgsVectorSimplifyMethod,
+    QgsVectorLayer
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -186,6 +187,11 @@ class TestQgsRenderContext(QgisTestCase):
         ms.setFrameRate(30)
         ms.setCurrentFrame(6)
 
+        layer1 = QgsVectorLayer('Point?crs=EPSG:3857', '', 'memory')
+        layer2 = QgsVectorLayer('Point?crs=EPSG:3857', '', 'memory')
+        layer3 = QgsVectorLayer('Point?crs=EPSG:3857', '', 'memory')
+        ms.setLayers([layer1, layer2, layer3])
+
         ms.setTextRenderFormat(QgsRenderContext.TextRenderFormat.TextFormatAlwaysText)
         rc = QgsRenderContext.fromMapSettings(ms)
         self.assertEqual(rc.textRenderFormat(), QgsRenderContext.TextRenderFormat.TextFormatAlwaysText)
@@ -200,6 +206,7 @@ class TestQgsRenderContext(QgisTestCase):
         self.assertEqual(rc.imageFormat(), QImage.Format.Format_Alpha8)
         self.assertEqual(rc.frameRate(), 30)
         self.assertEqual(rc.currentFrame(), 6)
+        self.assertEqual(rc.customRenderingFlags()['visible_layer_ids'], [layer1.id(), layer2.id(), layer3.id()])
 
         # should have an valid mapToPixel
         self.assertTrue(rc.mapToPixel().isValid())


### PR DESCRIPTION
Provides a means for retrieving the visible layer ids from a render context, via:

    layer_ids = rc.customRenderingFlags().get('visible_layer_ids')
