### PR TITLE
[metasearch] Consider also name and description for link text

### DIFF
--- a/python/plugins/MetaSearch/resources/templates/record_metadata_dc.html
+++ b/python/plugins/MetaSearch/resources/templates/record_metadata_dc.html
@@ -75,10 +75,20 @@
             <h4>Links</h4>
             <ul>
             {% for link in obj.references %}
-                <li><a href="{{ link['url'] }}">{{ link['scheme'] if link['scheme'] not in [None, 'None', ''] else gettext('Access Link') }}</a></li>
+                <li><a href="{{ link['url'] }}">
+                    {{ link['name'] if link['name'] not in [None, 'None', '']
+                       else link['description'] if link['description'] not in [None, 'None', '']
+                       else link['scheme'] if link['scheme'] not in [None, 'None', '']
+                       else gettext('Access Link') }}
+                </a></li>
             {% endfor %}
             {% for link in obj.uris %}
-                <li><a href="{{ link['url'] }}">{{ link['protocol'] if link['protocol'] not in [None, 'None', ''] else gettext('Access Link') }}</a></li>
+                <li><a href="{{ link['url'] }}">
+                    {{ link['name'] if link['name'] not in [None, 'None', '']
+                       else link['description'] if link['description'] not in [None, 'None', '']
+                       else link['protocol'] if link['protocol'] not in [None, 'None', '']
+                       else gettext('Access Link') }}
+                </a></li>
             {% endfor %}
             </ul>
         </section>

--- a/python/plugins/MetaSearch/resources/templates/record_metadata_dc.html
+++ b/python/plugins/MetaSearch/resources/templates/record_metadata_dc.html
@@ -80,6 +80,11 @@
                        else link['description'] if link['description'] not in [None, 'None', '']
                        else link['scheme'] if link['scheme'] not in [None, 'None', '']
                        else gettext('Access Link') }}
+                    {% if link['scheme'] not in [None, 'None', '']
+                       and ( link['name'] not in [None, 'None', '']
+                       or link['description'] not in [None, 'None', ''] ) %}
+                           ({{ link['scheme'] }})
+                    {% endif %}
                 </a></li>
             {% endfor %}
             {% for link in obj.uris %}
@@ -88,6 +93,11 @@
                        else link['description'] if link['description'] not in [None, 'None', '']
                        else link['protocol'] if link['protocol'] not in [None, 'None', '']
                        else gettext('Access Link') }}
+                    {% if link['protocol'] not in [None, 'None', '']
+                       and ( link['name'] not in [None, 'None', '']
+                       or link['description'] not in [None, 'None', ''] ) %}
+                           ({{ link['protocol'] }})
+                    {% endif %}
                 </a></li>
             {% endfor %}
             </ul>


### PR DESCRIPTION
They should be more informative than scheme, protocol or the static string "Access Link".

**Example 1**
https://csw.open.canada.ca/geonetwork/srv/eng/csw?service=CSW&version=2.0.2&request=GetRecordById&outputFormat=application%2Fxml&outputSchema=http%3A%2F%2Fwww.opengis.net%2Fcat%2Fcsw%2F2.0.2&elementsetname=full&id=c7f8c2cb-4863-48a0-97fa-daafeb6b4395

before
<img src="https://github.com/user-attachments/assets/f564d38b-8e2a-473d-8ab8-dd8088eadc49" width="500" />

this PR
<img src="https://github.com/user-attachments/assets/8dfc7fbc-3068-493c-89ad-0c72a2aad718" width="500" />


**Example 2**
https://geodatenkatalog-niederrhein.de/csw?service=CSW&version=2.0.2&request=GetRecordById&outputFormat=application%2Fxml&outputSchema=http%3A%2F%2Fwww.opengis.net%2Fcat%2Fcsw%2F2.0.2&elementsetname=full&id=96d7c1c0-e58c-40d5-a335-9b2041fe223a

before
<img src="https://github.com/user-attachments/assets/4b2aec7b-519b-41b3-ac5e-0db016a074d1" width="500" />

this PR
<img src="https://github.com/user-attachments/assets/5952dade-16ba-4ec9-b23f-b8a201b90f43" width="500" />

**Example 3**
https://daten.geoportal.ruhr/srv/ger/csw?service=CSW&version=2.0.2&request=GetRecordById&outputFormat=application%2Fxml&outputSchema=http%3A%2F%2Fwww.opengis.net%2Fcat%2Fcsw%2F2.0.2&elementsetname=full&id=823ffb608ff1e40b3b3a3bf7e5e69bed74c02e8f

before
<img src="https://github.com/user-attachments/assets/c238db3d-cd67-4235-9f06-a4c132c26690" width="500" />

this PR
<img src="https://github.com/user-attachments/assets/18076754-0ae7-47cd-8d00-207dd2fc44ba" width="500" />
