### PR TITLE
[CMYK] Properties widget

### DIFF
--- a/python/PyQt6/core/auto_generated/qgscolorutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorutils.sip.in
@@ -95,6 +95,16 @@ message
 .. versionadded:: 3.40
 %End
 
+    static QString saveIccProfile( const QColorSpace &colorSpace, const QString &iccProfileFilePath );
+%Docstring
+Save color space ``colorSpace`` to an ICC profile file ``iccProfileFilePath``.
+
+:return: error message if an error occurred else empty string.
+
+.. versionadded:: 3.40
+%End
+
+
 
 
 

--- a/python/core/auto_generated/qgscolorutils.sip.in
+++ b/python/core/auto_generated/qgscolorutils.sip.in
@@ -95,6 +95,16 @@ message
 .. versionadded:: 3.40
 %End
 
+    static QString saveIccProfile( const QColorSpace &colorSpace, const QString &iccProfileFilePath );
+%Docstring
+Save color space ``colorSpace`` to an ICC profile file ``iccProfileFilePath``.
+
+:return: error message if an error occurred else empty string.
+
+.. versionadded:: 3.40
+%End
+
+
 
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12595,6 +12595,7 @@ QMap< QString, QString > QgisApp::projectPropertiesPagesMap()
     sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "CRS" ), QStringLiteral( "mProjOptsCRS" ) );
     sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "Transformations" ), QStringLiteral( "mProjTransformations" ) );
     sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "Styles" ), QStringLiteral( "mProjOptsSymbols" ) );
+    sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "Colors" ), QStringLiteral( "mTabColors" ) );
     sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "Data Sources" ), QStringLiteral( "mTab_DataSources" ) );
     sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "Relations" ), QStringLiteral( "mTabRelations" ) );
     sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "Variables" ), QStringLiteral( "mTab_Variables" ) );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2740,12 +2740,13 @@ void QgsProjectProperties::removeIccProfile()
 
 void QgsProjectProperties::saveIccProfile()
 {
-  QString fileName = QFileDialog::getSaveFileName( this, tr( "Save ICC profile" ), QDir::homePath(),
+  QString fileName = QFileDialog::getSaveFileName( this, tr( "Save ICC Profile" ), QDir::homePath(),
                      tr( "ICC profile files (*.icc *.ICC)" ) );
 
   if ( fileName.isEmpty() )
     return;
 
+  fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, { QStringLiteral( "icc" ) } );
   const QString error = QgsColorUtils::saveIccProfile( mColorSpace, fileName );
   if ( !error.isEmpty() )
   {

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -138,6 +138,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   connect( mAddIccProfile, &QToolButton::clicked, this, static_cast<void ( QgsProjectProperties::* )()>( &QgsProjectProperties::addIccProfile ) );
   connect( mRemoveIccProfile, &QToolButton::clicked, this, &QgsProjectProperties::removeIccProfile );
+  connect( mSaveIccProfile, &QToolButton::clicked, this, &QgsProjectProperties::saveIccProfile );
 #endif
 
   // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
@@ -1042,6 +1043,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mColorSpaceName->setVisible( false );
   mAddIccProfile->setVisible( false );
   mRemoveIccProfile->setVisible( false );
+  mSaveIccProfile->setVisible( false );
 #endif
   // Default alpha transparency
   mDefaultOpacityWidget->setOpacity( QgsProject::instance()->styleSettings()->defaultSymbolOpacity() );
@@ -2736,10 +2738,27 @@ void QgsProjectProperties::removeIccProfile()
   updateColorSpaceWidgets();
 }
 
+void QgsProjectProperties::saveIccProfile()
+{
+  QString fileName = QFileDialog::getSaveFileName( this, tr( "Save ICC profile" ), QDir::homePath(),
+                     tr( "ICC profile files (*.icc *.ICC)" ) );
+
+  if ( fileName.isEmpty() )
+    return;
+
+  const QString error = QgsColorUtils::saveIccProfile( mColorSpace, fileName );
+  if ( !error.isEmpty() )
+  {
+    QMessageBox::warning( this, tr( "Save ICC profile" ), error );
+  }
+}
+
+
 void QgsProjectProperties::updateColorSpaceWidgets()
 {
   mColorSpaceName->setText( mColorSpace.isValid() ? mColorSpace.description() : tr( "<i>None</i>" ) );
   mRemoveIccProfile->setEnabled( mColorSpace.isValid() );
+  mSaveIccProfile->setEnabled( mColorSpace.isValid() );
 
   // force color model index according to color space one
   if ( mColorSpace.isValid() )

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1036,7 +1036,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   mColorSpace = QgsProject::instance()->styleSettings()->colorSpace();
-  updateColorSpaceWidget();
+  updateColorSpaceWidgets();
 #else
   mIccProfileLabel->setVisible( false );
   mColorSpaceName->setVisible( false );
@@ -2708,7 +2708,7 @@ void QgsProjectProperties::addIccProfile()
                                        this,
                                        tr( "Load ICC Profile" ),
                                        QDir::homePath(),
-                                       tr( "Style databases" ) + tr( "ICC Profile" ) + QStringLiteral( " (*.icc)" ) );
+                                       tr( "ICC Profile" ) + QStringLiteral( " (*.icc)" ) );
 
   addIccProfile( iccProfileFilePath );
 }
@@ -2727,16 +2727,16 @@ void QgsProjectProperties::addIccProfile( const QString &iccProfileFilePath )
   }
 
   mColorSpace = colorSpace;
-  updateColorSpaceWidget();
+  updateColorSpaceWidgets();
 }
 
 void QgsProjectProperties::removeIccProfile()
 {
   mColorSpace = QColorSpace();
-  updateColorSpaceWidget();
+  updateColorSpaceWidgets();
 }
 
-void QgsProjectProperties::updateColorSpaceWidget()
+void QgsProjectProperties::updateColorSpaceWidgets()
 {
   mColorSpaceName->setText( mColorSpace.isValid() ? mColorSpace.description() : tr( "<i>None</i>" ) );
   mRemoveIccProfile->setEnabled( mColorSpace.isValid() );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2740,6 +2740,15 @@ void QgsProjectProperties::updateColorSpaceWidget()
 {
   mColorSpaceName->setText( mColorSpace.isValid() ? mColorSpace.description() : tr( "<i>None</i>" ) );
   mRemoveIccProfile->setEnabled( mColorSpace.isValid() );
+
+  // force color model index according to color space one
+  if ( mColorSpace.isValid() )
+  {
+    const Qgis::ColorModel colorModel = QgsColorUtils::toColorModel( mColorSpace.colorModel() );
+    mColorModel->setCurrentIndex( mColorModel->findData( QVariant::fromValue( colorModel ) ) );
+  }
+
+  mColorModel->setEnabled( !mColorSpace.isValid() );
 }
 
 #endif

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -209,27 +209,23 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
     /**
      * Called whenever user select the add ICC profile button
-     * \since QGIS 3.40
      */
     void addIccProfile();
 
     /**
      * load \a iccProfileFilePath and set resulting color space to project
-     * \since QGIS 3.40
      */
     void addIccProfile( const QString &iccProfileFilePath );
 
     /**
      * Called whenever user select the remove ICC profile button
-     * \since QGIS 3.40
      */
     void removeIccProfile();
 
     /**
      * Update color space widget according to current project color space
-     * \since QGIS 3.40
      */
-    void updateColorSpaceWidget();
+    void updateColorSpaceWidgets();
 
 #endif
 

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -29,6 +29,7 @@
 #include "qgis_app.h"
 
 #include <QList>
+#include <QColorSpace>
 
 class QgsMapCanvas;
 class QgsRelationManagerDialog;
@@ -204,6 +205,34 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void removeStyleDatabase();
     void newStyleDatabase();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+
+    /**
+     * Called whenever user select the add ICC profile button
+     * \since QGIS 3.40
+     */
+    void addIccProfile();
+
+    /**
+     * load \a iccProfileFilePath and set resulting color space to project
+     * \since QGIS 3.40
+     */
+    void addIccProfile( const QString &iccProfileFilePath );
+
+    /**
+     * Called whenever user select the remove ICC profile button
+     * \since QGIS 3.40
+     */
+    void removeIccProfile();
+
+    /**
+     * Update color space widget according to current project color space
+     * \since QGIS 3.40
+     */
+    void updateColorSpaceWidget();
+
+#endif
+
   private:
 
     /**
@@ -240,6 +269,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     QList<EllipsoidDefs> mEllipsoidList;
     int mEllipsoidIndex;
     bool mBlockCrsUpdates = false;
+    QColorSpace mColorSpace;
 
     QList< QgsOptionsPageWidget * > mAdditionalProjectPropertiesWidgets;
 

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -223,6 +223,11 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void removeIccProfile();
 
     /**
+     * Called whenever user select the save ICC profile button
+     */
+    void saveIccProfile();
+
+    /**
      * Update color space widget according to current project color space
      */
     void updateColorSpaceWidgets();

--- a/src/core/qgscolorutils.cpp
+++ b/src/core/qgscolorutils.cpp
@@ -377,6 +377,22 @@ QColorSpace QgsColorUtils::iccProfile( const QString &iccProfileFilePath, QStrin
   return colorSpace;
 }
 
+
+QString QgsColorUtils::saveIccProfile( const QColorSpace &colorSpace, const QString &iccProfileFilePath )
+{
+  if ( !colorSpace.isValid() )
+    return QObject::tr( "Invalid ICC profile" );
+
+  QFile iccProfile( iccProfileFilePath );
+  if ( !iccProfile.open( QIODevice::WriteOnly ) )
+    return QObject::tr( "File access error '%1'" ).arg( iccProfileFilePath );
+
+  if ( iccProfile.write( colorSpace.iccProfile() ) < 0 )
+    return QObject::tr( "Error while writing to file '%1'" ).arg( iccProfileFilePath );
+
+  return QString();
+}
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
 
 Qgis::ColorModel QgsColorUtils::toColorModel( QColorSpace::ColorModel colorModel, bool *ok )

--- a/src/core/qgscolorutils.h
+++ b/src/core/qgscolorutils.h
@@ -108,6 +108,15 @@ class CORE_EXPORT QgsColorUtils
      */
     static QColorSpace iccProfile( const QString &iccProfileFilePath, QString &errorMsg SIP_OUT );
 
+    /**
+     * Save color space \a colorSpace to an ICC profile file \a iccProfileFilePath.
+     * \returns error message if an error occurred else empty string.
+     *
+     * \since QGIS 3.40
+     */
+    static QString saveIccProfile( const QColorSpace &colorSpace, const QString &iccProfileFilePath );
+
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
 
     /**

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -1500,17 +1500,45 @@
               <string notr="true">projstyles</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_4">
-              <item row="6" column="0" colspan="3">
-               <widget class="QCheckBox" name="cbxStyleRandomColors">
+              <item row="1" column="0">
+               <widget class="QLabel" name="mIccProfileLabel">
                 <property name="text">
-                 <string>Assign random colors to symbols</string>
+                 <string>ICC Profile</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_14">
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_27">
                 <property name="text">
-                 <string>Color model</string>
+                 <string>Opacity</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1" colspan="4">
+               <widget class="QgsOpacityWidget" name="mDefaultOpacityWidget" native="true">
+                <property name="focusPolicy">
+                 <enum>Qt::StrongFocus</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
+               <widget class="QToolButton" name="mAddIccProfile">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load an ICC profile file and attach it to the project.&lt;/p&gt;&lt;p&gt;Color model will be updated accordingly.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1" colspan="4">
+               <widget class="QComboBox" name="mColorModel">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color model used as default when selecting a color in the whole application.&lt;/p&gt;&lt;p&gt;Any color defined in a different color model than the one specified here will be converted to this color model when exporting a layout.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -1535,45 +1563,31 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_27">
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_14">
                 <property name="text">
-                 <string>Opacity</string>
+                 <string>Color model</string>
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="mIccProfileLabel">
+              <item row="6" column="0" colspan="3">
+               <widget class="QCheckBox" name="cbxStyleRandomColors">
                 <property name="text">
-                 <string>ICC Profile</string>
+                 <string>Assign random colors to symbols</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="3">
-               <widget class="QToolButton" name="mAddIccProfile">
+               <widget class="QToolButton" name="mSaveIccProfile">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load an ICC profile file and attach it to the project.&lt;/p&gt;&lt;p&gt;Color model will be updated accordingly.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save ICC profile&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string/>
                 </property>
                 <property name="icon">
                  <iconset resource="../../images/images.qrc">
-                  <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1" colspan="3">
-               <widget class="QComboBox" name="mColorModel">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color model used as default when selecting a color in the whole application.&lt;/p&gt;&lt;p&gt;Any color defined in a different color model than the one specified here will be converted to this color model when exporting a layout.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1" colspan="3">
-               <widget class="QgsOpacityWidget" name="mDefaultOpacityWidget" native="true">
-                <property name="focusPolicy">
-                 <enum>Qt::StrongFocus</enum>
+                  <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
                 </property>
                </widget>
               </item>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -269,7 +269,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>10</number>
+          <number>5</number>
          </property>
          <widget class="QWidget" name="mProjOptsGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -298,8 +298,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>640</width>
-                <height>971</height>
+                <width>673</width>
+                <height>852</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -317,7 +317,7 @@
                  <property name="title">
                   <string>General Settings</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_26">
@@ -578,7 +578,7 @@
                  <property name="title">
                   <string>Measurements</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayoutMeasureTool">
@@ -647,7 +647,7 @@
                  <property name="title">
                   <string>Coordinate and Bearing Display</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_18">
@@ -797,7 +797,7 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="mCoordinateCrs">
+                   <widget class="QgsProjectionSelectionWidget" name="mCoordinateCrs" native="true">
                     <property name="enabled">
                      <bool>false</bool>
                     </property>
@@ -901,7 +901,7 @@
              <property name="checked">
               <bool>false</bool>
              </property>
-             <property name="syncGroup">
+             <property name="syncGroup" stdset="0">
               <string notr="true">projgeneral</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_7">
@@ -1042,8 +1042,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>340</width>
-                <height>57</height>
+                <width>279</width>
+                <height>52</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -1107,8 +1107,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>634</width>
-                <height>90</height>
+                <width>523</width>
+                <height>80</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -1179,8 +1179,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>344</width>
-                <height>817</height>
+                <width>673</width>
+                <height>846</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12" stretch="0,0,1,1">
@@ -1201,7 +1201,7 @@
                  <property name="title">
                   <string>Default Symbols</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projstyles</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
@@ -1219,7 +1219,7 @@
                    </widget>
                   </item>
                   <item row="3" column="0">
-                   <widget class="QSvgWidget" name="pixStyleColorRamp">
+                   <widget class="QSvgWidget" name="pixStyleColorRamp" native="true">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                       <horstretch>0</horstretch>
@@ -1353,7 +1353,7 @@
                    </widget>
                   </item>
                   <item row="4" column="0">
-                   <widget class="QSvgWidget" name="pixStyleTextFormat">
+                   <widget class="QSvgWidget" name="pixStyleTextFormat" native="true">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                       <horstretch>0</horstretch>
@@ -1393,32 +1393,74 @@
                  <property name="title">
                   <string>Options</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projstyles</string>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_18">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,1">
-                    <item>
-                     <widget class="QLabel" name="label_27">
-                      <property name="text">
-                       <string>Opacity</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsOpacityWidget" name="mDefaultOpacityWidget">
-                      <property name="focusPolicy">
-                       <enum>Qt::StrongFocus</enum>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
+                 <layout class="QGridLayout" name="gridLayout_4">
+                  <item row="6" column="0" colspan="3">
                    <widget class="QCheckBox" name="cbxStyleRandomColors">
                     <property name="text">
                      <string>Assign random colors to symbols</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_14">
+                    <property name="text">
+                     <string>Color model</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QToolButton" name="mRemoveIccProfile">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../images/images.qrc">
+                      <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="mColorSpaceName">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_27">
+                    <property name="text">
+                     <string>Opacity</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="mIccProfileLabel">
+                    <property name="text">
+                     <string>ICC Profile</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="3">
+                   <widget class="QToolButton" name="mAddIccProfile">
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../images/images.qrc">
+                      <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="3">
+                   <widget class="QComboBox" name="mColorModel"/>
+                  </item>
+                  <item row="3" column="1" colspan="3">
+                   <widget class="QgsOpacityWidget" name="mDefaultOpacityWidget" native="true">
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
                     </property>
                    </widget>
                   </item>
@@ -1554,7 +1596,7 @@
                  <property name="checked">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_20">
@@ -1852,8 +1894,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>176</width>
-                <height>45</height>
+                <width>151</width>
+                <height>42</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1935,8 +1977,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>679</width>
-                <height>1515</height>
+                <width>673</width>
+                <height>1503</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1990,13 +2032,13 @@
                        <property name="checked">
                         <bool>false</bool>
                        </property>
-                       <property name="collapsed">
+                       <property name="collapsed" stdset="0">
                         <bool>false</bool>
                        </property>
-                       <property name="syncGroup">
+                       <property name="syncGroup" stdset="0">
                         <string notr="true">projowsserver</string>
                        </property>
-                       <property name="saveCollapsedState">
+                       <property name="saveCollapsedState" stdset="0">
                         <bool>true</bool>
                        </property>
                        <layout class="QGridLayout" name="gridLayout_6">
@@ -2692,10 +2734,10 @@
                        <property name="checked">
                         <bool>false</bool>
                        </property>
-                       <property name="collapsed">
+                       <property name="collapsed" stdset="0">
                         <bool>false</bool>
                        </property>
-                       <property name="saveCollapsedState">
+                       <property name="saveCollapsedState" stdset="0">
                         <bool>true</bool>
                        </property>
                        <layout class="QGridLayout" name="gridLayout">

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -163,6 +163,15 @@
          </item>
          <item>
           <property name="text">
+           <string>Colors</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/colors.svg</normaloff>:/images/themes/default/propertyicons/colors.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Data Sources</string>
           </property>
           <property name="toolTip">
@@ -269,7 +278,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>5</number>
+          <number>6</number>
          </property>
          <widget class="QWidget" name="mProjOptsGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -298,7 +307,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>522</width>
+                <width>673</width>
                 <height>852</height>
                </rect>
               </property>
@@ -1042,8 +1051,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>279</width>
-                <height>52</height>
+                <width>694</width>
+                <height>789</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -1107,8 +1116,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>523</width>
-                <height>80</height>
+                <width>694</width>
+                <height>789</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -1179,11 +1188,11 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>673</width>
-                <height>846</height>
+                <width>694</width>
+                <height>789</height>
                </rect>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_12" stretch="0,0,1,1">
+              <layout class="QVBoxLayout" name="verticalLayout_12" stretch="0,1">
                <property name="leftMargin">
                 <number>0</number>
                </property>
@@ -1389,207 +1398,6 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
-                 <property name="title">
-                  <string>Options</string>
-                 </property>
-                 <property name="syncGroup" stdset="0">
-                  <string notr="true">projstyles</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_4">
-                  <item row="6" column="0" colspan="3">
-                   <widget class="QCheckBox" name="cbxStyleRandomColors">
-                    <property name="text">
-                     <string>Assign random colors to symbols</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_14">
-                    <property name="text">
-                     <string>Color model</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QToolButton" name="mRemoveIccProfile">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected ICC profile&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLabel" name="mColorSpaceName">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label_27">
-                    <property name="text">
-                     <string>Opacity</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="mIccProfileLabel">
-                    <property name="text">
-                     <string>ICC Profile</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="3">
-                   <widget class="QToolButton" name="mAddIccProfile">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load an ICC profile file and attach it to the project.&lt;/p&gt;&lt;p&gt;Color model will be updated accordingly.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1" colspan="3">
-                   <widget class="QComboBox" name="mColorModel">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color model used as default when selecting a color in the whole application.&lt;/p&gt;&lt;p&gt;Any color defined in a different color model than the one specified here will be converted to this color model when exporting a layout.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1" colspan="3">
-                   <widget class="QgsOpacityWidget" name="mDefaultOpacityWidget" native="true">
-                    <property name="focusPolicy">
-                     <enum>Qt::StrongFocus</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_7">
-                 <property name="title">
-                  <string>Project Colors</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_12">
-                  <item row="2" column="1">
-                   <widget class="QToolButton" name="mButtonCopyColors">
-                    <property name="toolTip">
-                     <string>Copy colors</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="1">
-                   <spacer name="verticalSpacer_12">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>40</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QToolButton" name="mButtonAddColor">
-                    <property name="toolTip">
-                     <string>Add color</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QToolButton" name="mButtonPasteColors">
-                    <property name="toolTip">
-                     <string>Paste colors</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionEditPaste.svg</normaloff>:/images/themes/default/mActionEditPaste.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QToolButton" name="mButtonRemoveColor">
-                    <property name="toolTip">
-                     <string>Remove color</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0" rowspan="8">
-                   <widget class="QgsColorSchemeList" name="mTreeProjectColors" native="true"/>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QToolButton" name="mButtonImportColors">
-                    <property name="toolTip">
-                     <string>Import colors</string>
-                    </property>
-                    <property name="statusTip">
-                     <string/>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="1">
-                   <widget class="QToolButton" name="mButtonExportColors">
-                    <property name="toolTip">
-                     <string>Export colors</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
                 <widget class="QgsCollapsibleGroupBox" name="mGroupBoxStyleDatabases">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -1677,6 +1485,211 @@
                </item>
               </layout>
              </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mTabColors">
+          <layout class="QVBoxLayout" name="verticalLayout_18">
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
+             <property name="title">
+              <string>Options</string>
+             </property>
+             <property name="syncGroup" stdset="0">
+              <string notr="true">projstyles</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_4">
+              <item row="6" column="0" colspan="3">
+               <widget class="QCheckBox" name="cbxStyleRandomColors">
+                <property name="text">
+                 <string>Assign random colors to symbols</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>Color model</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QToolButton" name="mRemoveIccProfile">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected ICC profile&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="mColorSpaceName">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_27">
+                <property name="text">
+                 <string>Opacity</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="mIccProfileLabel">
+                <property name="text">
+                 <string>ICC Profile</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QToolButton" name="mAddIccProfile">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load an ICC profile file and attach it to the project.&lt;/p&gt;&lt;p&gt;Color model will be updated accordingly.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1" colspan="3">
+               <widget class="QComboBox" name="mColorModel">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color model used as default when selecting a color in the whole application.&lt;/p&gt;&lt;p&gt;Any color defined in a different color model than the one specified here will be converted to this color model when exporting a layout.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1" colspan="3">
+               <widget class="QgsOpacityWidget" name="mDefaultOpacityWidget" native="true">
+                <property name="focusPolicy">
+                 <enum>Qt::StrongFocus</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="groupBox_7">
+             <property name="title">
+              <string>Project Colors</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_12">
+              <item row="2" column="1">
+               <widget class="QToolButton" name="mButtonCopyColors">
+                <property name="toolTip">
+                 <string>Copy colors</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="1">
+               <spacer name="verticalSpacer_12">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="1">
+               <widget class="QToolButton" name="mButtonAddColor">
+                <property name="toolTip">
+                 <string>Add color</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QToolButton" name="mButtonPasteColors">
+                <property name="toolTip">
+                 <string>Paste colors</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/mActionEditPaste.svg</normaloff>:/images/themes/default/mActionEditPaste.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QToolButton" name="mButtonRemoveColor">
+                <property name="toolTip">
+                 <string>Remove color</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" rowspan="8">
+               <widget class="QgsColorSchemeList" name="mTreeProjectColors" native="true"/>
+              </item>
+              <item row="4" column="1">
+               <widget class="QToolButton" name="mButtonImportColors">
+                <property name="toolTip">
+                 <string>Import colors</string>
+                </property>
+                <property name="statusTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="QToolButton" name="mButtonExportColors">
+                <property name="toolTip">
+                 <string>Export colors</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
           </layout>
@@ -1904,8 +1917,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>151</width>
-                <height>42</height>
+                <width>694</width>
+                <height>789</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1987,7 +2000,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>627</width>
+                <width>673</width>
                 <height>1503</height>
                </rect>
               </property>
@@ -3643,14 +3656,6 @@
   <tabstop>mStyleFillSymbol</tabstop>
   <tabstop>mStyleColorRampSymbol</tabstop>
   <tabstop>mStyleTextFormat</tabstop>
-  <tabstop>mDefaultOpacityWidget</tabstop>
-  <tabstop>cbxStyleRandomColors</tabstop>
-  <tabstop>mButtonAddColor</tabstop>
-  <tabstop>mButtonRemoveColor</tabstop>
-  <tabstop>mButtonCopyColors</tabstop>
-  <tabstop>mButtonPasteColors</tabstop>
-  <tabstop>mButtonImportColors</tabstop>
-  <tabstop>mButtonExportColors</tabstop>
   <tabstop>mListStyleDatabases</tabstop>
   <tabstop>mButtonAddStyleDatabase</tabstop>
   <tabstop>mButtonRemoveStyleDatabase</tabstop>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -298,7 +298,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>673</width>
+                <width>522</width>
                 <height>852</height>
                </rect>
               </property>
@@ -1413,6 +1413,9 @@
                   </item>
                   <item row="1" column="2">
                    <widget class="QToolButton" name="mRemoveIccProfile">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected ICC profile&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
                     <property name="text">
                      <string>...</string>
                     </property>
@@ -1445,6 +1448,9 @@
                   </item>
                   <item row="1" column="3">
                    <widget class="QToolButton" name="mAddIccProfile">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load an ICC profile file and attach it to the project.&lt;/p&gt;&lt;p&gt;Color model will be updated accordingly.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
                     <property name="text">
                      <string/>
                     </property>
@@ -1455,7 +1461,11 @@
                    </widget>
                   </item>
                   <item row="0" column="1" colspan="3">
-                   <widget class="QComboBox" name="mColorModel"/>
+                   <widget class="QComboBox" name="mColorModel">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color model used as default when selecting a color in the whole application.&lt;/p&gt;&lt;p&gt;Any color defined in a different color model than the one specified here will be converted to this color model when exporting a layout.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="3" column="1" colspan="3">
                    <widget class="QgsOpacityWidget" name="mDefaultOpacityWidget" native="true">
@@ -1977,7 +1987,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>673</width>
+                <width>627</width>
                 <height>1503</height>
                </rect>
               </property>
@@ -3488,31 +3498,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsExtentGroupBox</class>
-   <extends>QgsCollapsibleGroupBox</extends>
-   <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsOpacityWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsopacitywidget.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -3521,19 +3509,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -3558,6 +3536,38 @@
    <extends>QWidget</extends>
    <header>qgsdatumtransformtablewidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionTreeWidget</class>

--- a/tests/src/app/testqgsprojectproperties.cpp
+++ b/tests/src/app/testqgsprojectproperties.cpp
@@ -266,8 +266,15 @@ void TestQgsProjectProperties::testColorSettings()
   std::unique_ptr< QgsProjectProperties > pp = std::make_unique< QgsProjectProperties >( mQgisApp->mapCanvas() );
   QCOMPARE( static_cast<Qgis::ColorModel>( pp->mColorModel->currentData().toInt() ), Qgis::ColorModel::Rgb );
   QVERIFY( !pp->mColorSpace.isValid() );
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   QCOMPARE( pp->mColorSpaceName->text(), QStringLiteral( "<i>None</i>" ) );
   QVERIFY( !pp->mRemoveIccProfile->isEnabled() );
+#else
+  QVERIFY( !pp->mRemoveIccProfile->isVisible() );
+  QVERIFY( !pp->mAddIccProfile->isVisible() );
+  QVERIFY( !pp->mColorSpaceName->isVisible() );
+  QVERIFY( !pp->mIccProfileLabel->isVisible() );
+#endif
 
   pp->mColorModel->setCurrentIndex( pp->mColorModel->findData( QVariant::fromValue( Qgis::ColorModel::Cmyk ) ) );
   QCOMPARE( static_cast<Qgis::ColorModel>( pp->mColorModel->currentData().toInt() ), Qgis::ColorModel::Cmyk );

--- a/tests/src/app/testqgsprojectproperties.cpp
+++ b/tests/src/app/testqgsprojectproperties.cpp
@@ -272,6 +272,7 @@ void TestQgsProjectProperties::testColorSettings()
 #else
   QVERIFY( !pp->mRemoveIccProfile->isVisible() );
   QVERIFY( !pp->mAddIccProfile->isVisible() );
+  QVERIFY( !pp->mSaveIccProfile->isVisible() );
   QVERIFY( !pp->mColorSpaceName->isVisible() );
   QVERIFY( !pp->mIccProfileLabel->isVisible() );
 #endif

--- a/tests/src/app/testqgsprojectproperties.cpp
+++ b/tests/src/app/testqgsprojectproperties.cpp
@@ -278,9 +278,11 @@ void TestQgsProjectProperties::testColorSettings()
   pp->addIccProfile( iccProfileFilePath );
   QCOMPARE( pp->mColorSpaceName->text(), QStringLiteral( "sRGB2014" ) );
   QVERIFY( pp->mRemoveIccProfile->isEnabled() );
+  QVERIFY( !pp->mColorModel->isEnabled() );
+  QCOMPARE( static_cast<Qgis::ColorModel>( pp->mColorModel->currentData().toInt() ), Qgis::ColorModel::Rgb );
 
   pp->apply();
-  QCOMPARE( QgsProject::instance()->styleSettings()->colorModel(), Qgis::ColorModel::Cmyk );
+  QCOMPARE( QgsProject::instance()->styleSettings()->colorModel(), Qgis::ColorModel::Rgb );
   QVERIFY( QgsProject::instance()->styleSettings()->colorSpace().isValid() );
   QCOMPARE( QgsProject::instance()->styleSettings()->colorSpace().description(), QStringLiteral( "sRGB2014" ) );
 

--- a/tests/src/app/testqgsprojectproperties.cpp
+++ b/tests/src/app/testqgsprojectproperties.cpp
@@ -24,6 +24,7 @@
 #include "qgsbearingnumericformat.h"
 #include "qgsrasterlayer.h"
 #include "qgsprojecttimesettings.h"
+#include "qgsprojectstylesettings.h"
 #include "qgsmaplayertemporalproperties.h"
 #include "qgsrasterlayertemporalproperties.h"
 
@@ -48,6 +49,7 @@ class TestQgsProjectProperties : public QObject
     void testEllipsoidCrsSync();
     void testBearingFormat();
     void testTimeSettings();
+    void testColorSettings();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -254,6 +256,44 @@ void TestQgsProjectProperties::testTimeSettings()
 
   QCOMPARE( secondProjectRange, expectedRange );
 }
+
+void TestQgsProjectProperties::testColorSettings()
+{
+  QgsProject::instance()->clear();
+  QCOMPARE( QgsProject::instance()->styleSettings()->colorModel(), Qgis::ColorModel::Rgb );
+  QVERIFY( !QgsProject::instance()->styleSettings()->colorSpace().isValid() );
+
+  std::unique_ptr< QgsProjectProperties > pp = std::make_unique< QgsProjectProperties >( mQgisApp->mapCanvas() );
+  QCOMPARE( static_cast<Qgis::ColorModel>( pp->mColorModel->currentData().toInt() ), Qgis::ColorModel::Rgb );
+  QVERIFY( !pp->mColorSpace.isValid() );
+  QCOMPARE( pp->mColorSpaceName->text(), QStringLiteral( "<i>None</i>" ) );
+  QVERIFY( !pp->mRemoveIccProfile->isEnabled() );
+
+  pp->mColorModel->setCurrentIndex( pp->mColorModel->findData( QVariant::fromValue( Qgis::ColorModel::Cmyk ) ) );
+  QCOMPARE( static_cast<Qgis::ColorModel>( pp->mColorModel->currentData().toInt() ), Qgis::ColorModel::Cmyk );
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+
+  const QString iccProfileFilePath = QStringLiteral( TEST_DATA_DIR ) + "/sRGB2014.icc";
+  pp->addIccProfile( iccProfileFilePath );
+  QCOMPARE( pp->mColorSpaceName->text(), QStringLiteral( "sRGB2014" ) );
+  QVERIFY( pp->mRemoveIccProfile->isEnabled() );
+
+  pp->apply();
+  QCOMPARE( QgsProject::instance()->styleSettings()->colorModel(), Qgis::ColorModel::Cmyk );
+  QVERIFY( QgsProject::instance()->styleSettings()->colorSpace().isValid() );
+  QCOMPARE( QgsProject::instance()->styleSettings()->colorSpace().description(), QStringLiteral( "sRGB2014" ) );
+
+  pp->removeIccProfile();
+  QVERIFY( !pp->mColorSpace.isValid() );
+  QCOMPARE( pp->mColorSpaceName->text(), QStringLiteral( "<i>None</i>" ) );
+  QVERIFY( !pp->mRemoveIccProfile->isEnabled() );
+
+#endif
+
+}
+
+
 
 QGSTEST_MAIN( TestQgsProjectProperties )
 

--- a/tests/src/python/test_qgscolorutils.py
+++ b/tests/src/python/test_qgscolorutils.py
@@ -9,10 +9,17 @@ __author__ = 'Nyall Dawson'
 __date__ = '06/07/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
+import os
+
+from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import QgsColorUtils, QgsReadWriteContext, QgsSymbolLayerUtils
 from qgis.testing import unittest
+
+from utilities import unitTestDataPath
+
+TEST_DATA_DIR = unitTestDataPath()
 
 
 class TestQgsColorUtils(unittest.TestCase):
@@ -287,6 +294,21 @@ class TestQgsColorUtils(unittest.TestCase):
         self.assertEqual(res.green(), 33)
         self.assertAlmostEqual(res.blue(), 23, delta=1)
         self.assertEqual(res.alpha(), 220)
+
+    def test_icc_profile(self):
+        """
+        Test ICC profile load and save method
+        """
+
+        iccProfileFilePath = os.path.join(TEST_DATA_DIR, "sRGB2014.icc")
+        colorSpace, errorMsg = QgsColorUtils.iccProfile(iccProfileFilePath)
+        self.assertTrue(colorSpace.isValid())
+
+        tmpDir = QTemporaryDir()
+        tmpFile = f"{tmpDir.path()}/test.icc"
+
+        error = QgsColorUtils.saveIccProfile(colorSpace, tmpFile)
+        self.assertTrue(not error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add CMYK project properties configuration widgets.

When loading and ICC profile, QGIS force color model to keep consistency between color model and color space.

**ICC profile widget part is not visible if QGIS is not built with Qt 6.8.0 or greater** (That maybe require to be clearly advertise it t

![cmyk_widget](https://github.com/user-attachments/assets/28ec4173-341a-44d2-9004-7402d287d857)
he changelog)

**Funded by Bordeaux Métropole**
