### PR TITLE
When selecting overlapping annotations, prefer the smallest

### DIFF
--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -725,7 +725,7 @@ const QgsRenderedAnnotationItemDetails *QgsMapToolModifyAnnotation::findClosestI
 {
   const QgsRenderedAnnotationItemDetails *closestItem = nullptr;
   double closestItemDistance = std::numeric_limits< double >::max();
-  int closestItemZ = 0;
+  double closestItemArea = std::numeric_limits< double >::max();
 
   for ( const QgsRenderedAnnotationItemDetails *item : items )
   {
@@ -735,11 +735,11 @@ const QgsRenderedAnnotationItemDetails *QgsMapToolModifyAnnotation::findClosestI
 
     const QgsRectangle itemBounds = item->boundingBox();
     const double itemDistance = itemBounds.contains( mapPoint ) ? 0 : itemBounds.distance( mapPoint );
-    if ( !closestItem || itemDistance < closestItemDistance || ( itemDistance == closestItemDistance && annotationItem->zIndex() > closestItemZ ) )
+    if ( !closestItem || itemDistance < closestItemDistance || ( itemDistance == closestItemDistance && itemBounds.area() < closestItemArea ) )
     {
       closestItem = item;
       closestItemDistance = itemDistance;
-      closestItemZ = annotationItem->zIndex();
+      closestItemArea = itemBounds.area();
       bounds = itemBounds;
     }
   }

--- a/tests/src/app/testqgsmaptooleditannotation.cpp
+++ b/tests/src/app/testqgsmaptooleditannotation.cpp
@@ -94,8 +94,8 @@ void TestQgsMapToolEditAnnotation::testSelectItem()
   item1->setZIndex( 1 );
   const QString i1id = layer->addItem( item1 );
 
-  QgsAnnotationPolygonItem *item2 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 4 ), QgsPoint( 5, 4 ), QgsPoint( 5, 9 ), QgsPoint( 1, 9 ), QgsPoint( 1, 4 ) } ) ) );
-  item2->setZIndex( 2 );
+  QgsAnnotationPolygonItem *item2 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 4 ), QgsPoint( 1.6, 4 ), QgsPoint( 1.6, 4.6 ), QgsPoint( 1, 4.6 ), QgsPoint( 1, 4 ) } ) ) );
+  item2->setZIndex( 0 );
   const QString i2id = layer->addItem( item2 );
 
   QgsAnnotationPolygonItem *item3 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 7, 1 ), QgsPoint( 8, 1 ), QgsPoint( 8, 2 ), QgsPoint( 7, 2 ), QgsPoint( 7, 1 ) } ) ) );
@@ -131,7 +131,7 @@ void TestQgsMapToolEditAnnotation::testSelectItem()
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
 
-  // overlapping items, highest z order should be selected
+  // overlapping items, smallest area item should be selected
   utils.mouseMove( 1.5, 4.5 );
   utils.mouseClick( 1.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   QCOMPARE( spy.count(), 2 );


### PR DESCRIPTION
When the mouse is over multiple overlapping annotations, prefer to pick the one with smallest area. This makes it possible to select smaller annotations stacked under larger ones, and makes the annotation modification map tool match the behavior of the modify label map tool.
