### PR TITLE
show information messagebox when metadata saved to the default location

### DIFF
--- a/src/gui/qgslayerpropertiesdialog.cpp
+++ b/src/gui/qgslayerpropertiesdialog.cpp
@@ -125,7 +125,7 @@ void QgsLayerPropertiesDialog::saveMetadataAsDefault()
   mMetadataWidget->acceptMetadata();
 
   bool defaultSavedFlag = false;
-  const QString infoWindowTitle = QObject::tr( "Save default metadata" );
+  const QString infoWindowTitle = QObject::tr( "Save Default Metadata" );
   const QString errorMsg = mLayer->saveDefaultMetadata( defaultSavedFlag );
   if ( !defaultSavedFlag )
   {

--- a/src/gui/qgslayerpropertiesdialog.cpp
+++ b/src/gui/qgslayerpropertiesdialog.cpp
@@ -125,11 +125,16 @@ void QgsLayerPropertiesDialog::saveMetadataAsDefault()
   mMetadataWidget->acceptMetadata();
 
   bool defaultSavedFlag = false;
+  const QString infoWindowTitle = QObject::tr( "Save default metadata" );
   const QString errorMsg = mLayer->saveDefaultMetadata( defaultSavedFlag );
   if ( !defaultSavedFlag )
   {
-    QMessageBox::warning( this, tr( "Default Metadata" ), errorMsg );
+    QMessageBox::warning( this, infoWindowTitle, errorMsg );
     refocusDialog();
+  }
+  else
+  {
+    QMessageBox::information( this, infoWindowTitle, tr( "Metadata saved." ) );
   }
 }
 


### PR DESCRIPTION
## Description

There is no feedback when user saves layer metadata to the default location, this leaves user wondering whether operation was completed/successful or not. Also this is not consistent with the QGIS behaviour when saving style to the database. In the latter case user sees a messagebox confirming that everything was saved.

Funded by [NaturalGIS](https://www.naturalgis.pt/).