### PR TITLE
Fix inconsistency between layer providers in geometry checker

### DIFF
--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
@@ -121,10 +121,13 @@ To be used by implementations of ``addFeature``.
    the original layer's thread.
 %End
 
-    void refreshCache( QgsFeature feature );
+    void refreshCache( QgsFeature feature, const QgsFeature origFeature );
 %Docstring
 Changes a feature in the cache and the spatial index.
 To be used by implementations of ``updateFeature``.
+
+:param feature: the new feature to put in the cache and index
+:param origFeature: the original feature to remove from the index
 
 .. note::
 

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
@@ -121,7 +121,7 @@ To be used by implementations of ``addFeature``.
    the original layer's thread.
 %End
 
-    void refreshCache( const QgsFeature &feature );
+    void refreshCache( QgsFeature feature );
 %Docstring
 Changes a feature in the cache and the spatial index.
 To be used by implementations of ``updateFeature``.

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
@@ -121,10 +121,13 @@ To be used by implementations of ``addFeature``.
    the original layer's thread.
 %End
 
-    void refreshCache( QgsFeature feature );
+    void refreshCache( QgsFeature feature, const QgsFeature origFeature );
 %Docstring
 Changes a feature in the cache and the spatial index.
 To be used by implementations of ``updateFeature``.
+
+:param feature: the new feature to put in the cache and index
+:param origFeature: the original feature to remove from the index
 
 .. note::
 

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
@@ -121,7 +121,7 @@ To be used by implementations of ``addFeature``.
    the original layer's thread.
 %End
 
-    void refreshCache( const QgsFeature &feature );
+    void refreshCache( QgsFeature feature );
 %Docstring
 Changes a feature in the cache and the spatial index.
 To be used by implementations of ``updateFeature``.

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -131,11 +131,11 @@ void QgsFeaturePool::insertFeature( const QgsFeature &feature, bool skipLock )
   mIndex.addFeature( indexFeature );
 }
 
-void QgsFeaturePool::refreshCache( QgsFeature feature )
+void QgsFeaturePool::refreshCache( QgsFeature feature, const QgsFeature origFeature )
 {
   QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Write );
   mFeatureCache.insert( feature.id(), new QgsFeature( feature ) );
-  mIndex.deleteFeature( feature );
+  mIndex.deleteFeature( origFeature );
   mIndex.addFeature( feature );
   locker.unlock();
 }

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -131,15 +131,13 @@ void QgsFeaturePool::insertFeature( const QgsFeature &feature, bool skipLock )
   mIndex.addFeature( indexFeature );
 }
 
-void QgsFeaturePool::refreshCache( const QgsFeature &feature )
+void QgsFeaturePool::refreshCache( QgsFeature feature )
 {
   QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Write );
-  mFeatureCache.remove( feature.id() );
+  mFeatureCache.insert( feature.id(), new QgsFeature( feature ) );
   mIndex.deleteFeature( feature );
+  mIndex.addFeature( feature );
   locker.unlock();
-
-  QgsFeature tempFeature;
-  getFeature( feature.id(), tempFeature );
 }
 
 void QgsFeaturePool::removeFeature( const QgsFeatureId featureId )

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -49,7 +49,7 @@ bool QgsFeaturePool::getFeature( QgsFeatureId id, QgsFeature &feature )
   //
   // https://bugreports.qt.io/browse/QTBUG-19794
 
-  QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Write );
+  QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Read );
   QgsFeature *cachedFeature = mFeatureCache.object( id );
   if ( cachedFeature )
   {

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -171,10 +171,13 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink SIP_ABSTRACT
      * Changes a feature in the cache and the spatial index.
      * To be used by implementations of ``updateFeature``.
      *
+     * \param feature the new feature to put in the cache and index
+     * \param origFeature the original feature to remove from the index
+     *
      * \note This method can safely be called from a different thread vs the object's creation thread or
      * the original layer's thread.
      */
-    void refreshCache( QgsFeature feature );
+    void refreshCache( QgsFeature feature, const QgsFeature origFeature );
 
     /**
      * Removes a feature from the cache and the spatial index.

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -174,7 +174,7 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink SIP_ABSTRACT
      * \note This method can safely be called from a different thread vs the object's creation thread or
      * the original layer's thread.
      */
-    void refreshCache( const QgsFeature &feature );
+    void refreshCache( QgsFeature feature );
 
     /**
      * Removes a feature from the cache and the spatial index.

--- a/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
@@ -153,7 +153,7 @@ void QgsVectorDataProviderFeaturePool::updateFeature( QgsFeature &feature )
     }
   } );
 
-  refreshCache( feature );
+  refreshCache( feature, origFeature );
 }
 
 void QgsVectorDataProviderFeaturePool::deleteFeature( QgsFeatureId fid )

--- a/tests/src/geometry_checker/testqgsvectorlayerfeaturepool.cpp
+++ b/tests/src/geometry_checker/testqgsvectorlayerfeaturepool.cpp
@@ -142,29 +142,21 @@ void TestQgsVectorLayerFeaturePool::changeGeometry()
   feat.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon((100 100, 110 100, 110 110, 100 110, 100 100))" ) ) );
   vl->updateFeature( feat );
 
-  // Still working on the cached data
+  // Cached data updated with geometryChanged vector layer signal
   const QgsFeatureIds ids3 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
-  QCOMPARE( ids3.size(), 1 );
-
-  // Repopulate the cache
-  const QgsFeatureIds ids4 = pool.getFeatures( QgsFeatureRequest().setFilterRect( QgsRectangle( 0, 0, 10, 10 ) ) );
-  QCOMPARE( ids4.size(), 0 );
+  QCOMPARE( ids3.size(), 0 );
 
   // Still working on the cached data
-  const QgsFeatureIds ids5 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
-  QCOMPARE( ids5.size(), 0 );
+  const QgsFeatureIds ids4 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
+  QCOMPARE( ids4.size(), 0 );
 
   // Update a feature to be inside the AOI
   feat.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon((0 0, 10 0, 10 10, 0 10, 0 0))" ) ) );
   vl->updateFeature( feat );
 
-  // Still cached
-  const QgsFeatureIds ids6 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
-  QCOMPARE( ids6.size(), 0 );
-
-  // One in there again
-  const QgsFeatureIds ids7 = pool.getFeatures( QgsFeatureRequest().setFilterRect( QgsRectangle( 0, 0, 10, 10 ) ) );
-  QCOMPARE( ids7.size(), 1 );
+  // Cached data updated with geometryChanged vector layer signal
+  const QgsFeatureIds ids5 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
+  QCOMPARE( ids5.size(), 1 );
 }
 
 std::unique_ptr<QgsVectorLayer> TestQgsVectorLayerFeaturePool::createPopulatedLayer()


### PR DESCRIPTION
Geometry checker does not work properly with memory layers, so we change how the cache in the QgsFeaturePool object is managed, to refresh it more often.

Fixes #58113 