### PR TITLE
[3D] Use QGIS material for the terrain

### DIFF
--- a/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
@@ -126,7 +126,7 @@ Sets diffuse color component
 %Docstring
 Sets specular color component
 %End
-    void setShininess( float shininess );
+    void setShininess( double shininess );
 %Docstring
 Sets shininess of the surface
 %End

--- a/python/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
@@ -90,7 +90,7 @@ during triangulation.quiresTextureCoordinates
 Returns the texture rotation, in degrees.
 %End
 
-    float opacity() const;
+    double opacity() const;
 %Docstring
 Returns the opacity of the surface
 

--- a/python/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
@@ -57,7 +57,7 @@ Returns ambient color component
 %Docstring
 Returns specular color component
 %End
-    float shininess() const;
+    double shininess() const;
 %Docstring
 Returns shininess of the surface
 %End
@@ -106,7 +106,7 @@ Sets ambient color component
 %Docstring
 Sets specular color component
 %End
-    void setShininess( float shininess );
+    void setShininess( double shininess );
 %Docstring
 Sets shininess of the surface
 %End

--- a/python/PyQt6/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
@@ -126,7 +126,7 @@ Sets diffuse color component
 %Docstring
 Sets specular color component
 %End
-    void setShininess( float shininess );
+    void setShininess( double shininess );
 %Docstring
 Sets shininess of the surface
 %End

--- a/python/PyQt6/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
@@ -90,7 +90,7 @@ during triangulation.quiresTextureCoordinates
 Returns the texture rotation, in degrees.
 %End
 
-    float opacity() const;
+    double opacity() const;
 %Docstring
 Returns the opacity of the surface
 

--- a/python/PyQt6/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
@@ -57,7 +57,7 @@ Returns ambient color component
 %Docstring
 Returns specular color component
 %End
-    float shininess() const;
+    double shininess() const;
 %Docstring
 Returns shininess of the surface
 %End
@@ -106,7 +106,7 @@ Sets ambient color component
 %Docstring
 Sets specular color component
 %End
-    void setShininess( float shininess );
+    void setShininess( double shininess );
 %Docstring
 Sets shininess of the surface
 %End

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -74,6 +74,7 @@ set(QGIS_3D_SRCS
   materials/qgsphongtexturedmaterial.cpp
   materials/qgsphongtexturedmaterialsettings.cpp
   materials/qgssimplelinematerialsettings.cpp
+  materials/qgstexturematerial.cpp
 
   processing/qgs3dalgorithms.cpp
   processing/qgsalgorithmtessellate.cpp
@@ -167,6 +168,7 @@ set(QGIS_3D_HDRS
   materials/qgsphongtexturedmaterial.h
   materials/qgsphongtexturedmaterialsettings.h
   materials/qgssimplelinematerialsettings.h
+  materials/qgstexturematerial.h
 
   symbols/qgsbillboardgeometry.h
   symbols/qgsline3dsymbol.h

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -71,6 +71,7 @@ set(QGIS_3D_SRCS
   materials/qgsmetalroughmaterialsettings.cpp
   materials/qgsnullmaterialsettings.cpp
   materials/qgsphongmaterialsettings.cpp
+  materials/qgsphongtexturedmaterial.cpp
   materials/qgsphongtexturedmaterialsettings.cpp
   materials/qgssimplelinematerialsettings.cpp
 
@@ -163,6 +164,7 @@ set(QGIS_3D_HDRS
   materials/qgsmetalroughmaterialsettings.h
   materials/qgsnullmaterialsettings.h
   materials/qgsphongmaterialsettings.h
+  materials/qgsphongtexturedmaterial.h
   materials/qgsphongtexturedmaterialsettings.h
   materials/qgssimplelinematerialsettings.h
 

--- a/src/3d/materials/qgsphongmaterialsettings.h
+++ b/src/3d/materials/qgsphongmaterialsettings.h
@@ -112,7 +112,7 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
     //! Sets specular color component
     void setSpecular( const QColor &specular ) { mSpecular = specular; }
     //! Sets shininess of the surface
-    void setShininess( float shininess ) { mShininess = shininess; }
+    void setShininess( double shininess ) { mShininess = shininess; }
 
     /**
      * Sets opacity of the surface

--- a/src/3d/materials/qgsphongtexturedmaterial.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial.cpp
@@ -1,0 +1,178 @@
+/***************************************************************************
+  qgsphongtexturedmaterial.cpp
+  --------------------------------------
+  Date                 : August 2024
+  Copyright            : (C) 2024 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QUrl>
+
+#include <Qt3DRender/QEffect>
+#include <Qt3DRender/QGraphicsApiFilter>
+#include <Qt3DRender/QParameter>
+#include <Qt3DRender/QTechnique>
+
+#include "qgsphongtexturedmaterial.h"
+
+///@cond PRIVATE
+QgsPhongTexturedMaterial::QgsPhongTexturedMaterial( QNode *parent )
+  : QMaterial( parent )
+  , mAmbientParameter( new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), QColor::fromRgbF( 0.05f, 0.05f, 0.05f, 1.0f ) ) )
+  , mDiffuseTextureParameter( new Qt3DRender::QParameter( QStringLiteral( "diffuseTexture" ), QVariant() ) )
+  , mDiffuseTextureScaleParameter( new Qt3DRender::QParameter( QStringLiteral( "texCoordScale" ), 1.0f ) )
+  , mSpecularParameter( new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), QColor::fromRgbF( 0.01f, 0.01f, 0.01f, 1.0f ) ) )
+  , mShininessParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), 150.0f ) )
+  , mOpacityParameter( new Qt3DRender::QParameter( QStringLiteral( "opacity" ), 1.0f ) )
+{
+  init();
+}
+
+QgsPhongTexturedMaterial::~QgsPhongTexturedMaterial() = default;
+
+
+void QgsPhongTexturedMaterial::init()
+{
+  connect( mAmbientParameter, &Qt3DRender::QParameter::valueChanged,
+           this, &QgsPhongTexturedMaterial::handleAmbientChanged );
+  connect( mDiffuseTextureParameter, &Qt3DRender::QParameter::valueChanged,
+           this, &QgsPhongTexturedMaterial::handleDiffuseTextureChanged );
+  connect( mDiffuseTextureScaleParameter, &Qt3DRender::QParameter::valueChanged,
+           this, &QgsPhongTexturedMaterial::handleDiffuseTextureScaleChanged );
+  connect( mSpecularParameter, &Qt3DRender::QParameter::valueChanged,
+           this, &QgsPhongTexturedMaterial::handleSpecularChanged );
+  connect( mShininessParameter, &Qt3DRender::QParameter::valueChanged,
+           this, &QgsPhongTexturedMaterial::handleShininessChanged );
+  connect( mOpacityParameter, &Qt3DRender::QParameter::valueChanged,
+           this, &QgsPhongTexturedMaterial::handleOpacityChanged );
+
+  Qt3DRender::QEffect *effect = new Qt3DRender::QEffect();
+  effect->addParameter( mAmbientParameter );
+  effect->addParameter( mDiffuseTextureParameter );
+  effect->addParameter( mDiffuseTextureScaleParameter );
+  effect->addParameter( mSpecularParameter );
+  effect->addParameter( mShininessParameter );
+  effect->addParameter( mOpacityParameter );
+
+  Qt3DRender::QShaderProgram *gL3Shader = new Qt3DRender::QShaderProgram();
+  gL3Shader->setVertexShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( QStringLiteral( "qrc:/shaders/default.vert" ) ) ) );
+  gL3Shader->setFragmentShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( QStringLiteral( "qrc:/shaders/diffuseSpecular.frag" ) ) ) );
+
+  Qt3DRender::QTechnique *gL3Technique = new Qt3DRender::QTechnique();
+  gL3Technique->graphicsApiFilter()->setApi( Qt3DRender::QGraphicsApiFilter::OpenGL );
+  gL3Technique->graphicsApiFilter()->setMajorVersion( 3 );
+  gL3Technique->graphicsApiFilter()->setMinorVersion( 1 );
+  gL3Technique->graphicsApiFilter()->setProfile( Qt3DRender::QGraphicsApiFilter::CoreProfile );
+
+  Qt3DRender::QFilterKey *filterKey = new Qt3DRender::QFilterKey( this );
+  filterKey->setName( QStringLiteral( "renderingStyle" ) );
+  filterKey->setValue( QStringLiteral( "forward" ) );
+
+  gL3Technique->addFilterKey( filterKey );
+
+  Qt3DRender::QRenderPass *gL3RenderPass = new Qt3DRender::QRenderPass();
+  gL3RenderPass->setShaderProgram( gL3Shader );
+  gL3Technique->addRenderPass( gL3RenderPass );
+  effect->addTechnique( gL3Technique );
+
+  setEffect( effect );
+}
+
+void QgsPhongTexturedMaterial::setAmbient( const QColor &ambient )
+{
+  mAmbientParameter->setValue( ambient );
+}
+
+void QgsPhongTexturedMaterial::setDiffuseTexture( Qt3DRender::QAbstractTexture *diffuseTexture )
+{
+  mDiffuseTextureParameter->setValue( QVariant::fromValue( diffuseTexture ) );
+}
+
+void QgsPhongTexturedMaterial::setDiffuseTextureScale( float diffuseTextureScale )
+{
+  mDiffuseTextureScaleParameter->setValue( diffuseTextureScale );
+}
+
+void QgsPhongTexturedMaterial::setSpecular( const QColor &specular )
+{
+  mSpecularParameter->setValue( specular );
+}
+
+void QgsPhongTexturedMaterial::setShininess( float shininess )
+{
+  mShininessParameter->setValue( shininess );
+}
+
+void QgsPhongTexturedMaterial::setOpacity( float opacity )
+{
+  mOpacityParameter->setValue( opacity );
+}
+
+QColor QgsPhongTexturedMaterial::ambient() const
+{
+  return mAmbientParameter->value().value<QColor>();
+}
+
+Qt3DRender::QAbstractTexture *QgsPhongTexturedMaterial::diffuseTexture() const
+{
+  return mDiffuseTextureParameter->value().value<Qt3DRender::QAbstractTexture *>();
+}
+
+float QgsPhongTexturedMaterial::diffuseTextureScale() const
+{
+  return mDiffuseTextureScaleParameter->value().toFloat();
+}
+
+QColor QgsPhongTexturedMaterial::specular() const
+{
+  return mSpecularParameter->value().value<QColor>();
+}
+
+float QgsPhongTexturedMaterial::shininess() const
+{
+  return mShininessParameter->value().toFloat();
+}
+
+float QgsPhongTexturedMaterial::opacity() const
+{
+  return mOpacityParameter->value().toFloat();
+}
+
+void QgsPhongTexturedMaterial::handleAmbientChanged( const QVariant &var )
+{
+  emit ambientChanged( var.value<QColor>() );
+}
+
+void QgsPhongTexturedMaterial::handleDiffuseTextureChanged( const QVariant &var )
+{
+  emit diffuseTextureChanged( var.value<Qt3DRender::QAbstractTexture *>() );
+}
+
+void QgsPhongTexturedMaterial::handleDiffuseTextureScaleChanged( const QVariant &var )
+{
+  emit diffuseTextureScaleChanged( var.toFloat() );
+}
+
+void QgsPhongTexturedMaterial::handleSpecularChanged( const QVariant &var )
+{
+  emit specularChanged( var.value<QColor>() );
+}
+
+void QgsPhongTexturedMaterial::handleShininessChanged( const QVariant &var )
+{
+  emit shininessChanged( var.toFloat() );
+}
+
+void QgsPhongTexturedMaterial::handleOpacityChanged( const QVariant &var )
+{
+  emit opacityChanged( var.toFloat() );
+}
+
+///@endcond PRIVATE

--- a/src/3d/materials/qgsphongtexturedmaterial.h
+++ b/src/3d/materials/qgsphongtexturedmaterial.h
@@ -1,0 +1,108 @@
+/***************************************************************************
+  qgsphongtexturedmaterial.h
+  --------------------------------------
+  Date                 : August 2024
+  Copyright            : (C) 2024 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPHONGTEXTUREDMATERIAL_H
+#define QGSPHONGTEXTUREDMATERIAL_H
+
+#include "qgis_3d.h"
+
+#include <QColor>
+#include <QObject>
+#include <Qt3DRender/QMaterial>
+#include <Qt3DRender/QTexture>
+
+#define SIP_NO_FILE
+
+namespace Qt3DRender
+{
+  class QParameter;
+
+} // namespace Qt3DRender
+
+///@cond PRIVATE
+
+/**
+ * \ingroup 3d
+ * \brief A diffuseSpecular material adapted from Qt's qdiffusespecularmaterial.h
+ * \since QGIS 3.40
+ */
+class _3D_EXPORT QgsPhongTexturedMaterial : public Qt3DRender::QMaterial
+{
+    Q_OBJECT
+    Q_PROPERTY( QColor ambient READ ambient WRITE setAmbient NOTIFY ambientChanged )
+    Q_PROPERTY( Qt3DRender::QAbstractTexture *diffuseTexture READ diffuseTexture WRITE setDiffuseTexture NOTIFY diffuseTextureChanged )
+    Q_PROPERTY( float diffuseTextureScale READ diffuseTextureScale WRITE setDiffuseTextureScale NOTIFY diffuseTextureScaleChanged )
+    Q_PROPERTY( QColor specular READ specular WRITE setSpecular NOTIFY specularChanged )
+    Q_PROPERTY( float shininess READ shininess WRITE setShininess NOTIFY shininessChanged )
+    Q_PROPERTY( float opacity READ opacity WRITE setOpacity NOTIFY opacityChanged )
+
+  public:
+
+    /**
+     * Constructor for QgsPhongTexturedMaterial, with the specified \a parent node.
+     */
+    explicit QgsPhongTexturedMaterial( Qt3DCore::QNode *parent = nullptr );
+    ~QgsPhongTexturedMaterial() override;
+
+    QColor ambient() const;
+    Qt3DRender::QAbstractTexture *diffuseTexture() const;
+    float diffuseTextureScale() const;
+    QColor specular() const;
+    float shininess() const;
+    float opacity() const;
+
+  public Q_SLOTS:
+    void setAmbient( const QColor &ambient );
+
+    /**
+     * Sets the diffuse component of the material.
+     * Ownership is transferred to the material.
+     */
+    void setDiffuseTexture( Qt3DRender::QAbstractTexture *texture );
+
+    void setDiffuseTextureScale( float textureScale );
+    void setSpecular( const QColor &specular );
+    void setShininess( float shininess );
+    void setOpacity( float opacity );
+
+  Q_SIGNALS:
+    void ambientChanged( const QColor &ambient );
+    void diffuseTextureChanged( Qt3DRender::QAbstractTexture *diffuseTexture );
+    void diffuseTextureScaleChanged( float diffuseTextureScale );
+    void specularChanged( const QColor &specular );
+    void shininessChanged( float shininess );
+    void opacityChanged( float opacity );
+
+  private:
+    void init();
+
+    void handleAmbientChanged( const QVariant &var );
+    void handleDiffuseTextureChanged( const QVariant &var );
+    void handleDiffuseTextureScaleChanged( const QVariant &var );
+    void handleSpecularChanged( const QVariant &var );
+    void handleShininessChanged( const QVariant &var );
+    void handleOpacityChanged( const QVariant &var );
+
+    Qt3DRender::QParameter *mAmbientParameter = nullptr;
+    Qt3DRender::QParameter *mDiffuseTextureParameter = nullptr;
+    Qt3DRender::QParameter *mDiffuseTextureScaleParameter = nullptr;
+    Qt3DRender::QParameter *mSpecularParameter = nullptr;
+    Qt3DRender::QParameter *mShininessParameter = nullptr;
+    Qt3DRender::QParameter *mOpacityParameter = nullptr;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSPHONGTEXTUREDMATERIAL_H

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
@@ -149,7 +149,7 @@ Qt3DRender::QMaterial *QgsPhongTexturedMaterialSettings::toMaterial( QgsMaterial
       renderPass->setShaderProgram( shaderProgram );
       technique->addRenderPass( renderPass );
 
-      int opacity = mOpacity * 255;
+      int opacity = static_cast<int>( mOpacity * 255.0 );
       QColor ambient = context.isSelected() ? context.selectionColor().darker() : mAmbient;
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), QColor( ambient.red(), ambient.green(), ambient.blue(), opacity ) ) );
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), QColor( mSpecular.red(), mSpecular.green(), mSpecular.blue(), opacity ) ) );

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
@@ -71,7 +71,7 @@ void QgsPhongTexturedMaterialSettings::readXml( const QDomElement &elem, const Q
 {
   mAmbient = QgsColorUtils::colorFromString( elem.attribute( QStringLiteral( "ambient" ), QStringLiteral( "25,25,25" ) ) );
   mSpecular = QgsColorUtils::colorFromString( elem.attribute( QStringLiteral( "specular" ), QStringLiteral( "255,255,255" ) ) );
-  mShininess = elem.attribute( QStringLiteral( "shininess" ) ).toFloat();
+  mShininess = elem.attribute( QStringLiteral( "shininess" ) ).toDouble();
   mOpacity = elem.attribute( QStringLiteral( "opacity" ), QStringLiteral( "1.0" ) ).toFloat();
   mDiffuseTexturePath = elem.attribute( QStringLiteral( "diffuse_texture_path" ), QString() );
   mTextureScale = elem.attribute( QStringLiteral( "texture_scale" ), QString( "1.0" ) ).toFloat();
@@ -153,7 +153,7 @@ Qt3DRender::QMaterial *QgsPhongTexturedMaterialSettings::toMaterial( QgsMaterial
       QColor ambient = context.isSelected() ? context.selectionColor().darker() : mAmbient;
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), QColor( ambient.red(), ambient.green(), ambient.blue(), opacity ) ) );
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), QColor( mSpecular.red(), mSpecular.green(), mSpecular.blue(), opacity ) ) );
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess ) );
+      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), static_cast<float>( mShininess ) ) );
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "opacity" ), mOpacity ) );
 
       // TODO : if ( context.isSelected() ) dampen the color of diffuse texture
@@ -202,7 +202,7 @@ void QgsPhongTexturedMaterialSettings::addParametersToEffect( Qt3DRender::QEffec
 
   Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), ambientColor );
   Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), mSpecular );
-  Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess );
+  Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), static_cast<float>( mShininess ) );
 
   effect->addParameter( ambientParameter );
   effect->addParameter( specularParameter );

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
@@ -72,7 +72,7 @@ void QgsPhongTexturedMaterialSettings::readXml( const QDomElement &elem, const Q
   mAmbient = QgsColorUtils::colorFromString( elem.attribute( QStringLiteral( "ambient" ), QStringLiteral( "25,25,25" ) ) );
   mSpecular = QgsColorUtils::colorFromString( elem.attribute( QStringLiteral( "specular" ), QStringLiteral( "255,255,255" ) ) );
   mShininess = elem.attribute( QStringLiteral( "shininess" ) ).toDouble();
-  mOpacity = elem.attribute( QStringLiteral( "opacity" ), QStringLiteral( "1.0" ) ).toFloat();
+  mOpacity = elem.attribute( QStringLiteral( "opacity" ), QStringLiteral( "1.0" ) ).toDouble();
   mDiffuseTexturePath = elem.attribute( QStringLiteral( "diffuse_texture_path" ), QString() );
   mTextureScale = elem.attribute( QStringLiteral( "texture_scale" ), QString( "1.0" ) ).toFloat();
   mTextureRotation = elem.attribute( QStringLiteral( "texture-rotation" ), QString( "0.0" ) ).toFloat();
@@ -154,7 +154,7 @@ Qt3DRender::QMaterial *QgsPhongTexturedMaterialSettings::toMaterial( QgsMaterial
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), QColor( ambient.red(), ambient.green(), ambient.blue(), opacity ) ) );
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), QColor( mSpecular.red(), mSpecular.green(), mSpecular.blue(), opacity ) ) );
       effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), static_cast<float>( mShininess ) ) );
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "opacity" ), mOpacity ) );
+      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "opacity" ), static_cast<float>( mOpacity ) ) );
 
       // TODO : if ( context.isSelected() ) dampen the color of diffuse texture
       // with context.map().selectionColor()

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.cpp
@@ -20,6 +20,7 @@
 #include "qgsimagecache.h"
 #include "qgsimagetexture.h"
 #include "qgsphongmaterialsettings.h"
+#include "qgsphongtexturedmaterial.h"
 #include <Qt3DRender/QPaintedTextureImage>
 #include <Qt3DRender/QTexture>
 #include <Qt3DRender/QParameter>
@@ -122,39 +123,14 @@ Qt3DRender::QMaterial *QgsPhongTexturedMaterialSettings::toMaterial( QgsMaterial
         return material;
       }
 
-      // Use a custom material because Qt3DRender::QTexture2D does not handle opacity.
-      Qt3DRender::QMaterial *material = new Qt3DRender::QMaterial;
-
-      Qt3DRender::QEffect *effect = new Qt3DRender::QEffect( material );
-
-      Qt3DRender::QTechnique *technique = new Qt3DRender::QTechnique;
-      technique->graphicsApiFilter()->setApi( Qt3DRender::QGraphicsApiFilter::OpenGL );
-      technique->graphicsApiFilter()->setProfile( Qt3DRender::QGraphicsApiFilter::CoreProfile );
-      technique->graphicsApiFilter()->setMajorVersion( 3 );
-      technique->graphicsApiFilter()->setMinorVersion( 3 );
-      Qt3DRender::QFilterKey *filterKey = new Qt3DRender::QFilterKey();
-      filterKey->setName( QStringLiteral( "renderingStyle" ) );
-      filterKey->setValue( QStringLiteral( "forward" ) );
-      technique->addFilterKey( filterKey );
-
-      Qt3DRender::QRenderPass *renderPass = new Qt3DRender::QRenderPass();
-      Qt3DRender::QShaderProgram *shaderProgram = new Qt3DRender::QShaderProgram();
-
-      //Load shader programs
-      const QUrl urlVert( QStringLiteral( "qrc:/shaders/default.vert" ) );
-      shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
-      const QUrl urlFrag( QStringLiteral( "qrc:/shaders/diffuseSpecular.frag" ) );
-      shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Fragment, Qt3DRender::QShaderProgram::loadSource( urlFrag ) );
-
-      renderPass->setShaderProgram( shaderProgram );
-      technique->addRenderPass( renderPass );
+      QgsPhongTexturedMaterial *material = new QgsPhongTexturedMaterial();
 
       int opacity = static_cast<int>( mOpacity * 255.0 );
       QColor ambient = context.isSelected() ? context.selectionColor().darker() : mAmbient;
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "ambientColor" ), QColor( ambient.red(), ambient.green(), ambient.blue(), opacity ) ) );
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "specularColor" ), QColor( mSpecular.red(), mSpecular.green(), mSpecular.blue(), opacity ) ) );
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), static_cast<float>( mShininess ) ) );
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "opacity" ), static_cast<float>( mOpacity ) ) );
+      material->setAmbient( QColor( ambient.red(), ambient.green(), ambient.blue(), opacity ) );
+      material->setSpecular( QColor( mSpecular.red(), mSpecular.green(), mSpecular.blue(), opacity ) );
+      material->setShininess( static_cast<float>( mShininess ) );
+      material->setOpacity( static_cast<float>( mOpacity ) );
 
       // TODO : if ( context.isSelected() ) dampen the color of diffuse texture
       // with context.map().selectionColor()
@@ -172,11 +148,9 @@ Qt3DRender::QMaterial *QgsPhongTexturedMaterialSettings::toMaterial( QgsMaterial
       texture->setMagnificationFilter( Qt3DRender::QTexture2D::Linear );
       texture->setMinificationFilter( Qt3DRender::QTexture2D::Linear );
 
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "diffuseTexture" ), QVariant::fromValue( texture ) ) );
-      effect->addParameter( new Qt3DRender::QParameter( QStringLiteral( "texCoordScale" ), mTextureScale ) );
+      material->setDiffuseTexture( texture );
+      material->setDiffuseTextureScale( mTextureScale );
 
-      effect->addTechnique( technique );
-      material->setEffect( effect );
       return material;
     }
 

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.h
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.h
@@ -60,7 +60,7 @@ class _3D_EXPORT QgsPhongTexturedMaterialSettings : public QgsAbstractMaterialSe
     //! Returns specular color component
     QColor specular() const { return mSpecular; }
     //! Returns shininess of the surface
-    float shininess() const { return mShininess; }
+    double shininess() const { return mShininess; }
 
     QMap<QString, QString> toExportParameters() const override;
 
@@ -101,7 +101,7 @@ class _3D_EXPORT QgsPhongTexturedMaterialSettings : public QgsAbstractMaterialSe
     //! Sets specular color component
     void setSpecular( const QColor &specular ) { mSpecular = specular; }
     //! Sets shininess of the surface
-    void setShininess( float shininess ) { mShininess = shininess; }
+    void setShininess( double shininess ) { mShininess = shininess; }
 
     /**
      * Sets the \a path of the diffuse texture.
@@ -147,7 +147,7 @@ class _3D_EXPORT QgsPhongTexturedMaterialSettings : public QgsAbstractMaterialSe
   private:
     QColor mAmbient{ QColor::fromRgbF( 0.1f, 0.1f, 0.1f, 1.0f ) };
     QColor mSpecular{ QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) };
-    float mShininess = 0.0f;
+    double mShininess = 0.0;
     float mOpacity = 1.0f;
     QString mDiffuseTexturePath;
     float mTextureScale{ 1.0f };

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.h
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.h
@@ -93,7 +93,7 @@ class _3D_EXPORT QgsPhongTexturedMaterialSettings : public QgsAbstractMaterialSe
      * Returns the opacity of the surface
      * \since QGIS 3.28
      */
-    float opacity() const { return mOpacity; }
+    double opacity() const { return mOpacity; }
 
     //! Sets ambient color component
     void setAmbient( const QColor &ambient ) { mAmbient = ambient; }
@@ -148,7 +148,7 @@ class _3D_EXPORT QgsPhongTexturedMaterialSettings : public QgsAbstractMaterialSe
     QColor mAmbient{ QColor::fromRgbF( 0.1f, 0.1f, 0.1f, 1.0f ) };
     QColor mSpecular{ QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) };
     double mShininess = 0.0;
-    float mOpacity = 1.0f;
+    double mOpacity = 1.0;
     QString mDiffuseTexturePath;
     float mTextureScale{ 1.0f };
     float mTextureRotation{ 0.0f };

--- a/src/3d/materials/qgstexturematerial.cpp
+++ b/src/3d/materials/qgstexturematerial.cpp
@@ -1,0 +1,87 @@
+/***************************************************************************
+  qgstexturematerial.cpp
+  --------------------------------------
+  Date                 : March 2024
+  Copyright            : (C) 2024 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QUrl>
+
+#include <Qt3DRender/QEffect>
+#include <Qt3DRender/QGraphicsApiFilter>
+#include <Qt3DRender/QParameter>
+#include <Qt3DRender/QRenderPass>
+#include <Qt3DRender/QShaderProgram>
+#include <Qt3DRender/QTechnique>
+#include <Qt3DRender/QTexture>
+
+#include "qgstexturematerial.h"
+
+///@cond PRIVATE
+QgsTextureMaterial::QgsTextureMaterial( QNode *parent )
+  : QMaterial( parent )
+  , mTextureParameter( new Qt3DRender::QParameter( QStringLiteral( "diffuseTexture" ), new Qt3DRender::QTexture2D ) )
+  , mGL3Technique( new Qt3DRender::QTechnique( this ) )
+  , mGL3RenderPass( new Qt3DRender::QRenderPass( this ) )
+  , mGL3Shader( new Qt3DRender::QShaderProgram( this ) )
+  , mFilterKey( new Qt3DRender::QFilterKey( this ) )
+{
+  init();
+}
+
+QgsTextureMaterial::~QgsTextureMaterial() = default;
+
+
+void QgsTextureMaterial::init()
+{
+  connect( mTextureParameter, &Qt3DRender::QParameter::valueChanged,
+           this, &QgsTextureMaterial::handleTextureChanged );
+
+  Qt3DRender::QEffect *effect = new Qt3DRender::QEffect();
+
+  effect->addParameter( mTextureParameter );
+
+  mGL3Shader->setFragmentShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( QStringLiteral( "qrc:/shaders/texture.frag" ) ) ) );
+  mGL3Shader->setVertexShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( QStringLiteral( "qrc:/shaders/texture.vert" ) ) ) );
+
+  mGL3Technique->graphicsApiFilter()->setApi( Qt3DRender::QGraphicsApiFilter::OpenGL );
+  mGL3Technique->graphicsApiFilter()->setMajorVersion( 3 );
+  mGL3Technique->graphicsApiFilter()->setMinorVersion( 1 );
+  mGL3Technique->graphicsApiFilter()->setProfile( Qt3DRender::QGraphicsApiFilter::CoreProfile );
+
+  mFilterKey->setParent( this );
+  mFilterKey->setName( QStringLiteral( "renderingStyle" ) );
+  mFilterKey->setValue( QStringLiteral( "forward" ) );
+
+  mGL3Technique->addFilterKey( mFilterKey );
+  mGL3RenderPass->setShaderProgram( mGL3Shader );
+  mGL3Technique->addRenderPass( mGL3RenderPass );
+  effect->addTechnique( mGL3Technique );
+
+  setEffect( effect );
+}
+
+void QgsTextureMaterial::setTexture( Qt3DRender::QAbstractTexture *texture )
+{
+  mTextureParameter->setValue( QVariant::fromValue( texture ) );
+}
+
+Qt3DRender::QAbstractTexture *QgsTextureMaterial::texture() const
+{
+  return mTextureParameter->value().value<Qt3DRender::QAbstractTexture *>();
+}
+
+void QgsTextureMaterial::handleTextureChanged( const QVariant &var )
+{
+  emit textureChanged( var.value<Qt3DRender::QAbstractTexture *>() );
+}
+
+///@endcond PRIVATE

--- a/src/3d/materials/qgstexturematerial.h
+++ b/src/3d/materials/qgstexturematerial.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+  qgstexturematerial.h
+  --------------------------------------
+  Date                 : March 2024
+  Copyright            : (C) 2024 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTEXTUREMATERIAL_H
+#define QGSTEXTUREMATERIAL_H
+
+#include "qgis_3d.h"
+
+#include <Qt3DRender/QMaterial>
+#include <QObject>
+
+#define SIP_NO_FILE
+
+// adapted from Qt's qtexturematerial.h
+namespace Qt3DRender
+{
+
+  class QFilterKey;
+  class QAbstractTexture;
+  class QTechnique;
+  class QParameter;
+  class QShaderProgram;
+  class QRenderPass;
+
+} // namespace Qt3DRender
+
+///@cond PRIVATE
+
+/**
+ * \ingroup 3d
+ * \brief A unlit texture material
+ * \since QGIS 3.40
+ */
+class _3D_EXPORT QgsTextureMaterial : public Qt3DRender::QMaterial
+{
+    Q_OBJECT
+    Q_PROPERTY( Qt3DRender::QAbstractTexture *texture READ texture WRITE setTexture NOTIFY textureChanged )
+
+  public:
+
+    /**
+     * Constructor for QgsTextureMaterial, with the specified \a parent node.
+     */
+    explicit QgsTextureMaterial( Qt3DCore::QNode *parent = nullptr );
+    ~QgsTextureMaterial() override;
+
+    Qt3DRender::QAbstractTexture *texture() const;
+
+  public Q_SLOTS:
+
+    /**
+     * Sets the diffuse component of the material.
+     * Ownership is transferred to the material.
+     */
+    void setTexture( Qt3DRender::QAbstractTexture *texture );
+
+  Q_SIGNALS:
+    void textureChanged( Qt3DRender::QAbstractTexture *texture );
+
+  private:
+    void init();
+
+    void handleTextureChanged( const QVariant &var );
+
+    Qt3DRender::QParameter *mTextureParameter = nullptr;
+    Qt3DRender::QTechnique *mGL3Technique = nullptr;
+    Qt3DRender::QRenderPass *mGL3RenderPass = nullptr;
+    Qt3DRender::QShaderProgram *mGL3Shader = nullptr;
+    Qt3DRender::QFilterKey *mFilterKey = nullptr;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSTEXTUREMATERIAL_H

--- a/src/3d/shaders.qrc
+++ b/src/3d/shaders.qrc
@@ -34,5 +34,7 @@
         <file>shaders/ssao_factor_blur.vert</file>
         <file>shaders/metalrough.frag</file>
         <file>shaders/default.vert</file>
+        <file>shaders/texture.frag</file>
+        <file>shaders/texture.vert</file>
     </qresource>
 </RCC>

--- a/src/3d/shaders/texture.frag
+++ b/src/3d/shaders/texture.frag
@@ -1,0 +1,12 @@
+#version 150 core
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+uniform sampler2D diffuseTexture;
+
+void main()
+{
+    fragColor = texture( diffuseTexture, texCoord );
+}

--- a/src/3d/shaders/texture.vert
+++ b/src/3d/shaders/texture.vert
@@ -1,0 +1,16 @@
+#version 150 core
+
+in vec3 vertexPosition;
+in vec2 vertexTexCoord;
+
+out vec2 texCoord;
+
+uniform mat4 mvp;
+
+void main()
+{
+    // Pass through scaled texture coordinates
+    texCoord = vertexTexCoord;
+
+    gl_Position = mvp * vec4( vertexPosition, 1.0 );
+}

--- a/src/3d/terrain/qgsterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsterraintileloader_p.cpp
@@ -31,7 +31,6 @@
 
 #include <Qt3DExtras/QTextureMaterial>
 #include <Qt3DExtras/QDiffuseSpecularMaterial>
-#include <Qt3DExtras/QPhongMaterial>
 
 /// @cond PRIVATE
 
@@ -77,12 +76,9 @@ void QgsTerrainTileLoader::createTextureComponent( QgsTerrainTileEntity *entity,
   }
   else
   {
-    Qt3DExtras::QPhongMaterial *phongMaterial  = new Qt3DExtras::QPhongMaterial;
-    phongMaterial->setDiffuse( shadingMaterial.diffuse() );
-    phongMaterial->setAmbient( shadingMaterial.ambient() );
-    phongMaterial->setSpecular( shadingMaterial.specular() );
-    phongMaterial->setShininess( shadingMaterial.shininess() );
-    material = phongMaterial;
+    QgsMaterialContext materialContext;
+    materialContext.setIsSelected( false );
+    material = shadingMaterial.toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, materialContext );
   }
 
   // no backface culling on terrain, to allow terrain to be viewed from underground

--- a/src/3d/terrain/qgsterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsterraintileloader_p.cpp
@@ -25,12 +25,11 @@
 #include "qgsterraintexturegenerator_p.h"
 #include "qgsterraintileentity_p.h"
 #include "qgscoordinatetransform.h"
+#include "qgstexturematerial.h"
 
 #include <Qt3DRender/QTexture>
 #include <Qt3DRender/QTechnique>
 #include <Qt3DRender/QCullFace>
-
-#include <Qt3DExtras/QTextureMaterial>
 
 /// @cond PRIVATE
 
@@ -70,7 +69,7 @@ void QgsTerrainTileLoader::createTextureComponent( QgsTerrainTileEntity *entity,
     }
     else
     {
-      Qt3DExtras::QTextureMaterial *textureMaterial = new Qt3DExtras::QTextureMaterial;
+      QgsTextureMaterial *textureMaterial = new QgsTextureMaterial;
       textureMaterial->setTexture( texture );
       material = textureMaterial;
     }

--- a/src/3d/terrain/qgsterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsterraintileloader_p.cpp
@@ -18,6 +18,7 @@
 #include "qgs3dmapsettings.h"
 #include "qgs3dutils.h"
 #include "qgschunknode_p.h"
+#include "qgsphongtexturedmaterial.h"
 #include "qgsterrainentity_p.h"
 #include "qgsterraingenerator.h"
 #include "qgsterraintextureimage_p.h"
@@ -30,7 +31,6 @@
 #include <Qt3DRender/QCullFace>
 
 #include <Qt3DExtras/QTextureMaterial>
-#include <Qt3DExtras/QDiffuseSpecularMaterial>
 
 /// @cond PRIVATE
 
@@ -60,12 +60,13 @@ void QgsTerrainTileLoader::createTextureComponent( QgsTerrainTileEntity *entity,
   {
     if ( isShadingEnabled )
     {
-      Qt3DExtras::QDiffuseSpecularMaterial *diffuseMapMaterial = new Qt3DExtras::QDiffuseSpecularMaterial;
-      diffuseMapMaterial->setDiffuse( QVariant::fromValue( texture ) );
-      diffuseMapMaterial->setAmbient( shadingMaterial.ambient() );
-      diffuseMapMaterial->setSpecular( shadingMaterial.specular() );
-      diffuseMapMaterial->setShininess( shadingMaterial.shininess() );
-      material = diffuseMapMaterial;
+      QgsPhongTexturedMaterial *phongTexturedMaterial = new QgsPhongTexturedMaterial();
+      phongTexturedMaterial->setAmbient( shadingMaterial.ambient() );
+      phongTexturedMaterial->setSpecular( shadingMaterial.specular() );
+      phongTexturedMaterial->setShininess( static_cast<float>( shadingMaterial.shininess() ) );
+      phongTexturedMaterial->setDiffuseTexture( texture );
+      phongTexturedMaterial->setOpacity( static_cast<float>( shadingMaterial.opacity() ) );
+      material = phongTexturedMaterial;
     }
     else
     {

--- a/src/3d/terrain/qgsterraintileloader_p.h
+++ b/src/3d/terrain/qgsterraintileloader_p.h
@@ -65,7 +65,7 @@ class QgsTerrainTileLoader : public QgsChunkLoader
     //! Starts asynchronous rendering of map texture
     void loadTexture();
 
-    //! Creates a new texture thaht is linked to the entity
+    //! Creates a new texture that is linked to the entity
     Qt3DRender::QTexture2D *createTexture( QgsTerrainTileEntity *entity );
     //! Creates material component for the entity with the rendered map as a texture
     void createTextureComponent( QgsTerrainTileEntity *entity, bool isShadingEnabled, const QgsPhongMaterialSettings &shadingMaterial, bool useTexture );


### PR DESCRIPTION
## Description

This is factored out from https://github.com/qgis/QGIS/pull/57899

It allows to use QGIS material for the terrain instead of native qt3D ones. It will make it possible to customize those shaders. There are 3 different cases to handle: 
- no texture: there is a drop-in replacement with `QgsPhongMaterialSettings`
- texture, no shading: `QgsPhongTexturedMaterialSettings` is extended to handle both textures and textures from a path
- texture, shading. A new material is introduced: `QgsTextureMaterial`

This PR needs https://github.com/qgis/QGIS/pull/58114 to be merged first and thus it includes it.
