### PR TITLE
Fix Point Displacement / Point Cluster symbology when switching between them (Fix #58040)

### DIFF
--- a/src/core/symbology/qgspointclusterrenderer.cpp
+++ b/src/core/symbology/qgspointclusterrenderer.cpp
@@ -200,8 +200,6 @@ QgsPointClusterRenderer *QgsPointClusterRenderer::convertFromRenderer( const Qgs
     pointRenderer->setTolerance( displacementRenderer->tolerance() );
     pointRenderer->setToleranceUnit( displacementRenderer->toleranceUnit() );
     pointRenderer->setToleranceMapUnitScale( displacementRenderer->toleranceMapUnitScale() );
-    if ( const_cast< QgsPointDisplacementRenderer * >( displacementRenderer )->centerSymbol() )
-      pointRenderer->setClusterSymbol( const_cast< QgsPointDisplacementRenderer * >( displacementRenderer )->centerSymbol()->clone() );
     renderer->copyRendererData( pointRenderer );
     return pointRenderer;
   }

--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -492,8 +492,6 @@ QgsPointDisplacementRenderer *QgsPointDisplacementRenderer::convertFromRenderer(
     pointRenderer->setTolerance( clusterRenderer->tolerance() );
     pointRenderer->setToleranceUnit( clusterRenderer->toleranceUnit() );
     pointRenderer->setToleranceMapUnitScale( clusterRenderer->toleranceMapUnitScale() );
-    if ( const_cast< QgsPointClusterRenderer * >( clusterRenderer )->clusterSymbol() )
-      pointRenderer->setCenterSymbol( const_cast< QgsPointClusterRenderer * >( clusterRenderer )->clusterSymbol()->clone() );
     renderer->copyRendererData( pointRenderer );
     return pointRenderer;
   }

--- a/tests/src/python/test_qgspointclusterrenderer.py
+++ b/tests/src/python/test_qgspointclusterrenderer.py
@@ -166,7 +166,6 @@ class TestQgsPointClusterRenderer(QgisTestCase):
         self.assertEqual(d.tolerance(), 5)
         self.assertEqual(d.toleranceUnit(), QgsUnitTypes.RenderUnit.RenderMapUnits)
         self.assertEqual(d.toleranceMapUnitScale(), QgsMapUnitScale(5, 15))
-        self.assertEqual(d.clusterSymbol().color(), QColor(0, 255, 0))
         self.assertEqual(d.embeddedRenderer().symbol().color().name(), '#fdbf6f')
 
     def testRenderNoCluster(self):

--- a/tests/src/python/test_qgspointdisplacementrenderer.py
+++ b/tests/src/python/test_qgspointdisplacementrenderer.py
@@ -193,7 +193,6 @@ class TestQgsPointDisplacementRenderer(QgisTestCase):
         self.assertEqual(d.tolerance(), 5)
         self.assertEqual(d.toleranceUnit(), QgsUnitTypes.RenderUnit.RenderMapUnits)
         self.assertEqual(d.toleranceMapUnitScale(), QgsMapUnitScale(5, 15))
-        self.assertEqual(d.centerSymbol().color(), QColor(0, 255, 0))
         self.assertEqual(d.embeddedRenderer().symbol().color().name(), '#fdbf6f')
 
     def testRenderNoCluster(self):


### PR DESCRIPTION
## Description

Fixes #58040 just avoiding to clone and set (in `QgsPointClusterRenderer::convertFromRenderer` and `QgsPointDisplacementRenderer::convertFromRenderer`) the Cluster / Center symbol when directly switching the symbology from Point Displacement to Point Cluster and viceversa.

The following tests had to be removed: `self.assertEqual(d.clusterSymbol().color(), QColor(0, 255, 0))` in test_qgspointclusterrenderer.py and `self.assertEqual(d.centerSymbol().color(), QColor(0, 255, 0))` in test_qgspointdisplacementrenderer.py.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
