### PR TITLE
Show snapping indicator for create point text annotation tool

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
@@ -39,6 +39,7 @@ Creates an advanced digitizing maptool
 :param canvas: The map canvas on which the tool works
 :param cadDockWidget: The cad dock widget which will be used to adjust mouse events
 %End
+    ~QgsMapToolAdvancedDigitizing();
 
     virtual void canvasPressEvent( QgsMapMouseEvent *e );
 
@@ -91,6 +92,8 @@ may keep advanced digitizing allowed all the time.
 If ``True`` is returned, that does not mean that advanced digitizing is actually active,
 because it is up to the user to enable/disable it when it is allowed.
 
+The default is that advanced digitizing is allowed.
+
 .. seealso:: :py:func:`setAdvancedDigitizingAllowed`
 %End
 
@@ -101,7 +104,20 @@ Returns whether mouse events (press/move/release) should automatically try to sn
 to the tool. This may be desirable default behavior for some map tools, but not for other map tools.
 It is therefore possible to configure the behavior by the map tool.
 
+The default is that auto snapping is enabled.
+
 .. seealso:: :py:func:`isAutoSnapEnabled`
+%End
+
+    bool useSnappingIndicator() const;
+%Docstring
+Returns whether the snapping indicator should automatically be used.
+
+The default is that a snap indicator is not used.
+
+.. seealso:: :py:func:`setUseSnappingIndicator`
+
+.. versionadded:: 3.40
 %End
 
   protected:
@@ -111,6 +127,8 @@ It is therefore possible to configure the behavior by the map tool.
 Sets whether functionality of advanced digitizing dock widget is currently allowed.
 This method is protected because it should be a decision of the map tool and not from elsewhere.
 
+The default is that advanced digitizing is allowed.
+
 .. seealso:: :py:func:`isAdvancedDigitizingAllowed`
 %End
 
@@ -119,7 +137,20 @@ This method is protected because it should be a decision of the map tool and not
 Sets whether mouse events (press/move/release) should automatically try to snap mouse position
 This method is protected because it should be a decision of the map tool and not from elsewhere.
 
+The default is that auto snapping is enabled.
+
 .. seealso:: :py:func:`isAutoSnapEnabled`
+%End
+
+    void setUseSnappingIndicator( bool enabled );
+%Docstring
+Sets whether a snapping indicator should automatically be used.
+
+The default is that a snap indicator is not used.
+
+.. seealso:: :py:func:`useSnappingIndicator`
+
+.. versionadded:: 3.40
 %End
 
 

--- a/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
@@ -39,6 +39,7 @@ Creates an advanced digitizing maptool
 :param canvas: The map canvas on which the tool works
 :param cadDockWidget: The cad dock widget which will be used to adjust mouse events
 %End
+    ~QgsMapToolAdvancedDigitizing();
 
     virtual void canvasPressEvent( QgsMapMouseEvent *e );
 
@@ -91,6 +92,8 @@ may keep advanced digitizing allowed all the time.
 If ``True`` is returned, that does not mean that advanced digitizing is actually active,
 because it is up to the user to enable/disable it when it is allowed.
 
+The default is that advanced digitizing is allowed.
+
 .. seealso:: :py:func:`setAdvancedDigitizingAllowed`
 %End
 
@@ -101,7 +104,20 @@ Returns whether mouse events (press/move/release) should automatically try to sn
 to the tool. This may be desirable default behavior for some map tools, but not for other map tools.
 It is therefore possible to configure the behavior by the map tool.
 
+The default is that auto snapping is enabled.
+
 .. seealso:: :py:func:`isAutoSnapEnabled`
+%End
+
+    bool useSnappingIndicator() const;
+%Docstring
+Returns whether the snapping indicator should automatically be used.
+
+The default is that a snap indicator is not used.
+
+.. seealso:: :py:func:`setUseSnappingIndicator`
+
+.. versionadded:: 3.40
 %End
 
   protected:
@@ -111,6 +127,8 @@ It is therefore possible to configure the behavior by the map tool.
 Sets whether functionality of advanced digitizing dock widget is currently allowed.
 This method is protected because it should be a decision of the map tool and not from elsewhere.
 
+The default is that advanced digitizing is allowed.
+
 .. seealso:: :py:func:`isAdvancedDigitizingAllowed`
 %End
 
@@ -119,7 +137,20 @@ This method is protected because it should be a decision of the map tool and not
 Sets whether mouse events (press/move/release) should automatically try to snap mouse position
 This method is protected because it should be a decision of the map tool and not from elsewhere.
 
+The default is that auto snapping is enabled.
+
 .. seealso:: :py:func:`isAutoSnapEnabled`
+%End
+
+    void setUseSnappingIndicator( bool enabled );
+%Docstring
+Sets whether a snapping indicator should automatically be used.
+
+The default is that a snap indicator is not used.
+
+.. seealso:: :py:func:`useSnappingIndicator`
+
+.. versionadded:: 3.40
 %End
 
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -87,7 +87,7 @@ QgsCreatePointTextItemMapTool::QgsCreatePointTextItemMapTool( QgsMapCanvas *canv
   : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
   , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
 {
-
+  setUseSnappingIndicator( true );
 }
 
 QgsCreatePointTextItemMapTool::~QgsCreatePointTextItemMapTool() = default;

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -29,6 +29,8 @@ QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas
   connect( canvas, &QgsMapCanvas::currentLayerChanged, this, &QgsMapToolAdvancedDigitizing::onCurrentLayerChanged );
 }
 
+QgsMapToolAdvancedDigitizing::~QgsMapToolAdvancedDigitizing() = default;
+
 void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
 {
   if ( isAdvancedDigitizingAllowed() && mCadDockWidget->cadEnabled() )
@@ -115,6 +117,11 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
     mSnapToGridCanvasItem->setPoint( e->mapPoint() );
   }
 
+  if ( mSnapIndicator )
+  {
+    mSnapIndicator->setMatch( e->mapPointMatch() );
+  }
+
   cadCanvasMoveEvent( e );
 }
 
@@ -140,11 +147,31 @@ void QgsMapToolAdvancedDigitizing::deactivate()
   mCadDockWidget->disable();
   delete mSnapToGridCanvasItem;
   mSnapToGridCanvasItem = nullptr;
+
+  if ( mSnapIndicator )
+    mSnapIndicator->setMatch( QgsPointLocator::Match() );
 }
 
 QgsMapLayer *QgsMapToolAdvancedDigitizing::layer() const
 {
   return canvas()->currentLayer();
+}
+
+bool QgsMapToolAdvancedDigitizing::useSnappingIndicator() const
+{
+  return static_cast< bool >( mSnapIndicator.get() );
+}
+
+void QgsMapToolAdvancedDigitizing::setUseSnappingIndicator( bool enabled )
+{
+  if ( enabled && !mSnapIndicator )
+  {
+    mSnapIndicator = std::make_unique< QgsSnapIndicator >( mCanvas );
+  }
+  else if ( !enabled && mSnapIndicator )
+  {
+    mSnapIndicator.reset();
+  }
 }
 
 void QgsMapToolAdvancedDigitizing::cadPointChanged( const QgsPointXY &point )

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -19,10 +19,12 @@
 
 #include "qgsmaptooledit.h"
 #include "qgis_gui.h"
+#include <memory>
 
 class QgsMapMouseEvent;
 class QgsAdvancedDigitizingDockWidget;
 class QgsSnapToGridCanvasItem;
+class QgsSnapIndicator;
 
 /**
  * \ingroup gui
@@ -44,6 +46,7 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      * \param cadDockWidget  The cad dock widget which will be used to adjust mouse events
      */
     explicit QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    ~QgsMapToolAdvancedDigitizing() override;
 
     //! Catch the mouse press event, filters it, transforms it to map coordinates and send it to virtual method
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
@@ -83,6 +86,9 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      *
      * If TRUE is returned, that does not mean that advanced digitizing is actually active,
      * because it is up to the user to enable/disable it when it is allowed.
+     *
+     * The default is that advanced digitizing is allowed.
+     *
      * \see setAdvancedDigitizingAllowed()
      */
     bool isAdvancedDigitizingAllowed() const { return mAdvancedDigitizingAllowed; }
@@ -92,15 +98,31 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      * (according to the snapping configuration of map canvas) before passing the mouse coordinates
      * to the tool. This may be desirable default behavior for some map tools, but not for other map tools.
      * It is therefore possible to configure the behavior by the map tool.
+     *
+     * The default is that auto snapping is enabled.
+     *
      * \see isAutoSnapEnabled()
      */
     bool isAutoSnapEnabled() const { return mAutoSnapEnabled; }
+
+    /**
+     * Returns whether the snapping indicator should automatically be used.
+     *
+     * The default is that a snap indicator is not used.
+     *
+     * \see setUseSnappingIndicator()
+     * \since QGIS 3.40
+     */
+    bool useSnappingIndicator() const;
 
   protected:
 
     /**
      * Sets whether functionality of advanced digitizing dock widget is currently allowed.
      * This method is protected because it should be a decision of the map tool and not from elsewhere.
+     *
+     * The default is that advanced digitizing is allowed.
+     *
      * \see isAdvancedDigitizingAllowed()
      */
     void setAdvancedDigitizingAllowed( bool allowed ) { mAdvancedDigitizingAllowed = allowed; }
@@ -108,9 +130,22 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     /**
      * Sets whether mouse events (press/move/release) should automatically try to snap mouse position
      * This method is protected because it should be a decision of the map tool and not from elsewhere.
+     *
+     * The default is that auto snapping is enabled.
+     *
      * \see isAutoSnapEnabled()
      */
     void setAutoSnapEnabled( bool enabled ) { mAutoSnapEnabled = enabled; }
+
+    /**
+     * Sets whether a snapping indicator should automatically be used.
+     *
+     * The default is that a snap indicator is not used.
+     *
+     * \see useSnappingIndicator()
+     * \since QGIS 3.40
+     */
+    void setUseSnappingIndicator( bool enabled );
 
 
     QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
@@ -188,6 +223,8 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     //! Whether to snap to grid before passing coordinates to cadCanvas*Event()
     bool mSnapToLayerGridEnabled = true;
     QgsSnapToGridCanvasItem *mSnapToGridCanvasItem = nullptr;
+
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 };
 
 #endif // QGSMAPTOOLADVANCEDDIGITIZE_H


### PR DESCRIPTION
And Add easy way for QgsMapToolAdvancedDigitizing to show snapping indicator. Instead of requiring all subclasses to manually implement this logic, add QgsMapToolAdvancedDigitizing::setUseSnappingIndicator so that the base class takes care of this for us