### PR TITLE
Respect layer/project vert datum in identify results

### DIFF
--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -38,6 +38,7 @@ class QgsPointCloudLayer;
 class QgsPointCloudLayerElevationProperties;
 class QgsFeatureRenderer;
 class QgsExpressionContext;
+class QgsCoordinateReferenceSystem;
 
 /**
  * \ingroup gui
@@ -295,12 +296,19 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     /**
      * Adds details of the closest vertex to derived attributes
      */
-    void closestVertexAttributes( const QgsAbstractGeometry &geometry, QgsVertexId vId, QgsMapLayer *layer, QMap< QString, QString > &derivedAttributes );
+    void closestVertexAttributes( const QgsCoordinateTransform layerToMapTransform,
+                                  const QgsCoordinateReferenceSystem &layerVertCrs,
+                                  const QgsCoordinateReferenceSystem &mapVertCrs,
+                                  const QgsAbstractGeometry &geometry, QgsVertexId vId,
+                                  bool showTransformedZ, QMap< QString, QString > &derivedAttributes );
 
     /**
      * Adds details of the closest point to derived attributes
     */
-    void closestPointAttributes( const QgsAbstractGeometry &geometry, const QgsPointXY &layerPoint, QMap< QString, QString > &derivedAttributes );
+    void closestPointAttributes( const QgsCoordinateTransform layerToMapTransform,
+                                 const QgsCoordinateReferenceSystem &layerVertCrs,
+                                 const QgsCoordinateReferenceSystem &mapVertCrs,
+                                 const QgsAbstractGeometry &geometry, const QgsPointXY &layerPoint, bool showTransformedZ, QMap< QString, QString > &derivedAttributes );
 
     void formatCoordinate( const QgsPointXY &canvasPoint, QString &x, QString &y ) const;
 

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -1192,7 +1192,7 @@ void TestQgsIdentify::testPointZ()
   const QgsPointXY mapPoint = canvas->getCoordinateTransform()->transform( 134.445567853, -23.445567853 );
 
   std::unique_ptr< QgsMapToolIdentifyAction > action( new QgsMapToolIdentifyAction( canvas ) );
-  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
+  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( static_cast< int >( mapPoint.x() ), static_cast< int >( mapPoint.y() ), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
   double z4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Z (EPSG:4979 - WGS 84)" )].toDouble();
   double z4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Z (EPSG:4985 - WGS 72)" )].toDouble();
@@ -1223,7 +1223,7 @@ void TestQgsIdentify::testLineStringZ()
   const QgsPointXY mapPoint = canvas->getCoordinateTransform()->transform( 136.46, -23.445567853 );
 
   std::unique_ptr< QgsMapToolIdentifyAction > action( new QgsMapToolIdentifyAction( canvas ) );
-  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
+  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( static_cast< int >( mapPoint.x() ), static_cast< int >( mapPoint.y() ), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
   double interpolatedZ4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4979 - WGS 84)" )].toDouble();
   double interpolatedZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4985 - WGS 72)" )].toDouble();
@@ -1258,7 +1258,7 @@ void TestQgsIdentify::testPolygonZ()
   const QgsPointXY mapPoint = canvas->getCoordinateTransform()->transform( 136.46, -23.445567853 );
 
   std::unique_ptr< QgsMapToolIdentifyAction > action( new QgsMapToolIdentifyAction( canvas ) );
-  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
+  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( static_cast< int >( mapPoint.x() ), static_cast< int >( mapPoint.y() ), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
   double interpolatedZ4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4979 - WGS 84)" )].toDouble();
   double interpolatedZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4985 - WGS 72)" )].toDouble();

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -1264,8 +1264,8 @@ void TestQgsIdentify::testPolygonZ()
   double interpolatedZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4985 - WGS 72)" )].toDouble();
   double closestZ4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Closest vertex Z (EPSG:4979 - WGS 84)" )].toDouble();
   double closestZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Closest vertex Z (EPSG:4985 - WGS 72)" )].toDouble();
-  QGSCOMPARENEAR( interpolatedZ4979, 5549.9817600000, 0.001 );
-  QGSCOMPARENEAR( interpolatedZ4985, 5552.3424580000, 0.01 );
+  QGSCOMPARENEAR( interpolatedZ4979, 5549.9817600000, 0.02 );
+  QGSCOMPARENEAR( interpolatedZ4985, 5552.3424580000, 0.02 );
   QGSCOMPARENEAR( closestZ4979, 5543.325, 0.001 );
   QGSCOMPARENEAR( closestZ4985, 5545.6857, 0.01 );
 }

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -66,6 +66,9 @@ class TestQgsIdentify : public QObject
     void clickxy(); // test if click_x and click_y variables are propagated
     void closestPoint();
     void testRelations();
+    void testPointZ();
+    void testLineStringZ();
+    void testPolygonZ();
 
   private:
     void doAction();
@@ -1167,6 +1170,105 @@ void TestQgsIdentify::testRelations()
   }
 }
 
+void TestQgsIdentify::testPointZ()
+{
+  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "PointZ?crs=epsg:4979" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  QVERIFY( tempLayer->isValid() );
+  QCOMPARE( tempLayer->crs3D().horizontalCrs().authid(), QStringLiteral( "EPSG:4979" ) );
+
+  QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
+  f1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "PointZ(134.445567853 -23.445567853 5543.325)" ) ) );
+  tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 );
+
+  // set project CRS and ellipsoid
+  const QgsCoordinateReferenceSystem srs( QStringLiteral( "EPSG:4985" ) );
+  QgsProject::instance()->setCrs( srs );
+  canvas->setDestinationCrs( srs );
+  QCOMPARE( QgsProject::instance()->crs3D().horizontalCrs().authid(), QStringLiteral( "EPSG:4985" ) );
+
+  QgsProject::instance()->writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ), false );
+  QgsProject::instance()->writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 3 );
+
+  const QgsPointXY mapPoint = canvas->getCoordinateTransform()->transform( 134.445567853, -23.445567853 );
+
+  std::unique_ptr< QgsMapToolIdentifyAction > action( new QgsMapToolIdentifyAction( canvas ) );
+  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
+  QCOMPARE( result.length(), 1 );
+  double z4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Z (EPSG:4979 - WGS 84)" )].toDouble();
+  double z4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Z (EPSG:4985 - WGS 72)" )].toDouble();
+  QGSCOMPARENEAR( z4979, 5543.325, 0.001 );
+  QGSCOMPARENEAR( z4985, 5545.6857, 0.01 );
+}
+
+void TestQgsIdentify::testLineStringZ()
+{
+  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "LineStringZ?crs=epsg:4979" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  QVERIFY( tempLayer->isValid() );
+  QCOMPARE( tempLayer->crs3D().horizontalCrs().authid(), QStringLiteral( "EPSG:4979" ) );
+
+  QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
+  f1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "LineStringZ(134.445567853 -23.445567853 5543.325, 140.485567853 -23.445567853 5563.325)" ) ) );
+  tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 );
+
+  // set project CRS and ellipsoid
+  const QgsCoordinateReferenceSystem srs( QStringLiteral( "EPSG:4985" ) );
+  QgsProject::instance()->setCrs( srs );
+  canvas->setDestinationCrs( srs );
+  canvas->setExtent( tempLayer->extent() );
+  QCOMPARE( QgsProject::instance()->crs3D().horizontalCrs().authid(), QStringLiteral( "EPSG:4985" ) );
+
+  QgsProject::instance()->writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ), false );
+  QgsProject::instance()->writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 3 );
+
+  const QgsPointXY mapPoint = canvas->getCoordinateTransform()->transform( 136.46, -23.445567853 );
+
+  std::unique_ptr< QgsMapToolIdentifyAction > action( new QgsMapToolIdentifyAction( canvas ) );
+  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
+  QCOMPARE( result.length(), 1 );
+  double interpolatedZ4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4979 - WGS 84)" )].toDouble();
+  double interpolatedZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4985 - WGS 72)" )].toDouble();
+  double closestZ4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Closest vertex Z (EPSG:4979 - WGS 84)" )].toDouble();
+  double closestZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Closest vertex Z (EPSG:4985 - WGS 72)" )].toDouble();
+  QGSCOMPARENEAR( interpolatedZ4979, 5548.472636, 0.001 );
+  QGSCOMPARENEAR( interpolatedZ4985, 5550.8333350, 0.01 );
+  QGSCOMPARENEAR( closestZ4979, 5543.325, 0.001 );
+  QGSCOMPARENEAR( closestZ4985, 5545.6857, 0.01 );
+}
+
+void TestQgsIdentify::testPolygonZ()
+{
+  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "PolygonZ?crs=epsg:4979" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  QVERIFY( tempLayer->isValid() );
+  QCOMPARE( tempLayer->crs3D().horizontalCrs().authid(), QStringLiteral( "EPSG:4979" ) );
+
+  QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
+  f1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "PolygonZ((134.445567853 -23.445567853 5543.325, 140.485567853 -23.445567853 5563.325, 140.485567853 -20.445567853 5523.325, 134.445567853 -23.445567853 5543.325))" ) ) );
+  tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 );
+
+  // set project CRS and ellipsoid
+  const QgsCoordinateReferenceSystem srs( QStringLiteral( "EPSG:4985" ) );
+  QgsProject::instance()->setCrs( srs );
+  canvas->setDestinationCrs( srs );
+  canvas->setExtent( tempLayer->extent() );
+  QCOMPARE( QgsProject::instance()->crs3D().horizontalCrs().authid(), QStringLiteral( "EPSG:4985" ) );
+
+  QgsProject::instance()->writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ), false );
+  QgsProject::instance()->writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 3 );
+
+  const QgsPointXY mapPoint = canvas->getCoordinateTransform()->transform( 136.46, -23.445567853 );
+
+  std::unique_ptr< QgsMapToolIdentifyAction > action( new QgsMapToolIdentifyAction( canvas ) );
+  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
+  QCOMPARE( result.length(), 1 );
+  double interpolatedZ4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4979 - WGS 84)" )].toDouble();
+  double interpolatedZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Interpolated Z (EPSG:4985 - WGS 72)" )].toDouble();
+  double closestZ4979 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Closest vertex Z (EPSG:4979 - WGS 84)" )].toDouble();
+  double closestZ4985 = result.at( 0 ).mDerivedAttributes[ QStringLiteral( "Closest vertex Z (EPSG:4985 - WGS 72)" )].toDouble();
+  QGSCOMPARENEAR( interpolatedZ4979, 5549.9817600000, 0.001 );
+  QGSCOMPARENEAR( interpolatedZ4985, 5552.3424580000, 0.01 );
+  QGSCOMPARENEAR( closestZ4979, 5543.325, 0.001 );
+  QGSCOMPARENEAR( closestZ4985, 5545.6857, 0.01 );
+}
 
 QGSTEST_MAIN( TestQgsIdentify )
 #include "testqgsidentify.moc"


### PR DESCRIPTION
When a vector layer and the project have vertical datums present, and they differ, then include the transformed Z value for the identified features in the project's datum too.

![image](https://github.com/user-attachments/assets/268f76df-697c-4816-9b4d-0e9ac1033b51)
