### PR TITLE
Respect vector layer vertical crs settings in 3d map views

### DIFF
--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -73,7 +73,9 @@ QgsVectorLayerChunkLoader::QgsVectorLayerChunkLoader( const QgsVectorLayerChunkL
 
   // build the feature request
   QgsFeatureRequest req;
-  req.setDestinationCrs( map.crs(), map.transformContext() );
+  req.setCoordinateTransform(
+    QgsCoordinateTransform( layer->crs3D(), map.crs(), map.transformContext() )
+  );
   req.setSubsetOfAttributes( attributeNames, layer->fields() );
 
   // only a subset of data to be queried

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13503,9 +13503,9 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name )
     QgsSettings settings;
 
     Qgs3DMapSettings *map = new Qgs3DMapSettings;
-    if ( !prj->crs().isGeographic() )
+    if ( !prj->crs3D().isGeographic() )
     {
-      map->setCrs( prj->crs() );
+      map->setCrs( prj->crs3D() );
     }
     else
     {


### PR DESCRIPTION
Requires that:

1. A project has a non-geographic CRS set, and a vertical CRS set
2. NEW 3d maps are created -- we don't currently expose any setting for users to modify the CRS for existing 3d maps