### PR TITLE
support multiple URLs/sources for vector tiles

### DIFF
--- a/src/analysis/processing/qgsalgorithmdownloadvectortiles.cpp
+++ b/src/analysis/processing/qgsalgorithmdownloadvectortiles.cpp
@@ -193,10 +193,14 @@ QVariantMap QgsDownloadVectorTilesAlgorithm::processAlgorithm( const QVariantMap
       if ( feedback->isCanceled() )
         break;
 
-      if ( !rawTile.data.isEmpty() )
+      // TODO: at the moment, it handles single source only of tiles
+      // takes the first one
+      QByteArray data = rawTile.data.first();
+
+      if ( !data.isEmpty() )
       {
         QByteArray gzipTileData;
-        QgsZipUtils::encodeGzip( rawTile.data, gzipTileData );
+        QgsZipUtils::encodeGzip( data, gzipTileData );
         int rowTMS = pow( 2, rawTile.id.zoomLevel() ) - rawTile.id.row() - 1;
         writer->setTileData( rawTile.id.zoomLevel(), rawTile.id.column(), rowTMS, gzipTileData );
       }

--- a/src/analysis/processing/qgsalgorithmdownloadvectortiles.cpp
+++ b/src/analysis/processing/qgsalgorithmdownloadvectortiles.cpp
@@ -195,7 +195,7 @@ QVariantMap QgsDownloadVectorTilesAlgorithm::processAlgorithm( const QVariantMap
 
       // TODO: at the moment, it handles single source only of tiles
       // takes the first one
-      QByteArray data = rawTile.data.first();
+      const QByteArray data = rawTile.data.first();
 
       if ( !data.isEmpty() )
       {

--- a/src/core/vectortile/qgsvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvectortiledataprovider.cpp
@@ -21,6 +21,12 @@
 #include <QNetworkRequest>
 #include <QImage>
 
+
+int QgsVectorTileDataProvider::DATA_COLUMN = QNetworkRequest::User + 1;
+int QgsVectorTileDataProvider::DATA_ROW = QNetworkRequest::User + 2;
+int QgsVectorTileDataProvider::DATA_ZOOM = QNetworkRequest::User + 3;
+int QgsVectorTileDataProvider::DATA_SOURCE_ID = QNetworkRequest::User + 4;
+
 QgsVectorTileDataProvider::QgsVectorTileDataProvider(
   const QString &uri,
   const ProviderOptions &options,
@@ -70,11 +76,11 @@ bool QgsVectorTileDataProvider::supportsAsync() const
   return false;
 }
 
-QNetworkRequest QgsVectorTileDataProvider::tileRequest( const QgsTileMatrixSet &, const QgsTileXYZ &, Qgis::RendererUsage ) const
+QList<QNetworkRequest> QgsVectorTileDataProvider::tileRequests( const QgsTileMatrixSet &, const QgsTileXYZ &, Qgis::RendererUsage ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return QNetworkRequest();
+  return QList<QNetworkRequest>();
 }
 
 QVariantMap QgsVectorTileDataProvider::styleDefinition() const

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -42,6 +42,7 @@ class QgsVectorTileMatrixSet;
 class QgsVectorTileDataProviderSharedData
 {
   public:
+
     QgsVectorTileDataProviderSharedData();
 
     /**
@@ -76,6 +77,11 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
     Q_OBJECT
 
   public:
+
+    static int DATA_COLUMN;
+    static int DATA_ROW;
+    static int DATA_ZOOM;
+    static int DATA_SOURCE_ID;
 
     /**
      * Constructor for QgsVectorTileDataProvider, with the specified \a uri.
@@ -114,6 +120,17 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
      */
     virtual QString sourcePath() const = 0;
 
+
+    /**
+     * Returns the list of source paths for the data.
+     * \since QGIS 3.40
+     */
+    virtual QgsStringMap sourcePaths() const
+    {
+      return {{QString(), sourcePath()}};
+    }
+
+
     /**
      * Returns a clone of the data provider.
      */
@@ -146,7 +163,7 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
      *
      * The default implementation returns an invalid request.
      */
-    virtual QNetworkRequest tileRequest( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const;
+    virtual QList<QNetworkRequest> tileRequests( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const;
 
     /**
      * Returns the style definition for the provider, if available.

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -78,9 +78,13 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
 
   public:
 
+    //! Role to set column attribute in the request so it can be retrieved later
     static int DATA_COLUMN;
+    //! Role to set row attribute in the request so it can be retrieved later
     static int DATA_ROW;
+    //! Role to set zoom attribute in the request so it can be retrieved later
     static int DATA_ZOOM;
+    //! Role to set source ID attribute in the request so it can be retrieved later
     static int DATA_SOURCE_ID;
 
     /**

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -127,7 +127,7 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
      */
     virtual QgsStringMap sourcePaths() const
     {
-      return {{QString(), sourcePath()}};
+      return { { QString(), sourcePath() } };
     }
 
 

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -149,7 +149,7 @@ void QgsVectorTileLoader::canceled()
   int repliesCount = std::accumulate( mReplies.constBegin(), mReplies.constEnd(), 0, []( int count, QList<QgsTileDownloadManagerReply *> replies ) {return count + replies.count();} );
   QgsDebugMsgLevel( QStringLiteral( "Canceling %1 pending requests" ).arg( repliesCount ), 2 );
   QHash<QgsTileXYZ, QList<QgsTileDownloadManagerReply *>>::iterator it = mReplies.begin();
-  for ( ; it != mReplies.end(); it++ )
+  for ( ; it != mReplies.end(); ++it )
     qDeleteAll( it.value() );
   mReplies.clear();
 

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -67,7 +67,8 @@ void QgsVectorTileLoader::downloadBlocking()
     return; // nothing to do
   }
 
-  QgsDebugMsgLevel( QStringLiteral( "Starting event loop with %1 requests" ).arg( mReplies.count() ), 2 );
+  int repliesCount = std::accumulate( mReplies.constBegin(), mReplies.constEnd(), 0, []( int count, QList<QgsTileDownloadManagerReply *> replies ) {return count + replies.count();} );
+  QgsDebugMsgLevel( QStringLiteral( "Starting event loop with %1 requests" ).arg( repliesCount ), 2 );
 
   mEventLoop->exec( QEventLoop::ExcludeUserInputEvents );
 
@@ -78,20 +79,25 @@ void QgsVectorTileLoader::downloadBlocking()
 
 void QgsVectorTileLoader::loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrixSet &tileMatrixSet, const QgsVectorTileDataProvider *provider, Qgis::RendererUsage usage )
 {
-  QNetworkRequest request = provider->tileRequest( tileMatrixSet, id, usage );
+  const QList<QNetworkRequest> requests = provider->tileRequests( tileMatrixSet, id, usage );
 
-  QgsTileDownloadManagerReply *reply = QgsApplication::tileDownloadManager()->get( request );
-  connect( reply, &QgsTileDownloadManagerReply::finished, this, &QgsVectorTileLoader::tileReplyFinished );
-  mReplies << reply;
+  for ( const QNetworkRequest &request : requests )
+  {
+    QgsTileDownloadManagerReply *reply = QgsApplication::tileDownloadManager()->get( request );
+    connect( reply, &QgsTileDownloadManagerReply::finished, this, &QgsVectorTileLoader::tileReplyFinished );
+    mReplies[id].append( reply );
+  }
 }
 
 void QgsVectorTileLoader::tileReplyFinished()
 {
   QgsTileDownloadManagerReply *reply = qobject_cast<QgsTileDownloadManagerReply *>( sender() );
 
-  int reqX = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 1 ) ).toInt();
-  int reqY = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 2 ) ).toInt();
-  int reqZ = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 3 ) ).toInt();
+  int reqX = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_COLUMN ) ).toInt();
+  int reqY = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_ROW ) ).toInt();
+  int reqZ = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_ZOOM ) ).toInt();
+  QString sourceId = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_SOURCE_ID ) ).toString();
+
   QgsTileXYZ tileID( reqX, reqY, reqZ );
 
   if ( reply->error() == QNetworkReply::NoError )
@@ -100,10 +106,15 @@ void QgsVectorTileLoader::tileReplyFinished()
 
     QgsDebugMsgLevel( QStringLiteral( "Tile download successful: " ) + tileID.toString(), 2 );
     QByteArray rawData = reply->data();
-    mReplies.removeOne( reply );
+    mReplies[tileID].removeOne( reply );
+    mPendingRawData[tileID][sourceId] = rawData;
     reply->deleteLater();
 
-    emit tileRequestFinished( QgsVectorTileRawData( tileID, rawData ) );
+    if ( mReplies[tileID].count() == 0 )
+    {
+      mReplies.remove( tileID );
+      emit tileRequestFinished( QgsVectorTileRawData( tileID, mPendingRawData.take( tileID ) ) );
+    }
   }
   else
   {
@@ -116,10 +127,14 @@ void QgsVectorTileLoader::tileReplyFinished()
     }
 
     QgsDebugError( QStringLiteral( "Tile download failed! " ) + reply->errorString() );
-    mReplies.removeOne( reply );
+    mReplies[tileID].removeOne( reply );
     reply->deleteLater();
 
-    emit tileRequestFinished( QgsVectorTileRawData( tileID, QByteArray() ) );
+    if ( mReplies[tileID].count() == 0 )
+    {
+      mReplies.remove( tileID );
+      emit tileRequestFinished( QgsVectorTileRawData( tileID ) );
+    }
   }
 
   if ( mReplies.isEmpty() )
@@ -131,8 +146,11 @@ void QgsVectorTileLoader::tileReplyFinished()
 
 void QgsVectorTileLoader::canceled()
 {
-  QgsDebugMsgLevel( QStringLiteral( "Canceling %1 pending requests" ).arg( mReplies.count() ), 2 );
-  qDeleteAll( mReplies );
+  int repliesCount = std::accumulate( mReplies.constBegin(), mReplies.constEnd(), 0, []( int count, QList<QgsTileDownloadManagerReply *> replies ) {return count + replies.count();} );
+  QgsDebugMsgLevel( QStringLiteral( "Canceling %1 pending requests" ).arg( repliesCount ), 2 );
+  QHash<QgsTileXYZ, QList<QgsTileDownloadManagerReply *>>::iterator it = mReplies.begin();
+  for ( ; it != mReplies.end(); it++ )
+    qDeleteAll( it.value() );
   mReplies.clear();
 
   // stop blocking download

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -68,6 +68,7 @@ void QgsVectorTileLoader::downloadBlocking()
   }
 
   int repliesCount = std::accumulate( mReplies.constBegin(), mReplies.constEnd(), 0, []( int count, QList<QgsTileDownloadManagerReply *> replies ) {return count + replies.count();} );
+  Q_UNUSED( repliesCount )
   QgsDebugMsgLevel( QStringLiteral( "Starting event loop with %1 requests" ).arg( repliesCount ), 2 );
 
   mEventLoop->exec( QEventLoop::ExcludeUserInputEvents );
@@ -147,6 +148,7 @@ void QgsVectorTileLoader::tileReplyFinished()
 void QgsVectorTileLoader::canceled()
 {
   int repliesCount = std::accumulate( mReplies.constBegin(), mReplies.constEnd(), 0, []( int count, QList<QgsTileDownloadManagerReply *> replies ) {return count + replies.count();} );
+  Q_UNUSED( repliesCount )
   QgsDebugMsgLevel( QStringLiteral( "Canceling %1 pending requests" ).arg( repliesCount ), 2 );
   QHash<QgsTileXYZ, QList<QgsTileDownloadManagerReply *>>::iterator it = mReplies.begin();
   for ( ; it != mReplies.end(); ++it )

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -31,7 +31,7 @@ class QEventLoop;
 
 /**
  * \ingroup core
- * \brief Keeps track of raw tile data from multiple sources that need to be decoded
+ * \brief Keeps track of raw tile data from one or more sources that need to be decoded
  *
  * \since QGIS 3.14
  */
@@ -40,9 +40,9 @@ class CORE_EXPORT QgsVectorTileRawData
   public:
     //! Constructs a raw tile object for single source
     QgsVectorTileRawData( QgsTileXYZ tileID = QgsTileXYZ(), const QByteArray &data = QByteArray() )
-      : id( tileID ), tileGeometryId( tileID ), data( {{QString(), data}} ) {}
+      : id( tileID ), tileGeometryId( tileID ), data( { { QString(), data } } ) {}
 
-    //! Constructs a raw tile object for multiple sources
+    //! Constructs a raw tile object for one or more sources
     QgsVectorTileRawData( QgsTileXYZ tileID, const QMap<QString, QByteArray> &data )
       : id( tileID ), tileGeometryId( tileID ), data( data ) {}
 

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -28,18 +28,23 @@ class QByteArray;
 class QNetworkReply;
 class QEventLoop;
 
+
 /**
  * \ingroup core
- * \brief Keeps track of raw tile data that need to be decoded
+ * \brief Keeps track of raw tile data from multiple sources that need to be decoded
  *
  * \since QGIS 3.14
  */
 class CORE_EXPORT QgsVectorTileRawData
 {
   public:
-    //! Constructs a raw tile object
-    QgsVectorTileRawData( QgsTileXYZ tileID = QgsTileXYZ(), const QByteArray &raw = QByteArray() )
-      : id( tileID ), tileGeometryId( tileID ), data( raw ) {}
+    //! Constructs a raw tile object for single source
+    QgsVectorTileRawData( QgsTileXYZ tileID = QgsTileXYZ(), const QByteArray &data = QByteArray() )
+      : id( tileID ), tileGeometryId( tileID ), data( {{QString(), data}} ) {}
+
+    //! Constructs a raw tile object for multiple sources
+    QgsVectorTileRawData( QgsTileXYZ tileID, const QMap<QString, QByteArray> &data )
+      : id( tileID ), tileGeometryId( tileID ), data( data ) {}
 
     //! Tile position in tile matrix set
     QgsTileXYZ id;
@@ -54,8 +59,8 @@ class CORE_EXPORT QgsVectorTileRawData
      */
     QgsTileXYZ tileGeometryId;
 
-    //! Raw tile data
-    QByteArray data;
+    //! Raw tile data by source ID
+    QMap<QString, QByteArray> data;
 };
 
 
@@ -113,7 +118,10 @@ class CORE_EXPORT QgsVectorTileLoader : public QObject
     QgsFeedback *mFeedback;
 
     //! Running tile requests
-    QList<QgsTileDownloadManagerReply *> mReplies;
+    QHash<QgsTileXYZ, QList<QgsTileDownloadManagerReply *>> mReplies;
+
+    //! Raw data is stored until all sources are fetched
+    QHash<QgsTileXYZ, QMap<QString, QByteArray>> mPendingRawData;
 
     QString mError;
 };

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -39,50 +39,72 @@ QgsVectorTileMVTDecoder::~QgsVectorTileMVTDecoder() = default;
 
 bool QgsVectorTileMVTDecoder::decode( const QgsVectorTileRawData &rawTileData )
 {
-  if ( !tile.ParseFromArray( rawTileData.data.constData(), rawTileData.data.count() ) )
-    return false;
+  mLayerNameToIndex.clear();
+
+  QMap<QString, QByteArray>::const_iterator it = rawTileData.data.constBegin();
+  for ( ; it != rawTileData.data.constEnd(); it++ )
+  {
+    QString sourceId = it.key();
+
+    vector_tile::Tile tile;
+    if ( !tile.ParseFromArray( it.value().constData(), it.value().count() ) )
+      return false;
+
+    for ( int layerNum = 0; layerNum < tile.layers_size(); layerNum++ )
+    {
+      const ::vector_tile::Tile_Layer &layer = tile.layers( layerNum );
+      const QString layerName = layer.name().c_str();
+      mLayerNameToIndex[sourceId][layerName] = layerNum;
+    }
+
+    tiles[sourceId] = tile;
+
+  }
 
   mTileID = rawTileData.tileGeometryId;
 
-  mLayerNameToIndex.clear();
-  for ( int layerNum = 0; layerNum < tile.layers_size(); layerNum++ )
-  {
-    const ::vector_tile::Tile_Layer &layer = tile.layers( layerNum );
-    const QString layerName = layer.name().c_str();
-    mLayerNameToIndex[layerName] = layerNum;
-  }
   return true;
 }
 
 QStringList QgsVectorTileMVTDecoder::layers() const
 {
   QStringList layerNames;
-  const int layerSize = tile.layers_size();
+  const int layerSize = std::accumulate( tiles.constBegin(), tiles.constEnd(), 0, []( int count, const vector_tile::Tile & tile ) {return count + tile.layers_size();} );
   layerNames.reserve( layerSize );
-  for ( int layerNum = 0; layerNum < layerSize; layerNum++ )
+
+  QMap<QString, vector_tile::Tile>::const_iterator it = tiles.constBegin();
+  for ( ; it != tiles.constEnd(); it++ )
   {
-    const ::vector_tile::Tile_Layer &layer = tile.layers( layerNum );
-    const QString layerName = layer.name().c_str();
-    layerNames << layerName;
+    for ( int layerNum = 0; layerNum < layerSize; layerNum++ )
+    {
+      const ::vector_tile::Tile_Layer &layer = it.value().layers( layerNum );
+      const QString layerName = layer.name().c_str();
+      layerNames << layerName;
+    }
   }
   return layerNames;
 }
 
 QStringList QgsVectorTileMVTDecoder::layerFieldNames( const QString &layerName ) const
 {
-  if ( !mLayerNameToIndex.contains( layerName ) )
-    return QStringList();
-
-  const ::vector_tile::Tile_Layer &layer = tile.layers( mLayerNameToIndex[layerName] );
-  QStringList fieldNames;
-  const int size = layer.keys_size();
-  fieldNames.reserve( size );
-  for ( int i = 0; i < size; ++i )
+  QMap<QString, vector_tile::Tile>::const_iterator it = tiles.constBegin();
+  for ( ; it != tiles.constEnd(); it++ )
   {
-    const QString fieldName = layer.keys( i ).c_str();
-    fieldNames << fieldName;
+    if ( !mLayerNameToIndex[it.key()].contains( layerName ) )
+      continue;
+
+    const ::vector_tile::Tile_Layer &layer = it.value().layers( mLayerNameToIndex[it.key()][layerName] );
+    QStringList fieldNames;
+    const int size = layer.keys_size();
+    fieldNames.reserve( size );
+    for ( int i = 0; i < size; ++i )
+    {
+      const QString fieldName = layer.keys( i ).c_str();
+      fieldNames << fieldName;
+    }
+    return fieldNames;
   }
-  return fieldNames;
+  return QStringList();
 }
 
 QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString, QgsFields> &perLayerFields, const QgsCoordinateTransform &ct, const QSet<QString> *layerSubset ) const
@@ -101,280 +123,286 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
   const double tileXMin = z0xMinimum + mTileID.column() * tileDX;
   const double tileYMax = z0yMaximum - mTileID.row() * tileDY;
 
-  for ( int layerNum = 0; layerNum < tile.layers_size(); layerNum++ )
+  QMap<QString, vector_tile::Tile>::const_iterator it = tiles.constBegin();
+  for ( ; it != tiles.constEnd(); it++ )
   {
-    const ::vector_tile::Tile_Layer &layer = tile.layers( layerNum );
+    vector_tile::Tile tile = it.value();
 
-    const QString layerName = layer.name().c_str();
-    if ( layerSubset && !layerSubset->contains( QString() ) && !layerSubset->contains( layerName ) )
-      continue;
-
-    QVector<QgsFeature> layerFeatures;
-    QgsFields layerFields = perLayerFields[layerName];
-
-    const auto allLayerFields = perLayerFields.find( QString() );
-    if ( allLayerFields != perLayerFields.end() )
+    for ( int layerNum = 0; layerNum < tile.layers_size(); layerNum++ )
     {
-      // need to add the fields from any "all layer" rules to every layer
-      for ( const QgsField &field : allLayerFields.value() )
+      const ::vector_tile::Tile_Layer &layer = tile.layers( layerNum );
+
+      const QString layerName = layer.name().c_str();
+      if ( layerSubset && !layerSubset->contains( QString() ) && !layerSubset->contains( layerName ) )
+        continue;
+
+      QVector<QgsFeature> layerFeatures;
+      QgsFields layerFields = perLayerFields[layerName];
+
+      const auto allLayerFields = perLayerFields.find( QString() );
+      if ( allLayerFields != perLayerFields.end() )
       {
-        if ( layerFields.lookupField( field.name() ) == -1 )
+        // need to add the fields from any "all layer" rules to every layer
+        for ( const QgsField &field : allLayerFields.value() )
         {
-          layerFields.append( field );
-        }
-      }
-    }
-
-    // figure out how field indexes in MVT encoding map to field indexes in QgsFields (we may not use all available fields)
-    QHash<int, int> tagKeyIndexToFieldIndex;
-    for ( int i = 0; i < layer.keys_size(); ++i )
-    {
-      const int fieldIndex = layerFields.indexOf( layer.keys( i ).c_str() );
-      if ( fieldIndex != -1 )
-        tagKeyIndexToFieldIndex.insert( i, fieldIndex );
-    }
-
-    // go through features of a layer
-    for ( int featureNum = 0; featureNum < layer.features_size(); featureNum++ )
-    {
-      const ::vector_tile::Tile_Feature &feature = layer.features( featureNum );
-
-      QgsFeatureId fid;
-#if 0
-      // even if a feature has an internal ID, it's not guaranteed to be unique across different
-      // tiles. This may violate the specifications, but it's been seen on mbtiles files in the wild...
-      if ( feature.has_id() )
-        fid = static_cast<QgsFeatureId>( feature.id() );
-      else
-#endif
-      {
-        // There is no assigned ID, but some parts of QGIS do not work correctly if all IDs are zero
-        // (e.g. labeling will not register two features with the same FID within a single layer),
-        // so let's generate some pseudo-unique FIDs to keep those bits happy
-        fid = featureNum;
-        fid |= ( layerNum & 0xff ) << 24;
-        fid |= ( static_cast<QgsFeatureId>( mTileID.row() ) & 0xff ) << 32;
-        fid |= ( static_cast<QgsFeatureId>( mTileID.column() ) & 0xff ) << 40;
-      }
-
-      QgsFeature f( layerFields, fid );
-
-      //
-      // parse attributes
-      //
-
-      for ( int tagNum = 0; tagNum + 1 < feature.tags_size(); tagNum += 2 )
-      {
-        const int keyIndex = static_cast<int>( feature.tags( tagNum ) );
-        const int fieldIndex = tagKeyIndexToFieldIndex.value( keyIndex, -1 );
-        if ( fieldIndex == -1 )
-          continue;
-
-        const int valueIndex = static_cast<int>( feature.tags( tagNum + 1 ) );
-        if ( valueIndex >= layer.values_size() )
-        {
-          QgsDebugError( QStringLiteral( "Invalid value index for attribute" ) );
-          continue;
-        }
-        const ::vector_tile::Tile_Value &value = layer.values( valueIndex );
-
-        if ( value.has_string_value() )
-          f.setAttribute( fieldIndex, QString::fromStdString( value.string_value() ) );
-        else if ( value.has_float_value() )
-          f.setAttribute( fieldIndex, static_cast<double>( value.float_value() ) );
-        else if ( value.has_double_value() )
-          f.setAttribute( fieldIndex, value.double_value() );
-        else if ( value.has_int_value() )
-          f.setAttribute( fieldIndex, static_cast<int>( value.int_value() ) );
-        else if ( value.has_uint_value() )
-          f.setAttribute( fieldIndex, static_cast<int>( value.uint_value() ) );
-        else if ( value.has_sint_value() )
-          f.setAttribute( fieldIndex, static_cast<int>( value.sint_value() ) );
-        else if ( value.has_bool_value() )
-          f.setAttribute( fieldIndex, static_cast<bool>( value.bool_value() ) );
-        else
-        {
-          QgsDebugError( QStringLiteral( "Unexpected attribute value" ) );
-        }
-      }
-
-      //
-      // parse geometry
-      //
-
-      const int extent = static_cast<int>( layer.extent() );
-      int cursorx = 0, cursory = 0;
-
-      QVector<QgsPoint *> outputPoints; // for point/multi-point
-      QVector<QgsLineString *> outputLinestrings;  // for linestring/multi-linestring
-      QVector<QgsPolygon *> outputPolygons;
-      QVector<QgsPoint> tmpPoints;
-
-      for ( int i = 0; i < feature.geometry_size(); i ++ )
-      {
-        const unsigned g = feature.geometry( i );
-        const unsigned cmdId = g & 0x7;
-        const unsigned cmdCount = g >> 3;
-        if ( cmdId == 1 ) // MoveTo
-        {
-          if ( i + static_cast<int>( cmdCount ) * 2 >= feature.geometry_size() )
+          if ( layerFields.lookupField( field.name() ) == -1 )
           {
-            QgsDebugError( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
-            break;
+            layerFields.append( field );
           }
+        }
+      }
 
-          if ( feature.type() == vector_tile::Tile_GeomType_POINT )
-            outputPoints.reserve( outputPoints.size() + cmdCount );
-          else
-            tmpPoints.reserve( tmpPoints.size() + cmdCount );
+      // figure out how field indexes in MVT encoding map to field indexes in QgsFields (we may not use all available fields)
+      QHash<int, int> tagKeyIndexToFieldIndex;
+      for ( int i = 0; i < layer.keys_size(); ++i )
+      {
+        const int fieldIndex = layerFields.indexOf( layer.keys( i ).c_str() );
+        if ( fieldIndex != -1 )
+          tagKeyIndexToFieldIndex.insert( i, fieldIndex );
+      }
 
-          for ( unsigned j = 0; j < cmdCount; j++ )
+      // go through features of a layer
+      for ( int featureNum = 0; featureNum < layer.features_size(); featureNum++ )
+      {
+        const ::vector_tile::Tile_Feature &feature = layer.features( featureNum );
+
+        QgsFeatureId fid;
+#if 0
+        // even if a feature has an internal ID, it's not guaranteed to be unique across different
+        // tiles. This may violate the specifications, but it's been seen on mbtiles files in the wild...
+        if ( feature.has_id() )
+          fid = static_cast<QgsFeatureId>( feature.id() );
+        else
+#endif
+        {
+          // There is no assigned ID, but some parts of QGIS do not work correctly if all IDs are zero
+          // (e.g. labeling will not register two features with the same FID within a single layer),
+          // so let's generate some pseudo-unique FIDs to keep those bits happy
+          fid = featureNum;
+          fid |= ( layerNum & 0xff ) << 24;
+          fid |= ( static_cast<QgsFeatureId>( mTileID.row() ) & 0xff ) << 32;
+          fid |= ( static_cast<QgsFeatureId>( mTileID.column() ) & 0xff ) << 40;
+        }
+
+        QgsFeature f( layerFields, fid );
+
+        //
+        // parse attributes
+        //
+
+        for ( int tagNum = 0; tagNum + 1 < feature.tags_size(); tagNum += 2 )
+        {
+          const int keyIndex = static_cast<int>( feature.tags( tagNum ) );
+          const int fieldIndex = tagKeyIndexToFieldIndex.value( keyIndex, -1 );
+          if ( fieldIndex == -1 )
+            continue;
+
+          const int valueIndex = static_cast<int>( feature.tags( tagNum + 1 ) );
+          if ( valueIndex >= layer.values_size() )
           {
-            const unsigned v = feature.geometry( i + 1 );
-            const unsigned w = feature.geometry( i + 2 );
-            const int dx = ( ( v >> 1 ) ^ ( -( v & 1 ) ) );
-            const int dy = ( ( w >> 1 ) ^ ( -( w & 1 ) ) );
-            cursorx += dx;
-            cursory += dy;
-            const double px = tileXMin + tileDX * double( cursorx ) / double( extent );
-            const double py = tileYMax - tileDY * double( cursory ) / double( extent );
+            QgsDebugError( QStringLiteral( "Invalid value index for attribute" ) );
+            continue;
+          }
+          const ::vector_tile::Tile_Value &value = layer.values( valueIndex );
+
+          if ( value.has_string_value() )
+            f.setAttribute( fieldIndex, QString::fromStdString( value.string_value() ) );
+          else if ( value.has_float_value() )
+            f.setAttribute( fieldIndex, static_cast<double>( value.float_value() ) );
+          else if ( value.has_double_value() )
+            f.setAttribute( fieldIndex, value.double_value() );
+          else if ( value.has_int_value() )
+            f.setAttribute( fieldIndex, static_cast<int>( value.int_value() ) );
+          else if ( value.has_uint_value() )
+            f.setAttribute( fieldIndex, static_cast<int>( value.uint_value() ) );
+          else if ( value.has_sint_value() )
+            f.setAttribute( fieldIndex, static_cast<int>( value.sint_value() ) );
+          else if ( value.has_bool_value() )
+            f.setAttribute( fieldIndex, static_cast<bool>( value.bool_value() ) );
+          else
+          {
+            QgsDebugError( QStringLiteral( "Unexpected attribute value" ) );
+          }
+        }
+
+        //
+        // parse geometry
+        //
+
+        const int extent = static_cast<int>( layer.extent() );
+        int cursorx = 0, cursory = 0;
+
+        QVector<QgsPoint *> outputPoints; // for point/multi-point
+        QVector<QgsLineString *> outputLinestrings;  // for linestring/multi-linestring
+        QVector<QgsPolygon *> outputPolygons;
+        QVector<QgsPoint> tmpPoints;
+
+        for ( int i = 0; i < feature.geometry_size(); i ++ )
+        {
+          const unsigned g = feature.geometry( i );
+          const unsigned cmdId = g & 0x7;
+          const unsigned cmdCount = g >> 3;
+          if ( cmdId == 1 ) // MoveTo
+          {
+            if ( i + static_cast<int>( cmdCount ) * 2 >= feature.geometry_size() )
+            {
+              QgsDebugError( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
+              break;
+            }
 
             if ( feature.type() == vector_tile::Tile_GeomType_POINT )
-            {
-              outputPoints.append( new QgsPoint( px, py ) );
-            }
-            else if ( feature.type() == vector_tile::Tile_GeomType_LINESTRING )
-            {
-              if ( tmpPoints.size() > 0 )
-              {
-                outputLinestrings.append( new QgsLineString( tmpPoints ) );
-                tmpPoints.clear();
-              }
-              tmpPoints.append( QgsPoint( px, py ) );
-            }
-            else if ( feature.type() == vector_tile::Tile_GeomType_POLYGON )
-            {
-              tmpPoints.append( QgsPoint( px, py ) );
-            }
-            i += 2;
-          }
-        }
-        else if ( cmdId == 2 ) // LineTo
-        {
-          if ( i + static_cast<int>( cmdCount ) * 2 >= feature.geometry_size() )
-          {
-            QgsDebugError( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
-            break;
-          }
-          tmpPoints.reserve( tmpPoints.size() + cmdCount );
-          for ( unsigned j = 0; j < cmdCount; j++ )
-          {
-            const unsigned v = feature.geometry( i + 1 );
-            const unsigned w = feature.geometry( i + 2 );
-            const int dx = ( ( v >> 1 ) ^ ( -( v & 1 ) ) );
-            const int dy = ( ( w >> 1 ) ^ ( -( w & 1 ) ) );
-            cursorx += dx;
-            cursory += dy;
-            const double px = tileXMin + tileDX * double( cursorx ) / double( extent );
-            const double py = tileYMax - tileDY * double( cursory ) / double( extent );
-
-            tmpPoints.push_back( QgsPoint( px, py ) );
-            i += 2;
-          }
-        }
-        else if ( cmdId == 7 ) // ClosePath
-        {
-          if ( feature.type() == vector_tile::Tile_GeomType_POLYGON )
-          {
-            tmpPoints.append( tmpPoints.first() );  // close the ring
-
-            std::unique_ptr<QgsLineString> ring( new QgsLineString( tmpPoints ) );
-            tmpPoints.clear();
-
-            if ( QgsVectorTileMVTUtils::isExteriorRing( ring.get() ) )
-            {
-              // start a new polygon
-              QgsPolygon *p = new QgsPolygon;
-              p->setExteriorRing( ring.release() );
-              outputPolygons.append( p );
-            }
+              outputPoints.reserve( outputPoints.size() + cmdCount );
             else
+              tmpPoints.reserve( tmpPoints.size() + cmdCount );
+
+            for ( unsigned j = 0; j < cmdCount; j++ )
             {
-              // interior ring (hole)
-              if ( outputPolygons.count() != 0 )
+              const unsigned v = feature.geometry( i + 1 );
+              const unsigned w = feature.geometry( i + 2 );
+              const int dx = ( ( v >> 1 ) ^ ( -( v & 1 ) ) );
+              const int dy = ( ( w >> 1 ) ^ ( -( w & 1 ) ) );
+              cursorx += dx;
+              cursory += dy;
+              const double px = tileXMin + tileDX * double( cursorx ) / double( extent );
+              const double py = tileYMax - tileDY * double( cursory ) / double( extent );
+
+              if ( feature.type() == vector_tile::Tile_GeomType_POINT )
               {
-                outputPolygons[outputPolygons.count() - 1]->addInteriorRing( ring.release() );
+                outputPoints.append( new QgsPoint( px, py ) );
+              }
+              else if ( feature.type() == vector_tile::Tile_GeomType_LINESTRING )
+              {
+                if ( tmpPoints.size() > 0 )
+                {
+                  outputLinestrings.append( new QgsLineString( tmpPoints ) );
+                  tmpPoints.clear();
+                }
+                tmpPoints.append( QgsPoint( px, py ) );
+              }
+              else if ( feature.type() == vector_tile::Tile_GeomType_POLYGON )
+              {
+                tmpPoints.append( QgsPoint( px, py ) );
+              }
+              i += 2;
+            }
+          }
+          else if ( cmdId == 2 ) // LineTo
+          {
+            if ( i + static_cast<int>( cmdCount ) * 2 >= feature.geometry_size() )
+            {
+              QgsDebugError( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
+              break;
+            }
+            tmpPoints.reserve( tmpPoints.size() + cmdCount );
+            for ( unsigned j = 0; j < cmdCount; j++ )
+            {
+              const unsigned v = feature.geometry( i + 1 );
+              const unsigned w = feature.geometry( i + 2 );
+              const int dx = ( ( v >> 1 ) ^ ( -( v & 1 ) ) );
+              const int dy = ( ( w >> 1 ) ^ ( -( w & 1 ) ) );
+              cursorx += dx;
+              cursory += dy;
+              const double px = tileXMin + tileDX * double( cursorx ) / double( extent );
+              const double py = tileYMax - tileDY * double( cursory ) / double( extent );
+
+              tmpPoints.push_back( QgsPoint( px, py ) );
+              i += 2;
+            }
+          }
+          else if ( cmdId == 7 ) // ClosePath
+          {
+            if ( feature.type() == vector_tile::Tile_GeomType_POLYGON )
+            {
+              tmpPoints.append( tmpPoints.first() );  // close the ring
+
+              std::unique_ptr<QgsLineString> ring( new QgsLineString( tmpPoints ) );
+              tmpPoints.clear();
+
+              if ( QgsVectorTileMVTUtils::isExteriorRing( ring.get() ) )
+              {
+                // start a new polygon
+                QgsPolygon *p = new QgsPolygon;
+                p->setExteriorRing( ring.release() );
+                outputPolygons.append( p );
               }
               else
               {
-                QgsDebugError( QStringLiteral( "Malformed geometry: first ring of a polygon is interior ring" ) );
+                // interior ring (hole)
+                if ( outputPolygons.count() != 0 )
+                {
+                  outputPolygons[outputPolygons.count() - 1]->addInteriorRing( ring.release() );
+                }
+                else
+                {
+                  QgsDebugError( QStringLiteral( "Malformed geometry: first ring of a polygon is interior ring" ) );
+                }
               }
             }
+
           }
+          else
+          {
+            QgsDebugError( QStringLiteral( "Unexpected command ID: %1" ).arg( cmdId ) );
+          }
+        }
 
-        }
-        else
+        QString geomType;
+        if ( feature.type() == vector_tile::Tile_GeomType_POINT )
         {
-          QgsDebugError( QStringLiteral( "Unexpected command ID: %1" ).arg( cmdId ) );
+          geomType = QStringLiteral( "Point" );
+          if ( outputPoints.count() == 1 )
+            f.setGeometry( QgsGeometry( outputPoints.at( 0 ) ) );
+          else
+          {
+            QgsMultiPoint *mp = new QgsMultiPoint;
+            mp->reserve( outputPoints.count() );
+            for ( int k = 0; k < outputPoints.count(); ++k )
+              mp->addGeometry( outputPoints[k] );
+            f.setGeometry( QgsGeometry( mp ) );
+          }
         }
+        else if ( feature.type() == vector_tile::Tile_GeomType_LINESTRING )
+        {
+          geomType = QStringLiteral( "LineString" );
+
+          // finish the linestring we have started
+          outputLinestrings.append( new QgsLineString( tmpPoints ) );
+
+          if ( outputLinestrings.count() == 1 )
+            f.setGeometry( QgsGeometry( outputLinestrings.at( 0 ) ) );
+          else
+          {
+            QgsMultiLineString *mls = new QgsMultiLineString;
+            mls->reserve( outputLinestrings.size() );
+            for ( int k = 0; k < outputLinestrings.count(); ++k )
+              mls->addGeometry( outputLinestrings[k] );
+            f.setGeometry( QgsGeometry( mls ) );
+          }
+        }
+        else if ( feature.type() == vector_tile::Tile_GeomType_POLYGON )
+        {
+          geomType = QStringLiteral( "Polygon" );
+
+          if ( outputPolygons.count() == 1 )
+            f.setGeometry( QgsGeometry( outputPolygons.at( 0 ) ) );
+          else
+          {
+            QgsMultiPolygon *mpl = new QgsMultiPolygon;
+            mpl->reserve( outputPolygons.size() );
+            for ( int k = 0; k < outputPolygons.count(); ++k )
+              mpl->addGeometry( outputPolygons[k] );
+            f.setGeometry( QgsGeometry( mpl ) );
+          }
+        }
+
+        f.setAttribute( QStringLiteral( "_geom_type" ), geomType );
+        f.geometry().transform( ct );
+
+        layerFeatures.append( f );
       }
 
-      QString geomType;
-      if ( feature.type() == vector_tile::Tile_GeomType_POINT )
-      {
-        geomType = QStringLiteral( "Point" );
-        if ( outputPoints.count() == 1 )
-          f.setGeometry( QgsGeometry( outputPoints.at( 0 ) ) );
-        else
-        {
-          QgsMultiPoint *mp = new QgsMultiPoint;
-          mp->reserve( outputPoints.count() );
-          for ( int k = 0; k < outputPoints.count(); ++k )
-            mp->addGeometry( outputPoints[k] );
-          f.setGeometry( QgsGeometry( mp ) );
-        }
-      }
-      else if ( feature.type() == vector_tile::Tile_GeomType_LINESTRING )
-      {
-        geomType = QStringLiteral( "LineString" );
-
-        // finish the linestring we have started
-        outputLinestrings.append( new QgsLineString( tmpPoints ) );
-
-        if ( outputLinestrings.count() == 1 )
-          f.setGeometry( QgsGeometry( outputLinestrings.at( 0 ) ) );
-        else
-        {
-          QgsMultiLineString *mls = new QgsMultiLineString;
-          mls->reserve( outputLinestrings.size() );
-          for ( int k = 0; k < outputLinestrings.count(); ++k )
-            mls->addGeometry( outputLinestrings[k] );
-          f.setGeometry( QgsGeometry( mls ) );
-        }
-      }
-      else if ( feature.type() == vector_tile::Tile_GeomType_POLYGON )
-      {
-        geomType = QStringLiteral( "Polygon" );
-
-        if ( outputPolygons.count() == 1 )
-          f.setGeometry( QgsGeometry( outputPolygons.at( 0 ) ) );
-        else
-        {
-          QgsMultiPolygon *mpl = new QgsMultiPolygon;
-          mpl->reserve( outputPolygons.size() );
-          for ( int k = 0; k < outputPolygons.count(); ++k )
-            mpl->addGeometry( outputPolygons[k] );
-          f.setGeometry( QgsGeometry( mpl ) );
-        }
-      }
-
-      f.setAttribute( QStringLiteral( "_geom_type" ), geomType );
-      f.geometry().transform( ct );
-
-      layerFeatures.append( f );
+      features[layerName] = layerFeatures;
     }
-
-    features[layerName] = layerFeatures;
   }
   return features;
 }

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -167,13 +167,6 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
         const ::vector_tile::Tile_Feature &feature = layer.features( featureNum );
 
         QgsFeatureId fid;
-#if 0
-        // even if a feature has an internal ID, it's not guaranteed to be unique across different
-        // tiles. This may violate the specifications, but it's been seen on mbtiles files in the wild...
-        if ( feature.has_id() )
-          fid = static_cast<QgsFeatureId>( feature.id() );
-        else
-#endif
         {
           // There is no assigned ID, but some parts of QGIS do not work correctly if all IDs are zero
           // (e.g. labeling will not register two features with the same FID within a single layer),

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -234,7 +234,7 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
         {
           const unsigned g = feature.geometry( i );
           const unsigned cmdId = g & 0x7;
-          const unsigned cmdCount = g >> 3;
+          const int cmdCount = static_cast<int>( g >> 3 );
           if ( cmdId == 1 ) // MoveTo
           {
             if ( i + static_cast<int>( cmdCount ) * 2 >= feature.geometry_size() )
@@ -248,7 +248,7 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
             else
               tmpPoints.reserve( static_cast<int>( tmpPoints.size() ) + cmdCount );
 
-            for ( unsigned j = 0; j < cmdCount; j++ )
+            for ( int j = 0; j < cmdCount; j++ )
             {
               const int v = static_cast<int>( feature.geometry( i + 1 ) );
               const int w = static_cast<int>( feature.geometry( i + 2 ) );
@@ -286,8 +286,8 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
               QgsDebugError( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
               break;
             }
-            tmpPoints.reserve( static_cast<int>( tmpPoints.size() ) + cmdCount );
-            for ( unsigned j = 0; j < cmdCount; j++ )
+            tmpPoints.reserve( tmpPoints.size() + cmdCount );
+            for ( int j = 0; j < cmdCount; j++ )
             {
               const int v = static_cast<int>( feature.geometry( i + 1 ) );
               const int w = static_cast<int>( feature.geometry( i + 2 ) );

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -250,8 +250,8 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
 
             for ( unsigned j = 0; j < cmdCount; j++ )
             {
-              const unsigned v = feature.geometry( i + 1 );
-              const unsigned w = feature.geometry( i + 2 );
+              const int v = static_cast<int>( feature.geometry( i + 1 ) );
+              const int w = static_cast<int>( feature.geometry( i + 2 ) );
               const int dx = ( ( v >> 1 ) ^ ( -( v & 1 ) ) );
               const int dy = ( ( w >> 1 ) ^ ( -( w & 1 ) ) );
               cursorx += dx;
@@ -289,10 +289,10 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
             tmpPoints.reserve( tmpPoints.size() + cmdCount );
             for ( unsigned j = 0; j < cmdCount; j++ )
             {
-              const unsigned v = feature.geometry( i + 1 );
-              const unsigned w = feature.geometry( i + 2 );
-              const int dx = ( ( v >> 1 ) ^ ( -( v & 1 ) ) );
-              const int dy = ( ( w >> 1 ) ^ ( -( w & 1 ) ) );
+              const int v = static_cast<int>( feature.geometry( i + 1 ) );
+              const int w = static_cast<int>( feature.geometry( i + 2 ) );
+              const int dx = ( v >> 1 ) ^ ( -( v & 1 ) );
+              const int dy = ( w >> 1 ) ^ ( -( w & 1 ) );
               cursorx += dx;
               cursory += dy;
               const double px = tileXMin + tileDX * double( cursorx ) / double( extent );

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -244,9 +244,9 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
             }
 
             if ( feature.type() == vector_tile::Tile_GeomType_POINT )
-              outputPoints.reserve( outputPoints.size() + cmdCount );
+              outputPoints.reserve( static_cast<int>( outputPoints.size() ) + cmdCount );
             else
-              tmpPoints.reserve( tmpPoints.size() + cmdCount );
+              tmpPoints.reserve( static_cast<int>( tmpPoints.size() ) + cmdCount );
 
             for ( unsigned j = 0; j < cmdCount; j++ )
             {
@@ -286,7 +286,7 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
               QgsDebugError( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
               break;
             }
-            tmpPoints.reserve( tmpPoints.size() + cmdCount );
+            tmpPoints.reserve( static_cast<int>( tmpPoints.size() ) + cmdCount );
             for ( unsigned j = 0; j < cmdCount; j++ )
             {
               const int v = static_cast<int>( feature.geometry( i + 1 ) );

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -42,7 +42,7 @@ bool QgsVectorTileMVTDecoder::decode( const QgsVectorTileRawData &rawTileData )
   mLayerNameToIndex.clear();
 
   QMap<QString, QByteArray>::const_iterator it = rawTileData.data.constBegin();
-  for ( ; it != rawTileData.data.constEnd(); it++ )
+  for ( ; it != rawTileData.data.constEnd(); ++it )
   {
     QString sourceId = it.key();
 
@@ -73,7 +73,7 @@ QStringList QgsVectorTileMVTDecoder::layers() const
   layerNames.reserve( layerSize );
 
   QMap<QString, vector_tile::Tile>::const_iterator it = tiles.constBegin();
-  for ( ; it != tiles.constEnd(); it++ )
+  for ( ; it != tiles.constEnd(); ++it )
   {
     for ( int layerNum = 0; layerNum < layerSize; layerNum++ )
     {
@@ -88,7 +88,7 @@ QStringList QgsVectorTileMVTDecoder::layers() const
 QStringList QgsVectorTileMVTDecoder::layerFieldNames( const QString &layerName ) const
 {
   QMap<QString, vector_tile::Tile>::const_iterator it = tiles.constBegin();
-  for ( ; it != tiles.constEnd(); it++ )
+  for ( ; it != tiles.constEnd(); ++it )
   {
     if ( !mLayerNameToIndex[it.key()].contains( layerName ) )
       continue;
@@ -124,7 +124,7 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
   const double tileYMax = z0yMaximum - mTileID.row() * tileDY;
 
   QMap<QString, vector_tile::Tile>::const_iterator it = tiles.constBegin();
-  for ( ; it != tiles.constEnd(); it++ )
+  for ( ; it != tiles.constEnd(); ++it )
   {
     vector_tile::Tile tile = it.value();
 

--- a/src/core/vectortile/qgsvectortilemvtdecoder.h
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.h
@@ -64,10 +64,10 @@ class CORE_EXPORT QgsVectorTileMVTDecoder
                                          const QSet< QString > *layerSubset = nullptr ) const;
 
   private:
-    vector_tile::Tile tile;
+    QMap<QString, vector_tile::Tile> tiles;
     QgsTileXYZ mTileID;
     QgsVectorTileMatrixSet mStructure;
-    QMap<QString, int> mLayerNameToIndex;
+    QMap<QString, QMap<QString, int>> mLayerNameToIndex;
 };
 
 #endif // QGSVECTORTILEMVTDECODER_H

--- a/src/core/vectortile/qgsvectortilemvtdecoder.h
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsVectorTileMVTDecoder
                                          const QSet< QString > *layerSubset = nullptr ) const;
 
   private:
+    //! map of tiles for each source
     QMap<QString, vector_tile::Tile> tiles;
     QgsTileXYZ mTileID;
     QgsVectorTileMatrixSet mStructure;

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -97,7 +97,7 @@ QList<QNetworkRequest> QgsXyzVectorTileDataProviderBase::tileRequests( const Qgs
 
   QgsStringMap::const_iterator it = sourcesPaths.constBegin();
 
-  for ( ; it != sourcesPaths.constEnd(); it++ )
+  for ( ; it != sourcesPaths.constEnd(); ++it )
   {
     QString urlTemplate = it.value();
     QString layerName = it.key();

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -457,7 +457,7 @@ QgsStringMap QgsXyzVectorTileDataProvider::sourcePaths() const
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( dataSourceUri() );
 
-  QgsStringMap paths = {{ dsUri.param( QStringLiteral( "urlName" ) ), dsUri.param( QStringLiteral( "url" ) ) }};
+  QgsStringMap paths = { { dsUri.param( QStringLiteral( "urlName" ) ), dsUri.param( QStringLiteral( "url" ) ) } };
 
   int i = 2;
   while ( true )

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsvectortiledataprovider.h"
 #include "qgsxyzvectortiledataprovider.h"
 #include "qgsthreadingutils.h"
 #include "qgstiles.h"
@@ -67,62 +68,81 @@ QList<QgsVectorTileRawData> QgsXyzVectorTileDataProviderBase::readTiles( const Q
 {
   QList<QgsVectorTileRawData> rawTiles;
   rawTiles.reserve( tiles.size() );
-  const QString source = sourcePath();
   for ( QgsTileXYZ id : std::as_const( tiles ) )
   {
-    if ( feedback && feedback->isCanceled() )
-      break;
-
-    const QByteArray rawData = loadFromNetwork( id, set.tileMatrix( id.zoomLevel() ), source, mAuthCfg, mHeaders, feedback, usage );
-    if ( !rawData.isEmpty() )
+    QMap<QString, QByteArray> data;
+    const QgsStringMap sources = sourcePaths();
+    QgsStringMap::const_iterator it = sources.constBegin();
+    for ( ; it != sources.constEnd(); ++it )
     {
-      rawTiles.append( QgsVectorTileRawData( id, rawData ) );
+      if ( feedback && feedback->isCanceled() )
+        break;
+
+      const QByteArray rawData = loadFromNetwork( id, set.tileMatrix( id.zoomLevel() ), it.value(), mAuthCfg, mHeaders, feedback, usage );
+      if ( !rawData.isEmpty() )
+      {
+        data[it.key()] = rawData;
+      }
     }
+    rawTiles.append( QgsVectorTileRawData( id, data ) );
   }
   return rawTiles;
 }
 
-QNetworkRequest QgsXyzVectorTileDataProviderBase::tileRequest( const QgsTileMatrixSet &set, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const
+QList<QNetworkRequest> QgsXyzVectorTileDataProviderBase::tileRequests( const QgsTileMatrixSet &set, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const
 {
-  QString urlTemplate = sourcePath();
+  QList<QNetworkRequest> requests;
 
-  if ( urlTemplate.contains( QLatin1String( "{usage}" ) ) )
+  const QgsStringMap sourcesPaths = sourcePaths();
+
+  QgsStringMap::const_iterator it = sourcesPaths.constBegin();
+
+  for ( ; it != sourcesPaths.constEnd(); it++ )
   {
-    switch ( usage )
+    QString urlTemplate = it.value();
+    QString layerName = it.key();
+
+    if ( urlTemplate.contains( QLatin1String( "{usage}" ) ) )
     {
-      case Qgis::RendererUsage::View:
-        urlTemplate.replace( QLatin1String( "{usage}" ), QLatin1String( "view" ) );
-        break;
-      case Qgis::RendererUsage::Export:
-        urlTemplate.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
-        break;
-      case Qgis::RendererUsage::Unknown:
-        urlTemplate.replace( QLatin1String( "{usage}" ), QString() );
-        break;
+      switch ( usage )
+      {
+        case Qgis::RendererUsage::View:
+          urlTemplate.replace( QLatin1String( "{usage}" ), QLatin1String( "view" ) );
+          break;
+        case Qgis::RendererUsage::Export:
+          urlTemplate.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
+          break;
+        case Qgis::RendererUsage::Unknown:
+          urlTemplate.replace( QLatin1String( "{usage}" ), QString() );
+          break;
+      }
     }
+
+    const QString url = QgsVectorTileUtils::formatXYZUrlTemplate( urlTemplate, id, set.tileMatrix( id.zoomLevel() ) );
+
+    QNetworkRequest request( url );
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsXyzVectorTileDataProvider" ) );
+    QgsSetRequestInitiatorId( request, id.toString() );
+
+    request.setAttribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_COLUMN ), id.column() );
+    request.setAttribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_ROW ), id.row() );
+    request.setAttribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_ZOOM ), id.zoomLevel() );
+    request.setAttribute( static_cast<QNetworkRequest::Attribute>( QgsVectorTileDataProvider::DATA_SOURCE_ID ), layerName );
+
+    request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
+    request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
+
+    mHeaders.updateNetworkRequest( request );
+
+    if ( !mAuthCfg.isEmpty() &&  !QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg ) )
+    {
+      QgsMessageLog::logMessage( tr( "network request update failed for authentication config" ), tr( "Network" ) );
+    }
+
+    requests << request;
   }
 
-  const QString url = QgsVectorTileUtils::formatXYZUrlTemplate( urlTemplate, id, set.tileMatrix( id.zoomLevel() ) );
-
-  QNetworkRequest request( url );
-  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsXyzVectorTileDataProvider" ) );
-  QgsSetRequestInitiatorId( request, id.toString() );
-
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 1 ), id.column() );
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 2 ), id.row() );
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 3 ), id.zoomLevel() );
-
-  request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
-  request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
-
-  mHeaders.updateNetworkRequest( request );
-
-  if ( !mAuthCfg.isEmpty() &&  !QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg ) )
-  {
-    QgsMessageLog::logMessage( tr( "network request update failed for authentication config" ), tr( "Network" ) );
-  }
-
-  return request;
+  return requests;
 }
 
 QByteArray QgsXyzVectorTileDataProviderBase::loadFromNetwork( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QString &requestUrl, const QString &authid, const QgsHttpHeaders &headers, QgsFeedback *feedback, Qgis::RendererUsage usage )
@@ -207,7 +227,21 @@ QVariantMap QgsXyzVectorTileDataProviderMetadata::decodeUri( const QString &uri 
   else
   {
     uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
+    if ( dsUri.hasParam( QStringLiteral( "urlName" ) ) )
+      uriComponents.insert( QStringLiteral( "urlName" ), dsUri.param( QStringLiteral( "urlName" ) ) );
   }
+  int i = 2;
+  while ( true )
+  {
+    QString url = dsUri.param( QStringLiteral( "url_%2" ).arg( i ) );
+    QString urlName = dsUri.param( QStringLiteral( "urlName_%2" ).arg( i ) );
+    if ( url.isEmpty() || urlName.isEmpty() )
+      break;
+    uriComponents.insert( QStringLiteral( "urlName_%2" ).arg( i ), urlName );
+    uriComponents.insert( QStringLiteral( "url_%2" ).arg( i ), url );
+    i++;
+  }
+
 
   if ( dsUri.hasParam( QStringLiteral( "zmin" ) ) )
     uriComponents.insert( QStringLiteral( "zmin" ), dsUri.param( QStringLiteral( "zmin" ) ) );
@@ -231,6 +265,26 @@ QString QgsXyzVectorTileDataProviderMetadata::encodeUri( const QVariantMap &part
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
+  if ( parts.contains( QStringLiteral( "urlName" ) ) )
+    dsUri.setParam( QStringLiteral( "urlName" ), parts[ QStringLiteral( "urlName" ) ].toString() );
+
+  int i = 2;
+  while ( true )
+  {
+    QString urlNameKey = QStringLiteral( "urlName_%2" ).arg( i );
+    QString urlKey = QStringLiteral( "url_%2" ).arg( i );
+
+    if ( !parts.contains( urlNameKey ) || !parts.contains( urlKey ) )
+      break;
+    QString url = dsUri.param( QStringLiteral( "url_%2" ).arg( i ) );
+    QString urlName = dsUri.param( QStringLiteral( "urlName_%2" ).arg( i ) );
+    if ( url.isEmpty() || urlName.isEmpty() )
+      break;
+
+    dsUri.setParam( urlNameKey, parts[ urlNameKey ].toString() );
+    dsUri.setParam( urlKey, parts[ urlKey ].toString() );
+    i++;
+  }
 
   if ( parts.contains( QStringLiteral( "zmin" ) ) )
     dsUri.setParam( QStringLiteral( "zmin" ), parts[ QStringLiteral( "zmin" ) ].toString() );
@@ -394,6 +448,30 @@ QString QgsXyzVectorTileDataProvider::sourcePath() const
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( dataSourceUri() );
   return dsUri.param( QStringLiteral( "url" ) );
+}
+
+QgsStringMap QgsXyzVectorTileDataProvider::sourcePaths() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( dataSourceUri() );
+
+  QgsStringMap paths = {{ dsUri.param( QStringLiteral( "urlName" ) ), dsUri.param( QStringLiteral( "url" ) ) }};
+
+  int i = 2;
+  while ( true )
+  {
+    QString url = dsUri.param( QStringLiteral( "url_%2" ).arg( i ) );
+    QString urlName = dsUri.param( QStringLiteral( "urlName_%2" ).arg( i ) );
+    if ( url.isEmpty() || urlName.isEmpty() )
+      break;
+
+    paths.insert( urlName, url );
+    i++;
+  }
+
+  return paths;
 }
 
 ///@endcond

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.h
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsXyzVectorTileDataProviderBase : public QgsVectorTileDataPro
     bool supportsAsync() const override;
     QgsVectorTileRawData readTile( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr, Qgis::RendererUsage usage = Qgis::RendererUsage::Unknown ) const override;
-    QNetworkRequest tileRequest( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const override;
+    QList<QNetworkRequest> tileRequests( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const override;
 
   protected:
 
@@ -84,6 +84,7 @@ class CORE_EXPORT QgsXyzVectorTileDataProvider : public QgsXyzVectorTileDataProv
     QString description() const override;
     QgsVectorTileDataProvider *clone() const override;
     QString sourcePath() const override;
+    QgsStringMap sourcePaths() const override;
     bool isValid() const override;
     QgsRectangle extent() const override;
     QgsCoordinateReferenceSystem crs() const override;
@@ -91,7 +92,6 @@ class CORE_EXPORT QgsXyzVectorTileDataProvider : public QgsXyzVectorTileDataProv
 
     static QString XYZ_DATA_PROVIDER_KEY;
     static QString XYZ_DATA_PROVIDER_DESCRIPTION;
-
   protected:
 
     bool mIsValid = false;

--- a/tests/src/core/testqgsvectortilelayer.cpp
+++ b/tests/src/core/testqgsvectortilelayer.cpp
@@ -133,10 +133,10 @@ void TestQgsVectorTileLayer::test_basic()
 {
   // tile fetch test
   const QgsVectorTileRawData tile0rawData = mLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
-  QCOMPARE( tile0rawData.data.length(), 64822 );
+  QCOMPARE( tile0rawData.data.first().length(), 64822 );
 
   const QgsVectorTileRawData invalidTileRawData = mLayer->getRawTile( QgsTileXYZ( 0, 0, 99 ) );
-  QCOMPARE( invalidTileRawData.data.length(), 0 );
+  QCOMPARE( invalidTileRawData.data.first().length(), 0 );
 
   // an xyz vector tile layer should be considered as a basemap layer
   QCOMPARE( mLayer->properties(), Qgis::MapLayerProperties( Qgis::MapLayerProperty::IsBasemapLayer ) );


### PR DESCRIPTION
This is a draft/POC to allow a discussion.

## Goal: rendering Mapbox Vector Tile layer having multiple sources 

for instance: https://vectortiles.geo.admin.ch/styles/ch.swisstopo.basemap.vt/style.json
(see online: https://cms.geo.admin.ch/fmc/bm.html)
```json
{
  "version": 8,
  "id": "2fa0964e-8ce3-4fe9-91b3-2a0d18663c9d",
  "name": "basemap_v1.15.0",
  "sources": {
    "terrain_v1.0.0": {
      "url": "https://vectortiles.geo.admin.ch/tiles/ch.swisstopo.relief.vt/v1.0.0/tiles.json",
      "type": "vector"
    },
    "base_v1.0.0": {
      "url": "https://vectortiles.geo.admin.ch/tiles/ch.swisstopo.base.vt/v1.0.0/tiles.json",
      "type": "vector"
    }
  },
  "layers": [
…
```

This cannot be solved by using several QGIS layers since the symbols ordering doesn't necessarily match with the layers/sources.

The idea is to allow listing several URLs in the layer. The rendering of each tile will be done at once when every source are fetched.

I have adapted `QgsVectorTileRawData` so that it contains a list of `QByteData` instead of a single one. The MVT decoder has been adapted accordingly. 

For the download algorithm I suppose we need to recombine the data into a single array.

The layer names are considered unique across sources. It might be necessary to map layer names to the proper source.

I have successfuly tested this for asynchronous tile fetching. Sync is implemented but not tested.

There is no UX yet to play with this, it will be done if the approach is accepted.
But here is a project to play with: [mapbox-multi-sources.qgs.zip](https://github.com/user-attachments/files/16266834/mapbox-multi-sources.qgs.zip)

Screenshot with the log of the 2 sources fetched:
![image](https://github.com/user-attachments/assets/90577280-dbce-4a74-ac77-ac1cfa6618c8)

Looking forward to read your thoughts :)


