### PR TITLE
Add vertical CRS selection widget to vector layer properties

### DIFF
--- a/src/app/vector/qgsvectorelevationpropertieswidget.h
+++ b/src/app/vector/qgsvectorelevationpropertieswidget.h
@@ -24,6 +24,7 @@
 
 class QgsVectorLayer;
 class QgsPropertyOverrideButton;
+class QgsProjectionSelectionWidget;
 
 class QgsVectorElevationPropertiesWidget : public QgsMapLayerConfigWidget, private Ui::QgsVectorElevationPropertiesWidgetBase, private QgsExpressionContextGenerator
 {
@@ -46,6 +47,7 @@ class QgsVectorElevationPropertiesWidget : public QgsMapLayerConfigWidget, priva
     void bindingChanged();
     void toggleSymbolWidgets();
     void updateProperty();
+    void updateVerticalCrsOptions();
 
   private:
 
@@ -67,6 +69,9 @@ class QgsVectorElevationPropertiesWidget : public QgsMapLayerConfigWidget, priva
      * Updates a specific property override \a button to reflect the widgets's current properties.
      */
     void updateDataDefinedButton( QgsPropertyOverrideButton *button );
+
+    QgsProjectionSelectionWidget *mVerticalCrsWidget = nullptr;
+
     QgsPropertyCollection mPropertyCollection;
 
     QgsVectorLayer *mLayer = nullptr;

--- a/src/ui/qgsvectorelevationpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorelevationpropertieswidgetbase.ui
@@ -27,6 +27,58 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Vertical Reference System</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QgsStackedWidget" name="mVerticalCrsStackedWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <widget class="QWidget" name="mCrsPageDisabled">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="mCrsDisabledLabel">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="mCrsPageEnabled"/>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="mElevationGroupBox">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
@@ -40,28 +92,11 @@
      <property name="syncGroup" stdset="0">
       <string notr="true">vectorgeneral</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,0">
-      <item row="2" column="0">
-       <widget class="QLabel" name="mLabelScale">
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
+      <item row="3" column="3">
+       <widget class="QgsPropertyOverrideButton" name="mOffsetDDBtn">
         <property name="text">
-         <string>Scale</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="3">
-       <widget class="QLabel" name="mLabelClampingExplanation">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="mOffsetLabel">
-        <property name="text">
-         <string>Offset</string>
+         <string>…</string>
         </property>
        </widget>
       </item>
@@ -75,6 +110,23 @@
         </property>
         <property name="maximum">
          <double>99999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="mOffsetLabel">
+        <property name="text">
+         <string>Offset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="3">
+       <widget class="QLabel" name="mLabelClampingExplanation">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -94,10 +146,10 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
-       <widget class="QgsPropertyOverrideButton" name="mOffsetDDBtn">
+      <item row="2" column="0">
+       <widget class="QLabel" name="mLabelScale">
         <property name="text">
-         <string>…</string>
+         <string>Scale</string>
         </property>
        </widget>
       </item>
@@ -537,9 +589,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSymbolButton</class>
@@ -547,9 +599,15 @@
    <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsStackedWidget</class>
+   <extends>QStackedWidget</extends>
+   <header>qgsstackedwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorelevationpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorelevationpropertieswidgetbase.ui
@@ -75,6 +75,23 @@
         <widget class="QWidget" name="mCrsPageEnabled"/>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vertical reference systems are supported for vector layers by:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Elevation profiles&lt;/li&gt;
+&lt;li&gt;Identify tool results&lt;/li&gt;
+&lt;li&gt;3D map views (when 3D view has a vertical reference system set)&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;i&gt;Other tools or plugins may ignore the vertical reference system, and care should be taken to validate results accordingly.&lt;/i&gt;&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Follows the same behavior as the project setting, i.e.: 

If the layer has a 3d crs set, then the widget is disabled with an explanatory note:

![image](https://github.com/user-attachments/assets/bad9d15e-9cc0-4b13-8703-1a0b39c2a409)

If the layer has a 2d crs set, then the user can select the appropriate vertical crs:

![image](https://github.com/user-attachments/assets/e840ea49-595d-4d8c-9f57-47d91d41f9ac)

There's also a explanatory note detailing where vertical CRS are respected, along with a warning:

![image](https://github.com/user-attachments/assets/7b05c4df-b066-4136-95f1-abe3024f1104)

