### PR TITLE
[metasearch] Improve empty field handling

### DIFF
--- a/python/plugins/MetaSearch/resources/templates/record_metadata_dc.html
+++ b/python/plugins/MetaSearch/resources/templates/record_metadata_dc.html
@@ -23,51 +23,64 @@
             <table>
                 <tr>
                     <td>{{ gettext('Identifier') }}</td>
-                    <td>{{ obj.identifier }}</td>
+                    <td>{{ obj.identifier if obj.identifier not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Title') }}</td>
-                    <td>{{ obj.title }}</td>
+                    <td>{{ obj.title if obj.title not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Abstract') }}</td>
-                    <td>{{ obj.abstract }}</td>
+                    <td>{{ obj.abstract if obj.abstract not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Subjects') }}</td>
-                    <td>{{ obj.subjects|join(',') }}</td>
+                    <td>{% set filteredSubjects = obj.subjects | select('ne', None) | select('ne', 'None') | select('ne', '') | list %}
+                        {{ filteredSubjects | join(',') if filteredSubjects else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Creator') }}</td>
-                    <td>{{ obj.creator }}</td>
+                    <td>{{ obj.creator if obj.creator not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Contributor') }}</td>
-                    <td>{{ obj.contributor}}</td>
+                    <td>{{ obj.contributor if obj.contributor not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Publisher') }}</td>
-                    <td>{{ obj.publisher}}</td>
+                    <td>{{ obj.publisher if obj.publisher not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Modified') }}</td>
-                    <td>{{ obj.modified }}</td>
+                    <td>{{ obj.modified if obj.modified not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Language') }}</td>
-                    <td>{{ obj.language }}</td>
+                    <td>{{ obj.language if obj.language not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Format') }}</td>
-                    <td>{{ obj.format }}</td>
+                    <td>{{ obj.format if obj.format not in [None, 'None', '']
+                        else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Rights') }}</td>
-                    <td>{{ obj.rights|join(',') }}</td>
+                    <td>{% set filteredRights = obj.rights | select('ne', None) | select('ne', 'None') | select('ne', '') | list %}
+                        {{ filteredRights | join(',') if filteredRights else gettext('None') }}</td>
                 </tr>
                 <tr>
                     <td>{{ gettext('Bounding Box') }}</td>
-                    <td>{{ [obj.bbox.minx, obj.bbox.miny, obj.bbox.maxx, obj.bbox.maxy]|join(',') }}</td>
+                    <td>{{ [obj.bbox.minx, obj.bbox.miny, obj.bbox.maxx, obj.bbox.maxy] | join(',')
+                           if obj.bbox not in [None, 'None', '']
+                           else gettext('None') }}</td>
                 </tr>
             </table>
         </section>


### PR DESCRIPTION
**Example:**
https://geodatenkatalog-niederrhein.de/csw?service=CSW&version=2.0.2&request=GetRecordById&outputFormat=application%2Fxml&outputSchema=http%3A%2F%2Fwww.opengis.net%2Fcat%2Fcsw%2F2.0.2&elementsetname=full&id=beff24a7-491b-4617-ad7b-5e6f32a1d1ef

**before:**
<img src="https://github.com/user-attachments/assets/dc1f1bb4-1f2d-4cf4-9970-7be251cc506e" width=500 />

**this PR:**
<img src="https://github.com/user-attachments/assets/4564fa28-49a0-49c9-943f-27317e42ed1d" width=500 />
