### PR TITLE
use WKB type instead of geometry type when saving and restoring layer metadata

### DIFF
--- a/src/providers/postgres/qgspostgresprovidermetadatautils.cpp
+++ b/src/providers/postgres/qgspostgresprovidermetadatautils.cpp
@@ -102,8 +102,10 @@ QList<QgsLayerMetadataProviderResult> QgsPostgresProviderMetadataUtils::searchLa
       uri.setSchema( res.PQgetvalue( row, 1 ) );
       uri.setTable( res.PQgetvalue( row, 2 ) );
       uri.setGeometryColumn( res.PQgetvalue( row, 3 ) );
+      const Qgis::WkbType wkbType =  QgsWkbTypes::parseType( res.PQgetvalue( row, 7 ) );
+      uri.setWkbType( wkbType );
       result.setStandardUri( QStringLiteral( "http://mrcc.com/qgis.dtd" ) );
-      result.setGeometryType( QgsWkbTypes::geometryType( QgsWkbTypes::parseType( res.PQgetvalue( row, 7 ) ) ) );
+      result.setGeometryType( QgsWkbTypes::geometryType( wkbType ) );
       QgsPolygon geographicExtent;
       geographicExtent.fromWkt( res.PQgetvalue( row, 8 ) );
       result.setGeographicExtent( geographicExtent );
@@ -207,7 +209,7 @@ bool QgsPostgresProviderMetadataUtils::saveLayerMetadata( const Qgis::LayerType 
     }
   }
 
-  const QString wkbTypeString = QgsWkbTypes::geometryDisplayString( QgsWkbTypes::geometryType( dsUri.wkbType() ) );
+  const QString wkbTypeString = QgsWkbTypes::displayString( dsUri.wkbType() );
 
   const QgsCoordinateReferenceSystem metadataCrs { metadata.crs() };
   QgsCoordinateReferenceSystem destCrs {QgsCoordinateReferenceSystem::fromEpsgId( 4326 ) };


### PR DESCRIPTION
## Description

When saving layer metadata in the PostGIS database we save layer WKB type (extracted from the data source URI WKB type) as a geometry type display string (e.g. `Point`, `Line` or `Polygon`). But when loading metadata we do not restore WKB type information in the data source URI.

As a result, when user adds a layer from the Metadata Search tab of the Datasource Manager and updates metadata QGIS sets geometry type field to `Unknown geometry` and layer receives incorrect icon and is excluded from the results when filtering by geometry type is applied.

To prevent the loss of information this PR proposes to save layer WKB type instead of geometry type and also populate WKB type field of the data source URI.

Funded by [NaturalGIS](https://www.naturalgis.pt/).