### PR TITLE
Fix crash when extracting symbols from project with layout legend

### DIFF
--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemlegend.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemlegend.sip.in
@@ -122,6 +122,7 @@ Returns whether the legend should automatically resize to fit its contents.
 Returns the legend model.
 %End
 
+
     void setAutoUpdateModel( bool autoUpdate );
 %Docstring
 Sets whether the legend content should auto update to reflect changes in the project's

--- a/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
@@ -122,6 +122,7 @@ Returns whether the legend should automatically resize to fit its contents.
 Returns the legend model.
 %End
 
+
     void setAutoUpdateModel( bool autoUpdate );
 %Docstring
 Sets whether the legend content should auto update to reflect changes in the project's

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -319,16 +319,23 @@ void QgsLayoutItemLegend::setCustomLayerTree( QgsLayerTree *rootGroup )
   mCustomLayerTree.reset( rootGroup );
 }
 
-void QgsLayoutItemLegend::ensureModelIsInitialized()
+void QgsLayoutItemLegend::ensureModelIsInitialized() const
 {
   if ( mDeferLegendModelInitialization )
   {
-    mDeferLegendModelInitialization = false;
-    setCustomLayerTree( mCustomLayerTree.release() );
+    QgsLayoutItemLegend *mutableThis = const_cast< QgsLayoutItemLegend * >( this );
+    mutableThis->mDeferLegendModelInitialization = false;
+    mutableThis->setCustomLayerTree( mutableThis->mCustomLayerTree.release() );
   }
 }
 
 QgsLegendModel *QgsLayoutItemLegend::model()
+{
+  ensureModelIsInitialized();
+  return mLegendModel.get();
+}
+
+const QgsLegendModel *QgsLayoutItemLegend::model() const
 {
   ensureModelIsInitialized();
   return mLegendModel.get();
@@ -1345,7 +1352,7 @@ bool QgsLayoutItemLegend::accept( QgsStyleEntityVisitorInterface *visitor ) cons
     }
     return true;
   };
-  return visit( mLegendModel->rootGroup( ) );
+  return visit( model()->rootGroup( ) );
 }
 
 bool QgsLayoutItemLegend::isRefreshing() const

--- a/src/core/layout/qgslayoutitemlegend.h
+++ b/src/core/layout/qgslayoutitemlegend.h
@@ -159,6 +159,13 @@ class CORE_EXPORT QgsLayoutItemLegend : public QgsLayoutItem
     QgsLegendModel *model();
 
     /**
+     * Returns the legend model.
+     *
+     * \note Not available in Python bindings
+     */
+    const QgsLegendModel *model() const SIP_SKIP;
+
+    /**
      * Sets whether the legend content should auto update to reflect changes in the project's
      * layer tree.
      * \see autoUpdateModel()
@@ -634,7 +641,7 @@ class CORE_EXPORT QgsLayoutItemLegend : public QgsLayoutItem
 
     void setModelStyleOverrides( const QMap<QString, QString> &overrides );
 
-    void ensureModelIsInitialized();
+    void ensureModelIsInitialized() const;
     std::unique_ptr< QgsLegendModel > mLegendModel;
     std::unique_ptr< QgsLayerTree > mCustomLayerTree;
     bool mDeferLegendModelInitialization = true;


### PR DESCRIPTION
Legend must be initialized before calling style visitor function

Fixes #57609
