### PR TITLE
Ignore =default constructors in doxygen check 

### DIFF
--- a/python/3d/auto_generated/materials/qgsgoochmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsgoochmaterialsettings.sip.in
@@ -30,9 +30,6 @@ with three color components: ambient, diffuse and specular.
   public:
 
     QgsGoochMaterialSettings();
-%Docstring
-Constructor for QgsGoochMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/3d/auto_generated/materials/qgsmetalroughmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsmetalroughmaterialsettings.sip.in
@@ -29,9 +29,6 @@ A PBR metal rough shading material used for rendering.
   public:
 
     QgsMetalRoughMaterialSettings();
-%Docstring
-Constructor for QgsMetalRoughMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/3d/auto_generated/materials/qgsnullmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsnullmaterialsettings.sip.in
@@ -30,9 +30,6 @@ Null shading material used for rendering models and scenes with native textures.
   public:
 
     QgsNullMaterialSettings();
-%Docstring
-Constructor for QgsNullMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
@@ -28,9 +28,6 @@ with three color components: ambient, diffuse and specular.
   public:
 
     QgsPhongMaterialSettings();
-%Docstring
-Constructor for QgsPhongMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
@@ -29,9 +29,6 @@ A phong shading model with diffuse texture map.
   public:
 
     QgsPhongTexturedMaterialSettings();
-%Docstring
-Constructor for QgsPhongTexturedMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/3d/auto_generated/materials/qgssimplelinematerialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgssimplelinematerialsettings.sip.in
@@ -30,9 +30,6 @@ Basic shading material used for rendering simple lines as solid line components.
   public:
 
     QgsSimpleLineMaterialSettings();
-%Docstring
-Constructor for QgsSimpleLineMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/PyQt6/3d/auto_generated/materials/qgsgoochmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsgoochmaterialsettings.sip.in
@@ -30,9 +30,6 @@ with three color components: ambient, diffuse and specular.
   public:
 
     QgsGoochMaterialSettings();
-%Docstring
-Constructor for QgsGoochMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/PyQt6/3d/auto_generated/materials/qgsmetalroughmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsmetalroughmaterialsettings.sip.in
@@ -29,9 +29,6 @@ A PBR metal rough shading material used for rendering.
   public:
 
     QgsMetalRoughMaterialSettings();
-%Docstring
-Constructor for QgsMetalRoughMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/PyQt6/3d/auto_generated/materials/qgsnullmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsnullmaterialsettings.sip.in
@@ -30,9 +30,6 @@ Null shading material used for rendering models and scenes with native textures.
   public:
 
     QgsNullMaterialSettings();
-%Docstring
-Constructor for QgsNullMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/PyQt6/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
@@ -28,9 +28,6 @@ with three color components: ambient, diffuse and specular.
   public:
 
     QgsPhongMaterialSettings();
-%Docstring
-Constructor for QgsPhongMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/PyQt6/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgsphongtexturedmaterialsettings.sip.in
@@ -29,9 +29,6 @@ A phong shading model with diffuse texture map.
   public:
 
     QgsPhongTexturedMaterialSettings();
-%Docstring
-Constructor for QgsPhongTexturedMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/PyQt6/3d/auto_generated/materials/qgssimplelinematerialsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/materials/qgssimplelinematerialsettings.sip.in
@@ -30,9 +30,6 @@ Basic shading material used for rendering simple lines as solid line components.
   public:
 
     QgsSimpleLineMaterialSettings();
-%Docstring
-Constructor for QgsSimpleLineMaterialSettings.
-%End
 
     virtual QString type() const;
 

--- a/python/PyQt6/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/PyQt6/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -40,9 +40,6 @@ based on a transformation method and a list of GCPs.
     };
 
     QgsGcpTransformerInterface();
-%Docstring
-Constructor for QgsGcpTransformerInterface
-%End
 
     virtual ~QgsGcpTransformerInterface();
 

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -25,9 +25,6 @@ Constructor for :py:class:`QgsInterpolatorVertexData` with the specified
 %End
 
   QgsInterpolatorVertexData();
-%Docstring
-Constructor for :py:class:`QgsInterpolatorVertexData`
-%End
 
   double x;
   double y;

--- a/python/PyQt6/analysis/auto_generated/network/qgsgraph.sip.in
+++ b/python/PyQt6/analysis/auto_generated/network/qgsgraph.sip.in
@@ -24,9 +24,6 @@ This class implements a graph edge
   public:
 
     QgsGraphEdge();
-%Docstring
-Constructor for QgsGraphEdge.
-%End
 
     QVariant cost( int strategyIndex ) const;
 %Docstring
@@ -71,9 +68,6 @@ This class implements a graph vertex
   public:
 
     QgsGraphVertex();
-%Docstring
-Default constructor. It is needed for Qt's container, e.g. QVector
-%End
 
 
     QgsGraphVertex( const QgsPointXY &point );
@@ -115,9 +109,6 @@ Mathematical graph representation
   public:
 
     QgsGraph();
-%Docstring
-Constructor for QgsGraph.
-%End
 
 
     int addVertex( const QgsPointXY &pt );

--- a/python/PyQt6/analysis/auto_generated/network/qgsnetworkstrategy.sip.in
+++ b/python/PyQt6/analysis/auto_generated/network/qgsnetworkstrategy.sip.in
@@ -38,9 +38,6 @@ implemented in the analysis library: :py:class:`QgsNetworkDistanceStrategy` and 
   public:
 
     QgsNetworkStrategy();
-%Docstring
-Default constructor
-%End
 
     virtual ~QgsNetworkStrategy();
 

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
@@ -62,9 +62,6 @@ Represents a node in a raster calculator.
     };
 
     QgsRasterCalcNode();
-%Docstring
-Constructor for QgsRasterCalcNode.
-%End
 
     QgsRasterCalcNode( double number );
     QgsRasterCalcNode( QgsRasterMatrix *matrix );

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastermatrix.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastermatrix.sip.in
@@ -55,9 +55,6 @@ Represents a matrix in a raster calculator operation.
     };
 
     QgsRasterMatrix();
-%Docstring
-Takes ownership of data array
-%End
 
     QgsRasterMatrix( const QgsRasterMatrix &m );
     ~QgsRasterMatrix();

--- a/python/PyQt6/core/auto_generated/3d/qgs3drendererregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/3d/qgs3drendererregistry.sip.in
@@ -56,10 +56,8 @@ Keeps track of available 3D renderers. Should be accessed through :py:func:`QgsA
 #include "qgs3drendererregistry.h"
 %End
   public:
+
     Qgs3DRendererRegistry();
-%Docstring
-Creates registry of 3D renderers
-%End
 
     ~Qgs3DRendererRegistry();
 

--- a/python/PyQt6/core/auto_generated/3d/qgsabstract3drenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/3d/qgsabstract3drenderer.sip.in
@@ -52,10 +52,8 @@ Resolves references to other objects - second phase of loading - after :py:func:
 %End
 
   protected:
+
     QgsAbstract3DRenderer();
-%Docstring
-Default constructor
-%End
 
   private:
     QgsAbstract3DRenderer( const QgsAbstract3DRenderer & );

--- a/python/PyQt6/core/auto_generated/3d/qgsabstractpointcloud3drenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/3d/qgsabstractpointcloud3drenderer.sip.in
@@ -34,10 +34,8 @@ Updates the 3D renderer's symbol to match that of a given :py:class:`QgsPointClo
 %End
 
   protected:
+
     QgsAbstractPointCloud3DRenderer();
-%Docstring
-Default constructor
-%End
 
   private:
     QgsAbstractPointCloud3DRenderer( const QgsAbstractPointCloud3DRenderer & );

--- a/python/PyQt6/core/auto_generated/actions/qgsaction.sip.in
+++ b/python/PyQt6/core/auto_generated/actions/qgsaction.sip.in
@@ -22,9 +22,6 @@ Utility class that encapsulates an action based on vector attributes.
   public:
 
     QgsAction();
-%Docstring
-Default constructor
-%End
 
     QgsAction( Qgis::AttributeActionType type, const QString &description, const QString &command, bool capture = false);
 %Docstring

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationitem.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationitem.sip.in
@@ -50,9 +50,6 @@ Abstract base class for annotation items which are drawn with :py:class:`QgsAnno
   public:
 
     QgsAnnotationItem();
-%Docstring
-Constructor for an annotation item.
-%End
 
 
     virtual ~QgsAnnotationItem();

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationitemnode.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationitemnode.sip.in
@@ -23,9 +23,6 @@ Contains information about a node used for editing an annotation item.
   public:
 
     QgsAnnotationItemNode();
-%Docstring
-Default constructor
-%End
 
     QgsAnnotationItemNode( const QgsVertexId &id, const QgsPointXY &point, Qgis::AnnotationItemNodeType type );
 %Docstring

--- a/python/PyQt6/core/auto_generated/diagram/qgsdiagram.sip.in
+++ b/python/PyQt6/core/auto_generated/diagram/qgsdiagram.sip.in
@@ -80,9 +80,6 @@ Returns the size of the legend item for the diagram corresponding to a specified
   protected:
 
     QgsDiagram();
-%Docstring
-Constructor for QgsDiagram.
-%End
     QgsDiagram( const QgsDiagram &other );
 
     void setPenWidth( QPen &pen, const QgsDiagramSettings &s, const QgsRenderContext &c );

--- a/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -28,9 +28,6 @@ Contains configuration settings for an editor form.
     struct GroupData
     {
       GroupData();
-%Docstring
-Constructor for GroupData
-%End
       GroupData( const QString &name, const QList<QString> &fields );
       QString mName;
       QList<QString> mFields;
@@ -39,9 +36,6 @@ Constructor for GroupData
     struct TabData
     {
       TabData();
-%Docstring
-Constructor for TabData
-%End
       TabData( const QString &name, const QList<QString> &fields, const QList<QgsEditFormConfig::GroupData> &groups );
       QString mName;
       QList<QString> mFields;

--- a/python/PyQt6/core/auto_generated/effects/qgsblureffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgsblureffect.sip.in
@@ -38,9 +38,6 @@ Creates a new QgsBlurEffect effect from a properties string map.
 %End
 
     QgsBlurEffect();
-%Docstring
-Constructor for QgsBlurEffect.
-%End
 
     virtual QString type() const;
     virtual QVariantMap properties() const;

--- a/python/PyQt6/core/auto_generated/effects/qgseffectstack.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgseffectstack.sip.in
@@ -43,9 +43,6 @@ the map parameter, and always returns an empty effect stack.
 %End
 
     QgsEffectStack();
-%Docstring
-Constructor for empty QgsEffectStack.
-%End
 
     QgsEffectStack( const QgsEffectStack &other );
 

--- a/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
@@ -84,9 +84,6 @@ and render the result to the render context's paint device.
     };
 
     QgsPaintEffect();
-%Docstring
-Constructor for QgsPaintEffect.
-%End
 
     QgsPaintEffect( const QgsPaintEffect &other );
     virtual ~QgsPaintEffect();
@@ -337,9 +334,6 @@ If no alterations are performed then the original picture will be rendered as a 
   public:
 
     QgsDrawSourceEffect();
-%Docstring
-Constructor for QgsDrawSourceEffect
-%End
 
     static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring

--- a/python/PyQt6/core/auto_generated/effects/qgstransformeffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgstransformeffect.sip.in
@@ -31,9 +31,6 @@ Creates a new QgsTransformEffect effect from a properties string map.
 %End
 
     QgsTransformEffect();
-%Docstring
-Constructor for QgsTransformEffect.
-%End
 
     virtual QString type() const;
     virtual QVariantMap properties() const;

--- a/python/PyQt6/core/auto_generated/elevation/qgsterrainprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgsterrainprovider.sip.in
@@ -139,9 +139,6 @@ Returns the vertical ``offset`` value, used for adjusting the heights from the t
   protected:
 
     QgsAbstractTerrainProvider();
-%Docstring
-Constructor for QgsAbstractTerrainProvider.
-%End
 
 
     void writeCommonProperties( QDomElement &element, const QgsReadWriteContext &context ) const;
@@ -175,9 +172,6 @@ A terrain provider where the terrain is a simple flat surface.
   public:
 
     QgsFlatTerrainProvider();
-%Docstring
-Constructor for QgsFlatTerrainProvider.
-%End
 
     virtual QString type() const;
 
@@ -211,9 +205,6 @@ A terrain provider where the terrain source is a raster DEM layer.
   public:
 
     QgsRasterDemTerrainProvider();
-%Docstring
-Constructor for QgsRasterDemTerrainProvider.
-%End
 
 
     virtual QString type() const;
@@ -267,9 +258,6 @@ A terrain provider that uses the Z values of a mesh layer to build a terrain sur
   public:
 
     QgsMeshTerrainProvider();
-%Docstring
-Constructor for QgsMeshTerrainProvider.
-%End
 
 
     virtual QString type() const;

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -295,9 +295,6 @@ Returns a reference to the current object if no optimizations were applied.
   protected:
 
     QgsExpressionNode();
-%Docstring
-Constructor.
-%End
 
     QgsExpressionNode( const QgsExpressionNode &other );
 %Docstring

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
@@ -28,9 +28,6 @@ Field formatter for a checkbox field.
     };
 
     QgsCheckBoxFieldFormatter();
-%Docstring
-Constructor for QgsCheckBoxFieldFormatter.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -29,9 +29,6 @@ the field configuration.
     static QString DATETIME_DISPLAY_FORMAT; //! Date time display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
 
     QgsDateTimeFieldFormatter();
-%Docstring
-Default constructor of field formatter for a date time field.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsfallbackfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsfallbackfieldformatter.sip.in
@@ -21,9 +21,6 @@ The values will be returned unmodified.
   public:
 
     QgsFallbackFieldFormatter();
-%Docstring
-Default constructor of field formatter as a fallback when no specialized formatter is defined.
-%End
     virtual QString id() const;
 
 };

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgskeyvaluefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgskeyvaluefieldformatter.sip.in
@@ -25,9 +25,6 @@ E.g. "color: yellow, amount: 5"
   public:
 
     QgsKeyValueFieldFormatter();
-%Docstring
-Default constructor of field formatter for a key value field.
-%End
     virtual QString id() const;
 
     virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgslistfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgslistfieldformatter.sip.in
@@ -22,9 +22,6 @@ Values will be represented as a comma-separated list.
   public:
 
     QgsListFieldFormatter();
-%Docstring
-Default constructor of field formatter for a list field.
-%End
     virtual QString id() const;
 
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsrangefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsrangefieldformatter.sip.in
@@ -19,9 +19,6 @@ Field formatter for a range (double) field with precision and locale.
   public:
 
     QgsRangeFieldFormatter();
-%Docstring
-Default constructor of field formatter for a range (double)field.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -30,9 +30,6 @@ Constructor for ValueRelationItem
 %End
 
       ValueRelationItem();
-%Docstring
-Constructor for ValueRelationItem
-%End
 
       QVariant key;
       QString value;

--- a/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -88,9 +88,6 @@ Abstract base class for all geometries
     };
 
     QgsAbstractGeometry();
-%Docstring
-Constructor for QgsAbstractGeometry.
-%End
     virtual ~QgsAbstractGeometry();
     QgsAbstractGeometry( const QgsAbstractGeometry &geom );
 
@@ -983,10 +980,8 @@ Java-style iterator for traversal of vertices of a geometry
 #include "qgsabstractgeometry.h"
 %End
   public:
+
     QgsVertexIterator();
-%Docstring
-Constructor for QgsVertexIterator
-%End
 
     QgsVertexIterator( const QgsAbstractGeometry *geometry );
 %Docstring
@@ -1030,10 +1025,8 @@ Java-style iterator for traversal of parts of a geometry
 #include "qgsabstractgeometry.h"
 %End
   public:
+
     QgsGeometryPartIterator();
-%Docstring
-Constructor for QgsGeometryPartIterator
-%End
 
     QgsGeometryPartIterator( QgsAbstractGeometry *geometry );
 %Docstring
@@ -1078,10 +1071,8 @@ Java-style iterator for const traversal of parts of a geometry
 #include "qgsabstractgeometry.h"
 %End
   public:
+
     QgsGeometryConstPartIterator();
-%Docstring
-Constructor for QgsGeometryConstPartIterator
-%End
 
     QgsGeometryConstPartIterator( const QgsAbstractGeometry *geometry );
 %Docstring

--- a/python/PyQt6/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgscurve.sip.in
@@ -22,9 +22,6 @@ Abstract base class for curved geometry type
   public:
 
     QgsCurve();
-%Docstring
-Constructor for QgsCurve.
-%End
 
     virtual bool equals( const QgsCurve &other ) const = 0;
 %Docstring

--- a/python/PyQt6/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
@@ -67,9 +67,6 @@ and ``crs``.
 %End
 
     QgsReferencedRectangle();
-%Docstring
-Constructor for QgsReferencedRectangle.
-%End
 
     operator QVariant() const;
 
@@ -103,9 +100,6 @@ and ``crs``.
 %End
 
     QgsReferencedPointXY();
-%Docstring
-Constructor for QgsReferencedPointXY.
-%End
 
     operator QVariant() const;
 
@@ -141,9 +135,6 @@ and ``crs``.
 %End
 
     QgsReferencedGeometry();
-%Docstring
-Constructor for QgsReferencedGeometry.
-%End
 
     operator QVariant() const;
 

--- a/python/PyQt6/core/auto_generated/gps/qgsbabelgpsdevice.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgsbabelgpsdevice.sip.in
@@ -24,9 +24,6 @@ A babel format capable of interacting directly with a GPS device.
   public:
 
     QgsBabelGpsDeviceFormat();
-%Docstring
-Default constructor
-%End
 
     QgsBabelGpsDeviceFormat( const QString &waypointDownloadCommand,
                              const QString &waypointUploadCommand,

--- a/python/PyQt6/core/auto_generated/gps/qgsgpsconnectionregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgsgpsconnectionregistry.sip.in
@@ -27,9 +27,6 @@ is available to all classes and plugins.
   public:
 
     QgsGpsConnectionRegistry();
-%Docstring
-Constructor for QgsGpsConnectionRegistry.
-%End
     ~QgsGpsConnectionRegistry();
 
 

--- a/python/PyQt6/core/auto_generated/labeling/qgscalloutposition.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgscalloutposition.sip.in
@@ -33,9 +33,6 @@ Constructor for QgsCalloutPosition.
 %End
 
     QgsCalloutPosition();
-%Docstring
-Constructor for QgsCalloutPosition
-%End
 
     QgsFeatureId featureId;
 

--- a/python/PyQt6/core/auto_generated/labeling/qgslabelposition.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgslabelposition.sip.in
@@ -44,9 +44,6 @@ Constructor for QgsLabelPosition.
 %End
 
     QgsLabelPosition();
-%Docstring
-Constructor for QgsLabelPosition
-%End
 
     SIP_PYOBJECT __repr__();
 %MethodCode

--- a/python/PyQt6/core/auto_generated/labeling/qgsvectorlayerlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgsvectorlayerlabeling.sip.in
@@ -31,9 +31,6 @@ Abstract base class - its implementations define different approaches to the lab
   public:
 
     QgsAbstractVectorLayerLabeling();
-%Docstring
-Default constructor
-%End
     virtual ~QgsAbstractVectorLayerLabeling();
 
     virtual QString type() const = 0;

--- a/python/PyQt6/core/auto_generated/layout/qgslayouteffect.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayouteffect.sip.in
@@ -27,9 +27,6 @@ onto a scene with custom composition modes.
   public:
 
     QgsLayoutEffect();
-%Docstring
-Constructor for QgsLayoutEffect.
-%End
 
  void setCompositionMode( QPainter::CompositionMode mode ) /Deprecated/;
 %Docstring

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutmeasurementconverter.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutmeasurementconverter.sip.in
@@ -27,9 +27,6 @@ dots per inch (DPI) property for the converter. Converters default to using
   public:
 
     QgsLayoutMeasurementConverter();
-%Docstring
-Constructor for QgsLayoutMeasurementConverter.
-%End
 
     void setDpi( const double dpi );
 %Docstring

--- a/python/PyQt6/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayouttable.sip.in
@@ -34,9 +34,6 @@ Styling option for a layout table cell
   public:
 
     QgsLayoutTableStyle();
-%Docstring
-Constructor for QgsLayoutTableStyle
-%End
 
     bool enabled;
 

--- a/python/PyQt6/core/auto_generated/locator/qgslocatorcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/locator/qgslocatorcontext.sip.in
@@ -21,9 +21,6 @@ Encapsulates the properties relating to the context of a locator search.
   public:
 
     QgsLocatorContext();
-%Docstring
-Constructor for QgsLocatorContext.
-%End
 
     QgsRectangle targetExtent;
 

--- a/python/PyQt6/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/PyQt6/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -23,9 +23,6 @@ Encapsulates properties of an individual matching result found by a :py:class:`Q
   public:
 
     QgsLocatorResult();
-%Docstring
-Constructor for QgsLocatorResult.
-%End
 
     QgsLocatorResult( QgsLocatorFilter *filter, const QString &displayString, const QVariant &userData = QVariant() );
 %Docstring
@@ -61,10 +58,8 @@ Set ``userData`` for the locator result
     struct ResultAction
     {
       public:
+
         ResultAction();
-%Docstring
-Constructor for ResultAction
-%End
 
         ResultAction( int id, QString text, QString iconPath = QString() );
 %Docstring

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
@@ -127,9 +127,6 @@ expressionZ: "if( $vertex_x <= 100 , $vertex_z + 80 , $vertex_z - 150)"
   public:
 
     QgsMeshTransformVerticesByExpression();
-%Docstring
-Constructor
-%End
 
     virtual QString text() const;
 

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -586,10 +586,8 @@ Abstract class that represents a dataset
 #include "qgsmeshdataset.h"
 %End
   public:
+
     QgsMeshDataset();
-%Docstring
-Constructor
-%End
 
     virtual ~QgsMeshDataset();
 
@@ -647,9 +645,6 @@ Abstract class that represents a dataset group
     };
 
     QgsMeshDatasetGroup();
-%Docstring
-Default constructor
-%End
     virtual ~QgsMeshDatasetGroup();
 
     QgsMeshDatasetGroup( const QString &name );

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
@@ -29,9 +29,6 @@ Other option has also to be set before calling :py:func:`QgsMeshEditor.advancedE
   public:
 
     QgsMeshEditForceByLine();
-%Docstring
-Constructor
-%End
 
     void setInputLine( const QgsPoint &pt1, const QgsPoint &pt2, double tolerance, bool newVertexOnIntersection );
 %Docstring
@@ -84,9 +81,6 @@ before applying the edition with :py:func:`QgsMeshEditor.advancedEdit()`
   public:
 
     QgsMeshEditForceByPolylines();
-%Docstring
-Constructor
-%End
 
     virtual QString text() const;
 

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshlayerlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshlayerlabeling.sip.in
@@ -27,9 +27,6 @@ Abstract base class - its implementations define different approaches to the lab
   public:
 
     QgsAbstractMeshLayerLabeling();
-%Docstring
-Default constructor
-%End
     virtual ~QgsAbstractMeshLayerLabeling();
 
     virtual QString type() const = 0;

--- a/python/PyQt6/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
@@ -47,9 +47,6 @@ Constructor for QgsLayerMetadataProviderResult.
 %End
 
     QgsLayerMetadataProviderResult( );
-%Docstring
-Default constructor.
-%End
 
     const QgsPolygon &geographicExtent() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/metadata/qgslayermetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgslayermetadata.sip.in
@@ -109,9 +109,6 @@ Constructor for Constraint.
     typedef QList< QgsLayerMetadata::Constraint > ConstraintList;
 
     QgsLayerMetadata();
-%Docstring
-Constructor for QgsLayerMetadata.
-%End
 
 
     virtual QgsLayerMetadata *clone() const /Factory/;

--- a/python/PyQt6/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
@@ -89,9 +89,6 @@ A validator for the native base QGIS metadata schema definition.
   public:
 
     QgsNativeMetadataBaseValidator();
-%Docstring
-Constructor for QgsNativeMetadataBaseValidator.
-%End
 
     virtual bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results /Out/ ) const;
 
@@ -110,11 +107,7 @@ A validator for the native QGIS layer metadata schema definition.
 #include "qgslayermetadatavalidator.h"
 %End
   public:
-
     QgsNativeMetadataValidator();
-%Docstring
-Constructor for QgsNativeMetadataValidator.
-%End
 
     virtual bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results /Out/ ) const;
 
@@ -136,9 +129,6 @@ A validator for the native QGIS project metadata schema definition.
   public:
 
     QgsNativeProjectMetadataValidator();
-%Docstring
-Constructor for QgsNativeProjectMetadataValidator.
-%End
 
     virtual bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results /Out/ ) const;
 

--- a/python/PyQt6/core/auto_generated/metadata/qgsprojectmetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgsprojectmetadata.sip.in
@@ -43,9 +43,6 @@ using :py:class:`QgsNativeProjectMetadataValidator`.
   public:
 
     QgsProjectMetadata();
-%Docstring
-Constructor for QgsProjectMetadata.
-%End
 
     virtual QgsProjectMetadata *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -31,9 +31,6 @@ Encapsulates parameters and properties of a network request.
     };
 
     QgsNetworkRequestParameters();
-%Docstring
-Default constructor.
-%End
 
     QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation,
                                  const QNetworkRequest &request,

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkcontentfetcher.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkcontentfetcher.sip.in
@@ -28,9 +28,6 @@ handled.
   public:
 
     QgsNetworkContentFetcher();
-%Docstring
-Constructor for QgsNetworkContentFetcher.
-%End
 
     ~QgsNetworkContentFetcher();
 

--- a/python/PyQt6/core/auto_generated/numericformats/qgsfallbacknumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsfallbacknumericformat.sip.in
@@ -21,9 +21,6 @@ A basic numeric formatter which returns a simple text representation of a value.
   public:
 
     QgsFallbackNumericFormat();
-%Docstring
-Default constructor
-%End
     virtual QString id() const;
 
     virtual QString visibleName() const;

--- a/python/PyQt6/core/auto_generated/numericformats/qgsnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsnumericformat.sip.in
@@ -207,9 +207,6 @@ This is an abstract base class and will always need to be subclassed.
   public:
 
     QgsNumericFormat();
-%Docstring
-Default constructor
-%End
 
     virtual ~QgsNumericFormat();
 

--- a/python/PyQt6/core/auto_generated/plot/qgsplot.sip.in
+++ b/python/PyQt6/core/auto_generated/plot/qgsplot.sip.in
@@ -29,9 +29,6 @@ Base class for plot/chart/graphs.
   public:
 
     QgsPlot();
-%Docstring
-Constructor for QgsPlot.
-%End
 
     virtual ~QgsPlot();
 

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudclassifiedrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudclassifiedrenderer.sip.in
@@ -24,9 +24,6 @@ Represents an individual category (class) from a :py:class:`QgsPointCloudClassif
   public:
 
     QgsPointCloudCategory();
-%Docstring
-Constructor for QgsPointCloudCategory.
-%End
 
     QgsPointCloudCategory( int value, const QColor &color, const QString &label, bool render = true, double pointSize = 0 );
 %Docstring

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -194,9 +194,6 @@ Abstract base class for 2d point cloud renderers.
   public:
 
     QgsPointCloudRenderer();
-%Docstring
-Constructor for QgsPointCloudRenderer.
-%End
 
     virtual ~QgsPointCloudRenderer();
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -1151,9 +1151,6 @@ algorithm in "chains", avoiding the need for temporary outputs in multi-step mod
   public:
 
     QgsProcessingFeatureBasedAlgorithm();
-%Docstring
-Constructor for QgsProcessingFeatureBasedAlgorithm.
-%End
 
     virtual Qgis::ProcessingAlgorithmFlags flags() const /HoldGIL/;
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -216,9 +216,6 @@ Constructor for LayerDetails.
 %End
 
         LayerDetails();
-%Docstring
-Default constructor
-%End
 
         QString name;
 

--- a/python/PyQt6/core/auto_generated/project/qgsprojectproperty.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectproperty.sip.in
@@ -116,9 +116,6 @@ Project property value node, contains a :py:class:`QgsProjectPropertyKey`'s valu
   public:
 
     QgsProjectPropertyValue();
-%Docstring
-Constructor for QgsProjectPropertyValue.
-%End
 
     QgsProjectPropertyValue( const QVariant &value );
 %Docstring

--- a/python/PyQt6/core/auto_generated/project/qgsprojectservervalidator.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectservervalidator.sip.in
@@ -24,9 +24,6 @@ Validates the server specific parts of the configuration of a QGIS project.
   public:
 
     QgsProjectServerValidator();
-%Docstring
-Constructor for QgsProjectServerValidator.
-%End
 
     enum ValidationError /BaseType=IntEnum/
     {

--- a/python/PyQt6/core/auto_generated/qgsattributetableconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsattributetableconfig.sip.in
@@ -31,9 +31,6 @@ The configuration is specific for one vector layer.
     struct ColumnConfig
     {
       ColumnConfig();
-%Docstring
-Constructor for ColumnConfig
-%End
 
 
       QgsAttributeTableConfig::Type type;
@@ -52,9 +49,6 @@ Constructor for ColumnConfig
     };
 
     QgsAttributeTableConfig();
-%Docstring
-Constructor for QgsAttributeTableConfig.
-%End
 
     QVector<QgsAttributeTableConfig::ColumnConfig> columns() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgscacheindex.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscacheindex.sip.in
@@ -22,9 +22,6 @@ Abstract base class for cache indices
   public:
 
     QgsAbstractCacheIndex();
-%Docstring
-Constructor for QgsAbstractCacheIndex.
-%End
     virtual ~QgsAbstractCacheIndex();
 
     virtual void flushFeature( QgsFeatureId fid ) = 0;

--- a/python/PyQt6/core/auto_generated/qgscolorrampimpl.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorrampimpl.sip.in
@@ -493,9 +493,6 @@ to some hardcoded saturation and value ranges to prevent ugly color generation.
   public:
 
     QgsRandomColorRamp();
-%Docstring
-Constructor for QgsRandomColorRamp.
-%End
 
     virtual int count() const;
 

--- a/python/PyQt6/core/auto_generated/qgscolorscheme.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorscheme.sip.in
@@ -51,9 +51,6 @@ can be generated using an optional base color.
 
 
     QgsColorScheme();
-%Docstring
-Constructor for QgsColorScheme.
-%End
 
     virtual ~QgsColorScheme();
 
@@ -132,9 +129,6 @@ A color scheme which stores its colors in a gpl palette file.
   public:
 
     QgsGplColorScheme();
-%Docstring
-Constructor for QgsGplColorScheme.
-%End
 
      virtual QgsNamedColorList fetchColors( const QString &context = QString(),
                                    const QColor &baseColor = QColor() );
@@ -226,9 +220,6 @@ A color scheme which contains the most recently used colors.
   public:
 
     QgsRecentColorScheme();
-%Docstring
-Constructor for QgsRecentColorScheme.
-%End
 
     virtual QString schemeName() const;
 
@@ -269,9 +260,6 @@ A color scheme which contains custom colors set through QGIS app options dialog.
   public:
 
     QgsCustomColorScheme();
-%Docstring
-Constructor for QgsCustomColorScheme.
-%End
 
     virtual QString schemeName() const;
 
@@ -301,9 +289,6 @@ A color scheme which contains project specific colors set through project proper
   public:
 
     QgsProjectColorScheme();
-%Docstring
-Constructor for QgsProjectColorScheme.
-%End
 
     virtual QString schemeName() const;
 

--- a/python/PyQt6/core/auto_generated/qgscredentials.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscredentials.sip.in
@@ -92,9 +92,6 @@ Returns pointer to mutex
   protected:
 
     QgsCredentials();
-%Docstring
-Constructor for QgsCredentials.
-%End
 
     virtual bool request( const QString &realm, QString &username /In,Out/, QString &password /In,Out/, const QString &message = QString() ) = 0;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsdartmeasurement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdartmeasurement.sip.in
@@ -24,9 +24,6 @@ class QgsDartMeasurement
     };
 
     QgsDartMeasurement();
-%Docstring
-Constructor for QgsDartMeasurement
-%End
 
     QgsDartMeasurement( const QString &name, Type type, const QString &value );
 

--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -604,9 +604,6 @@ Evaluates and returns the diagram settings relating to a diagram for a specific 
   public:
 
     QgsDiagramRenderer();
-%Docstring
-Constructor for QgsDiagramRenderer.
-%End
     virtual ~QgsDiagramRenderer();
 
     virtual QgsDiagramRenderer *clone() const = 0 /Factory/;
@@ -744,9 +741,6 @@ Renders the diagrams for all features with the same settings
   public:
 
     QgsSingleCategoryDiagramRenderer();
-%Docstring
-Constructor for QgsSingleCategoryDiagramRenderer
-%End
 
     virtual QgsSingleCategoryDiagramRenderer *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/qgseditorwidgetsetup.sip.in
+++ b/python/PyQt6/core/auto_generated/qgseditorwidgetsetup.sip.in
@@ -25,9 +25,6 @@ Constructor
 %End
 
     QgsEditorWidgetSetup();
-%Docstring
-Constructor for QgsEditorWidgetSetup
-%End
 
     QString type() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgselevationmap.sip.in
+++ b/python/PyQt6/core/auto_generated/qgselevationmap.sip.in
@@ -33,9 +33,6 @@ in meters.
   public:
 
     QgsElevationMap();
-%Docstring
-Default constructor
-%End
 
     explicit QgsElevationMap( const QSize &size, float devicePixelRatio = 1.0 );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgserror.sip.in
+++ b/python/PyQt6/core/auto_generated/qgserror.sip.in
@@ -27,9 +27,6 @@ class QgsErrorMessage
     };
 
     QgsErrorMessage();
-%Docstring
-Constructor for QgsErrorMessage
-%End
 
     QgsErrorMessage( const QString &message, const QString &tag = QString(), const QString &file = QString(), const QString &function = QString(), int line = 0 );
 %Docstring
@@ -64,9 +61,6 @@ Higher level messages are appended at the end.
   public:
 
     QgsError();
-%Docstring
-Constructor for QgsError
-%End
 
     QgsError( const QString &message, const QString &tag );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsexpressionfieldbuffer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsexpressionfieldbuffer.sip.in
@@ -29,9 +29,6 @@ Buffers information about expression fields for a vector layer.
     };
 
     QgsExpressionFieldBuffer();
-%Docstring
-Constructor for QgsExpressionFieldBuffer.
-%End
 
     void addExpression( const QString &exp, const QgsField &fld );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsfeaturestore.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturestore.sip.in
@@ -18,9 +18,6 @@ A container for features with the same fields and crs.
 %End
   public:
     QgsFeatureStore();
-%Docstring
-Constructor
-%End
 
     QgsFeatureStore( const QgsFields &fields, const QgsCoordinateReferenceSystem &crs );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
@@ -23,9 +23,6 @@ A context for field formatter containing information like the project
   public:
 
     QgsFieldFormatterContext();
-%Docstring
-Constructor
-%End
 
     QgsProject *project() const;
 %Docstring
@@ -63,9 +60,6 @@ This is an abstract base class and will always need to be subclassed.
   public:
 
     QgsFieldFormatter();
-%Docstring
-Default constructor
-%End
 
     virtual ~QgsFieldFormatter();
 

--- a/python/PyQt6/core/auto_generated/qgsgmlschema.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsgmlschema.sip.in
@@ -20,9 +20,6 @@ Description of feature class in GML
   public:
 
     QgsGmlFeatureClass();
-%Docstring
-Constructor for QgsGmlFeatureClass.
-%End
     QgsGmlFeatureClass( const QString &name, const QString &path );
 
     QList<QgsField> &fields();

--- a/python/PyQt6/core/auto_generated/qgshistogram.sip.in
+++ b/python/PyQt6/core/auto_generated/qgshistogram.sip.in
@@ -25,9 +25,6 @@ Calculator for a numeric histogram from a list of values.
   public:
 
     QgsHistogram();
-%Docstring
-Constructor for QgsHistogram.
-%End
 
     virtual ~QgsHistogram();
 

--- a/python/PyQt6/core/auto_generated/qgsidentifycontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsidentifycontext.sip.in
@@ -23,9 +23,6 @@ an identify action.
   public:
 
     QgsIdentifyContext();
-%Docstring
-Constructor for QgsIdentifyContext
-%End
 
     void setTemporalRange( const QgsDateTimeRange &range );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmapdecoration.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmapdecoration.sip.in
@@ -22,9 +22,6 @@ Interface for map decorations.
   public:
 
     QgsMapDecoration();
-%Docstring
-Constructor for QgsMapDecoration.
-%End
 
     virtual ~QgsMapDecoration();
 

--- a/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
@@ -31,9 +31,6 @@ window for the user.
   public:
 
     QgsMessageLog();
-%Docstring
-Constructor for QgsMessageLog.
-%End
 
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
@@ -87,9 +87,6 @@ be the right choice for apps without GUI.
   public:
 
     QgsMessageOutputConsole();
-%Docstring
-Constructor for QgsMessageOutputConsole.
-%End
 
     virtual void setMessage( const QString &message, MessageType msgType );
 

--- a/python/PyQt6/core/auto_generated/qgsobjectcustomproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsobjectcustomproperties.sip.in
@@ -23,9 +23,6 @@ in \verbatim <customproperties> \endverbatim element.
   public:
 
     QgsObjectCustomProperties();
-%Docstring
-Constructor for QgsObjectCustomProperties.
-%End
 
     QStringList keys() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgspluginlayerregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspluginlayerregistry.sip.in
@@ -61,9 +61,6 @@ A registry of plugin layers types.
   public:
 
     QgsPluginLayerRegistry();
-%Docstring
-Constructor for QgsPluginLayerRegistry.
-%End
     ~QgsPluginLayerRegistry();
 
 

--- a/python/PyQt6/core/auto_generated/qgspointxy.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspointxy.sip.in
@@ -45,6 +45,7 @@ Use cases for which :py:class:`QgsPointXY` is NOT a valid choice include:
     static const QMetaObject staticMetaObject;
 
   public:
+
     QgsPointXY();
 
     QgsPointXY( const QgsPointXY &p ) /HoldGIL/;

--- a/python/PyQt6/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertycollection.sip.in
@@ -468,9 +468,6 @@ priority over earlier collections.
   public:
 
     QgsPropertyCollectionStack();
-%Docstring
-Constructor for QgsPropertyCollectionStack.
-%End
 
     ~QgsPropertyCollectionStack();
 

--- a/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
@@ -262,10 +262,8 @@ A list of nodes.
 #include "qgssqlstatement.h"
 %End
       public:
+
         NodeList();
-%Docstring
-Constructor
-%End
         virtual ~NodeList();
 
         void append( QgsSQLStatement::Node *node /Transfer/ );
@@ -990,10 +988,8 @@ A visitor that recursively explores all children
 #include "qgssqlstatement.h"
 %End
       public:
+
         RecursiveVisitor();
-%Docstring
-Constructor
-%End
 
         virtual void visit( const QgsSQLStatement::NodeUnaryOperator &n );
         virtual void visit( const QgsSQLStatement::NodeBinaryOperator &n );

--- a/python/PyQt6/core/auto_generated/qgsstoredexpressionmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsstoredexpressionmanager.sip.in
@@ -56,9 +56,6 @@ Manages stored expressions regarding creation, modification and storing in the p
   public:
 
     QgsStoredExpressionManager();
-%Docstring
-Constructor for QgsStoredExpressionManager
-%End
 
     QString addStoredExpression( const QString &name, const QString &expression, const QgsStoredExpression::Category &tag =  QgsStoredExpression::Category::FilterExpression );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgstrackedvectorlayertools.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstrackedvectorlayertools.sip.in
@@ -16,9 +16,6 @@ class QgsTrackedVectorLayerTools : QgsVectorLayerTools
   public:
 
     QgsTrackedVectorLayerTools();
-%Docstring
-Constructor for QgsTrackedVectorLayerTools.
-%End
 
     virtual bool addFeatureV2( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature /Out/, const QgsVectorLayerToolsContext &context ) const;
 

--- a/python/PyQt6/core/auto_generated/qgstranslationcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstranslationcontext.sip.in
@@ -24,9 +24,6 @@ Used for the collecting of strings from projects for translation and creation of
   public:
 
     QgsTranslationContext();
-%Docstring
-Constructor
-%End
 
     QgsProject *project() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsunsetattributevalue.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsunsetattributevalue.sip.in
@@ -23,9 +23,6 @@ Represents a default, "not-specified" value for a feature attribute.
   public:
 
     QgsUnsetAttributeValue();
-%Docstring
-Constructor for a QgsUnsetAttributeValue.
-%End
 
     explicit QgsUnsetAttributeValue( const QString &defaultValueClause );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -108,10 +108,8 @@ There are two possibilities how to use this class:
 
     struct MetaData
     {
+
       MetaData();
-%Docstring
-Constructor for MetaData
-%End
 
       MetaData( const QString &longName, const QString &trLongName, const QString &glob, const QString &ext, const QMap<QString, QgsVectorFileWriter::Option *> &driverOptions, const QMap<QString, QgsVectorFileWriter::Option *> &layerOptions, const QString &compulsoryEncoding = QString() );
 
@@ -164,10 +162,8 @@ Interface to convert raw field values to their user-friendly value.
 #include "qgsvectorfilewriter.h"
 %End
       public:
+
         FieldValueConverter();
-%Docstring
-Constructor
-%End
 
         virtual ~FieldValueConverter();
 

--- a/python/PyQt6/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -23,9 +23,6 @@ Bilinear Raster Resampler
   public:
 
     QgsBilinearRasterResampler();
-%Docstring
-Constructor for QgsBilinearRasterResampler.
-%End
  virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
 

--- a/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -45,10 +45,8 @@ Copy constructor
 
     struct ColorRampItem
     {
+
       ColorRampItem();
-%Docstring
-default constructor
-%End
       ColorRampItem( double val, const QColor &col, const QString &lbl = QString() );
 %Docstring
 convenience constructor

--- a/python/PyQt6/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -22,9 +22,6 @@ Cubic Raster Resampler.
   public:
 
     QgsCubicRasterResampler();
-%Docstring
-Constructor for QgsCubicRasterResampler.
-%End
     virtual QgsCubicRasterResampler *clone() const /Factory/;
 
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterbandstats.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterbandstats.sip.in
@@ -24,9 +24,6 @@ raster band.
   public:
 
     QgsRasterBandStats();
-%Docstring
-Constructor for QgsRasterBandStats.
-%End
 
     bool contains( const QgsRasterBandStats &s ) const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/raster/qgsrasteridentifyresult.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasteridentifyresult.sip.in
@@ -21,9 +21,6 @@ Raster identify results container.
   public:
 
     QgsRasterIdentifyResult();
-%Docstring
-Constructor for QgsRasterIdentifyResult.
-%End
 
     QgsRasterIdentifyResult( Qgis::RasterIdentifyFormat format, const QMap<int, QVariant> &results );
 %Docstring

--- a/python/PyQt6/core/auto_generated/raster/qgsrastertransparency.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrastertransparency.sip.in
@@ -21,9 +21,6 @@ transparent when rendering rasters.
   public:
 
     QgsRasterTransparency();
-%Docstring
-Constructor for QgsRasterTransparency.
-%End
 
     struct TransparentThreeValuePixel
     {

--- a/python/PyQt6/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
@@ -20,9 +20,6 @@ Double box with alternating colors.
   public:
 
     QgsDoubleBoxScaleBarRenderer();
-%Docstring
-Constructor for QgsDoubleBoxScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
@@ -23,9 +23,6 @@ alternating segments. AKA "South African" style.
   public:
 
     QgsHollowScaleBarRenderer();
-%Docstring
-Constructor for QgsHollowScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
@@ -20,9 +20,6 @@ A scale bar style that draws text in the form of '1:XXXXX'.
   public:
 
     QgsNumericScaleBarRenderer();
-%Docstring
-Constructor for QgsNumericScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
@@ -58,9 +58,6 @@ custom labeling.
     };
 
     QgsScaleBarRenderer();
-%Docstring
-Constructor for QgsScaleBarRenderer.
-%End
     virtual ~QgsScaleBarRenderer();
 
  QString name() const /Deprecated/;

--- a/python/PyQt6/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
@@ -21,9 +21,6 @@ color for the segments.
   public:
 
     QgsSingleBoxScaleBarRenderer();
-%Docstring
-Constructor for QgsSingleBoxScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgssteppedlinescalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgssteppedlinescalebarrenderer.sip.in
@@ -22,9 +22,6 @@ Scalebar style that draws a stepped line representation of a scalebar.
   public:
 
     QgsSteppedLineScaleBarRenderer();
-%Docstring
-Constructor for QgsSteppedLineScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -21,9 +21,6 @@ Represents an individual category (class) from a :py:class:`QgsCategorizedSymbol
   public:
 
     QgsRendererCategory();
-%Docstring
-Constructor for QgsRendererCategory.
-%End
 
     QgsRendererCategory( const QVariant &value, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true, const QString &uuid = QString() );
 %Docstring

--- a/python/PyQt6/core/auto_generated/symbology/qgslegendsymbolitem.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgslegendsymbolitem.sip.in
@@ -25,9 +25,6 @@ that can be used by legend model for rendering of legend.
   public:
 
     QgsLegendSymbolItem();
-%Docstring
-Constructor for QgsLegendSymbolItem.
-%End
 
     QgsLegendSymbolItem( QgsSymbol *symbol, const QString &label, const QString &ruleKey, bool checkable = false, int scaleMinDenom = -1, int scaleMaxDenom = -1, int level = 0, const QString &parentRuleKey = QString() );
 %Docstring

--- a/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -21,9 +21,6 @@ class QgsRendererRange
   public:
 
     QgsRendererRange();
-%Docstring
-Constructor for QgsRendererRange.
-%End
     ~QgsRendererRange();
 
     QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol /Transfer/, bool render = true, const QString &uuid = QString() );

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
@@ -105,10 +105,8 @@ Type used to refer to a specific symbol layer in a symbol of a layer.
 #include "qgssymbollayerreference.h"
 %End
   public:
+
     QgsSymbolLayerReference();
-%Docstring
-Default constructor
-%End
 
  QgsSymbolLayerReference( const QString &layerId, const QgsSymbolLayerId &symbolLayer ) /Deprecated/;
 %Docstring

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
@@ -31,9 +31,6 @@ settings from a :py:class:`QgsTextFormat` for individual characters (or sets of 
   public:
 
     QgsTextCharacterFormat();
-%Docstring
-Constructor for QgsTextCharacterFormat.
-%End
 
     QgsTextCharacterFormat( const QTextCharFormat &format );
 %Docstring

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
@@ -107,9 +107,6 @@ Abstract base class for 2d tiled scene renderers.
   public:
 
     QgsTiledSceneRenderer();
-%Docstring
-Constructor for QgsTiledSceneRenderer.
-%End
 
     virtual ~QgsTiledSceneRenderer();
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -269,9 +269,6 @@ Emitted after committing an attribute rename
   protected:
 
     QgsVectorLayerEditBuffer();
-%Docstring
-Constructor for QgsVectorLayerEditBuffer
-%End
 
     void updateFeatureGeometry( QgsFeature &f );
 %Docstring

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
@@ -22,9 +22,6 @@ The join is done based on [our layer].targetField = [join layer].joinField
   public:
 
     QgsVectorLayerJoinInfo();
-%Docstring
-Constructor for QgsVectorLayerJoinInfo.
-%End
 
     void setJoinLayer( QgsVectorLayer *layer );
 %Docstring

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
@@ -24,9 +24,6 @@ consider.
   public:
 
     QgsVectorLayerToolsContext();
-%Docstring
-Constructor for QgsVectorLayerToolsContext.
-%End
 
     QgsVectorLayerToolsContext( const QgsVectorLayerToolsContext &other );
 %Docstring

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -35,9 +35,6 @@ Contains mainly the QMap with :py:class:`QgsVectorLayer` and :py:class:`QgsFeatu
       public:
 
         QgsDuplicateFeatureContext();
-%Docstring
-Constructor for QgsDuplicateFeatureContext
-%End
 
         QList<QgsVectorLayer *> layers() const;
 %Docstring

--- a/python/PyQt6/gui/auto_generated/actions/qgsactionmenu.sip.in
+++ b/python/PyQt6/gui/auto_generated/actions/qgsactionmenu.sip.in
@@ -26,9 +26,6 @@ This class is a menu that is populated automatically with the actions defined fo
     {
 
       ActionData();
-%Docstring
-Constructor for ActionData.
-%End
       ActionData( const QgsAction &action, QgsFeatureId featureId, QgsMapLayer *mapLayer );
       ActionData( QgsMapLayerAction *action, QgsFeatureId featureId, QgsMapLayer *mapLayer );
 

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -22,9 +22,6 @@ class QgsFeatureListModel : QSortFilterProxyModel, QgsFeatureModel
       public:
 
         FeatureInfo();
-%Docstring
-Constructor for FeatureInfo.
-%End
 
         bool isNew;
 

--- a/python/PyQt6/gui/auto_generated/history/qgshistoryentrynode.sip.in
+++ b/python/PyQt6/gui/auto_generated/history/qgshistoryentrynode.sip.in
@@ -22,9 +22,6 @@ Base class for nodes representing a :py:class:`QgsHistoryEntry`.
   public:
 
     QgsHistoryEntryNode();
-%Docstring
-Constructor for QgsHistoryEntryNode.
-%End
     virtual ~QgsHistoryEntryNode();
 
 
@@ -108,9 +105,6 @@ Base class for history entry "group" nodes, which contain children of their own.
   public:
 
     QgsHistoryEntryGroup();
-%Docstring
-Constructor for QgsHistoryEntryGroup
-%End
     ~QgsHistoryEntryGroup();
 
 

--- a/python/PyQt6/gui/auto_generated/history/qgshistorywidgetcontext.sip.in
+++ b/python/PyQt6/gui/auto_generated/history/qgshistorywidgetcontext.sip.in
@@ -23,9 +23,6 @@ Contains settings which reflect the context in which a history widget is shown, 
   public:
 
     QgsHistoryWidgetContext();
-%Docstring
-Constructor for QgsHistoryWidgetContext.
-%End
 
     void setMessageBar( QgsMessageBar *bar );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
@@ -118,9 +118,6 @@ Processing toolbox model node corresponding to the recent algorithms group
   public:
 
     QgsProcessingToolboxModelRecentNode();
-%Docstring
-Constructor for QgsProcessingToolboxModelRecentNode.
-%End
 
     virtual NodeType nodeType() const;
 
@@ -144,9 +141,6 @@ Processing toolbox model node corresponding to the favorite algorithms group
   public:
 
     QgsProcessingToolboxModelFavoriteNode();
-%Docstring
-Constructor for :py:class:`QgsProcessingToolboxModelRecentNode`.
-%End
 
     virtual NodeType nodeType() const;
 

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -88,9 +88,6 @@ to fine-tune its behavior.
   public:
 
     QgsProcessingParameterWidgetContext();
-%Docstring
-Constructor for QgsProcessingParameterWidgetContext.
-%End
 
     void setMapCanvas( QgsMapCanvas *canvas );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
@@ -37,9 +37,6 @@ could provide their own implementation to be able to use plugins.
   public:
 
     QgisInterface();
-%Docstring
-Constructor
-%End
 
     virtual QgsPluginManagerInterface *pluginManagerInterface() = 0;
 

--- a/python/PyQt6/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -53,9 +53,6 @@ showing an embedded form due to relations)
     };
 
     QgsAttributeEditorContext();
-%Docstring
-Constructor for QgsAttributeEditorContext
-%End
 
     QgsAttributeEditorContext( const QgsAttributeEditorContext &parentContext, FormMode formMode );
 

--- a/python/PyQt6/gui/auto_generated/qgsdataitemguiprovider.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsdataitemguiprovider.sip.in
@@ -24,9 +24,6 @@ Encapsulates the context in which a :py:class:`QgsDataItem` is shown within the 
   public:
 
     QgsDataItemGuiContext();
-%Docstring
-Constructor for QgsDataItemGuiContext.
-%End
 
     QgsMessageBar *messageBar() const;
 %Docstring

--- a/python/PyQt6/gui/auto_generated/qgsdecoratedscrollbar.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsdecoratedscrollbar.sip.in
@@ -39,9 +39,6 @@ Constructor for QgsScrollBarHighlight.
 %End
 
     QgsScrollBarHighlight();
-%Docstring
-Default constructor for QgsScrollBarHighlight.
-%End
 
     int category;
 

--- a/python/PyQt6/gui/auto_generated/qgsdetaileditemdata.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsdetaileditemdata.sip.in
@@ -22,9 +22,6 @@ This class is the data only representation of a
   public:
 
     QgsDetailedItemData();
-%Docstring
-Constructor for QgsDetailedItemData.
-%End
 
     void setTitle( const QString &title );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -133,10 +133,8 @@ instance to provide custom context menus (opened upon right-click).
 #include "qgsexpressiontreeview.h"
 %End
       public:
+
         explicit MenuProvider();
-%Docstring
-Constructor
-%End
         virtual ~MenuProvider();
 
         virtual QMenu *createContextMenu( QgsExpressionItem *item ) /Factory/;

--- a/python/PyQt6/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsidentifymenu.sip.in
@@ -31,10 +31,8 @@ If used in a :py:class:`QgsMapToolIdentify`, it is accessible via :py:func:`QgsM
 
     struct ActionData
     {
+
       ActionData();
-%Docstring
-Constructor for ActionData
-%End
 
       ActionData( QgsMapLayer *layer, QgsMapLayerAction *mapLayerAction = 0 );
 

--- a/python/PyQt6/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
@@ -27,9 +27,6 @@ Factory class for creating custom map layer property pages
     };
 
     QgsMapLayerConfigWidgetFactory();
-%Docstring
-Constructor
-%End
 
     QgsMapLayerConfigWidgetFactory( const QString &title, const QIcon &icon );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/qgsmaptoolidentify.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaptoolidentify.sip.in
@@ -50,10 +50,8 @@ after selecting a point, performs the identification:
 
     struct IdentifyResult
     {
+
       IdentifyResult();
-%Docstring
-Constructor for IdentifyResult
-%End
 
       IdentifyResult( QgsMapLayer *layer, const QgsFeature &feature, const QMap< QString, QString > &derivedAttributes );
       IdentifyResult( QgsMapLayer *layer, const QString &label, const QMap< QString, QString > &attributes, const QMap< QString, QString > &derivedAttributes );

--- a/python/PyQt6/gui/auto_generated/qgsoptionswidgetfactory.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsoptionswidgetfactory.sip.in
@@ -82,9 +82,6 @@ class QgsOptionsWidgetFactory : QObject
   public:
 
     QgsOptionsWidgetFactory();
-%Docstring
-Constructor
-%End
 
     QgsOptionsWidgetFactory( const QString &title, const QIcon &icon, const QString &key = QString() );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/qgspluginmanagerinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgspluginmanagerinterface.sip.in
@@ -18,9 +18,6 @@ class QgsPluginManagerInterface : QObject
   public:
 
     QgsPluginManagerInterface();
-%Docstring
-Constructor
-%End
 
     virtual void clearPythonPluginMetadata() = 0;
 %Docstring

--- a/python/PyQt6/gui/auto_generated/qgstablewidgetitem.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgstablewidgetitem.sip.in
@@ -20,9 +20,6 @@ specific role can be set to sort.
   public:
 
     QgsTableWidgetItem();
-%Docstring
-Constructor for QgsTableWidgetItem.
-%End
 
     QgsTableWidgetItem( const QString &text );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
@@ -22,9 +22,6 @@ map canvas and relevant expression contexts.
   public:
 
     QgsSymbolWidgetContext();
-%Docstring
-Constructor for QgsSymbolWidgetContext.
-%End
 
     QgsSymbolWidgetContext( const QgsSymbolWidgetContext &other );
 %Docstring

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -40,9 +40,6 @@ based on a transformation method and a list of GCPs.
     };
 
     QgsGcpTransformerInterface();
-%Docstring
-Constructor for QgsGcpTransformerInterface
-%End
 
     virtual ~QgsGcpTransformerInterface();
 

--- a/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -25,9 +25,6 @@ Constructor for :py:class:`QgsInterpolatorVertexData` with the specified
 %End
 
   QgsInterpolatorVertexData();
-%Docstring
-Constructor for :py:class:`QgsInterpolatorVertexData`
-%End
 
   double x;
   double y;

--- a/python/analysis/auto_generated/network/qgsgraph.sip.in
+++ b/python/analysis/auto_generated/network/qgsgraph.sip.in
@@ -24,9 +24,6 @@ This class implements a graph edge
   public:
 
     QgsGraphEdge();
-%Docstring
-Constructor for QgsGraphEdge.
-%End
 
     QVariant cost( int strategyIndex ) const;
 %Docstring
@@ -71,9 +68,6 @@ This class implements a graph vertex
   public:
 
     QgsGraphVertex();
-%Docstring
-Default constructor. It is needed for Qt's container, e.g. QVector
-%End
 
 
     QgsGraphVertex( const QgsPointXY &point );
@@ -115,9 +109,6 @@ Mathematical graph representation
   public:
 
     QgsGraph();
-%Docstring
-Constructor for QgsGraph.
-%End
 
 
     int addVertex( const QgsPointXY &pt );

--- a/python/analysis/auto_generated/network/qgsnetworkstrategy.sip.in
+++ b/python/analysis/auto_generated/network/qgsnetworkstrategy.sip.in
@@ -38,9 +38,6 @@ implemented in the analysis library: :py:class:`QgsNetworkDistanceStrategy` and 
   public:
 
     QgsNetworkStrategy();
-%Docstring
-Default constructor
-%End
 
     virtual ~QgsNetworkStrategy();
 

--- a/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
@@ -62,9 +62,6 @@ Represents a node in a raster calculator.
     };
 
     QgsRasterCalcNode();
-%Docstring
-Constructor for QgsRasterCalcNode.
-%End
 
     QgsRasterCalcNode( double number );
     QgsRasterCalcNode( QgsRasterMatrix *matrix );

--- a/python/analysis/auto_generated/raster/qgsrastermatrix.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastermatrix.sip.in
@@ -55,9 +55,6 @@ Represents a matrix in a raster calculator operation.
     };
 
     QgsRasterMatrix();
-%Docstring
-Takes ownership of data array
-%End
 
     QgsRasterMatrix( const QgsRasterMatrix &m );
     ~QgsRasterMatrix();

--- a/python/core/auto_generated/3d/qgs3drendererregistry.sip.in
+++ b/python/core/auto_generated/3d/qgs3drendererregistry.sip.in
@@ -56,10 +56,8 @@ Keeps track of available 3D renderers. Should be accessed through :py:func:`QgsA
 #include "qgs3drendererregistry.h"
 %End
   public:
+
     Qgs3DRendererRegistry();
-%Docstring
-Creates registry of 3D renderers
-%End
 
     ~Qgs3DRendererRegistry();
 

--- a/python/core/auto_generated/3d/qgsabstract3drenderer.sip.in
+++ b/python/core/auto_generated/3d/qgsabstract3drenderer.sip.in
@@ -52,10 +52,8 @@ Resolves references to other objects - second phase of loading - after :py:func:
 %End
 
   protected:
+
     QgsAbstract3DRenderer();
-%Docstring
-Default constructor
-%End
 
   private:
     QgsAbstract3DRenderer( const QgsAbstract3DRenderer & );

--- a/python/core/auto_generated/3d/qgsabstractpointcloud3drenderer.sip.in
+++ b/python/core/auto_generated/3d/qgsabstractpointcloud3drenderer.sip.in
@@ -34,10 +34,8 @@ Updates the 3D renderer's symbol to match that of a given :py:class:`QgsPointClo
 %End
 
   protected:
+
     QgsAbstractPointCloud3DRenderer();
-%Docstring
-Default constructor
-%End
 
   private:
     QgsAbstractPointCloud3DRenderer( const QgsAbstractPointCloud3DRenderer & );

--- a/python/core/auto_generated/actions/qgsaction.sip.in
+++ b/python/core/auto_generated/actions/qgsaction.sip.in
@@ -22,9 +22,6 @@ Utility class that encapsulates an action based on vector attributes.
   public:
 
     QgsAction();
-%Docstring
-Default constructor
-%End
 
     QgsAction( Qgis::AttributeActionType type, const QString &description, const QString &command, bool capture = false);
 %Docstring

--- a/python/core/auto_generated/annotations/qgsannotationitem.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitem.sip.in
@@ -50,9 +50,6 @@ Abstract base class for annotation items which are drawn with :py:class:`QgsAnno
   public:
 
     QgsAnnotationItem();
-%Docstring
-Constructor for an annotation item.
-%End
 
 
     virtual ~QgsAnnotationItem();

--- a/python/core/auto_generated/annotations/qgsannotationitemnode.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitemnode.sip.in
@@ -23,9 +23,6 @@ Contains information about a node used for editing an annotation item.
   public:
 
     QgsAnnotationItemNode();
-%Docstring
-Default constructor
-%End
 
     QgsAnnotationItemNode( const QgsVertexId &id, const QgsPointXY &point, Qgis::AnnotationItemNodeType type );
 %Docstring

--- a/python/core/auto_generated/diagram/qgsdiagram.sip.in
+++ b/python/core/auto_generated/diagram/qgsdiagram.sip.in
@@ -80,9 +80,6 @@ Returns the size of the legend item for the diagram corresponding to a specified
   protected:
 
     QgsDiagram();
-%Docstring
-Constructor for QgsDiagram.
-%End
     QgsDiagram( const QgsDiagram &other );
 
     void setPenWidth( QPen &pen, const QgsDiagramSettings &s, const QgsRenderContext &c );

--- a/python/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -28,9 +28,6 @@ Contains configuration settings for an editor form.
     struct GroupData
     {
       GroupData();
-%Docstring
-Constructor for GroupData
-%End
       GroupData( const QString &name, const QList<QString> &fields );
       QString mName;
       QList<QString> mFields;
@@ -39,9 +36,6 @@ Constructor for GroupData
     struct TabData
     {
       TabData();
-%Docstring
-Constructor for TabData
-%End
       TabData( const QString &name, const QList<QString> &fields, const QList<QgsEditFormConfig::GroupData> &groups );
       QString mName;
       QList<QString> mFields;

--- a/python/core/auto_generated/effects/qgsblureffect.sip.in
+++ b/python/core/auto_generated/effects/qgsblureffect.sip.in
@@ -38,9 +38,6 @@ Creates a new QgsBlurEffect effect from a properties string map.
 %End
 
     QgsBlurEffect();
-%Docstring
-Constructor for QgsBlurEffect.
-%End
 
     virtual QString type() const;
     virtual QVariantMap properties() const;

--- a/python/core/auto_generated/effects/qgseffectstack.sip.in
+++ b/python/core/auto_generated/effects/qgseffectstack.sip.in
@@ -43,9 +43,6 @@ the map parameter, and always returns an empty effect stack.
 %End
 
     QgsEffectStack();
-%Docstring
-Constructor for empty QgsEffectStack.
-%End
 
     QgsEffectStack( const QgsEffectStack &other );
 

--- a/python/core/auto_generated/effects/qgspainteffect.sip.in
+++ b/python/core/auto_generated/effects/qgspainteffect.sip.in
@@ -84,9 +84,6 @@ and render the result to the render context's paint device.
     };
 
     QgsPaintEffect();
-%Docstring
-Constructor for QgsPaintEffect.
-%End
 
     QgsPaintEffect( const QgsPaintEffect &other );
     virtual ~QgsPaintEffect();
@@ -337,9 +334,6 @@ If no alterations are performed then the original picture will be rendered as a 
   public:
 
     QgsDrawSourceEffect();
-%Docstring
-Constructor for QgsDrawSourceEffect
-%End
 
     static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring

--- a/python/core/auto_generated/effects/qgstransformeffect.sip.in
+++ b/python/core/auto_generated/effects/qgstransformeffect.sip.in
@@ -31,9 +31,6 @@ Creates a new QgsTransformEffect effect from a properties string map.
 %End
 
     QgsTransformEffect();
-%Docstring
-Constructor for QgsTransformEffect.
-%End
 
     virtual QString type() const;
     virtual QVariantMap properties() const;

--- a/python/core/auto_generated/elevation/qgsterrainprovider.sip.in
+++ b/python/core/auto_generated/elevation/qgsterrainprovider.sip.in
@@ -139,9 +139,6 @@ Returns the vertical ``offset`` value, used for adjusting the heights from the t
   protected:
 
     QgsAbstractTerrainProvider();
-%Docstring
-Constructor for QgsAbstractTerrainProvider.
-%End
 
 
     void writeCommonProperties( QDomElement &element, const QgsReadWriteContext &context ) const;
@@ -175,9 +172,6 @@ A terrain provider where the terrain is a simple flat surface.
   public:
 
     QgsFlatTerrainProvider();
-%Docstring
-Constructor for QgsFlatTerrainProvider.
-%End
 
     virtual QString type() const;
 
@@ -211,9 +205,6 @@ A terrain provider where the terrain source is a raster DEM layer.
   public:
 
     QgsRasterDemTerrainProvider();
-%Docstring
-Constructor for QgsRasterDemTerrainProvider.
-%End
 
 
     virtual QString type() const;
@@ -267,9 +258,6 @@ A terrain provider that uses the Z values of a mesh layer to build a terrain sur
   public:
 
     QgsMeshTerrainProvider();
-%Docstring
-Constructor for QgsMeshTerrainProvider.
-%End
 
 
     virtual QString type() const;

--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -295,9 +295,6 @@ Returns a reference to the current object if no optimizations were applied.
   protected:
 
     QgsExpressionNode();
-%Docstring
-Constructor.
-%End
 
     QgsExpressionNode( const QgsExpressionNode &other );
 %Docstring

--- a/python/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
@@ -28,9 +28,6 @@ Field formatter for a checkbox field.
     };
 
     QgsCheckBoxFieldFormatter();
-%Docstring
-Constructor for QgsCheckBoxFieldFormatter.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -29,9 +29,6 @@ the field configuration.
     static QString DATETIME_DISPLAY_FORMAT; //! Date time display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
 
     QgsDateTimeFieldFormatter();
-%Docstring
-Default constructor of field formatter for a date time field.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/fieldformatter/qgsfallbackfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsfallbackfieldformatter.sip.in
@@ -21,9 +21,6 @@ The values will be returned unmodified.
   public:
 
     QgsFallbackFieldFormatter();
-%Docstring
-Default constructor of field formatter as a fallback when no specialized formatter is defined.
-%End
     virtual QString id() const;
 
 };

--- a/python/core/auto_generated/fieldformatter/qgskeyvaluefieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgskeyvaluefieldformatter.sip.in
@@ -25,9 +25,6 @@ E.g. "color: yellow, amount: 5"
   public:
 
     QgsKeyValueFieldFormatter();
-%Docstring
-Default constructor of field formatter for a key value field.
-%End
     virtual QString id() const;
 
     virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;

--- a/python/core/auto_generated/fieldformatter/qgslistfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgslistfieldformatter.sip.in
@@ -22,9 +22,6 @@ Values will be represented as a comma-separated list.
   public:
 
     QgsListFieldFormatter();
-%Docstring
-Default constructor of field formatter for a list field.
-%End
     virtual QString id() const;
 
 

--- a/python/core/auto_generated/fieldformatter/qgsrangefieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsrangefieldformatter.sip.in
@@ -19,9 +19,6 @@ Field formatter for a range (double) field with precision and locale.
   public:
 
     QgsRangeFieldFormatter();
-%Docstring
-Default constructor of field formatter for a range (double)field.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -30,9 +30,6 @@ Constructor for ValueRelationItem
 %End
 
       ValueRelationItem();
-%Docstring
-Constructor for ValueRelationItem
-%End
 
       QVariant key;
       QString value;

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -88,9 +88,6 @@ Abstract base class for all geometries
     };
 
     QgsAbstractGeometry();
-%Docstring
-Constructor for QgsAbstractGeometry.
-%End
     virtual ~QgsAbstractGeometry();
     QgsAbstractGeometry( const QgsAbstractGeometry &geom );
 
@@ -983,10 +980,8 @@ Java-style iterator for traversal of vertices of a geometry
 #include "qgsabstractgeometry.h"
 %End
   public:
+
     QgsVertexIterator();
-%Docstring
-Constructor for QgsVertexIterator
-%End
 
     QgsVertexIterator( const QgsAbstractGeometry *geometry );
 %Docstring
@@ -1030,10 +1025,8 @@ Java-style iterator for traversal of parts of a geometry
 #include "qgsabstractgeometry.h"
 %End
   public:
+
     QgsGeometryPartIterator();
-%Docstring
-Constructor for QgsGeometryPartIterator
-%End
 
     QgsGeometryPartIterator( QgsAbstractGeometry *geometry );
 %Docstring
@@ -1078,10 +1071,8 @@ Java-style iterator for const traversal of parts of a geometry
 #include "qgsabstractgeometry.h"
 %End
   public:
+
     QgsGeometryConstPartIterator();
-%Docstring
-Constructor for QgsGeometryConstPartIterator
-%End
 
     QgsGeometryConstPartIterator( const QgsAbstractGeometry *geometry );
 %Docstring

--- a/python/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscurve.sip.in
@@ -22,9 +22,6 @@ Abstract base class for curved geometry type
   public:
 
     QgsCurve();
-%Docstring
-Constructor for QgsCurve.
-%End
 
     virtual bool equals( const QgsCurve &other ) const = 0;
 %Docstring

--- a/python/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
@@ -67,9 +67,6 @@ and ``crs``.
 %End
 
     QgsReferencedRectangle();
-%Docstring
-Constructor for QgsReferencedRectangle.
-%End
 
     operator QVariant() const;
 
@@ -103,9 +100,6 @@ and ``crs``.
 %End
 
     QgsReferencedPointXY();
-%Docstring
-Constructor for QgsReferencedPointXY.
-%End
 
     operator QVariant() const;
 
@@ -141,9 +135,6 @@ and ``crs``.
 %End
 
     QgsReferencedGeometry();
-%Docstring
-Constructor for QgsReferencedGeometry.
-%End
 
     operator QVariant() const;
 

--- a/python/core/auto_generated/gps/qgsbabelgpsdevice.sip.in
+++ b/python/core/auto_generated/gps/qgsbabelgpsdevice.sip.in
@@ -24,9 +24,6 @@ A babel format capable of interacting directly with a GPS device.
   public:
 
     QgsBabelGpsDeviceFormat();
-%Docstring
-Default constructor
-%End
 
     QgsBabelGpsDeviceFormat( const QString &waypointDownloadCommand,
                              const QString &waypointUploadCommand,

--- a/python/core/auto_generated/gps/qgsgpsconnectionregistry.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnectionregistry.sip.in
@@ -27,9 +27,6 @@ is available to all classes and plugins.
   public:
 
     QgsGpsConnectionRegistry();
-%Docstring
-Constructor for QgsGpsConnectionRegistry.
-%End
     ~QgsGpsConnectionRegistry();
 
 

--- a/python/core/auto_generated/labeling/qgscalloutposition.sip.in
+++ b/python/core/auto_generated/labeling/qgscalloutposition.sip.in
@@ -33,9 +33,6 @@ Constructor for QgsCalloutPosition.
 %End
 
     QgsCalloutPosition();
-%Docstring
-Constructor for QgsCalloutPosition
-%End
 
     QgsFeatureId featureId;
 

--- a/python/core/auto_generated/labeling/qgslabelposition.sip.in
+++ b/python/core/auto_generated/labeling/qgslabelposition.sip.in
@@ -44,9 +44,6 @@ Constructor for QgsLabelPosition.
 %End
 
     QgsLabelPosition();
-%Docstring
-Constructor for QgsLabelPosition
-%End
 
     SIP_PYOBJECT __repr__();
 %MethodCode

--- a/python/core/auto_generated/labeling/qgsvectorlayerlabeling.sip.in
+++ b/python/core/auto_generated/labeling/qgsvectorlayerlabeling.sip.in
@@ -31,9 +31,6 @@ Abstract base class - its implementations define different approaches to the lab
   public:
 
     QgsAbstractVectorLayerLabeling();
-%Docstring
-Default constructor
-%End
     virtual ~QgsAbstractVectorLayerLabeling();
 
     virtual QString type() const = 0;

--- a/python/core/auto_generated/layout/qgslayouteffect.sip.in
+++ b/python/core/auto_generated/layout/qgslayouteffect.sip.in
@@ -27,9 +27,6 @@ onto a scene with custom composition modes.
   public:
 
     QgsLayoutEffect();
-%Docstring
-Constructor for QgsLayoutEffect.
-%End
 
  void setCompositionMode( QPainter::CompositionMode mode ) /Deprecated/;
 %Docstring

--- a/python/core/auto_generated/layout/qgslayoutmeasurementconverter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmeasurementconverter.sip.in
@@ -27,9 +27,6 @@ dots per inch (DPI) property for the converter. Converters default to using
   public:
 
     QgsLayoutMeasurementConverter();
-%Docstring
-Constructor for QgsLayoutMeasurementConverter.
-%End
 
     void setDpi( const double dpi );
 %Docstring

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -34,9 +34,6 @@ Styling option for a layout table cell
   public:
 
     QgsLayoutTableStyle();
-%Docstring
-Constructor for QgsLayoutTableStyle
-%End
 
     bool enabled;
 

--- a/python/core/auto_generated/locator/qgslocatorcontext.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorcontext.sip.in
@@ -21,9 +21,6 @@ Encapsulates the properties relating to the context of a locator search.
   public:
 
     QgsLocatorContext();
-%Docstring
-Constructor for QgsLocatorContext.
-%End
 
     QgsRectangle targetExtent;
 

--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -23,9 +23,6 @@ Encapsulates properties of an individual matching result found by a :py:class:`Q
   public:
 
     QgsLocatorResult();
-%Docstring
-Constructor for QgsLocatorResult.
-%End
 
     QgsLocatorResult( QgsLocatorFilter *filter, const QString &displayString, const QVariant &userData = QVariant() );
 %Docstring
@@ -61,10 +58,8 @@ Set ``userData`` for the locator result
     struct ResultAction
     {
       public:
+
         ResultAction();
-%Docstring
-Constructor for ResultAction
-%End
 
         ResultAction( int id, QString text, QString iconPath = QString() );
 %Docstring

--- a/python/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
@@ -127,9 +127,6 @@ expressionZ: "if( $vertex_x <= 100 , $vertex_z + 80 , $vertex_z - 150)"
   public:
 
     QgsMeshTransformVerticesByExpression();
-%Docstring
-Constructor
-%End
 
     virtual QString text() const;
 

--- a/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -586,10 +586,8 @@ Abstract class that represents a dataset
 #include "qgsmeshdataset.h"
 %End
   public:
+
     QgsMeshDataset();
-%Docstring
-Constructor
-%End
 
     virtual ~QgsMeshDataset();
 
@@ -647,9 +645,6 @@ Abstract class that represents a dataset group
     };
 
     QgsMeshDatasetGroup();
-%Docstring
-Default constructor
-%End
     virtual ~QgsMeshDatasetGroup();
 
     QgsMeshDatasetGroup( const QString &name );

--- a/python/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
@@ -29,9 +29,6 @@ Other option has also to be set before calling :py:func:`QgsMeshEditor.advancedE
   public:
 
     QgsMeshEditForceByLine();
-%Docstring
-Constructor
-%End
 
     void setInputLine( const QgsPoint &pt1, const QgsPoint &pt2, double tolerance, bool newVertexOnIntersection );
 %Docstring
@@ -84,9 +81,6 @@ before applying the edition with :py:func:`QgsMeshEditor.advancedEdit()`
   public:
 
     QgsMeshEditForceByPolylines();
-%Docstring
-Constructor
-%End
 
     virtual QString text() const;
 

--- a/python/core/auto_generated/mesh/qgsmeshlayerlabeling.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayerlabeling.sip.in
@@ -27,9 +27,6 @@ Abstract base class - its implementations define different approaches to the lab
   public:
 
     QgsAbstractMeshLayerLabeling();
-%Docstring
-Default constructor
-%End
     virtual ~QgsAbstractMeshLayerLabeling();
 
     virtual QString type() const = 0;

--- a/python/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
+++ b/python/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
@@ -47,9 +47,6 @@ Constructor for QgsLayerMetadataProviderResult.
 %End
 
     QgsLayerMetadataProviderResult( );
-%Docstring
-Default constructor.
-%End
 
     const QgsPolygon &geographicExtent() const;
 %Docstring

--- a/python/core/auto_generated/metadata/qgslayermetadata.sip.in
+++ b/python/core/auto_generated/metadata/qgslayermetadata.sip.in
@@ -109,9 +109,6 @@ Constructor for Constraint.
     typedef QList< QgsLayerMetadata::Constraint > ConstraintList;
 
     QgsLayerMetadata();
-%Docstring
-Constructor for QgsLayerMetadata.
-%End
 
 
     virtual QgsLayerMetadata *clone() const /Factory/;

--- a/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
+++ b/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
@@ -89,9 +89,6 @@ A validator for the native base QGIS metadata schema definition.
   public:
 
     QgsNativeMetadataBaseValidator();
-%Docstring
-Constructor for QgsNativeMetadataBaseValidator.
-%End
 
     virtual bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results /Out/ ) const;
 
@@ -110,11 +107,7 @@ A validator for the native QGIS layer metadata schema definition.
 #include "qgslayermetadatavalidator.h"
 %End
   public:
-
     QgsNativeMetadataValidator();
-%Docstring
-Constructor for QgsNativeMetadataValidator.
-%End
 
     virtual bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results /Out/ ) const;
 
@@ -136,9 +129,6 @@ A validator for the native QGIS project metadata schema definition.
   public:
 
     QgsNativeProjectMetadataValidator();
-%Docstring
-Constructor for QgsNativeProjectMetadataValidator.
-%End
 
     virtual bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results /Out/ ) const;
 

--- a/python/core/auto_generated/metadata/qgsprojectmetadata.sip.in
+++ b/python/core/auto_generated/metadata/qgsprojectmetadata.sip.in
@@ -43,9 +43,6 @@ using :py:class:`QgsNativeProjectMetadataValidator`.
   public:
 
     QgsProjectMetadata();
-%Docstring
-Constructor for QgsProjectMetadata.
-%End
 
     virtual QgsProjectMetadata *clone() const /Factory/;
 

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -31,9 +31,6 @@ Encapsulates parameters and properties of a network request.
     };
 
     QgsNetworkRequestParameters();
-%Docstring
-Default constructor.
-%End
 
     QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation,
                                  const QNetworkRequest &request,

--- a/python/core/auto_generated/network/qgsnetworkcontentfetcher.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkcontentfetcher.sip.in
@@ -28,9 +28,6 @@ handled.
   public:
 
     QgsNetworkContentFetcher();
-%Docstring
-Constructor for QgsNetworkContentFetcher.
-%End
 
     ~QgsNetworkContentFetcher();
 

--- a/python/core/auto_generated/numericformats/qgsfallbacknumericformat.sip.in
+++ b/python/core/auto_generated/numericformats/qgsfallbacknumericformat.sip.in
@@ -21,9 +21,6 @@ A basic numeric formatter which returns a simple text representation of a value.
   public:
 
     QgsFallbackNumericFormat();
-%Docstring
-Default constructor
-%End
     virtual QString id() const;
 
     virtual QString visibleName() const;

--- a/python/core/auto_generated/numericformats/qgsnumericformat.sip.in
+++ b/python/core/auto_generated/numericformats/qgsnumericformat.sip.in
@@ -207,9 +207,6 @@ This is an abstract base class and will always need to be subclassed.
   public:
 
     QgsNumericFormat();
-%Docstring
-Default constructor
-%End
 
     virtual ~QgsNumericFormat();
 

--- a/python/core/auto_generated/plot/qgsplot.sip.in
+++ b/python/core/auto_generated/plot/qgsplot.sip.in
@@ -29,9 +29,6 @@ Base class for plot/chart/graphs.
   public:
 
     QgsPlot();
-%Docstring
-Constructor for QgsPlot.
-%End
 
     virtual ~QgsPlot();
 

--- a/python/core/auto_generated/pointcloud/qgspointcloudclassifiedrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudclassifiedrenderer.sip.in
@@ -24,9 +24,6 @@ Represents an individual category (class) from a :py:class:`QgsPointCloudClassif
   public:
 
     QgsPointCloudCategory();
-%Docstring
-Constructor for QgsPointCloudCategory.
-%End
 
     QgsPointCloudCategory( int value, const QColor &color, const QString &label, bool render = true, double pointSize = 0 );
 %Docstring

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -194,9 +194,6 @@ Abstract base class for 2d point cloud renderers.
   public:
 
     QgsPointCloudRenderer();
-%Docstring
-Constructor for QgsPointCloudRenderer.
-%End
 
     virtual ~QgsPointCloudRenderer();
 

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -1151,9 +1151,6 @@ algorithm in "chains", avoiding the need for temporary outputs in multi-step mod
   public:
 
     QgsProcessingFeatureBasedAlgorithm();
-%Docstring
-Constructor for QgsProcessingFeatureBasedAlgorithm.
-%End
 
     virtual Qgis::ProcessingAlgorithmFlags flags() const /HoldGIL/;
 

--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -216,9 +216,6 @@ Constructor for LayerDetails.
 %End
 
         LayerDetails();
-%Docstring
-Default constructor
-%End
 
         QString name;
 

--- a/python/core/auto_generated/project/qgsprojectproperty.sip.in
+++ b/python/core/auto_generated/project/qgsprojectproperty.sip.in
@@ -116,9 +116,6 @@ Project property value node, contains a :py:class:`QgsProjectPropertyKey`'s valu
   public:
 
     QgsProjectPropertyValue();
-%Docstring
-Constructor for QgsProjectPropertyValue.
-%End
 
     QgsProjectPropertyValue( const QVariant &value );
 %Docstring

--- a/python/core/auto_generated/project/qgsprojectservervalidator.sip.in
+++ b/python/core/auto_generated/project/qgsprojectservervalidator.sip.in
@@ -24,9 +24,6 @@ Validates the server specific parts of the configuration of a QGIS project.
   public:
 
     QgsProjectServerValidator();
-%Docstring
-Constructor for QgsProjectServerValidator.
-%End
 
     enum ValidationError
     {

--- a/python/core/auto_generated/qgsattributetableconfig.sip.in
+++ b/python/core/auto_generated/qgsattributetableconfig.sip.in
@@ -31,9 +31,6 @@ The configuration is specific for one vector layer.
     struct ColumnConfig
     {
       ColumnConfig();
-%Docstring
-Constructor for ColumnConfig
-%End
 
 
       QgsAttributeTableConfig::Type type;
@@ -52,9 +49,6 @@ Constructor for ColumnConfig
     };
 
     QgsAttributeTableConfig();
-%Docstring
-Constructor for QgsAttributeTableConfig.
-%End
 
     QVector<QgsAttributeTableConfig::ColumnConfig> columns() const;
 %Docstring

--- a/python/core/auto_generated/qgscacheindex.sip.in
+++ b/python/core/auto_generated/qgscacheindex.sip.in
@@ -22,9 +22,6 @@ Abstract base class for cache indices
   public:
 
     QgsAbstractCacheIndex();
-%Docstring
-Constructor for QgsAbstractCacheIndex.
-%End
     virtual ~QgsAbstractCacheIndex();
 
     virtual void flushFeature( QgsFeatureId fid ) = 0;

--- a/python/core/auto_generated/qgscolorrampimpl.sip.in
+++ b/python/core/auto_generated/qgscolorrampimpl.sip.in
@@ -493,9 +493,6 @@ to some hardcoded saturation and value ranges to prevent ugly color generation.
   public:
 
     QgsRandomColorRamp();
-%Docstring
-Constructor for QgsRandomColorRamp.
-%End
 
     virtual int count() const;
 

--- a/python/core/auto_generated/qgscolorscheme.sip.in
+++ b/python/core/auto_generated/qgscolorscheme.sip.in
@@ -51,9 +51,6 @@ can be generated using an optional base color.
 
 
     QgsColorScheme();
-%Docstring
-Constructor for QgsColorScheme.
-%End
 
     virtual ~QgsColorScheme();
 
@@ -132,9 +129,6 @@ A color scheme which stores its colors in a gpl palette file.
   public:
 
     QgsGplColorScheme();
-%Docstring
-Constructor for QgsGplColorScheme.
-%End
 
      virtual QgsNamedColorList fetchColors( const QString &context = QString(),
                                    const QColor &baseColor = QColor() );
@@ -226,9 +220,6 @@ A color scheme which contains the most recently used colors.
   public:
 
     QgsRecentColorScheme();
-%Docstring
-Constructor for QgsRecentColorScheme.
-%End
 
     virtual QString schemeName() const;
 
@@ -269,9 +260,6 @@ A color scheme which contains custom colors set through QGIS app options dialog.
   public:
 
     QgsCustomColorScheme();
-%Docstring
-Constructor for QgsCustomColorScheme.
-%End
 
     virtual QString schemeName() const;
 
@@ -301,9 +289,6 @@ A color scheme which contains project specific colors set through project proper
   public:
 
     QgsProjectColorScheme();
-%Docstring
-Constructor for QgsProjectColorScheme.
-%End
 
     virtual QString schemeName() const;
 

--- a/python/core/auto_generated/qgscredentials.sip.in
+++ b/python/core/auto_generated/qgscredentials.sip.in
@@ -92,9 +92,6 @@ Returns pointer to mutex
   protected:
 
     QgsCredentials();
-%Docstring
-Constructor for QgsCredentials.
-%End
 
     virtual bool request( const QString &realm, QString &username /In,Out/, QString &password /In,Out/, const QString &message = QString() ) = 0;
 %Docstring

--- a/python/core/auto_generated/qgsdartmeasurement.sip.in
+++ b/python/core/auto_generated/qgsdartmeasurement.sip.in
@@ -24,9 +24,6 @@ class QgsDartMeasurement
     };
 
     QgsDartMeasurement();
-%Docstring
-Constructor for QgsDartMeasurement
-%End
 
     QgsDartMeasurement( const QString &name, Type type, const QString &value );
 

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -604,9 +604,6 @@ Evaluates and returns the diagram settings relating to a diagram for a specific 
   public:
 
     QgsDiagramRenderer();
-%Docstring
-Constructor for QgsDiagramRenderer.
-%End
     virtual ~QgsDiagramRenderer();
 
     virtual QgsDiagramRenderer *clone() const = 0 /Factory/;
@@ -744,9 +741,6 @@ Renders the diagrams for all features with the same settings
   public:
 
     QgsSingleCategoryDiagramRenderer();
-%Docstring
-Constructor for QgsSingleCategoryDiagramRenderer
-%End
 
     virtual QgsSingleCategoryDiagramRenderer *clone() const /Factory/;
 

--- a/python/core/auto_generated/qgseditorwidgetsetup.sip.in
+++ b/python/core/auto_generated/qgseditorwidgetsetup.sip.in
@@ -25,9 +25,6 @@ Constructor
 %End
 
     QgsEditorWidgetSetup();
-%Docstring
-Constructor for QgsEditorWidgetSetup
-%End
 
     QString type() const;
 %Docstring

--- a/python/core/auto_generated/qgselevationmap.sip.in
+++ b/python/core/auto_generated/qgselevationmap.sip.in
@@ -33,9 +33,6 @@ in meters.
   public:
 
     QgsElevationMap();
-%Docstring
-Default constructor
-%End
 
     explicit QgsElevationMap( const QSize &size, float devicePixelRatio = 1.0 );
 %Docstring

--- a/python/core/auto_generated/qgserror.sip.in
+++ b/python/core/auto_generated/qgserror.sip.in
@@ -27,9 +27,6 @@ class QgsErrorMessage
     };
 
     QgsErrorMessage();
-%Docstring
-Constructor for QgsErrorMessage
-%End
 
     QgsErrorMessage( const QString &message, const QString &tag = QString(), const QString &file = QString(), const QString &function = QString(), int line = 0 );
 %Docstring
@@ -64,9 +61,6 @@ Higher level messages are appended at the end.
   public:
 
     QgsError();
-%Docstring
-Constructor for QgsError
-%End
 
     QgsError( const QString &message, const QString &tag );
 %Docstring

--- a/python/core/auto_generated/qgsexpressionfieldbuffer.sip.in
+++ b/python/core/auto_generated/qgsexpressionfieldbuffer.sip.in
@@ -29,9 +29,6 @@ Buffers information about expression fields for a vector layer.
     };
 
     QgsExpressionFieldBuffer();
-%Docstring
-Constructor for QgsExpressionFieldBuffer.
-%End
 
     void addExpression( const QString &exp, const QgsField &fld );
 %Docstring

--- a/python/core/auto_generated/qgsfeaturestore.sip.in
+++ b/python/core/auto_generated/qgsfeaturestore.sip.in
@@ -18,9 +18,6 @@ A container for features with the same fields and crs.
 %End
   public:
     QgsFeatureStore();
-%Docstring
-Constructor
-%End
 
     QgsFeatureStore( const QgsFields &fields, const QgsCoordinateReferenceSystem &crs );
 %Docstring

--- a/python/core/auto_generated/qgsfieldformatter.sip.in
+++ b/python/core/auto_generated/qgsfieldformatter.sip.in
@@ -23,9 +23,6 @@ A context for field formatter containing information like the project
   public:
 
     QgsFieldFormatterContext();
-%Docstring
-Constructor
-%End
 
     QgsProject *project() const;
 %Docstring
@@ -63,9 +60,6 @@ This is an abstract base class and will always need to be subclassed.
   public:
 
     QgsFieldFormatter();
-%Docstring
-Default constructor
-%End
 
     virtual ~QgsFieldFormatter();
 

--- a/python/core/auto_generated/qgsgmlschema.sip.in
+++ b/python/core/auto_generated/qgsgmlschema.sip.in
@@ -20,9 +20,6 @@ Description of feature class in GML
   public:
 
     QgsGmlFeatureClass();
-%Docstring
-Constructor for QgsGmlFeatureClass.
-%End
     QgsGmlFeatureClass( const QString &name, const QString &path );
 
     QList<QgsField> &fields();

--- a/python/core/auto_generated/qgshistogram.sip.in
+++ b/python/core/auto_generated/qgshistogram.sip.in
@@ -25,9 +25,6 @@ Calculator for a numeric histogram from a list of values.
   public:
 
     QgsHistogram();
-%Docstring
-Constructor for QgsHistogram.
-%End
 
     virtual ~QgsHistogram();
 

--- a/python/core/auto_generated/qgsidentifycontext.sip.in
+++ b/python/core/auto_generated/qgsidentifycontext.sip.in
@@ -23,9 +23,6 @@ an identify action.
   public:
 
     QgsIdentifyContext();
-%Docstring
-Constructor for QgsIdentifyContext
-%End
 
     void setTemporalRange( const QgsDateTimeRange &range );
 %Docstring

--- a/python/core/auto_generated/qgsmapdecoration.sip.in
+++ b/python/core/auto_generated/qgsmapdecoration.sip.in
@@ -22,9 +22,6 @@ Interface for map decorations.
   public:
 
     QgsMapDecoration();
-%Docstring
-Constructor for QgsMapDecoration.
-%End
 
     virtual ~QgsMapDecoration();
 

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -31,9 +31,6 @@ window for the user.
   public:
 
     QgsMessageLog();
-%Docstring
-Constructor for QgsMessageLog.
-%End
 
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true );
 %Docstring

--- a/python/core/auto_generated/qgsmessageoutput.sip.in
+++ b/python/core/auto_generated/qgsmessageoutput.sip.in
@@ -87,9 +87,6 @@ be the right choice for apps without GUI.
   public:
 
     QgsMessageOutputConsole();
-%Docstring
-Constructor for QgsMessageOutputConsole.
-%End
 
     virtual void setMessage( const QString &message, MessageType msgType );
 

--- a/python/core/auto_generated/qgsobjectcustomproperties.sip.in
+++ b/python/core/auto_generated/qgsobjectcustomproperties.sip.in
@@ -23,9 +23,6 @@ in \verbatim <customproperties> \endverbatim element.
   public:
 
     QgsObjectCustomProperties();
-%Docstring
-Constructor for QgsObjectCustomProperties.
-%End
 
     QStringList keys() const;
 %Docstring

--- a/python/core/auto_generated/qgspluginlayerregistry.sip.in
+++ b/python/core/auto_generated/qgspluginlayerregistry.sip.in
@@ -61,9 +61,6 @@ A registry of plugin layers types.
   public:
 
     QgsPluginLayerRegistry();
-%Docstring
-Constructor for QgsPluginLayerRegistry.
-%End
     ~QgsPluginLayerRegistry();
 
 

--- a/python/core/auto_generated/qgspointxy.sip.in
+++ b/python/core/auto_generated/qgspointxy.sip.in
@@ -45,6 +45,7 @@ Use cases for which :py:class:`QgsPointXY` is NOT a valid choice include:
     static const QMetaObject staticMetaObject;
 
   public:
+
     QgsPointXY();
 
     QgsPointXY( const QgsPointXY &p ) /HoldGIL/;

--- a/python/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/core/auto_generated/qgspropertycollection.sip.in
@@ -468,9 +468,6 @@ priority over earlier collections.
   public:
 
     QgsPropertyCollectionStack();
-%Docstring
-Constructor for QgsPropertyCollectionStack.
-%End
 
     ~QgsPropertyCollectionStack();
 

--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -262,10 +262,8 @@ A list of nodes.
 #include "qgssqlstatement.h"
 %End
       public:
+
         NodeList();
-%Docstring
-Constructor
-%End
         virtual ~NodeList();
 
         void append( QgsSQLStatement::Node *node /Transfer/ );
@@ -990,10 +988,8 @@ A visitor that recursively explores all children
 #include "qgssqlstatement.h"
 %End
       public:
+
         RecursiveVisitor();
-%Docstring
-Constructor
-%End
 
         virtual void visit( const QgsSQLStatement::NodeUnaryOperator &n );
         virtual void visit( const QgsSQLStatement::NodeBinaryOperator &n );

--- a/python/core/auto_generated/qgsstoredexpressionmanager.sip.in
+++ b/python/core/auto_generated/qgsstoredexpressionmanager.sip.in
@@ -56,9 +56,6 @@ Manages stored expressions regarding creation, modification and storing in the p
   public:
 
     QgsStoredExpressionManager();
-%Docstring
-Constructor for QgsStoredExpressionManager
-%End
 
     QString addStoredExpression( const QString &name, const QString &expression, const QgsStoredExpression::Category &tag =  QgsStoredExpression::Category::FilterExpression );
 %Docstring

--- a/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
+++ b/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
@@ -16,9 +16,6 @@ class QgsTrackedVectorLayerTools : QgsVectorLayerTools
   public:
 
     QgsTrackedVectorLayerTools();
-%Docstring
-Constructor for QgsTrackedVectorLayerTools.
-%End
 
     virtual bool addFeatureV2( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature /Out/, const QgsVectorLayerToolsContext &context ) const;
 

--- a/python/core/auto_generated/qgstranslationcontext.sip.in
+++ b/python/core/auto_generated/qgstranslationcontext.sip.in
@@ -24,9 +24,6 @@ Used for the collecting of strings from projects for translation and creation of
   public:
 
     QgsTranslationContext();
-%Docstring
-Constructor
-%End
 
     QgsProject *project() const;
 %Docstring

--- a/python/core/auto_generated/qgsunsetattributevalue.sip.in
+++ b/python/core/auto_generated/qgsunsetattributevalue.sip.in
@@ -23,9 +23,6 @@ Represents a default, "not-specified" value for a feature attribute.
   public:
 
     QgsUnsetAttributeValue();
-%Docstring
-Constructor for a QgsUnsetAttributeValue.
-%End
 
     explicit QgsUnsetAttributeValue( const QString &defaultValueClause );
 %Docstring

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -108,10 +108,8 @@ There are two possibilities how to use this class:
 
     struct MetaData
     {
+
       MetaData();
-%Docstring
-Constructor for MetaData
-%End
 
       MetaData( const QString &longName, const QString &trLongName, const QString &glob, const QString &ext, const QMap<QString, QgsVectorFileWriter::Option *> &driverOptions, const QMap<QString, QgsVectorFileWriter::Option *> &layerOptions, const QString &compulsoryEncoding = QString() );
 
@@ -164,10 +162,8 @@ Interface to convert raw field values to their user-friendly value.
 #include "qgsvectorfilewriter.h"
 %End
       public:
+
         FieldValueConverter();
-%Docstring
-Constructor
-%End
 
         virtual ~FieldValueConverter();
 

--- a/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -23,9 +23,6 @@ Bilinear Raster Resampler
   public:
 
     QgsBilinearRasterResampler();
-%Docstring
-Constructor for QgsBilinearRasterResampler.
-%End
  virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
 

--- a/python/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -45,10 +45,8 @@ Copy constructor
 
     struct ColorRampItem
     {
+
       ColorRampItem();
-%Docstring
-default constructor
-%End
       ColorRampItem( double val, const QColor &col, const QString &lbl = QString() );
 %Docstring
 convenience constructor

--- a/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -22,9 +22,6 @@ Cubic Raster Resampler.
   public:
 
     QgsCubicRasterResampler();
-%Docstring
-Constructor for QgsCubicRasterResampler.
-%End
     virtual QgsCubicRasterResampler *clone() const /Factory/;
 
 

--- a/python/core/auto_generated/raster/qgsrasterbandstats.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterbandstats.sip.in
@@ -24,9 +24,6 @@ raster band.
   public:
 
     QgsRasterBandStats();
-%Docstring
-Constructor for QgsRasterBandStats.
-%End
 
     bool contains( const QgsRasterBandStats &s ) const;
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasteridentifyresult.sip.in
+++ b/python/core/auto_generated/raster/qgsrasteridentifyresult.sip.in
@@ -21,9 +21,6 @@ Raster identify results container.
   public:
 
     QgsRasterIdentifyResult();
-%Docstring
-Constructor for QgsRasterIdentifyResult.
-%End
 
     QgsRasterIdentifyResult( Qgis::RasterIdentifyFormat format, const QMap<int, QVariant> &results );
 %Docstring

--- a/python/core/auto_generated/raster/qgsrastertransparency.sip.in
+++ b/python/core/auto_generated/raster/qgsrastertransparency.sip.in
@@ -21,9 +21,6 @@ transparent when rendering rasters.
   public:
 
     QgsRasterTransparency();
-%Docstring
-Constructor for QgsRasterTransparency.
-%End
 
     struct TransparentThreeValuePixel
     {

--- a/python/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
@@ -20,9 +20,6 @@ Double box with alternating colors.
   public:
 
     QgsDoubleBoxScaleBarRenderer();
-%Docstring
-Constructor for QgsDoubleBoxScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
@@ -23,9 +23,6 @@ alternating segments. AKA "South African" style.
   public:
 
     QgsHollowScaleBarRenderer();
-%Docstring
-Constructor for QgsHollowScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
@@ -20,9 +20,6 @@ A scale bar style that draws text in the form of '1:XXXXX'.
   public:
 
     QgsNumericScaleBarRenderer();
-%Docstring
-Constructor for QgsNumericScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
@@ -58,9 +58,6 @@ custom labeling.
     };
 
     QgsScaleBarRenderer();
-%Docstring
-Constructor for QgsScaleBarRenderer.
-%End
     virtual ~QgsScaleBarRenderer();
 
  QString name() const /Deprecated/;

--- a/python/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
@@ -21,9 +21,6 @@ color for the segments.
   public:
 
     QgsSingleBoxScaleBarRenderer();
-%Docstring
-Constructor for QgsSingleBoxScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/scalebar/qgssteppedlinescalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgssteppedlinescalebarrenderer.sip.in
@@ -22,9 +22,6 @@ Scalebar style that draws a stepped line representation of a scalebar.
   public:
 
     QgsSteppedLineScaleBarRenderer();
-%Docstring
-Constructor for QgsSteppedLineScaleBarRenderer.
-%End
 
     virtual QString id() const;
 

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -21,9 +21,6 @@ Represents an individual category (class) from a :py:class:`QgsCategorizedSymbol
   public:
 
     QgsRendererCategory();
-%Docstring
-Constructor for QgsRendererCategory.
-%End
 
     QgsRendererCategory( const QVariant &value, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true, const QString &uuid = QString() );
 %Docstring

--- a/python/core/auto_generated/symbology/qgslegendsymbolitem.sip.in
+++ b/python/core/auto_generated/symbology/qgslegendsymbolitem.sip.in
@@ -25,9 +25,6 @@ that can be used by legend model for rendering of legend.
   public:
 
     QgsLegendSymbolItem();
-%Docstring
-Constructor for QgsLegendSymbolItem.
-%End
 
     QgsLegendSymbolItem( QgsSymbol *symbol, const QString &label, const QString &ruleKey, bool checkable = false, int scaleMinDenom = -1, int scaleMaxDenom = -1, int level = 0, const QString &parentRuleKey = QString() );
 %Docstring

--- a/python/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -21,9 +21,6 @@ class QgsRendererRange
   public:
 
     QgsRendererRange();
-%Docstring
-Constructor for QgsRendererRange.
-%End
     ~QgsRendererRange();
 
     QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol /Transfer/, bool render = true, const QString &uuid = QString() );

--- a/python/core/auto_generated/symbology/qgssymbollayerreference.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerreference.sip.in
@@ -105,10 +105,8 @@ Type used to refer to a specific symbol layer in a symbol of a layer.
 #include "qgssymbollayerreference.h"
 %End
   public:
+
     QgsSymbolLayerReference();
-%Docstring
-Default constructor
-%End
 
  QgsSymbolLayerReference( const QString &layerId, const QgsSymbolLayerId &symbolLayer ) /Deprecated/;
 %Docstring

--- a/python/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
@@ -31,9 +31,6 @@ settings from a :py:class:`QgsTextFormat` for individual characters (or sets of 
   public:
 
     QgsTextCharacterFormat();
-%Docstring
-Constructor for QgsTextCharacterFormat.
-%End
 
     QgsTextCharacterFormat( const QTextCharFormat &format );
 %Docstring

--- a/python/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
@@ -107,9 +107,6 @@ Abstract base class for 2d tiled scene renderers.
   public:
 
     QgsTiledSceneRenderer();
-%Docstring
-Constructor for QgsTiledSceneRenderer.
-%End
 
     virtual ~QgsTiledSceneRenderer();
 

--- a/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -269,9 +269,6 @@ Emitted after committing an attribute rename
   protected:
 
     QgsVectorLayerEditBuffer();
-%Docstring
-Constructor for QgsVectorLayerEditBuffer
-%End
 
     void updateFeatureGeometry( QgsFeature &f );
 %Docstring

--- a/python/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
@@ -22,9 +22,6 @@ The join is done based on [our layer].targetField = [join layer].joinField
   public:
 
     QgsVectorLayerJoinInfo();
-%Docstring
-Constructor for QgsVectorLayerJoinInfo.
-%End
 
     void setJoinLayer( QgsVectorLayer *layer );
 %Docstring

--- a/python/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
@@ -24,9 +24,6 @@ consider.
   public:
 
     QgsVectorLayerToolsContext();
-%Docstring
-Constructor for QgsVectorLayerToolsContext.
-%End
 
     QgsVectorLayerToolsContext( const QgsVectorLayerToolsContext &other );
 %Docstring

--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -35,9 +35,6 @@ Contains mainly the QMap with :py:class:`QgsVectorLayer` and :py:class:`QgsFeatu
       public:
 
         QgsDuplicateFeatureContext();
-%Docstring
-Constructor for QgsDuplicateFeatureContext
-%End
 
         QList<QgsVectorLayer *> layers() const;
 %Docstring

--- a/python/gui/auto_generated/actions/qgsactionmenu.sip.in
+++ b/python/gui/auto_generated/actions/qgsactionmenu.sip.in
@@ -26,9 +26,6 @@ This class is a menu that is populated automatically with the actions defined fo
     {
 
       ActionData();
-%Docstring
-Constructor for ActionData.
-%End
       ActionData( const QgsAction &action, QgsFeatureId featureId, QgsMapLayer *mapLayer );
       ActionData( QgsMapLayerAction *action, QgsFeatureId featureId, QgsMapLayer *mapLayer );
 

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -22,9 +22,6 @@ class QgsFeatureListModel : QSortFilterProxyModel, QgsFeatureModel
       public:
 
         FeatureInfo();
-%Docstring
-Constructor for FeatureInfo.
-%End
 
         bool isNew;
 

--- a/python/gui/auto_generated/history/qgshistoryentrynode.sip.in
+++ b/python/gui/auto_generated/history/qgshistoryentrynode.sip.in
@@ -22,9 +22,6 @@ Base class for nodes representing a :py:class:`QgsHistoryEntry`.
   public:
 
     QgsHistoryEntryNode();
-%Docstring
-Constructor for QgsHistoryEntryNode.
-%End
     virtual ~QgsHistoryEntryNode();
 
 
@@ -108,9 +105,6 @@ Base class for history entry "group" nodes, which contain children of their own.
   public:
 
     QgsHistoryEntryGroup();
-%Docstring
-Constructor for QgsHistoryEntryGroup
-%End
     ~QgsHistoryEntryGroup();
 
 

--- a/python/gui/auto_generated/history/qgshistorywidgetcontext.sip.in
+++ b/python/gui/auto_generated/history/qgshistorywidgetcontext.sip.in
@@ -23,9 +23,6 @@ Contains settings which reflect the context in which a history widget is shown, 
   public:
 
     QgsHistoryWidgetContext();
-%Docstring
-Constructor for QgsHistoryWidgetContext.
-%End
 
     void setMessageBar( QgsMessageBar *bar );
 %Docstring

--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
@@ -118,9 +118,6 @@ Processing toolbox model node corresponding to the recent algorithms group
   public:
 
     QgsProcessingToolboxModelRecentNode();
-%Docstring
-Constructor for QgsProcessingToolboxModelRecentNode.
-%End
 
     virtual NodeType nodeType() const;
 
@@ -144,9 +141,6 @@ Processing toolbox model node corresponding to the favorite algorithms group
   public:
 
     QgsProcessingToolboxModelFavoriteNode();
-%Docstring
-Constructor for :py:class:`QgsProcessingToolboxModelRecentNode`.
-%End
 
     virtual NodeType nodeType() const;
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -88,9 +88,6 @@ to fine-tune its behavior.
   public:
 
     QgsProcessingParameterWidgetContext();
-%Docstring
-Constructor for QgsProcessingParameterWidgetContext.
-%End
 
     void setMapCanvas( QgsMapCanvas *canvas );
 %Docstring

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -37,9 +37,6 @@ could provide their own implementation to be able to use plugins.
   public:
 
     QgisInterface();
-%Docstring
-Constructor
-%End
 
     virtual QgsPluginManagerInterface *pluginManagerInterface() = 0;
 

--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -53,9 +53,6 @@ showing an embedded form due to relations)
     };
 
     QgsAttributeEditorContext();
-%Docstring
-Constructor for QgsAttributeEditorContext
-%End
 
     QgsAttributeEditorContext( const QgsAttributeEditorContext &parentContext, FormMode formMode );
 

--- a/python/gui/auto_generated/qgsdataitemguiprovider.sip.in
+++ b/python/gui/auto_generated/qgsdataitemguiprovider.sip.in
@@ -24,9 +24,6 @@ Encapsulates the context in which a :py:class:`QgsDataItem` is shown within the 
   public:
 
     QgsDataItemGuiContext();
-%Docstring
-Constructor for QgsDataItemGuiContext.
-%End
 
     QgsMessageBar *messageBar() const;
 %Docstring

--- a/python/gui/auto_generated/qgsdecoratedscrollbar.sip.in
+++ b/python/gui/auto_generated/qgsdecoratedscrollbar.sip.in
@@ -39,9 +39,6 @@ Constructor for QgsScrollBarHighlight.
 %End
 
     QgsScrollBarHighlight();
-%Docstring
-Default constructor for QgsScrollBarHighlight.
-%End
 
     int category;
 

--- a/python/gui/auto_generated/qgsdetaileditemdata.sip.in
+++ b/python/gui/auto_generated/qgsdetaileditemdata.sip.in
@@ -22,9 +22,6 @@ This class is the data only representation of a
   public:
 
     QgsDetailedItemData();
-%Docstring
-Constructor for QgsDetailedItemData.
-%End
 
     void setTitle( const QString &title );
 %Docstring

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -133,10 +133,8 @@ instance to provide custom context menus (opened upon right-click).
 #include "qgsexpressiontreeview.h"
 %End
       public:
+
         explicit MenuProvider();
-%Docstring
-Constructor
-%End
         virtual ~MenuProvider();
 
         virtual QMenu *createContextMenu( QgsExpressionItem *item ) /Factory/;

--- a/python/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/gui/auto_generated/qgsidentifymenu.sip.in
@@ -31,10 +31,8 @@ If used in a :py:class:`QgsMapToolIdentify`, it is accessible via :py:func:`QgsM
 
     struct ActionData
     {
+
       ActionData();
-%Docstring
-Constructor for ActionData
-%End
 
       ActionData( QgsMapLayer *layer, QgsMapLayerAction *mapLayerAction = 0 );
 

--- a/python/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
@@ -27,9 +27,6 @@ Factory class for creating custom map layer property pages
     };
 
     QgsMapLayerConfigWidgetFactory();
-%Docstring
-Constructor
-%End
 
     QgsMapLayerConfigWidgetFactory( const QString &title, const QIcon &icon );
 %Docstring

--- a/python/gui/auto_generated/qgsmaptoolidentify.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolidentify.sip.in
@@ -50,10 +50,8 @@ after selecting a point, performs the identification:
 
     struct IdentifyResult
     {
+
       IdentifyResult();
-%Docstring
-Constructor for IdentifyResult
-%End
 
       IdentifyResult( QgsMapLayer *layer, const QgsFeature &feature, const QMap< QString, QString > &derivedAttributes );
       IdentifyResult( QgsMapLayer *layer, const QString &label, const QMap< QString, QString > &attributes, const QMap< QString, QString > &derivedAttributes );

--- a/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
@@ -82,9 +82,6 @@ class QgsOptionsWidgetFactory : QObject
   public:
 
     QgsOptionsWidgetFactory();
-%Docstring
-Constructor
-%End
 
     QgsOptionsWidgetFactory( const QString &title, const QIcon &icon, const QString &key = QString() );
 %Docstring

--- a/python/gui/auto_generated/qgspluginmanagerinterface.sip.in
+++ b/python/gui/auto_generated/qgspluginmanagerinterface.sip.in
@@ -18,9 +18,6 @@ class QgsPluginManagerInterface : QObject
   public:
 
     QgsPluginManagerInterface();
-%Docstring
-Constructor
-%End
 
     virtual void clearPythonPluginMetadata() = 0;
 %Docstring

--- a/python/gui/auto_generated/qgstablewidgetitem.sip.in
+++ b/python/gui/auto_generated/qgstablewidgetitem.sip.in
@@ -20,9 +20,6 @@ specific role can be set to sort.
   public:
 
     QgsTableWidgetItem();
-%Docstring
-Constructor for QgsTableWidgetItem.
-%End
 
     QgsTableWidgetItem( const QString &text );
 %Docstring

--- a/python/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
@@ -22,9 +22,6 @@ map canvas and relevant expression contexts.
   public:
 
     QgsSymbolWidgetContext();
-%Docstring
-Constructor for QgsSymbolWidgetContext.
-%End
 
     QgsSymbolWidgetContext( const QgsSymbolWidgetContext &other );
 %Docstring

--- a/src/3d/materials/qgsgoochmaterialsettings.h
+++ b/src/3d/materials/qgsgoochmaterialsettings.h
@@ -37,9 +37,6 @@ class _3D_EXPORT QgsGoochMaterialSettings : public QgsAbstractMaterialSettings
 {
   public:
 
-    /**
-     * Constructor for QgsGoochMaterialSettings.
-     */
     QgsGoochMaterialSettings() = default;
 
     QString type() const override;

--- a/src/3d/materials/qgsmetalroughmaterialsettings.h
+++ b/src/3d/materials/qgsmetalroughmaterialsettings.h
@@ -36,9 +36,6 @@ class _3D_EXPORT QgsMetalRoughMaterialSettings : public QgsAbstractMaterialSetti
 {
   public:
 
-    /**
-     * Constructor for QgsMetalRoughMaterialSettings.
-     */
     QgsMetalRoughMaterialSettings() = default;
 
     QString type() const override;

--- a/src/3d/materials/qgsnullmaterialsettings.h
+++ b/src/3d/materials/qgsnullmaterialsettings.h
@@ -37,9 +37,6 @@ class _3D_EXPORT QgsNullMaterialSettings : public QgsAbstractMaterialSettings
 {
   public:
 
-    /**
-     * Constructor for QgsNullMaterialSettings.
-     */
     QgsNullMaterialSettings() = default;
 
     QString type() const override;

--- a/src/3d/materials/qgsphongmaterialsettings.h
+++ b/src/3d/materials/qgsphongmaterialsettings.h
@@ -36,9 +36,6 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
 {
   public:
 
-    /**
-     * Constructor for QgsPhongMaterialSettings.
-     */
     QgsPhongMaterialSettings() = default;
 
     QString type() const override;

--- a/src/3d/materials/qgsphongtexturedmaterialsettings.h
+++ b/src/3d/materials/qgsphongtexturedmaterialsettings.h
@@ -36,9 +36,6 @@ class _3D_EXPORT QgsPhongTexturedMaterialSettings : public QgsAbstractMaterialSe
 {
   public:
 
-    /**
-     * Constructor for QgsPhongTexturedMaterialSettings.
-     */
     QgsPhongTexturedMaterialSettings() = default;
 
     QString type() const override;

--- a/src/3d/materials/qgssimplelinematerialsettings.h
+++ b/src/3d/materials/qgssimplelinematerialsettings.h
@@ -37,9 +37,6 @@ class _3D_EXPORT QgsSimpleLineMaterialSettings : public QgsAbstractMaterialSetti
 {
   public:
 
-    /**
-     * Constructor for QgsSimpleLineMaterialSettings.
-     */
     QgsSimpleLineMaterialSettings() = default;
 
     QString type() const override;

--- a/src/3d/qgs3daxissettings.h
+++ b/src/3d/qgs3daxissettings.h
@@ -46,7 +46,6 @@ class _3D_EXPORT Qgs3DAxisSettings
       Cube = 3, //!< Abstract cube mode
     };
 
-    //! default constructor
     Qgs3DAxisSettings() = default;
 
     //! Returns true if both objects are equal

--- a/src/3d/qgsambientocclusionsettings.h
+++ b/src/3d/qgsambientocclusionsettings.h
@@ -35,7 +35,7 @@ class QDomElement;
 class _3D_EXPORT QgsAmbientOcclusionSettings
 {
   public:
-    //! Default constructor
+
     QgsAmbientOcclusionSettings() = default;
     //! Copy constructor
     QgsAmbientOcclusionSettings( const QgsAmbientOcclusionSettings &other );

--- a/src/3d/qgsshadowsettings.h
+++ b/src/3d/qgsshadowsettings.h
@@ -34,7 +34,7 @@ class QDomElement;
 class _3D_EXPORT QgsShadowSettings
 {
   public:
-    //! Default constructor
+
     QgsShadowSettings() = default;
     //! Copy constructor
     QgsShadowSettings( const QgsShadowSettings &other );

--- a/src/3d/qgsskyboxsettings.h
+++ b/src/3d/qgsskyboxsettings.h
@@ -36,7 +36,7 @@ class QDomElement;
 class _3D_EXPORT QgsSkyboxSettings
 {
   public:
-    //! default constructor
+
     QgsSkyboxSettings() = default;
     //! copy constructor
     QgsSkyboxSettings( const QgsSkyboxSettings &other );

--- a/src/3d/terrain/qgsdemterraingenerator.h
+++ b/src/3d/terrain/qgsdemterraingenerator.h
@@ -42,7 +42,6 @@ class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator
     Q_OBJECT
 
   public:
-    //! Constructor for QgsDemTerrainGenerator
     QgsDemTerrainGenerator() = default;
     ~QgsDemTerrainGenerator() override;
 

--- a/src/3d/terrain/qgsflatterraingenerator.h
+++ b/src/3d/terrain/qgsflatterraingenerator.h
@@ -52,7 +52,7 @@ class _3D_EXPORT QgsFlatTerrainGenerator : public QgsTerrainGenerator
 {
     Q_OBJECT
   public:
-    //! Creates flat terrain generator object
+
     QgsFlatTerrainGenerator() = default;
 
     QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override SIP_FACTORY;

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -53,7 +53,6 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
     };
     Q_ENUM( TransformMethod )
 
-    //! Constructor for QgsGcpTransformerInterface
     QgsGcpTransformerInterface() = default;
 
     virtual ~QgsGcpTransformerInterface() = default;
@@ -153,7 +152,6 @@ class ANALYSIS_EXPORT QgsLinearGeorefTransform : public QgsGcpTransformerInterfa
 {
   public:
 
-    //! Constructor for QgsLinearGeorefTransform
     QgsLinearGeorefTransform() = default;
 
     /**
@@ -192,7 +190,6 @@ class ANALYSIS_EXPORT QgsHelmertGeorefTransform : public QgsGcpTransformerInterf
 {
   public:
 
-    //! Constructor for QgsHelmertGeorefTransform
     QgsHelmertGeorefTransform() = default;
 
     /**

--- a/src/analysis/interpolation/Bezier3D.h
+++ b/src/analysis/interpolation/Bezier3D.h
@@ -35,7 +35,7 @@ class ANALYSIS_EXPORT Bezier3D: public ParametricLine
   protected:
 
   public:
-    //! Default constructor
+
     Bezier3D() = default;
     //! Constructor, par is a pointer to the parent, controlpoly a controlpolygon
     Bezier3D( ParametricLine *par, QVector<QgsPoint *> *controlpoly );

--- a/src/analysis/interpolation/CloughTocherInterpolator.h
+++ b/src/analysis/interpolation/CloughTocherInterpolator.h
@@ -101,7 +101,7 @@ class ANALYSIS_EXPORT CloughTocherInterpolator : public TriangleInterpolator
     double calcBernsteinPoly( int n, int i, int j, int k, double u, double v, double w );
 
   public:
-    //! Standard constructor
+
     CloughTocherInterpolator() = default;
 
     //! Constructor with a pointer to the triangulation as argument

--- a/src/analysis/interpolation/LinTriangleInterpolator.h
+++ b/src/analysis/interpolation/LinTriangleInterpolator.h
@@ -31,7 +31,7 @@
 class ANALYSIS_EXPORT LinTriangleInterpolator : public TriangleInterpolator
 {
   public:
-    //! Default constructor
+
     LinTriangleInterpolator() = default;
     //! Constructor with reference to a DualEdgeTriangulation object
     LinTriangleInterpolator( QgsDualEdgeTriangulation *tin );

--- a/src/analysis/interpolation/ParametricLine.h
+++ b/src/analysis/interpolation/ParametricLine.h
@@ -44,7 +44,7 @@ class ANALYSIS_EXPORT ParametricLine
     //! MControlPoly stores the points of the control polygon
     QVector<QgsPoint *> *mControlPoly = nullptr;
   public:
-    //! Default constructor
+
     ParametricLine() = default;
 
     /**

--- a/src/analysis/interpolation/TriDecorator.h
+++ b/src/analysis/interpolation/TriDecorator.h
@@ -31,7 +31,7 @@
 class ANALYSIS_EXPORT TriDecorator : public QgsTriangulation
 {
   public:
-    //! Constructor for TriDecorator
+
     TriDecorator() = default;
     //! Constructor for TriDecorator with an existing triangulation
     explicit TriDecorator( QgsTriangulation *t );

--- a/src/analysis/interpolation/Vector3D.h
+++ b/src/analysis/interpolation/Vector3D.h
@@ -45,7 +45,7 @@ class ANALYSIS_EXPORT Vector3D
   public:
     //! Constructor taking the three components as arguments
     Vector3D( double x, double y, double z );
-    //! Default constructor
+
     Vector3D() = default;
 
     // TODO c++20 - replace with = default

--- a/src/analysis/interpolation/qgsinterpolator.h
+++ b/src/analysis/interpolation/qgsinterpolator.h
@@ -51,7 +51,6 @@ struct ANALYSIS_EXPORT QgsInterpolatorVertexData
     , z( z )
   {}
 
-  //! Constructor for QgsInterpolatorVertexData
   QgsInterpolatorVertexData() = default;
 
   //! X-coordinate

--- a/src/analysis/network/qgsgraph.h
+++ b/src/analysis/network/qgsgraph.h
@@ -44,9 +44,6 @@ class ANALYSIS_EXPORT QgsGraphEdge
 {
   public:
 
-    /**
-     * Constructor for QgsGraphEdge.
-     */
     QgsGraphEdge() = default;
 
     /**
@@ -94,9 +91,6 @@ class ANALYSIS_EXPORT QgsGraphVertex
 {
   public:
 
-    /**
-     * Default constructor. It is needed for Qt's container, e.g. QVector
-     */
     QgsGraphVertex() = default;
 
     /**
@@ -140,9 +134,6 @@ class ANALYSIS_EXPORT QgsGraph
 {
   public:
 
-    /**
-     * Constructor for QgsGraph.
-     */
     QgsGraph() = default;
 
     // Graph constructing methods

--- a/src/analysis/network/qgsnetworkstrategy.h
+++ b/src/analysis/network/qgsnetworkstrategy.h
@@ -53,9 +53,6 @@ class ANALYSIS_EXPORT QgsNetworkStrategy
 
   public:
 
-    /**
-     * Default constructor
-     */
     QgsNetworkStrategy() = default;
 
     virtual ~QgsNetworkStrategy() = default;

--- a/src/analysis/raster/qgsrastercalcnode.h
+++ b/src/analysis/raster/qgsrastercalcnode.h
@@ -80,9 +80,6 @@ class ANALYSIS_EXPORT QgsRasterCalcNode
       opNONE,
     };
 
-    /**
-     * Constructor for QgsRasterCalcNode.
-     */
     QgsRasterCalcNode() = default;
 
     QgsRasterCalcNode( double number );

--- a/src/analysis/raster/qgsrastermatrix.h
+++ b/src/analysis/raster/qgsrastermatrix.h
@@ -64,10 +64,12 @@ class ANALYSIS_EXPORT QgsRasterMatrix
       opABS,
     };
 
-    //! Takes ownership of data array
     QgsRasterMatrix() = default;
 
-    //! \note note available in Python bindings
+    /**
+     * Takes ownership of \a data array.
+     * \note note available in Python bindings
+     */
     QgsRasterMatrix( int nCols, int nRows, double *data, double nodataValue ) SIP_SKIP;
     QgsRasterMatrix( const QgsRasterMatrix &m );
     ~QgsRasterMatrix();

--- a/src/core/3d/qgs3drendererregistry.h
+++ b/src/core/3d/qgs3drendererregistry.h
@@ -67,7 +67,7 @@ class CORE_EXPORT Qgs3DRendererAbstractMetadata
 class CORE_EXPORT Qgs3DRendererRegistry
 {
   public:
-    //! Creates registry of 3D renderers
+
     Qgs3DRendererRegistry() = default;
 
     ~Qgs3DRendererRegistry();

--- a/src/core/3d/qgsabstract3drenderer.h
+++ b/src/core/3d/qgsabstract3drenderer.h
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsAbstract3DRenderer SIP_ABSTRACT
     virtual void resolveReferences( const QgsProject &project );
 
   protected:
-    //! Default constructor
+
     QgsAbstract3DRenderer() = default;
 
   private:

--- a/src/core/3d/qgsabstractpointcloud3drenderer.h
+++ b/src/core/3d/qgsabstractpointcloud3drenderer.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsAbstractPointCloud3DRenderer : public QgsAbstract3DRenderer
     virtual bool convertFrom2DRenderer( QgsPointCloudRenderer *renderer ) = 0;
 
   protected:
-    //! Default constructor
+
     QgsAbstractPointCloud3DRenderer() = default;
 
   private:

--- a/src/core/actions/qgsaction.h
+++ b/src/core/actions/qgsaction.h
@@ -37,9 +37,6 @@ class CORE_EXPORT QgsAction
 {
   public:
 
-    /**
-     * Default constructor
-     */
     QgsAction() = default;
 
     /**

--- a/src/core/annotations/qgsannotationitem.h
+++ b/src/core/annotations/qgsannotationitem.h
@@ -71,9 +71,6 @@ class CORE_EXPORT QgsAnnotationItem
 
   public:
 
-    /**
-     * Constructor for an annotation item.
-     */
     QgsAnnotationItem() = default;
 
 #ifndef SIP_RUN

--- a/src/core/annotations/qgsannotationitemnode.h
+++ b/src/core/annotations/qgsannotationitemnode.h
@@ -32,9 +32,6 @@ class CORE_EXPORT QgsAnnotationItemNode
 {
   public:
 
-    /**
-     * Default constructor
-     */
     QgsAnnotationItemNode() = default;
 
     /**

--- a/src/core/diagram/qgsdiagram.h
+++ b/src/core/diagram/qgsdiagram.h
@@ -93,9 +93,6 @@ class CORE_EXPORT QgsDiagram SIP_NODEFAULTCTORS
 
   protected:
 
-    /**
-     * Constructor for QgsDiagram.
-     */
     QgsDiagram() = default;
     QgsDiagram( const QgsDiagram &other );
 

--- a/src/core/editform/qgseditformconfig.h
+++ b/src/core/editform/qgseditformconfig.h
@@ -46,7 +46,6 @@ class CORE_EXPORT QgsEditFormConfig
 
     struct GroupData
     {
-      //! Constructor for GroupData
       GroupData() = default;
       GroupData( const QString &name, const QList<QString> &fields )
         : mName( name )
@@ -58,7 +57,6 @@ class CORE_EXPORT QgsEditFormConfig
 
     struct TabData
     {
-      //! Constructor for TabData
       TabData() = default;
       TabData( const QString &name, const QList<QString> &fields, const QList<QgsEditFormConfig::GroupData> &groups )
         : mName( name )

--- a/src/core/effects/qgsblureffect.h
+++ b/src/core/effects/qgsblureffect.h
@@ -52,9 +52,6 @@ class CORE_EXPORT QgsBlurEffect : public QgsPaintEffect SIP_NODEFAULTCTORS
      */
     static QgsPaintEffect *create( const QVariantMap &map ) SIP_FACTORY;
 
-    /**
-     * Constructor for QgsBlurEffect.
-     */
     QgsBlurEffect() = default;
 
     QString type() const override { return QStringLiteral( "blur" ); }

--- a/src/core/effects/qgseffectstack.h
+++ b/src/core/effects/qgseffectstack.h
@@ -53,9 +53,6 @@ class CORE_EXPORT QgsEffectStack : public QgsPaintEffect SIP_NODEFAULTCTORS
      */
     static QgsPaintEffect *create( const QVariantMap &map ) SIP_FACTORY;
 
-    /**
-     * Constructor for empty QgsEffectStack.
-     */
     QgsEffectStack() = default;
 
     QgsEffectStack( const QgsEffectStack &other );

--- a/src/core/effects/qgspainteffect.h
+++ b/src/core/effects/qgspainteffect.h
@@ -106,9 +106,6 @@ class CORE_EXPORT QgsPaintEffect SIP_NODEFAULTCTORS
       ModifyAndRender //!< The result of the effect is both rendered and passed on to subsequent effects in the stack
     };
 
-    /**
-     * Constructor for QgsPaintEffect.
-     */
     QgsPaintEffect() = default;
 
     QgsPaintEffect( const QgsPaintEffect &other );
@@ -328,7 +325,6 @@ class CORE_EXPORT QgsDrawSourceEffect : public QgsPaintEffect SIP_NODEFAULTCTORS
 {
   public:
 
-    //! Constructor for QgsDrawSourceEffect
     QgsDrawSourceEffect() = default;
 
     /**

--- a/src/core/effects/qgstransformeffect.h
+++ b/src/core/effects/qgstransformeffect.h
@@ -44,9 +44,6 @@ class CORE_EXPORT QgsTransformEffect : public QgsPaintEffect SIP_NODEFAULTCTORS
      */
     static QgsPaintEffect *create( const QVariantMap &map ) SIP_FACTORY;
 
-    /**
-     * Constructor for QgsTransformEffect.
-     */
     QgsTransformEffect() = default;
 
     QString type() const override { return QStringLiteral( "transform" ); }

--- a/src/core/elevation/qgsterrainprovider.h
+++ b/src/core/elevation/qgsterrainprovider.h
@@ -158,9 +158,6 @@ class CORE_EXPORT QgsAbstractTerrainProvider
 
   protected:
 
-    /**
-     * Constructor for QgsAbstractTerrainProvider.
-     */
     QgsAbstractTerrainProvider() = default;
 
 #ifndef SIP_RUN
@@ -206,9 +203,6 @@ class CORE_EXPORT QgsFlatTerrainProvider : public QgsAbstractTerrainProvider
 {
   public:
 
-    /**
-     * Constructor for QgsFlatTerrainProvider.
-     */
     QgsFlatTerrainProvider() = default;
 
     QString type() const override;
@@ -231,9 +225,6 @@ class CORE_EXPORT QgsRasterDemTerrainProvider : public QgsAbstractTerrainProvide
 {
   public:
 
-    /**
-     * Constructor for QgsRasterDemTerrainProvider.
-     */
     QgsRasterDemTerrainProvider() = default;
 
 #ifndef SIP_RUN
@@ -285,9 +276,6 @@ class CORE_EXPORT QgsMeshTerrainProvider : public QgsAbstractTerrainProvider
 {
   public:
 
-    /**
-     * Constructor for QgsMeshTerrainProvider.
-     */
     QgsMeshTerrainProvider() = default;
 
 #ifndef SIP_RUN

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -110,7 +110,6 @@ struct HelpVariant
 
 struct Help
 {
-  //! Constructor for expression help
   Help() = default;
 
   Help( const QString &name, const QString &type, const QString &description, const QList<HelpVariant> &variants )

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -357,9 +357,6 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
 
   protected:
 
-    /**
-     * Constructor.
-     */
     QgsExpressionNode() = default;
 
     //! Copy constructor

--- a/src/core/fieldformatter/qgscheckboxfieldformatter.h
+++ b/src/core/fieldformatter/qgscheckboxfieldformatter.h
@@ -41,9 +41,6 @@ class CORE_EXPORT QgsCheckBoxFieldFormatter : public QgsFieldFormatter
       ShowStoredValues, //!< Shows actual stored field value
     };
 
-    /**
-     * Constructor for QgsCheckBoxFieldFormatter.
-     */
     QgsCheckBoxFieldFormatter() = default;
 
     QString id() const override;

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.h
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.h
@@ -38,9 +38,6 @@ class CORE_EXPORT QgsDateTimeFieldFormatter : public QgsFieldFormatter
     static QString DATE_DISPLAY_FORMAT; //! Date display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
     static QString DATETIME_DISPLAY_FORMAT; //! Date time display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
 
-    /**
-      * Default constructor of field formatter for a date time field.
-      */
     QgsDateTimeFieldFormatter() = default;
 
     QString id() const override;

--- a/src/core/fieldformatter/qgsfallbackfieldformatter.h
+++ b/src/core/fieldformatter/qgsfallbackfieldformatter.h
@@ -30,9 +30,6 @@ class CORE_EXPORT QgsFallbackFieldFormatter : public QgsFieldFormatter
 {
   public:
 
-    /**
-      * Default constructor of field formatter as a fallback when no specialized formatter is defined.
-      */
     QgsFallbackFieldFormatter() = default;
     QString id() const override;
 };

--- a/src/core/fieldformatter/qgskeyvaluefieldformatter.h
+++ b/src/core/fieldformatter/qgskeyvaluefieldformatter.h
@@ -34,9 +34,6 @@ class CORE_EXPORT QgsKeyValueFieldFormatter : public QgsFieldFormatter
 {
   public:
 
-    /**
-      * Default constructor of field formatter for a key value field.
-      */
     QgsKeyValueFieldFormatter() = default;
     QString id() const override;
     QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const override;

--- a/src/core/fieldformatter/qgslistfieldformatter.h
+++ b/src/core/fieldformatter/qgslistfieldformatter.h
@@ -31,9 +31,6 @@ class CORE_EXPORT QgsListFieldFormatter : public QgsFieldFormatter
 {
   public:
 
-    /**
-      * Default constructor of field formatter for a list field.
-      */
     QgsListFieldFormatter() = default;
     QString id() const override;
 

--- a/src/core/fieldformatter/qgsrangefieldformatter.h
+++ b/src/core/fieldformatter/qgsrangefieldformatter.h
@@ -28,9 +28,6 @@ class CORE_EXPORT QgsRangeFieldFormatter : public QgsFieldFormatter
 {
   public:
 
-    /**
-      * Default constructor of field formatter for a range (double)field.
-      */
     QgsRangeFieldFormatter() = default;
 
     QString id() const override;

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -46,7 +46,6 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
         , group( group )
       {}
 
-      //! Constructor for ValueRelationItem
       ValueRelationItem() = default;
 
       QVariant key;

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -150,9 +150,6 @@ class CORE_EXPORT QgsAbstractGeometry
     };
     Q_ENUM( QgsAbstractGeometry::AxisOrder )
 
-    /**
-     * Constructor for QgsAbstractGeometry.
-     */
     QgsAbstractGeometry() = default;
     virtual ~QgsAbstractGeometry() = default;
     QgsAbstractGeometry( const QgsAbstractGeometry &geom );
@@ -1204,7 +1201,7 @@ inline T qgsgeometry_cast( const QgsAbstractGeometry *geom )
 class CORE_EXPORT QgsVertexIterator
 {
   public:
-    //! Constructor for QgsVertexIterator
+
     QgsVertexIterator() = default;
 
     //! Constructs iterator for the given geometry
@@ -1253,7 +1250,7 @@ class CORE_EXPORT QgsVertexIterator
 class CORE_EXPORT QgsGeometryPartIterator
 {
   public:
-    //! Constructor for QgsGeometryPartIterator
+
     QgsGeometryPartIterator() = default;
 
     //! Constructs iterator for the given geometry
@@ -1303,7 +1300,7 @@ class CORE_EXPORT QgsGeometryPartIterator
 class CORE_EXPORT QgsGeometryConstPartIterator
 {
   public:
-    //! Constructor for QgsGeometryConstPartIterator
+
     QgsGeometryConstPartIterator() = default;
 
     //! Constructs iterator for the given geometry

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -35,9 +35,6 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
 {
   public:
 
-    /**
-     * Constructor for QgsCurve.
-     */
     QgsCurve() = default;
 
     /**

--- a/src/core/geometry/qgsreferencedgeometry.h
+++ b/src/core/geometry/qgsreferencedgeometry.h
@@ -78,9 +78,6 @@ class CORE_EXPORT QgsReferencedRectangle : public QgsRectangle, public QgsRefere
      */
     QgsReferencedRectangle( const QgsRectangle &rectangle, const QgsCoordinateReferenceSystem &crs );
 
-    /**
-     * Constructor for QgsReferencedRectangle.
-     */
     QgsReferencedRectangle() = default;
 
     //! Allows direct construction of QVariants from rectangle.
@@ -118,9 +115,6 @@ class CORE_EXPORT QgsReferencedPointXY : public QgsPointXY, public QgsReferenced
      */
     QgsReferencedPointXY( const QgsPointXY &point, const QgsCoordinateReferenceSystem &crs );
 
-    /**
-     * Constructor for QgsReferencedPointXY.
-     */
     QgsReferencedPointXY() = default;
 
     //! Allows direct construction of QVariants from point.
@@ -159,9 +153,6 @@ class CORE_EXPORT QgsReferencedGeometry : public QgsGeometry, public QgsReferenc
      */
     QgsReferencedGeometry( const QgsGeometry &geometry, const QgsCoordinateReferenceSystem &crs );
 
-    /**
-     * Constructor for QgsReferencedGeometry.
-     */
     QgsReferencedGeometry() = default;
 
     //! Allows direct construction of QVariants from geometry.

--- a/src/core/gps/qgsbabelgpsdevice.h
+++ b/src/core/gps/qgsbabelgpsdevice.h
@@ -36,7 +36,6 @@ class CORE_EXPORT QgsBabelGpsDeviceFormat : public QgsAbstractBabelFormat
 {
   public:
 
-    //! Default constructor
     QgsBabelGpsDeviceFormat() = default;
 
     /**

--- a/src/core/gps/qgsgpsconnectionregistry.h
+++ b/src/core/gps/qgsgpsconnectionregistry.h
@@ -37,9 +37,6 @@ class CORE_EXPORT QgsGpsConnectionRegistry
 {
   public:
 
-    /**
-     * Constructor for QgsGpsConnectionRegistry.
-     */
     QgsGpsConnectionRegistry() = default;
     ~QgsGpsConnectionRegistry();
 

--- a/src/core/labeling/qgscalloutposition.h
+++ b/src/core/labeling/qgscalloutposition.h
@@ -45,7 +45,6 @@ class CORE_EXPORT QgsCalloutPosition
       , providerID( providerId )
     {}
 
-    //! Constructor for QgsCalloutPosition
     QgsCalloutPosition() = default;
 
     /**

--- a/src/core/labeling/qgslabelposition.h
+++ b/src/core/labeling/qgslabelposition.h
@@ -71,7 +71,6 @@ class CORE_EXPORT QgsLabelPosition
       , isUnplaced( isUnplaced )
     {}
 
-    //! Constructor for QgsLabelPosition
     QgsLabelPosition() = default;
 
 #ifdef SIP_RUN

--- a/src/core/labeling/qgsvectorlayerlabeling.h
+++ b/src/core/labeling/qgsvectorlayerlabeling.h
@@ -53,7 +53,6 @@ class CORE_EXPORT QgsAbstractVectorLayerLabeling
 
   public:
 
-    //! Default constructor
     QgsAbstractVectorLayerLabeling() = default;
     virtual ~QgsAbstractVectorLayerLabeling() = default;
 

--- a/src/core/layout/qgslayouteffect.h
+++ b/src/core/layout/qgslayouteffect.h
@@ -39,9 +39,6 @@ class CORE_EXPORT QgsLayoutEffect : public QGraphicsEffect
 
   public:
 
-    /**
-     * Constructor for QgsLayoutEffect.
-     */
     QgsLayoutEffect() = default;
 
     /**

--- a/src/core/layout/qgslayoutmeasurementconverter.h
+++ b/src/core/layout/qgslayoutmeasurementconverter.h
@@ -40,9 +40,6 @@ class CORE_EXPORT QgsLayoutMeasurementConverter
 {
   public:
 
-    /**
-     * Constructor for QgsLayoutMeasurementConverter.
-     */
     QgsLayoutMeasurementConverter() = default;
 
     /**

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -73,7 +73,6 @@ class CORE_EXPORT QgsLayoutTableStyle
 {
   public:
 
-    //! Constructor for QgsLayoutTableStyle
     QgsLayoutTableStyle() = default;
 
     //! Whether the styling option is enabled

--- a/src/core/locator/qgslocatorcontext.h
+++ b/src/core/locator/qgslocatorcontext.h
@@ -32,9 +32,6 @@ class CORE_EXPORT QgsLocatorContext
 {
   public:
 
-    /**
-     * Constructor for QgsLocatorContext.
-     */
     QgsLocatorContext() = default;
 
     /**

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -38,9 +38,6 @@ class CORE_EXPORT QgsLocatorResult
 {
   public:
 
-    /**
-     * Constructor for QgsLocatorResult.
-     */
     QgsLocatorResult() = default;
 
     /**
@@ -109,7 +106,7 @@ class CORE_EXPORT QgsLocatorResult
     struct CORE_EXPORT ResultAction
     {
       public:
-        //! Constructor for ResultAction
+
         ResultAction() = default;
 
         /**

--- a/src/core/mesh/qgsmeshadvancedediting.h
+++ b/src/core/mesh/qgsmeshadvancedediting.h
@@ -163,7 +163,6 @@ class CORE_EXPORT QgsMeshTransformVerticesByExpression : public QgsMeshAdvancedE
 {
   public:
 
-    //! Constructor
     QgsMeshTransformVerticesByExpression() = default;
 
     QString text() const override;

--- a/src/core/mesh/qgsmeshdataset.h
+++ b/src/core/mesh/qgsmeshdataset.h
@@ -561,7 +561,7 @@ class CORE_EXPORT QgsMeshDatasetMetadata
 class CORE_EXPORT QgsMeshDataset
 {
   public:
-    //! Constructor
+
     QgsMeshDataset() = default;
 
     //! Destructor
@@ -610,7 +610,6 @@ class CORE_EXPORT QgsMeshDatasetGroup
       Virtual, //! Virtual Dataset group defined by a formula
     };
 
-    //! Default constructor
     QgsMeshDatasetGroup() = default;
     virtual ~QgsMeshDatasetGroup();
 
@@ -722,7 +721,7 @@ class CORE_EXPORT QgsMeshDatasetGroup
 class CORE_EXPORT QgsMeshMemoryDataset: public QgsMeshDataset
 {
   public:
-    //! Constructor
+
     QgsMeshMemoryDataset() = default;
 
     QgsMeshDatasetValue datasetValue( int valueIndex ) const override;
@@ -755,7 +754,7 @@ class CORE_EXPORT QgsMeshMemoryDataset: public QgsMeshDataset
 class CORE_EXPORT QgsMeshMemoryDatasetGroup: public QgsMeshDatasetGroup
 {
   public:
-    //! Constructor
+
     QgsMeshMemoryDatasetGroup() = default;
     //! Constructor with the \a name of the group
     QgsMeshMemoryDatasetGroup( const QString &name );

--- a/src/core/mesh/qgsmeshforcebypolylines.h
+++ b/src/core/mesh/qgsmeshforcebypolylines.h
@@ -40,7 +40,6 @@ class CORE_EXPORT QgsMeshEditForceByLine : public QgsMeshAdvancedEditing
 {
   public:
 
-    //! Constructor
     QgsMeshEditForceByLine() = default;
 
     //! Sets the input forcing line in rendering coordinates
@@ -145,7 +144,6 @@ class CORE_EXPORT QgsMeshEditForceByPolylines : public QgsMeshEditForceByLine
 {
   public:
 
-    //! Constructor
     QgsMeshEditForceByPolylines() = default;
 
     QString text() const override;

--- a/src/core/mesh/qgsmeshlayerlabeling.h
+++ b/src/core/mesh/qgsmeshlayerlabeling.h
@@ -45,7 +45,6 @@ class CORE_EXPORT QgsAbstractMeshLayerLabeling
 {
   public:
 
-    //! Default constructor
     QgsAbstractMeshLayerLabeling() = default;
     virtual ~QgsAbstractMeshLayerLabeling() = default;
 

--- a/src/core/mesh/qgsmeshvectorrenderer.h
+++ b/src/core/mesh/qgsmeshvectorrenderer.h
@@ -39,7 +39,7 @@ class QgsMeshLayerRendererFeedback;
 class QgsMeshVectorRenderer
 {
   public:
-    //! Constructor
+
     QgsMeshVectorRenderer() = default;
 
     /**

--- a/src/core/metadata/qgsabstractlayermetadataprovider.h
+++ b/src/core/metadata/qgsabstractlayermetadataprovider.h
@@ -67,9 +67,6 @@ class CORE_EXPORT QgsLayerMetadataProviderResult: public QgsLayerMetadata
      */
     QgsLayerMetadataProviderResult( const QgsLayerMetadata &metadata );
 
-    /**
-     * Default constructor.
-     */
     QgsLayerMetadataProviderResult( ) = default;
 
     /**

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -166,9 +166,6 @@ class CORE_EXPORT QgsLayerMetadata : public QgsAbstractMetadataBase
      */
     typedef QList< QgsLayerMetadata::Constraint > ConstraintList;
 
-    /**
-     * Constructor for QgsLayerMetadata.
-     */
     QgsLayerMetadata() = default;
 
 

--- a/src/core/metadata/qgslayermetadatavalidator.h
+++ b/src/core/metadata/qgslayermetadatavalidator.h
@@ -109,9 +109,6 @@ class CORE_EXPORT QgsNativeMetadataBaseValidator : public QgsAbstractMetadataBas
 
   public:
 
-    /**
-     * Constructor for QgsNativeMetadataBaseValidator.
-     */
     QgsNativeMetadataBaseValidator() = default;
 
     bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results SIP_OUT ) const override;
@@ -129,10 +126,6 @@ class CORE_EXPORT QgsNativeMetadataValidator : public QgsNativeMetadataBaseValid
 {
 
   public:
-
-    /**
-     * Constructor for QgsNativeMetadataValidator.
-     */
     QgsNativeMetadataValidator() = default;
 
     bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results SIP_OUT ) const override;
@@ -151,9 +144,6 @@ class CORE_EXPORT QgsNativeProjectMetadataValidator : public QgsNativeMetadataBa
 
   public:
 
-    /**
-     * Constructor for QgsNativeProjectMetadataValidator.
-     */
     QgsNativeProjectMetadataValidator() = default;
 
     bool validate( const QgsAbstractMetadataBase *metadata, QList< QgsAbstractMetadataBaseValidator::ValidationResult > &results SIP_OUT ) const override;

--- a/src/core/metadata/qgsprojectmetadata.h
+++ b/src/core/metadata/qgsprojectmetadata.h
@@ -54,9 +54,6 @@ class CORE_EXPORT QgsProjectMetadata : public QgsAbstractMetadataBase
 {
   public:
 
-    /**
-     * Constructor for QgsProjectMetadata.
-     */
     QgsProjectMetadata() = default;
 
     QgsProjectMetadata *clone() const override SIP_FACTORY;

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -55,9 +55,6 @@ class CORE_EXPORT QgsNetworkRequestParameters
       AttributeInitiatorRequestId, //!< Internal ID used by originator object to identify requests
     };
 
-    /**
-     * Default constructor.
-     */
     QgsNetworkRequestParameters() = default;
 
     /**

--- a/src/core/network/qgsnetworkcontentfetcher.h
+++ b/src/core/network/qgsnetworkcontentfetcher.h
@@ -41,9 +41,6 @@ class CORE_EXPORT QgsNetworkContentFetcher : public QObject
 
   public:
 
-    /**
-     * Constructor for QgsNetworkContentFetcher.
-     */
     QgsNetworkContentFetcher() = default;
 
     ~QgsNetworkContentFetcher() override;

--- a/src/core/numericformats/qgsfallbacknumericformat.h
+++ b/src/core/numericformats/qgsfallbacknumericformat.h
@@ -29,9 +29,6 @@ class CORE_EXPORT QgsFallbackNumericFormat : public QgsNumericFormat
 {
   public:
 
-    /**
-      * Default constructor
-      */
     QgsFallbackNumericFormat() = default;
     QString id() const override;
     QString visibleName() const override;

--- a/src/core/numericformats/qgsnumericformat.h
+++ b/src/core/numericformats/qgsnumericformat.h
@@ -284,9 +284,6 @@ class CORE_EXPORT QgsNumericFormat
 
   public:
 
-    /**
-      * Default constructor
-      */
     QgsNumericFormat() = default;
 
     virtual ~QgsNumericFormat() = default;

--- a/src/core/pal/util.h
+++ b/src/core/pal/util.h
@@ -56,7 +56,7 @@ namespace pal
   class Feats
   {
     public:
-      //! Constructor for Feats
+
       Feats() = default;
 
       FeaturePart *feature = nullptr;

--- a/src/core/plot/qgsplot.h
+++ b/src/core/plot/qgsplot.h
@@ -44,9 +44,6 @@ class CORE_EXPORT QgsPlot
 {
   public:
 
-    /**
-     * Constructor for QgsPlot.
-     */
     QgsPlot() = default;
 
     virtual ~QgsPlot();

--- a/src/core/pointcloud/expression/qgspointcloudexpressionnode.h
+++ b/src/core/pointcloud/expression/qgspointcloudexpressionnode.h
@@ -218,9 +218,6 @@ class CORE_EXPORT QgsPointCloudExpressionNode
 
   protected:
 
-    /**
-     * Constructor.
-     */
     QgsPointCloudExpressionNode() = default;
 
     //! Copy constructor

--- a/src/core/pointcloud/qgspointcloudclassifiedrenderer.h
+++ b/src/core/pointcloud/qgspointcloudclassifiedrenderer.h
@@ -33,9 +33,6 @@ class CORE_EXPORT QgsPointCloudCategory
 {
   public:
 
-    /**
-     * Constructor for QgsPointCloudCategory.
-     */
     QgsPointCloudCategory() = default;
 
     /**

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -343,9 +343,6 @@ class CORE_EXPORT QgsPointCloudRenderer
 
   public:
 
-    /**
-     * Constructor for QgsPointCloudRenderer.
-     */
     QgsPointCloudRenderer() = default;
 
     virtual ~QgsPointCloudRenderer() = default;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -1152,9 +1152,6 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
 {
   public:
 
-    /**
-      * Constructor for QgsProcessingFeatureBasedAlgorithm.
-      */
     QgsProcessingFeatureBasedAlgorithm() = default;
 
     Qgis::ProcessingAlgorithmFlags flags() const override SIP_HOLDGIL;

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -263,7 +263,6 @@ class CORE_EXPORT QgsProcessingContext
           , project( project )
         {}
 
-        //! Default constructor
         LayerDetails() = default;
 
         /**

--- a/src/core/project/qgsprojectproperty.h
+++ b/src/core/project/qgsprojectproperty.h
@@ -127,7 +127,6 @@ class CORE_EXPORT QgsProjectPropertyValue : public QgsProjectProperty
 {
   public:
 
-    //! Constructor for QgsProjectPropertyValue.
     QgsProjectPropertyValue() = default;
 
     /**

--- a/src/core/project/qgsprojectservervalidator.h
+++ b/src/core/project/qgsprojectservervalidator.h
@@ -35,9 +35,6 @@ class CORE_EXPORT QgsProjectServerValidator
 
   public:
 
-    /**
-     * Constructor for QgsProjectServerValidator.
-     */
     QgsProjectServerValidator() = default;
 
     /**

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -72,9 +72,6 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
      */
     static QString geoPDFAvailabilityExplanation();
 
-    /**
-     * Constructor for QgsAbstractGeoPdfExporter.
-     */
     QgsAbstractGeoPdfExporter() = default;
 
     virtual ~QgsAbstractGeoPdfExporter() = default;
@@ -85,9 +82,6 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
     struct RenderedFeature
     {
 
-      /**
-       * Constructor for RenderedFeature.
-       */
       RenderedFeature() = default;
 
       /**

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -60,7 +60,6 @@ class QgsAttributes : public QVector<QVariant>
 {
   public:
 
-    //! Constructor for QgsAttributes
     QgsAttributes() = default;
 
     /**

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -50,7 +50,6 @@ class CORE_EXPORT QgsAttributeTableConfig
      */
     struct ColumnConfig
     {
-      //! Constructor for ColumnConfig
       ColumnConfig() = default;
 
       // TODO c++20 - replace with = default
@@ -78,9 +77,6 @@ class CORE_EXPORT QgsAttributeTableConfig
       DropDown      //!< A tool button with a drop-down to select the current action
     };
 
-    /**
-     * Constructor for QgsAttributeTableConfig.
-     */
     QgsAttributeTableConfig() = default;
 
     /**

--- a/src/core/qgscacheindex.h
+++ b/src/core/qgscacheindex.h
@@ -32,9 +32,6 @@ class CORE_EXPORT QgsAbstractCacheIndex
 {
   public:
 
-    /**
-     * Constructor for QgsAbstractCacheIndex.
-     */
     QgsAbstractCacheIndex() = default;
     virtual ~QgsAbstractCacheIndex() = default;
 

--- a/src/core/qgscolorrampimpl.h
+++ b/src/core/qgscolorrampimpl.h
@@ -487,9 +487,6 @@ class CORE_EXPORT QgsRandomColorRamp: public QgsColorRamp
 {
   public:
 
-    /**
-     * Constructor for QgsRandomColorRamp.
-     */
     QgsRandomColorRamp() = default;
 
     int count() const override;

--- a/src/core/qgscolorscheme.h
+++ b/src/core/qgscolorscheme.h
@@ -74,9 +74,6 @@ class CORE_EXPORT QgsColorScheme
     };
     Q_DECLARE_FLAGS( SchemeFlags, SchemeFlag )
 
-    /**
-     * Constructor for QgsColorScheme.
-     */
     QgsColorScheme() = default;
 
     virtual ~QgsColorScheme() = default;
@@ -142,9 +139,6 @@ class CORE_EXPORT QgsGplColorScheme : public QgsColorScheme
 {
   public:
 
-    /**
-     * Constructor for QgsGplColorScheme.
-     */
     QgsGplColorScheme() = default;
 
     QgsNamedColorList fetchColors( const QString &context = QString(),
@@ -225,9 +219,6 @@ class CORE_EXPORT QgsRecentColorScheme : public QgsColorScheme
 {
   public:
 
-    /**
-     * Constructor for QgsRecentColorScheme.
-     */
     QgsRecentColorScheme() = default;
 
     QString schemeName() const override { return QObject::tr( "Recent colors" ); }
@@ -262,9 +253,6 @@ class CORE_EXPORT QgsCustomColorScheme : public QgsColorScheme
 {
   public:
 
-    /**
-     * Constructor for QgsCustomColorScheme.
-     */
     QgsCustomColorScheme() = default;
 
     QString schemeName() const override { return QObject::tr( "Standard colors" ); }
@@ -290,9 +278,6 @@ class CORE_EXPORT QgsProjectColorScheme : public QgsColorScheme
 {
   public:
 
-    /**
-     * Constructor for QgsProjectColorScheme.
-     */
     QgsProjectColorScheme() = default;
 
     QString schemeName() const override { return QObject::tr( "Project colors" ); }

--- a/src/core/qgscredentials.h
+++ b/src/core/qgscredentials.h
@@ -103,9 +103,6 @@ class CORE_EXPORT QgsCredentials
 
   protected:
 
-    /**
-     * Constructor for QgsCredentials.
-     */
     QgsCredentials() = default;
 
     //! request a password

--- a/src/core/qgsdartmeasurement.h
+++ b/src/core/qgsdartmeasurement.h
@@ -34,7 +34,6 @@ class CORE_EXPORT QgsDartMeasurement
       Integer
     };
 
-    //! Constructor for QgsDartMeasurement
     QgsDartMeasurement() = default;
 
     QgsDartMeasurement( const QString &name, Type type, const QString &value );

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -666,9 +666,6 @@ class CORE_EXPORT QgsDiagramRenderer
 
   public:
 
-    /**
-     * Constructor for QgsDiagramRenderer.
-     */
     QgsDiagramRenderer() = default;
     virtual ~QgsDiagramRenderer() = default;
 
@@ -785,7 +782,6 @@ class CORE_EXPORT QgsSingleCategoryDiagramRenderer : public QgsDiagramRenderer
 {
   public:
 
-    //! Constructor for QgsSingleCategoryDiagramRenderer
     QgsSingleCategoryDiagramRenderer() = default;
 
     QgsSingleCategoryDiagramRenderer *clone() const override SIP_FACTORY;

--- a/src/core/qgseditorwidgetsetup.h
+++ b/src/core/qgseditorwidgetsetup.h
@@ -36,7 +36,6 @@ class CORE_EXPORT QgsEditorWidgetSetup
       , mConfig( config )
     {}
 
-    //! Constructor for QgsEditorWidgetSetup
     QgsEditorWidgetSetup() = default;
 
     /**

--- a/src/core/qgselevationmap.h
+++ b/src/core/qgselevationmap.h
@@ -43,7 +43,6 @@ class CORE_EXPORT QgsElevationMap
 {
   public:
 
-    //! Default constructor
     QgsElevationMap() = default;
 
     //! Constructs an elevation map with the given width and height

--- a/src/core/qgserror.h
+++ b/src/core/qgserror.h
@@ -39,7 +39,6 @@ class CORE_EXPORT QgsErrorMessage
       Html
     };
 
-    //! Constructor for QgsErrorMessage
     QgsErrorMessage() = default;
 
     /**
@@ -81,7 +80,6 @@ class CORE_EXPORT QgsError
 {
   public:
 
-    //! Constructor for QgsError
     QgsError() = default;
 
     /**

--- a/src/core/qgsexpressionfieldbuffer.h
+++ b/src/core/qgsexpressionfieldbuffer.h
@@ -45,9 +45,6 @@ class CORE_EXPORT QgsExpressionFieldBuffer
       QgsField field;
     };
 
-    /**
-     * Constructor for QgsExpressionFieldBuffer.
-     */
     QgsExpressionFieldBuffer() = default;
 
     /**

--- a/src/core/qgsfeaturefilterprovider.h
+++ b/src/core/qgsfeaturefilterprovider.h
@@ -44,7 +44,6 @@ class CORE_EXPORT QgsFeatureFilterProvider
 
 #ifndef SIP_RUN
 
-    //! Constructor
     QgsFeatureFilterProvider() = default;
 
     virtual ~QgsFeatureFilterProvider() = default;

--- a/src/core/qgsfeaturestore.h
+++ b/src/core/qgsfeaturestore.h
@@ -32,7 +32,6 @@
 class CORE_EXPORT QgsFeatureStore : public QgsFeatureSink
 {
   public:
-    //! Constructor
     QgsFeatureStore() = default;
 
     //! Constructor

--- a/src/core/qgsfieldformatter.h
+++ b/src/core/qgsfieldformatter.h
@@ -34,9 +34,6 @@ class CORE_EXPORT QgsFieldFormatterContext
 {
   public:
 
-    /**
-     * Constructor
-     */
     QgsFieldFormatterContext() = default;
 
     /**
@@ -72,9 +69,6 @@ class CORE_EXPORT QgsFieldFormatter
 {
   public:
 
-    /**
-      * Default constructor
-      */
     QgsFieldFormatter() = default;
 
     virtual ~QgsFieldFormatter() = default;

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsGmlStreamingParser
     class LayerProperties
     {
       public:
-        //! Constructor
+
         LayerProperties() = default;
 
         //! Layer name

--- a/src/core/qgsgmlschema.h
+++ b/src/core/qgsgmlschema.h
@@ -41,9 +41,6 @@ class CORE_EXPORT QgsGmlFeatureClass
 {
   public:
 
-    /**
-     * Constructor for QgsGmlFeatureClass.
-     */
     QgsGmlFeatureClass() = default;
     QgsGmlFeatureClass( const QString &name, const QString &path );
 

--- a/src/core/qgshistogram.h
+++ b/src/core/qgshistogram.h
@@ -37,9 +37,6 @@ class CORE_EXPORT QgsHistogram
 {
   public:
 
-    /**
-     * Constructor for QgsHistogram.
-     */
     QgsHistogram() = default;
 
     virtual ~QgsHistogram() = default;

--- a/src/core/qgsidentifycontext.h
+++ b/src/core/qgsidentifycontext.h
@@ -32,7 +32,6 @@ class CORE_EXPORT QgsIdentifyContext
 {
   public:
 
-    //! Constructor for QgsIdentifyContext
     QgsIdentifyContext() = default;
 
     /**

--- a/src/core/qgsmapdecoration.h
+++ b/src/core/qgsmapdecoration.h
@@ -35,9 +35,6 @@ class CORE_EXPORT QgsMapDecoration
 
   public:
 
-    /**
-     * Constructor for QgsMapDecoration.
-     */
     QgsMapDecoration() = default;
 
     virtual ~QgsMapDecoration() = default;

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -42,9 +42,6 @@ class CORE_EXPORT QgsMessageLog : public QObject
 
   public:
 
-    /**
-     * Constructor for QgsMessageLog.
-     */
     QgsMessageLog() = default;
 
     /**

--- a/src/core/qgsmessageoutput.h
+++ b/src/core/qgsmessageoutput.h
@@ -100,9 +100,6 @@ class CORE_EXPORT QgsMessageOutputConsole : public QObject, public QgsMessageOut
 
   public:
 
-    /**
-     * Constructor for QgsMessageOutputConsole.
-     */
     QgsMessageOutputConsole() = default;
 
     void setMessage( const QString &message, MessageType msgType ) override;

--- a/src/core/qgsobjectcustomproperties.h
+++ b/src/core/qgsobjectcustomproperties.h
@@ -35,9 +35,6 @@ class CORE_EXPORT QgsObjectCustomProperties
 {
   public:
 
-    /**
-     * Constructor for QgsObjectCustomProperties.
-     */
     QgsObjectCustomProperties() = default;
 
     /**

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -255,7 +255,6 @@ class CORE_EXPORT QgsOgcUtils
     class LayerProperties
     {
       public:
-        //! Constructor
         LayerProperties() = default;
 
         //! Layer name

--- a/src/core/qgspluginlayerregistry.h
+++ b/src/core/qgspluginlayerregistry.h
@@ -68,9 +68,6 @@ class CORE_EXPORT QgsPluginLayerRegistry
 {
   public:
 
-    /**
-     * Constructor for QgsPluginLayerRegistry.
-     */
     QgsPluginLayerRegistry() = default;
     ~QgsPluginLayerRegistry();
 

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsPointXY
     Q_PROPERTY( double y READ y WRITE setY )
 
   public:
-    /// Default constructor
+
     QgsPointXY() = default;
 
     //! Create a point from another point

--- a/src/core/qgspropertycollection.h
+++ b/src/core/qgspropertycollection.h
@@ -489,9 +489,6 @@ class CORE_EXPORT QgsPropertyCollectionStack : public QgsAbstractPropertyCollect
 {
   public:
 
-    /**
-     * Constructor for QgsPropertyCollectionStack.
-     */
     QgsPropertyCollectionStack() = default;
 
     ~QgsPropertyCollectionStack() override;

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -293,7 +293,7 @@ class CORE_EXPORT QgsSQLStatement
     class CORE_EXPORT NodeList
     {
       public:
-        //! Constructor
+
         NodeList() = default;
         virtual ~NodeList() { qDeleteAll( mList ); }
 
@@ -825,7 +825,7 @@ class CORE_EXPORT QgsSQLStatement
     class CORE_EXPORT RecursiveVisitor: public QgsSQLStatement::Visitor
     {
       public:
-        //! Constructor
+
         RecursiveVisitor() = default;
 
         void visit( const QgsSQLStatement::NodeUnaryOperator &n ) override { n.operand()->accept( *this ); }

--- a/src/core/qgsstoredexpressionmanager.h
+++ b/src/core/qgsstoredexpressionmanager.h
@@ -57,9 +57,6 @@ class CORE_EXPORT QgsStoredExpression
 
 #ifndef SIP_RUN
 
-    /**
-     * Constructor for QgsStoredExpression
-     */
     QgsStoredExpression() = default;
 
     /**
@@ -98,9 +95,6 @@ class CORE_EXPORT QgsStoredExpressionManager : public QObject
 
   public:
 
-    /**
-    * Constructor for QgsStoredExpressionManager
-    */
     QgsStoredExpressionManager() = default;
 
     /**

--- a/src/core/qgstrackedvectorlayertools.h
+++ b/src/core/qgstrackedvectorlayertools.h
@@ -29,9 +29,6 @@ class CORE_EXPORT QgsTrackedVectorLayerTools : public QgsVectorLayerTools
     Q_OBJECT
   public:
 
-    /**
-     * Constructor for QgsTrackedVectorLayerTools.
-     */
     QgsTrackedVectorLayerTools() = default;
 
     /**

--- a/src/core/qgstranslationcontext.h
+++ b/src/core/qgstranslationcontext.h
@@ -46,9 +46,6 @@ class CORE_EXPORT QgsTranslationContext
 
   public:
 
-    /**
-     * Constructor
-     */
     QgsTranslationContext() = default;
 
     /**

--- a/src/core/qgsunsetattributevalue.h
+++ b/src/core/qgsunsetattributevalue.h
@@ -32,9 +32,6 @@ class CORE_EXPORT QgsUnsetAttributeValue
 {
   public:
 
-    /**
-     * Constructor for a QgsUnsetAttributeValue.
-     */
     QgsUnsetAttributeValue() = default;
 
     /**

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -143,7 +143,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 
     struct MetaData
     {
-      //! Constructor for MetaData
+
       MetaData() = default;
 
       MetaData( const QString &longName, const QString &trLongName, const QString &glob, const QString &ext, const QMap<QString, QgsVectorFileWriter::Option *> &driverOptions, const QMap<QString, QgsVectorFileWriter::Option *> &layerOptions, const QString &compulsoryEncoding = QString() )
@@ -210,7 +210,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     class CORE_EXPORT FieldValueConverter
     {
       public:
-        //! Constructor
+
         FieldValueConverter() = default;
 
         virtual ~FieldValueConverter() = default;

--- a/src/core/raster/qgsbilinearrasterresampler.h
+++ b/src/core/raster/qgsbilinearrasterresampler.h
@@ -34,9 +34,6 @@ class CORE_EXPORT QgsBilinearRasterResampler: public QgsRasterResamplerV2
 {
   public:
 
-    /**
-     * Constructor for QgsBilinearRasterResampler.
-     */
     QgsBilinearRasterResampler() = default;
     Q_DECL_DEPRECATED void resample( const QImage &srcImage, QImage &dstImage ) override SIP_DEPRECATED;
 

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -88,7 +88,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     //not a color but a quantity, e.g. temperature or elevation
     struct ColorRampItem
     {
-      //! default constructor
+
       ColorRampItem() = default;
       //! convenience constructor
       ColorRampItem( double val, const QColor &col, const QString &lbl = QString() )

--- a/src/core/raster/qgscubicrasterresampler.h
+++ b/src/core/raster/qgscubicrasterresampler.h
@@ -33,9 +33,6 @@ class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResamplerV2
 {
   public:
 
-    /**
-     * Constructor for QgsCubicRasterResampler.
-     */
     QgsCubicRasterResampler() = default;
     QgsCubicRasterResampler *clone() const override SIP_FACTORY;
 

--- a/src/core/raster/qgsrasterbandstats.h
+++ b/src/core/raster/qgsrasterbandstats.h
@@ -37,9 +37,6 @@ class CORE_EXPORT QgsRasterBandStats
 {
   public:
 
-    /**
-     * Constructor for QgsRasterBandStats.
-     */
     QgsRasterBandStats() = default;
 
     //! Compares region, size etc. not collected statistics

--- a/src/core/raster/qgsrasteridentifyresult.h
+++ b/src/core/raster/qgsrasteridentifyresult.h
@@ -31,9 +31,6 @@ class CORE_EXPORT QgsRasterIdentifyResult
 {
   public:
 
-    /**
-     * Constructor for QgsRasterIdentifyResult.
-     */
     QgsRasterIdentifyResult() = default;
 
     /**

--- a/src/core/raster/qgsrasterrendererregistry.h
+++ b/src/core/raster/qgsrasterrendererregistry.h
@@ -52,9 +52,6 @@ struct CORE_EXPORT QgsRasterRendererRegistryEntry
   QgsRasterRendererRegistryEntry( const QString &name, const QString &visibleName, QgsRasterRendererCreateFunc rendererFunction,
                                   QgsRasterRendererWidgetCreateFunc widgetFunction, Qgis::RasterRendererCapabilities capabilities = Qgis::RasterRendererCapabilities() );
 
-  /**
-   * Constructor for QgsRasterRendererRegistryEntry.
-   */
   QgsRasterRendererRegistryEntry() = default;
   QString name;
   QString visibleName; //visible (and translatable) name

--- a/src/core/raster/qgsrastertransparency.h
+++ b/src/core/raster/qgsrastertransparency.h
@@ -35,9 +35,6 @@ class CORE_EXPORT QgsRasterTransparency
 
   public:
 
-    /**
-     * Constructor for QgsRasterTransparency.
-     */
     QgsRasterTransparency() = default;
 
     /**

--- a/src/core/scalebar/qgsdoubleboxscalebarrenderer.h
+++ b/src/core/scalebar/qgsdoubleboxscalebarrenderer.h
@@ -30,9 +30,6 @@ class CORE_EXPORT QgsDoubleBoxScaleBarRenderer: public QgsScaleBarRenderer
 {
   public:
 
-    /**
-     * Constructor for QgsDoubleBoxScaleBarRenderer.
-     */
     QgsDoubleBoxScaleBarRenderer() = default;
 
     QString id() const override;

--- a/src/core/scalebar/qgshollowscalebarrenderer.h
+++ b/src/core/scalebar/qgshollowscalebarrenderer.h
@@ -32,9 +32,6 @@ class CORE_EXPORT QgsHollowScaleBarRenderer: public QgsScaleBarRenderer
 {
   public:
 
-    /**
-     * Constructor for QgsHollowScaleBarRenderer.
-     */
     QgsHollowScaleBarRenderer() = default;
 
     QString id() const override;

--- a/src/core/scalebar/qgsnumericscalebarrenderer.h
+++ b/src/core/scalebar/qgsnumericscalebarrenderer.h
@@ -30,9 +30,6 @@ class CORE_EXPORT QgsNumericScaleBarRenderer: public QgsScaleBarRenderer
 {
   public:
 
-    /**
-     * Constructor for QgsNumericScaleBarRenderer.
-     */
     QgsNumericScaleBarRenderer() = default;
 
     QString id() const override;

--- a/src/core/scalebar/qgsscalebarrenderer.h
+++ b/src/core/scalebar/qgsscalebarrenderer.h
@@ -90,9 +90,6 @@ class CORE_EXPORT QgsScaleBarRenderer
 
     };
 
-    /**
-     * Constructor for QgsScaleBarRenderer.
-     */
     QgsScaleBarRenderer() = default;
     virtual ~QgsScaleBarRenderer() = default;
 

--- a/src/core/scalebar/qgssingleboxscalebarrenderer.h
+++ b/src/core/scalebar/qgssingleboxscalebarrenderer.h
@@ -31,9 +31,6 @@ class CORE_EXPORT QgsSingleBoxScaleBarRenderer: public QgsScaleBarRenderer
 {
   public:
 
-    /**
-     * Constructor for QgsSingleBoxScaleBarRenderer.
-     */
     QgsSingleBoxScaleBarRenderer() = default;
 
     QString id() const override;

--- a/src/core/scalebar/qgssteppedlinescalebarrenderer.h
+++ b/src/core/scalebar/qgssteppedlinescalebarrenderer.h
@@ -31,9 +31,6 @@ class CORE_EXPORT QgsSteppedLineScaleBarRenderer: public QgsScaleBarRenderer
 {
   public:
 
-    /**
-     * Constructor for QgsSteppedLineScaleBarRenderer.
-     */
     QgsSteppedLineScaleBarRenderer() = default;
 
     QString id() const override;

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -36,9 +36,6 @@ class CORE_EXPORT QgsRendererCategory
 {
   public:
 
-    /**
-     * Constructor for QgsRendererCategory.
-     */
     QgsRendererCategory() = default;
 
     /**

--- a/src/core/symbology/qgslegendsymbolitem.h
+++ b/src/core/symbology/qgslegendsymbolitem.h
@@ -36,9 +36,6 @@ class CORE_EXPORT QgsLegendSymbolItem
 {
   public:
 
-    /**
-     * Constructor for QgsLegendSymbolItem.
-     */
     QgsLegendSymbolItem() = default;
 
     /**

--- a/src/core/symbology/qgsrendererrange.h
+++ b/src/core/symbology/qgsrendererrange.h
@@ -37,9 +37,6 @@ class CORE_EXPORT QgsRendererRange
 {
   public:
 
-    /**
-     * Constructor for QgsRendererRange.
-     */
     QgsRendererRange() = default;
     ~QgsRendererRange();
 

--- a/src/core/symbology/qgssymbollayerreference.h
+++ b/src/core/symbology/qgssymbollayerreference.h
@@ -137,7 +137,7 @@ class CORE_EXPORT QgsSymbolLayerId
 class CORE_EXPORT QgsSymbolLayerReference
 {
   public:
-    //! Default constructor
+
     QgsSymbolLayerReference() = default;
 
     /**

--- a/src/core/textrenderer/qgstextcharacterformat.h
+++ b/src/core/textrenderer/qgstextcharacterformat.h
@@ -42,9 +42,6 @@ class CORE_EXPORT QgsTextCharacterFormat
 {
   public:
 
-    /**
-     * Constructor for QgsTextCharacterFormat.
-     */
     QgsTextCharacterFormat() = default;
 
     /**

--- a/src/core/tiledscene/qgstiledscenerenderer.h
+++ b/src/core/tiledscene/qgstiledscenerenderer.h
@@ -138,9 +138,6 @@ class CORE_EXPORT QgsTiledSceneRenderer
 
   public:
 
-    /**
-     * Constructor for QgsTiledSceneRenderer.
-     */
     QgsTiledSceneRenderer() = default;
 
     virtual ~QgsTiledSceneRenderer() = default;

--- a/src/core/vector/qgsvectorlayereditbuffer.h
+++ b/src/core/vector/qgsvectorlayereditbuffer.h
@@ -251,7 +251,6 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
   protected:
 
-    //! Constructor for QgsVectorLayerEditBuffer
     QgsVectorLayerEditBuffer() = default;
 
     //! Update feature with uncommitted geometry updates

--- a/src/core/vector/qgsvectorlayerjoininfo.h
+++ b/src/core/vector/qgsvectorlayerjoininfo.h
@@ -33,9 +33,6 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
 {
   public:
 
-    /**
-     * Constructor for QgsVectorLayerJoinInfo.
-     */
     QgsVectorLayerJoinInfo() = default;
 
     //! Sets weak reference to the joined layer

--- a/src/core/vector/qgsvectorlayertoolscontext.h
+++ b/src/core/vector/qgsvectorlayertoolscontext.h
@@ -32,9 +32,6 @@ class CORE_EXPORT QgsVectorLayerToolsContext
 {
   public:
 
-    /**
-     * Constructor for QgsVectorLayerToolsContext.
-     */
     QgsVectorLayerToolsContext() = default;
 
     /**

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -62,7 +62,6 @@ class CORE_EXPORT QgsVectorLayerUtils
     {
       public:
 
-        //! Constructor for QgsDuplicateFeatureContext
         QgsDuplicateFeatureContext() = default;
 
         /**

--- a/src/gui/actions/qgsactionmenu.h
+++ b/src/gui/actions/qgsactionmenu.h
@@ -44,9 +44,6 @@ class GUI_EXPORT QgsActionMenu : public QMenu
     struct GUI_EXPORT ActionData
     {
 
-      /**
-       * Constructor for ActionData.
-       */
       ActionData() = default;
       ActionData( const QgsAction &action, QgsFeatureId featureId, QgsMapLayer *mapLayer );
       ActionData( QgsMapLayerAction *action, QgsFeatureId featureId, QgsMapLayer *mapLayer );

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -45,9 +45,6 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
     {
       public:
 
-        /**
-         * Constructor for FeatureInfo.
-         */
         FeatureInfo() = default;
 
         //! True if feature is a newly added feature.

--- a/src/gui/history/qgshistoryentrynode.h
+++ b/src/gui/history/qgshistoryentrynode.h
@@ -40,9 +40,6 @@ class GUI_EXPORT QgsHistoryEntryNode
 {
   public:
 
-    /**
-     * Constructor for QgsHistoryEntryNode.
-     */
     QgsHistoryEntryNode() = default;
     virtual ~QgsHistoryEntryNode();
 
@@ -134,7 +131,6 @@ class GUI_EXPORT QgsHistoryEntryGroup : public QgsHistoryEntryNode
 {
   public:
 
-    //! Constructor for QgsHistoryEntryGroup
     QgsHistoryEntryGroup() = default;
     ~QgsHistoryEntryGroup() override;
 

--- a/src/gui/history/qgshistorywidgetcontext.h
+++ b/src/gui/history/qgshistorywidgetcontext.h
@@ -32,9 +32,6 @@ class GUI_EXPORT QgsHistoryWidgetContext
 {
   public:
 
-    /**
-     * Constructor for QgsHistoryWidgetContext.
-     */
     QgsHistoryWidgetContext() = default;
 
     /**

--- a/src/gui/maptools/qgsmaptoolshaperegistry.h
+++ b/src/gui/maptools/qgsmaptoolshaperegistry.h
@@ -81,7 +81,7 @@ class GUI_EXPORT QgsMapToolShapeRegistry
 class GUI_EXPORT QgsMapToolShapeMetadata
 {
   public:
-    //! Constructor
+
     QgsMapToolShapeMetadata() = default;
 
     virtual ~QgsMapToolShapeMetadata() = default;

--- a/src/gui/processing/qgsprocessingtoolboxmodel.h
+++ b/src/gui/processing/qgsprocessingtoolboxmodel.h
@@ -147,9 +147,6 @@ class GUI_EXPORT QgsProcessingToolboxModelRecentNode : public QgsProcessingToolb
 
   public:
 
-    /**
-     * Constructor for QgsProcessingToolboxModelRecentNode.
-     */
     QgsProcessingToolboxModelRecentNode() = default;
 
     NodeType nodeType() const override { return NodeType::Recent; }
@@ -168,9 +165,6 @@ class GUI_EXPORT QgsProcessingToolboxModelFavoriteNode : public QgsProcessingToo
 
   public:
 
-    /**
-     * Constructor for QgsProcessingToolboxModelRecentNode.
-     */
     QgsProcessingToolboxModelFavoriteNode() = default;
 
     NodeType nodeType() const override { return NodeType::Favorite; }

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -115,9 +115,6 @@ class GUI_EXPORT QgsProcessingParameterWidgetContext
 {
   public:
 
-    /**
-     * Constructor for QgsProcessingParameterWidgetContext.
-     */
     QgsProcessingParameterWidgetContext() = default;
 
     /**

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -100,7 +100,6 @@ class GUI_EXPORT QgisInterface : public QObject
 
   public:
 
-    //! Constructor
     QgisInterface() = default;
 
     virtual QgsPluginManagerInterface *pluginManagerInterface() = 0;

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -74,7 +74,6 @@ class GUI_EXPORT QgsAttributeEditorContext
       Popup             //!< A widget was opened as a popup (e.g. attribute table editor widget)
     };
 
-    //! Constructor for QgsAttributeEditorContext
     QgsAttributeEditorContext() = default;
 
     QgsAttributeEditorContext( const QgsAttributeEditorContext &parentContext, FormMode formMode )

--- a/src/gui/qgsdataitemguiprovider.h
+++ b/src/gui/qgsdataitemguiprovider.h
@@ -42,9 +42,6 @@ class GUI_EXPORT QgsDataItemGuiContext
 {
   public:
 
-    /**
-     * Constructor for QgsDataItemGuiContext.
-     */
     QgsDataItemGuiContext() = default;
 
     /**

--- a/src/gui/qgsdecoratedscrollbar.h
+++ b/src/gui/qgsdecoratedscrollbar.h
@@ -57,9 +57,6 @@ class GUI_EXPORT QgsScrollBarHighlight
     */
     QgsScrollBarHighlight( int category, int position, const QColor &color, QgsScrollBarHighlight::Priority priority = QgsScrollBarHighlight::Priority::NormalPriority );
 
-    /**
-    * Default constructor for QgsScrollBarHighlight.
-    */
     QgsScrollBarHighlight() = default;
 
     //! Category ID

--- a/src/gui/qgsdetaileditemdata.h
+++ b/src/gui/qgsdetaileditemdata.h
@@ -32,9 +32,6 @@ class GUI_EXPORT QgsDetailedItemData
 {
   public:
 
-    /**
-     * Constructor for QgsDetailedItemData.
-     */
     QgsDetailedItemData() = default;
 
     /**

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -162,7 +162,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
     class MenuProvider
     {
       public:
-        //! Constructor
+
         explicit MenuProvider() = default;
         virtual ~MenuProvider() = default;
 

--- a/src/gui/qgsidentifymenu.h
+++ b/src/gui/qgsidentifymenu.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsIdentifyMenu : public QMenu
 
     struct ActionData
     {
-      //! Constructor for ActionData
+
       ActionData() = default;
 
       ActionData( QgsMapLayer *layer, QgsMapLayerAction *mapLayerAction = nullptr )

--- a/src/gui/qgsmaplayerconfigwidgetfactory.h
+++ b/src/gui/qgsmaplayerconfigwidgetfactory.h
@@ -46,7 +46,6 @@ class GUI_EXPORT QgsMapLayerConfigWidgetFactory
       Temporal, //!< Factory creates sub-components of the temporal properties page (only supported for raster layer temporal properties)
     };
 
-    //! Constructor
     QgsMapLayerConfigWidgetFactory() = default;
 
     //! Constructor

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -79,7 +79,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
 
     struct IdentifyResult
     {
-      //! Constructor for IdentifyResult
+
       IdentifyResult() = default;
 
       IdentifyResult( QgsMapLayer *layer, const QgsFeature &feature, const QMap< QString, QString > &derivedAttributes )

--- a/src/gui/qgsoptionswidgetfactory.h
+++ b/src/gui/qgsoptionswidgetfactory.h
@@ -113,7 +113,6 @@ class GUI_EXPORT QgsOptionsWidgetFactory : public QObject
 
   public:
 
-    //! Constructor
     QgsOptionsWidgetFactory() = default;
 
     //! Constructor

--- a/src/gui/qgspluginmanagerinterface.h
+++ b/src/gui/qgspluginmanagerinterface.h
@@ -34,7 +34,6 @@ class GUI_EXPORT QgsPluginManagerInterface : public QObject
 
   public:
 
-    //! Constructor
     QgsPluginManagerInterface() = default;
 
     //! remove Python plugins from the metadata registry (c++ plugins stay)

--- a/src/gui/qgssqlcomposerdialog.h
+++ b/src/gui/qgssqlcomposerdialog.h
@@ -106,7 +106,7 @@ class GUI_EXPORT QgsSQLComposerDialog : public QgsSubsetStringEditorInterface, p
       Function( const QString &nameIn, int args ) : name( nameIn ), minArgs( args ), maxArgs( args ) {}
       //! constructor with name and min,max number of arguments
       Function( const QString &nameIn, int minArgs, int maxArgsIn ) : name( nameIn ), minArgs( minArgs ), maxArgs( maxArgsIn ) {}
-      //! default constructor
+
       Function() = default;
     };
 

--- a/src/gui/qgstablewidgetitem.h
+++ b/src/gui/qgstablewidgetitem.h
@@ -28,9 +28,6 @@ class GUI_EXPORT QgsTableWidgetItem : public QTableWidgetItem
 {
   public:
 
-    /**
-      * Constructor for QgsTableWidgetItem.
-      */
     QgsTableWidgetItem() = default;
 
     /**

--- a/src/gui/qgstabwidget.h
+++ b/src/gui/qgstabwidget.h
@@ -98,7 +98,6 @@ class GUI_EXPORT QgsTabWidget : public QTabWidget
         , label( lbl )
       {}
 
-      //! Constructor for TabInformation
       TabInformation() = default;
 
       bool operator ==( const TabInformation &other ) const;

--- a/src/gui/symbology/qgssymbolwidgetcontext.h
+++ b/src/gui/symbology/qgssymbolwidgetcontext.h
@@ -35,9 +35,6 @@ class GUI_EXPORT QgsSymbolWidgetContext // clazy:exclude=rule-of-three
 {
   public:
 
-    /**
-     * Constructor for QgsSymbolWidgetContext.
-     */
     QgsSymbolWidgetContext() = default;
 
     /**

--- a/tests/code_layout/doxygen_parser.py
+++ b/tests/code_layout/doxygen_parser.py
@@ -381,7 +381,7 @@ class DoxygenParser():
         # ignore constructors with no arguments
         if self.isConstructor(elem):
             try:
-                if elem.find('argsstring').text == '()':
+                if re.match(r'^\s*\(\s*\)\s*(?:=\s*default\s*)?$', elem.find('argsstring').text):
                     return False
             except:
                 pass


### PR DESCRIPTION
And remove a bunch of useless default constructor doxygen. These add no value and just make the PyQGIS docs look messier, because they get appended automatically to the initial class docstrings.