### PR TITLE
Don't mandate documentation for copy constructors, self-documenting operators

### DIFF
--- a/python/3d/auto_generated/qgs3d.sip.in
+++ b/python/3d/auto_generated/qgs3d.sip.in
@@ -25,7 +25,6 @@ related to 3D classes.
   public:
 
 
-
     static Qgs3D *instance();
 %Docstring
 Returns a pointer to the singleton instance.

--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -22,14 +22,9 @@ Definition of the world.
 #include "qgs3dmapsettings.h"
 %End
   public:
+
     Qgs3DMapSettings();
-%Docstring
-Constructor for Qgs3DMapSettings
-%End
     Qgs3DMapSettings( const Qgs3DMapSettings &other );
-%Docstring
-Copy constructor
-%End
     ~Qgs3DMapSettings();
 
 

--- a/python/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
@@ -32,9 +32,6 @@ Constructor for QgsPoint3DSymbol with default QgsMarkerSymbol as the billboardSy
 %End
 
     QgsPoint3DSymbol( const QgsPoint3DSymbol &other );
-%Docstring
-Copy Constructor for QgsPoint3DSymbol
-%End
 
     ~QgsPoint3DSymbol();
 

--- a/python/PyQt6/3d/auto_generated/qgs3d.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3d.sip.in
@@ -25,7 +25,6 @@ related to 3D classes.
   public:
 
 
-
     static Qgs3D *instance();
 %Docstring
 Returns a pointer to the singleton instance.

--- a/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -22,14 +22,9 @@ Definition of the world.
 #include "qgs3dmapsettings.h"
 %End
   public:
+
     Qgs3DMapSettings();
-%Docstring
-Constructor for Qgs3DMapSettings
-%End
     Qgs3DMapSettings( const Qgs3DMapSettings &other );
-%Docstring
-Copy constructor
-%End
     ~Qgs3DMapSettings();
 
 

--- a/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
+++ b/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
@@ -32,9 +32,6 @@ Constructor for QgsPoint3DSymbol with default QgsMarkerSymbol as the billboardSy
 %End
 
     QgsPoint3DSymbol( const QgsPoint3DSymbol &other );
-%Docstring
-Copy Constructor for QgsPoint3DSymbol
-%End
 
     ~QgsPoint3DSymbol();
 

--- a/python/PyQt6/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
+++ b/python/PyQt6/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
@@ -40,12 +40,8 @@ list of source and destination coordinates to transform geometries.
     ~QgsGcpGeometryTransformer();
 
 
-
     virtual bool transformPoint( double &x /In,Out/, double &y /In,Out/, double &z /In,Out/, double &m /In,Out/ );
 
-%Docstring
-QgsGcpGeometryTransformer cannot be copied
-%End
 
     QgsGeometry transform( const QgsGeometry &geometry, bool &ok /Out/, QgsFeedback *feedback = 0 );
 %Docstring

--- a/python/PyQt6/analysis/auto_generated/qgsanalysis.sip.in
+++ b/python/PyQt6/analysis/auto_generated/qgsanalysis.sip.in
@@ -26,7 +26,6 @@ related to analysis classes.
   public:
 
 
-
     static QgsAnalysis *instance();
 %Docstring
 Returns a pointer to the singleton instance.

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
@@ -75,9 +75,6 @@ Constructor for the tFunction type
 
 
     Type type() const;
-%Docstring
-QgsRasterCalcNode cannot be copied
-%End
 
     void setLeft( QgsRasterCalcNode *left );
     void setRight( QgsRasterCalcNode *right );

--- a/python/PyQt6/core/auto_generated/auth/qgsauthconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthconfig.sip.in
@@ -33,7 +33,6 @@ Construct a configuration for an authentication method
 
 
     bool operator==( const QgsAuthMethodConfig &other ) const;
-
     bool operator!=( const QgsAuthMethodConfig &other ) const;
 
     const QString id() const;

--- a/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -52,9 +52,6 @@ Contains configuration settings for an editor form.
     };
 
     QgsEditFormConfig( const QgsEditFormConfig &o );
-%Docstring
-Copy constructor
-%End
     ~QgsEditFormConfig();
 
     bool operator==( const QgsEditFormConfig &o ) const;

--- a/python/PyQt6/core/auto_generated/elevation/qgsprofileexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgsprofileexporter.sip.in
@@ -33,7 +33,6 @@ After construction, call :py:func:`~QgsProfileExporter.run` to initiate the prof
 %End
 
 
-
     ~QgsProfileExporter();
 
     void run( QgsFeedback *feedback = 0 );

--- a/python/PyQt6/core/auto_generated/elevation/qgsprofilerequest.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgsprofilerequest.sip.in
@@ -32,9 +32,6 @@ to the request.
 %End
 
     QgsProfileRequest( const QgsProfileRequest &other );
-%Docstring
-Copy constructor.
-%End
 
     ~QgsProfileRequest();
 

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -295,11 +295,7 @@ Returns a reference to the current object if no optimizations were applied.
   protected:
 
     QgsExpressionNode();
-
     QgsExpressionNode( const QgsExpressionNode &other );
-%Docstring
-Copy constructor
-%End
 
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -101,13 +101,10 @@ raw geometry primitive, such as the point, line, polygon, curve or other geometr
   public:
 
     QgsGeometry() /HoldGIL/;
-%Docstring
-Constructor
-%End
 
     QgsGeometry( const QgsGeometry & );
 %Docstring
-Copy constructor will prompt a deep copy of the object
+Copy constructor will prompt a shallow copy of the geometry
 %End
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -53,9 +53,6 @@ The rectangle is NOT normalized after construction.
 %End
 
     QgsRectangle( const QgsRectangle &other ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
 
     ~QgsRectangle();
 

--- a/python/PyQt6/core/auto_generated/labeling/qgslabelsearchtree.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgslabelsearchtree.sip.in
@@ -24,9 +24,6 @@ A class to query the labeling structure at a given point (small wrapper around p
   public:
 
     QgsLabelSearchTree();
-%Docstring
-Constructor for QgsLabelSearchTree.
-%End
     ~QgsLabelSearchTree();
 
 
@@ -71,9 +68,7 @@ Sets the map ``settings`` associated with the labeling run.
 %End
 
   private:
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree( const QgsLabelSearchTree &rh );
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree &operator=( const QgsLabelSearchTree & );
 };
 

--- a/python/PyQt6/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
@@ -34,9 +34,6 @@ Settings for a color ramp legend node.
     ~QgsColorRampLegendNodeSettings();
 
     QgsColorRampLegendNodeSettings( const QgsColorRampLegendNodeSettings &other );
-%Docstring
-Copy constructor
-%End
 
 
     QgsColorRampLegendNodeSettings::Direction direction() const;

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreefiltersettings.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreefiltersettings.sip.in
@@ -31,9 +31,6 @@ Constructor for QgsLayerTreeFilterSettings, using the specified map ``settings``
     ~QgsLayerTreeFilterSettings();
 
     QgsLayerTreeFilterSettings( const QgsLayerTreeFilterSettings &other );
-%Docstring
-Copy constructor.
-%End
 
 
     QgsMapSettings &mapSettings();

--- a/python/PyQt6/core/auto_generated/layout/qgsabstractreportsection.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgsabstractreportsection.sip.in
@@ -65,8 +65,6 @@ Note that ownership is not transferred to ``parent``.
 
     ~QgsAbstractReportSection();
 
-
-
     virtual QString type() const = 0;
 %Docstring
 Returns the section subclass type.

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -33,7 +33,6 @@ regardless of the current view zoom.
 %End
 
 
-
     QgsRenderContext &renderContext();
 %Docstring
 Returns a reference to the context's render context.

--- a/python/PyQt6/core/auto_generated/mesh/qgsmesh3daveraging.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmesh3daveraging.sip.in
@@ -343,9 +343,6 @@ The elevation will be truncated at the surface and bed levels.
   public:
 
     QgsMeshElevationAveragingMethod();
-%Docstring
-Ctor
-%End
 
     QgsMeshElevationAveragingMethod( double startElevation, double endElevation );
 %Docstring

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -47,6 +47,7 @@ Returns a dataset index within :py:func:`~QgsMeshDatasetIndex.group`
 %Docstring
 Returns whether index is valid, ie at least groups is set
 %End
+
     bool operator == ( QgsMeshDatasetIndex other ) const;
     bool operator != ( QgsMeshDatasetIndex other ) const;
 };

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -119,9 +119,6 @@ data.
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsMeshLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsMeshLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
@@ -54,9 +54,6 @@ that of the spatial index construction.
 %End
 
     QgsMeshSpatialIndex( const QgsMeshSpatialIndex &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsMeshSpatialIndex();
 

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshtracerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshtracerenderer.sip.in
@@ -35,9 +35,6 @@ Constructor to use with Python binding
 %End
 
     QgsMeshVectorTraceAnimationGenerator( const QgsMeshVectorTraceAnimationGenerator &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsMeshVectorTraceAnimationGenerator();
 

--- a/python/PyQt6/core/auto_generated/plot/qgsplot.sip.in
+++ b/python/PyQt6/core/auto_generated/plot/qgsplot.sip.in
@@ -257,9 +257,6 @@ Constructor for Qgs2DPlot.
 
     virtual bool writeXml( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const;
 
-%Docstring
-Qgs2DPlot cannot be copied
-%End
     virtual bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 
 

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudattribute.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudattribute.sip.in
@@ -40,9 +40,6 @@ pair of name and size in bytes
     };
 
     QgsPointCloudAttribute();
-%Docstring
-Ctor
-%End
     QgsPointCloudAttribute( const QString &name, DataType type );
 %Docstring
 Ctor
@@ -110,10 +107,8 @@ Collection of point cloud attributes
 #include "qgspointcloudattribute.h"
 %End
   public:
+
     QgsPointCloudAttributeCollection();
-%Docstring
-Ctor
-%End
     QgsPointCloudAttributeCollection( const QVector<QgsPointCloudAttribute> &attributes );
 %Docstring
 Ctor with given attributes

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
@@ -32,6 +32,7 @@ Base class for storing raw data from point cloud nodes
 %Docstring
 Ctor
 %End
+
     virtual ~QgsPointCloudBlock();
 
     QgsPointCloudBlock *clone() const /Factory/;

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -69,9 +69,6 @@ Constructor - creates a point cloud layer
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsPointCloudLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsPointCloudLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -41,7 +41,6 @@ taken from the point cloud index.
 %End
 
 
-
     QgsRenderContext &renderContext();
 %Docstring
 Returns a reference to the context's render context.

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -35,9 +35,6 @@ expression context.
 
 
     QgsProcessingContext();
-%Docstring
-Constructor for QgsProcessingContext.
-%End
 
 
     ~QgsProcessingContext();

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -598,7 +598,6 @@ pieces of information about CRS.
 %End
 
     bool operator==( const QgsCoordinateReferenceSystem &srs ) const;
-
     bool operator!=( const QgsCoordinateReferenceSystem &srs ) const;
 
     bool readXml( const QDomNode &node );

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -237,10 +237,6 @@ A CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
 %End
 
     QgsCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &srs );
-%Docstring
-Copy constructor
-%End
-
 
     operator QVariant() const;
 

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -131,10 +131,6 @@ datum transforms (see :py:class:`QgsDatumTransform`).
 %End
 
     QgsCoordinateTransform( const QgsCoordinateTransform &o );
-%Docstring
-Copy constructor
-%End
-
 
     ~QgsCoordinateTransform();
 

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
@@ -48,10 +48,6 @@ Constructor for QgsCoordinateTransformContext.
     ~QgsCoordinateTransformContext();
 
     QgsCoordinateTransformContext( const QgsCoordinateTransformContext &rhs );
-%Docstring
-Copy constructor
-%End
-
 
     bool operator==( const QgsCoordinateTransformContext &rhs ) const;
 

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -2324,7 +2324,6 @@ This will block dirtying the specified ``project`` for the lifetime of this obje
 %End
 
 
-
     ~QgsProjectDirtyBlocker();
 
   private:

--- a/python/PyQt6/core/auto_generated/project/qgsprojectversion.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectversion.sip.in
@@ -64,15 +64,10 @@ Returns ``True`` if this is a NULL project version.
 %End
 
     bool operator==( const QgsProjectVersion &other ) const;
-
     bool operator!=( const QgsProjectVersion &other ) const;
-
     bool operator>=( const QgsProjectVersion &other ) const;
-
     bool operator>( const QgsProjectVersion &other ) const;
-
     bool operator<( const QgsProjectVersion &other ) const;
-
     bool operator<=( const QgsProjectVersion &other ) const;
 
 };

--- a/python/PyQt6/core/auto_generated/qgsarchive.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsarchive.sip.in
@@ -22,14 +22,8 @@ Class allowing to manage the zip/unzip actions
   public:
 
     QgsArchive();
-%Docstring
-Constructor
-%End
 
     QgsArchive( const QgsArchive &other );
-%Docstring
-Copy constructor
-%End
 
 
     virtual ~QgsArchive();

--- a/python/PyQt6/core/auto_generated/qgsdatadefinedsizelegend.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdatadefinedsizelegend.sip.in
@@ -33,9 +33,6 @@ Constructor for QgsDataDefinedSizeLegend.
     ~QgsDataDefinedSizeLegend();
 
     QgsDataDefinedSizeLegend( const QgsDataDefinedSizeLegend &other );
-%Docstring
-Copy constructor
-%End
 
     enum LegendType /BaseType=IntEnum/
     {

--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -69,14 +69,8 @@ Returns the diagram property definitions.
 %End
 
     QgsDiagramLayerSettings();
-%Docstring
-Constructor for QgsDiagramLayerSettings.
-%End
 
     QgsDiagramLayerSettings( const QgsDiagramLayerSettings &rh );
-%Docstring
-Copy constructor
-%End
 
 
     ~QgsDiagramLayerSettings();
@@ -328,15 +322,8 @@ QgsDiagramLayerSettings stores settings which control how ALL diagrams within a 
     };
 
     QgsDiagramSettings();
-%Docstring
-Constructor for QgsDiagramSettings
-%End
     ~QgsDiagramSettings();
-
     QgsDiagramSettings( const QgsDiagramSettings &other );
-%Docstring
-Copy constructor
-%End
 
 
     bool enabled;
@@ -781,9 +768,6 @@ class QgsLinearlyInterpolatedDiagramRenderer : QgsDiagramRenderer
     QgsLinearlyInterpolatedDiagramRenderer();
     ~QgsLinearlyInterpolatedDiagramRenderer();
     QgsLinearlyInterpolatedDiagramRenderer( const QgsLinearlyInterpolatedDiagramRenderer &other );
-%Docstring
-Copy constructor
-%End
 
 
     virtual QgsLinearlyInterpolatedDiagramRenderer *clone() const /Factory/;

--- a/python/PyQt6/core/auto_generated/qgsdistancearea.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdistancearea.sip.in
@@ -38,15 +38,9 @@ Internally, the GeographicLib library is used to calculate all ellipsoid based m
   public:
 
     QgsDistanceArea();
-%Docstring
-Constructor
-%End
     ~QgsDistanceArea();
 
     QgsDistanceArea( const QgsDistanceArea &other );
-%Docstring
-Copy constructor
-%End
 
     bool willUseEllipsoid() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgselevationmap.sip.in
+++ b/python/PyQt6/core/auto_generated/qgselevationmap.sip.in
@@ -50,9 +50,6 @@ The image must have ARGB32 format and obtained by the :py:func:`~QgsElevationMap
 %End
 
     QgsElevationMap( const QgsElevationMap &other );
-%Docstring
-Copy constructor
-%End
 
     void applyEyeDomeLighting( QImage &image, int distance, float strength, float rendererScale ) const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsexpressioncontext.sip.in
@@ -119,9 +119,6 @@ Constructor for QgsExpressionContextScope
 %End
 
     QgsExpressionContextScope( const QgsExpressionContextScope &other );
-%Docstring
-Copy constructor
-%End
 
 
     ~QgsExpressionContextScope();
@@ -488,9 +485,6 @@ See :py:class:`QgsExpressionContextUtils` for helper methods for working with :p
   public:
 
     QgsExpressionContext();
-%Docstring
-Constructor for QgsExpressionContext
-%End
 
     explicit QgsExpressionContext( const QList<QgsExpressionContextScope *> &scopes /Transfer/ );
 %Docstring
@@ -499,9 +493,6 @@ Ownership of the scopes is transferred to the stack.
 %End
 
     QgsExpressionContext( const QgsExpressionContext &other );
-%Docstring
-Copy constructor
-%End
 
 
 

--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -309,13 +309,7 @@ Constructor for QgsFeature
 %End
 
     QgsFeature( const QgsFeature &rhs ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
-
-
     bool operator==( const QgsFeature &other ) const /HoldGIL/;
-
     bool operator!=( const QgsFeature &other ) const /HoldGIL/;
 
     virtual ~QgsFeature();

--- a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
@@ -276,9 +276,6 @@ should use the same CRS as the source layer/provider.
 construct a request with a filter expression
 %End
     QgsFeatureRequest( const QgsFeatureRequest &rh );
-%Docstring
-copy constructor
-%End
 
     bool compare( const QgsFeatureRequest &other ) const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsfield.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfield.sip.in
@@ -87,10 +87,6 @@ Constructor. Constructs a new QgsField object.
 %End
 
     QgsField( const QgsField &other ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
-
 
     virtual ~QgsField();
 

--- a/python/PyQt6/core/auto_generated/qgsfields.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfields.sip.in
@@ -40,10 +40,6 @@ Constructor for an empty field container
 %End
 
     QgsFields( const QgsFields &other ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
-
 
     QgsFields( const QList< QgsField > &fields ) /HoldGIL/;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
@@ -93,7 +93,6 @@ This will block the log from emitting the messageReceived( bool ) signal for the
 %End
 
 
-
     ~QgsMessageLogNotifyBlocker();
 
   private:

--- a/python/PyQt6/core/auto_generated/qgspointxy.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspointxy.sip.in
@@ -49,9 +49,6 @@ Use cases for which :py:class:`QgsPointXY` is NOT a valid choice include:
     QgsPointXY();
 
     QgsPointXY( const QgsPointXY &p ) /HoldGIL/;
-%Docstring
-Create a point from another point
-%End
 
     QgsPointXY( double x, double y ) /HoldGIL/;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsproperty.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsproperty.sip.in
@@ -223,10 +223,6 @@ Returns a new StaticProperty created from the specified value.
 %End
 
     QgsProperty( const QgsProperty &other );
-%Docstring
-Copy constructor
-%End
-
 
     operator bool() const;
 

--- a/python/PyQt6/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertycollection.sip.in
@@ -381,9 +381,6 @@ Constructor for QgsPropertyCollection
 %End
 
     QgsPropertyCollection( const QgsPropertyCollection &other );
-%Docstring
-Copy constructor.
-%End
 
 
     bool operator==( const QgsPropertyCollection &other ) const;
@@ -472,9 +469,6 @@ priority over earlier collections.
     ~QgsPropertyCollectionStack();
 
     QgsPropertyCollectionStack( const QgsPropertyCollectionStack &other );
-%Docstring
-Copy constructor
-%End
 
 
     int count() const;

--- a/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
@@ -50,9 +50,6 @@ list.
     ~QgsCurveTransform();
 
     QgsCurveTransform( const QgsCurveTransform &other );
-%Docstring
-Copy constructor
-%End
 
 
     QList< QgsPointXY > controlPoints() const;
@@ -182,9 +179,6 @@ Constructor for QgsPropertyTransformer
 %End
 
     QgsPropertyTransformer( const QgsPropertyTransformer &other );
-%Docstring
-Copy constructor.
-%End
 
     virtual ~QgsPropertyTransformer();
 
@@ -634,10 +628,6 @@ Constructor for QgsColorRampTransformer.
 %End
 
     QgsColorRampTransformer( const QgsColorRampTransformer &other );
-%Docstring
-Copy constructor
-%End
-
 
     virtual Type transformerType() const;
     virtual QgsColorRampTransformer *clone() const /Factory/;

--- a/python/PyQt6/core/auto_generated/qgsproxyprogresstask.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsproxyprogresstask.sip.in
@@ -96,7 +96,6 @@ Sets the ``progress`` (from 0 to 100) for the proxied operation.
 %End
 
   private:
-    //! QgsScopedProxyProgressTask cannot be copied
     QgsScopedProxyProgressTask( const QgsScopedProxyProgressTask &other );
 };
 

--- a/python/PyQt6/core/auto_generated/qgsrelationcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrelationcontext.sip.in
@@ -39,10 +39,6 @@ project instance
     ~QgsRelationContext();
 
     QgsRelationContext( const QgsRelationContext &other );
-%Docstring
-Copy constructor
-%End
-
 
 };
 

--- a/python/PyQt6/core/auto_generated/qgssimplifymethod.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssimplifymethod.sip.in
@@ -73,7 +73,6 @@ Creates a geometry simplifier according to specified method
 %End
 
     bool operator==( const QgsSimplifyMethod &v ) const;
-
     bool operator!=( const QgsSimplifyMethod &v ) const;
 
   protected:

--- a/python/PyQt6/core/auto_generated/qgssldexportcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssldexportcontext.sip.in
@@ -28,10 +28,6 @@ Constructs a default SLD export context
     ~QgsSldExportContext();
 
     QgsSldExportContext( const QgsSldExportContext &other );
-%Docstring
-Constructs a copy of SLD export context ``other``
-%End
-
 
     QgsSldExportContext( const Qgis::SldExportOptions &options, const Qgis::SldExportVendorExtension &vendorExtension, const QString &filePath );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsspatialindex.sip.in
@@ -73,9 +73,6 @@ that of the spatial index construction.
 %End
 
     QgsSpatialIndex( const QgsSpatialIndex &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsSpatialIndex();
 

--- a/python/PyQt6/core/auto_generated/qgsspatialindexkdbush.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsspatialindexkdbush.sip.in
@@ -60,10 +60,6 @@ Any non-single point features encountered during iteration will be ignored and n
 
 
     QgsSpatialIndexKDBush( const QgsSpatialIndexKDBush &other );
-%Docstring
-Copy constructor
-%End
-
 
     ~QgsSpatialIndexKDBush();
 

--- a/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
@@ -26,9 +26,6 @@ Creates a new statement based on the provided string.
 %End
 
     QgsSQLStatement( const QgsSQLStatement &other );
-%Docstring
-Create a copy of this statement.
-%End
 
     virtual ~QgsSQLStatement();
 

--- a/python/PyQt6/core/auto_generated/qgstablecell.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstablecell.sip.in
@@ -27,9 +27,6 @@ Constructor for QgsTableCell, with the specified ``content``.
 %End
 
     QgsTableCell( const QgsTableCell &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsTableCell();
 

--- a/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -36,10 +36,6 @@ Creates a new color ramp shader.
     ~QgsColorRampShader();
 
     QgsColorRampShader( const QgsColorRampShader &other );
-%Docstring
-Copy constructor
-%End
-
 
     bool operator==( const QgsColorRampShader &other ) const;
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterminmaxorigin.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterminmaxorigin.sip.in
@@ -56,9 +56,6 @@ itself the min/max values.
     };
 
     QgsRasterMinMaxOrigin();
-%Docstring
-Default constructor.
-%End
 
     bool operator ==( const QgsRasterMinMaxOrigin &other ) const;
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
@@ -22,16 +22,10 @@ for scalebar drawing with :py:class:`QgsScaleBarRenderer`.
   public:
 
     QgsScaleBarSettings();
-%Docstring
-Constructor for QgsScaleBarSettings.
-%End
 
     ~QgsScaleBarSettings();
 
     QgsScaleBarSettings( const QgsScaleBarSettings &other );
-%Docstring
-Copy constructor
-%End
 
 
     int numberOfSegments() const;

--- a/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -38,9 +38,6 @@ The optional ``uuid`` argument manually set the UUID key identifier for the cate
 %End
 
     QgsRendererCategory( const QgsRendererCategory &cat );
-%Docstring
-Copy constructor.
-%End
     ~QgsRendererCategory();
 
     QString uuid() const;

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -177,7 +177,6 @@ Returns the symbol layer property definitions.
     virtual ~QgsSymbolLayer();
 
 
-
     virtual Qgis::SymbolLayerFlags flags() const;
 %Docstring
 Returns flags which control the symbol layer's behavior.
@@ -772,12 +771,8 @@ Abstract base class for marker symbol layers.
     };
 
 
-
     virtual void startRender( QgsSymbolRenderContext &context );
 
-%Docstring
-QgsMarkerSymbolLayer cannot be copied
-%End
 
     virtual void stopRender( QgsSymbolRenderContext &context );
 
@@ -1139,12 +1134,8 @@ class QgsLineSymbolLayer : QgsSymbolLayer
     };
 
 
-
     virtual void setOutputUnit( Qgis::RenderUnit unit );
 
-%Docstring
-QgsLineSymbolLayer cannot be copied
-%End
     virtual Qgis::RenderUnit outputUnit() const;
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
@@ -1348,7 +1339,6 @@ class QgsFillSymbolLayer : QgsSymbolLayer
 #include "qgssymbollayer.h"
 %End
   public:
-
 
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context ) = 0;

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
@@ -58,10 +58,6 @@ QgsSymbolLayerId constructor with a symbol key and an index path
 %End
 
     QgsSymbolLayerId( const QgsSymbolLayerId &other );
-%Docstring
-Default copy constructor
-%End
-
 
     QString symbolKey() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
@@ -52,11 +52,6 @@ Container for settings relating to a text background object.
     QgsTextBackgroundSettings();
 
     QgsTextBackgroundSettings( const QgsTextBackgroundSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsTextBackgroundSettings
-%End
 
 
     ~QgsTextBackgroundSettings();

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
@@ -28,11 +28,6 @@ Container for settings relating to a text buffer.
     QgsTextBufferSettings();
 
     QgsTextBufferSettings( const QgsTextBufferSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source settings
-%End
 
 
     ~QgsTextBufferSettings();

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -32,11 +32,6 @@ set to an invalid state (see :py:func:`~QgsTextFormat.isValid`).
 %End
 
     QgsTextFormat( const QgsTextFormat &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsTextFormat
-%End
 
 
     ~QgsTextFormat();

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
@@ -37,12 +37,6 @@ A selective masking only makes sense in contexts where the text is rendered over
     QgsTextMaskSettings();
 
     QgsTextMaskSettings( const QgsTextMaskSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source settings
-%End
-
 
     ~QgsTextMaskSettings();
 

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
@@ -34,13 +34,7 @@ Container for settings relating to a text shadow.
     };
 
     QgsTextShadowSettings();
-
     QgsTextShadowSettings( const QgsTextShadowSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsTextShadowSettings
-%End
 
 
     ~QgsTextShadowSettings();

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenedataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenedataprovider.sip.in
@@ -34,10 +34,6 @@ Constructor for QgsTiledSceneDataProvider
     ~QgsTiledSceneDataProvider();
 
     QgsTiledSceneDataProvider( const QgsTiledSceneDataProvider &other );
-%Docstring
-Copy constructor.
-%End
-
 
     virtual Qgis::TiledSceneProviderCapabilities capabilities() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledsceneindex.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledsceneindex.sip.in
@@ -35,9 +35,6 @@ threads.
     ~QgsTiledSceneIndex();
 
     QgsTiledSceneIndex( const QgsTiledSceneIndex &other );
-%Docstring
-Copy constructor
-%End
 
     bool isValid() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
@@ -51,9 +51,6 @@ Constructor for QgsTiledSceneLayer.
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsTiledSceneLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsTiledSceneLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
@@ -31,7 +31,6 @@ Constructor for QgsTiledSceneRenderContext.
 %End
 
 
-
     QgsRenderContext &renderContext();
 %Docstring
 Returns a reference to the context's render context.

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
@@ -40,9 +40,6 @@ Constructor for an valid tile.
     ~QgsTiledSceneTile();
 
     QgsTiledSceneTile( const QgsTiledSceneTile &other );
-%Docstring
-Copy constructor
-%End
 
     bool isValid() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -423,9 +423,6 @@ data.
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsVectorLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsVectorLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
@@ -26,12 +26,6 @@ consider.
     QgsVectorLayerToolsContext();
 
     QgsVectorLayerToolsContext( const QgsVectorLayerToolsContext &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsVectorLayerToolsContext
-%End
-
 
     void setExpressionContext( const QgsExpressionContext *context );
 %Docstring

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
@@ -38,10 +38,8 @@ zoom levels, or by disabling it.
 %Docstring
 Constructs a style object
 %End
+
     QgsVectorTileBasicRendererStyle( const QgsVectorTileBasicRendererStyle &other );
-%Docstring
-Constructs a style object as a copy of another style
-%End
     ~QgsVectorTileBasicRendererStyle();
 
     void setStyleName( const QString &name );

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvtpktiles.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvtpktiles.sip.in
@@ -102,7 +102,6 @@ exists but has a zero size.
 %End
 
   private:
-    //! QgsVtpkTiles cannot be copied
     QgsVtpkTiles( const QgsVtpkTiles &other );
 };
 

--- a/python/PyQt6/gui/auto_generated/qgsgui.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgui.sip.in
@@ -29,7 +29,6 @@ related to GUI classes.
     };
 
 
-
     static QgsGui *instance();
 %Docstring
 Returns a pointer to the singleton instance.

--- a/python/PyQt6/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
@@ -22,14 +22,7 @@ map canvas and relevant expression contexts.
   public:
 
     QgsSymbolWidgetContext();
-
     QgsSymbolWidgetContext( const QgsSymbolWidgetContext &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsSymbolWidgetContext
-%End
-
 
     void setMapCanvas( QgsMapCanvas *canvas );
 %Docstring

--- a/python/PyQt6/server/auto_generated/qgsaccesscontrol.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsaccesscontrol.sip.in
@@ -29,9 +29,6 @@ Constructor
 %End
 
     QgsAccessControl( const QgsAccessControl &copy );
-%Docstring
-Constructor
-%End
 
 
     ~QgsAccessControl();

--- a/python/PyQt6/server/auto_generated/qgsbufferserverresponse.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsbufferserverresponse.sip.in
@@ -22,7 +22,6 @@ Class defining buffered response
 
     QgsBufferServerResponse();
 
-
     virtual void setHeader( const QString &key, const QString &value );
 
 %Docstring

--- a/python/PyQt6/server/auto_generated/qgsservercachemanager.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsservercachemanager.sip.in
@@ -30,11 +30,6 @@ Constructor
 %End
 
     QgsServerCacheManager( const QgsServerCacheManager &copy );
-%Docstring
-Copy constructor
-%End
-
-
     ~QgsServerCacheManager();
 
     bool getCachedDocument( QDomDocument *doc, const QgsProject *project, const QgsServerRequest &request, QgsAccessControl *accessControl ) const;

--- a/python/PyQt6/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverrequest.sip.in
@@ -66,9 +66,6 @@ class QgsServerRequest
     };
 
     QgsServerRequest();
-%Docstring
-Constructor
-%End
 
     QgsServerRequest( const QString &url, QgsServerRequest::Method method = QgsServerRequest::GetMethod, const QgsServerRequest::Headers &headers = QgsServerRequest::Headers() );
 %Docstring
@@ -89,10 +86,6 @@ Constructor
 %End
 
     QgsServerRequest( const QgsServerRequest &other );
-%Docstring
-Copy constructor.
-%End
-
 
     virtual ~QgsServerRequest();
 

--- a/python/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
@@ -40,12 +40,8 @@ list of source and destination coordinates to transform geometries.
     ~QgsGcpGeometryTransformer();
 
 
-
     virtual bool transformPoint( double &x /In,Out/, double &y /In,Out/, double &z /In,Out/, double &m /In,Out/ );
 
-%Docstring
-QgsGcpGeometryTransformer cannot be copied
-%End
 
     QgsGeometry transform( const QgsGeometry &geometry, bool &ok /Out/, QgsFeedback *feedback = 0 );
 %Docstring

--- a/python/analysis/auto_generated/qgsanalysis.sip.in
+++ b/python/analysis/auto_generated/qgsanalysis.sip.in
@@ -26,7 +26,6 @@ related to analysis classes.
   public:
 
 
-
     static QgsAnalysis *instance();
 %Docstring
 Returns a pointer to the singleton instance.

--- a/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
@@ -75,9 +75,6 @@ Constructor for the tFunction type
 
 
     Type type() const;
-%Docstring
-QgsRasterCalcNode cannot be copied
-%End
 
     void setLeft( QgsRasterCalcNode *left );
     void setRight( QgsRasterCalcNode *right );

--- a/python/core/auto_generated/auth/qgsauthconfig.sip.in
+++ b/python/core/auto_generated/auth/qgsauthconfig.sip.in
@@ -33,7 +33,6 @@ Construct a configuration for an authentication method
 
 
     bool operator==( const QgsAuthMethodConfig &other ) const;
-
     bool operator!=( const QgsAuthMethodConfig &other ) const;
 
     const QString id() const;

--- a/python/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -52,9 +52,6 @@ Contains configuration settings for an editor form.
     };
 
     QgsEditFormConfig( const QgsEditFormConfig &o );
-%Docstring
-Copy constructor
-%End
     ~QgsEditFormConfig();
 
     bool operator==( const QgsEditFormConfig &o ) const;

--- a/python/core/auto_generated/elevation/qgsprofileexporter.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofileexporter.sip.in
@@ -33,7 +33,6 @@ After construction, call :py:func:`~QgsProfileExporter.run` to initiate the prof
 %End
 
 
-
     ~QgsProfileExporter();
 
     void run( QgsFeedback *feedback = 0 );

--- a/python/core/auto_generated/elevation/qgsprofilerequest.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofilerequest.sip.in
@@ -32,9 +32,6 @@ to the request.
 %End
 
     QgsProfileRequest( const QgsProfileRequest &other );
-%Docstring
-Copy constructor.
-%End
 
     ~QgsProfileRequest();
 

--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -295,11 +295,7 @@ Returns a reference to the current object if no optimizations were applied.
   protected:
 
     QgsExpressionNode();
-
     QgsExpressionNode( const QgsExpressionNode &other );
-%Docstring
-Copy constructor
-%End
 
 
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -101,13 +101,10 @@ raw geometry primitive, such as the point, line, polygon, curve or other geometr
   public:
 
     QgsGeometry() /HoldGIL/;
-%Docstring
-Constructor
-%End
 
     QgsGeometry( const QgsGeometry & );
 %Docstring
-Copy constructor will prompt a deep copy of the object
+Copy constructor will prompt a shallow copy of the geometry
 %End
 
 

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -53,9 +53,6 @@ The rectangle is NOT normalized after construction.
 %End
 
     QgsRectangle( const QgsRectangle &other ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
 
     ~QgsRectangle();
 

--- a/python/core/auto_generated/labeling/qgslabelsearchtree.sip.in
+++ b/python/core/auto_generated/labeling/qgslabelsearchtree.sip.in
@@ -24,9 +24,6 @@ A class to query the labeling structure at a given point (small wrapper around p
   public:
 
     QgsLabelSearchTree();
-%Docstring
-Constructor for QgsLabelSearchTree.
-%End
     ~QgsLabelSearchTree();
 
 
@@ -71,9 +68,7 @@ Sets the map ``settings`` associated with the labeling run.
 %End
 
   private:
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree( const QgsLabelSearchTree &rh );
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree &operator=( const QgsLabelSearchTree & );
 };
 

--- a/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
+++ b/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
@@ -34,9 +34,6 @@ Settings for a color ramp legend node.
     ~QgsColorRampLegendNodeSettings();
 
     QgsColorRampLegendNodeSettings( const QgsColorRampLegendNodeSettings &other );
-%Docstring
-Copy constructor
-%End
 
 
     QgsColorRampLegendNodeSettings::Direction direction() const;

--- a/python/core/auto_generated/layertree/qgslayertreefiltersettings.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreefiltersettings.sip.in
@@ -31,9 +31,6 @@ Constructor for QgsLayerTreeFilterSettings, using the specified map ``settings``
     ~QgsLayerTreeFilterSettings();
 
     QgsLayerTreeFilterSettings( const QgsLayerTreeFilterSettings &other );
-%Docstring
-Copy constructor.
-%End
 
 
     QgsMapSettings &mapSettings();

--- a/python/core/auto_generated/layout/qgsabstractreportsection.sip.in
+++ b/python/core/auto_generated/layout/qgsabstractreportsection.sip.in
@@ -65,8 +65,6 @@ Note that ownership is not transferred to ``parent``.
 
     ~QgsAbstractReportSection();
 
-
-
     virtual QString type() const = 0;
 %Docstring
 Returns the section subclass type.

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -33,7 +33,6 @@ regardless of the current view zoom.
 %End
 
 
-
     QgsRenderContext &renderContext();
 %Docstring
 Returns a reference to the context's render context.

--- a/python/core/auto_generated/mesh/qgsmesh3daveraging.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesh3daveraging.sip.in
@@ -343,9 +343,6 @@ The elevation will be truncated at the surface and bed levels.
   public:
 
     QgsMeshElevationAveragingMethod();
-%Docstring
-Ctor
-%End
 
     QgsMeshElevationAveragingMethod( double startElevation, double endElevation );
 %Docstring

--- a/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -47,6 +47,7 @@ Returns a dataset index within :py:func:`~QgsMeshDatasetIndex.group`
 %Docstring
 Returns whether index is valid, ie at least groups is set
 %End
+
     bool operator == ( QgsMeshDatasetIndex other ) const;
     bool operator != ( QgsMeshDatasetIndex other ) const;
 };

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -119,9 +119,6 @@ data.
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsMeshLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsMeshLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
@@ -54,9 +54,6 @@ that of the spatial index construction.
 %End
 
     QgsMeshSpatialIndex( const QgsMeshSpatialIndex &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsMeshSpatialIndex();
 

--- a/python/core/auto_generated/mesh/qgsmeshtracerenderer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshtracerenderer.sip.in
@@ -35,9 +35,6 @@ Constructor to use with Python binding
 %End
 
     QgsMeshVectorTraceAnimationGenerator( const QgsMeshVectorTraceAnimationGenerator &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsMeshVectorTraceAnimationGenerator();
 

--- a/python/core/auto_generated/plot/qgsplot.sip.in
+++ b/python/core/auto_generated/plot/qgsplot.sip.in
@@ -257,9 +257,6 @@ Constructor for Qgs2DPlot.
 
     virtual bool writeXml( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const;
 
-%Docstring
-Qgs2DPlot cannot be copied
-%End
     virtual bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 
 

--- a/python/core/auto_generated/pointcloud/qgspointcloudattribute.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudattribute.sip.in
@@ -40,9 +40,6 @@ pair of name and size in bytes
     };
 
     QgsPointCloudAttribute();
-%Docstring
-Ctor
-%End
     QgsPointCloudAttribute( const QString &name, DataType type );
 %Docstring
 Ctor
@@ -110,10 +107,8 @@ Collection of point cloud attributes
 #include "qgspointcloudattribute.h"
 %End
   public:
+
     QgsPointCloudAttributeCollection();
-%Docstring
-Ctor
-%End
     QgsPointCloudAttributeCollection( const QVector<QgsPointCloudAttribute> &attributes );
 %Docstring
 Ctor with given attributes

--- a/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
@@ -32,6 +32,7 @@ Base class for storing raw data from point cloud nodes
 %Docstring
 Ctor
 %End
+
     virtual ~QgsPointCloudBlock();
 
     QgsPointCloudBlock *clone() const /Factory/;

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -69,9 +69,6 @@ Constructor - creates a point cloud layer
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsPointCloudLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsPointCloudLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -41,7 +41,6 @@ taken from the point cloud index.
 %End
 
 
-
     QgsRenderContext &renderContext();
 %Docstring
 Returns a reference to the context's render context.

--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -35,9 +35,6 @@ expression context.
 
 
     QgsProcessingContext();
-%Docstring
-Constructor for QgsProcessingContext.
-%End
 
 
     ~QgsProcessingContext();

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -598,7 +598,6 @@ pieces of information about CRS.
 %End
 
     bool operator==( const QgsCoordinateReferenceSystem &srs ) const;
-
     bool operator!=( const QgsCoordinateReferenceSystem &srs ) const;
 
     bool readXml( const QDomNode &node );

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -237,10 +237,6 @@ A CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
 %End
 
     QgsCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &srs );
-%Docstring
-Copy constructor
-%End
-
 
     operator QVariant() const;
 

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -131,10 +131,6 @@ datum transforms (see :py:class:`QgsDatumTransform`).
 %End
 
     QgsCoordinateTransform( const QgsCoordinateTransform &o );
-%Docstring
-Copy constructor
-%End
-
 
     ~QgsCoordinateTransform();
 

--- a/python/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
@@ -48,10 +48,6 @@ Constructor for QgsCoordinateTransformContext.
     ~QgsCoordinateTransformContext();
 
     QgsCoordinateTransformContext( const QgsCoordinateTransformContext &rhs );
-%Docstring
-Copy constructor
-%End
-
 
     bool operator==( const QgsCoordinateTransformContext &rhs ) const;
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -2324,7 +2324,6 @@ This will block dirtying the specified ``project`` for the lifetime of this obje
 %End
 
 
-
     ~QgsProjectDirtyBlocker();
 
   private:

--- a/python/core/auto_generated/project/qgsprojectversion.sip.in
+++ b/python/core/auto_generated/project/qgsprojectversion.sip.in
@@ -64,15 +64,10 @@ Returns ``True`` if this is a NULL project version.
 %End
 
     bool operator==( const QgsProjectVersion &other ) const;
-
     bool operator!=( const QgsProjectVersion &other ) const;
-
     bool operator>=( const QgsProjectVersion &other ) const;
-
     bool operator>( const QgsProjectVersion &other ) const;
-
     bool operator<( const QgsProjectVersion &other ) const;
-
     bool operator<=( const QgsProjectVersion &other ) const;
 
 };

--- a/python/core/auto_generated/qgsarchive.sip.in
+++ b/python/core/auto_generated/qgsarchive.sip.in
@@ -22,14 +22,8 @@ Class allowing to manage the zip/unzip actions
   public:
 
     QgsArchive();
-%Docstring
-Constructor
-%End
 
     QgsArchive( const QgsArchive &other );
-%Docstring
-Copy constructor
-%End
 
 
     virtual ~QgsArchive();

--- a/python/core/auto_generated/qgsdatadefinedsizelegend.sip.in
+++ b/python/core/auto_generated/qgsdatadefinedsizelegend.sip.in
@@ -33,9 +33,6 @@ Constructor for QgsDataDefinedSizeLegend.
     ~QgsDataDefinedSizeLegend();
 
     QgsDataDefinedSizeLegend( const QgsDataDefinedSizeLegend &other );
-%Docstring
-Copy constructor
-%End
 
     enum LegendType
     {

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -69,14 +69,8 @@ Returns the diagram property definitions.
 %End
 
     QgsDiagramLayerSettings();
-%Docstring
-Constructor for QgsDiagramLayerSettings.
-%End
 
     QgsDiagramLayerSettings( const QgsDiagramLayerSettings &rh );
-%Docstring
-Copy constructor
-%End
 
 
     ~QgsDiagramLayerSettings();
@@ -328,15 +322,8 @@ QgsDiagramLayerSettings stores settings which control how ALL diagrams within a 
     };
 
     QgsDiagramSettings();
-%Docstring
-Constructor for QgsDiagramSettings
-%End
     ~QgsDiagramSettings();
-
     QgsDiagramSettings( const QgsDiagramSettings &other );
-%Docstring
-Copy constructor
-%End
 
 
     bool enabled;
@@ -781,9 +768,6 @@ class QgsLinearlyInterpolatedDiagramRenderer : QgsDiagramRenderer
     QgsLinearlyInterpolatedDiagramRenderer();
     ~QgsLinearlyInterpolatedDiagramRenderer();
     QgsLinearlyInterpolatedDiagramRenderer( const QgsLinearlyInterpolatedDiagramRenderer &other );
-%Docstring
-Copy constructor
-%End
 
 
     virtual QgsLinearlyInterpolatedDiagramRenderer *clone() const /Factory/;

--- a/python/core/auto_generated/qgsdistancearea.sip.in
+++ b/python/core/auto_generated/qgsdistancearea.sip.in
@@ -38,15 +38,9 @@ Internally, the GeographicLib library is used to calculate all ellipsoid based m
   public:
 
     QgsDistanceArea();
-%Docstring
-Constructor
-%End
     ~QgsDistanceArea();
 
     QgsDistanceArea( const QgsDistanceArea &other );
-%Docstring
-Copy constructor
-%End
 
     bool willUseEllipsoid() const;
 %Docstring

--- a/python/core/auto_generated/qgselevationmap.sip.in
+++ b/python/core/auto_generated/qgselevationmap.sip.in
@@ -50,9 +50,6 @@ The image must have ARGB32 format and obtained by the :py:func:`~QgsElevationMap
 %End
 
     QgsElevationMap( const QgsElevationMap &other );
-%Docstring
-Copy constructor
-%End
 
     void applyEyeDomeLighting( QImage &image, int distance, float strength, float rendererScale ) const;
 %Docstring

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -119,9 +119,6 @@ Constructor for QgsExpressionContextScope
 %End
 
     QgsExpressionContextScope( const QgsExpressionContextScope &other );
-%Docstring
-Copy constructor
-%End
 
 
     ~QgsExpressionContextScope();
@@ -488,9 +485,6 @@ See :py:class:`QgsExpressionContextUtils` for helper methods for working with :p
   public:
 
     QgsExpressionContext();
-%Docstring
-Constructor for QgsExpressionContext
-%End
 
     explicit QgsExpressionContext( const QList<QgsExpressionContextScope *> &scopes /Transfer/ );
 %Docstring
@@ -499,9 +493,6 @@ Ownership of the scopes is transferred to the stack.
 %End
 
     QgsExpressionContext( const QgsExpressionContext &other );
-%Docstring
-Copy constructor
-%End
 
 
 

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -327,13 +327,7 @@ Constructor for QgsFeature
 %End
 
     QgsFeature( const QgsFeature &rhs ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
-
-
     bool operator==( const QgsFeature &other ) const /HoldGIL/;
-
     bool operator!=( const QgsFeature &other ) const /HoldGIL/;
 
     virtual ~QgsFeature();

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -276,9 +276,6 @@ should use the same CRS as the source layer/provider.
 construct a request with a filter expression
 %End
     QgsFeatureRequest( const QgsFeatureRequest &rh );
-%Docstring
-copy constructor
-%End
 
     bool compare( const QgsFeatureRequest &other ) const;
 %Docstring

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -87,10 +87,6 @@ Constructor. Constructs a new QgsField object.
 %End
 
     QgsField( const QgsField &other ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
-
 
     virtual ~QgsField();
 

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -40,10 +40,6 @@ Constructor for an empty field container
 %End
 
     QgsFields( const QgsFields &other ) /HoldGIL/;
-%Docstring
-Copy constructor
-%End
-
 
     QgsFields( const QList< QgsField > &fields ) /HoldGIL/;
 %Docstring

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -93,7 +93,6 @@ This will block the log from emitting the messageReceived( bool ) signal for the
 %End
 
 
-
     ~QgsMessageLogNotifyBlocker();
 
   private:

--- a/python/core/auto_generated/qgspointxy.sip.in
+++ b/python/core/auto_generated/qgspointxy.sip.in
@@ -49,9 +49,6 @@ Use cases for which :py:class:`QgsPointXY` is NOT a valid choice include:
     QgsPointXY();
 
     QgsPointXY( const QgsPointXY &p ) /HoldGIL/;
-%Docstring
-Create a point from another point
-%End
 
     QgsPointXY( double x, double y ) /HoldGIL/;
 %Docstring

--- a/python/core/auto_generated/qgsproperty.sip.in
+++ b/python/core/auto_generated/qgsproperty.sip.in
@@ -223,10 +223,6 @@ Returns a new StaticProperty created from the specified value.
 %End
 
     QgsProperty( const QgsProperty &other );
-%Docstring
-Copy constructor
-%End
-
 
     operator bool() const;
 

--- a/python/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/core/auto_generated/qgspropertycollection.sip.in
@@ -381,9 +381,6 @@ Constructor for QgsPropertyCollection
 %End
 
     QgsPropertyCollection( const QgsPropertyCollection &other );
-%Docstring
-Copy constructor.
-%End
 
 
     bool operator==( const QgsPropertyCollection &other ) const;
@@ -472,9 +469,6 @@ priority over earlier collections.
     ~QgsPropertyCollectionStack();
 
     QgsPropertyCollectionStack( const QgsPropertyCollectionStack &other );
-%Docstring
-Copy constructor
-%End
 
 
     int count() const;

--- a/python/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/core/auto_generated/qgspropertytransformer.sip.in
@@ -50,9 +50,6 @@ list.
     ~QgsCurveTransform();
 
     QgsCurveTransform( const QgsCurveTransform &other );
-%Docstring
-Copy constructor
-%End
 
 
     QList< QgsPointXY > controlPoints() const;
@@ -182,9 +179,6 @@ Constructor for QgsPropertyTransformer
 %End
 
     QgsPropertyTransformer( const QgsPropertyTransformer &other );
-%Docstring
-Copy constructor.
-%End
 
     virtual ~QgsPropertyTransformer();
 
@@ -634,10 +628,6 @@ Constructor for QgsColorRampTransformer.
 %End
 
     QgsColorRampTransformer( const QgsColorRampTransformer &other );
-%Docstring
-Copy constructor
-%End
-
 
     virtual Type transformerType() const;
     virtual QgsColorRampTransformer *clone() const /Factory/;

--- a/python/core/auto_generated/qgsproxyprogresstask.sip.in
+++ b/python/core/auto_generated/qgsproxyprogresstask.sip.in
@@ -96,7 +96,6 @@ Sets the ``progress`` (from 0 to 100) for the proxied operation.
 %End
 
   private:
-    //! QgsScopedProxyProgressTask cannot be copied
     QgsScopedProxyProgressTask( const QgsScopedProxyProgressTask &other );
 };
 

--- a/python/core/auto_generated/qgsrelationcontext.sip.in
+++ b/python/core/auto_generated/qgsrelationcontext.sip.in
@@ -39,10 +39,6 @@ project instance
     ~QgsRelationContext();
 
     QgsRelationContext( const QgsRelationContext &other );
-%Docstring
-Copy constructor
-%End
-
 
 };
 

--- a/python/core/auto_generated/qgssimplifymethod.sip.in
+++ b/python/core/auto_generated/qgssimplifymethod.sip.in
@@ -73,7 +73,6 @@ Creates a geometry simplifier according to specified method
 %End
 
     bool operator==( const QgsSimplifyMethod &v ) const;
-
     bool operator!=( const QgsSimplifyMethod &v ) const;
 
   protected:

--- a/python/core/auto_generated/qgssldexportcontext.sip.in
+++ b/python/core/auto_generated/qgssldexportcontext.sip.in
@@ -28,10 +28,6 @@ Constructs a default SLD export context
     ~QgsSldExportContext();
 
     QgsSldExportContext( const QgsSldExportContext &other );
-%Docstring
-Constructs a copy of SLD export context ``other``
-%End
-
 
     QgsSldExportContext( const Qgis::SldExportOptions &options, const Qgis::SldExportVendorExtension &vendorExtension, const QString &filePath );
 %Docstring

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -73,9 +73,6 @@ that of the spatial index construction.
 %End
 
     QgsSpatialIndex( const QgsSpatialIndex &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsSpatialIndex();
 

--- a/python/core/auto_generated/qgsspatialindexkdbush.sip.in
+++ b/python/core/auto_generated/qgsspatialindexkdbush.sip.in
@@ -60,10 +60,6 @@ Any non-single point features encountered during iteration will be ignored and n
 
 
     QgsSpatialIndexKDBush( const QgsSpatialIndexKDBush &other );
-%Docstring
-Copy constructor
-%End
-
 
     ~QgsSpatialIndexKDBush();
 

--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -26,9 +26,6 @@ Creates a new statement based on the provided string.
 %End
 
     QgsSQLStatement( const QgsSQLStatement &other );
-%Docstring
-Create a copy of this statement.
-%End
 
     virtual ~QgsSQLStatement();
 

--- a/python/core/auto_generated/qgstablecell.sip.in
+++ b/python/core/auto_generated/qgstablecell.sip.in
@@ -27,9 +27,6 @@ Constructor for QgsTableCell, with the specified ``content``.
 %End
 
     QgsTableCell( const QgsTableCell &other );
-%Docstring
-Copy constructor
-%End
 
     ~QgsTableCell();
 

--- a/python/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -36,10 +36,6 @@ Creates a new color ramp shader.
     ~QgsColorRampShader();
 
     QgsColorRampShader( const QgsColorRampShader &other );
-%Docstring
-Copy constructor
-%End
-
 
     bool operator==( const QgsColorRampShader &other ) const;
 

--- a/python/core/auto_generated/raster/qgsrasterminmaxorigin.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterminmaxorigin.sip.in
@@ -56,9 +56,6 @@ itself the min/max values.
     };
 
     QgsRasterMinMaxOrigin();
-%Docstring
-Default constructor.
-%End
 
     bool operator ==( const QgsRasterMinMaxOrigin &other ) const;
 

--- a/python/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
+++ b/python/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
@@ -22,16 +22,10 @@ for scalebar drawing with :py:class:`QgsScaleBarRenderer`.
   public:
 
     QgsScaleBarSettings();
-%Docstring
-Constructor for QgsScaleBarSettings.
-%End
 
     ~QgsScaleBarSettings();
 
     QgsScaleBarSettings( const QgsScaleBarSettings &other );
-%Docstring
-Copy constructor
-%End
 
 
     int numberOfSegments() const;

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -38,9 +38,6 @@ The optional ``uuid`` argument manually set the UUID key identifier for the cate
 %End
 
     QgsRendererCategory( const QgsRendererCategory &cat );
-%Docstring
-Copy constructor.
-%End
     ~QgsRendererCategory();
 
     QString uuid() const;

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -177,7 +177,6 @@ Returns the symbol layer property definitions.
     virtual ~QgsSymbolLayer();
 
 
-
     virtual Qgis::SymbolLayerFlags flags() const;
 %Docstring
 Returns flags which control the symbol layer's behavior.
@@ -772,12 +771,8 @@ Abstract base class for marker symbol layers.
     };
 
 
-
     virtual void startRender( QgsSymbolRenderContext &context );
 
-%Docstring
-QgsMarkerSymbolLayer cannot be copied
-%End
 
     virtual void stopRender( QgsSymbolRenderContext &context );
 
@@ -1139,12 +1134,8 @@ class QgsLineSymbolLayer : QgsSymbolLayer
     };
 
 
-
     virtual void setOutputUnit( Qgis::RenderUnit unit );
 
-%Docstring
-QgsLineSymbolLayer cannot be copied
-%End
     virtual Qgis::RenderUnit outputUnit() const;
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
@@ -1348,7 +1339,6 @@ class QgsFillSymbolLayer : QgsSymbolLayer
 #include "qgssymbollayer.h"
 %End
   public:
-
 
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context ) = 0;

--- a/python/core/auto_generated/symbology/qgssymbollayerreference.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerreference.sip.in
@@ -58,10 +58,6 @@ QgsSymbolLayerId constructor with a symbol key and an index path
 %End
 
     QgsSymbolLayerId( const QgsSymbolLayerId &other );
-%Docstring
-Default copy constructor
-%End
-
 
     QString symbolKey() const;
 %Docstring

--- a/python/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
@@ -52,11 +52,6 @@ Container for settings relating to a text background object.
     QgsTextBackgroundSettings();
 
     QgsTextBackgroundSettings( const QgsTextBackgroundSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsTextBackgroundSettings
-%End
 
 
     ~QgsTextBackgroundSettings();

--- a/python/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
@@ -28,11 +28,6 @@ Container for settings relating to a text buffer.
     QgsTextBufferSettings();
 
     QgsTextBufferSettings( const QgsTextBufferSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source settings
-%End
 
 
     ~QgsTextBufferSettings();

--- a/python/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -32,11 +32,6 @@ set to an invalid state (see :py:func:`~QgsTextFormat.isValid`).
 %End
 
     QgsTextFormat( const QgsTextFormat &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsTextFormat
-%End
 
 
     ~QgsTextFormat();

--- a/python/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
@@ -37,12 +37,6 @@ A selective masking only makes sense in contexts where the text is rendered over
     QgsTextMaskSettings();
 
     QgsTextMaskSettings( const QgsTextMaskSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source settings
-%End
-
 
     ~QgsTextMaskSettings();
 

--- a/python/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
@@ -34,13 +34,7 @@ Container for settings relating to a text shadow.
     };
 
     QgsTextShadowSettings();
-
     QgsTextShadowSettings( const QgsTextShadowSettings &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsTextShadowSettings
-%End
 
 
     ~QgsTextShadowSettings();

--- a/python/core/auto_generated/tiledscene/qgstiledscenedataprovider.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenedataprovider.sip.in
@@ -34,10 +34,6 @@ Constructor for QgsTiledSceneDataProvider
     ~QgsTiledSceneDataProvider();
 
     QgsTiledSceneDataProvider( const QgsTiledSceneDataProvider &other );
-%Docstring
-Copy constructor.
-%End
-
 
     virtual Qgis::TiledSceneProviderCapabilities capabilities() const;
 %Docstring

--- a/python/core/auto_generated/tiledscene/qgstiledsceneindex.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledsceneindex.sip.in
@@ -35,9 +35,6 @@ threads.
     ~QgsTiledSceneIndex();
 
     QgsTiledSceneIndex( const QgsTiledSceneIndex &other );
-%Docstring
-Copy constructor
-%End
 
     bool isValid() const;
 %Docstring

--- a/python/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
@@ -51,9 +51,6 @@ Constructor for QgsTiledSceneLayer.
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsTiledSceneLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsTiledSceneLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenerenderer.sip.in
@@ -31,7 +31,6 @@ Constructor for QgsTiledSceneRenderContext.
 %End
 
 
-
     QgsRenderContext &renderContext();
 %Docstring
 Returns a reference to the context's render context.

--- a/python/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
@@ -40,9 +40,6 @@ Constructor for an valid tile.
     ~QgsTiledSceneTile();
 
     QgsTiledSceneTile( const QgsTiledSceneTile &other );
-%Docstring
-Copy constructor
-%End
 
     bool isValid() const;
 %Docstring

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -423,9 +423,6 @@ data.
 
 
     SIP_PYOBJECT __repr__();
-%Docstring
-QgsVectorLayer cannot be copied.
-%End
 %MethodCode
     QString str = QStringLiteral( "<QgsVectorLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );

--- a/python/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
@@ -26,12 +26,6 @@ consider.
     QgsVectorLayerToolsContext();
 
     QgsVectorLayerToolsContext( const QgsVectorLayerToolsContext &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsVectorLayerToolsContext
-%End
-
 
     void setExpressionContext( const QgsExpressionContext *context );
 %Docstring

--- a/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
@@ -38,10 +38,8 @@ zoom levels, or by disabling it.
 %Docstring
 Constructs a style object
 %End
+
     QgsVectorTileBasicRendererStyle( const QgsVectorTileBasicRendererStyle &other );
-%Docstring
-Constructs a style object as a copy of another style
-%End
     ~QgsVectorTileBasicRendererStyle();
 
     void setStyleName( const QString &name );

--- a/python/core/auto_generated/vectortile/qgsvtpktiles.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvtpktiles.sip.in
@@ -102,7 +102,6 @@ exists but has a zero size.
 %End
 
   private:
-    //! QgsVtpkTiles cannot be copied
     QgsVtpkTiles( const QgsVtpkTiles &other );
 };
 

--- a/python/gui/auto_generated/qgsgui.sip.in
+++ b/python/gui/auto_generated/qgsgui.sip.in
@@ -29,7 +29,6 @@ related to GUI classes.
     };
 
 
-
     static QgsGui *instance();
 %Docstring
 Returns a pointer to the singleton instance.

--- a/python/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
@@ -22,14 +22,7 @@ map canvas and relevant expression contexts.
   public:
 
     QgsSymbolWidgetContext();
-
     QgsSymbolWidgetContext( const QgsSymbolWidgetContext &other );
-%Docstring
-Copy constructor.
-
-:param other: source QgsSymbolWidgetContext
-%End
-
 
     void setMapCanvas( QgsMapCanvas *canvas );
 %Docstring

--- a/python/server/auto_generated/qgsaccesscontrol.sip.in
+++ b/python/server/auto_generated/qgsaccesscontrol.sip.in
@@ -29,9 +29,6 @@ Constructor
 %End
 
     QgsAccessControl( const QgsAccessControl &copy );
-%Docstring
-Constructor
-%End
 
 
     ~QgsAccessControl();

--- a/python/server/auto_generated/qgsbufferserverresponse.sip.in
+++ b/python/server/auto_generated/qgsbufferserverresponse.sip.in
@@ -22,7 +22,6 @@ Class defining buffered response
 
     QgsBufferServerResponse();
 
-
     virtual void setHeader( const QString &key, const QString &value );
 
 %Docstring

--- a/python/server/auto_generated/qgsservercachemanager.sip.in
+++ b/python/server/auto_generated/qgsservercachemanager.sip.in
@@ -30,11 +30,6 @@ Constructor
 %End
 
     QgsServerCacheManager( const QgsServerCacheManager &copy );
-%Docstring
-Copy constructor
-%End
-
-
     ~QgsServerCacheManager();
 
     bool getCachedDocument( QDomDocument *doc, const QgsProject *project, const QgsServerRequest &request, QgsAccessControl *accessControl ) const;

--- a/python/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/server/auto_generated/qgsserverrequest.sip.in
@@ -66,9 +66,6 @@ class QgsServerRequest
     };
 
     QgsServerRequest();
-%Docstring
-Constructor
-%End
 
     QgsServerRequest( const QString &url, QgsServerRequest::Method method = QgsServerRequest::GetMethod, const QgsServerRequest::Headers &headers = QgsServerRequest::Headers() );
 %Docstring
@@ -89,10 +86,6 @@ Constructor
 %End
 
     QgsServerRequest( const QgsServerRequest &other );
-%Docstring
-Copy constructor.
-%End
-
 
     virtual ~QgsServerRequest();
 

--- a/src/3d/materials/qgsmaterialregistry.h
+++ b/src/3d/materials/qgsmaterialregistry.h
@@ -189,9 +189,7 @@ class _3D_EXPORT QgsMaterialRegistry
     QgsMaterialRegistry();
     ~QgsMaterialRegistry();
 
-    //! QgsMaterialRegistry cannot be copied.
     QgsMaterialRegistry( const QgsMaterialRegistry &rh ) = delete;
-    //! QgsMaterialRegistry cannot be copied.
     QgsMaterialRegistry &operator=( const QgsMaterialRegistry &rh ) = delete;
 
     //! Returns metadata for specified material settings \a type. Returns NULLPTR if not found

--- a/src/3d/qgs3d.h
+++ b/src/3d/qgs3d.h
@@ -34,10 +34,7 @@ class _3D_EXPORT Qgs3D
 
   public:
 
-    //! Qgs3D cannot be copied
     Qgs3D( const Qgs3D &other ) = delete;
-
-    //! Qgs3D cannot be copied
     Qgs3D &operator=( const Qgs3D &other ) = delete;
 
     /**

--- a/src/3d/qgs3danimationsettings.h
+++ b/src/3d/qgs3danimationsettings.h
@@ -38,7 +38,7 @@ class QgsReadWriteContext;
 class _3D_EXPORT Qgs3DAnimationSettings
 {
   public:
-    //! ctor
+
     Qgs3DAnimationSettings();
 
     //! keyframe definition

--- a/src/3d/qgs3daxissettings.h
+++ b/src/3d/qgs3daxissettings.h
@@ -48,10 +48,7 @@ class _3D_EXPORT Qgs3DAxisSettings
 
     Qgs3DAxisSettings() = default;
 
-    //! Returns true if both objects are equal
     bool operator==( Qgs3DAxisSettings const &rhs ) const;
-
-    //! Returns true if objects are not equal
     bool operator!=( Qgs3DAxisSettings const &rhs ) const;
 
     //! Reads settings from a DOM \a element

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -52,9 +52,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
 {
     Q_OBJECT
   public:
-    //! Constructor for Qgs3DMapSettings
+
     Qgs3DMapSettings();
-    //! Copy constructor
     Qgs3DMapSettings( const Qgs3DMapSettings &other );
     ~Qgs3DMapSettings() override;
 

--- a/src/3d/qgsambientocclusionsettings.h
+++ b/src/3d/qgsambientocclusionsettings.h
@@ -37,9 +37,7 @@ class _3D_EXPORT QgsAmbientOcclusionSettings
   public:
 
     QgsAmbientOcclusionSettings() = default;
-    //! Copy constructor
     QgsAmbientOcclusionSettings( const QgsAmbientOcclusionSettings &other );
-    //! delete assignment operator
     QgsAmbientOcclusionSettings &operator=( QgsAmbientOcclusionSettings const &rhs );
 
     //! Reads settings from a DOM \a element

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -55,10 +55,7 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
     QgsPointCloud3DRenderContext( const Qgs3DMapSettings &map, const QgsCoordinateTransform &coordinateTransform, std::unique_ptr< QgsPointCloud3DSymbol > symbol,
                                   double zValueScale, double zValueFixedOffset );
 
-    //! QgsPointCloudRenderContext cannot be copied.
     QgsPointCloud3DRenderContext( const QgsPointCloud3DRenderContext &rh ) = delete;
-
-    //! QgsPointCloudRenderContext cannot be copied.
     QgsPointCloud3DRenderContext &operator=( const QgsPointCloud3DRenderContext & ) = delete;
 
     /**

--- a/src/3d/qgsrulebased3drenderer.h
+++ b/src/3d/qgsrulebased3drenderer.h
@@ -78,9 +78,7 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstractVectorLayer3DRendere
         Rule( QgsAbstract3DSymbol *symbol SIP_TRANSFER, const QString &filterExp = QString(), const QString &description = QString(), bool elseRule = false );
         ~Rule();
 
-        //! Rules cannot be copied.
         Rule( const Rule &rh ) = delete;
-        //! Rules cannot be copied.
         Rule &operator=( const Rule &rh ) = delete;
 
         //! The result of registering a rule

--- a/src/3d/qgsshadowsettings.h
+++ b/src/3d/qgsshadowsettings.h
@@ -36,9 +36,7 @@ class _3D_EXPORT QgsShadowSettings
   public:
 
     QgsShadowSettings() = default;
-    //! Copy constructor
     QgsShadowSettings( const QgsShadowSettings &other );
-    //! delete assignment operator
     QgsShadowSettings &operator=( QgsShadowSettings const &rhs );
 
     //! Reads settings from a DOM \a element

--- a/src/3d/qgsskyboxsettings.h
+++ b/src/3d/qgsskyboxsettings.h
@@ -38,9 +38,7 @@ class _3D_EXPORT QgsSkyboxSettings
   public:
 
     QgsSkyboxSettings() = default;
-    //! copy constructor
     QgsSkyboxSettings( const QgsSkyboxSettings &other );
-    //! delete assignment operator
     QgsSkyboxSettings &operator=( QgsSkyboxSettings const &rhs );
 
     //! Reads settings from a DOM \a element

--- a/src/3d/symbols/qgspoint3dsymbol.h
+++ b/src/3d/symbols/qgspoint3dsymbol.h
@@ -41,7 +41,6 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
     //! Constructor for QgsPoint3DSymbol with default QgsMarkerSymbol as the billboardSymbol
     QgsPoint3DSymbol();
 
-    //! Copy Constructor for QgsPoint3DSymbol
     QgsPoint3DSymbol( const QgsPoint3DSymbol &other );
 
     ~QgsPoint3DSymbol() override;

--- a/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
+++ b/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
@@ -53,10 +53,7 @@ class ANALYSIS_EXPORT QgsGcpGeometryTransformer : public QgsAbstractGeometryTran
 
     ~QgsGcpGeometryTransformer() override;
 
-    //! QgsGcpGeometryTransformer cannot be copied
     QgsGcpGeometryTransformer( const QgsGcpGeometryTransformer &other ) = delete;
-
-    //! QgsGcpGeometryTransformer cannot be copied
     QgsGcpGeometryTransformer &operator=( const QgsGcpGeometryTransformer &other ) = delete;
 
     bool transformPoint( double &x SIP_INOUT, double &y SIP_INOUT, double &z SIP_INOUT, double &m SIP_INOUT ) override;

--- a/src/analysis/interpolation/qgsdualedgetriangulation.h
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.h
@@ -51,9 +51,7 @@ class ANALYSIS_EXPORT QgsDualEdgeTriangulation: public QgsTriangulation
   public:
     QgsDualEdgeTriangulation();
 
-    //! QgsDualEdgeTriangulation cannot be copied
     QgsDualEdgeTriangulation( const QgsDualEdgeTriangulation & ) = delete;
-    //! QgsDualEdgeTriangulation cannot be copied
     QgsDualEdgeTriangulation &operator=( const QgsDualEdgeTriangulation &other ) = delete;
 
     //! Constructor with a number of points to reserve

--- a/src/analysis/qgsanalysis.h
+++ b/src/analysis/qgsanalysis.h
@@ -35,10 +35,7 @@ class ANALYSIS_EXPORT QgsAnalysis
 {
   public:
 
-    //! QgsAnalysis cannot be copied
     QgsAnalysis( const QgsAnalysis &other ) = delete;
-
-    //! QgsAnalysis cannot be copied
     QgsAnalysis &operator=( const QgsAnalysis &other ) = delete;
 
     /**

--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -100,9 +100,7 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
      */
     QgsKernelDensityEstimation( const Parameters &parameters, const QString &outputFile, const QString &outputFormat );
 
-    //! QgsKernelDensityEstimation cannot be copied.
     QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other ) = delete;
-    //! QgsKernelDensityEstimation cannot be copied.
     QgsKernelDensityEstimation &operator=( const QgsKernelDensityEstimation &other ) = delete;
 
     /**

--- a/src/analysis/raster/qgsrastercalcnode.h
+++ b/src/analysis/raster/qgsrastercalcnode.h
@@ -90,9 +90,7 @@ class ANALYSIS_EXPORT QgsRasterCalcNode
     QgsRasterCalcNode( const QString &rasterName );
     ~QgsRasterCalcNode();
 
-    //! QgsRasterCalcNode cannot be copied
     QgsRasterCalcNode( const QgsRasterCalcNode &rh ) = delete;
-    //! QgsRasterCalcNode cannot be copied
     QgsRasterCalcNode &operator=( const QgsRasterCalcNode &rh ) = delete;
 
     Type type() const { return mType; }

--- a/src/analysis/raster/qgsrelief.h
+++ b/src/analysis/raster/qgsrelief.h
@@ -49,9 +49,7 @@ class ANALYSIS_EXPORT QgsRelief
     QgsRelief( const QString &inputFile, const QString &outputFile, const QString &outputFormat );
     ~QgsRelief();
 
-    //! QgsRelief cannot be copied
     QgsRelief( const QgsRelief &rh ) = delete;
-    //! QgsRelief cannot be copied
     QgsRelief &operator=( const QgsRelief &rh ) = delete;
 
     /**

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -148,9 +148,6 @@ class ANALYSIS_EXPORT QgsGeometryCheckerUtils
              */
             iterator( const QStringList::const_iterator &layerIt, const LayerFeatures *parent );
 
-            /**
-             * Copies the iterator \a rh.
-             */
             iterator( const iterator &rh );
             ~iterator();
 

--- a/src/core/3d/qgs3dsymbolregistry.h
+++ b/src/core/3d/qgs3dsymbolregistry.h
@@ -187,9 +187,7 @@ class CORE_EXPORT Qgs3DSymbolRegistry
     Qgs3DSymbolRegistry();
     ~Qgs3DSymbolRegistry();
 
-    //! Qgs3DSymbolRegistry cannot be copied.
     Qgs3DSymbolRegistry( const Qgs3DSymbolRegistry &rh ) = delete;
-    //! Qgs3DSymbolRegistry cannot be copied.
     Qgs3DSymbolRegistry &operator=( const Qgs3DSymbolRegistry &rh ) = delete;
 
     //! Returns metadata for specified symbol \a type. Returns NULLPTR if not found

--- a/src/core/actions/qgsactionscope.h
+++ b/src/core/actions/qgsactionscope.h
@@ -65,9 +65,6 @@ class CORE_EXPORT QgsActionScope
      */
     explicit QgsActionScope( const QString &id, const QString &title, const QString &description, const QgsExpressionContextScope &expressionContextScope = QgsExpressionContextScope() );
 
-    /**
-     * Compares two action scopes
-     */
     bool operator==( const QgsActionScope &other ) const;
 
     /**

--- a/src/core/annotations/qgsannotationitem.h
+++ b/src/core/annotations/qgsannotationitem.h
@@ -74,9 +74,7 @@ class CORE_EXPORT QgsAnnotationItem
     QgsAnnotationItem() = default;
 
 #ifndef SIP_RUN
-    //! QgsAnnotationItem cannot be copied
     QgsAnnotationItem( const QgsAnnotationItem &other ) = delete;
-    //! QgsAnnotationItem cannot be copied
     QgsAnnotationItem &operator=( const QgsAnnotationItem &other ) = delete;
 #endif
 

--- a/src/core/annotations/qgsannotationitemregistry.h
+++ b/src/core/annotations/qgsannotationitemregistry.h
@@ -163,9 +163,7 @@ class CORE_EXPORT QgsAnnotationItemRegistry : public QObject
      */
     bool populate();
 
-    //! QgsAnnotationItemRegistry cannot be copied.
     QgsAnnotationItemRegistry( const QgsAnnotationItemRegistry &rh ) = delete;
-    //! QgsAnnotationItemRegistry cannot be copied.
     QgsAnnotationItemRegistry &operator=( const QgsAnnotationItemRegistry &rh ) = delete;
 
     /**

--- a/src/core/auth/qgsauthconfig.h
+++ b/src/core/auth/qgsauthconfig.h
@@ -51,10 +51,7 @@ class CORE_EXPORT QgsAuthMethodConfig
 
     // TODO c++20 - replace with = default
 
-    //! Operator used to compare configs' equality
     bool operator==( const QgsAuthMethodConfig &other ) const;
-
-    //! Operator used to compare configs' inequality
     bool operator!=( const QgsAuthMethodConfig &other ) const;
 
     /**

--- a/src/core/browser/qgsdataitemproviderregistry.h
+++ b/src/core/browser/qgsdataitemproviderregistry.h
@@ -44,9 +44,7 @@ class CORE_EXPORT QgsDataItemProviderRegistry : public QObject
 
     ~QgsDataItemProviderRegistry();
 
-    //! QgsDataItemProviderRegistry cannot be copied.
     QgsDataItemProviderRegistry( const QgsDataItemProviderRegistry &rh ) = delete;
-    //! QgsDataItemProviderRegistry cannot be copied.
     QgsDataItemProviderRegistry &operator=( const QgsDataItemProviderRegistry &rh ) = delete;
 
     /**

--- a/src/core/callouts/qgscallout.h
+++ b/src/core/callouts/qgscallout.h
@@ -517,10 +517,6 @@ class CORE_EXPORT QgsSimpleLineCallout : public QgsCallout
     ~QgsSimpleLineCallout() override;
 
 #ifndef SIP_RUN
-
-    /**
-     * Copy constructor.
-     */
     QgsSimpleLineCallout( const QgsSimpleLineCallout &other );
     QgsSimpleLineCallout &operator=( const QgsSimpleLineCallout & ) = delete;
 #endif
@@ -753,12 +749,7 @@ class CORE_EXPORT QgsManhattanLineCallout : public QgsSimpleLineCallout
     QgsManhattanLineCallout();
 
 #ifndef SIP_RUN
-
-    /**
-     * Copy constructor.
-     */
     QgsManhattanLineCallout( const QgsManhattanLineCallout &other );
-
     QgsManhattanLineCallout &operator=( const QgsManhattanLineCallout & ) = delete;
 #endif
 
@@ -806,12 +797,7 @@ class CORE_EXPORT QgsCurvedLineCallout : public QgsSimpleLineCallout
     QgsCurvedLineCallout();
 
 #ifndef SIP_RUN
-
-    /**
-     * Copy constructor.
-     */
     QgsCurvedLineCallout( const QgsCurvedLineCallout &other );
-
     QgsCurvedLineCallout &operator=( const QgsCurvedLineCallout & ) = delete;
 #endif
 
@@ -897,10 +883,6 @@ class CORE_EXPORT QgsBalloonCallout : public QgsCallout
     ~QgsBalloonCallout() override;
 
 #ifndef SIP_RUN
-
-    /**
-     * Copy constructor.
-     */
     QgsBalloonCallout( const QgsBalloonCallout &other );
     QgsBalloonCallout &operator=( const QgsBalloonCallout & ) = delete;
 #endif

--- a/src/core/callouts/qgscalloutsregistry.h
+++ b/src/core/callouts/qgscalloutsregistry.h
@@ -159,9 +159,7 @@ class CORE_EXPORT QgsCalloutRegistry
     QgsCalloutRegistry();
     ~QgsCalloutRegistry();
 
-    //! QgsCalloutRegistry cannot be copied.
     QgsCalloutRegistry( const QgsCalloutRegistry &rh ) = delete;
-    //! QgsCalloutRegistry cannot be copied.
     QgsCalloutRegistry &operator=( const QgsCalloutRegistry &rh ) = delete;
 
     /**

--- a/src/core/editform/qgseditformconfig.h
+++ b/src/core/editform/qgseditformconfig.h
@@ -86,10 +86,6 @@ class CORE_EXPORT QgsEditFormConfig
     };
     // *INDENT-ON*
 
-    /**
-     * Copy constructor
-     *
-     */
     QgsEditFormConfig( const QgsEditFormConfig &o );
     ~QgsEditFormConfig();
 

--- a/src/core/effects/qgspainteffectregistry.h
+++ b/src/core/effects/qgspainteffectregistry.h
@@ -176,9 +176,7 @@ class CORE_EXPORT QgsPaintEffectRegistry
     QgsPaintEffectRegistry();
     ~QgsPaintEffectRegistry();
 
-    //! QgsPaintEffectRegistry cannot be copied.
     QgsPaintEffectRegistry( const QgsPaintEffectRegistry &rh ) = delete;
-    //! QgsPaintEffectRegistry cannot be copied.
     QgsPaintEffectRegistry &operator=( const QgsPaintEffectRegistry &rh ) = delete;
 
     /**

--- a/src/core/elevation/qgsprofileexporter.h
+++ b/src/core/elevation/qgsprofileexporter.h
@@ -48,10 +48,7 @@ class CORE_EXPORT QgsProfileExporter
                         const QgsProfileRequest &request,
                         Qgis::ProfileExportType type );
 
-    //! QgsProfileExporter cannot be copied
     QgsProfileExporter( const QgsProfileExporter &other ) = delete;
-
-    //! QgsProfileExporter cannot be copied
     QgsProfileExporter &operator=( const QgsProfileExporter &other ) = delete;
 
     ~QgsProfileExporter();

--- a/src/core/elevation/qgsprofilerequest.h
+++ b/src/core/elevation/qgsprofilerequest.h
@@ -47,9 +47,6 @@ class CORE_EXPORT QgsProfileRequest
      */
     QgsProfileRequest( QgsCurve *curve SIP_TRANSFER );
 
-    /**
-     * Copy constructor.
-     */
     QgsProfileRequest( const QgsProfileRequest &other );
 
     ~QgsProfileRequest();

--- a/src/core/elevation/qgsprofilerequest.h
+++ b/src/core/elevation/qgsprofilerequest.h
@@ -51,9 +51,6 @@ class CORE_EXPORT QgsProfileRequest
 
     ~QgsProfileRequest();
 
-    /**
-     * Assignment operator
-     */
     QgsProfileRequest &operator=( const QgsProfileRequest &other );
 
     bool operator==( const QgsProfileRequest &other ) const;

--- a/src/core/elevation/qgsterrainprovider.h
+++ b/src/core/elevation/qgsterrainprovider.h
@@ -65,9 +65,6 @@ class CORE_EXPORT QgsAbstractTerrainProvider
 
     virtual ~QgsAbstractTerrainProvider();
 
-    /**
-     * QgsAbstractTerrainProvider cannot be assigned.
-     */
     QgsAbstractTerrainProvider &operator=( const QgsAbstractTerrainProvider &other ) = delete;
 
     /**
@@ -161,10 +158,6 @@ class CORE_EXPORT QgsAbstractTerrainProvider
     QgsAbstractTerrainProvider() = default;
 
 #ifndef SIP_RUN
-
-    /**
-     * Copy constructor
-     */
     QgsAbstractTerrainProvider( const QgsAbstractTerrainProvider &other );
 #endif
 
@@ -228,7 +221,6 @@ class CORE_EXPORT QgsRasterDemTerrainProvider : public QgsAbstractTerrainProvide
     QgsRasterDemTerrainProvider() = default;
 
 #ifndef SIP_RUN
-    //! QgsRasterDemTerrainProvider cannot be assigned
     const QgsRasterDemTerrainProvider *operator=( const QgsRasterDemTerrainProvider &other ) = delete;
 #endif
 
@@ -279,7 +271,6 @@ class CORE_EXPORT QgsMeshTerrainProvider : public QgsAbstractTerrainProvider
     QgsMeshTerrainProvider() = default;
 
 #ifndef SIP_RUN
-    //! QgsMeshTerrainProvider cannot be assigned
     const QgsMeshTerrainProvider *operator=( const QgsMeshTerrainProvider &other ) = delete;
 #endif
 

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -358,10 +358,7 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
   protected:
 
     QgsExpressionNode() = default;
-
-    //! Copy constructor
     QgsExpressionNode( const QgsExpressionNode &other );
-    //! Assignment operator
     QgsExpressionNode &operator=( const QgsExpressionNode &other );
 
     /**

--- a/src/core/expression/qgsexpressionnodeimpl.h
+++ b/src/core/expression/qgsexpressionnodeimpl.h
@@ -575,9 +575,7 @@ class CORE_EXPORT QgsExpressionNodeCondition : public QgsExpressionNode
         WhenThen( QgsExpressionNode *whenExp, QgsExpressionNode *thenExp );
         ~WhenThen();
 
-        //! WhenThen nodes cannot be copied.
         WhenThen( const WhenThen &rh ) = delete;
-        //! WhenThen nodes cannot be copied.
         WhenThen &operator=( const WhenThen &rh ) = delete;
 
         /**

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -166,14 +166,13 @@ class CORE_EXPORT QgsGeometry
 
   public:
 
-    //! Constructor
     QgsGeometry() SIP_HOLDGIL;
 
-    //! Copy constructor will prompt a deep copy of the object
+    //! Copy constructor will prompt a shallow copy of the geometry
     QgsGeometry( const QgsGeometry & );
 
     /**
-     * Creates a deep copy of the object
+     * Creates a shallow copy of the geometry
      * \note not available in Python bindings
      */
     QgsGeometry &operator=( QgsGeometry const &rhs ) SIP_SKIP;

--- a/src/core/geometry/qgslinesegment.h
+++ b/src/core/geometry/qgslinesegment.h
@@ -220,13 +220,11 @@ class CORE_EXPORT QgsLineSegment2D
 
     // TODO c++20 - replace with = default
 
-    //! Equality operator
     bool operator==( const QgsLineSegment2D &other ) const SIP_HOLDGIL
     {
       return mStart == other.mStart && mEnd == other.mEnd;
     }
 
-    //! Inequality operator
     bool operator!=( const QgsLineSegment2D &other ) const SIP_HOLDGIL
     {
       return mStart != other.mStart || mEnd != other.mEnd;

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -540,10 +540,6 @@ class CORE_EXPORT QgsRectangle
      */
     QString asPolygon() const;
 
-    /**
-     * Comparison operator
-     * \returns TRUE if rectangles are equal
-     */
     bool operator==( const QgsRectangle &r1 ) const
     {
       if ( isNull() ) return r1.isNull();
@@ -554,19 +550,11 @@ class CORE_EXPORT QgsRectangle
              qgsDoubleNear( r1.yMinimum(), yMinimum() );
     }
 
-    /**
-     * Comparison operator
-     * \returns FALSE if rectangles are equal
-     */
     bool operator!=( const QgsRectangle &r1 ) const
     {
       return ( ! operator==( r1 ) );
     }
 
-    /**
-     * Assignment operator
-     * \param r1 QgsRectangle to assign from
-     */
     QgsRectangle &operator=( const QgsRectangle &r1 )
     {
       if ( &r1 != this )

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -85,7 +85,6 @@ class CORE_EXPORT QgsRectangle
       mYmax = qRectF.bottomRight().y();
     }
 
-    //! Copy constructor
     QgsRectangle( const QgsRectangle &other ) SIP_HOLDGIL
     {
       mXmin = other.xMinimum();

--- a/src/core/gps/qgsbabelformatregistry.h
+++ b/src/core/gps/qgsbabelformatregistry.h
@@ -59,9 +59,7 @@ class CORE_EXPORT QgsBabelFormatRegistry
     QgsBabelFormatRegistry();
     ~QgsBabelFormatRegistry();
 
-    //! QgsBabelFormatRegistry cannot be copied.
     QgsBabelFormatRegistry( const QgsBabelFormatRegistry &rh ) = delete;
-    //! QgsBabelFormatRegistry cannot be copied.
     QgsBabelFormatRegistry &operator=( const QgsBabelFormatRegistry &rh ) = delete;
 
     /**

--- a/src/core/gps/qgsgpsconnectionregistry.h
+++ b/src/core/gps/qgsgpsconnectionregistry.h
@@ -40,9 +40,7 @@ class CORE_EXPORT QgsGpsConnectionRegistry
     QgsGpsConnectionRegistry() = default;
     ~QgsGpsConnectionRegistry();
 
-    //! QgsGpsConnectionRegistry cannot be copied.
     QgsGpsConnectionRegistry( const QgsGpsConnectionRegistry &rh ) = delete;
-    //! QgsGpsConnectionRegistry cannot be copied.
     QgsGpsConnectionRegistry &operator=( const QgsGpsConnectionRegistry &rh ) = delete;
 
     //! Inserts a connection into the registry. The connection is owned by the registry class until it is unregistered again

--- a/src/core/labeling/qgslabelingengine.h
+++ b/src/core/labeling/qgslabelingengine.h
@@ -345,9 +345,7 @@ class CORE_EXPORT QgsLabelingEngine
     //! Clean up everything (especially the registered providers)
     virtual ~QgsLabelingEngine();
 
-    //! QgsLabelingEngine cannot be copied.
     QgsLabelingEngine( const QgsLabelingEngine &rh ) = delete;
-    //! QgsLabelingEngine cannot be copied.
     QgsLabelingEngine &operator=( const QgsLabelingEngine &rh ) = delete;
 
     //! Associate map settings instance
@@ -467,9 +465,7 @@ class CORE_EXPORT QgsDefaultLabelingEngine : public QgsLabelingEngine
     //! Construct the labeling engine with default settings
     QgsDefaultLabelingEngine();
 
-    //! QgsDefaultLabelingEngine cannot be copied.
     QgsDefaultLabelingEngine( const QgsDefaultLabelingEngine &rh ) = delete;
-    //! QgsDefaultLabelingEngine cannot be copied.
     QgsDefaultLabelingEngine &operator=( const QgsDefaultLabelingEngine &rh ) = delete;
 
     void run( QgsRenderContext &context ) override;
@@ -493,9 +489,7 @@ class CORE_EXPORT QgsStagedRenderLabelingEngine : public QgsLabelingEngine
     //! Construct the labeling engine with default settings
     QgsStagedRenderLabelingEngine();
 
-    //! QgsStagedRenderLabelingEngine cannot be copied.
     QgsStagedRenderLabelingEngine( const QgsStagedRenderLabelingEngine &rh ) = delete;
-    //! QgsStagedRenderLabelingEngine cannot be copied.
     QgsStagedRenderLabelingEngine &operator=( const QgsStagedRenderLabelingEngine &rh ) = delete;
 
     void run( QgsRenderContext &context ) override;

--- a/src/core/labeling/qgslabelingresults.h
+++ b/src/core/labeling/qgslabelingresults.h
@@ -36,9 +36,7 @@ class CORE_EXPORT QgsLabelingResults
     QgsLabelingResults();
     ~QgsLabelingResults();
 
-    //! QgsLabelingResults cannot be copied.
     QgsLabelingResults( const QgsLabelingResults & ) = delete;
-    //! QgsLabelingResults cannot be copied.
     QgsLabelingResults &operator=( const QgsLabelingResults &rh ) = delete;
 
     /**

--- a/src/core/labeling/qgslabelsearchtree.h
+++ b/src/core/labeling/qgslabelsearchtree.h
@@ -47,15 +47,10 @@ class CORE_EXPORT QgsLabelSearchTree
 {
   public:
 
-    /**
-     * Constructor for QgsLabelSearchTree.
-     */
     QgsLabelSearchTree();
     ~QgsLabelSearchTree();
 
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree( const QgsLabelSearchTree &rh ) = delete;
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree &operator=( const QgsLabelSearchTree &rh ) = delete;
 
     /**
@@ -141,9 +136,7 @@ class CORE_EXPORT QgsLabelSearchTree
     QTransform mTransform;
 
 #ifdef SIP_RUN
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree( const QgsLabelSearchTree &rh );
-    //! QgsLabelSearchTree cannot be copied.
     QgsLabelSearchTree &operator=( const QgsLabelSearchTree & );
 #endif
 };

--- a/src/core/labeling/qgsrulebasedlabeling.h
+++ b/src/core/labeling/qgsrulebasedlabeling.h
@@ -57,9 +57,7 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
         Rule( QgsPalLayerSettings *settings SIP_TRANSFER, double maximumScale = 0, double minimumScale = 0, const QString &filterExp = QString(), const QString &description = QString(), bool elseRule = false );
         ~Rule();
 
-        //! Rules cannot be copied.
         Rule( const Rule &rh ) = delete;
-        //! Rules cannot be copied.
         Rule &operator=( const Rule &rh ) = delete;
 
         //! The result of registering a rule

--- a/src/core/layertree/qgscolorramplegendnodesettings.h
+++ b/src/core/layertree/qgscolorramplegendnodesettings.h
@@ -51,7 +51,6 @@ class CORE_EXPORT QgsColorRampLegendNodeSettings
 
     ~QgsColorRampLegendNodeSettings();
 
-    //! Copy constructor
     QgsColorRampLegendNodeSettings( const QgsColorRampLegendNodeSettings &other );
 
     QgsColorRampLegendNodeSettings &operator=( const QgsColorRampLegendNodeSettings &other );

--- a/src/core/layertree/qgslayertree.h
+++ b/src/core/layertree/qgslayertree.h
@@ -214,7 +214,6 @@ class CORE_EXPORT QgsLayerTree : public QgsLayerTreeGroup
     void nodeRemovedChildren();
 
   private:
-    //! Copy constructor \see clone()
     QgsLayerTree( const QgsLayerTree &other );
 
     void init();

--- a/src/core/layertree/qgslayertreefiltersettings.h
+++ b/src/core/layertree/qgslayertreefiltersettings.h
@@ -47,9 +47,6 @@ class CORE_EXPORT QgsLayerTreeFilterSettings
 
     ~QgsLayerTreeFilterSettings();
 
-    /**
-     * Copy constructor.
-     */
     QgsLayerTreeFilterSettings( const QgsLayerTreeFilterSettings &other );
 
     QgsLayerTreeFilterSettings &operator=( const QgsLayerTreeFilterSettings &other );

--- a/src/core/layout/qgsabstractreportsection.h
+++ b/src/core/layout/qgsabstractreportsection.h
@@ -77,11 +77,7 @@ class CORE_EXPORT QgsAbstractReportSection : public QgsAbstractLayoutIterator
     QgsAbstractReportSection( QgsAbstractReportSection *parentSection = nullptr );
 
     ~QgsAbstractReportSection() override;
-
-    //! QgsAbstractReportSection cannot be copied
     QgsAbstractReportSection( const QgsAbstractReportSection &other ) = delete;
-
-    //! QgsAbstractReportSection cannot be copied
     QgsAbstractReportSection &operator=( const QgsAbstractReportSection &other ) = delete;
 
     /**

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -55,10 +55,7 @@ class CORE_EXPORT QgsLayoutItemRenderContext
      */
     QgsLayoutItemRenderContext( QgsRenderContext &context, double viewScaleFactor = 1.0 );
 
-    //! QgsLayoutItemRenderContext cannot be copied.
     QgsLayoutItemRenderContext( const QgsLayoutItemRenderContext &other ) = delete;
-
-    //! QgsLayoutItemRenderContext cannot be copied.
     QgsLayoutItemRenderContext &operator=( const QgsLayoutItemRenderContext &other ) = delete;
 
     /**

--- a/src/core/layout/qgslayoutitemregistry.h
+++ b/src/core/layout/qgslayoutitemregistry.h
@@ -390,9 +390,7 @@ class CORE_EXPORT QgsLayoutItemRegistry : public QObject
      */
     bool populate();
 
-    //! QgsLayoutItemRegistry cannot be copied.
     QgsLayoutItemRegistry( const QgsLayoutItemRegistry &rh ) = delete;
-    //! QgsLayoutItemRegistry cannot be copied.
     QgsLayoutItemRegistry &operator=( const QgsLayoutItemRegistry &rh ) = delete;
 
     /**

--- a/src/core/maprenderer/qgsmaprendererjob.h
+++ b/src/core/maprenderer/qgsmaprendererjob.h
@@ -56,10 +56,7 @@ class LayerRenderJob
 
     LayerRenderJob() = default;
 
-    //! LayerRenderJob cannot be copied
     LayerRenderJob( const LayerRenderJob & ) = delete;
-
-    //! LayerRenderJob cannot be copied
     LayerRenderJob &operator=( const LayerRenderJob & ) = delete;
 
     LayerRenderJob( LayerRenderJob && );

--- a/src/core/maprenderer/qgsrendereditemresults.h
+++ b/src/core/maprenderer/qgsrendereditemresults.h
@@ -52,9 +52,7 @@ class CORE_EXPORT QgsRenderedItemResults
     QgsRenderedItemResults( const QgsRectangle &extent = QgsRectangle() );
     ~QgsRenderedItemResults();
 
-    //! QgsRenderedItemResults cannot be copied.
     QgsRenderedItemResults( const QgsRenderedItemResults & ) = delete;
-    //! QgsRenderedItemResults cannot be copied.
     QgsRenderedItemResults &operator=( const QgsRenderedItemResults &rh ) = delete;
 
     /**

--- a/src/core/mesh/qgsmesh3daveraging.h
+++ b/src/core/mesh/qgsmesh3daveraging.h
@@ -368,7 +368,6 @@ class CORE_EXPORT QgsMeshElevationAveragingMethod: public QgsMesh3DAveragingMeth
 {
   public:
 
-    //! Ctor
     QgsMeshElevationAveragingMethod();
 
     /**

--- a/src/core/mesh/qgsmeshdataset.h
+++ b/src/core/mesh/qgsmeshdataset.h
@@ -60,9 +60,8 @@ class CORE_EXPORT QgsMeshDatasetIndex
     int dataset() const;
     //! Returns whether index is valid, ie at least groups is set
     bool isValid() const;
-    //! Equality operator
+
     bool operator == ( QgsMeshDatasetIndex other ) const;
-    //! Inequality operator
     bool operator != ( QgsMeshDatasetIndex other ) const;
   private:
     int mGroupIndex = -1;

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -161,9 +161,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
 
     ~QgsMeshLayer() override;
 
-    //! QgsMeshLayer cannot be copied.
     QgsMeshLayer( const QgsMeshLayer &rhs ) = delete;
-    //! QgsMeshLayer cannot be copied.
     QgsMeshLayer &operator=( QgsMeshLayer const &rhs ) = delete;
 
 #ifdef SIP_RUN

--- a/src/core/mesh/qgsmeshspatialindex.h
+++ b/src/core/mesh/qgsmeshspatialindex.h
@@ -67,13 +67,11 @@ class CORE_EXPORT QgsMeshSpatialIndex
      */
     explicit QgsMeshSpatialIndex( const QgsMesh &mesh, QgsFeedback *feedback = nullptr, QgsMesh::ElementType elementType = QgsMesh::ElementType::Face );
 
-    //! Copy constructor
     QgsMeshSpatialIndex( const QgsMeshSpatialIndex &other );
 
     //! Destructor finalizes work with spatial index
     ~QgsMeshSpatialIndex();
 
-    //! Implement assignment operator
     QgsMeshSpatialIndex &operator=( const QgsMeshSpatialIndex &other );
 
     /**

--- a/src/core/mesh/qgsmeshtracerenderer.h
+++ b/src/core/mesh/qgsmeshtracerenderer.h
@@ -650,7 +650,6 @@ class CORE_EXPORT QgsMeshVectorTraceAnimationGenerator
     //! Sets the visual persistence of the tail
     void setTailPersitence( double p );
 
-    //! Assignment operator
     QgsMeshVectorTraceAnimationGenerator &operator=( const QgsMeshVectorTraceAnimationGenerator &other );
 
   private:

--- a/src/core/mesh/qgsmeshtracerenderer.h
+++ b/src/core/mesh/qgsmeshtracerenderer.h
@@ -59,13 +59,11 @@ class QgsMeshVectorValueInterpolator
       const QgsMeshDataBlock &datasetVectorValues,
       const QgsMeshDataBlock &scalarActiveFaceFlagValues );
 
-    //! Copy constructor
     QgsMeshVectorValueInterpolator( const QgsMeshVectorValueInterpolator &other );
 
     //! Clone
     virtual QgsMeshVectorValueInterpolator *clone() = 0;
 
-    //! Destructor
     virtual ~QgsMeshVectorValueInterpolator() = default;
 
     /**
@@ -117,13 +115,11 @@ class QgsMeshVectorValueInterpolatorFromVertex: public QgsMeshVectorValueInterpo
       const QgsMeshDataBlock &datasetVectorValues,
       const QgsMeshDataBlock &scalarActiveFaceFlagValues );
 
-    //! Copy constructor
     QgsMeshVectorValueInterpolatorFromVertex( const QgsMeshVectorValueInterpolatorFromVertex &other );
 
     //! Clone the instance
     virtual QgsMeshVectorValueInterpolatorFromVertex *clone() override;
 
-    //! Assignment operator
     QgsMeshVectorValueInterpolatorFromVertex &operator=( const QgsMeshVectorValueInterpolatorFromVertex &other );
 
   private:
@@ -152,13 +148,11 @@ class QgsMeshVectorValueInterpolatorFromFace: public QgsMeshVectorValueInterpola
       const QgsMeshDataBlock &datasetVectorValues,
       const QgsMeshDataBlock &scalarActiveFaceFlagValues );
 
-    //! Copy constructor
     QgsMeshVectorValueInterpolatorFromFace( const QgsMeshVectorValueInterpolatorFromFace &other );
 
     //! Clone the instance
     virtual QgsMeshVectorValueInterpolatorFromFace *clone() override;
 
-    //! Assignment operator
     QgsMeshVectorValueInterpolatorFromFace &operator=( const QgsMeshVectorValueInterpolatorFromFace &other );
 
   private:
@@ -196,10 +190,7 @@ class QgsMeshStreamField
       const QgsInterpolatedLineColor &vectorColoring,
       int resolution = 1 );
 
-    //! Copy constructor
     QgsMeshStreamField( const QgsMeshStreamField &other );
-
-    //! Destructor
     virtual ~QgsMeshStreamField();
 
     /**
@@ -432,7 +423,6 @@ class QgsMeshParticleTracesField: public QgsMeshStreamField
       const QgsRenderContext &rendererContext,
       const QgsInterpolatedLineColor vectorColoring );
 
-    //! Copy constructor
     QgsMeshParticleTracesField( const QgsMeshParticleTracesField &other );
 
     //! Adds a particle in the vector field from a start point (pixel) with a specified life time
@@ -626,10 +616,8 @@ class CORE_EXPORT QgsMeshVectorTraceAnimationGenerator
     //!Constructor to use with Python binding
     QgsMeshVectorTraceAnimationGenerator( QgsMeshLayer *layer, const QgsRenderContext &rendererContext );
 
-    //! Copy constructor
     QgsMeshVectorTraceAnimationGenerator( const QgsMeshVectorTraceAnimationGenerator &other );
 
-    //! Destructor
     ~QgsMeshVectorTraceAnimationGenerator() = default;
 
     //! seeds particles in the vector fields

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -51,9 +51,8 @@ class QgsRectangle;
 class CORE_EXPORT QgsTriangularMesh // TODO rename to QgsRendererMesh in QGIS 4
 {
   public:
-    //! Ctor
+
     QgsTriangularMesh();
-    //! Dtor
     ~QgsTriangularMesh();
 
     /**

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -94,7 +94,6 @@ namespace pal
                      double alpha, double cost,
                      FeaturePart *feature, bool isReversed = false, Quadrant quadrant = QuadrantOver );
 
-      //! Copy constructor
       LabelPosition( const LabelPosition &other );
 
       ~LabelPosition() override;

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -92,16 +92,10 @@ namespace pal
       static const QgsSettingsEntryInteger *settingsRenderingLabelCandidatesLimitLines;
       static const QgsSettingsEntryInteger *settingsRenderingLabelCandidatesLimitPolygons;
 
-      /**
-       * \brief Create an new pal instance
-       */
       Pal();
-
       ~Pal();
 
-      //! Pal cannot be copied.
       Pal( const Pal &other ) = delete;
-      //! Pal cannot be copied.
       Pal &operator=( const Pal &other ) = delete;
 
       /**

--- a/src/core/pal/palstat.h
+++ b/src/core/pal/palstat.h
@@ -55,9 +55,7 @@ namespace pal
 
       ~PalStat();
 
-      //! PalStat cannot be copied
       PalStat( const PalStat &other ) = delete;
-      //! PalStat cannot be copied
       PalStat &operator=( const PalStat &other ) = delete;
 
       /**

--- a/src/core/pal/priorityqueue.h
+++ b/src/core/pal/priorityqueue.h
@@ -63,9 +63,7 @@ namespace pal
       PriorityQueue( int n, int maxId, bool min );
       ~PriorityQueue();
 
-      //! PriorityQueue cannot be copied.
       PriorityQueue( const PriorityQueue & ) = delete;
-      //! PriorityQueue cannot be copied.
       PriorityQueue &operator=( const PriorityQueue & ) = delete;
 
       void print();

--- a/src/core/pal/problem.h
+++ b/src/core/pal/problem.h
@@ -86,9 +86,7 @@ namespace pal
 
       ~Problem();
 
-      //! Problem cannot be copied
       Problem( const Problem &other ) = delete;
-      //! Problem cannot be copied
       Problem &operator=( const Problem &other ) = delete;
 
       /**

--- a/src/core/pdf/qgspdfrenderer.h
+++ b/src/core/pdf/qgspdfrenderer.h
@@ -53,9 +53,7 @@ class CORE_EXPORT QgsPdfRenderer
     QgsPdfRenderer( const QString &path );
     ~QgsPdfRenderer();
 
-    //! QgsPdfRenderer cannot be copied
     QgsPdfRenderer( const QgsPdfRenderer &other ) = delete;
-    //! QgsPdfRenderer cannot be copied
     QgsPdfRenderer &operator=( const QgsPdfRenderer &other ) = delete;
 
     /**

--- a/src/core/plot/qgsplot.h
+++ b/src/core/plot/qgsplot.h
@@ -78,9 +78,7 @@ class CORE_EXPORT QgsPlotAxis
     QgsPlotAxis();
     ~QgsPlotAxis();
 
-    //! QgsPlotAxis cannot be copied
     QgsPlotAxis( const QgsPlotAxis &other ) = delete;
-    //! QgsPlotAxis cannot be copied
     QgsPlotAxis &operator=( const QgsPlotAxis &other ) = delete;
 
     /**
@@ -282,9 +280,7 @@ class CORE_EXPORT Qgs2DPlot : public QgsPlot
 
     ~Qgs2DPlot() override;
 
-    //! Qgs2DPlot cannot be copied
     Qgs2DPlot( const Qgs2DPlot &other ) = delete;
-    //! Qgs2DPlot cannot be copied
     Qgs2DPlot &operator=( const Qgs2DPlot &other ) = delete;
 
     bool writeXml( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const override;

--- a/src/core/pointcloud/qgspointcloudattribute.h
+++ b/src/core/pointcloud/qgspointcloudattribute.h
@@ -55,7 +55,6 @@ class CORE_EXPORT QgsPointCloudAttribute
       Double, //!< Double 8 bytes
     };
 
-    //! Ctor
     QgsPointCloudAttribute();
     //! Ctor
     QgsPointCloudAttribute( const QString &name, DataType type );
@@ -141,7 +140,7 @@ class CORE_EXPORT QgsPointCloudAttribute
 class CORE_EXPORT QgsPointCloudAttributeCollection
 {
   public:
-    //! Ctor
+
     QgsPointCloudAttributeCollection();
     //! Ctor with given attributes
     QgsPointCloudAttributeCollection( const QVector<QgsPointCloudAttribute> &attributes );

--- a/src/core/pointcloud/qgspointcloudblock.h
+++ b/src/core/pointcloud/qgspointcloudblock.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsPointCloudBlock
     QgsPointCloudBlock( int count,
                         const QgsPointCloudAttributeCollection &attributes,
                         const QByteArray &data, const QgsVector3D &scale, const QgsVector3D &offset );
-    //! Dtor
+
     virtual ~QgsPointCloudBlock() = default;
 
     /**

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -68,7 +68,6 @@ class CORE_EXPORT IndexedPointCloudNode
 
     // TODO c++20 - replace with = default
 
-    //! Compares nodes
     bool operator==( IndexedPointCloudNode other ) const
     {
       return mD == other.d() && mX == other.x() && mY == other.y() && mZ == other.z();
@@ -122,7 +121,6 @@ class CORE_EXPORT QgsPointCloudCacheKey
     //! Ctor
     QgsPointCloudCacheKey( const IndexedPointCloudNode &n, const QgsPointCloudRequest &request, const QgsPointCloudExpression &expression, const QString &uri );
 
-    //! Compares keys
     bool operator==( const QgsPointCloudCacheKey &other ) const;
 
     //! Returns the key's IndexedPointCloudNode

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -116,9 +116,7 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer, public QgsAbstractPro
 
     ~QgsPointCloudLayer() override;
 
-    //! QgsPointCloudLayer cannot be copied.
     QgsPointCloudLayer( const QgsPointCloudLayer &rhs ) = delete;
-    //! QgsPointCloudLayer cannot be copied.
     QgsPointCloudLayer &operator=( QgsPointCloudLayer const &rhs ) = delete;
 
 #ifdef SIP_RUN

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -58,10 +58,7 @@ class CORE_EXPORT QgsPointCloudRenderContext
     QgsPointCloudRenderContext( QgsRenderContext &context, const QgsVector3D &scale, const QgsVector3D &offset,
                                 double zValueScale, double zValueFixedOffset, QgsFeedback *feedback = nullptr );
 
-    //! QgsPointCloudRenderContext cannot be copied.
     QgsPointCloudRenderContext( const QgsPointCloudRenderContext &rh ) = delete;
-
-    //! QgsPointCloudRenderContext cannot be copied.
     QgsPointCloudRenderContext &operator=( const QgsPointCloudRenderContext & ) = delete;
 
     /**

--- a/src/core/pointcloud/qgspointcloudrendererregistry.h
+++ b/src/core/pointcloud/qgspointcloudrendererregistry.h
@@ -188,9 +188,7 @@ class CORE_EXPORT QgsPointCloudRendererRegistry
     QgsPointCloudRendererRegistry();
     ~QgsPointCloudRendererRegistry();
 
-    //! QgsPointCloudRendererRegistry cannot be copied.
     QgsPointCloudRendererRegistry( const QgsPointCloudRendererRegistry &rh ) = delete;
-    //! QgsPointCloudRendererRegistry cannot be copied.
     QgsPointCloudRendererRegistry &operator=( const QgsPointCloudRendererRegistry &rh ) = delete;
 
     /**

--- a/src/core/pointcloud/qgspointcloudrequest.h
+++ b/src/core/pointcloud/qgspointcloudrequest.h
@@ -41,10 +41,9 @@
 class CORE_EXPORT QgsPointCloudRequest
 {
   public:
-    //! Ctor
+
     QgsPointCloudRequest();
 
-    //! Equality operator
     bool operator==( const QgsPointCloudRequest &other ) const;
 
     //! Returns attributes

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -53,14 +53,9 @@ class CORE_EXPORT QgsProcessingContext
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 
-    /**
-     * Constructor for QgsProcessingContext.
-     */
     QgsProcessingContext();
 
-    //! QgsProcessingContext cannot be copied
     QgsProcessingContext( const QgsProcessingContext &other ) = delete;
-    //! QgsProcessingContext cannot be copied
     QgsProcessingContext &operator=( const QgsProcessingContext &other ) = delete;
 
     ~QgsProcessingContext();

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -44,9 +44,7 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
 
     ~QgsProcessingProvider() override;
 
-    //! Providers cannot be copied
     QgsProcessingProvider( const QgsProcessingProvider &other ) = delete;
-    //! Providers cannot be copied
     QgsProcessingProvider &operator=( const QgsProcessingProvider &other ) = delete;
 
     /**

--- a/src/core/processing/qgsprocessingregistry.h
+++ b/src/core/processing/qgsprocessingregistry.h
@@ -66,9 +66,7 @@ class CORE_EXPORT QgsProcessingRegistry : public QObject
 
     ~QgsProcessingRegistry() override;
 
-    //! Registry cannot be copied
     QgsProcessingRegistry( const QgsProcessingRegistry &other ) = delete;
-    //! Registry cannot be copied
     QgsProcessingRegistry &operator=( const QgsProcessingRegistry &other ) = delete;
 
     /**

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -266,10 +266,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     Q_DECL_DEPRECATED explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId ) SIP_DEPRECATED;
 
-    //! Copy constructor
     QgsCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &srs );
-
-    //! Assignment operator
     QgsCoordinateReferenceSystem &operator=( const QgsCoordinateReferenceSystem &srs );
 
     //! Allows direct construction of QVariants from QgsCoordinateReferenceSystem.

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -549,18 +549,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     Q_DECL_DEPRECATED long findMatchingProj() SIP_DEPRECATED;
 
-    /**
-     * Overloaded == operator used to compare to CRS's.
-     *
-     *  Internally it will use authid() for comparison.
-     */
     bool operator==( const QgsCoordinateReferenceSystem &srs ) const;
-
-    /**
-     * Overloaded != operator used to compare to CRS's.
-     *
-     *  Returns opposite bool value to operator ==
-     */
     bool operator!=( const QgsCoordinateReferenceSystem &srs ) const;
 
     /**

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -135,14 +135,7 @@ class CORE_EXPORT QgsCoordinateTransform
         int sourceDatumTransformId,
         int destinationDatumTransformId ) SIP_DEPRECATED;
 
-    /**
-     * Copy constructor
-     */
     QgsCoordinateTransform( const QgsCoordinateTransform &o );
-
-    /**
-     * Assignment operator
-     */
     QgsCoordinateTransform &operator=( const QgsCoordinateTransform &o );
 
     ~QgsCoordinateTransform();

--- a/src/core/proj/qgscoordinatetransformcontext.h
+++ b/src/core/proj/qgscoordinatetransformcontext.h
@@ -64,14 +64,7 @@ class CORE_EXPORT QgsCoordinateTransformContext
 
     ~QgsCoordinateTransformContext() ;
 
-    /**
-     * Copy constructor
-     */
     QgsCoordinateTransformContext( const QgsCoordinateTransformContext &rhs );
-
-    /**
-     * Assignment operator
-     */
     QgsCoordinateTransformContext &operator=( const QgsCoordinateTransformContext &rhs ) SIP_SKIP;
 
     bool operator==( const QgsCoordinateTransformContext &rhs ) const ;

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -2529,10 +2529,7 @@ class CORE_EXPORT QgsProjectDirtyBlocker
       mProject->mDirtyBlockCount++;
     }
 
-    //! QgsProjectDirtyBlocker cannot be copied
     QgsProjectDirtyBlocker( const QgsProjectDirtyBlocker &other ) = delete;
-
-    //! QgsProjectDirtyBlocker cannot be copied
     QgsProjectDirtyBlocker &operator=( const QgsProjectDirtyBlocker &other ) = delete;
 
     ~QgsProjectDirtyBlocker()

--- a/src/core/project/qgsprojectversion.h
+++ b/src/core/project/qgsprojectversion.h
@@ -74,34 +74,11 @@ class CORE_EXPORT QgsProjectVersion
      */
     bool isNull() const;
 
-    /**
-     * Boolean equal operator
-     */
     bool operator==( const QgsProjectVersion &other ) const;
-
-    /**
-     * Boolean not equal operator
-     */
     bool operator!=( const QgsProjectVersion &other ) const;
-
-    /**
-     * Boolean >= operator
-     */
     bool operator>=( const QgsProjectVersion &other ) const;
-
-    /**
-     * Boolean > operator
-     */
     bool operator>( const QgsProjectVersion &other ) const;
-
-    /**
-     * Boolean < operator
-     */
     bool operator<( const QgsProjectVersion &other ) const;
-
-    /**
-     * Boolean <= operator
-     */
     bool operator<=( const QgsProjectVersion &other ) const;
 
   private:

--- a/src/core/providers/ogr/qgsogrconnpool.h
+++ b/src/core/providers/ogr/qgsogrconnpool.h
@@ -86,10 +86,7 @@ class QgsOgrConnPoolGroup : public QObject, public QgsConnectionPoolGroup<QgsOgr
       initTimer( this );
     }
 
-    //! QgsOgrConnPoolGroup cannot be copied
     QgsOgrConnPoolGroup( const QgsOgrConnPoolGroup &other ) = delete;
-
-    //! QgsOgrConnPoolGroup cannot be copied
     QgsOgrConnPoolGroup &operator=( const QgsOgrConnPoolGroup &other ) = delete;
 
     void ref() { ++mRefCount; }
@@ -132,10 +129,7 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn *, QgsOgrConnPoolGrou
     //
     static void cleanupInstance();
 
-    //! QgsOgrConnPool cannot be copied
     QgsOgrConnPool( const QgsOgrConnPool &other ) = delete;
-
-    //! QgsOgrConnPool cannot be copied
     QgsOgrConnPool &operator=( const QgsOgrConnPool &other ) = delete;
 
     /**

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -59,9 +59,7 @@ class CORE_EXPORT QgsAbstractContentCacheEntry
 
     virtual ~QgsAbstractContentCacheEntry() = default;
 
-    //! QgsAbstractContentCacheEntry cannot be copied.
     QgsAbstractContentCacheEntry( const QgsAbstractContentCacheEntry &rh ) = delete;
-    //! QgsAbstractContentCacheEntry cannot be copied.
     QgsAbstractContentCacheEntry &operator=( const QgsAbstractContentCacheEntry &rh ) = delete;
 
     /**

--- a/src/core/qgsarchive.h
+++ b/src/core/qgsarchive.h
@@ -35,21 +35,12 @@ class CORE_EXPORT QgsArchive
 {
   public:
 
-    /**
-     * Constructor
-     */
     QgsArchive();
 
-    /**
-     * Copy constructor
-     */
     QgsArchive( const QgsArchive &other );
 
     QgsArchive &operator=( const QgsArchive &other );
 
-    /**
-     * Destructor
-     */
     virtual ~QgsArchive() = default;
 
     /**

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -311,9 +311,6 @@ class CORE_EXPORT QgsAttributeTableConfig
      */
     bool hasSameColumns( const QgsAttributeTableConfig &other ) const;
 
-    /**
-     * Compare this configuration to other.
-     */
     bool operator!= ( const QgsAttributeTableConfig &other ) const;
 
   private:

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -73,9 +73,6 @@ class CORE_EXPORT QgsAuxiliaryLayer : public QgsVectorLayer
      */
     QgsAuxiliaryLayer( const QString &pkField, const QString &filename, const QString &table, QgsVectorLayer *vlayer );
 
-    /**
-     * Copy constructor deactivated
-     */
     QgsAuxiliaryLayer( const QgsAuxiliaryLayer &rhs ) = delete;
 
     QgsAuxiliaryLayer &operator=( QgsAuxiliaryLayer const &rhs ) = delete;

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -70,6 +70,9 @@ class QgsConnectionPoolGroup
       QTime lastUsedTime;
     };
 
+    /**
+     * Constructor for QgsConnectionPoolGroup, with the specified connection info.
+     */
     QgsConnectionPoolGroup( const QString &ci )
       : connInfo( ci )
       , sem( QgsApplication::instance()->maxConcurrentConnectionsPerPool() + CONN_POOL_SPARE_CONNECTIONS )
@@ -84,9 +87,7 @@ class QgsConnectionPoolGroup
       }
     }
 
-    //! QgsConnectionPoolGroup cannot be copied
     QgsConnectionPoolGroup( const QgsConnectionPoolGroup &other ) = delete;
-    //! QgsConnectionPoolGroup cannot be copied
     QgsConnectionPoolGroup &operator=( const QgsConnectionPoolGroup &other ) = delete;
 
     /**

--- a/src/core/qgsconnectionregistry.h
+++ b/src/core/qgsconnectionregistry.h
@@ -46,9 +46,7 @@ class CORE_EXPORT QgsConnectionRegistry : public QObject
      */
     QgsConnectionRegistry( QObject *parent SIP_TRANSFERTHIS = nullptr );
 
-    //! Registry cannot be copied
     QgsConnectionRegistry( const QgsConnectionRegistry &other ) = delete;
-    //! Registry cannot be copied
     QgsConnectionRegistry &operator=( const QgsConnectionRegistry &other ) = delete;
 
     /**

--- a/src/core/qgsdatadefinedsizelegend.h
+++ b/src/core/qgsdatadefinedsizelegend.h
@@ -49,7 +49,6 @@ class CORE_EXPORT QgsDataDefinedSizeLegend
 
     ~QgsDataDefinedSizeLegend();
 
-    //! Copy constructor
     QgsDataDefinedSizeLegend( const QgsDataDefinedSizeLegend &other );
     QgsDataDefinedSizeLegend &operator=( const QgsDataDefinedSizeLegend &other );
 

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -108,12 +108,8 @@ class CORE_EXPORT QgsDiagramLayerSettings
      */
     static const QgsPropertiesDefinition &propertyDefinitions();
 
-    /**
-     * Constructor for QgsDiagramLayerSettings.
-     */
     QgsDiagramLayerSettings();
 
-    //! Copy constructor
     QgsDiagramLayerSettings( const QgsDiagramLayerSettings &rh );
 
     QgsDiagramLayerSettings &operator=( const QgsDiagramLayerSettings &rh );
@@ -382,11 +378,8 @@ class CORE_EXPORT QgsDiagramSettings
       Counterclockwise, //!< Counter-clockwise orientation
     };
 
-    //! Constructor for QgsDiagramSettings
     QgsDiagramSettings();
     ~QgsDiagramSettings();
-
-    //! Copy constructor
     QgsDiagramSettings( const QgsDiagramSettings &other );
 
     QgsDiagramSettings &operator=( const QgsDiagramSettings &other );
@@ -817,7 +810,6 @@ class CORE_EXPORT QgsLinearlyInterpolatedDiagramRenderer : public QgsDiagramRend
   public:
     QgsLinearlyInterpolatedDiagramRenderer();
     ~QgsLinearlyInterpolatedDiagramRenderer() override;
-    //! Copy constructor
     QgsLinearlyInterpolatedDiagramRenderer( const QgsLinearlyInterpolatedDiagramRenderer &other );
 
     QgsLinearlyInterpolatedDiagramRenderer &operator=( const QgsLinearlyInterpolatedDiagramRenderer &other );

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -53,11 +53,9 @@ class CORE_EXPORT QgsDistanceArea
 {
   public:
 
-    //! Constructor
     QgsDistanceArea();
     ~QgsDistanceArea();
 
-    //! Copy constructor
     QgsDistanceArea( const QgsDistanceArea &other );
     QgsDistanceArea &operator=( const QgsDistanceArea &other );
 

--- a/src/core/qgselevationmap.h
+++ b/src/core/qgselevationmap.h
@@ -57,7 +57,6 @@ class CORE_EXPORT QgsElevationMap
      */
     explicit QgsElevationMap( const QImage &image );
 
-    //! Copy constructor
     QgsElevationMap( const QgsElevationMap &other );
 
     /**

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -158,9 +158,6 @@ class CORE_EXPORT QgsExpressionContextScope
      */
     QgsExpressionContextScope( const QString &name = QString() );
 
-    /**
-     * Copy constructor
-     */
     QgsExpressionContextScope( const QgsExpressionContextScope &other );
 
     QgsExpressionContextScope &operator=( const QgsExpressionContextScope &other );
@@ -471,7 +468,6 @@ class CORE_EXPORT QgsExpressionContext
 {
   public:
 
-    //! Constructor for QgsExpressionContext
     QgsExpressionContext();
 
     /**
@@ -480,9 +476,6 @@ class CORE_EXPORT QgsExpressionContext
      */
     explicit QgsExpressionContext( const QList<QgsExpressionContextScope *> &scopes SIP_TRANSFER );
 
-    /**
-     * Copy constructor
-     */
     QgsExpressionContext( const QgsExpressionContext &other );
 
     QgsExpressionContext &operator=( const QgsExpressionContext &other ) SIP_SKIP;

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -503,24 +503,9 @@ class CORE_EXPORT QgsFeature
     QgsFeature( const QgsFields &fields, qint64 id = FID_NULL ) SIP_HOLDGIL;
 #endif
 
-    /**
-     * Copy constructor
-     */
     QgsFeature( const QgsFeature &rhs ) SIP_HOLDGIL;
-
-    /**
-     * Assignment operator
-     */
     QgsFeature &operator=( const QgsFeature &rhs ) SIP_HOLDGIL;
-
-    /**
-     * Compares two features
-     */
     bool operator==( const QgsFeature &other ) const SIP_HOLDGIL;
-
-    /**
-     * Compares two features
-     */
     bool operator!=( const QgsFeature &other ) const SIP_HOLDGIL;
 
     virtual ~QgsFeature();

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -301,9 +301,7 @@ class CORE_EXPORT QgsFeatureRequest
 
     //! construct a request with a filter expression
     explicit QgsFeatureRequest( const QgsExpression &expr, const QgsExpressionContext &context = QgsExpressionContext() );
-    //! copy constructor
     QgsFeatureRequest( const QgsFeatureRequest &rh );
-    //! Assignment operator
     QgsFeatureRequest &operator=( const QgsFeatureRequest &rh );
 
     /**

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -116,14 +116,7 @@ class CORE_EXPORT QgsField
                                 const QString &comment = QString(),
                                 QVariant::Type subType = QVariant::Invalid ) SIP_HOLDGIL SIP_DEPRECATED;
 
-    /**
-     * Copy constructor
-     */
     QgsField( const QgsField &other ) SIP_HOLDGIL;
-
-    /**
-     * Assignment operator
-     */
     QgsField &operator =( const QgsField &other ) SIP_SKIP;
 
     virtual ~QgsField();

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -82,14 +82,7 @@ class CORE_EXPORT QgsFields
      */
     QgsFields() SIP_HOLDGIL;
 
-    /**
-     * Copy constructor
-     */
     QgsFields( const QgsFields &other ) SIP_HOLDGIL;
-
-    /**
-     * Assignment operator
-     */
     QgsFields &operator =( const QgsFields &other ) SIP_SKIP;
 
     /**

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -99,9 +99,7 @@ class CORE_EXPORT QgsGmlStreamingParser
                            bool invertAxisOrientation = false );
     ~QgsGmlStreamingParser();
 
-    //! QgsGmlStreamingParser cannot be copied.
     QgsGmlStreamingParser( const QgsGmlStreamingParser &other ) = delete;
-    //! QgsGmlStreamingParser cannot be copied.
     QgsGmlStreamingParser &operator=( const QgsGmlStreamingParser &other ) = delete;
 
     /**

--- a/src/core/qgslocalec.h
+++ b/src/core/qgslocalec.h
@@ -36,9 +36,7 @@ class CORE_EXPORT QgsLocaleNumC
     QgsLocaleNumC();
     ~QgsLocaleNumC();
 
-    //! QgsLocaleNumC cannot be copied
     QgsLocaleNumC( const QgsLocaleNumC &rh ) = delete;
-    //! QgsLocaleNumC cannot be copied
     QgsLocaleNumC &operator=( const QgsLocaleNumC &rh ) = delete;
 
 };

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -201,10 +201,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     ~QgsMapLayer() override;
 
-    //! QgsMapLayer cannot be copied
-    QgsMapLayer( QgsMapLayer const & ) = delete;
-    //! QgsMapLayer cannot be copied
-    QgsMapLayer &operator=( QgsMapLayer const & ) = delete;
+    QgsMapLayer( const QgsMapLayer & ) = delete;
+    QgsMapLayer &operator=( const QgsMapLayer & ) = delete;
 
     /**
      * Returns a new instance equivalent to this one except for the id which

--- a/src/core/qgsmaplayerdependency.h
+++ b/src/core/qgsmaplayerdependency.h
@@ -68,7 +68,6 @@ class CORE_EXPORT QgsMapLayerDependency
 
     // TODO c++20 - replace with = default
 
-    //! Comparison operator
     bool operator==( const QgsMapLayerDependency &other ) const
     {
       return layerId() == other.layerId() && origin() == other.origin() && type() == other.type();

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -109,10 +109,7 @@ class CORE_EXPORT QgsMessageLogNotifyBlocker
      */
     QgsMessageLogNotifyBlocker();
 
-    //! QgsMessageLogNotifyBlocker cannot be copied
     QgsMessageLogNotifyBlocker( const QgsMessageLogNotifyBlocker &other ) = delete;
-
-    //! QgsMessageLogNotifyBlocker cannot be copied
     QgsMessageLogNotifyBlocker &operator=( const QgsMessageLogNotifyBlocker &other ) = delete;
 
     ~QgsMessageLogNotifyBlocker();

--- a/src/core/qgspluginlayerregistry.h
+++ b/src/core/qgspluginlayerregistry.h
@@ -71,9 +71,7 @@ class CORE_EXPORT QgsPluginLayerRegistry
     QgsPluginLayerRegistry() = default;
     ~QgsPluginLayerRegistry();
 
-    //! QgsPluginLayerRegistry cannot be copied.
     QgsPluginLayerRegistry( const QgsPluginLayerRegistry &rh ) = delete;
-    //! QgsPluginLayerRegistry cannot be copied.
     QgsPluginLayerRegistry &operator=( const QgsPluginLayerRegistry &rh ) = delete;
 
     /**

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -67,7 +67,6 @@ class CORE_EXPORT QgsPointXY
 
     QgsPointXY() = default;
 
-    //! Create a point from another point
     QgsPointXY( const QgsPointXY &p ) SIP_HOLDGIL;
 
     /**
@@ -271,7 +270,6 @@ class CORE_EXPORT QgsPointXY
       return QgsGeometryUtilsBase::fuzzyDistanceEqual( epsilon, mX, mY, other.x(), other.y() );
     }
 
-    //! equality operator
     bool operator==( const QgsPointXY &other ) SIP_HOLDGIL
     {
       if ( isEmpty() && other.isEmpty() )
@@ -284,7 +282,6 @@ class CORE_EXPORT QgsPointXY
       return QgsGeometryUtilsBase::fuzzyEqual( 1E-8, mX, mY, other.x(), other.y() );
     }
 
-    //! Inequality operator
     bool operator!=( const QgsPointXY &other ) const SIP_HOLDGIL
     {
       if ( isEmpty() && other.isEmpty() )
@@ -304,7 +301,6 @@ class CORE_EXPORT QgsPointXY
       mY *= scalar;
     }
 
-    //! Assignment
     QgsPointXY &operator=( const QgsPointXY &other ) SIP_HOLDGIL
     {
       if ( &other != this )

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -265,9 +265,7 @@ class CORE_EXPORT QgsProperty
      */
     static QgsProperty fromValue( const QVariant &value, bool isActive = true );
 
-    //! Copy constructor
     QgsProperty( const QgsProperty &other );
-
     QgsProperty &operator=( const QgsProperty &other );
 
     /**

--- a/src/core/qgspropertycollection.h
+++ b/src/core/qgspropertycollection.h
@@ -350,9 +350,6 @@ class CORE_EXPORT QgsPropertyCollection : public QgsAbstractPropertyCollection
      */
     QgsPropertyCollection( const QString &name = QString() );
 
-    /**
-     * Copy constructor.
-     */
     QgsPropertyCollection( const QgsPropertyCollection &other );
 
     QgsPropertyCollection &operator=( const QgsPropertyCollection &other );
@@ -493,7 +490,6 @@ class CORE_EXPORT QgsPropertyCollectionStack : public QgsAbstractPropertyCollect
 
     ~QgsPropertyCollectionStack() override;
 
-    //! Copy constructor
     QgsPropertyCollectionStack( const QgsPropertyCollectionStack &other );
 
     QgsPropertyCollectionStack &operator=( const QgsPropertyCollectionStack &other );

--- a/src/core/qgspropertytransformer.h
+++ b/src/core/qgspropertytransformer.h
@@ -71,9 +71,6 @@ class CORE_EXPORT QgsCurveTransform
 
     ~QgsCurveTransform();
 
-    /**
-     * Copy constructor
-     */
     QgsCurveTransform( const QgsCurveTransform &other );
 
     QgsCurveTransform &operator=( const QgsCurveTransform &other );
@@ -204,9 +201,6 @@ class CORE_EXPORT QgsPropertyTransformer
      */
     QgsPropertyTransformer( double minValue = 0.0, double maxValue = 1.0 );
 
-    /**
-     * Copy constructor.
-     */
     QgsPropertyTransformer( const QgsPropertyTransformer &other );
     QgsPropertyTransformer &operator=( const QgsPropertyTransformer &other );
 
@@ -618,9 +612,7 @@ class CORE_EXPORT QgsColorRampTransformer : public QgsPropertyTransformer
                              const QColor &nullColor = QColor( 0, 0, 0, 0 ),
                              const QString &rampName = QString() );
 
-    //! Copy constructor
     QgsColorRampTransformer( const QgsColorRampTransformer &other );
-
     QgsColorRampTransformer &operator=( const QgsColorRampTransformer &other );
 
     Type transformerType() const override { return ColorRampTransformer; }

--- a/src/core/qgsproxyprogresstask.h
+++ b/src/core/qgsproxyprogresstask.h
@@ -45,9 +45,7 @@ class CORE_EXPORT QgsProxyProgressTask : public QgsTask
      */
     QgsProxyProgressTask( const QString &description, bool canCancel = false );
 
-    //! QgsProxyProgressTask cannot be copied
     QgsProxyProgressTask( const QgsProxyProgressTask &other ) = delete;
-    //! QgsProxyProgressTask cannot be copied
     QgsProxyProgressTask &operator=( const QgsProxyProgressTask &other ) = delete;
 
     /**
@@ -105,9 +103,7 @@ class CORE_EXPORT QgsScopedProxyProgressTask
      */
     QgsScopedProxyProgressTask( const QString &description );
 
-    //! QgsScopedProxyProgressTask cannot be copied
     QgsScopedProxyProgressTask( const QgsScopedProxyProgressTask &other ) = delete;
-    //! QgsScopedProxyProgressTask cannot be copied
     QgsScopedProxyProgressTask &operator=( const QgsScopedProxyProgressTask &other ) = delete;
 
     ~QgsScopedProxyProgressTask();
@@ -122,7 +118,6 @@ class CORE_EXPORT QgsScopedProxyProgressTask
     QgsProxyProgressTask *mTask = nullptr;
 
 #ifdef SIP_RUN
-    //! QgsScopedProxyProgressTask cannot be copied
     QgsScopedProxyProgressTask( const QgsScopedProxyProgressTask &other );
 #endif
 

--- a/src/core/qgsrecentstylehandler.h
+++ b/src/core/qgsrecentstylehandler.h
@@ -47,9 +47,7 @@ class CORE_EXPORT QgsRecentStyleHandler
     */
     QgsRecentStyleHandler();
 
-    //! QgsRecentStyleHandler cannot be copied
     QgsRecentStyleHandler( const QgsRecentStyleHandler &other ) = delete;
-    //! QgsRecentStyleHandler cannot be copied
     QgsRecentStyleHandler &operator=( const QgsRecentStyleHandler &other ) = delete;
 
     ~QgsRecentStyleHandler();

--- a/src/core/qgsrelationcontext.h
+++ b/src/core/qgsrelationcontext.h
@@ -47,14 +47,7 @@ class CORE_EXPORT QgsRelationContext
 
     ~QgsRelationContext();
 
-    /**
-     * Copy constructor
-     */
     QgsRelationContext( const QgsRelationContext &other );
-
-    /**
-     * Assignment operator
-     */
     QgsRelationContext &operator=( const QgsRelationContext &other );
 
   private:

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -65,9 +65,7 @@ class CORE_EXPORT QgsRuntimeProfilerNode
      */
     QgsRuntimeProfilerNode( const QString &group, const QString &name, const QString &id = QString() );
 
-    //! QgsRuntimeProfilerNode cannot be copied
     QgsRuntimeProfilerNode( const QgsRuntimeProfilerNode &other ) = delete;
-    //! QgsRuntimeProfilerNode cannot be copied
     QgsRuntimeProfilerNode &operator=( const QgsRuntimeProfilerNode &other ) = delete;
 
     ~QgsRuntimeProfilerNode();

--- a/src/core/qgssimplifymethod.h
+++ b/src/core/qgssimplifymethod.h
@@ -60,10 +60,7 @@ class CORE_EXPORT QgsSimplifyMethod
     //! Creates a geometry simplifier according to specified method
     static QgsAbstractGeometrySimplifier *createGeometrySimplifier( const QgsSimplifyMethod &simplifyMethod );
 
-    //! Equality operator
     bool operator==( const QgsSimplifyMethod &v ) const;
-
-    //! Inequality operator
     bool operator!=( const QgsSimplifyMethod &v ) const;
 
   protected:

--- a/src/core/qgssldexportcontext.h
+++ b/src/core/qgssldexportcontext.h
@@ -36,14 +36,7 @@ class CORE_EXPORT QgsSldExportContext
 
     ~QgsSldExportContext() = default;
 
-    /**
-     * Constructs a copy of SLD export context \a other
-     */
     QgsSldExportContext( const QgsSldExportContext &other ) = default;
-
-    /**
-     * Copy the values of \a other into the SLD export context
-     */
     QgsSldExportContext &operator=( const QgsSldExportContext &other ) = default;
 
     /**

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -204,9 +204,6 @@ class CORE_EXPORT QgsSnappingConfig
          */
         void setMaximumScale( double maxScale );
 
-        /**
-         * Compare this configuration to other.
-         */
         bool operator!= ( const QgsSnappingConfig::IndividualLayerSettings &other ) const;
 
         // TODO c++20 - replace with = default
@@ -395,9 +392,6 @@ class CORE_EXPORT QgsSnappingConfig
      */
     void clearIndividualLayerSettings();
 
-    /**
-     * Compare this configuration to other.
-     */
     bool operator!= ( const QgsSnappingConfig &other ) const;
 
     /**

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -122,13 +122,11 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
      */
     explicit QgsSpatialIndex( const QgsFeatureSource &source, QgsFeedback *feedback = nullptr, QgsSpatialIndex::Flags flags = QgsSpatialIndex::Flags() );
 
-    //! Copy constructor
     QgsSpatialIndex( const QgsSpatialIndex &other );
 
     //! Destructor finalizes work with spatial index
     ~QgsSpatialIndex() override;
 
-    //! Implement assignment operator
     QgsSpatialIndex &operator=( const QgsSpatialIndex &other );
 
     /* operations */

--- a/src/core/qgsspatialindexkdbush.h
+++ b/src/core/qgsspatialindexkdbush.h
@@ -99,10 +99,7 @@ class CORE_EXPORT QgsSpatialIndexKDBush
     explicit QgsSpatialIndexKDBush( QgsFeatureIterator &fi, const std::function< bool( const QgsFeature & ) > &callback, QgsFeedback *feedback = nullptr );
 #endif
 
-    //! Copy constructor
     QgsSpatialIndexKDBush( const QgsSpatialIndexKDBush &other );
-
-    //! Assignment operator
     QgsSpatialIndexKDBush &operator=( const QgsSpatialIndexKDBush &other );
 
     ~QgsSpatialIndexKDBush();

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -41,14 +41,8 @@ class CORE_EXPORT QgsSQLStatement
      */
     QgsSQLStatement( const QString &statement );
 
-    /**
-     * Create a copy of this statement.
-     */
     QgsSQLStatement( const QgsSQLStatement &other );
 
-    /**
-     * Create a copy of this statement.
-     */
     QgsSQLStatement &operator=( const QgsSQLStatement &other );
     virtual ~QgsSQLStatement();
 

--- a/src/core/qgstablecell.h
+++ b/src/core/qgstablecell.h
@@ -42,7 +42,6 @@ class CORE_EXPORT QgsTableCell
      */
     QgsTableCell( const QVariant &content = QVariant() );
 
-    //! Copy constructor
     QgsTableCell( const QgsTableCell &other );
 
     ~QgsTableCell();

--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -93,9 +93,7 @@ class QgsScopedAssignObjectToCurrentThread
       mObject->moveToThread( nullptr );
     }
 
-    //! QgsScopedAssignObjectToCurrentThread cannot be copied
     QgsScopedAssignObjectToCurrentThread( const QgsScopedAssignObjectToCurrentThread &other ) = delete;
-    //! QgsScopedAssignObjectToCurrentThread cannot be copied
     QgsScopedAssignObjectToCurrentThread &operator =( const QgsScopedAssignObjectToCurrentThread & ) = delete;
 
   private:

--- a/src/core/qgsvector.h
+++ b/src/core/qgsvector.h
@@ -203,13 +203,11 @@ class CORE_EXPORT QgsVector
      */
     QgsVector normalized() const SIP_THROW( QgsException );
 
-    //! Equality operator
     bool operator==( QgsVector other ) const SIP_HOLDGIL
     {
       return qgsDoubleNear( mX, other.mX ) && qgsDoubleNear( mY, other.mY );
     }
 
-    //! Inequality operator
     bool operator!=( QgsVector other ) const
     {
       return !qgsDoubleNear( mX, other.mX ) || !qgsDoubleNear( mY, other.mY );

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -674,9 +674,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                                            const QgsAbstractDatabaseProviderConnection *sourceDatabaseProviderConnection = nullptr
                                          ) SIP_SKIP;
 
-    //! QgsVectorFileWriter cannot be copied.
     QgsVectorFileWriter( const QgsVectorFileWriter &rh ) = delete;
-    //! QgsVectorFileWriter cannot be copied.
     QgsVectorFileWriter &operator=( const QgsVectorFileWriter &rh ) = delete;
 
     /**

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -57,14 +57,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
 
     ~QgsColorRampShader() override;
 
-    /**
-     * Copy constructor
-     */
     QgsColorRampShader( const QgsColorRampShader &other );
-
-    /**
-     * Assignment operator
-     */
     QgsColorRampShader &operator=( const QgsColorRampShader &other );
 
     bool operator==( const QgsColorRampShader &other ) const

--- a/src/core/raster/qgsrasterminmaxorigin.h
+++ b/src/core/raster/qgsrasterminmaxorigin.h
@@ -83,10 +83,8 @@ class CORE_EXPORT QgsRasterMinMaxOrigin
       Estimated
     };
 
-    //! \brief Default constructor.
     QgsRasterMinMaxOrigin();
 
-    //! \brief Equality operator.
     bool operator ==( const QgsRasterMinMaxOrigin &other ) const;
 
     //////// Getter methods /////////////////////

--- a/src/core/raster/qgsrasterpipe.h
+++ b/src/core/raster/qgsrasterpipe.h
@@ -67,9 +67,6 @@ class CORE_EXPORT QgsRasterPipe
      */
     QgsRasterPipe() = default;
 
-    /**
-     * Copy constructor.
-     */
     QgsRasterPipe( const QgsRasterPipe &pipe ) SIP_SKIP;
 
     ~QgsRasterPipe();

--- a/src/core/raster/qgsrastershader.h
+++ b/src/core/raster/qgsrastershader.h
@@ -38,9 +38,7 @@ class CORE_EXPORT QgsRasterShader
   public:
     QgsRasterShader( double minimumValue = 0.0, double maximumValue = 255.0 );
 
-    //! QgsRasterShader cannot be copied
     QgsRasterShader( const QgsRasterShader &rh ) = delete;
-    //! QgsRasterShader cannot be copied
     QgsRasterShader &operator=( const QgsRasterShader &rh ) = delete;
 
     /*

--- a/src/core/scalebar/qgsscalebarsettings.h
+++ b/src/core/scalebar/qgsscalebarsettings.h
@@ -39,16 +39,10 @@ class CORE_EXPORT QgsScaleBarSettings
 {
   public:
 
-    /**
-     * Constructor for QgsScaleBarSettings.
-     */
     QgsScaleBarSettings();
 
     ~QgsScaleBarSettings();
 
-    /**
-     * Copy constructor
-     */
     QgsScaleBarSettings( const QgsScaleBarSettings &other );
 
     QgsScaleBarSettings &operator=( const QgsScaleBarSettings &other );

--- a/src/core/sensor/qgssensorregistry.h
+++ b/src/core/sensor/qgssensorregistry.h
@@ -151,9 +151,7 @@ class CORE_EXPORT QgsSensorRegistry : public QObject
      */
     bool populate();
 
-    //! QgsSensorRegistry cannot be copied.
     QgsSensorRegistry( const QgsSensorRegistry &rh ) = delete;
-    //! QgsSensorRegistry cannot be copied.
     QgsSensorRegistry &operator=( const QgsSensorRegistry &rh ) = delete;
 
     /**

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -53,9 +53,6 @@ class CORE_EXPORT QgsRendererCategory
     */
     QgsRendererCategory( const QVariant &value, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true, const QString &uuid = QString() );
 
-    /**
-     * Copy constructor.
-     */
     QgsRendererCategory( const QgsRendererCategory &cat );
     QgsRendererCategory &operator=( QgsRendererCategory cat );
     ~QgsRendererCategory();

--- a/src/core/symbology/qgscptcityarchive.h
+++ b/src/core/symbology/qgscptcityarchive.h
@@ -43,9 +43,7 @@ class CORE_EXPORT QgsCptCityArchive
                        const QString &baseDir = QString() );
     ~QgsCptCityArchive();
 
-    //! QgsCptCityArchive cannot be copied
     QgsCptCityArchive( const QgsCptCityArchive &rh ) = delete;
-    //! QgsCptCityArchive cannot be copied
     QgsCptCityArchive &operator=( const QgsCptCityArchive &rh ) = delete;
 
     // basic dir info

--- a/src/core/symbology/qgsrendererregistry.h
+++ b/src/core/symbology/qgsrendererregistry.h
@@ -229,9 +229,7 @@ class CORE_EXPORT QgsRendererRegistry
     QgsRendererRegistry();
     ~QgsRendererRegistry();
 
-    //! QgsRendererRegistry cannot be copied.
     QgsRendererRegistry( const QgsRendererRegistry &rh ) = delete;
-    //! QgsRendererRegistry cannot be copied.
     QgsRendererRegistry &operator=( const QgsRendererRegistry &rh ) = delete;
 
     /**

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -162,9 +162,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
               const QString &label = QString(), const QString &description = QString(), bool elseRule = false );
         ~Rule();
 
-        //! Rules cannot be copied
         Rule( const Rule &rh ) = delete;
-        //! Rules cannot be copied
         Rule &operator=( const Rule &rh ) = delete;
 
         /**

--- a/src/core/symbology/qgssvgcache.h
+++ b/src/core/symbology/qgssvgcache.h
@@ -51,9 +51,7 @@ class CORE_EXPORT QgsSvgCacheEntry : public QgsAbstractContentCacheEntry
     QgsSvgCacheEntry( const QString &path, double size, double strokeWidth, double widthScaleFactor, const QColor &fill, const QColor &stroke,
                       double fixedAspectRatio = 0, const QMap<QString, QString> &parameters = QMap<QString, QString>() ) ;
 
-    //! QgsSvgCacheEntry cannot be copied.
     QgsSvgCacheEntry( const QgsSvgCacheEntry &rh ) = delete;
-    //! QgsSvgCacheEntry cannot be copied.
     QgsSvgCacheEntry &operator=( const QgsSvgCacheEntry &rh ) = delete;
 
     double size = 0.0; //size in pixels (cast to int for QImage)

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -222,10 +222,7 @@ class CORE_EXPORT QgsSymbolLayer
 
     virtual ~QgsSymbolLayer();
 
-    //! QgsSymbolLayer cannot be copied
     QgsSymbolLayer( const QgsSymbolLayer &other ) = delete;
-
-    //! QgsSymbolLayer cannot be copied
     QgsSymbolLayer &operator=( const QgsSymbolLayer &other ) = delete;
 
     /**
@@ -780,10 +777,7 @@ class CORE_EXPORT QgsMarkerSymbolLayer : public QgsSymbolLayer
       Bottom, //!< Align to bottom of symbol
     };
 
-    //! QgsMarkerSymbolLayer cannot be copied
     QgsMarkerSymbolLayer( const QgsMarkerSymbolLayer &other ) = delete;
-
-    //! QgsMarkerSymbolLayer cannot be copied
     QgsMarkerSymbolLayer &operator=( const QgsMarkerSymbolLayer &other ) = delete;
 
     void startRender( QgsSymbolRenderContext &context ) override;
@@ -1091,10 +1085,7 @@ class CORE_EXPORT QgsLineSymbolLayer : public QgsSymbolLayer
       InteriorRingsOnly, //!< Render the interior rings only
     };
 
-    //! QgsLineSymbolLayer cannot be copied
     QgsLineSymbolLayer( const QgsLineSymbolLayer &other ) = delete;
-
-    //! QgsLineSymbolLayer cannot be copied
     QgsLineSymbolLayer &operator=( const QgsLineSymbolLayer &other ) = delete;
 
     void setOutputUnit( Qgis::RenderUnit unit ) override;
@@ -1281,10 +1272,7 @@ class CORE_EXPORT QgsFillSymbolLayer : public QgsSymbolLayer
 {
   public:
 
-    //! QgsFillSymbolLayer cannot be copied
     QgsFillSymbolLayer( const QgsFillSymbolLayer &other ) = delete;
-
-    //! QgsFillSymbolLayer cannot be copied
     QgsFillSymbolLayer &operator=( const QgsFillSymbolLayer &other ) = delete;
 
     /**

--- a/src/core/symbology/qgssymbollayerreference.h
+++ b/src/core/symbology/qgssymbollayerreference.h
@@ -73,10 +73,7 @@ class CORE_EXPORT QgsSymbolLayerId
       : mSymbolKey( key ), mIndexPath( { indexPath } )
     {}
 
-    //! Default copy constructor
     QgsSymbolLayerId( const QgsSymbolLayerId &other ) = default;
-
-    //! Default assignment operator
     QgsSymbolLayerId &operator=( const QgsSymbolLayerId &other ) = default;
 
     /**

--- a/src/core/symbology/qgssymbollayerreference.h
+++ b/src/core/symbology/qgssymbollayerreference.h
@@ -88,7 +88,6 @@ class CORE_EXPORT QgsSymbolLayerId
 
     // TODO c++20 - replace with = default
 
-    //! Equality operator
     bool operator==( const QgsSymbolLayerId &other ) const
     {
       return ( mSymbolKey == other.mSymbolKey && mIndexPath == other.mIndexPath );
@@ -174,7 +173,6 @@ class CORE_EXPORT QgsSymbolLayerReference
      */
     QString symbolLayerIdV2() const { return mSymbolLayerId; }
 
-    //! Comparison operator
     bool operator==( const QgsSymbolLayerReference &other ) const
     {
       return mLayerId == other.mLayerId

--- a/src/core/symbology/qgssymbollayerregistry.h
+++ b/src/core/symbology/qgssymbollayerregistry.h
@@ -186,9 +186,7 @@ class CORE_EXPORT QgsSymbolLayerRegistry
     QgsSymbolLayerRegistry();
     ~QgsSymbolLayerRegistry();
 
-    //! QgsSymbolLayerRegistry cannot be copied.
     QgsSymbolLayerRegistry( const QgsSymbolLayerRegistry &rh ) = delete;
-    //! QgsSymbolLayerRegistry cannot be copied.
     QgsSymbolLayerRegistry &operator=( const QgsSymbolLayerRegistry &rh ) = delete;
 
     //! Returns metadata for specified symbol layer. Returns NULLPTR if not found

--- a/src/core/symbology/qgssymbolrendercontext.h
+++ b/src/core/symbology/qgssymbolrendercontext.h
@@ -51,7 +51,6 @@ class CORE_EXPORT QgsSymbolRenderContext
 
     ~QgsSymbolRenderContext();
 
-    //! QgsSymbolRenderContext cannot be copied.
     QgsSymbolRenderContext( const QgsSymbolRenderContext &rh ) = delete;
 
     /**

--- a/src/core/textrenderer/qgstextbackgroundsettings.h
+++ b/src/core/textrenderer/qgstextbackgroundsettings.h
@@ -81,10 +81,6 @@ class CORE_EXPORT QgsTextBackgroundSettings
 
     QgsTextBackgroundSettings();
 
-    /**
-     * Copy constructor.
-     * \param other source QgsTextBackgroundSettings
-     */
     QgsTextBackgroundSettings( const QgsTextBackgroundSettings &other );
 
     QgsTextBackgroundSettings &operator=( const QgsTextBackgroundSettings &other );

--- a/src/core/textrenderer/qgstextbuffersettings.h
+++ b/src/core/textrenderer/qgstextbuffersettings.h
@@ -44,16 +44,8 @@ class CORE_EXPORT QgsTextBufferSettings
 
     QgsTextBufferSettings();
 
-    /**
-     * Copy constructor.
-     * \param other source settings
-     */
     QgsTextBufferSettings( const QgsTextBufferSettings &other );
 
-    /**
-     * Copy constructor.
-     * \param other source QgsTextBufferSettings
-     */
     QgsTextBufferSettings &operator=( const QgsTextBufferSettings &other );
 
     ~QgsTextBufferSettings();

--- a/src/core/textrenderer/qgstextformat.h
+++ b/src/core/textrenderer/qgstextformat.h
@@ -47,10 +47,6 @@ class CORE_EXPORT QgsTextFormat
      */
     QgsTextFormat();
 
-    /**
-     * Copy constructor.
-     * \param other source QgsTextFormat
-     */
     QgsTextFormat( const QgsTextFormat &other );
 
     QgsTextFormat &operator=( const QgsTextFormat &other );

--- a/src/core/textrenderer/qgstextmasksettings.h
+++ b/src/core/textrenderer/qgstextmasksettings.h
@@ -52,16 +52,7 @@ class CORE_EXPORT QgsTextMaskSettings
 
     QgsTextMaskSettings();
 
-    /**
-     * Copy constructor.
-     * \param other source settings
-     */
     QgsTextMaskSettings( const QgsTextMaskSettings &other );
-
-    /**
-     * Copy constructor.
-     * \param other source QgsTextMaskSettings
-     */
     QgsTextMaskSettings &operator=( const QgsTextMaskSettings &other );
 
     ~QgsTextMaskSettings();

--- a/src/core/textrenderer/qgstextshadowsettings.h
+++ b/src/core/textrenderer/qgstextshadowsettings.h
@@ -48,11 +48,6 @@ class CORE_EXPORT QgsTextShadowSettings
     };
 
     QgsTextShadowSettings();
-
-    /**
-     * Copy constructor.
-     * \param other source QgsTextShadowSettings
-     */
     QgsTextShadowSettings( const QgsTextShadowSettings &other );
 
     QgsTextShadowSettings &operator=( const QgsTextShadowSettings &other );

--- a/src/core/tiledscene/qgstiledscenedataprovider.h
+++ b/src/core/tiledscene/qgstiledscenedataprovider.h
@@ -45,14 +45,7 @@ class CORE_EXPORT QgsTiledSceneDataProvider: public QgsDataProvider
 
     ~QgsTiledSceneDataProvider() override;
 
-    /**
-     * Copy constructor.
-     */
     QgsTiledSceneDataProvider( const QgsTiledSceneDataProvider &other );
-
-    /**
-     * QgsTiledSceneDataProvider cannot be assigned.
-     */
     QgsTiledSceneDataProvider &operator=( const QgsTiledSceneDataProvider &other ) = delete;
 
     /**

--- a/src/core/tiledscene/qgstiledsceneindex.h
+++ b/src/core/tiledscene/qgstiledsceneindex.h
@@ -47,9 +47,7 @@ class CORE_EXPORT QgsAbstractTiledSceneIndex
     QgsAbstractTiledSceneIndex();
     virtual ~QgsAbstractTiledSceneIndex();
 
-    //! QgsAbstractTiledSceneIndex cannot be copied
     QgsAbstractTiledSceneIndex( const QgsAbstractTiledSceneIndex &other ) = delete;
-    //! QgsAbstractTiledSceneIndex cannot be copied
     QgsAbstractTiledSceneIndex &operator=( const QgsAbstractTiledSceneIndex &other ) = delete;
 
     /**
@@ -160,7 +158,6 @@ class CORE_EXPORT QgsTiledSceneIndex
 
     ~QgsTiledSceneIndex();
 
-    //! Copy constructor
     QgsTiledSceneIndex( const QgsTiledSceneIndex &other );
     QgsTiledSceneIndex &operator=( const QgsTiledSceneIndex &other );
 

--- a/src/core/tiledscene/qgstiledscenelayer.h
+++ b/src/core/tiledscene/qgstiledscenelayer.h
@@ -83,9 +83,7 @@ class CORE_EXPORT QgsTiledSceneLayer : public QgsMapLayer
 
     ~QgsTiledSceneLayer() override;
 
-    //! QgsTiledSceneLayer cannot be copied.
     QgsTiledSceneLayer( const QgsTiledSceneLayer &other ) = delete;
-    //! QgsTiledSceneLayer cannot be copied.
     QgsTiledSceneLayer &operator=( QgsTiledSceneLayer const &other ) = delete;
 
 #ifdef SIP_RUN

--- a/src/core/tiledscene/qgstiledscenenode.h
+++ b/src/core/tiledscene/qgstiledscenenode.h
@@ -43,9 +43,7 @@ class QgsTiledSceneNode
      */
     QgsTiledSceneNode( QgsTiledSceneTile *tile SIP_TRANSFER );
 
-    //! QgsTiledSceneNode cannot be copied
     QgsTiledSceneNode( const QgsTiledSceneNode &other ) = delete;
-    //! QgsTiledSceneNode cannot be copied
     QgsTiledSceneNode &operator=( const QgsTiledSceneNode &other ) = delete;
 
     ~QgsTiledSceneNode();

--- a/src/core/tiledscene/qgstiledscenerenderer.h
+++ b/src/core/tiledscene/qgstiledscenerenderer.h
@@ -43,10 +43,7 @@ class CORE_EXPORT QgsTiledSceneRenderContext
      */
     QgsTiledSceneRenderContext( QgsRenderContext &context, QgsFeedback *feedback = nullptr );
 
-    //! QgsTiledSceneRenderContext cannot be copied.
     QgsTiledSceneRenderContext( const QgsTiledSceneRenderContext &rh ) = delete;
-
-    //! QgsTiledSceneRenderContext cannot be copied.
     QgsTiledSceneRenderContext &operator=( const QgsTiledSceneRenderContext & ) = delete;
 
     /**

--- a/src/core/tiledscene/qgstiledscenerendererregistry.h
+++ b/src/core/tiledscene/qgstiledscenerendererregistry.h
@@ -185,9 +185,7 @@ class CORE_EXPORT QgsTiledSceneRendererRegistry
     QgsTiledSceneRendererRegistry();
     ~QgsTiledSceneRendererRegistry();
 
-    //! QgsTiledSceneRendererRegistry cannot be copied.
     QgsTiledSceneRendererRegistry( const QgsTiledSceneRendererRegistry &rh ) = delete;
-    //! QgsTiledSceneRendererRegistry cannot be copied.
     QgsTiledSceneRendererRegistry &operator=( const QgsTiledSceneRendererRegistry &rh ) = delete;
 
     /**

--- a/src/core/tiledscene/qgstiledscenetile.h
+++ b/src/core/tiledscene/qgstiledscenetile.h
@@ -52,9 +52,7 @@ class CORE_EXPORT QgsTiledSceneTile
 
     ~QgsTiledSceneTile();
 
-    //! Copy constructor
     QgsTiledSceneTile( const QgsTiledSceneTile &other );
-    //! Assignment operator
     QgsTiledSceneTile &operator=( const QgsTiledSceneTile &other );
 
     /**

--- a/src/core/validity/qgsvaliditycheckregistry.h
+++ b/src/core/validity/qgsvaliditycheckregistry.h
@@ -42,9 +42,7 @@ class CORE_EXPORT QgsValidityCheckRegistry
 
     ~QgsValidityCheckRegistry();
 
-    //! QgsValidityCheckRegistry cannot be copied.
     QgsValidityCheckRegistry( const QgsValidityCheckRegistry &rh ) = delete;
-    //! QgsValidityCheckRegistry cannot be copied.
     QgsValidityCheckRegistry &operator=( const QgsValidityCheckRegistry &rh ) = delete;
 
     /**

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -577,9 +577,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     ~QgsVectorLayer() override;
 
-    //! QgsVectorLayer cannot be copied.
     QgsVectorLayer( const QgsVectorLayer &rhs ) = delete;
-    //! QgsVectorLayer cannot be copied.
     QgsVectorLayer &operator=( QgsVectorLayer const &rhs ) = delete;
 
 #ifdef SIP_RUN

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -93,9 +93,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
                             const QMap<QString, QVariant> &options = QMap<QString, QVariant>(),
                             QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 
-    //! QgsVectorLayerExporter cannot be copied
     QgsVectorLayerExporter( const QgsVectorLayerExporter &rh ) = delete;
-    //! QgsVectorLayerExporter cannot be copied
     QgsVectorLayerExporter &operator=( const QgsVectorLayerExporter &rh ) = delete;
 
     /**

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -59,9 +59,7 @@ class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
      */
     explicit QgsVectorLayerFeatureSource( const QgsVectorLayer *layer );
 
-    //! QgsVectorLayerFeatureSource cannot be copied
     QgsVectorLayerFeatureSource( const QgsVectorLayerFeatureSource &other ) = delete;
-    //! QgsVectorLayerFeatureSource cannot be copied
     QgsVectorLayerFeatureSource &operator==( const QgsVectorLayerFeatureSource &other ) = delete;
 
     ~QgsVectorLayerFeatureSource() override;
@@ -378,9 +376,7 @@ class CORE_EXPORT QgsVectorLayerSelectedFeatureSource : public QgsFeatureSource,
      */
     QgsVectorLayerSelectedFeatureSource( QgsVectorLayer *layer );
 
-    //! QgsVectorLayerSelectedFeatureSource cannot be copied
     QgsVectorLayerSelectedFeatureSource( const QgsVectorLayerSelectedFeatureSource &other ) = delete;
-    //! QgsVectorLayerSelectedFeatureSource cannot be copied
     QgsVectorLayerSelectedFeatureSource &operator==( const QgsVectorLayerSelectedFeatureSource &other ) = delete;
 
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const override;

--- a/src/core/vector/qgsvectorlayertoolscontext.h
+++ b/src/core/vector/qgsvectorlayertoolscontext.h
@@ -34,12 +34,7 @@ class CORE_EXPORT QgsVectorLayerToolsContext
 
     QgsVectorLayerToolsContext() = default;
 
-    /**
-     * Copy constructor.
-     * \param other source QgsVectorLayerToolsContext
-     */
     QgsVectorLayerToolsContext( const QgsVectorLayerToolsContext &other );
-
     QgsVectorLayerToolsContext &operator=( const QgsVectorLayerToolsContext &other );
 
     /**

--- a/src/core/vectortile/qgsarcgisvectortileservicedataprovider.h
+++ b/src/core/vectortile/qgsarcgisvectortileservicedataprovider.h
@@ -36,9 +36,6 @@ class CORE_EXPORT QgsArcGisVectorTileServiceDataProvider : public QgsXyzVectorTi
 
     QgsArcGisVectorTileServiceDataProvider( const QgsArcGisVectorTileServiceDataProvider &other );
 
-    /**
-     * QgsArcGisVectorTileServiceDataProvider cannot be assigned.
-     */
     QgsArcGisVectorTileServiceDataProvider &operator=( const QgsArcGisVectorTileServiceDataProvider &other ) = delete;
 
     Qgis::DataProviderFlags flags() const override;

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -349,9 +349,7 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      */
     QgsMapBoxGlStyleConverter();
 
-    //! QgsMapBoxGlStyleConverter cannot be copied
     QgsMapBoxGlStyleConverter( const QgsMapBoxGlStyleConverter &other ) = delete;
-    //! QgsMapBoxGlStyleConverter cannot be copied
     QgsMapBoxGlStyleConverter &operator=( const QgsMapBoxGlStyleConverter &other ) = delete;
 
     ~QgsMapBoxGlStyleConverter();

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
@@ -39,9 +39,6 @@ class CORE_EXPORT QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataPro
 
     QgsMbTilesVectorTileDataProvider( const QgsMbTilesVectorTileDataProvider &other );
 
-    /**
-     * QgsMbTilesVectorTileDataProvider cannot be assigned.
-     */
     QgsMbTilesVectorTileDataProvider &operator=( const QgsMbTilesVectorTileDataProvider &other ) = delete;
 
     Qgis::DataProviderFlags flags() const override;

--- a/src/core/vectortile/qgsvectortilebasicrenderer.h
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.h
@@ -49,7 +49,7 @@ class CORE_EXPORT QgsVectorTileBasicRendererStyle
   public:
     //! Constructs a style object
     QgsVectorTileBasicRendererStyle( const QString &stName = QString(), const QString &laName = QString(), Qgis::GeometryType geomType = Qgis::GeometryType::Unknown );
-    //! Constructs a style object as a copy of another style
+
     QgsVectorTileBasicRendererStyle( const QgsVectorTileBasicRendererStyle &other );
     QgsVectorTileBasicRendererStyle &operator=( const QgsVectorTileBasicRendererStyle &other );
     ~QgsVectorTileBasicRendererStyle();

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -84,14 +84,7 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
                                const QgsDataProvider::ProviderOptions &providerOptions,
                                Qgis::DataProviderReadFlags flags );
 
-    /**
-     * Copy constructor.
-     */
     QgsVectorTileDataProvider( const QgsVectorTileDataProvider &other );
-
-    /**
-     * QgsVectorTileDataProvider cannot be assigned.
-     */
     QgsVectorTileDataProvider &operator=( const QgsVectorTileDataProvider &other ) = delete;
 
     /**

--- a/src/core/vectortile/qgsvtpktiles.h
+++ b/src/core/vectortile/qgsvtpktiles.h
@@ -41,9 +41,7 @@ class CORE_EXPORT QgsVtpkTiles
     explicit QgsVtpkTiles( const QString &filename );
 
 #ifndef SIP_RUN
-    //! QgsVtpkTiles cannot be copied
     QgsVtpkTiles( const QgsVtpkTiles &other ) = delete;
-    //! QgsVtpkTiles cannot be copied
     QgsVtpkTiles &operator=( const QgsVtpkTiles &other ) = delete;
 #endif
     ~QgsVtpkTiles();
@@ -118,7 +116,6 @@ class CORE_EXPORT QgsVtpkTiles
   private:
 
 #ifdef SIP_RUN
-    //! QgsVtpkTiles cannot be copied
     QgsVtpkTiles( const QgsVtpkTiles &other );
 #endif
 

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.h
@@ -40,9 +40,6 @@ class CORE_EXPORT QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvid
                                    Qgis::DataProviderReadFlags flags );
     QgsVtpkVectorTileDataProvider( const QgsVtpkVectorTileDataProvider &other );
 
-    /**
-     * QgsVtpkVectorTileDataProvider cannot be assigned.
-     */
     QgsVtpkVectorTileDataProvider &operator=( const QgsVtpkVectorTileDataProvider &other ) = delete;
 
     Qgis::DataProviderFlags flags() const override;

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.h
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.h
@@ -36,9 +36,6 @@ class CORE_EXPORT QgsXyzVectorTileDataProviderBase : public QgsVectorTileDataPro
                                       Qgis::DataProviderReadFlags flags );
     QgsXyzVectorTileDataProviderBase( const QgsXyzVectorTileDataProviderBase &other );
 
-    /**
-     * QgsXyzVectorTileDataProviderBase cannot be assigned.
-     */
     QgsXyzVectorTileDataProviderBase &operator=( const QgsXyzVectorTileDataProviderBase &other ) = delete;
 
     bool supportsAsync() const override;
@@ -74,9 +71,6 @@ class CORE_EXPORT QgsXyzVectorTileDataProvider : public QgsXyzVectorTileDataProv
                                   Qgis::DataProviderReadFlags flags );
     QgsXyzVectorTileDataProvider( const QgsXyzVectorTileDataProvider &other );
 
-    /**
-     * QgsXyzVectorTileDataProvider cannot be assigned.
-     */
     QgsXyzVectorTileDataProvider &operator=( const QgsXyzVectorTileDataProvider &other ) = delete;
 
     Qgis::DataProviderFlags flags() const override;

--- a/src/gui/annotations/qgsannotationitemguiregistry.h
+++ b/src/gui/annotations/qgsannotationitemguiregistry.h
@@ -317,9 +317,7 @@ class GUI_EXPORT QgsAnnotationItemGuiRegistry : public QObject
 
     ~QgsAnnotationItemGuiRegistry() override;
 
-    //! QgsAnnotationItemGuiRegistry cannot be copied.
     QgsAnnotationItemGuiRegistry( const QgsAnnotationItemGuiRegistry &rh ) = delete;
-    //! QgsAnnotationItemGuiRegistry cannot be copied.
     QgsAnnotationItemGuiRegistry &operator=( const QgsAnnotationItemGuiRegistry &rh ) = delete;
 
     /**

--- a/src/gui/history/qgshistoryentrynode.h
+++ b/src/gui/history/qgshistoryentrynode.h
@@ -43,9 +43,7 @@ class GUI_EXPORT QgsHistoryEntryNode
     QgsHistoryEntryNode() = default;
     virtual ~QgsHistoryEntryNode();
 
-    //! QgsHistoryEntryNode cannot be copied
     QgsHistoryEntryNode( const QgsHistoryEntryNode &other ) = delete;
-    //! QgsHistoryEntryNode cannot be copied
     QgsHistoryEntryNode &operator=( const QgsHistoryEntryNode &other ) = delete;
 
     /**
@@ -134,9 +132,7 @@ class GUI_EXPORT QgsHistoryEntryGroup : public QgsHistoryEntryNode
     QgsHistoryEntryGroup() = default;
     ~QgsHistoryEntryGroup() override;
 
-    //! QgsHistoryEntryGroup cannot be copied
     QgsHistoryEntryGroup( const QgsHistoryEntryGroup &other ) = delete;
-    //! QgsHistoryEntryGroup cannot be copied
     QgsHistoryEntryGroup &operator=( const QgsHistoryEntryGroup &other ) = delete;
 
     /**

--- a/src/gui/layertree/qgslayertreeembeddedwidgetregistry.h
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetregistry.h
@@ -79,9 +79,7 @@ class GUI_EXPORT QgsLayerTreeEmbeddedWidgetRegistry
 
     ~QgsLayerTreeEmbeddedWidgetRegistry();
 
-    //! QgsLayerTreeEmbeddedWidgetRegistry cannot be copied.
     QgsLayerTreeEmbeddedWidgetRegistry( const QgsLayerTreeEmbeddedWidgetRegistry &other ) = delete;
-    //! QgsLayerTreeEmbeddedWidgetRegistry cannot be copied.
     QgsLayerTreeEmbeddedWidgetRegistry &operator=( const QgsLayerTreeEmbeddedWidgetRegistry &other ) = delete;
 
     //! Returns list of all registered providers

--- a/src/gui/layout/qgslayoutitemguiregistry.h
+++ b/src/gui/layout/qgslayoutitemguiregistry.h
@@ -369,9 +369,7 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
 
     ~QgsLayoutItemGuiRegistry() override;
 
-    //! QgsLayoutItemGuiRegistry cannot be copied.
     QgsLayoutItemGuiRegistry( const QgsLayoutItemGuiRegistry &rh ) = delete;
-    //! QgsLayoutItemGuiRegistry cannot be copied.
     QgsLayoutItemGuiRegistry &operator=( const QgsLayoutItemGuiRegistry &rh ) = delete;
 
     /**

--- a/src/gui/qgsdataitemguiproviderregistry.h
+++ b/src/gui/qgsdataitemguiproviderregistry.h
@@ -40,9 +40,7 @@ class GUI_EXPORT QgsDataItemGuiProviderRegistry
     QgsDataItemGuiProviderRegistry();
     ~QgsDataItemGuiProviderRegistry();
 
-    //! QgsDataItemGuiProviderRegistry cannot be copied.
     QgsDataItemGuiProviderRegistry( const QgsDataItemGuiProviderRegistry &rh ) = delete;
-    //! QgsDataItemGuiProviderRegistry cannot be copied.
     QgsDataItemGuiProviderRegistry &operator=( const QgsDataItemGuiProviderRegistry &rh ) = delete;
 
     /**

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -73,10 +73,7 @@ class GUI_EXPORT QgsGui : public QObject
     };
     Q_ENUM( ProjectCrsBehavior )
 
-    //! QgsGui cannot be copied
     QgsGui( const QgsGui &other ) = delete;
-
-    //! QgsGui cannot be copied
     QgsGui &operator=( const QgsGui &other ) = delete;
 
     /**

--- a/src/gui/qgsguiutils.h
+++ b/src/gui/qgsguiutils.h
@@ -225,9 +225,7 @@ class GUI_EXPORT QWidgetUpdateBlocker
      */
     QWidgetUpdateBlocker( QWidget *widget );
 
-    //! QWidgetUpdateBlocker cannot be copied
     QWidgetUpdateBlocker( const QWidgetUpdateBlocker &other ) = delete;
-    //! QWidgetUpdateBlocker cannot be copied
     QWidgetUpdateBlocker &operator=( const QWidgetUpdateBlocker &other ) = delete;
 
     ~QWidgetUpdateBlocker();

--- a/src/gui/qgsprojectstorageguiregistry.h
+++ b/src/gui/qgsprojectstorageguiregistry.h
@@ -47,9 +47,7 @@ class GUI_EXPORT QgsProjectStorageGuiRegistry
     QgsProjectStorageGuiRegistry();
     ~QgsProjectStorageGuiRegistry();
 
-    //! QgsProjectStorageGuiRegistry cannot be copied.
     QgsProjectStorageGuiRegistry( const QgsProjectStorageGuiRegistry &rh ) = delete;
-    //! QgsProjectStorageGuiRegistry cannot be copied.
     QgsProjectStorageGuiRegistry &operator=( const QgsProjectStorageGuiRegistry &rh ) = delete;
 
     //! Returns storage implementation if the storage type matches one. Returns NULLPTR otherwise (it is a normal file)

--- a/src/gui/qgsprovidersourcewidgetproviderregistry.h
+++ b/src/gui/qgsprovidersourcewidgetproviderregistry.h
@@ -43,9 +43,7 @@ class GUI_EXPORT QgsProviderSourceWidgetProviderRegistry
     QgsProviderSourceWidgetProviderRegistry();
     ~QgsProviderSourceWidgetProviderRegistry();
 
-    //! QgsProviderSourceWidgetProviderRegistry cannot be copied.
     QgsProviderSourceWidgetProviderRegistry( const QgsProviderSourceWidgetProviderRegistry &rh ) = delete;
-    //! QgsProviderSourceWidgetProviderRegistry cannot be copied.
     QgsProviderSourceWidgetProviderRegistry &operator=( const QgsProviderSourceWidgetProviderRegistry &rh ) = delete;
 
     //! Gets list of available providers

--- a/src/gui/qgssourceselectproviderregistry.h
+++ b/src/gui/qgssourceselectproviderregistry.h
@@ -45,9 +45,7 @@ class GUI_EXPORT QgsSourceSelectProviderRegistry : public QObject
     QgsSourceSelectProviderRegistry();
     ~QgsSourceSelectProviderRegistry();
 
-    //! QgsDataItemProviderRegistry cannot be copied.
     QgsSourceSelectProviderRegistry( const QgsSourceSelectProviderRegistry &rh ) = delete;
-    //! QgsDataItemProviderRegistry cannot be copied.
     QgsSourceSelectProviderRegistry &operator=( const QgsSourceSelectProviderRegistry &rh ) = delete;
 
     //! Gets list of available providers

--- a/src/gui/qgssubsetstringeditorproviderregistry.h
+++ b/src/gui/qgssubsetstringeditorproviderregistry.h
@@ -44,9 +44,7 @@ class GUI_EXPORT QgsSubsetStringEditorProviderRegistry
     QgsSubsetStringEditorProviderRegistry();
     ~QgsSubsetStringEditorProviderRegistry();
 
-    //! QgsDataItemProviderRegistry cannot be copied.
     QgsSubsetStringEditorProviderRegistry( const QgsSubsetStringEditorProviderRegistry &rh ) = delete;
-    //! QgsDataItemProviderRegistry cannot be copied.
     QgsSubsetStringEditorProviderRegistry &operator=( const QgsSubsetStringEditorProviderRegistry &rh ) = delete;
 
     //! Gets list of available providers

--- a/src/gui/sensor/qgssensorguiregistry.h
+++ b/src/gui/sensor/qgssensorguiregistry.h
@@ -192,9 +192,7 @@ class GUI_EXPORT QgsSensorGuiRegistry : public QObject
     QgsSensorGuiRegistry( QObject *parent = nullptr );
     ~QgsSensorGuiRegistry() override;
 
-    //! QgsSensorGuiRegistry cannot be copied.
     QgsSensorGuiRegistry( const QgsSensorGuiRegistry &rh ) = delete;
-    //! QgsSensorGuiRegistry cannot be copied.
     QgsSensorGuiRegistry &operator=( const QgsSensorGuiRegistry &rh ) = delete;
 
     /**

--- a/src/gui/symbology/qgssymbolwidgetcontext.h
+++ b/src/gui/symbology/qgssymbolwidgetcontext.h
@@ -36,13 +36,7 @@ class GUI_EXPORT QgsSymbolWidgetContext // clazy:exclude=rule-of-three
   public:
 
     QgsSymbolWidgetContext() = default;
-
-    /**
-     * Copy constructor.
-     * \param other source QgsSymbolWidgetContext
-     */
     QgsSymbolWidgetContext( const QgsSymbolWidgetContext &other );
-
     QgsSymbolWidgetContext &operator=( const QgsSymbolWidgetContext &other );
 
     /**

--- a/src/server/qgsaccesscontrol.h
+++ b/src/server/qgsaccesscontrol.h
@@ -46,7 +46,6 @@ class SERVER_EXPORT QgsAccessControl : public QgsFeatureFilterProvider
       mResolved = false;
     }
 
-    //! Constructor
     QgsAccessControl( const QgsAccessControl &copy )
     {
       mPluginsAccessControls = new QgsAccessControlFilterMap( *copy.mPluginsAccessControls );
@@ -60,7 +59,6 @@ class SERVER_EXPORT QgsAccessControl : public QgsFeatureFilterProvider
       delete mPluginsAccessControls;
     }
 
-    //! Assignment operator
     QgsAccessControl &operator= ( const QgsAccessControl &other )
     {
       if ( this != &other )

--- a/src/server/qgsbufferserverresponse.h
+++ b/src/server/qgsbufferserverresponse.h
@@ -38,8 +38,6 @@ class SERVER_EXPORT QgsBufferServerResponse: public QgsServerResponse
   public:
 
     QgsBufferServerResponse();
-
-    //! QgsBufferServerResponse cannot be copied
     QgsBufferServerResponse( const QgsBufferServerResponse & ) = delete;
 
     /**

--- a/src/server/qgsfilterrestorer.h
+++ b/src/server/qgsfilterrestorer.h
@@ -47,9 +47,7 @@ class SERVER_EXPORT QgsOWSServerFilterRestorer
       restoreLayerFilters( mOriginalLayerFilters );
     }
 
-    //! QgsOWSServerFilterRestorer cannot be copied
     QgsOWSServerFilterRestorer( const QgsOWSServerFilterRestorer &rh ) = delete;
-    //! QgsOWSServerFilterRestorer cannot be copied
     QgsOWSServerFilterRestorer &operator=( const QgsOWSServerFilterRestorer &rh ) = delete;
 
     void restoreLayerFilters( const QHash<QgsMapLayer *, QString> &filterMap );

--- a/src/server/qgsservercachemanager.h
+++ b/src/server/qgsservercachemanager.h
@@ -48,13 +48,8 @@ class SERVER_EXPORT QgsServerCacheManager
     //! Constructor
     QgsServerCacheManager( const QgsServerSettings &settings = QgsServerSettings() );
 
-    //! Copy constructor
     QgsServerCacheManager( const QgsServerCacheManager &copy );
-
-    //! Assignment operator
     QgsServerCacheManager &operator=( const QgsServerCacheManager &copy );
-
-    //! Destructor
     ~QgsServerCacheManager();
 
     /**

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -92,9 +92,6 @@ class SERVER_EXPORT QgsServerRequest
     };
     Q_ENUM( RequestHeader )
 
-    /**
-     * Constructor
-     */
     QgsServerRequest() = default;
 
     /**
@@ -115,14 +112,9 @@ class SERVER_EXPORT QgsServerRequest
      */
     QgsServerRequest( const QUrl &url, QgsServerRequest::Method method = QgsServerRequest::GetMethod, const QgsServerRequest::Headers &headers = QgsServerRequest::Headers() );
 
-    /**
-     * Copy constructor.
-     */
     QgsServerRequest( const QgsServerRequest &other );
 
     QgsServerRequest &operator=( const QgsServerRequest & ) = default;
-
-    //! destructor
     virtual ~QgsServerRequest() = default;
 
     /**

--- a/tests/code_layout/doxygen_parser.py
+++ b/tests/code_layout/doxygen_parser.py
@@ -395,11 +395,8 @@ class DoxygenParser():
         name = elem.find('name')
 
         # ignore certain obvious operators
-        try:
-            if name.text in ('operator=', 'operator==', 'operator!=', 'Q_ENUM'):
-                return False
-        except:
-            pass
+        if name.text in ('operator=', 'operator==', 'operator!=', 'operator>=', 'operator>', 'operator<=', 'operator<', 'Q_ENUM'):
+            return False
 
         # ignore on_* slots
         try:

--- a/tests/code_layout/doxygen_parser.py
+++ b/tests/code_layout/doxygen_parser.py
@@ -378,13 +378,19 @@ class DoxygenParser():
         if self.isDestructor(elem):
             return False
 
-        # ignore constructors with no arguments
         if self.isConstructor(elem):
+            # ignore constructors with no arguments
             try:
                 if re.match(r'^\s*\(\s*\)\s*(?:=\s*default\s*)?$', elem.find('argsstring').text):
                     return False
             except:
                 pass
+
+            # ignore copy constructors
+            name = elem.find('name').text
+            match = re.match(r'^\s*\(\s*(?:const)?\s*' + name + r'\s*&?\s*(?:[a-zA-Z0-9_]+)?\s*\)\s*(?:=\s*(?:default|delete)\s*)?$', elem.find('argsstring').text)
+            if match:
+                return False
 
         name = elem.find('name')
 
@@ -463,7 +469,9 @@ class DoxygenParser():
             name = member_elem.find('name').text
             if f'{name}::{name}' in definition:
                 return True
-        except:
+            if re.match(rf'{name}\s*\<\s*[a-zA-Z0-9_]+\s*\>\s*::{name}', definition):
+                return True
+        except (AttributeError, re.error):
             pass
 
         return False


### PR DESCRIPTION
And drop more no-value documentation