### PR TITLE
Don't require an explicit tileMatrixSet URI param for WMTS 

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -62,6 +62,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     mInterpretation = uri.param( QStringLiteral( "interpretation" ) );
   }
 
+  mTiled = false;
   if ( uri.param( QStringLiteral( "type" ) ) == QLatin1String( "xyz" ) ||
        uri.param( QStringLiteral( "type" ) ) == QLatin1String( "mbtiles" ) )
   {
@@ -100,8 +101,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 
     return true;
   }
-
-  if ( uri.param( QStringLiteral( "type" ) ) == QLatin1String( "wmst" ) )
+  else if ( uri.param( QStringLiteral( "type" ) ) == QLatin1String( "wmst" ) )
   {
     mIsTemporal = true;
     mTemporalExtent = uri.param( QStringLiteral( "timeDimensionExtent" ) );
@@ -172,8 +172,11 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
       mIsBiTemporal = true;
     }
   }
+  else if ( uri.param( QStringLiteral( "type" ) ) == QLatin1String( "wmts" ) )
+  {
+    mTiled = true;
+  }
 
-  mTiled = false;
   mTileDimensionValues.clear();
 
   mHttpUri = uri.param( QStringLiteral( "url" ) );

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1868,6 +1868,8 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
     }
 
     mTileMatrixSets.insert( set.identifier, set );
+    if ( mFirstTileMatrixSetId.isEmpty() )
+      mFirstTileMatrixSetId = set.identifier;
   }
 
   //

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -1051,6 +1051,12 @@ class QgsWmsCapabilities
      */
     QHash<QString, QgsWmtsTileMatrixSet> mTileMatrixSets;
 
+    /**
+     * ID of the first tile matrix returned in the capabilities, to be used as the default
+     * if no specific tile matrix is specified.
+     */
+    QString mFirstTileMatrixSetId;
+
     //temporarily caches invert axis setting for each crs
     QHash<QString, bool> mCrsInvertAxis;
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -593,6 +593,22 @@ bool QgsWmsProvider::setImageCrs( QString const &crs )
     }
 
     mNativeResolutions.clear();
+
+    if ( mSettings.mTileMatrixSetId.isEmpty() && !mCaps.mFirstTileMatrixSetId.isEmpty() )
+    {
+      // if no explicit tile matrix set specified, use first listed
+      mSettings.mTileMatrixSetId = mCaps.mFirstTileMatrixSetId;
+      for ( int i = 0; i < mCaps.mTileLayersSupported.size(); i++ )
+      {
+        QgsWmtsTileLayer *tl = &mCaps.mTileLayersSupported[i];
+        if ( tl->identifier != mSettings.mActiveSubLayers[0] )
+          continue;
+
+        mTileLayer = tl;
+        break;
+      }
+    }
+
     if ( mCaps.mTileMatrixSets.contains( mSettings.mTileMatrixSetId ) )
     {
       mTileMatrixSet = &mCaps.mTileMatrixSets[ mSettings.mTileMatrixSetId ];

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -157,6 +157,7 @@ class TestQgsWmsProvider: public QgsTest
       // explicitly state crs and format
       {
         QgsWmsProvider provider( "contextualWMSLegend=0&crs=EPSG:4326&dpiMode=7&featureCount=10&format=image/jpg&layers=CountryGroup&styles=default&tileMatrixSet=standard&tilePixelRatio=0&url=http://localhost:8380/mapserv?xxx", QgsDataProvider::ProviderOptions(), &cap );
+        QVERIFY( provider.mSettings.mTiled );
         QCOMPARE( provider.mSettings.mTileMatrixSetId, QStringLiteral( "standard" ) );
         QCOMPARE( provider.crs().authid(), QStringLiteral( "EPSG:4326" ) );
         QCOMPARE( provider.mSettings.mImageMimeType, QStringLiteral( "image/jpg" ) );
@@ -164,6 +165,7 @@ class TestQgsWmsProvider: public QgsTest
       // no crs or format specified, should use tile matrix crs
       {
         QgsWmsProvider provider( "contextualWMSLegend=0&dpiMode=7&featureCount=10&layers=CountryGroup&styles=default&tileMatrixSet=standard&tilePixelRatio=0&url=http://localhost:8380/mapserv?xxx", QgsDataProvider::ProviderOptions(), &cap );
+        QVERIFY( provider.mSettings.mTiled );
         QCOMPARE( provider.mSettings.mTileMatrixSetId, QStringLiteral( "standard" ) );
         QCOMPARE( provider.crs().authid(), QStringLiteral( "EPSG:3857" ) );
         QCOMPARE( provider.mSettings.mImageMimeType, QStringLiteral( "image/png" ) );
@@ -171,6 +173,15 @@ class TestQgsWmsProvider: public QgsTest
       // no tileMatrixSet specified, should use first listed
       {
         QgsWmsProvider provider( "layers=CountryGroup&styles=default&tileDimensions=&url=http://localhost:8380/mapserv?xxx", QgsDataProvider::ProviderOptions(), &cap );
+        QVERIFY( provider.mSettings.mTiled );
+        QCOMPARE( provider.mSettings.mTileMatrixSetId, QStringLiteral( "standard" ) );
+        QCOMPARE( provider.crs().authid(), QStringLiteral( "EPSG:3857" ) );
+        QCOMPARE( provider.mSettings.mImageMimeType, QStringLiteral( "image/png" ) );
+      }
+      // no tileMatrixSet specified, using type=wmts to request wmts
+      {
+        QgsWmsProvider provider( "layers=CountryGroup&styles=default&type=wmts&url=http://localhost:8380/mapserv?xxx", QgsDataProvider::ProviderOptions(), &cap );
+        QVERIFY( provider.mSettings.mTiled );
         QCOMPARE( provider.mSettings.mTileMatrixSetId, QStringLiteral( "standard" ) );
         QCOMPARE( provider.crs().authid(), QStringLiteral( "EPSG:3857" ) );
         QCOMPARE( provider.mSettings.mImageMimeType, QStringLiteral( "image/png" ) );

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -157,12 +157,21 @@ class TestQgsWmsProvider: public QgsTest
       // explicitly state crs and format
       {
         QgsWmsProvider provider( "contextualWMSLegend=0&crs=EPSG:4326&dpiMode=7&featureCount=10&format=image/jpg&layers=CountryGroup&styles=default&tileMatrixSet=standard&tilePixelRatio=0&url=http://localhost:8380/mapserv?xxx", QgsDataProvider::ProviderOptions(), &cap );
+        QCOMPARE( provider.mSettings.mTileMatrixSetId, QStringLiteral( "standard" ) );
         QCOMPARE( provider.crs().authid(), QStringLiteral( "EPSG:4326" ) );
         QCOMPARE( provider.mSettings.mImageMimeType, QStringLiteral( "image/jpg" ) );
       }
       // no crs or format specified, should use tile matrix crs
       {
         QgsWmsProvider provider( "contextualWMSLegend=0&dpiMode=7&featureCount=10&layers=CountryGroup&styles=default&tileMatrixSet=standard&tilePixelRatio=0&url=http://localhost:8380/mapserv?xxx", QgsDataProvider::ProviderOptions(), &cap );
+        QCOMPARE( provider.mSettings.mTileMatrixSetId, QStringLiteral( "standard" ) );
+        QCOMPARE( provider.crs().authid(), QStringLiteral( "EPSG:3857" ) );
+        QCOMPARE( provider.mSettings.mImageMimeType, QStringLiteral( "image/png" ) );
+      }
+      // no tileMatrixSet specified, should use first listed
+      {
+        QgsWmsProvider provider( "layers=CountryGroup&styles=default&tileDimensions=&url=http://localhost:8380/mapserv?xxx", QgsDataProvider::ProviderOptions(), &cap );
+        QCOMPARE( provider.mSettings.mTileMatrixSetId, QStringLiteral( "standard" ) );
         QCOMPARE( provider.crs().authid(), QStringLiteral( "EPSG:3857" ) );
         QCOMPARE( provider.mSettings.mImageMimeType, QStringLiteral( "image/png" ) );
       }


### PR DESCRIPTION
When no explicit WMTS tileMatrixSet is specified, use the first returned by the GetCapabilities request. This allows creation
of raster layers with no upfront knowledge of the available tile matrix sets, and avoids the need for Python scripts to
manually retrieve and parse the GetCapabilities in advance in order to determine available tile set IDs.

Funded by North Road, thanks to SLYR