### PR TITLE
Keep attributes when adding 1-N related features with a multi-edition attribute form

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
@@ -101,6 +101,15 @@ Returns whether the parent widget should be hidden when showing tools' dialogues
 Sets whether the parent widget should be hidden when showing tools' dialogues.
 %End
 
+    bool forceSuppressFormPopup() const;
+%Docstring
+Returns whether the add feature form popup should be shown
+%End
+    void setForceSuppressFormPopup( bool forceSuppressFormPopup );
+%Docstring
+Sets whether the add feature form popup should be shown
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertoolscontext.sip.in
@@ -101,6 +101,15 @@ Returns whether the parent widget should be hidden when showing tools' dialogues
 Sets whether the parent widget should be hidden when showing tools' dialogues.
 %End
 
+    bool forceSuppressFormPopup() const;
+%Docstring
+Returns whether the add feature form popup should be shown
+%End
+    void setForceSuppressFormPopup( bool forceSuppressFormPopup );
+%Docstring
+Sets whether the add feature form popup should be shown
+%End
+
 };
 
 /************************************************************************

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -37,6 +37,11 @@ bool QgsGuiVectorLayerTools::addFeatureV2( QgsVectorLayer *layer, const QgsAttri
   f->setGeometry( defaultGeometry );
   QgsFeatureAction *a = new QgsFeatureAction( tr( "Add feature" ), *f, layer, QUuid(), -1, context.parentWidget() );
   a->setForceSuppressFormPopup( forceSuppressFormPopup() );
+
+  // Override with context
+  if ( context.forceSuppressFormPopup() )
+    a->setForceSuppressFormPopup( true );
+
   connect( a, &QgsFeatureAction::addFeatureFinished, a, &QObject::deleteLater );
   const QgsFeatureAction::AddFeatureResult result = a->addFeature( defaultValues, context.showModal(), std::unique_ptr<QgsExpressionContextScope>( context.additionalExpressionContextScope() ? new QgsExpressionContextScope( *context.additionalExpressionContextScope() ) : nullptr ), context.hideParent() );
   if ( !feature )

--- a/src/core/vector/qgsvectorlayertoolscontext.h
+++ b/src/core/vector/qgsvectorlayertoolscontext.h
@@ -101,6 +101,16 @@ class CORE_EXPORT QgsVectorLayerToolsContext
      */
     void setHideParent( bool hide ) { mHideParent = hide; }
 
+    /**
+     * Returns whether the add feature form popup should be shown
+     */
+    bool forceSuppressFormPopup() const { return mForceSuppressFormPopup; };
+
+    /**
+     * Sets whether the add feature form popup should be shown
+     */
+    void setForceSuppressFormPopup( bool forceSuppressFormPopup ) { mForceSuppressFormPopup = forceSuppressFormPopup; }
+
   private:
 
     std::unique_ptr< QgsExpressionContext > mExpressionContext;
@@ -109,6 +119,7 @@ class CORE_EXPORT QgsVectorLayerToolsContext
     QWidget *mParentWidget = nullptr;
     bool mShowModal = true;
     bool mHideParent = false;
+    bool mForceSuppressFormPopup = false;
 };
 
 #endif // QGSVECTORLAYERTOOLSCONTEXT_H


### PR DESCRIPTION
## Description

The bug is described in [this PR](https://github.com/qgis/QGIS/pull/53562), which has been merged, [and reverted](https://github.com/qgis/QGIS/pull/57875) recently.

Therefore, the bug is back again.

In this PR I want to discuss the right way to fix the bug (and propose an approach), and decide if we should fix it, or if we should re-think the behavior because the UX might be wrong.

### The bug

#### Context

We have a layer A (say buildings - Point) with a 1-N relation with layer B (say pictures - No geometry, one field for file path).

Each building can have multiple pictures.

#### Intent

The user wants to add the same picture to many (say 4) buildings.

![](https://private-user-images.githubusercontent.com/34267385/248207262-7203aee7-47c3-456f-9f7b-ddf5522eb765.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjk3ODQ0NzgsIm5iZiI6MTcyOTc4NDE3OCwicGF0aCI6Ii8zNDI2NzM4NS8yNDgyMDcyNjItNzIwM2FlZTctNDdjMy00NTZmLTlmN2ItZGRmNTUyMmViNzY1LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMjQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDI0VDE1MzYxOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTUwMWM1NGUzMDYwZmU2ZWE1ZjNmZGRjNzQ5OGQ0NGZhODM1MTk1OTcxMzU5NDA0Yzc2NGQ1YTA1YzdhOGQzNTUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.TOnPlcfFs2cn1VI2TodcRDGG5cK3PWEu-zR8y9Mxp8Q)

#### UX

It's possible with QGIS, and we see in the code that the intent is to create 4 identical picture features and reference them to each building.

#### Bug

Only one (the first) of the new picture features have the correct attributes:

![](https://private-user-images.githubusercontent.com/34267385/248207686-655e7379-b0fa-4ac4-aaae-0aba860ec773.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjk3ODQ0NzgsIm5iZiI6MTcyOTc4NDE3OCwicGF0aCI6Ii8zNDI2NzM4NS8yNDgyMDc2ODYtNjU1ZTczNzktYjBmYS00YWM0LWFhYWUtMGFiYTg2MGVjNzczLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMjQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDI0VDE1MzYxOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTkyODEwNzIxZDRmOWM1Y2E0NWJmZjcxNmZiYjNiZmJkOTE5YmEzZjBhOGY3ZDRkZGIzOTNlOTgzMDllNjI2NTEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.cOpT1sizPOo0yYczkL46CCONHRtf2Wk1d0IYEnMNfZ8)

### Cause of the bug

The first picture feature is added with `QgsVectorLayerTools::addFeatureV2()` in `QgsGuiVectorLayerTool` implementation, which delegates the feature addition to `QgsFeatureAction::addFeature()`, which delegates the feature addition to `QgsVectorLayerUtils::createFeature()` and the attribute form `QgsAttributeForm::featureSaved`, etc.

In this process, the attributes are set asynchronously through signals.

It means that when the user writes the file path in his new picture feature attribute, the other 3 picture features have already been added (without attributes, copied from the bare first picture feature).

1. The first picture feature is added (`AddFeatureResult::Pending`)
2. The 2nd, 3rd, 4th feature are added
3. The user finishes writing the attribute and clicks OK in the attribute form
4. The first picture feature is updated with the attributes

### Should it be even possible?

This kind of use-case might raise the question: "Maybe I need an N-M relation? One picture can be related to more than one building, and one building can be related to more than one picture."

So should QGIS really give the user the possibility to multi-edit a building to add a child feature on a 1-N relation?

### Fix the bug

I first fixed the bug [by making the add-a-child-popup modal](https://github.com/qgis/QGIS/pull/53562), but it created a [regression](https://github.com/qgis/QGIS/issues/57474).

Ways to fix:
1. wait for the attributes to be filled-in and the form to be validated (first reverted PR, and other ways I tried to no avail to catch the attributes as early as possible)
2. add the first feature with the attribute form, and the other features without showing the form but using the previous attributes (this PR, but not completely satisfied with this way)
3. other ideas welcome

ping @nyalldawson @nirvn @Guts 