### PR TITLE
drop backward compatibility of settings + run forward compatibility only once

### DIFF
--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -35,6 +35,8 @@
 
 #include "pal.h"
 
+const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsSettingsPre330Migrated = new QgsSettingsEntryBool( QStringLiteral( "settings-pre3.30-migrated" ), QgsSettingsTree::sTreeCore,  false );
+
 const QgsSettingsEntryEnumFlag<Qgis::SnappingMode> *QgsSettingsRegistryCore::settingsDigitizingDefaultSnapMode = new QgsSettingsEntryEnumFlag<Qgis::SnappingMode>( QStringLiteral( "default-snap-mode" ), QgsSettingsTree::sTreeDigitizing, Qgis::SnappingMode::AllLayers );
 
 const QgsSettingsEntryEnumFlag<Qgis::SnappingType> *QgsSettingsRegistryCore::settingsDigitizingDefaultSnapType = new QgsSettingsEntryEnumFlag<Qgis::SnappingType>( QStringLiteral( "default-snap-type" ), QgsSettingsTree::sTreeDigitizing, Qgis::SnappingType::Vertex );
@@ -125,452 +127,259 @@ QgsSettingsRegistryCore::~QgsSettingsRegistryCore()
 
 void QgsSettingsRegistryCore::migrateOldSettings()
 {
-  // copy values from old keys to new keys and delete the old ones
-  // for backward compatibility, old keys are recreated when the registry gets deleted
-
-  // single settings - added in 3.30
-  QgsLayout::settingsSearchPathForTemplates->copyValueFromKey( QStringLiteral( "core/Layout/searchPathsForTemplates" ) );
-
-  QgsProcessing::settingsPreferFilenameAsLayerName->copyValueFromKey( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ) );
-  QgsProcessing::settingsTempPath->copyValueFromKey( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) );
-  QgsProcessing::settingsDefaultOutputVectorLayerExt->copyValueFromKey( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->copyValueFromKey( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ) );
-
-  QgsNetworkAccessManager::settingsNetworkTimeout->copyValueFromKey( QStringLiteral( "qgis/networkAndProxy/networkTimeout" ) );
-
-  settingsLayerTreeShowFeatureCountForNewLayers->copyValueFromKey( QStringLiteral( "core/layer-tree/show_feature_count_for_new_layers" ) );
-
-#if defined( HAVE_QTSERIALPORT )
-  QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( QStringLiteral( "core/gps/stop_bits" ) );
-  QgsGpsDetector::settingsGpsFlowControl->copyValueFromKey( QStringLiteral( "core/gps/flow_control" ) );
-  QgsGpsDetector::settingsGpsDataBits->copyValueFromKey( QStringLiteral( "core/gps/data_bits" ) );
-  QgsGpsDetector::settingsGpsParity->copyValueFromKey( QStringLiteral( "core/gps/parity" ) );
-#endif
-
-  QgsRasterLayer::settingsRasterDefaultOversampling->copyValueFromKey( QStringLiteral( "Raster/defaultOversampling" ), true );
-  QgsRasterLayer::settingsRasterDefaultEarlyResampling->copyValueFromKey( QStringLiteral( "Raster/defaultEarlyResampling" ), true );
-
-  pal::Pal::settingsRenderingLabelCandidatesLimitPoints->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_points" ), true );
-  pal::Pal::settingsRenderingLabelCandidatesLimitLines->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_lines" ), true );
-  pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_polygons" ), true );
-
-  // handle bad migration - Fix profiles for old QGIS versions (restore the Map/scales key on windows)
-  // TODO: Remove this from QGIS 3.36
-  // PR Link: https://github.com/qgis/QGIS/pull/52580
-  if ( QgsSettings().contains( QStringLiteral( "Map/scales" ) ) )
+  if ( !settingsSettingsPre330Migrated->value() )
   {
-    const QStringList oldScales = QgsSettings().value( QStringLiteral( "Map/scales" ) ).toStringList();
-    if ( ! oldScales.isEmpty() && !oldScales.at( 0 ).isEmpty() )
-      QgsSettings().setValue( QStringLiteral( "Map/scales" ), oldScales.join( ',' ) );
-    else
-      QgsSettings().setValue( QStringLiteral( "Map/scales" ), Qgis::defaultProjectScales() );
-  }
+    // copy values from old keys to new keys and delete the old ones
+    // for backward compatibility, old keys are recreated when the registry gets deleted
 
-  // migrate only one way for map scales
-  if ( !settingsMapScales->exists() )
-  {
-    // Handle bad migration. Prefer map/scales over Map/scales
-    // TODO: Discard this part starting from QGIS 3.36
-    const QStringList oldScales = QgsSettings().value( QStringLiteral( "map/scales" ) ).toStringList();
-    if ( ! oldScales.isEmpty() && !oldScales.at( 0 ).isEmpty() )
-    {
-      // If migration has failed before (QGIS < 3.30.2), all scales might be
-      // concatenated in the first element of the list
-      QStringList actualScales;
-      for ( const QString &element : oldScales )
-      {
-        actualScales << element.split( "," );
-      }
-      settingsMapScales->setValue( actualScales );
-    }
-    // TODO: keep only this part of the migration starting from QGIS 3.36
-    else if ( QgsSettings().contains( QStringLiteral( "Map/scales" ) ) )
-    {
-      settingsMapScales->setValue( QgsSettings().value( QStringLiteral( "Map/scales" ) ).toString().split( ',' ) );
-    }
-  }
+    // single settings - added in 3.30
+    QgsLayout::settingsSearchPathForTemplates->copyValueFromKey( QStringLiteral( "core/Layout/searchPathsForTemplates" ) );
 
-  // digitizing settings - added in 3.30
-  {
-    settingsDigitizingLineColor->copyValueFromKeys( QStringLiteral( "qgis/digitizing/line_color_red" ), QStringLiteral( "qgis/digitizing/line_color_green" ), QStringLiteral( "qgis/digitizing/line_color_blue" ), QStringLiteral( "qgis/digitizing/line_color_alpha" ) );
-    settingsDigitizingFillColor->copyValueFromKeys( QStringLiteral( "qgis/digitizing/fill_color_red" ), QStringLiteral( "qgis/digitizing/fill_color_green" ), QStringLiteral( "qgis/digitizing/fill_color_blue" ), QStringLiteral( "qgis/digitizing/fill_color_alpha" ) );
+    QgsProcessing::settingsPreferFilenameAsLayerName->copyValueFromKey( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ) );
+    QgsProcessing::settingsTempPath->copyValueFromKey( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) );
+    QgsProcessing::settingsDefaultOutputVectorLayerExt->copyValueFromKey( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ) );
+    QgsProcessing::settingsDefaultOutputRasterLayerExt->copyValueFromKey( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ) );
 
-    const QList<const QgsSettingsEntryBase *> settings = QgsSettingsTree::sTreeDigitizing->childrenSettings();
-    for ( const QgsSettingsEntryBase *setting : settings )
+    QgsNetworkAccessManager::settingsNetworkTimeout->copyValueFromKey( QStringLiteral( "qgis/networkAndProxy/networkTimeout" ) );
+
+    settingsLayerTreeShowFeatureCountForNewLayers->copyValueFromKey( QStringLiteral( "core/layer-tree/show_feature_count_for_new_layers" ) );
+
+  #if defined( HAVE_QTSERIALPORT )
+    QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( QStringLiteral( "core/gps/stop_bits" ) );
+    QgsGpsDetector::settingsGpsFlowControl->copyValueFromKey( QStringLiteral( "core/gps/flow_control" ) );
+    QgsGpsDetector::settingsGpsDataBits->copyValueFromKey( QStringLiteral( "core/gps/data_bits" ) );
+    QgsGpsDetector::settingsGpsParity->copyValueFromKey( QStringLiteral( "core/gps/parity" ) );
+  #endif
+
+    QgsRasterLayer::settingsRasterDefaultOversampling->copyValueFromKey( QStringLiteral( "Raster/defaultOversampling" ) );
+    QgsRasterLayer::settingsRasterDefaultEarlyResampling->copyValueFromKey( QStringLiteral( "Raster/defaultEarlyResampling" ) );
+
+    pal::Pal::settingsRenderingLabelCandidatesLimitPoints->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_points" ) );
+    pal::Pal::settingsRenderingLabelCandidatesLimitLines->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_lines" ) );
+    pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_polygons" ) );
+
+    // handle bad migration - Fix profiles for old QGIS versions (restore the Map/scales key on windows)
+    // TODO: Remove this from QGIS 3.36
+    // PR Link: https://github.com/qgis/QGIS/pull/52580
+    if ( QgsSettings().contains( QStringLiteral( "Map/scales" ) ) )
     {
-      QString name = setting->name();
-      if (
-        name == settingsDigitizingStreamTolerance->name() ||
-        name == settingsDigitizingLineColor->name() ||
-        name == settingsDigitizingFillColor->name()
-      )
-        continue;
-      if ( name == settingsDigitizingReuseLastValues->name() )
-      {
-        name = QStringLiteral( "reuseLastValues" );
-      }
+      const QStringList oldScales = QgsSettings().value( QStringLiteral( "Map/scales" ) ).toStringList();
+      if ( ! oldScales.isEmpty() && !oldScales.at( 0 ).isEmpty() )
+        QgsSettings().setValue( QStringLiteral( "Map/scales" ), oldScales.join( ',' ) );
       else
+        QgsSettings().setValue( QStringLiteral( "Map/scales" ), Qgis::defaultProjectScales() );
+    }
+
+    // migrate only one way for map scales
+    if ( !settingsMapScales->exists() )
+    {
+      // Handle bad migration. Prefer map/scales over Map/scales
+      // TODO: Discard this part starting from QGIS 3.36
+      const QStringList oldScales = QgsSettings().value( QStringLiteral( "map/scales" ) ).toStringList();
+      if ( ! oldScales.isEmpty() && !oldScales.at( 0 ).isEmpty() )
       {
-        name.replace( '-', '_' );
+        // If migration has failed before (QGIS < 3.30.2), all scales might be
+        // concatenated in the first element of the list
+        QStringList actualScales;
+        for ( const QString &element : oldScales )
+        {
+          actualScales << element.split( "," );
+        }
+        settingsMapScales->setValue( actualScales );
       }
-      setting->copyValueFromKey( QString( "qgis/digitizing/%1" ).arg( name ) );
-    }
-  }
-
-  // locator filters - added in 3.30
-  {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "gui/locator_filters" ) );
-    const QStringList childKeys = settings.childKeys();
-    for ( const QString &childKey : childKeys )
-    {
-      if ( childKey.startsWith( QLatin1String( "enabled" ) ) )
+      // TODO: keep only this part of the migration starting from QGIS 3.36
+      else if ( QgsSettings().contains( QStringLiteral( "Map/scales" ) ) )
       {
-        QString filter = childKey;
-        filter.remove( QStringLiteral( "enabled_" ) );
-        QgsLocator::settingsLocatorFilterEnabled->copyValueFromKey( QStringLiteral( "gui/locator_filters/enabled_%1" ), {filter}, true );
-        QgsLocator::settingsLocatorFilterDefault->copyValueFromKey( QStringLiteral( "gui/locator_filters/default_%1" ), {filter}, true );
-        QgsLocator::settingsLocatorFilterPrefix->copyValueFromKey( QStringLiteral( "gui/locator_filters/prefix_%1" ), {filter}, true );
+        settingsMapScales->setValue( QgsSettings().value( QStringLiteral( "Map/scales" ) ).toString().split( ',' ) );
       }
     }
-  }
 
-  // connections settings - added in 3.30
-  const QStringList services = {QStringLiteral( "WMS" ), QStringLiteral( "WFS" ), QStringLiteral( "WCS" )};
-  for ( const QString &service : services )
-  {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-%1" ).arg( service.toLower() ) );
-    const QStringList connections = settings.childGroups();
-    if ( connections.count() == 0 )
-      continue;
-    for ( const QString &connection : connections )
+    // digitizing settings - added in 3.30
     {
-      QgsOwsConnection::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/url" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsVersion->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/version" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsIgnoreGetMapURI->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/ignoreGetMapURI" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsIgnoreGetFeatureInfoURI->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/ignoreGetFeatureInfoURI" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsSmoothPixmapTransform->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/smoothPixmapTransform" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsReportedLayerExtents->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/reportedLayerExtents" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsDpiMode->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/dpiMode" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsTilePixelRatio->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/tilePixelRatio" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsMaxNumFeatures->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/maxnumfeatures" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsPagesize->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/pagesize" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsPagingEnabled->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/pagingenabled" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsPreferCoordinatesForWfsT11->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/preferCoordinatesForWfsT11" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsIgnoreAxisOrientation->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/ignoreAxisOrientation" ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsInvertAxisOrientation->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/invertAxisOrientation" ), {service.toLower(), connection}, true );
+      settingsDigitizingLineColor->copyValueFromKeys( QStringLiteral( "qgis/digitizing/line_color_red" ), QStringLiteral( "qgis/digitizing/line_color_green" ), QStringLiteral( "qgis/digitizing/line_color_blue" ), QStringLiteral( "qgis/digitizing/line_color_alpha" ) );
+      settingsDigitizingFillColor->copyValueFromKeys( QStringLiteral( "qgis/digitizing/fill_color_red" ), QStringLiteral( "qgis/digitizing/fill_color_green" ), QStringLiteral( "qgis/digitizing/fill_color_blue" ), QStringLiteral( "qgis/digitizing/fill_color_alpha" ) );
 
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
-      QgsOwsConnection::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), {service.toLower(), connection} );
-      settings.remove( QStringLiteral( "http-header" ) );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
-
-      QgsOwsConnection::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/username" ).arg( service, connection ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/password" ).arg( service, connection ), {service.toLower(), connection}, true );
-      QgsOwsConnection::settingsAuthCfg->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ).arg( service, connection ), {service.toLower(), connection}, true );
+      const QList<const QgsSettingsEntryBase *> settings = QgsSettingsTree::sTreeDigitizing->childrenSettings();
+      for ( const QgsSettingsEntryBase *setting : settings )
+      {
+        QString name = setting->name();
+        if (
+          name == settingsDigitizingStreamTolerance->name() ||
+          name == settingsDigitizingLineColor->name() ||
+          name == settingsDigitizingFillColor->name()
+        )
+          continue;
+        if ( name == settingsDigitizingReuseLastValues->name() )
+        {
+          name = QStringLiteral( "reuseLastValues" );
+        }
+        else
+        {
+          name.replace( '-', '_' );
+        }
+        setting->copyValueFromKey( QString( "qgis/digitizing/%1" ).arg( name ) );
+      }
     }
-    if ( settings.contains( QStringLiteral( "selected" ) ) )
-      QgsOwsConnection::sTreeOwsConnections->setSelectedItem( settings.value( QStringLiteral( "selected" ) ).toString(), {service.toLower()} );
-  }
 
-  // Vector tile - added in 3.30
-  {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-vector-tile" ) );
-    const QStringList connections = settings.childGroups();
-    for ( const QString &connection : connections )
+    // locator filters - added in 3.30
     {
-      QgsVectorTileProviderConnection::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/url" ), {connection}, true );
-      QgsVectorTileProviderConnection::settingsZmin->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmin" ), {connection}, true );
-      QgsVectorTileProviderConnection::settingsZmax->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmax" ), {connection}, true );
-      QgsVectorTileProviderConnection::settingsAuthcfg->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/authcfg" ), {connection}, true );
-      QgsVectorTileProviderConnection::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/username" ), {connection}, true );
-      QgsVectorTileProviderConnection::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/password" ), {connection}, true );
-      QgsVectorTileProviderConnection::settingsStyleUrl->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/styleUrl" ), {connection}, true );
-      QgsVectorTileProviderConnection::settingsServiceType->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/serviceType" ), {connection}, true );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
-      QgsVectorTileProviderConnection::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), connection );
-      settings.remove( QStringLiteral( "http-header" ) );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
+      QgsSettings settings;
+      settings.beginGroup( QStringLiteral( "gui/locator_filters" ) );
+      const QStringList childKeys = settings.childKeys();
+      for ( const QString &childKey : childKeys )
+      {
+        if ( childKey.startsWith( QLatin1String( "enabled" ) ) )
+        {
+          QString filter = childKey;
+          filter.remove( QStringLiteral( "enabled_" ) );
+          QgsLocator::settingsLocatorFilterEnabled->copyValueFromKey( QStringLiteral( "gui/locator_filters/enabled_%1" ), {filter} );
+          QgsLocator::settingsLocatorFilterDefault->copyValueFromKey( QStringLiteral( "gui/locator_filters/default_%1" ), {filter} );
+          QgsLocator::settingsLocatorFilterPrefix->copyValueFromKey( QStringLiteral( "gui/locator_filters/prefix_%1" ), {filter} );
+        }
+      }
     }
-  }
 
-  // xyz - added in 3.30
-  {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-xyz" ) );
-    const QStringList connections = settings.childGroups();
-    for ( const QString &connection : connections )
+    // connections settings - added in 3.30
+    const QStringList services = {QStringLiteral( "WMS" ), QStringLiteral( "WFS" ), QStringLiteral( "WCS" )};
+    for ( const QString &service : services )
     {
-      QgsXyzConnectionSettings::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/url" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsZmin->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/zmin" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsZmax->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/zmax" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsAuthcfg->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/authcfg" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/username" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/password" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsTilePixelRatio->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/tilePixelRatio" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsHidden->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/hidden" ), {connection}, true );
-      QgsXyzConnectionSettings::settingsInterpretation->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/interpretation" ), {connection}, true );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
-      QgsXyzConnectionSettings::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), connection );
-      settings.remove( QStringLiteral( "http-header" ) );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
+      QgsSettings settings;
+      settings.beginGroup( QStringLiteral( "qgis/connections-%1" ).arg( service.toLower() ) );
+      const QStringList connections = settings.childGroups();
+      if ( connections.count() == 0 )
+        continue;
+      for ( const QString &connection : connections )
+      {
+        QgsOwsConnection::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/url" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsVersion->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/version" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsIgnoreGetMapURI->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/ignoreGetMapURI" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsIgnoreGetFeatureInfoURI->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/ignoreGetFeatureInfoURI" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsSmoothPixmapTransform->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/smoothPixmapTransform" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsReportedLayerExtents->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/reportedLayerExtents" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsDpiMode->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/dpiMode" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsTilePixelRatio->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/tilePixelRatio" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsMaxNumFeatures->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/maxnumfeatures" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsPagesize->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/pagesize" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsPagingEnabled->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/pagingenabled" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsPreferCoordinatesForWfsT11->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/preferCoordinatesForWfsT11" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsIgnoreAxisOrientation->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/ignoreAxisOrientation" ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsInvertAxisOrientation->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/invertAxisOrientation" ), {service.toLower(), connection} );
+
+        Q_NOWARN_DEPRECATED_PUSH
+        settings.beginGroup( connection );
+        QgsOwsConnection::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), {service.toLower(), connection} );
+        settings.remove( QStringLiteral( "http-header" ) );
+        settings.endGroup();
+        Q_NOWARN_DEPRECATED_POP
+
+        QgsOwsConnection::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/username" ).arg( service, connection ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/password" ).arg( service, connection ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsAuthCfg->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ).arg( service, connection ), {service.toLower(), connection} );
+      }
+      if ( settings.contains( QStringLiteral( "selected" ) ) )
+        QgsOwsConnection::sTreeOwsConnections->setSelectedItem( settings.value( QStringLiteral( "selected" ) ).toString(), {service.toLower()} );
     }
-  }
 
-  // arcgis - added in 3.30
-  {
-    // arcgismapserver entries are not used anymore (even in 3.28, only arcgisfeature server is used)
-    const QStringList serviceKeys = {QStringLiteral( "qgis/connections-arcgisfeatureserver" ), QStringLiteral( "qgis/connections-arcgismapserver" )};
-    QgsSettings settings;
-    for ( const QString &serviceKey : serviceKeys )
+    // Vector tile - added in 3.30
     {
-      settings.beginGroup( serviceKey );
+      QgsSettings settings;
+      settings.beginGroup( QStringLiteral( "qgis/connections-vector-tile" ) );
       const QStringList connections = settings.childGroups();
       for ( const QString &connection : connections )
       {
-        QgsArcGisConnectionSettings::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/url" ), {connection}, true );
-        QgsArcGisConnectionSettings::settingsAuthcfg->copyValueFromKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/authcfg" ), {connection}, true );
-        QgsArcGisConnectionSettings::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/username" ), {connection}, true );
-        QgsArcGisConnectionSettings::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/password" ), {connection}, true );
-        QgsArcGisConnectionSettings::settingsContentEndpoint->copyValueFromKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/content_endpoint" ), {connection}, true );
-        QgsArcGisConnectionSettings::settingsCommunityEndpoint->copyValueFromKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/community_endpoint" ), {connection}, true );
+        QgsVectorTileProviderConnection::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/url" ), {connection} );
+        QgsVectorTileProviderConnection::settingsZmin->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmin" ), {connection} );
+        QgsVectorTileProviderConnection::settingsZmax->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmax" ), {connection} );
+        QgsVectorTileProviderConnection::settingsAuthcfg->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/authcfg" ), {connection} );
+        QgsVectorTileProviderConnection::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/username" ), {connection} );
+        QgsVectorTileProviderConnection::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/password" ), {connection} );
+        QgsVectorTileProviderConnection::settingsStyleUrl->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/styleUrl" ), {connection} );
+        QgsVectorTileProviderConnection::settingsServiceType->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/serviceType" ), {connection} );
         Q_NOWARN_DEPRECATED_PUSH
         settings.beginGroup( connection );
-        QgsArcGisConnectionSettings::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), connection );
+        QgsVectorTileProviderConnection::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), connection );
         settings.remove( QStringLiteral( "http-header" ) );
         settings.endGroup();
         Q_NOWARN_DEPRECATED_POP
       }
-      settings.remove( serviceKey );
     }
-  }
 
-  // babel devices settings - added in 3.30
-  {
-    if ( QgsBabelFormatRegistry::sTreeBabelDevices->items().count() == 0 )
+    // xyz - added in 3.30
     {
-      const QStringList deviceNames = QgsSettings().value( QStringLiteral( "/Plugin-GPS/devices/deviceList" ) ).toStringList();
-
-      for ( const QString &device : deviceNames )
+      QgsSettings settings;
+      settings.beginGroup( QStringLiteral( "qgis/connections-xyz" ) );
+      const QStringList connections = settings.childGroups();
+      for ( const QString &connection : connections )
       {
-        QgsBabelFormatRegistry::settingsBabelWptDownload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/wptdownload" ), {device}, true );
-        QgsBabelFormatRegistry::settingsBabelWptUpload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/wptupload" ), {device}, true );
-        QgsBabelFormatRegistry::settingsBabelRteDownload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/rtedownload" ), {device}, true );
-        QgsBabelFormatRegistry::settingsBabelRteUpload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/rteupload" ), {device}, true );
-        QgsBabelFormatRegistry::settingsBabelTrkDownload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/trkdownload" ), {device}, true );
-        QgsBabelFormatRegistry::settingsBabelTrkUpload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/trkupload" ), {device}, true );
+        QgsXyzConnectionSettings::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/url" ), {connection} );
+        QgsXyzConnectionSettings::settingsZmin->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/zmin" ), {connection} );
+        QgsXyzConnectionSettings::settingsZmax->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/zmax" ), {connection} );
+        QgsXyzConnectionSettings::settingsAuthcfg->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/authcfg" ), {connection} );
+        QgsXyzConnectionSettings::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/username" ), {connection} );
+        QgsXyzConnectionSettings::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/password" ), {connection} );
+        QgsXyzConnectionSettings::settingsTilePixelRatio->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/tilePixelRatio" ), {connection} );
+        QgsXyzConnectionSettings::settingsHidden->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/hidden" ), {connection} );
+        QgsXyzConnectionSettings::settingsInterpretation->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/interpretation" ), {connection} );
+        Q_NOWARN_DEPRECATED_PUSH
+        settings.beginGroup( connection );
+        QgsXyzConnectionSettings::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), connection );
+        settings.remove( QStringLiteral( "http-header" ) );
+        settings.endGroup();
+        Q_NOWARN_DEPRECATED_POP
       }
     }
+
+    // arcgis - added in 3.30
+    {
+      // arcgismapserver entries are not used anymore (even in 3.28, only arcgisfeature server is used)
+      const QStringList serviceKeys = {QStringLiteral( "qgis/connections-arcgisfeatureserver" ), QStringLiteral( "qgis/connections-arcgismapserver" )};
+      QgsSettings settings;
+      for ( const QString &serviceKey : serviceKeys )
+      {
+        settings.beginGroup( serviceKey );
+        const QStringList connections = settings.childGroups();
+        for ( const QString &connection : connections )
+        {
+          QgsArcGisConnectionSettings::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/url" ), {connection} );
+          QgsArcGisConnectionSettings::settingsAuthcfg->copyValueFromKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/authcfg" ), {connection} );
+          QgsArcGisConnectionSettings::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/username" ), {connection} );
+          QgsArcGisConnectionSettings::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/password" ), {connection} );
+          QgsArcGisConnectionSettings::settingsContentEndpoint->copyValueFromKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/content_endpoint" ), {connection} );
+          QgsArcGisConnectionSettings::settingsCommunityEndpoint->copyValueFromKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/community_endpoint" ), {connection} );
+          Q_NOWARN_DEPRECATED_PUSH
+          settings.beginGroup( connection );
+          QgsArcGisConnectionSettings::settingsHeaders->setValue( QgsHttpHeaders( settings ).headers(), connection );
+          settings.remove( QStringLiteral( "http-header" ) );
+          settings.endGroup();
+          Q_NOWARN_DEPRECATED_POP
+        }
+        settings.remove( serviceKey );
+      }
+    }
+
+    // babel devices settings - added in 3.30
+    {
+      if ( QgsBabelFormatRegistry::sTreeBabelDevices->items().count() == 0 )
+      {
+        const QStringList deviceNames = QgsSettings().value( QStringLiteral( "/Plugin-GPS/devices/deviceList" ) ).toStringList();
+
+        for ( const QString &device : deviceNames )
+        {
+          QgsBabelFormatRegistry::settingsBabelWptDownload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/wptdownload" ), {device} );
+          QgsBabelFormatRegistry::settingsBabelWptUpload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/wptupload" ), {device} );
+          QgsBabelFormatRegistry::settingsBabelRteDownload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/rtedownload" ), {device} );
+          QgsBabelFormatRegistry::settingsBabelRteUpload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/rteupload" ), {device} );
+          QgsBabelFormatRegistry::settingsBabelTrkDownload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/trkdownload" ), {device} );
+          QgsBabelFormatRegistry::settingsBabelTrkUpload->copyValueFromKey( QStringLiteral( "/Plugin-GPS/devices/%1/trkupload" ), {device} );
+        }
+      }
+    }
+
+    settingsSettingsPre330Migrated->setValue( true );
   }
 }
 
 // TODO QGIS 4.0: Remove
 void QgsSettingsRegistryCore::backwardCompatibility()
-{
-  // single settings - added in 3.30
-  QgsLayout::settingsSearchPathForTemplates->copyValueToKey( QStringLiteral( "core/Layout/searchPathsForTemplates" ) );
-
-  QgsProcessing::settingsPreferFilenameAsLayerName->copyValueToKey( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ) );
-  QgsProcessing::settingsTempPath->copyValueToKey( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) );
-  QgsProcessing::settingsDefaultOutputVectorLayerExt->copyValueToKey( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->copyValueToKey( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ) );
-
-  QgsNetworkAccessManager::settingsNetworkTimeout->copyValueToKey( QStringLiteral( "qgis/networkAndProxy/networkTimeout" ) );
-
-  settingsLayerTreeShowFeatureCountForNewLayers->copyValueToKey( QStringLiteral( "core/layer-tree/show_feature_count_for_new_layers" ) );
-
-#if defined( HAVE_QTSERIALPORT )
-  QgsGpsDetector::settingsGpsStopBits->copyValueToKey( QStringLiteral( "core/gps/stop_bits" ) );
-  QgsGpsDetector::settingsGpsFlowControl->copyValueToKey( QStringLiteral( "core/gps/flow_control" ) );
-  QgsGpsDetector::settingsGpsDataBits->copyValueToKey( QStringLiteral( "core/gps/data_bits" ) );
-  QgsGpsDetector::settingsGpsParity->copyValueToKey( QStringLiteral( "core/gps/parity" ) );
-#endif
-
-  QgsRasterLayer::settingsRasterDefaultOversampling->copyValueToKey( QStringLiteral( "Raster/defaultOversampling" ) );
-  QgsRasterLayer::settingsRasterDefaultEarlyResampling->copyValueToKey( QStringLiteral( "Raster/defaultEarlyResampling" ) );
-
-  pal::Pal::settingsRenderingLabelCandidatesLimitPoints->copyValueToKey( QStringLiteral( "core/rendering/label_candidates_limit_points" ) );
-  pal::Pal::settingsRenderingLabelCandidatesLimitLines->copyValueToKey( QStringLiteral( "core/rendering/label_candidates_limit_lines" ) );
-  pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueToKey( QStringLiteral( "core/rendering/label_candidates_limit_polygons" ) );
-
-
-  // digitizing settings - added in 3.30
-  {
-    settingsDigitizingLineColor->copyValueToKeys( QStringLiteral( "qgis/digitizing/line_color_red" ), QStringLiteral( "qgis/digitizing/line_color_green" ), QStringLiteral( "qgis/digitizing/line_color_blue" ), QStringLiteral( "qgis/digitizing/line_color_alpha" ) );
-    settingsDigitizingFillColor->copyValueToKeys( QStringLiteral( "qgis/digitizing/fill_color_red" ), QStringLiteral( "qgis/digitizing/fill_color_green" ), QStringLiteral( "qgis/digitizing/fill_color_blue" ), QStringLiteral( "qgis/digitizing/fill_color_alpha" ) );
-
-    const QList<const QgsSettingsEntryBase *> settings = QgsSettingsTree::sTreeDigitizing->childrenSettings();
-    for ( const QgsSettingsEntryBase *setting : settings )
-    {
-      QString name = setting->name();
-      if (
-        name == settingsDigitizingLineColor->name() ||
-        name == settingsDigitizingFillColor->name()
-      )
-        continue;
-      if ( name == settingsDigitizingReuseLastValues->name() )
-      {
-        name = QStringLiteral( "reuseLastValues" );
-      }
-      else
-      {
-        name.replace( '-', '_' );
-      }
-      setting->copyValueToKey( QString( "qgis/digitizing/%1" ).arg( name ) );
-    }
-  }
-
-  // locator filters - added in 3.30
-  {
-    const QStringList filters = QgsLocator::sTreeLocatorFilters->items();
-    for ( const QString &filter : filters )
-    {
-      QgsLocator::settingsLocatorFilterEnabled->copyValueToKey( QStringLiteral( "gui/locator_filters/enabled_%1" ), {filter} );
-      QgsLocator::settingsLocatorFilterDefault->copyValueToKey( QStringLiteral( "gui/locator_filters/default_%1" ), {filter} );
-      QgsLocator::settingsLocatorFilterPrefix->copyValueToKey( QStringLiteral( "gui/locator_filters/prefix_%1" ), {filter} );
-    }
-  }
-
-  // OWS connections settings - added in 3.30
-  {
-    const QStringList services = {QStringLiteral( "WMS" ), QStringLiteral( "WFS" ), QStringLiteral( "WCS" )};
-    for ( const QString &service : services )
-    {
-      const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( {service.toLower()} );
-      if ( connections.count() == 0 )
-        continue;
-      QgsSettings settings;
-      settings.beginGroup( QStringLiteral( "qgis/connections-%1" ).arg( service.toLower() ) );
-      for ( const QString &connection : connections )
-      {
-        QgsOwsConnection::settingsUrl->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/url" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsVersion->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/version" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsIgnoreGetMapURI->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/ignoreGetMapURI" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsIgnoreGetFeatureInfoURI->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/ignoreGetFeatureInfoURI" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsSmoothPixmapTransform->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/smoothPixmapTransform" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsReportedLayerExtents->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/reportedLayerExtents" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsDpiMode->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/dpiMode" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsTilePixelRatio->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/tilePixelRatio" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsMaxNumFeatures->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/maxnumfeatures" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsPagesize->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/pagesize" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsPagingEnabled->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/pagingenabled" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsPreferCoordinatesForWfsT11->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/preferCoordinatesForWfsT11" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsIgnoreAxisOrientation->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/ignoreAxisOrientation" ), {service.toLower(), connection} );
-        QgsOwsConnection::settingsInvertAxisOrientation->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/invertAxisOrientation" ), {service.toLower(), connection} );
-
-        Q_NOWARN_DEPRECATED_PUSH
-        settings.beginGroup( connection );
-        if ( QgsOwsConnection::settingsHeaders->exists( {service.toLower(), connection} ) )
-          QgsHttpHeaders( QgsOwsConnection::settingsHeaders->value( {service.toLower(), connection} ) ).updateSettings( settings );
-        settings.endGroup();
-        Q_NOWARN_DEPRECATED_POP
-
-        QgsOwsConnection::settingsUsername->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/username" ), {service, connection} );
-        QgsOwsConnection::settingsPassword->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/password" ), {service, connection} );
-        QgsOwsConnection::settingsAuthCfg->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ), {service, connection} );
-
-        if ( settings.contains( QStringLiteral( "selected" ) ) )
-          QgsOwsConnection::sTreeOwsConnections->setSelectedItem( settings.value( QStringLiteral( "selected" ) ).toString(), {service.toLower()} );
-      }
-    }
-  }
-
-  // Vector tile - added in 3.30
-  {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-vector-tile" ) );
-
-    const QStringList connections = QgsVectorTileProviderConnection::sTreeConnectionVectorTile->items();
-    for ( const QString &connection : connections )
-    {
-      // do not overwrite already set setting
-      QgsVectorTileProviderConnection::settingsUrl->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/url" ), {connection} );
-      QgsVectorTileProviderConnection::settingsZmin->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmin" ), {connection} );
-      QgsVectorTileProviderConnection::settingsZmax->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmax" ), {connection} );
-      QgsVectorTileProviderConnection::settingsAuthcfg->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/authcfg" ), {connection} );
-      QgsVectorTileProviderConnection::settingsUsername->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/username" ), {connection} );
-      QgsVectorTileProviderConnection::settingsPassword->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/password" ), {connection} );
-      QgsVectorTileProviderConnection::settingsStyleUrl->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/styleUrl" ), {connection} );
-      QgsVectorTileProviderConnection::settingsServiceType->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/serviceType" ), {connection} );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
-      if ( QgsVectorTileProviderConnection::settingsHeaders->exists( connection ) )
-        QgsHttpHeaders( QgsVectorTileProviderConnection::settingsHeaders->value( connection ) ).updateSettings( settings );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
-    }
-  }
-
-  // xyz - added in 3.30
-  {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-xyz" ) );
-    const QStringList connections = QgsXyzConnectionSettings::sTreeXyzConnections->items();
-    for ( const QString &connection : connections )
-    {
-      QgsXyzConnectionSettings::settingsUrl->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/url" ), {connection} );
-      QgsXyzConnectionSettings::settingsZmin->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/zmin" ), {connection} );
-      QgsXyzConnectionSettings::settingsZmax->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/zmax" ), {connection} );
-      QgsXyzConnectionSettings::settingsAuthcfg->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/authcfg" ), {connection} );
-      QgsXyzConnectionSettings::settingsUsername->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/username" ), {connection} );
-      QgsXyzConnectionSettings::settingsPassword->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/password" ), {connection} );
-      QgsXyzConnectionSettings::settingsTilePixelRatio->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/tilePixelRatio" ), {connection} );
-      QgsXyzConnectionSettings::settingsHidden->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/hidden" ), {connection} );
-      QgsXyzConnectionSettings::settingsInterpretation->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/interpretation" ), {connection} );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
-      if ( QgsXyzConnectionSettings::settingsHeaders->exists( connection ) )
-        QgsHttpHeaders( QgsXyzConnectionSettings::settingsHeaders->value( connection ) ).updateSettings( settings );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
-    }
-  }
-
-  // Arcgis - added in 3.30
-  {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-arcgisfeatureserver" ) );
-
-    const QStringList connections = QgsArcGisConnectionSettings::sTreeConnectionArcgis->items();
-    for ( const QString &connection : connections )
-    {
-      // do not overwrite already set setting
-      QgsArcGisConnectionSettings::settingsUrl->copyValueToKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/url" ), {connection} );
-      QgsArcGisConnectionSettings::settingsAuthcfg->copyValueToKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/authcfg" ), {connection} );
-      QgsArcGisConnectionSettings::settingsUsername->copyValueToKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/username" ), {connection} );
-      QgsArcGisConnectionSettings::settingsPassword->copyValueToKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/password" ), {connection} );
-      QgsArcGisConnectionSettings::settingsContentEndpoint->copyValueToKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/content_endpoint" ), {connection} );
-      QgsArcGisConnectionSettings::settingsCommunityEndpoint->copyValueToKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/community_endpoint" ), {connection} );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
-      if ( QgsArcGisConnectionSettings::settingsHeaders->exists( connection ) )
-        QgsHttpHeaders( QgsArcGisConnectionSettings::settingsHeaders->value( connection ) ).updateSettings( settings );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
-    }
-  }
-
-  // babel devices settings - added in 3.30
-  {
-    const QStringList devices = QgsBabelFormatRegistry::sTreeBabelDevices->items();
-    QgsSettings().setValue( QStringLiteral( "/Plugin-GPS/devices/deviceList" ), devices );
-    for ( const QString &device : devices )
-    {
-      QgsBabelFormatRegistry::settingsBabelWptDownload->copyValueToKey( QStringLiteral( "/Plugin-GPS/devices/%1/wptdownload" ), {device} );
-      QgsBabelFormatRegistry::settingsBabelWptUpload->copyValueToKey( QStringLiteral( "/Plugin-GPS/devices/%1/wptupload" ), {device} );
-      QgsBabelFormatRegistry::settingsBabelRteDownload->copyValueToKey( QStringLiteral( "/Plugin-GPS/devices/%1/rtedownload" ), {device} );
-      QgsBabelFormatRegistry::settingsBabelRteUpload->copyValueToKey( QStringLiteral( "/Plugin-GPS/devices/%1/rteupload" ), {device} );
-      QgsBabelFormatRegistry::settingsBabelTrkDownload->copyValueToKey( QStringLiteral( "/Plugin-GPS/devices/%1/trkdownload" ), {device} );
-      QgsBabelFormatRegistry::settingsBabelTrkUpload->copyValueToKey( QStringLiteral( "/Plugin-GPS/devices/%1/trkupload" ), {device} );
-    }
-  }
-}
+{}
 

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -144,12 +144,12 @@ void QgsSettingsRegistryCore::migrateOldSettings()
 
     settingsLayerTreeShowFeatureCountForNewLayers->copyValueFromKey( QStringLiteral( "core/layer-tree/show_feature_count_for_new_layers" ) );
 
-  #if defined( HAVE_QTSERIALPORT )
+#if defined( HAVE_QTSERIALPORT )
     QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( QStringLiteral( "core/gps/stop_bits" ) );
     QgsGpsDetector::settingsGpsFlowControl->copyValueFromKey( QStringLiteral( "core/gps/flow_control" ) );
     QgsGpsDetector::settingsGpsDataBits->copyValueFromKey( QStringLiteral( "core/gps/data_bits" ) );
     QgsGpsDetector::settingsGpsParity->copyValueFromKey( QStringLiteral( "core/gps/parity" ) );
-  #endif
+#endif
 
     QgsRasterLayer::settingsRasterDefaultOversampling->copyValueFromKey( QStringLiteral( "Raster/defaultOversampling" ) );
     QgsRasterLayer::settingsRasterDefaultEarlyResampling->copyValueFromKey( QStringLiteral( "Raster/defaultEarlyResampling" ) );

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -56,6 +56,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     virtual ~QgsSettingsRegistryCore();
 
 #ifndef SIP_RUN
+    //! Settings to save if settings from pre 3.30 were migrated
+    static const QgsSettingsEntryBool *settingsSettingsPre330Migrated;
+
     //! Settings entry digitizing stream tolerance
     static const QgsSettingsEntryInteger *settingsDigitizingStreamTolerance;
 


### PR DESCRIPTION
fixes #57671

! This is for the release 3.34 branch !

If we merge this, we need to take the same approach in the new releases too.
I don't think it makes a lot of sense to keep updating settings fro 3.30 and older since 3.34 is now the LTR. We can do the same approach (migrate only once) in new releases so moving directly from 3.28 to 3.40 would work (which is probable in big organisations).
