### PR TITLE
[arcgisrest] Don't set crs parameter for new layers 

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -372,9 +372,9 @@ void QgsArcGisRestQueryUtils::visitServiceItems( const std::function<void ( cons
   }
 }
 
-void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QString &, ServiceTypeFilter, Qgis::GeometryType, const QString &, const QString &, const QString &, const QString &, bool, const QString &, const QString & )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, const ServiceTypeFilter filter )
+void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QString &, ServiceTypeFilter, Qgis::GeometryType, const QString &, const QString &, const QString &, const QString &, bool, const QgsCoordinateReferenceSystem &, const QString & )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, const ServiceTypeFilter filter )
 {
-  const QString authid = QgsArcGisRestUtils::convertSpatialReference( serviceData.value( QStringLiteral( "spatialReference" ) ).toMap() ).authid();
+  const QgsCoordinateReferenceSystem crs = QgsArcGisRestUtils::convertSpatialReference( serviceData.value( QStringLiteral( "spatialReference" ) ).toMap() );
 
   bool found = false;
   const QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
@@ -417,11 +417,11 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
     {
       if ( !layerInfoMap.value( QStringLiteral( "subLayerIds" ) ).toList().empty() )
       {
-        visitor( parentLayerId, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, id, name, description, parentUrl + '/' + id, true, QString(), format );
+        visitor( parentLayerId, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, id, name, description, parentUrl + '/' + id, true, QgsCoordinateReferenceSystem(), format );
       }
       else
       {
-        visitor( parentLayerId, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, id, name, description, parentUrl + '/' + id, false, authid, format );
+        visitor( parentLayerId, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, id, name, description, parentUrl + '/' + id, false, crs, format );
       }
     }
 
@@ -450,11 +450,11 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
 
       if ( !layerInfoMap.value( QStringLiteral( "subLayerIds" ) ).toList().empty() )
       {
-        visitor( parentLayerId, ServiceTypeFilter::Vector, QgsWkbTypes::geometryType( wkbType ), id, name, description, parentUrl + '/' + id, true, QString(), format );
+        visitor( parentLayerId, ServiceTypeFilter::Vector, QgsWkbTypes::geometryType( wkbType ), id, name, description, parentUrl + '/' + id, true, QgsCoordinateReferenceSystem(), format );
       }
       else
       {
-        visitor( parentLayerId, ServiceTypeFilter::Vector, QgsWkbTypes::geometryType( wkbType ), id, name, description, parentUrl + '/' + id, false, authid, format );
+        visitor( parentLayerId, ServiceTypeFilter::Vector, QgsWkbTypes::geometryType( wkbType ), id, name, description, parentUrl + '/' + id, false, crs, format );
       }
     }
   }
@@ -472,11 +472,11 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
     {
       if ( !tableInfoMap.value( QStringLiteral( "subLayerIds" ) ).toList().empty() )
       {
-        visitor( parentLayerId, ServiceTypeFilter::Vector, Qgis::GeometryType::Null, id, name, description, parentUrl + '/' + id, true, QString(), format );
+        visitor( parentLayerId, ServiceTypeFilter::Vector, Qgis::GeometryType::Null, id, name, description, parentUrl + '/' + id, true, QgsCoordinateReferenceSystem(), format );
       }
       else
       {
-        visitor( parentLayerId, ServiceTypeFilter::Vector, Qgis::GeometryType::Null, id, name, description, parentUrl + '/' + id, false, authid, format );
+        visitor( parentLayerId, ServiceTypeFilter::Vector, Qgis::GeometryType::Null, id, name, description, parentUrl + '/' + id, false, crs, format );
       }
     }
   }
@@ -486,7 +486,7 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
   {
     const QString name = QStringLiteral( "(%1)" ).arg( QObject::tr( "All layers" ) );
     const QString description = serviceData.value( QStringLiteral( "Comments" ) ).toString();
-    visitor( nullptr, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, nullptr, name, description, parentUrl, false, authid, format );
+    visitor( nullptr, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, nullptr, name, description, parentUrl, false, crs, format );
   }
 
   // Add root ImageServer as layer
@@ -494,7 +494,7 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
   {
     const QString name = serviceData.value( QStringLiteral( "name" ) ).toString();
     const QString description = serviceData.value( QStringLiteral( "description" ) ).toString();
-    visitor( nullptr, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, nullptr, name, description, parentUrl, false, authid, format );
+    visitor( nullptr, ServiceTypeFilter::Raster, Qgis::GeometryType::Unknown, nullptr, name, description, parentUrl, false, crs, format );
   }
 }
 

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -19,7 +19,6 @@
 
 #include "qgis_core.h"
 #include "qgsrectangle.h"
-#include "qgswkbtypes.h"
 #include "qgshttpheaders.h"
 
 #include <QString>
@@ -27,6 +26,7 @@
 
 class QgsFeedback;
 class QNetworkReply;
+class QgsCoordinateReferenceSystem;
 
 /**
  * \ingroup core
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
     /**
      * Calls the specified \a visitor function on all layer items found within the given service data.
      */
-    static void addLayerItems( const std::function<void ( const QString &parentLayerId, ServiceTypeFilter serviceType, Qgis::GeometryType geometryType, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid, const QString &format )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, const ServiceTypeFilter filter = ServiceTypeFilter::AllTypes );
+    static void addLayerItems( const std::function<void ( const QString &parentLayerId, ServiceTypeFilter serviceType, Qgis::GeometryType geometryType, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QgsCoordinateReferenceSystem &crs, const QString &format )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, const ServiceTypeFilter filter = ServiceTypeFilter::AllTypes );
 
     /**
      * Parses and processes a \a url.

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -591,7 +591,7 @@ QgsCoordinateReferenceSystem QgsArcGisRestLayerItem::crs() const
 QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers, const QString urlPrefix, Qgis::BrowserLayerType geometryType )
   : QgsArcGisRestLayerItem( parent, url, title, crs, geometryType, QStringLiteral( "arcgisfeatureserver" ) )
 {
-  mUri = QStringLiteral( "crs='%1' url='%2'" ).arg( crs.authid(), url );
+  mUri = QStringLiteral( "url='%1'" ).arg( url );
   if ( !authcfg.isEmpty() )
     mUri += QStringLiteral( " authcfg='%1'" ).arg( authcfg );
 
@@ -612,7 +612,7 @@ QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent,
   : QgsArcGisRestLayerItem( parent, url, title, crs, Qgis::BrowserLayerType::Raster, QStringLiteral( "arcgismapserver" ) )
 {
   const QString trimmedUrl = id.isEmpty() ? url : url.left( url.length() - 1 - id.length() ); // trim '/0' from end of url -- AMS provider requires this omitted
-  mUri = QStringLiteral( "crs='%1' format='%2' layer='%3' url='%4'" ).arg( crs.authid(), format, id, trimmedUrl );
+  mUri = QStringLiteral( "format='%1' layer='%2' url='%3'" ).arg( format, id, trimmedUrl );
   if ( !authcfg.isEmpty() )
     mUri += QStringLiteral( " authcfg='%1'" ).arg( authcfg );
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -143,14 +143,14 @@ void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceD
       switch ( serviceTypeFilter == QgsArcGisRestQueryUtils::ServiceTypeFilter::AllTypes ? serviceType : serviceTypeFilter )
       {
         case QgsArcGisRestQueryUtils::ServiceTypeFilter::Vector:
-          layerItem = std::make_unique< QgsArcGisFeatureServiceLayerItem >( parent, name, url, name, crs, authcfg, headers, urlPrefix, geometryType == Qgis::GeometryType::Polygon ? Qgis::BrowserLayerType::Polygon :
+          layerItem = std::make_unique< QgsArcGisFeatureServiceLayerItem >( parent, url, name, crs, authcfg, headers, urlPrefix, geometryType == Qgis::GeometryType::Polygon ? Qgis::BrowserLayerType::Polygon :
                       geometryType == Qgis::GeometryType::Line ? Qgis::BrowserLayerType::Line
                       : geometryType == Qgis::GeometryType::Point ? Qgis::BrowserLayerType::Point :
                       geometryType == Qgis::GeometryType::Null ? Qgis::BrowserLayerType::TableLayer : Qgis::BrowserLayerType::Vector );
           break;
 
         case QgsArcGisRestQueryUtils::ServiceTypeFilter::Raster:
-          layerItem = std::make_unique< QgsArcGisMapServiceLayerItem >( parent, name, url, id, name, crs, format, authcfg, headers, urlPrefix );
+          layerItem = std::make_unique< QgsArcGisMapServiceLayerItem >( parent, url, id, name, crs, format, authcfg, headers, urlPrefix );
           static_cast< QgsArcGisMapServiceLayerItem * >( layerItem.get() )->setSupportedFormats( supportedFormats );
           break;
 
@@ -572,7 +572,7 @@ bool QgsArcGisMapServiceItem::equal( const QgsDataItem *other )
 // QgsArcGisFeatureServiceLayerItem
 //
 
-QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers, const QString urlPrefix, Qgis::BrowserLayerType geometryType )
+QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers, const QString urlPrefix, Qgis::BrowserLayerType geometryType )
   : QgsLayerItem( parent, title, url, QString(), geometryType, QStringLiteral( "arcgisfeatureserver" ) )
 {
   mUri = QStringLiteral( "crs='%1' url='%2'" ).arg( crs.authid(), url );
@@ -592,7 +592,7 @@ QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem 
 // QgsArcGisMapServiceLayerItem
 //
 
-QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &, const QString &url, const QString &id, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix )
+QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &id, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix )
   : QgsLayerItem( parent, title, url, QString(), Qgis::BrowserLayerType::Raster, QStringLiteral( "arcgismapserver" ) )
 {
   const QString trimmedUrl = id.isEmpty() ? url : url.left( url.length() - 1 - id.length() ); // trim '/0' from end of url -- AMS provider requires this omitted

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -567,13 +567,29 @@ bool QgsArcGisMapServiceItem::equal( const QgsDataItem *other )
   return ( type() == other->type() && o && mPath == o->mPath && mName == o->mName );
 }
 
+//
+// QgsArcGisRestLayerItem
+//
+
+QgsArcGisRestLayerItem::QgsArcGisRestLayerItem( QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, Qgis::BrowserLayerType layerType, const QString &providerId )
+  : QgsLayerItem( parent, title, url, QString(), layerType, providerId )
+  , mCrs( crs )
+{
+
+}
+
+QgsCoordinateReferenceSystem QgsArcGisRestLayerItem::crs() const
+{
+  return mCrs;
+}
+
 
 //
 // QgsArcGisFeatureServiceLayerItem
 //
 
 QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers, const QString urlPrefix, Qgis::BrowserLayerType geometryType )
-  : QgsLayerItem( parent, title, url, QString(), geometryType, QStringLiteral( "arcgisfeatureserver" ) )
+  : QgsArcGisRestLayerItem( parent, url, title, crs, geometryType, QStringLiteral( "arcgisfeatureserver" ) )
 {
   mUri = QStringLiteral( "crs='%1' url='%2'" ).arg( crs.authid(), url );
   if ( !authcfg.isEmpty() )
@@ -593,7 +609,7 @@ QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem 
 //
 
 QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &id, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix )
-  : QgsLayerItem( parent, title, url, QString(), Qgis::BrowserLayerType::Raster, QStringLiteral( "arcgismapserver" ) )
+  : QgsArcGisRestLayerItem( parent, url, title, crs, Qgis::BrowserLayerType::Raster, QStringLiteral( "arcgismapserver" ) )
 {
   const QString trimmedUrl = id.isEmpty() ? url : url.left( url.length() - 1 - id.length() ); // trim '/0' from end of url -- AMS provider requires this omitted
   mUri = QStringLiteral( "crs='%1' format='%2' layer='%3' url='%4'" ).arg( crs.authid(), format, id, trimmedUrl );

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -232,9 +232,32 @@ class QgsArcGisRestParentLayerItem : public QgsDataItem
 };
 
 /**
+ * Represents a ArcGIS REST layer item.
+ */
+class QgsArcGisRestLayerItem : public QgsLayerItem
+{
+    Q_OBJECT
+
+  public:
+
+    QgsArcGisRestLayerItem( QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs,
+                            Qgis::BrowserLayerType layerType, const QString &providerId );
+
+    /**
+     * Returns the CRS for the layer.
+     */
+    QgsCoordinateReferenceSystem crs() const;
+
+  private:
+
+    QgsCoordinateReferenceSystem mCrs;
+};
+
+
+/**
  * Represents a ArcGIS REST "Feature Service" layer item.
  */
-class QgsArcGisFeatureServiceLayerItem : public QgsLayerItem
+class QgsArcGisFeatureServiceLayerItem : public QgsArcGisRestLayerItem
 {
     Q_OBJECT
 
@@ -249,7 +272,7 @@ class QgsArcGisFeatureServiceLayerItem : public QgsLayerItem
  * Represents a ArcGIS REST "Map Service" (or "Image Service") layer item.
  */
 
-class QgsArcGisMapServiceLayerItem : public QgsLayerItem
+class QgsArcGisMapServiceLayerItem : public QgsArcGisRestLayerItem
 {
     Q_OBJECT
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -240,7 +240,7 @@ class QgsArcGisFeatureServiceLayerItem : public QgsLayerItem
 
   public:
 
-    QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &title, const QString &authid, const QString &authcfg, const QgsHttpHeaders &headers,
+    QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers,
                                       const QString urlPrefix, Qgis::BrowserLayerType geometryType );
 
 };
@@ -254,7 +254,7 @@ class QgsArcGisMapServiceLayerItem : public QgsLayerItem
     Q_OBJECT
 
   public:
-    QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &id, const QString &title, const QString &authid, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
+    QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &id, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
     void setSupportedFormats( const QString &formats ) { mSupportedFormats = formats; }
     QString supportedFormats() const { return mSupportedFormats; }
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -240,7 +240,7 @@ class QgsArcGisFeatureServiceLayerItem : public QgsLayerItem
 
   public:
 
-    QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers,
+    QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers,
                                       const QString urlPrefix, Qgis::BrowserLayerType geometryType );
 
 };
@@ -254,7 +254,7 @@ class QgsArcGisMapServiceLayerItem : public QgsLayerItem
     Q_OBJECT
 
   public:
-    QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &id, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
+    QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &id, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
     void setSupportedFormats( const QString &formats ) { mSupportedFormats = formats; }
     QString supportedFormats() const { return mSupportedFormats; }
 

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -391,7 +391,6 @@ void QgsArcGisRestSourceSelect::updateCrsLabel()
 
 void QgsArcGisRestSourceSelect::updateImageEncodings()
 {
-  //evaluate currently selected typename and set the CRS filter in mProjectionSelector
   const QModelIndex currentIndex = mBrowserView->selectionModel()->currentIndex();
   if ( currentIndex.isValid() )
   {

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -570,8 +570,6 @@ QString QgsArcGisRestSourceSelect::indexToUri( const QModelIndex &proxyIndex, QS
     layerName = layerItem->name();
 
     QgsDataSourceUri uri( layerItem->uri() );
-    const QgsCoordinateReferenceSystem crs = layerItem->crs();
-    uri.setParam( QStringLiteral( "crs" ), crs.authid() );
     if ( qobject_cast< QgsArcGisFeatureServiceLayerItem *>( layerItem ) )
     {
       if ( !extent.isNull() )

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.h
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.h
@@ -110,6 +110,9 @@ class QgsArcGisRestSourceSelect : public QgsAbstractDataSourceWidget, protected 
 
   private:
 
+    QgsDataItem *indexToItem( const QModelIndex &proxyIndex );
+    QgsCoordinateReferenceSystem indexToCrs( const QModelIndex &proxyIndex );
+
     QString indexToUri( const QModelIndex &proxyIndex, QString &layerName, Qgis::ArcGisRestServiceType &serviceType, const QgsRectangle &extent = QgsRectangle() );
 
     QString mConnectedService;


### PR DESCRIPTION
When loading a new layer from ArcGIS rest (either FeatureServer or MapServer), don't explicitly set the crs parameter for the layer's URI.

The MapServer provider completely ignores this, and the FeatureServer provider falls back to the actual CRS used by the service when it is not explicitly specified in the layer's URI.

This is a safer approach, as we now default to not hardcoding the CRS and instead just always use the actual CRS for the service.
Otherwise, things go wonky when the backend service is updated and eg someone changes the CRS of the hosted layer!

Also a few related cleanups in CRS handling in the ArcGIS rest source select GUI / data items.