### PR TITLE
Fix compound CRSs axis order and orientation info

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -833,6 +833,9 @@ bool QgsCoordinateReferenceSystem::hasAxisInverted() const
 
 QList<Qgis::CrsAxisDirection> QgsCoordinateReferenceSystem::axisOrdering() const
 {
+  if ( type() == Qgis::CrsType::Compound )
+    return horizontalCrs().axisOrdering() + verticalCrs().axisOrdering();
+
   const PJ *projObject = d->threadLocalProjObject();
   if ( !projObject )
     return {};

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -117,7 +117,12 @@ bool QgsProjUtils::axisOrderIsSwapped( const PJ *crs )
     return false;
 
   PJ_CONTEXT *context = QgsProjContext::get();
-  QgsProjUtils::proj_pj_unique_ptr pjCs( proj_crs_get_coordinate_system( context, crs ) );
+
+  QgsProjUtils::proj_pj_unique_ptr horizCrs = crsToHorizontalCrs( crs );
+  if ( !horizCrs )
+    return false;
+
+  QgsProjUtils::proj_pj_unique_ptr pjCs( proj_crs_get_coordinate_system( context, horizCrs.get() ) );
   if ( !pjCs )
     return false;
 

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -289,6 +289,24 @@ void TestQgsCoordinateReferenceSystem::compoundCrs()
   QCOMPARE( crs.type(), Qgis::CrsType::Compound );
   QVERIFY( !crs.isGeographic() );
   QCOMPARE( crs.mapUnits(), Qgis::DistanceUnit::Meters );
+  QVERIFY( !crs.hasAxisInverted() );
+  QCOMPARE( crs.axisOrdering(),
+            QList<Qgis::CrsAxisDirection>()
+            << Qgis::CrsAxisDirection::East
+            << Qgis::CrsAxisDirection::North
+            << Qgis::CrsAxisDirection::Up );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3903" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.type(), Qgis::CrsType::Compound );
+  QVERIFY( !crs.isGeographic() );
+  QCOMPARE( crs.mapUnits(), Qgis::DistanceUnit::Meters );
+  QVERIFY( crs.hasAxisInverted() );
+  QCOMPARE( crs.axisOrdering(),
+            QList<Qgis::CrsAxisDirection>()
+            << Qgis::CrsAxisDirection::North
+            << Qgis::CrsAxisDirection::East
+            << Qgis::CrsAxisDirection::Up );
 }
 
 void TestQgsCoordinateReferenceSystem::verticalCrs()

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -94,6 +94,8 @@ void TestQgsProjUtils::axisOrderIsSwapped()
   QVERIFY( !QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
   crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::4326" ) );
   QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::3903" ) );
+  QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
 }
 
 void TestQgsProjUtils::searchPath()


### PR DESCRIPTION
## Description

Fixes #55458 where OAPIF provider has wrong CRS information on a compound CRS (`axisOrdering` is empty, and `hasAxisInverted` is always false).

2 options to fix the issue:
- option 1 (in this PR): fix CRSs information directly in `QgsCoordinateReferenceSystem` class
- option 2: fix in OAPIF provider to check if the CRS is a compound CRS and work with calls on `verticalCrs` and `horizontalCrs`? but need to fix other providers as well?

Discussion welcome, tests will be made accordingly.