### PR TITLE
Point cloud layer vertical crs handling

### DIFF
--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -16,14 +16,12 @@
 #include "qgspointcloudlayer3drenderer.h"
 
 #include "qgs3dutils.h"
-#include "qgschunkedentity_p.h"
 #include "qgspointcloudlayerchunkloader_p.h"
 
 #include "qgspointcloudindex.h"
 #include "qgspointcloudlayer.h"
 #include "qgsvirtualpointcloudentity_p.h"
 #include "qgsxmlutils.h"
-#include "qgsapplication.h"
 #include "qgs3dsymbolregistry.h"
 #include "qgspointcloud3dsymbol.h"
 #include "qgspointcloudlayerelevationproperties.h"
@@ -158,7 +156,7 @@ Qt3DCore::QEntity *QgsPointCloudLayer3DRenderer::createEntity( const Qgs3DMapSet
   if ( !mSymbol )
     return nullptr;
 
-  const QgsCoordinateTransform coordinateTransform( pcl->crs(), map.crs(), map.transformContext() );
+  const QgsCoordinateTransform coordinateTransform( pcl->crs3D(), map.crs(), map.transformContext() );
 
   Qt3DCore::QEntity *entity = nullptr;
   if ( pcl->dataProvider()->index() )

--- a/src/app/3d/qgs3dmaptoolidentify.cpp
+++ b/src/app/3d/qgs3dmaptoolidentify.cpp
@@ -142,7 +142,8 @@ void Qgs3DMapToolIdentify::mouseReleaseEvent( QMouseEvent *event )
   // Finally add all point cloud layers' results
   for ( auto it = pointCloudResults.constKeyValueBegin(); it != pointCloudResults.constKeyValueEnd(); ++it )
   {
-    QgsMapToolIdentify::fromPointCloudIdentificationToIdentifyResults( it->first, it->second, identifyResults );
+    QgsMapToolIdentify identifyTool( nullptr );
+    identifyTool.fromPointCloudIdentificationToIdentifyResults( it->first, it->second, identifyResults );
     identifyTool2D->showIdentifyResults( identifyResults );
   }
 

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
@@ -22,6 +22,7 @@
 #include "ui_qgspointcloudelevationpropertieswidgetbase.h"
 
 class QgsPointCloudLayer;
+class QgsProjectionSelectionWidget;
 
 class QgsPointCloudElevationPropertiesWidget : public QgsMapLayerConfigWidget, private Ui::QgsPointCloudElevationPropertiesWidgetBase
 {
@@ -40,9 +41,12 @@ class QgsPointCloudElevationPropertiesWidget : public QgsMapLayerConfigWidget, p
 
     void onChanged();
     void shiftPointCloudZAxis();
+    void updateVerticalCrsOptions();
+
   private:
 
     QgsPointCloudLayer *mLayer = nullptr;
+    QgsProjectionSelectionWidget *mVerticalCrsWidget = nullptr;
     bool mBlockUpdates = false;
 
 };

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -563,7 +563,7 @@ void QgsIdentifyResultsDialog::addFeature( const QgsMapToolIdentify::IdentifyRes
       addFeature( qobject_cast<QgsVectorTileLayer *>( result.mLayer ), result.mLabel, result.mFields, result.mFeature, result.mDerivedAttributes );
       break;
     case Qgis::LayerType::PointCloud:
-      addFeature( qobject_cast<QgsPointCloudLayer *>( result.mLayer ), result.mLabel, result.mAttributes );
+      addFeature( qobject_cast<QgsPointCloudLayer *>( result.mLayer ), result.mLabel, result.mAttributes, result.mDerivedAttributes );
       break;
     case Qgis::LayerType::Plugin:
     case Qgis::LayerType::Annotation:
@@ -1389,7 +1389,8 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorTileLayer *layer,
 
 void QgsIdentifyResultsDialog::addFeature( QgsPointCloudLayer *layer,
     const QString &label,
-    const QMap< QString, QString > &attributes )
+    const QMap< QString, QString > &attributes,
+    const QMap< QString, QString > &derivedAttributes )
 {
   QTreeWidgetItem *layItem = layerItem( layer );
 
@@ -1437,6 +1438,20 @@ void QgsIdentifyResultsDialog::addFeature( QgsPointCloudLayer *layer,
                               ? QStringLiteral( " [%1]" ).arg( layItem->childCount() )
                               : QString();
   layItem->setText( 0, QStringLiteral( "%1 %2" ).arg( layer->name(), countSuffix ) );
+
+  // derived attributes
+  if ( derivedAttributes.size() >= 0 && !QgsSettings().value( QStringLiteral( "/Map/hideDerivedAttributes" ), false ).toBool() )
+  {
+    QgsTreeWidgetItem *derivedItem = new QgsTreeWidgetItem( QStringList() << tr( "(Derived)" ) );
+    derivedItem->setData( 0, Qt::UserRole, "derived" );
+    derivedItem->setAlwaysOnTopPriority( 0 );
+    featItem->addChild( derivedItem );
+
+    for ( QMap< QString, QString>::const_iterator it = derivedAttributes.begin(); it != derivedAttributes.end(); ++it )
+    {
+      derivedItem->addChild( new QTreeWidgetItem( QStringList() << it.key() << it.value() ) );
+    }
+  }
 
   // attributes
   for ( QMap<QString, QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -201,7 +201,8 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
      */
     void addFeature( QgsPointCloudLayer *layer,
                      const QString &label,
-                     const QMap< QString, QString > &attributes );
+                     const QMap< QString, QString > &attributes,
+                     const QMap< QString, QString > &derivedAttributes );
 
     /**
      * Adds results from tiled scene layer

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -20,16 +20,14 @@
 #include "qgspointcloudlayer.h"
 #include "qgscoordinatetransform.h"
 #include "qgsgeos.h"
-#include "qgsterrainprovider.h"
-#include "qgslinesymbol.h"
 #include "qgspointcloudlayerelevationproperties.h"
 #include "qgsprofilesnapping.h"
 #include "qgsprofilepoint.h"
 #include "qgspointcloudrenderer.h"
 #include "qgspointcloudrequest.h"
 #include "qgspointcloudblockrequest.h"
-#include "qgsmarkersymbol.h"
 #include "qgsmessagelog.h"
+#include "qgsproject.h"
 
 //
 // QgsPointCloudLayerProfileGenerator
@@ -356,7 +354,7 @@ QgsPointCloudLayerProfileGenerator::QgsPointCloudLayerProfileGenerator( QgsPoint
   , mFeedback( std::make_unique< QgsFeedback >() )
   , mProfileCurve( request.profileCurve() ? request.profileCurve()->clone() : nullptr )
   , mTolerance( request.tolerance() )
-  , mSourceCrs( layer->crs() )
+  , mSourceCrs( layer->crs3D() )
   , mTargetCrs( request.crs() )
   , mTransformContext( request.transformContext() )
   , mZOffset( layer->elevationProperties()->zOffset() )

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -310,6 +310,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
                                  const QgsCoordinateReferenceSystem &mapVertCrs,
                                  const QgsAbstractGeometry &geometry, const QgsPointXY &layerPoint, bool showTransformedZ, QMap< QString, QString > &derivedAttributes );
 
+    static void formatCoordinate( const QgsPointXY &canvasPoint, QString &x, QString &y, const QgsCoordinateReferenceSystem &mapCrs, int coordinatePrecision );
     void formatCoordinate( const QgsPointXY &canvasPoint, QString &x, QString &y ) const;
 
     // Last geometry (point or polygon) in map CRS

--- a/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>413</width>
-    <height>439</height>
+    <width>433</width>
+    <height>652</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,6 +26,75 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Vertical Reference System</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QgsStackedWidget" name="mVerticalCrsStackedWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <widget class="QWidget" name="mCrsPageDisabled">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="mCrsDisabledLabel">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="mCrsPageEnabled"/>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vertical reference systems are supported for point cloud layers by:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Elevation profiles&lt;/li&gt;
+&lt;li&gt;Identify tool results&lt;/li&gt;
+&lt;li&gt;3D map views (when 3D view has a vertical reference system set)&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;i&gt;Other tools or plugins may ignore the vertical reference system, and care should be taken to validate results accordingly.&lt;/i&gt;&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QgsCollapsibleGroupBox" name="mCrsGroupBox_2">
      <property name="focusPolicy">
@@ -187,7 +256,24 @@
      <property name="title">
       <string>Profile Chart Appearance</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,1">
+     <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="mPointStyleComboBox"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblTransparency_4">
+        <property name="text">
+         <string>Point size</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
         <property name="decimals">
@@ -202,16 +288,6 @@
        <widget class="QCheckBox" name="mOpacityByDistanceCheckBox">
         <property name="text">
          <string>Apply opacity by distance from curve effect</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QComboBox" name="mPointStyleComboBox"/>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Color</string>
         </property>
        </widget>
       </item>
@@ -234,10 +310,10 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="lblTransparency_4">
+      <item row="4" column="0" colspan="3">
+       <widget class="QCheckBox" name="mCheckBoxRespectLayerColors">
         <property name="text">
-         <string>Point size</string>
+         <string>Respect layer's coloring</string>
         </property>
        </widget>
       </item>
@@ -248,17 +324,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Style</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="3">
-       <widget class="QCheckBox" name="mCheckBoxRespectLayerColors">
-        <property name="text">
-         <string>Respect layer's coloring</string>
+         <string>Color</string>
         </property>
        </widget>
       </item>
@@ -282,15 +351,21 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsStackedWidget</class>
+   <extends>QStackedWidget</extends>
+   <header>qgsstackedwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>


### PR DESCRIPTION
Ensures that point cloud layers respect vertical layer crs in:

- elevation profile results
- identify results
- 3d map views (when 3d view is created with a crs containing a vertical component)

Then, like https://github.com/qgis/QGIS/pull/58162, the vertical CRS option is exposed for users in the point cloud layer properties