### PR TITLE
Add expression variables for layer vertical crs

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -772,6 +772,11 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "layer" ), QCoreApplication::translate( "variable_help", "The current layer." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "layer_crs_ellipsoid" ), QCoreApplication::translate( "variable_help", "Ellipsoid acronym of current layer CRS." ) );
 
+  sVariableHelpTexts()->insert( QStringLiteral( "layer_vertical_crs" ), QCoreApplication::translate( "variable_help", "Identifier for the vertical coordinate reference system of the layer (e.g., 'EPSG:5703')." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "layer_vertical_crs_definition" ), QCoreApplication::translate( "variable_help", "Vertical coordinate reference system of layer (full definition)." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "layer_vertical_crs_description" ), QCoreApplication::translate( "variable_help", "Name of the vertical coordinate reference system of the layer." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "layer_vertical_crs_wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the vertical coordinate reference system of the layer." ) );
+
   //feature variables
   sVariableHelpTexts()->insert( QStringLiteral( "feature" ), QCoreApplication::translate( "variable_help", "The current feature being evaluated. This can be used with the 'attribute' function to evaluate attribute values from the current feature." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "id" ), QCoreApplication::translate( "variable_help", "The ID of the current feature being evaluated." ) );

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -386,6 +386,16 @@ QgsExpressionContextScope *QgsExpressionContextUtils::layerScope( const QgsMapLa
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer" ), QVariant::fromValue<QgsWeakMapLayerPointer >( QgsWeakMapLayerPointer( const_cast<QgsMapLayer *>( layer ) ) ), true, true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_crs_ellipsoid" ), layer->crs().ellipsoidAcronym(), true, true ) );
 
+
+  const QgsCoordinateReferenceSystem verticalCrs = layer->verticalCrs();
+  if ( verticalCrs.isValid() )
+  {
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_vertical_crs" ), verticalCrs.authid(), true, true ) );
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_vertical_crs_definition" ), verticalCrs.toProj(), true, true ) );
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_vertical_crs_description" ), verticalCrs.description(), true, true ) );
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_vertical_crs_wkt" ), verticalCrs.toWkt( Qgis::CrsWktVariant::Preferred ), true ) );
+  }
+
   const QgsVectorLayer *vLayer = qobject_cast< const QgsVectorLayer * >( layer );
   if ( vLayer )
   {

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1309,7 +1309,8 @@ QgsCoordinateReferenceSystem QgsMapLayer::crs() const
 
 QgsCoordinateReferenceSystem QgsMapLayer::verticalCrs() const
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+  // non fatal for now -- the "rasterize" processing algorithm is not thread safe and calls this
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
 
   switch ( mCRS.type() )
   {

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -12,6 +12,7 @@ __copyright__ = 'Copyright 2012, The QGIS Project'
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     NULL,
+    QgsCoordinateReferenceSystem,
     QgsExpression,
     QgsExpressionContext,
     QgsExpressionContextUtils,
@@ -462,6 +463,27 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         self.assertEqual(e.evaluate(context), "Test Context")
         e.setExpression("func_layer_name_operation('split')")
         self.assertEqual(e.evaluate(context), ["test", "context"])
+
+    def testLayerScopeVerticalCrs(self):
+        layer = QgsVectorLayer("Point?field=fldtxt:string", "layer", "memory")
+
+        # vertical crs info should be present in layer expression context scope
+        layer.setVerticalCrs(QgsCoordinateReferenceSystem('EPSG:5703'))
+        scope = QgsExpressionContextUtils.layerScope(layer)
+        self.assertEqual(scope.variable('layer_vertical_crs'), 'EPSG:5703')
+        self.assertEqual(scope.variable('layer_vertical_crs_definition'),
+                         '+vunits=m +no_defs')
+        self.assertEqual(scope.variable('layer_vertical_crs_description'),
+                         'NAVD88 height')
+        self.assertEqual(scope.variable('layer_vertical_crs_wkt')[:7],
+                         'VERTCRS')
+
+        layer.setVerticalCrs(QgsCoordinateReferenceSystem())
+        scope = QgsExpressionContextUtils.layerScope(layer)
+        self.assertFalse(scope.variable('layer_vertical_crs'))
+        self.assertFalse(scope.variable('layer_vertical_crs_definition'))
+        self.assertFalse(scope.variable('layer_vertical_crs_description'))
+        self.assertFalse(scope.variable('layer_vertical_crs_wkt'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following the equivalent variables for projects, this adds:

- @layer_vertical_crs
- @layer_vertical_crs_definition
- @layer_vertical_crs_description
- @layer_vertical_crs_wkt

Which will be populated whenever a map layer has a valid vertical CRS set
