### PR TITLE
fix(geometry_checker): do not call crs() on layer from another thread

### DIFF
--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
@@ -58,6 +58,7 @@ The geometry will not be reprojected regardless of useMapCrs.
 %End
 
 
+
         QString layerId() const;
 %Docstring
 The layer id.

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
@@ -58,6 +58,7 @@ The geometry will not be reprojected regardless of useMapCrs.
 %End
 
 
+
         QString layerId() const;
 %Docstring
 The layer id.

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
@@ -149,7 +149,7 @@ bool QgsGeometryChecker::fixError( QgsGeometryCheckError *error, int method, boo
   {
     const QMap<QgsFeatureId, QList<QgsGeometryCheck::Change>> &layerChanges = it.value();
     QgsFeaturePool *featurePool = mFeaturePools[it.key()];
-    QgsCoordinateTransform t( featurePool->layer()->crs(), mContext->mapCrs, QgsProject::instance() );
+    QgsCoordinateTransform t( featurePool->crs(), mContext->mapCrs, QgsProject::instance() );
     t.setBallparkTransformsAreAppropriate( true );
     for ( auto layerChangeIt = layerChanges.constBegin(); layerChangeIt != layerChanges.constEnd(); ++layerChangeIt )
     {
@@ -189,7 +189,7 @@ bool QgsGeometryChecker::fixError( QgsGeometryCheckError *error, int method, boo
   for ( auto it = mFeaturePools.constBegin(); it != mFeaturePools.constEnd(); it++ )
   {
     QgsFeaturePool *featurePool = it.value();
-    QgsCoordinateTransform t( mContext->mapCrs, featurePool->layer()->crs(), QgsProject::instance() );
+    QgsCoordinateTransform t( mContext->mapCrs, featurePool->crs(), QgsProject::instance() );
     recheckAreaFeatures[it.key()] = featurePool->getIntersects( t.transform( recheckArea ) );
   }
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerror.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerror.cpp
@@ -63,19 +63,15 @@ QgsGeometryCheckError::QgsGeometryCheckError( const QgsGeometryCheck *check,
   }
   if ( !layerFeature.useMapCrs() )
   {
-    QgsVectorLayer *vl = layerFeature.layer().data();
-    if ( vl )
+    const QgsCoordinateTransform ct( layerFeature.layerCrs(), check->context()->mapCrs, check->context()->transformContext );
+    try
     {
-      const QgsCoordinateTransform ct( vl->crs(), check->context()->mapCrs, check->context()->transformContext );
-      try
-      {
-        mGeometry.transform( ct );
-        mErrorLocation = ct.transform( mErrorLocation );
-      }
-      catch ( const QgsCsException & )
-      {
-        QgsDebugError( QStringLiteral( "Can not show error in current map coordinate reference system" ) );
-      }
+      mGeometry.transform( ct );
+      mErrorLocation = ct.transform( mErrorLocation );
+    }
+    catch ( const QgsCsException & )
+    {
+      QgsDebugError( QStringLiteral( "Can not show error in current map coordinate reference system" ) );
     }
   }
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -57,6 +57,11 @@ QgsFeature QgsGeometryCheckerUtils::LayerFeature::feature() const
   return mFeature;
 }
 
+QgsCoordinateReferenceSystem QgsGeometryCheckerUtils::LayerFeature::layerCrs() const
+{
+  return mFeaturePool->crs();
+}
+
 QPointer<QgsVectorLayer> QgsGeometryCheckerUtils::LayerFeature::layer() const
 {
   return mFeaturePool->layerPtr();

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -67,6 +67,11 @@ class ANALYSIS_EXPORT QgsGeometryCheckerUtils
         QgsFeature feature() const;
 
         /**
+         * The layer CRS.
+         */
+        QgsCoordinateReferenceSystem layerCrs() const SIP_SKIP;
+
+        /**
          * The layer.
          */
         QPointer<QgsVectorLayer> layer() const SIP_SKIP;


### PR DESCRIPTION
## Description

Following #58259 to use thread-safe `QgsFeaturePool::crs()` method instead of `QgsMapLayer::crs()` in another thread than the layer lives in.

Created a cheap `QgsGeometryCheckerUtils::LayerFeature::layerCrs()` method for this purpose.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
