### PR TITLE
Load OGR layers in parallel when opening a project

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1018,14 +1018,17 @@ void QgsOgrProvider::loadMetadata()
   {
     QRecursiveMutex *mutex = nullptr;
     OGRLayerH layer = mOgrOrigLayer->getHandleAndMutex( mutex );
-    QMutexLocker locker( mutex );
 
-    const QString identifier = GDALGetMetadataItem( layer, "IDENTIFIER", "" );
-    if ( !identifier.isEmpty() )
-      mLayerMetadata.setTitle( identifier ); // see geopackage specs -- "'identifier' is analogous to 'title'"
-    const QString abstract = GDALGetMetadataItem( layer, "DESCRIPTION", "" );
-    if ( !abstract.isEmpty() )
-      mLayerMetadata.setAbstract( abstract );
+    {
+      QMutexLocker locker( mutex );
+
+      const QString identifier = GDALGetMetadataItem( layer, "IDENTIFIER", "" );
+      if ( !identifier.isEmpty() )
+        mLayerMetadata.setTitle( identifier ); // see geopackage specs -- "'identifier' is analogous to 'title'"
+      const QString abstract = GDALGetMetadataItem( layer, "DESCRIPTION", "" );
+      if ( !abstract.isEmpty() )
+        mLayerMetadata.setAbstract( abstract );
+    }
 
     if ( mGDALDriverName == QLatin1String( "GPKG" ) )
     {

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -1250,7 +1250,7 @@ void QgsOgrProviderMetadata::saveConnection( const QgsAbstractProviderConnection
 
 QgsProviderMetadata::ProviderCapabilities QgsOgrProviderMetadata::providerCapabilities() const
 {
-  return FileBasedUris | SaveLayerMetadata;
+  return FileBasedUris | SaveLayerMetadata | ParallelCreateProvider;
 }
 
 ///@endcond


### PR DESCRIPTION
Parallel loading of GDAL and PostgreSQL layers (when opening a QGIS project) has been added in QGIS 3.32 (#53069) - this is a follow up that enables parallel loading of OGR layers.

In my testing scenario with a QGIS project with 7 remote GeoPackages (using `vsicurl`), the time to load map layers went down from ~5.5 seconds to ~1.5 seconds.

There are three commits that introduce it:
1. 5c94938d7b74a18faedbc5a4e0d2802f6cacf532 - enable the flag to allow loading of OGR data providers in parallel
2. 6630c22cdea2b239bf0e613c421fe7a915973839 - fix an existing deadlock in QGIS when creating multiple OGR providers at once
3. 5a94278dc25c088bf62faf7ea0dd6539f24e425d - update locking mechanism so that datasets can be actually loaded in parallel (rather than serialized due to locking)