### PR TITLE
Add duplicate functionality to Browser connection items

### DIFF
--- a/src/gui/providers/gdal/qgsgdalclouddataitemguiprovider.cpp
+++ b/src/gui/providers/gdal/qgsgdalclouddataitemguiprovider.cpp
@@ -34,6 +34,10 @@ void QgsGdalCloudDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QM
     connect( actionEdit, &QAction::triggered, this, [providerItem] { editConnection( providerItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), menu );
+    connect( actionDuplicate, &QAction::triggered, this, [providerItem] { duplicateConnection( providerItem ); } );
+    menu->addAction( actionDuplicate );
+
     const QList< QgsGdalCloudConnectionItem * > stConnectionItems = QgsDataItem::filteredItems<QgsGdalCloudConnectionItem>( selection );
     QAction *actionDelete = new QAction( stConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [stConnectionItems, item, context]
@@ -116,6 +120,32 @@ void QgsGdalCloudDataItemGuiProvider::editConnection( QgsGdalCloudConnectionItem
     cloudItem->refresh();
   else
     item->refresh();
+}
+
+void QgsGdalCloudDataItemGuiProvider::duplicateConnection( QgsGdalCloudConnectionItem *item )
+{
+  QgsGdalCloudProviderItem *cloudItem = qobject_cast< QgsGdalCloudProviderItem * >( item->parent() );
+  if ( !cloudItem )
+    return;
+
+  QgsGdalCloudRootItem *rootItem = qobject_cast< QgsGdalCloudRootItem * >( cloudItem->parent() );
+  if ( !rootItem )
+    return;
+
+  const QString connectionName = item->name();
+  const QgsGdalCloudProviderConnection::Data connection = QgsGdalCloudProviderConnection::connection( connectionName );
+  const QStringList connections = QgsGdalCloudProviderConnection::sTreeConnectionCloud->items();
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ) .arg( i );
+  }
+
+  QgsGdalCloudProviderConnection::addConnection( newConnectionName, connection );
+  cloudItem->refresh();
 }
 
 void QgsGdalCloudDataItemGuiProvider::newConnection( QgsDataItem *item, const QgsGdalUtils::VsiNetworkFileSystemDetails &driver )

--- a/src/gui/providers/gdal/qgsgdalclouddataitemguiprovider.cpp
+++ b/src/gui/providers/gdal/qgsgdalclouddataitemguiprovider.cpp
@@ -136,13 +136,7 @@ void QgsGdalCloudDataItemGuiProvider::duplicateConnection( QgsGdalCloudConnectio
   const QgsGdalCloudProviderConnection::Data connection = QgsGdalCloudProviderConnection::connection( connectionName );
   const QStringList connections = QgsGdalCloudProviderConnection::sTreeConnectionCloud->items();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ) .arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QgsGdalCloudProviderConnection::addConnection( newConnectionName, connection );
   cloudItem->refresh();

--- a/src/gui/providers/gdal/qgsgdalclouddataitemguiprovider.h
+++ b/src/gui/providers/gdal/qgsgdalclouddataitemguiprovider.h
@@ -38,6 +38,7 @@ class QgsGdalCloudDataItemGuiProvider : public QObject, public QgsDataItemGuiPro
 
   private:
     static void editConnection( QgsGdalCloudConnectionItem *item );
+    static void duplicateConnection( QgsGdalCloudConnectionItem *item );
     static void newConnection( QgsDataItem *item, const QgsGdalUtils::VsiNetworkFileSystemDetails &driver );
     static void saveConnections();
     static void loadConnections( QgsGdalCloudRootItem *item );

--- a/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.cpp
@@ -93,13 +93,7 @@ void QgsSensorThingsDataItemGuiProvider::duplicateConnection( QgsDataItem *item 
   const QgsSensorThingsProviderConnection::Data connection = QgsSensorThingsProviderConnection::connection( connectionName );
   const QStringList connections = QgsSensorThingsProviderConnection::sTreeSensorThingsConnections->items();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QgsSensorThingsProviderConnection::addConnection( newConnectionName, connection );
   item->parent()->refreshConnections();

--- a/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.cpp
@@ -33,6 +33,10 @@ void QgsSensorThingsDataItemGuiProvider::populateContextMenu( QgsDataItem *item,
     connect( actionEdit, &QAction::triggered, this, [connectionItem] { editConnection( connectionItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), menu );
+    connect( actionDuplicate, &QAction::triggered, this, [connectionItem] { duplicateConnection( connectionItem ); } );
+    menu->addAction( actionDuplicate );
+
     const QList< QgsSensorThingsConnectionItem * > stConnectionItems = QgsDataItem::filteredItems<QgsSensorThingsConnectionItem>( selection );
     QAction *actionDelete = new QAction( stConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [stConnectionItems, context]
@@ -82,6 +86,25 @@ void QgsSensorThingsDataItemGuiProvider::editConnection( QgsDataItem *item )
 
   item->parent()->refreshConnections();
 }
+
+void QgsSensorThingsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
+{
+  const QString connectionName = item->name();
+  const QgsSensorThingsProviderConnection::Data connection = QgsSensorThingsProviderConnection::connection( connectionName );
+  const QStringList connections = QgsSensorThingsProviderConnection::sTreeSensorThingsConnections->items();
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
+  }
+
+  QgsSensorThingsProviderConnection::addConnection( newConnectionName, connection );
+  item->parent()->refreshConnections();
+}
+
 
 void QgsSensorThingsDataItemGuiProvider::newConnection( QgsDataItem *item )
 {

--- a/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.h
+++ b/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.h
@@ -34,6 +34,7 @@ class QgsSensorThingsDataItemGuiProvider : public QObject, public QgsDataItemGui
 
   private:
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/gui/qgsdataitemguiproviderutils.cpp
+++ b/src/gui/qgsdataitemguiproviderutils.cpp
@@ -54,7 +54,7 @@ const QString QgsDataItemGuiProviderUtils::uniqueName( const QString &name, cons
   while ( connectionNames.contains( newConnectionName ) )
   {
     ++i;
-    newConnectionName = QString( "%1 (copy %2)" ).arg( name ) .arg( i );
+    newConnectionName = QObject::tr( "%1 (copy %2)" ).arg( name ) .arg( i );
   }
 
   return newConnectionName;

--- a/src/gui/qgsdataitemguiproviderutils.cpp
+++ b/src/gui/qgsdataitemguiproviderutils.cpp
@@ -46,3 +46,16 @@ void QgsDataItemGuiProviderUtils::deleteConnectionsPrivate( const QStringList &c
   if ( firstParent )
     firstParent->refreshConnections();
 }
+
+const QString QgsDataItemGuiProviderUtils::uniqueName( const QString &name, const QStringList &connectionNames )
+{
+  int i = 0;
+  QString newConnectionName( name );
+  while ( connectionNames.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 (copy %2)" ).arg( name ) .arg( i );
+  }
+
+  return newConnectionName;
+}

--- a/src/gui/qgsdataitemguiproviderutils.h
+++ b/src/gui/qgsdataitemguiproviderutils.h
@@ -61,6 +61,17 @@ class GUI_EXPORT QgsDataItemGuiProviderUtils
       QPointer< QgsDataItem > firstParent( items.at( 0 )->parent() );
       deleteConnectionsPrivate( connectionNames, deleteConnection, firstParent );
     }
+
+    /**
+     * Check if connection with \a name exists in \a connectionNames list and then try to
+     * append a number to it to get a unique name.
+     *
+     * \note Not available in Python bindings
+     *
+     * \since QGIS 3.40
+     */
+    static const QString uniqueName( const QString &name, const QStringList &connectionNames );
+
 #endif
 
   private:

--- a/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
+++ b/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
@@ -94,13 +94,7 @@ void QgsTiledSceneDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QgsTiledSceneProviderConnection::Data connection = QgsTiledSceneProviderConnection::connection( connectionName );
   const QStringList connections = QgsTiledSceneProviderConnection::sTreeConnectionTiledScene->items();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QgsTiledSceneProviderConnection::addConnection( newConnectionName, connection );
   item->parent()->refreshConnections();

--- a/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
+++ b/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
@@ -33,6 +33,10 @@ void QgsTiledSceneDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     connect( actionEdit, &QAction::triggered, this, [layerItem] { editConnection( layerItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), menu );
+    connect( actionDuplicate, &QAction::triggered, this, [layerItem] { duplicateConnection( layerItem ); } );
+    menu->addAction( actionDuplicate );
+
     const QList< QgsTiledSceneLayerItem * > sceneConnectionItems = QgsDataItem::filteredItems<QgsTiledSceneLayerItem>( selection );
     QAction *actionDelete = new QAction( sceneConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [sceneConnectionItems, context]
@@ -81,6 +85,24 @@ void QgsTiledSceneDataItemGuiProvider::editConnection( QgsDataItem *item )
 
   QgsTiledSceneProviderConnection::addConnection( dlg.connectionName(), newConnection );
 
+  item->parent()->refreshConnections();
+}
+
+void QgsTiledSceneDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
+{
+  const QString connectionName = item->name();
+  const QgsTiledSceneProviderConnection::Data connection = QgsTiledSceneProviderConnection::connection( connectionName );
+  const QStringList connections = QgsTiledSceneProviderConnection::sTreeConnectionTiledScene->items();
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
+  }
+
+  QgsTiledSceneProviderConnection::addConnection( newConnectionName, connection );
   item->parent()->refreshConnections();
 }
 

--- a/src/gui/tiledscene/qgstiledscenedataitemguiprovider.h
+++ b/src/gui/tiledscene/qgstiledscenedataitemguiprovider.h
@@ -34,6 +34,7 @@ class QgsTiledSceneDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
 
   private:
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void newCesium3dTilesConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -118,13 +118,7 @@ void QgsVectorTileDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QgsVectorTileProviderConnection::Data connection = QgsVectorTileProviderConnection::connection( connectionName );
   const QStringList connections = QgsVectorTileProviderConnection::sTreeConnectionVectorTile->items();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QgsVectorTileProviderConnection::addConnection( newConnectionName, connection );
   item->parent()->refreshConnections();

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -35,6 +35,10 @@ void QgsVectorTileDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     connect( actionEdit, &QAction::triggered, this, [layerItem] { editConnection( layerItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), menu );
+    connect( actionDuplicate, &QAction::triggered, this, [layerItem] { duplicateConnection( layerItem ); } );
+    menu->addAction( actionDuplicate );
+
     const QList< QgsVectorTileLayerItem * > vtConnectionItems = QgsDataItem::filteredItems<QgsVectorTileLayerItem>( selection );
     QAction *actionDelete = new QAction( vtConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [vtConnectionItems, context]
@@ -105,6 +109,24 @@ void QgsVectorTileDataItemGuiProvider::editConnection( QgsDataItem *item )
     }
   }
 
+  item->parent()->refreshConnections();
+}
+
+void QgsVectorTileDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
+{
+  const QString connectionName = item->name();
+  const QgsVectorTileProviderConnection::Data connection = QgsVectorTileProviderConnection::connection( connectionName );
+  const QStringList connections = QgsVectorTileProviderConnection::sTreeConnectionVectorTile->items();
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
+  }
+
+  QgsVectorTileProviderConnection::addConnection( newConnectionName, connection );
   item->parent()->refreshConnections();
 }
 

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
@@ -34,6 +34,7 @@ class QgsVectorTileDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
 
   private:
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void newArcGISConnection( QgsDataItem *item );
     static void saveXyzTilesServers();

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -179,13 +179,7 @@ void QgsArcGisRestDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QString connectionName = item->name();
   const QStringList connections = QgsArcGisConnectionSettings::sTreeConnectionArcgis->items();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QgsArcGisConnectionSettings::settingsUrl->setValue( QgsArcGisConnectionSettings::settingsUrl->value( connectionName ), newConnectionName );
 
@@ -202,7 +196,6 @@ void QgsArcGisRestDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   if ( item->parent() )
     item->parent()->refreshConnections();
 }
-
 
 void QgsArcGisRestDataItemGuiProvider::refreshConnection( QgsDataItem *item )
 {

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -58,6 +58,10 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     connect( actionEdit, &QAction::triggered, this, [connectionItem] { editConnection( connectionItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), menu );
+    connect( actionDuplicate, &QAction::triggered, this, [connectionItem] { duplicateConnection( connectionItem ); } );
+    menu->addAction( actionDuplicate );
+
     const QList< QgsArcGisRestConnectionItem * > arcgisConnectionItems = QgsDataItem::filteredItems<QgsArcGisRestConnectionItem>( selection );
     QAction *actionDelete = new QAction( arcgisConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [arcgisConnectionItems, context]
@@ -169,6 +173,36 @@ void QgsArcGisRestDataItemGuiProvider::editConnection( QgsDataItem *item )
       item->parent()->refreshConnections();
   }
 }
+
+void QgsArcGisRestDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
+{
+  const QString connectionName = item->name();
+  const QStringList connections = QgsArcGisConnectionSettings::sTreeConnectionArcgis->items();
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
+  }
+
+  QgsArcGisConnectionSettings::settingsUrl->setValue( QgsArcGisConnectionSettings::settingsUrl->value( connectionName ), newConnectionName );
+
+  QgsArcGisConnectionSettings::settingsContentEndpoint->setValue( QgsArcGisConnectionSettings::settingsContentEndpoint->value( connectionName ), newConnectionName );
+  QgsArcGisConnectionSettings::settingsCommunityEndpoint->setValue( QgsArcGisConnectionSettings::settingsCommunityEndpoint->value( connectionName ), newConnectionName );
+
+  QgsArcGisConnectionSettings::settingsUsername->setValue( QgsArcGisConnectionSettings::settingsUsername->value( connectionName ), newConnectionName );
+  QgsArcGisConnectionSettings::settingsPassword->setValue( QgsArcGisConnectionSettings::settingsPassword->value( connectionName ), newConnectionName );
+  QgsArcGisConnectionSettings::settingsAuthcfg->setValue( QgsArcGisConnectionSettings::settingsAuthcfg->value( connectionName ), newConnectionName );
+
+  QgsArcGisConnectionSettings::settingsHeaders->setValue( QgsArcGisConnectionSettings::settingsHeaders->value( connectionName ), newConnectionName );
+  QgsArcGisConnectionSettings::settingsUrlPrefix->setValue( QgsArcGisConnectionSettings::settingsUrlPrefix->value( connectionName ), newConnectionName );
+
+  if ( item->parent() )
+    item->parent()->refreshConnections();
+}
+
 
 void QgsArcGisRestDataItemGuiProvider::refreshConnection( QgsDataItem *item )
 {

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.h
@@ -39,6 +39,7 @@ class QgsArcGisRestDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -215,13 +215,7 @@ void QgsHanaDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QStringList connections = settings.childGroups();
   settings.endGroup();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QgsHanaSettings hanaSettings( connectionName, true );
   QgsHanaSettings newHanaSettings( newConnectionName );

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -218,39 +218,7 @@ void QgsHanaDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
 
   const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
-  QgsHanaSettings hanaSettings( connectionName, true );
-  QgsHanaSettings newHanaSettings( newConnectionName );
-
-  newHanaSettings.setConnectionType( hanaSettings.connectionType() );
-  newHanaSettings.setDsn( hanaSettings.dsn() );
-  newHanaSettings.setDriver( hanaSettings.driver() );
-  newHanaSettings.setHost( hanaSettings.host() );
-  newHanaSettings.setIdentifierType( hanaSettings.identifierType() );
-  newHanaSettings.setIdentifier( hanaSettings.identifier() );
-  newHanaSettings.setDatabase( hanaSettings.database() );
-  newHanaSettings.setMultitenant( hanaSettings.multitenant() );
-  newHanaSettings.setSchema( hanaSettings.schema() );
-  newHanaSettings.setAuthCfg( hanaSettings.authCfg() );
-  newHanaSettings.setUserName( hanaSettings.userName() );
-  newHanaSettings.setPassword( hanaSettings.password() );
-  newHanaSettings.setSaveUserName( hanaSettings.saveUserName() );
-  newHanaSettings.setSavePassword( hanaSettings.savePassword() );
-  newHanaSettings.setUserTablesOnly( hanaSettings.userTablesOnly() );
-  newHanaSettings.setAllowGeometrylessTables( hanaSettings.allowGeometrylessTables() );
-  newHanaSettings.setUseEstimatedMetadata( hanaSettings.useEstimatedMetadata() );
-  newHanaSettings.setEnableSsl( hanaSettings.enableSsl() );
-  newHanaSettings.setSslCryptoProvider( hanaSettings.sslCryptoProvider() );
-  newHanaSettings.setSslKeyStore( hanaSettings.sslKeyStore() );
-  newHanaSettings.setSslTrustStore( hanaSettings.sslTrustStore() );
-  newHanaSettings.setSslValidateCertificate( hanaSettings.sslValidateCertificate() );
-  newHanaSettings.setSslHostNameInCertificate( hanaSettings.sslHostNameInCertificate() );
-  newHanaSettings.setEnableProxy( hanaSettings.enableProxy() );
-  newHanaSettings.setEnableProxyHttp( hanaSettings.enableProxyHttp() );
-  newHanaSettings.setProxyHost( hanaSettings.proxyHost() );
-  newHanaSettings.setProxyPort( hanaSettings.proxyPort() );
-  newHanaSettings.setProxyUsername( hanaSettings.proxyUsername() );
-  newHanaSettings.setProxyPassword( hanaSettings.proxyPassword() );
-  newHanaSettings.save();
+  QgsHanaSettings::duplicateConnection( connectionName, newConnectionName );
 
   if ( item->parent() )
   {

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -50,6 +50,10 @@ void QgsHanaDataItemGuiProvider::populateContextMenu(
     connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), this );
+    connect( actionDuplicate, &QAction::triggered, this, [connItem] { duplicateConnection( connItem ); } );
+    menu->addAction( actionDuplicate )
+
     const QList< QgsHanaConnectionItem * > hanaConnectionItems = QgsDataItem::filteredItems<QgsHanaConnectionItem>( selection );
     QAction *actionDelete = new QAction( hanaConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [hanaConnectionItems, context]
@@ -200,6 +204,62 @@ void QgsHanaDataItemGuiProvider::editConnection( QgsDataItem *item )
     // the parent should be updated
     if ( item->parent() )
       item->parent()->refreshConnections();
+  }
+}
+
+void QgsHanaDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
+{
+  const QString connectionName = item->name();
+  QgsSettings settings;
+  settings.beginGroup( QStringLiteral( "/HANA/connections" ) );
+  const QStringList connections = settings.childGroups();
+  settings.endGroup();
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
+  }
+
+  QgsHanaSettings hanaSettings( connectionName, true );
+  QgsHanaSettings newHanaSettings( newConnectionName );
+
+  newHanaSettings.setConnectionType( hanaSettings.connectionType() );
+  newHanaSettings.setDsn( hanaSettings.dsn() );
+  newHanaSettings.setDriver( hanaSettings.driver() );
+  newHanaSettings.setHost( hanaSettings.host() );
+  newHanaSettings.setIdentifierType( hanaSettings.identifierType() );
+  newHanaSettings.setIdentifier( hanaSettings.identifier() );
+  newHanaSettings.setDatabase( hanaSettings.database() );
+  newHanaSettings.setMultitenant( hanaSettings.multitenant() );
+  newHanaSettings.setSchema( hanaSettings.schema() );
+  newHanaSettings.setAuthCfg( hanaSettings.authCfg() );
+  newHanaSettings.setUserName( hanaSettings.userName() );
+  newHanaSettings.setPassword( hanaSettings.password() );
+  newHanaSettings.setSaveUserName( hanaSettings.saveUserName() );
+  newHanaSettings.setSavePassword( hanaSettings.savePassword() );
+  newHanaSettings.setUserTablesOnly( hanaSettings.userTablesOnly() );
+  newHanaSettings.setAllowGeometrylessTables( hanaSettings.allowGeometrylessTables() );
+  newHanaSettings.setUseEstimatedMetadata( hanaSettings.useEstimatedMetadata() );
+  newHanaSettings.setEnableSsl( hanaSettings.enableSsl() );
+  newHanaSettings.setSslCryptoProvider( hanaSettings.sslCryptoProvider() );
+  newHanaSettings.setSslKeyStore( hanaSettings.sslKeyStore() );
+  newHanaSettings.setSslTrustStore( hanaSettings.sslTrustStore() );
+  newHanaSettings.setSslValidateCertificate( hanaSettings.sslValidateCertificate() );
+  newHanaSettings.setSslHostNameInCertificate( hanaSettings.sslHostNameInCertificate() );
+  newHanaSettings.setEnableProxy( hanaSettings.enableProxy() );
+  newHanaSettings.setEnableProxyHttp( hanaSettings.enableProxyHttp() );
+  newHanaSettings.setProxyHost( hanaSettings.proxyHost() );
+  newHanaSettings.setProxyPort( hanaSettings.proxyPort() );
+  newHanaSettings.setProxyUsername( hanaSettings.proxyUsername() );
+  newHanaSettings.setProxyPassword( hanaSettings.proxyPassword() );
+  newHanaSettings.save();
+
+  if ( item->parent() )
+  {
+    item->parent()->refreshConnections();
   }
 }
 

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -24,6 +24,7 @@
 #include "qgshanautils.h"
 #include "qgsnewnamedialog.h"
 #include "qgsdataitemguiproviderutils.h"
+#include "qgssettings.h"
 
 #include <QInputDialog>
 #include <QMessageBox>
@@ -52,7 +53,7 @@ void QgsHanaDataItemGuiProvider::populateContextMenu(
 
     QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), this );
     connect( actionDuplicate, &QAction::triggered, this, [connItem] { duplicateConnection( connItem ); } );
-    menu->addAction( actionDuplicate )
+    menu->addAction( actionDuplicate );
 
     const QList< QgsHanaConnectionItem * > hanaConnectionItems = QgsDataItem::filteredItems<QgsHanaConnectionItem>( selection );
     QAction *actionDelete = new QAction( hanaConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -42,6 +42,7 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void createSchema( QgsDataItem *item, QgsDataItemGuiContext context );
     static void deleteSchema( QgsHanaSchemaItem *schemaItem, QgsDataItemGuiContext context );

--- a/src/providers/hana/qgshanasettings.cpp
+++ b/src/providers/hana/qgshanasettings.cpp
@@ -64,7 +64,7 @@ void QgsHanaSettings::setKeyColumns( const QString &schemaName, const QString &o
 
 void QgsHanaSettings::setFromDataSourceUri( const QgsDataSourceUri &uri )
 {
-  if ( uri.hasParam( ( "connectionType" ) ) )
+  if ( uri.hasParam( QStringLiteral( "connectionType" ) ) )
     mConnectionType = static_cast<QgsHanaConnectionType>( uri.param( QStringLiteral( "connectionType" ) ).toUInt() );
   switch ( mConnectionType )
   {

--- a/src/providers/hana/qgshanasettings.cpp
+++ b/src/providers/hana/qgshanasettings.cpp
@@ -64,7 +64,7 @@ void QgsHanaSettings::setKeyColumns( const QString &schemaName, const QString &o
 
 void QgsHanaSettings::setFromDataSourceUri( const QgsDataSourceUri &uri )
 {
-  if ( uri.hasParam( QStringLiteral( "connectionType" ) ) )
+  if ( uri.hasParam( ( "connectionType" ) ) )
     mConnectionType = static_cast<QgsHanaConnectionType>( uri.param( QStringLiteral( "connectionType" ) ).toUInt() );
   switch ( mConnectionType )
   {
@@ -141,11 +141,11 @@ QgsDataSourceUri QgsHanaSettings::toDataSourceUri() const
 {
   QgsDataSourceUri uri;
   uri.setUseEstimatedMetadata( mUseEstimatedMetadata );
-  uri.setParam( "connectionType", QString::number( static_cast<uint>( mConnectionType ) ) );
+  uri.setParam( QStringLiteral( "connectionType" ), QString::number( static_cast<uint>( mConnectionType ) ) );
   switch ( mConnectionType )
   {
     case QgsHanaConnectionType::Dsn:
-      uri.setParam( "dsn", mDsn );
+      uri.setParam( QStringLiteral( "dsn" ), mDsn );
       uri.setUsername( mUserName );
       uri.setPassword( mPassword );
       break;
@@ -193,51 +193,51 @@ void QgsHanaSettings::load()
   QgsSettings settings;
   const QString key = path();
   mConnectionType = QgsHanaConnectionType::HostPort;
-  if ( settings.contains( key + "/connectionType" ) )
-    mConnectionType = static_cast<QgsHanaConnectionType>( settings.value( key + "/connectionType" ).toUInt() );
+  if ( settings.contains( key + QStringLiteral( "/connectionType" ) ) )
+    mConnectionType = static_cast<QgsHanaConnectionType>( settings.value( key + QStringLiteral( "/connectionType" ) ).toUInt() );
   switch ( mConnectionType )
   {
     case QgsHanaConnectionType::Dsn:
-      mDsn = settings.value( key + "/dsn" ).toString();
+      mDsn = settings.value( key + QStringLiteral( "/dsn" ) ).toString();
       break;
     case QgsHanaConnectionType::HostPort:
-      mDriver = settings.value( key + "/driver" ).toString();
-      mHost = settings.value( key + "/host" ).toString();
-      mIdentifierType = settings.value( key + "/identifierType" ).toUInt();
-      mIdentifier = settings.value( key + "/identifier" ).toString();
-      mMultitenant = settings.value( key + "/multitenant" ).toBool();
-      mDatabase = settings.value( key + "/database" ).toString();
+      mDriver = settings.value( key + QStringLiteral( "/driver" ) ).toString();
+      mHost = settings.value( key + QStringLiteral( "/host" ) ).toString();
+      mIdentifierType = settings.value( key + QStringLiteral( "/identifierType" ) ).toUInt();
+      mIdentifier = settings.value( key + QStringLiteral( "/identifier" ) ).toString();
+      mMultitenant = settings.value( key + QStringLiteral( "/multitenant" ) ).toBool();
+      mDatabase = settings.value( key + QStringLiteral( "/database" ) ).toString();
       break;
   }
-  mSchema = settings.value( key + "/schema" ).toString();
-  mAuthcfg = settings.value( key + "/authcfg" ).toString();
-  mSaveUserName = settings.value( key + "/saveUsername", false ).toBool();
+  mSchema = settings.value( key + QStringLiteral( "/schema" ) ).toString();
+  mAuthcfg = settings.value( key + QStringLiteral( "/authcfg" ) ).toString();
+  mSaveUserName = settings.value( key + QStringLiteral( "/saveUsername" ), false ).toBool();
   if ( mSaveUserName )
-    mUserName = settings.value( key + "/username" ).toString();
-  mSavePassword = settings.value( key + "/savePassword", false ).toBool();
+    mUserName = settings.value( key + QStringLiteral( "/username" ) ).toString();
+  mSavePassword = settings.value( key + QStringLiteral( "/savePassword" ), false ).toBool();
   if ( mSavePassword )
-    mPassword = settings.value( key + "/password" ).toString();
-  mUserTablesOnly = settings.value( key + "/userTablesOnly", true ).toBool();
-  mAllowGeometrylessTables = settings.value( key + "/allowGeometrylessTables", false ).toBool();
-  mUseEstimatedMetadata = settings.value( key + "/estimatedMetadata", false ).toBool();
+    mPassword = settings.value( key + QStringLiteral( "/password" ) ).toString();
+  mUserTablesOnly = settings.value( key + QStringLiteral( "/userTablesOnly" ), true ).toBool();
+  mAllowGeometrylessTables = settings.value( key + QStringLiteral( "/allowGeometrylessTables" ), false ).toBool();
+  mUseEstimatedMetadata = settings.value( key + QStringLiteral( "/estimatedMetadata" ), false ).toBool();
 
   // SSL parameters
-  mSslEnabled = settings.value( key + "/sslEnabled", false ).toBool();
-  mSslCryptoProvider = settings.value( key + "/sslCryptoProvider" ).toString();
-  mSslKeyStore = settings.value( key + "/sslKeyStore" ).toString();
-  mSslTrustStore = settings.value( key + "/sslTrustStore" ).toString();
-  mSslValidateCertificate = settings.value( key + "/sslValidateCertificate", true ).toBool();
-  mSslHostNameInCertificate = settings.value( key + "/sslHostNameInCertificate" ).toString();
+  mSslEnabled = settings.value( key + QStringLiteral( "/sslEnabled" ), false ).toBool();
+  mSslCryptoProvider = settings.value( key + QStringLiteral( "/sslCryptoProvider" ) ).toString();
+  mSslKeyStore = settings.value( key + QStringLiteral( "/sslKeyStore" ) ).toString();
+  mSslTrustStore = settings.value( key + QStringLiteral( "/sslTrustStore" ) ).toString();
+  mSslValidateCertificate = settings.value( key + QStringLiteral( "/sslValidateCertificate" ), true ).toBool();
+  mSslHostNameInCertificate = settings.value( key + QStringLiteral( "/sslHostNameInCertificate" ) ).toString();
 
   // Proxy parameters
-  mProxyEnabled = settings.value( key + "/proxyEnabled", false ).toBool();
-  mProxyHttp = settings.value( key + "/proxyHttp", false ).toBool();
-  mProxyHost = settings.value( key + "/proxyHost" ).toString();
-  mProxyPort = settings.value( key + "/proxyPort" ).toUInt();
-  mProxyUsername = settings.value( key + "/proxyUsername" ).toString();
-  mProxyPassword = settings.value( key + "/proxyPassword" ).toString();
+  mProxyEnabled = settings.value( key + QStringLiteral( "/proxyEnabled" ), false ).toBool();
+  mProxyHttp = settings.value( key + QStringLiteral( "/proxyHttp" ), false ).toBool();
+  mProxyHost = settings.value( key + QStringLiteral( "/proxyHost" ) ).toString();
+  mProxyPort = settings.value( key + QStringLiteral( "/proxyPort" ) ).toUInt();
+  mProxyUsername = settings.value( key + QStringLiteral( "/proxyUsername" ) ).toString();
+  mProxyPassword = settings.value( key + QStringLiteral( "/proxyPassword" ) ).toString();
 
-  const QString keysPath = key + "/keys";
+  const QString keysPath = key + QStringLiteral( "/keys" );
   settings.beginGroup( keysPath );
   const QStringList schemaNames = settings.childGroups();
   if ( !schemaNames.empty() )
@@ -265,47 +265,47 @@ void QgsHanaSettings::save()
   const QString key( path() );
   QgsSettings settings;
 
-  settings.setValue( key + "/connectionType", static_cast<uint>( mConnectionType ) );
+  settings.setValue( key + QStringLiteral( "/connectionType" ), static_cast<uint>( mConnectionType ) );
   switch ( mConnectionType )
   {
     case QgsHanaConnectionType::Dsn:
-      settings.setValue( key + "/dsn", mDsn );
+      settings.setValue( key + QStringLiteral( "/dsn" ), mDsn );
       break;
     case QgsHanaConnectionType::HostPort:
-      settings.setValue( key + "/driver", mDriver );
-      settings.setValue( key + "/host", mHost );
-      settings.setValue( key + "/identifierType", mIdentifierType );
-      settings.setValue( key + "/identifier", mIdentifier );
-      settings.setValue( key + "/multitenant", mMultitenant );
-      settings.setValue( key + "/database", mDatabase );
+      settings.setValue( key + QStringLiteral( "/driver" ), mDriver );
+      settings.setValue( key + QStringLiteral( "/host" ), mHost );
+      settings.setValue( key + QStringLiteral( "/identifierType" ), mIdentifierType );
+      settings.setValue( key + QStringLiteral( "/identifier" ), mIdentifier );
+      settings.setValue( key + QStringLiteral( "/multitenant" ), mMultitenant );
+      settings.setValue( key + QStringLiteral( "/database" ), mDatabase );
       break;
   }
 
-  settings.setValue( key + "/schema", mSchema );
-  settings.setValue( key + "/authcfg", mAuthcfg );
-  settings.setValue( key + "/saveUsername", mSaveUserName );
-  settings.setValue( key + "/username", mSaveUserName ? mUserName : QString( ) );
-  settings.setValue( key + "/savePassword", mSavePassword );
-  settings.setValue( key + "/password", mSavePassword ? mPassword : QString( ) );
-  settings.setValue( key + "/userTablesOnly", mUserTablesOnly );
-  settings.setValue( key + "/allowGeometrylessTables", mAllowGeometrylessTables );
-  settings.setValue( key + "/estimatedMetadata", mUseEstimatedMetadata );
-  settings.setValue( key + "/sslEnabled", mSslEnabled );
-  settings.setValue( key + "/sslCryptoProvider", mSslCryptoProvider );
-  settings.setValue( key + "/sslKeyStore", mSslKeyStore );
-  settings.setValue( key + "/sslTrustStore", mSslTrustStore );
-  settings.setValue( key + "/sslValidateCertificate", mSslValidateCertificate );
-  settings.setValue( key + "/sslHostNameInCertificate", mSslHostNameInCertificate );
-  settings.setValue( key + "/proxyEnabled", mProxyEnabled );
-  settings.setValue( key + "/proxyHttp", mProxyHttp );
-  settings.setValue( key + "/proxyHost", mProxyHost );
-  settings.setValue( key + "/proxyPort", mProxyPort );
-  settings.setValue( key + "/proxyUsername", mProxyUsername );
-  settings.setValue( key + "/proxyPassword", mProxyPassword );
+  settings.setValue( key + QStringLiteral( "/schema" ), mSchema );
+  settings.setValue( key + QStringLiteral( "/authcfg" ), mAuthcfg );
+  settings.setValue( key + QStringLiteral( "/saveUsername" ), mSaveUserName );
+  settings.setValue( key + QStringLiteral( "/username" ), mSaveUserName ? mUserName : QString( ) );
+  settings.setValue( key + QStringLiteral( "/savePassword" ), mSavePassword );
+  settings.setValue( key + QStringLiteral( "/password" ), mSavePassword ? mPassword : QString( ) );
+  settings.setValue( key + QStringLiteral( "/userTablesOnly" ), mUserTablesOnly );
+  settings.setValue( key + QStringLiteral( "/allowGeometrylessTables" ), mAllowGeometrylessTables );
+  settings.setValue( key + QStringLiteral( "/estimatedMetadata" ), mUseEstimatedMetadata );
+  settings.setValue( key + QStringLiteral( "/sslEnabled" ), mSslEnabled );
+  settings.setValue( key + QStringLiteral( "/sslCryptoProvider" ), mSslCryptoProvider );
+  settings.setValue( key + QStringLiteral( "/sslKeyStore" ), mSslKeyStore );
+  settings.setValue( key + QStringLiteral( "/sslTrustStore" ), mSslTrustStore );
+  settings.setValue( key + QStringLiteral( "/sslValidateCertificate" ), mSslValidateCertificate );
+  settings.setValue( key + QStringLiteral( "/sslHostNameInCertificate" ), mSslHostNameInCertificate );
+  settings.setValue( key + QStringLiteral( "/proxyEnabled" ), mProxyEnabled );
+  settings.setValue( key + QStringLiteral( "/proxyHttp" ), mProxyHttp );
+  settings.setValue( key + QStringLiteral( "/proxyHost" ), mProxyHost );
+  settings.setValue( key + QStringLiteral( "/proxyPort" ), mProxyPort );
+  settings.setValue( key + QStringLiteral( "/proxyUsername" ), mProxyUsername );
+  settings.setValue( key + QStringLiteral( "/proxyPassword" ), mProxyPassword );
 
   if ( !mKeyColumns.empty() )
   {
-    const QString keysPath = key + "/keys/";
+    const QString keysPath = key + QStringLiteral( "/keys/" );
     settings.beginGroup( keysPath );
     const QStringList schemaNames = mKeyColumns.keys();
     for ( const QString &schemaName : schemaNames )
@@ -328,37 +328,76 @@ void QgsHanaSettings::removeConnection( const QString &name )
 {
   const QString key( getBaseKey() + name );
   QgsSettings settings;
-  settings.remove( key + "/connectionType" );
-  settings.remove( key + "/dsn" );
-  settings.remove( key + "/driver" );
-  settings.remove( key + "/host" );
-  settings.remove( key + "/identifierType" );
-  settings.remove( key + "/identifier" );
-  settings.remove( key + "/multitenant" );
-  settings.remove( key + "/database" );
-  settings.remove( key + "/schema" );
-  settings.remove( key + "/userTablesOnly" );
-  settings.remove( key + "/allowGeometrylessTables" );
-  settings.remove( key + "/estimatedMetadata" );
-  settings.remove( key + "/username" );
-  settings.remove( key + "/password" );
-  settings.remove( key + "/saveUsername" );
-  settings.remove( key + "/savePassword" );
-  settings.remove( key + "/authcfg" );
-  settings.remove( key + "/sslEnabled" );
-  settings.remove( key + "/sslCryptoProvider" );
-  settings.remove( key + "/sslKeyStore" );
-  settings.remove( key + "/sslTrustStore" );
-  settings.remove( key + "/sslValidateCertificate" );
-  settings.remove( key + "/sslHostNameInCertificate" );
-  settings.remove( key + "/proxyEnabled" );
-  settings.remove( key + "/proxyHttp" );
-  settings.remove( key + "/proxyHost" );
-  settings.remove( key + "/proxyPort" );
-  settings.remove( key + "/proxyUsername" );
-  settings.remove( key + "/proxyPassword" );
-  settings.remove( key + "/keys" );
+  settings.remove( key + QStringLiteral( "/connectionType" ) );
+  settings.remove( key + QStringLiteral( "/dsn" ) );
+  settings.remove( key + QStringLiteral( "/driver" ) );
+  settings.remove( key + QStringLiteral( "/host" ) );
+  settings.remove( key + QStringLiteral( "/identifierType" ) );
+  settings.remove( key + QStringLiteral( "/identifier" ) );
+  settings.remove( key + QStringLiteral( "/multitenant" ) );
+  settings.remove( key + QStringLiteral( "/database" ) );
+  settings.remove( key + QStringLiteral( "/schema" ) );
+  settings.remove( key + QStringLiteral( "/userTablesOnly" ) );
+  settings.remove( key + QStringLiteral( "/allowGeometrylessTables" ) );
+  settings.remove( key + QStringLiteral( "/estimatedMetadata" ) );
+  settings.remove( key + QStringLiteral( "/username" ) );
+  settings.remove( key + QStringLiteral( "/password" ) );
+  settings.remove( key + QStringLiteral( "/saveUsername" ) );
+  settings.remove( key + QStringLiteral( "/savePassword" ) );
+  settings.remove( key + QStringLiteral( "/authcfg" ) );
+  settings.remove( key + QStringLiteral( "/sslEnabled" ) );
+  settings.remove( key + QStringLiteral( "/sslCryptoProvider" ) );
+  settings.remove( key + QStringLiteral( "/sslKeyStore" ) );
+  settings.remove( key + QStringLiteral( "/sslTrustStore" ) );
+  settings.remove( key + QStringLiteral( "/sslValidateCertificate" ) );
+  settings.remove( key + QStringLiteral( "/sslHostNameInCertificate" ) );
+  settings.remove( key + QStringLiteral( "/proxyEnabled" ) );
+  settings.remove( key + QStringLiteral( "/proxyHttp" ) );
+  settings.remove( key + QStringLiteral( "/proxyHost" ) );
+  settings.remove( key + QStringLiteral( "/proxyPort" ) );
+  settings.remove( key + QStringLiteral( "/proxyUsername" ) );
+  settings.remove( key + QStringLiteral( "/proxyPassword" ) );
+  settings.remove( key + QStringLiteral( "/keys" ) );
   settings.remove( key );
+  settings.sync();
+}
+
+void QgsHanaSettings::duplicateConnection( const QString &src, const QString &dst )
+{
+  const QString key( getBaseKey() + src );
+  const QString newKey( getBaseKey() + dst );
+
+  QgsSettings settings;
+  settings.setValue( newKey + QStringLiteral( "/connectionType" ), settings.value( key + QStringLiteral( "/connectionType" ) ).toUInt() );
+  settings.setValue( newKey + QStringLiteral( "/dsn" ), settings.value( key + QStringLiteral( "/dsn" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/driver" ), settings.value( key + QStringLiteral( "/driver" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/host" ), settings.value( key + QStringLiteral( "/host" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/identifierType" ), settings.value( key + QStringLiteral( "/identifierType" ) ).toUInt() );
+  settings.setValue( newKey + QStringLiteral( "/identifier" ), settings.value( key + QStringLiteral( "/identifier" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/multitenant" ), settings.value( key + QStringLiteral( "/multitenant" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/database" ), settings.value( key + QStringLiteral( "/database" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/schema" ), settings.value( key + QStringLiteral( "/schema" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/userTablesOnly" ), settings.value( key + QStringLiteral( "/userTablesOnly" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/allowGeometrylessTables" ), settings.value( key + QStringLiteral( "/allowGeometrylessTables" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/estimatedMetadata" ), settings.value( key + QStringLiteral( "/estimatedMetadata" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/username" ), settings.value( key + QStringLiteral( "/username" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/password" ), settings.value( key + QStringLiteral( "/password" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/authcfg" ), settings.value( key + QStringLiteral( "/authcfg" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/sslEnabled" ), settings.value( key + QStringLiteral( "/sslEnabled" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/sslCryptoProvider" ), settings.value( key + QStringLiteral( "/sslCryptoProvider" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/sslKeyStore" ), settings.value( key + QStringLiteral( "/sslKeyStore" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/sslTrustStore" ), settings.value( key + QStringLiteral( "/sslTrustStore" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/sslValidateCertificate" ), settings.value( key + QStringLiteral( "/sslValidateCertificate" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/sslHostNameInCertificate" ), settings.value( key + QStringLiteral( "/sslHostNameInCertificate" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/proxyEnabled" ), settings.value( key + QStringLiteral( "/proxyEnabled" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/proxyHttp" ), settings.value( key + QStringLiteral( "/proxyHttp" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/proxyHost" ), settings.value( key + QStringLiteral( "/proxyHost" ) ).toUInt() );
+  settings.setValue( newKey + QStringLiteral( "/proxyPort" ), settings.value( key + QStringLiteral( "/proxyPort" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/proxyUsername" ), settings.value( key + QStringLiteral( "/proxyUsername" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/proxyPassword" ), settings.value( key + QStringLiteral( "/proxyPassword" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/keys" ), settings.value( key + QStringLiteral( "/keys" ) ) );
   settings.sync();
 }
 
@@ -372,11 +411,11 @@ QStringList QgsHanaSettings::getConnectionNames()
 QString QgsHanaSettings::getSelectedConnection()
 {
   const QgsSettings settings;
-  return settings.value( getBaseKey() + "selected" ).toString();
+  return settings.value( getBaseKey() + QStringLiteral( "selected" ) ).toString();
 }
 
 void QgsHanaSettings::setSelectedConnection( const QString &name )
 {
   QgsSettings settings;
-  settings.setValue( getBaseKey() + "selected", name );
+  settings.setValue( getBaseKey() + QStringLiteral( "selected" ), name );
 }

--- a/src/providers/hana/qgshanasettings.h
+++ b/src/providers/hana/qgshanasettings.h
@@ -299,6 +299,12 @@ class QgsHanaSettings
      */
     void save();
 
+    /**
+     * Duplicates \a src connection settings to a new \a dst connection.
+     * \since QGIS 3.40
+     */
+    static void duplicateConnection( const QString &src, const QString &dst );
+
     static QStringList getConnectionNames();
     static QString getSelectedConnection();
     static void setSelectedConnection( const QString &name );

--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -32,73 +32,73 @@
 bool QgsMssqlConnection::geometryColumnsOnly( const QString &name )
 {
   const QgsSettings settings;
-  return settings.value( "/MSSQL/connections/" + name + "/geometryColumnsOnly", false ).toBool();
+  return settings.value( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/geometryColumnsOnly" ), false ).toBool();
 }
 
 void QgsMssqlConnection::setGeometryColumnsOnly( const QString &name, bool enabled )
 {
   QgsSettings settings;
-  settings.setValue( "/MSSQL/connections/" + name + "/geometryColumnsOnly", enabled );
+  settings.setValue( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/geometryColumnsOnly" ), enabled );
 }
 
 bool QgsMssqlConnection::extentInGeometryColumns( const QString &name )
 {
   const QgsSettings settings;
-  return settings.value( "/MSSQL/connections/" + name + "/extentInGeometryColumns", false ).toBool();
+  return settings.value( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/extentInGeometryColumns" ), false ).toBool();
 }
 
 void QgsMssqlConnection::setExtentInGeometryColumns( const QString &name, bool enabled )
 {
   QgsSettings settings;
-  settings.setValue( "/MSSQL/connections/" + name + "/extentInGeometryColumns", enabled );
+  settings.setValue( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/extentInGeometryColumns" ), enabled );
 }
 
 bool QgsMssqlConnection::primaryKeyInGeometryColumns( const QString &name )
 {
   const QgsSettings settings;
-  return settings.value( "/MSSQL/connections/" + name + "/primaryKeyInGeometryColumns", false ).toBool();
+  return settings.value( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/primaryKeyInGeometryColumns" ), false ).toBool();
 }
 
 void QgsMssqlConnection::setPrimaryKeyInGeometryColumns( const QString &name, bool enabled )
 {
   QgsSettings settings;
-  settings.setValue( "/MSSQL/connections/" + name + "/primaryKeyInGeometryColumns", enabled );
+  settings.setValue( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/primaryKeyInGeometryColumns" ), enabled );
 }
 
 bool QgsMssqlConnection::allowGeometrylessTables( const QString &name )
 {
   const QgsSettings settings;
-  return settings.value( "/MSSQL/connections/" + name + "/allowGeometrylessTables", false ).toBool();
+  return settings.value( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/allowGeometrylessTables" ), false ).toBool();
 }
 
 void QgsMssqlConnection::setAllowGeometrylessTables( const QString &name, bool enabled )
 {
   QgsSettings settings;
-  settings.setValue( "/MSSQL/connections/" + name + "/allowGeometrylessTables", enabled );
+  settings.setValue( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/allowGeometrylessTables" ), enabled );
 }
 
 bool QgsMssqlConnection::useEstimatedMetadata( const QString &name )
 {
   const QgsSettings settings;
-  return settings.value( "/MSSQL/connections/" + name + "/estimatedMetadata", false ).toBool();
+  return settings.value( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/estimatedMetadata" ), false ).toBool();
 }
 
 void QgsMssqlConnection::setUseEstimatedMetadata( const QString &name, bool enabled )
 {
   QgsSettings settings;
-  settings.setValue( "/MSSQL/connections/" + name + "/estimatedMetadata", enabled );
+  settings.setValue( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/estimatedMetadata" ), enabled );
 }
 
 bool QgsMssqlConnection::isInvalidGeometryHandlingDisabled( const QString &name )
 {
   const QgsSettings settings;
-  return settings.value( "/MSSQL/connections/" + name + "/disableInvalidGeometryHandling", false ).toBool();
+  return settings.value( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/disableInvalidGeometryHandling" ), false ).toBool();
 }
 
 void QgsMssqlConnection::setInvalidGeometryHandlingDisabled( const QString &name, bool disabled )
 {
   QgsSettings settings;
-  settings.setValue( "/MSSQL/connections/" + name + "/disableInvalidGeometryHandling", disabled );
+  settings.setValue( QStringLiteral( "/MSSQL/connections/" ) + name + QStringLiteral( "/disableInvalidGeometryHandling" ), disabled );
 }
 
 bool QgsMssqlConnection::dropView( const QString &uri, QString *errorMessage )
@@ -280,13 +280,13 @@ QgsDataSourceUri QgsMssqlConnection::connUri( const QString &connName )
 {
   const QgsSettings settings;
 
-  const QString key = "/MSSQL/connections/" + connName;
+  const QString key = QStringLiteral( "/MSSQL/connections/" ) + connName;
 
-  const QString service = settings.value( key + "/service" ).toString();
-  const QString host = settings.value( key + "/host" ).toString();
-  const QString database = settings.value( key + "/database" ).toString();
-  const QString username = settings.value( key + "/username" ).toString();
-  const QString password = settings.value( key + "/password" ).toString();
+  const QString service = settings.value( key + QStringLiteral( "/service" ) ).toString();
+  const QString host = settings.value( key + QStringLiteral( "/host" ) ).toString();
+  const QString database = settings.value( key + QStringLiteral( "/database" ) ).toString();
+  const QString username = settings.value( key + QStringLiteral( "/username" ) ).toString();
+  const QString password = settings.value( key + QStringLiteral( "/password" ) ).toString();
 
   const bool useGeometryColumns { QgsMssqlConnection::geometryColumnsOnly( connName ) };
   const bool useEstimatedMetadata { QgsMssqlConnection::useEstimatedMetadata( connName ) };
@@ -468,4 +468,28 @@ QString QgsMssqlConnection::buildQueryForTables( const QString &connName, bool a
 QString QgsMssqlConnection::buildQueryForTables( const QString &connName )
 {
   return buildQueryForTables( allowGeometrylessTables( connName ), geometryColumnsOnly( connName ), excludedSchemasList( connName ) );
+}
+
+void QgsMssqlConnection::duplicateConnection( const QString &src, const QString &dst )
+{
+  const QString key( QStringLiteral( "/MSSQL/connections/" ) + src );
+  const QString newKey( QStringLiteral( "/MSSQL/connections/" ) + dst );
+
+  QgsSettings settings;
+  settings.setValue( newKey + QStringLiteral( "/service" ), settings.value( key + QStringLiteral( "/service" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/host" ), settings.value( key + QStringLiteral( "/host" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/database" ), settings.value( key + QStringLiteral( "/database" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/username" ), settings.value( key + QStringLiteral( "/username" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/password" ), settings.value( key + QStringLiteral( "/password" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/geometryColumnsOnly" ), settings.value( key + QStringLiteral( "/geometryColumnsOnly" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/extentInGeometryColumns" ), settings.value( key + QStringLiteral( "/extentInGeometryColumns" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/primaryKeyInGeometryColumns" ), settings.value( key + QStringLiteral( "/primaryKeyInGeometryColumns" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/allowGeometrylessTables" ), settings.value( key + QStringLiteral( "/allowGeometrylessTables" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/estimatedMetadata" ), settings.value( key + QStringLiteral( "/estimatedMetadata" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/disableInvalidGeometryHandling" ), settings.value( key + QStringLiteral( "/disableInvalidGeometryHandling" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/schemasFiltering" ), settings.value( key + QStringLiteral( "/schemasFiltering" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/excludedSchemas" ), settings.value( key + QStringLiteral( "/excludedSchemas" ) ) );
+  settings.sync();
 }

--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -254,6 +254,12 @@ class QgsMssqlConnection
      */
     static QString buildQueryForTables( const QString &connName );
 
+    /**
+     * Duplicates \a src connection settings to new \a dst connection.
+     * \since QGIS 3.40
+     */
+    static void duplicateConnection( const QString &src, const QString &dst );
+
   private:
 
 

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -201,25 +201,7 @@ void QgsMssqlDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
 
   const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
-  const QString key = "/MSSQL/connections/" + connectionName;
-  const QString newKey = "/MSSQL/connections/" + newConnectionName;
-
-  settings.setValue( newKey + "/service", settings.value( key + "/service" ).toString() );
-  settings.setValue( newKey + "/host", settings.value( key + "/host" ).toString() );
-  settings.setValue( newKey + "/database", settings.value( key + "/database" ).toString() );
-  settings.setValue( newKey + "/username", settings.value( key + "/username" ).toString() );
-  settings.setValue( newKey + "/password", settings.value( key + "/password" ).toString() );
-  settings.setValue( newKey + "/saveUsername", settings.value( key + "/saveUsername" ).toString() );
-  settings.setValue( newKey + "/savePassword", settings.value( key + "/savePassword" ).toString() );
-  settings.setValue( newKey + "/excludedSchemas", settings.value( key + "/excludedSchemas" ) );
-  settings.setValue( newKey + "/schemasFiltering", settings.value( key + "/schemasFiltering" ).toBool() );
-
-  QgsMssqlConnection::setGeometryColumnsOnly( newConnectionName, QgsMssqlConnection::geometryColumnsOnly( connectionName ) );
-  QgsMssqlConnection::setExtentInGeometryColumns( newConnectionName, QgsMssqlConnection::extentInGeometryColumns( connectionName ) );
-  QgsMssqlConnection::setPrimaryKeyInGeometryColumns( newConnectionName, QgsMssqlConnection::primaryKeyInGeometryColumns( connectionName ) );
-  QgsMssqlConnection::setAllowGeometrylessTables( newConnectionName, QgsMssqlConnection::allowGeometrylessTables( connectionName ) );
-  QgsMssqlConnection::setUseEstimatedMetadata( newConnectionName, QgsMssqlConnection::useEstimatedMetadata( connectionName ) );
-  QgsMssqlConnection::setInvalidGeometryHandlingDisabled( newConnectionName, QgsMssqlConnection::isInvalidGeometryHandlingDisabled( connectionName ) );
+  QgsMssqlConnection::duplicateConnection( connectionName, newConnectionName );
 
   item->parent()->refreshConnections();
   item->refresh();

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -199,13 +199,7 @@ void QgsMssqlDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QStringList connections = settings.childGroups();
   settings.endGroup();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   const QString key = "/MSSQL/connections/" + connectionName;
   const QString newKey = "/MSSQL/connections/" + newConnectionName;

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -39,6 +39,7 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void createSchema( QgsMssqlConnectionItem *connItem );
     static void truncateTable( QgsMssqlLayerItem *layerItem );
     static void saveConnections();

--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -921,18 +921,51 @@ void QgsOracleConn::deleteConnection( const QString &connName )
   settings.remove( key + QStringLiteral( "/host" ) );
   settings.remove( key + QStringLiteral( "/port" ) );
   settings.remove( key + QStringLiteral( "/database" ) );
+  settings.remove( key + QStringLiteral( "/schema" ) );
   settings.remove( key + QStringLiteral( "/username" ) );
   settings.remove( key + QStringLiteral( "/password" ) );
+  settings.remove( key + QStringLiteral( "/authcfg" ) );
+  settings.remove( key + QStringLiteral( "/dboptions" ) );
+  settings.remove( key + QStringLiteral( "/dbworkspace" ) );
   settings.remove( key + QStringLiteral( "/userTablesOnly" ) );
   settings.remove( key + QStringLiteral( "/geometryColumnsOnly" ) );
   settings.remove( key + QStringLiteral( "/allowGeometrylessTables" ) );
   settings.remove( key + QStringLiteral( "/estimatedMetadata" ) );
   settings.remove( key + QStringLiteral( "/onlyExistingTypes" ) );
   settings.remove( key + QStringLiteral( "/includeGeoAttributes" ) );
+  settings.remove( key + QStringLiteral( "/projectsInDatabase" ) );
   settings.remove( key + QStringLiteral( "/saveUsername" ) );
   settings.remove( key + QStringLiteral( "/savePassword" ) );
   settings.remove( key + QStringLiteral( "/save" ) );
   settings.remove( key );
+}
+
+void QgsOracleConn::duplicateConnection( const QString &src, const QString &dst )
+{
+  const QString key( QStringLiteral( "/Oracle/connections/" ) + src );
+  const QString newKey( QStringLiteral( "/Oracle/connections/" ) + dst );
+
+  QgsSettings settings;
+  settings.setValue( newKey + QStringLiteral( "/host" ), settings.value( key + QStringLiteral( "/host" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/port" ), settings.value( key + QStringLiteral( "/port" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/database" ), settings.value( key + QStringLiteral( "/database" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/schema" ), settings.value( key + QStringLiteral( "/schema" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/username" ), settings.value( key + QStringLiteral( "/username" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/password" ), settings.value( key + QStringLiteral( "/password" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/authcfg" ), settings.value( key + QStringLiteral( "/authcfg" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/dboptions" ), settings.value( key + QStringLiteral( "/dboptions" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/dbworkspace" ), settings.value( key + QStringLiteral( "/dbworkspace" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/userTablesOnly" ), settings.value( key + QStringLiteral( "/userTablesOnly" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/geometryColumnsOnly" ), settings.value( key + QStringLiteral( "/geometryColumnsOnly" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/allowGeometrylessTables" ), settings.value( key + QStringLiteral( "/allowGeometrylessTables" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/estimatedMetadata" ), settings.value( key + QStringLiteral( "/estimatedMetadata" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/onlyExistingTypes" ), settings.value( key + QStringLiteral( "/onlyExistingTypes" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/includeGeoAttributes" ), settings.value( key + QStringLiteral( "/includeGeoAttributes" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/projectsInDatabase" ), settings.value( key + QStringLiteral( "/projectsInDatabase" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
+
+  settings.sync();
 }
 
 QString QgsOracleConn::selectedConnection()
@@ -991,7 +1024,7 @@ QgsDataSourceUri QgsOracleConn::connUri( const QString &connName )
     uri.setParam( QStringLiteral( "dbworkspace" ), settings.value( key + QStringLiteral( "/dbworkspace" ) ).toString() );
   }
 
-  QString authcfg = settings.value( key + "/authcfg" ).toString();
+  QString authcfg = settings.value( key + QStringLiteral( "/authcfg" ) ).toString();
   if ( !authcfg.isEmpty() )
   {
     uri.setAuthConfigId( authcfg );
@@ -1009,37 +1042,37 @@ bool QgsOracleConn::userTablesOnly( const QString &connName )
 QString QgsOracleConn::restrictToSchema( const QString &connName )
 {
   QgsSettings settings;
-  return settings.value( "/Oracle/connections/" + connName + "/schema" ).toString();
+  return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/schema" ) ).toString();
 }
 
 bool QgsOracleConn::geometryColumnsOnly( const QString &connName )
 {
   QgsSettings settings;
-  return settings.value( "/Oracle/connections/" + connName + "/geometryColumnsOnly", true ).toBool();
+  return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/geometryColumnsOnly" ), true ).toBool();
 }
 
 bool QgsOracleConn::allowGeometrylessTables( const QString &connName )
 {
   QgsSettings settings;
-  return settings.value( "/Oracle/connections/" + connName + "/allowGeometrylessTables", false ).toBool();
+  return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/allowGeometrylessTables" ), false ).toBool();
 }
 
 bool QgsOracleConn::allowProjectsInDatabase( const QString &connName )
 {
   QgsSettings settings;
-  return settings.value( "/Oracle/connections/" + connName + "/projectsInDatabase", false ).toBool();
+  return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/projectsInDatabase" ), false ).toBool();
 }
 
 bool QgsOracleConn::estimatedMetadata( const QString &connName )
 {
   QgsSettings settings;
-  return settings.value( "/Oracle/connections/" + connName + "/estimatedMetadata", false ).toBool();
+  return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/estimatedMetadata" ), false ).toBool();
 }
 
 bool QgsOracleConn::onlyExistingTypes( const QString &connName )
 {
   QgsSettings settings;
-  return settings.value( "/Oracle/connections/" + connName + "/onlyExistingTypes", false ).toBool();
+  return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/onlyExistingTypes" ), false ).toBool();
 }
 
 QString QgsOracleConn::databaseName( const QString &database, const QString &host, const QString &port )

--- a/src/providers/oracle/qgsoracleconn.h
+++ b/src/providers/oracle/qgsoracleconn.h
@@ -259,6 +259,12 @@ class QgsOracleConn : public QObject
     static QString databaseName( const QString &database, const QString &host, const QString &port );
     static QString toPoolName( const QgsDataSourceUri &uri );
 
+    /**
+     * Duplicates \a src connection settings to a new \a dst connection.
+     * \since QGIS 3.40
+     */
+    static void duplicateConnection( const QString &src, const QString &dst );
+
     operator QSqlDatabase() { return mDatabase; }
 
     static QString getLastExecutedQuery( const QSqlQuery &query );

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -315,27 +315,7 @@ void QgsOracleConnectionItem::duplicateConnection()
 
   const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( mName, connections );
 
-  QString key = QStringLiteral( "/Oracle/connections/" ) + mName;
-  QString newKey = QStringLiteral( "/Oracle/connections/" ) + newConnectionName;
-
-  settings.setValue( newKey + QStringLiteral( "/database" ), settings.value( key + QStringLiteral( "/database" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/host" ), settings.value( key + QStringLiteral( "/host" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/port" ), settings.value( key + QStringLiteral( "/port" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/username" ), settings.value( key + "/username" ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/password" ), settings.value( key + "/password" ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/authcfg" ), settings.value( key + "/authcfg" ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/userTablesOnly" ), settings.value( key + QStringLiteral( "/userTablesOnly" ), false ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/geometryColumnsOnly" ), settings.value( key + QStringLiteral( "/geometryColumnsOnly" ), true ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/allowGeometrylessTables" ), settings.value( key + QStringLiteral( "/allowGeometrylessTables" ), false ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/estimatedMetadata" ), settings.value( key + QStringLiteral( "/estimatedMetadata" ), false ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/onlyExistingTypes" ), settings.value( key + QStringLiteral( "/onlyExistingTypes" ), true ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/includeGeoAttributes" ), settings.value( key + QStringLiteral( "/includeGeoAttributes" ), false ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/projectsInDatabase" ), settings.value( key + "/projectsInDatabase", false ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/dboptions" ), settings.value( key + QStringLiteral( "/dboptions" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/dbworkspace" ), settings.value( key + QStringLiteral( "/dbworkspace" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/schema" ), settings.value( key + QStringLiteral( "/schema" ) ).toString() );
+  QgsOracleConn::duplicateConnection( mName, newConnectionName );
 
   mParent->refreshConnections();
 }

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -283,6 +283,10 @@ QList<QAction *> QgsOracleConnectionItem::actions( QWidget *parent )
   connect( actionEdit, &QAction::triggered, this, &QgsOracleConnectionItem::editConnection );
   lst.append( actionEdit );
 
+  QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), parent );
+  connect( actionDuplicate, &QAction::triggered, this, &QgsOracleConnectionItem::duplicateConnection );
+  lst.append( actionDuplicate );
+
   QAction *actionDelete = new QAction( tr( "Remove Connection" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsOracleConnectionItem::deleteConnection );
   lst.append( actionDelete );
@@ -299,6 +303,47 @@ void QgsOracleConnectionItem::editConnection()
     mParent->refreshConnections();
   }
 }
+
+void QgsOracleConnectionItem::duplicateConnection()
+{
+  QgsSettings settings;
+  settings.beginGroup( QStringLiteral( "/Oracle/connections" ) );
+  const QStringList connections = settings.childGroups();
+  settings.endGroup();
+
+  int i = 0;
+  QString newConnectionName( mName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( mName ).arg( i );
+  }
+
+  QString key = QStringLiteral( "/Oracle/connections/" ) + mName;
+  QString newKey = QStringLiteral( "/Oracle/connections/" ) + newConnectionName;
+
+  settings.setValue( newKey + QStringLiteral( "/database" ), settings.value( key + QStringLiteral( "/database" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/host" ), settings.value( key + QStringLiteral( "/host" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/port" ), settings.value( key + QStringLiteral( "/port" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/username" ), settings.value( key + "/username" ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/password" ), settings.value( key + "/password" ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/authcfg" ), settings.value( key + "/authcfg" ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/userTablesOnly" ), settings.value( key + QStringLiteral( "/userTablesOnly" ), false ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/geometryColumnsOnly" ), settings.value( key + QStringLiteral( "/geometryColumnsOnly" ), true ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/allowGeometrylessTables" ), settings.value( key + QStringLiteral( "/allowGeometrylessTables" ), false ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/estimatedMetadata" ), settings.value( key + QStringLiteral( "/estimatedMetadata" ), false ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/onlyExistingTypes" ), settings.value( key + QStringLiteral( "/onlyExistingTypes" ), true ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/includeGeoAttributes" ), settings.value( key + QStringLiteral( "/includeGeoAttributes" ), false ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/projectsInDatabase" ), ettings.value( key + "/projectsInDatabase", false ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/dboptions" ), settings.value( key + QStringLiteral( "/dboptions" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/dbworkspace" ), settings.value( key + QStringLiteral( "/dbworkspace" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/schema" ), settings.value( key + QStringLiteral( "/schema" ) ).toString() );
+
+  mParent->refreshConnections();
+}
+
 
 void QgsOracleConnectionItem::deleteConnection()
 {

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -24,6 +24,7 @@
 #include "qgsdbquerylog.h"
 #include "qgsdbquerylog_p.h"
 #include "qgsvectorlayerexporter.h"
+#include "qgsdataitemguiproviderutils.h"
 
 #include <QMessageBox>
 #include <QProgressDialog>
@@ -311,13 +312,7 @@ void QgsOracleConnectionItem::duplicateConnection()
   const QStringList connections = settings.childGroups();
   settings.endGroup();
 
-  int i = 0;
-  QString newConnectionName( mName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( mName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QString key = QStringLiteral( "/Oracle/connections/" ) + mName;
   QString newKey = QStringLiteral( "/Oracle/connections/" ) + newConnectionName;

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -25,6 +25,7 @@
 #include "qgsdbquerylog_p.h"
 #include "qgsvectorlayerexporter.h"
 #include "qgsdataitemguiproviderutils.h"
+#include "qgssettings.h"
 
 #include <QMessageBox>
 #include <QProgressDialog>
@@ -312,7 +313,7 @@ void QgsOracleConnectionItem::duplicateConnection()
   const QStringList connections = settings.childGroups();
   settings.endGroup();
 
-  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( mName, connections );
 
   QString key = QStringLiteral( "/Oracle/connections/" ) + mName;
   QString newKey = QStringLiteral( "/Oracle/connections/" ) + newConnectionName;
@@ -329,7 +330,7 @@ void QgsOracleConnectionItem::duplicateConnection()
   settings.setValue( newKey + QStringLiteral( "/estimatedMetadata" ), settings.value( key + QStringLiteral( "/estimatedMetadata" ), false ).toBool() );
   settings.setValue( newKey + QStringLiteral( "/onlyExistingTypes" ), settings.value( key + QStringLiteral( "/onlyExistingTypes" ), true ).toBool() );
   settings.setValue( newKey + QStringLiteral( "/includeGeoAttributes" ), settings.value( key + QStringLiteral( "/includeGeoAttributes" ), false ).toBool() );
-  settings.setValue( newKey + QStringLiteral( "/projectsInDatabase" ), ettings.value( key + "/projectsInDatabase", false ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/projectsInDatabase" ), settings.value( key + "/projectsInDatabase", false ).toBool() );
   settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
   settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
   settings.setValue( newKey + QStringLiteral( "/dboptions" ), settings.value( key + QStringLiteral( "/dboptions" ) ).toString() );

--- a/src/providers/oracle/qgsoracledataitems.h
+++ b/src/providers/oracle/qgsoracledataitems.h
@@ -77,6 +77,7 @@ class QgsOracleConnectionItem : public QgsDataCollectionItem
 
   public slots:
     void editConnection();
+    void duplicateConnection();
     void deleteConnection();
     void refreshConnection();
 

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -171,15 +171,15 @@ void QgsOracleNewConnection::accept()
   settings.setValue( baseKey + QStringLiteral( "/schema" ), txtSchema->text() );
 
   QVariantMap configuration;
-  configuration.insert( "userTablesOnly", cb_userTablesOnly->isChecked() );
-  configuration.insert( "geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
-  configuration.insert( "allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
-  configuration.insert( "onlyExistingTypes", cb_onlyExistingTypes->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
-  configuration.insert( "saveUsername", mAuthSettings->storeUsernameIsChecked( ) ? "true" : "false" );
-  configuration.insert( "savePassword", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? "true" : "false" );
-  configuration.insert( "includeGeoAttributes", cb_includeGeoAttributes->isChecked() );
-  configuration.insert( "schema", txtSchema->text() );
-  configuration.insert( "projectsInDatabase", cb_projectsInDatabase->isChecked() );
+  configuration.insert( QStringLiteral( "userTablesOnly" ), cb_userTablesOnly->isChecked() );
+  configuration.insert( QStringLiteral( "geometryColumnsOnly" ), cb_geometryColumnsOnly->isChecked() );
+  configuration.insert( QStringLiteral( "allowGeometrylessTables" ), cb_allowGeometrylessTables->isChecked() );
+  configuration.insert( QStringLiteral( "onlyExistingTypes" ), cb_onlyExistingTypes->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  configuration.insert( QStringLiteral( "saveUsername" ), mAuthSettings->storeUsernameIsChecked( ) ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  configuration.insert( QStringLiteral( "savePassword" ), mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  configuration.insert( QStringLiteral( "includeGeoAttributes" ), cb_includeGeoAttributes->isChecked() );
+  configuration.insert( QStringLiteral( "schema" ), txtSchema->text() );
+  configuration.insert( QStringLiteral( "projectsInDatabase" ), cb_projectsInDatabase->isChecked() );
 
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "oracle" ) );
   QgsOracleProviderConnection *providerConnection =  static_cast<QgsOracleProviderConnection *>( providerMetadata->createConnection( txtName->text() ) );

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -2757,44 +2757,44 @@ QgsDataSourceUri QgsPostgresConn::connUri( const QString &connName )
 
   QgsSettings settings;
 
-  QString key = "/PostgreSQL/connections/" + connName;
+  QString key = QStringLiteral( "/PostgreSQL/connections/" ) + connName;
 
-  QString service = settings.value( key + "/service" ).toString();
-  QString host = settings.value( key + "/host" ).toString();
-  QString port = settings.value( key + "/port" ).toString();
+  QString service = settings.value( key + QStringLiteral( "/service" ) ).toString();
+  QString host = settings.value( key + QStringLiteral( "/host" ) ).toString();
+  QString port = settings.value( key + QStringLiteral( "/port" ) ).toString();
   if ( port.length() == 0 )
   {
     port = QStringLiteral( "5432" );
   }
-  QString database = settings.value( key + "/database" ).toString();
+  QString database = settings.value( key + QStringLiteral( "/database" ) ).toString();
 
   bool estimatedMetadata = useEstimatedMetadata( connName );
-  QgsDataSourceUri::SslMode sslmode = settings.enumValue( key + "/sslmode", QgsDataSourceUri::SslPrefer );
+  QgsDataSourceUri::SslMode sslmode = settings.enumValue( key + QStringLiteral( "/sslmode" ), QgsDataSourceUri::SslPrefer );
 
   QString username;
   QString password;
-  if ( settings.value( key + "/saveUsername" ).toString() == QLatin1String( "true" ) )
+  if ( settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() == QLatin1String( "true" ) )
   {
-    username = settings.value( key + "/username" ).toString();
+    username = settings.value( key + QStringLiteral( "/username" ) ).toString();
   }
 
-  if ( settings.value( key + "/savePassword" ).toString() == QLatin1String( "true" ) )
+  if ( settings.value( key + QStringLiteral( "/savePassword" ) ).toString() == QLatin1String( "true" ) )
   {
-    password = settings.value( key + "/password" ).toString();
+    password = settings.value( key + QStringLiteral( "/password" ) ).toString();
   }
 
   // Old save setting
-  if ( settings.contains( key + "/save" ) )
+  if ( settings.contains( key + QStringLiteral( "/save" ) ) )
   {
-    username = settings.value( key + "/username" ).toString();
+    username = settings.value( key + QStringLiteral( "/username" ) ).toString();
 
-    if ( settings.value( key + "/save" ).toString() == QLatin1String( "true" ) )
+    if ( settings.value( key + QStringLiteral( "/save" ) ).toString() == QLatin1String( "true" ) )
     {
-      password = settings.value( key + "/password" ).toString();
+      password = settings.value( key + QStringLiteral( "/password" ) ).toString();
     }
   }
 
-  QString authcfg = settings.value( key + "/authcfg" ).toString();
+  QString authcfg = settings.value( key + QStringLiteral( "/authcfg" ) ).toString();
 
   QgsDataSourceUri uri;
   if ( !service.isEmpty() )
@@ -2870,8 +2870,39 @@ void QgsPostgresConn::deleteConnection( const QString &connName )
   settings.remove( key + "/savePassword" );
   settings.remove( key + "/save" );
   settings.remove( key + "/authcfg" );
-  settings.remove( key + "/keys" );
+  settings.remove( key + "/projectsInDatabase" );
+  settings.remove( key + "/metadataInDatabase" );
+  settings.remove( key + "/dontResolveType" );
+  settings.remove( key + "/session_role" );
   settings.remove( key );
+}
+
+void QgsPostgresConn::duplicateConnection( const QString &src, const QString &dst )
+{
+  const QString key( QStringLiteral( "/PostgreSQL/connections/" ) + src );
+  const QString newKey( QStringLiteral( "/PostgreSQL/connections/" ) + dst );
+
+  QgsSettings settings;
+  settings.setValue( newKey + QStringLiteral( "/service" ), settings.value( key + QStringLiteral( "/service" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/host" ), settings.value( key + QStringLiteral( "/host" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/port" ), settings.value( key + QStringLiteral( "/port" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/database" ), settings.value( key + QStringLiteral( "/database" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/username" ), settings.value( key + QStringLiteral( "/username" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/password" ), settings.value( key + QStringLiteral( "/password" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/sslmode" ), settings.value( key + QStringLiteral( "/sslmode" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/publicOnly" ), settings.value( key + QStringLiteral( "/publicOnly" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/geometryColumnsOnly" ), settings.value( key + QStringLiteral( "/geometryColumnsOnly" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/allowGeometrylessTables" ), settings.value( key + QStringLiteral( "/allowGeometrylessTables" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/estimatedMetadata" ), settings.value( key + QStringLiteral( "/estimatedMetadata" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/projectsInDatabase" ), settings.value( key + QStringLiteral( "/projectsInDatabase" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/metadataInDatabase" ), settings.value( key + QStringLiteral( "/metadataInDatabase" ) ).toBool() );
+  settings.setValue( newKey + QStringLiteral( "/dontResolveType" ), settings.value( key + QStringLiteral( "/dontResolveType" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/session_role" ), settings.value( key + QStringLiteral( "/session_role" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/authcfg" ), settings.value( key + QStringLiteral( "/authcfg" ) ).toString() );
+
+  settings.sync();
 }
 
 bool QgsPostgresConn::allowMetadataInDatabase( const QString &connName )

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -478,6 +478,12 @@ class QgsPostgresConn : public QObject
     static void deleteConnection( const QString &connName );
     static bool allowMetadataInDatabase( const QString &connName );
 
+    /**
+     * Duplicates \a src connection settings to a new \a dst connection.
+     * \since QGIS 3.40
+     */
+    static void duplicateConnection( const QString &src, const QString &dst );
+
     //! A connection needs to be locked when it uses transactions, see QgsPostgresConn::{begin,commit,rollback}
     void lock() { mLock.lock(); }
     void unlock() { mLock.unlock(); }

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -23,6 +23,7 @@
 #include "qgspgsourceselect.h"
 #include "qgsdataitemguiproviderutils.h"
 #include "qgssettings.h"
+#include "qgspostgresconn.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -259,27 +260,7 @@ void QgsPostgresDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
 
   const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
-  QString baseKey = QStringLiteral( "/PostgreSQL/connections/%1" ).arg( connectionName );
-  QString newBaseKey = QStringLiteral( "/PostgreSQL/connections/%1" ).arg( newConnectionName );
-
-  settings.setValue( newBaseKey + "/service", settings.value( baseKey + "/service" ).toString() );
-  settings.setValue( newBaseKey + "/host", settings.value( baseKey + "/host" ).toString() );
-  settings.setValue( newBaseKey + "/port", settings.value( baseKey + "/port" ).toString() );
-  settings.setValue( newBaseKey + "/database", settings.value( baseKey + "/database" ).toString() );
-  settings.setValue( newBaseKey + "/session_role", settings.value( baseKey + "/session_role" ).toString() );
-  settings.setValue( newBaseKey + "/publicOnly", settings.value( baseKey + "/publicOnly", false ).toBool() );
-  settings.setValue( newBaseKey + "/geometryColumnsOnly", settings.value( baseKey + "/geometryColumnsOnly", true ).toBool() );
-  settings.setValue( newBaseKey + "/dontResolveType", settings.value( baseKey + "/dontResolveType", false ).toBool() );
-  settings.setValue( newBaseKey + "/allowGeometrylessTables", settings.value( baseKey + "/allowGeometrylessTables", false ).toBool() );
-  settings.setValue( newBaseKey + "/estimatedMetadata", settings.value( baseKey + "/estimatedMetadata", false ).toBool() );
-  settings.setValue( newBaseKey + "/projectsInDatabase", settings.value( baseKey + "/projectsInDatabase", false ).toBool() );
-  settings.setValue( newBaseKey + "/metadataInDatabase", settings.value( baseKey + "/metadataInDatabase", false ).toBool() );
-  settings.setEnumValue( newBaseKey + "/sslmode", settings.enumValue( baseKey + "/sslmode", QgsDataSourceUri::SslPrefer ) );
-  settings.setValue( newBaseKey + "/saveUsername", settings.value( baseKey + "/saveUsername" ).toString() );
-  settings.setValue( newBaseKey + "/savePassword", settings.value( baseKey + "/savePassword" ).toString() );
-  settings.setValue( newBaseKey + "/username", settings.value( baseKey + "/username" ).toString() );
-  settings.setValue( newBaseKey + "/password", settings.value( baseKey + "/password" ).toString() );
-  settings.setValue( newBaseKey + "/authcfg", settings.value( baseKey + "/authcfg" ).toString() );
+  QgsPostgresConn::duplicateConnection( connectionName, newConnectionName );
 
   if ( item->parent() )
   {

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -257,13 +257,7 @@ void QgsPostgresDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QStringList connections = settings.childGroups();
   settings.endGroup();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QString baseKey = QStringLiteral( "/PostgreSQL/connections/%1" ).arg( connectionName );
   QString newBaseKey = QStringLiteral( "/PostgreSQL/connections/%1" ).arg( newConnectionName );

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -44,6 +44,7 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     static QString typeNameFromLayer( const QgsPostgresLayerProperty &layer );
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void createSchema( QgsDataItem *item, QgsDataItemGuiContext context );
     static void deleteSchema( QgsPGSchemaItem *schemaItem, QgsDataItemGuiContext context );

--- a/src/providers/wcs/qgswcsdataitemguiprovider.cpp
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.cpp
@@ -20,6 +20,8 @@
 #include "qgsnewhttpconnection.h"
 #include "qgsowsconnection.h"
 #include "qgsdataitemguiproviderutils.h"
+#include "qgssettingsentryenumflag.h"
+#include "qgssettingsentryimpl.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -54,6 +56,10 @@ void QgsWcsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), menu );
+    connect( actionDuplicate, &QAction::triggered, this, [connItem] { duplicateConnection( connItem ); } );
+    menu->addAction( actionDuplicate );
+
     const QList< QgsWCSConnectionItem * > wcsConnectionItems = QgsDataItem::filteredItems<QgsWCSConnectionItem>( selection );
     QAction *actionDelete = new QAction( wcsConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [wcsConnectionItems, context]
@@ -86,6 +92,42 @@ void QgsWcsDataItemGuiProvider::editConnection( QgsDataItem *item )
     // the parent should be updated
     item->parent()->refreshConnections();
   }
+}
+
+void QgsWcsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
+{
+  const QString connectionName = item->name();
+  const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( {QStringLiteral( "wcs" )} );
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
+  }
+
+  const QStringList detailsParameters { QStringLiteral( "wcs" ), connectionName };
+  const QStringList newDetailsParameters { QStringLiteral( "wcs" ), newConnectionName };
+
+  QgsOwsConnection::settingsUrl->setValue( QgsOwsConnection::settingsUrl->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsIgnoreAxisOrientation->setValue( QgsOwsConnection::settingsIgnoreAxisOrientation->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsInvertAxisOrientation->setValue( QgsOwsConnection::settingsInvertAxisOrientation->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsReportedLayerExtents->setValue( QgsOwsConnection::settingsReportedLayerExtents->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsIgnoreGetMapURI->setValue( QgsOwsConnection::settingsIgnoreGetMapURI->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsSmoothPixmapTransform->setValue( QgsOwsConnection::settingsSmoothPixmapTransform->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsDpiMode->setValue( QgsOwsConnection::settingsDpiMode->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsTilePixelRatio->setValue( QgsOwsConnection::settingsTilePixelRatio->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsHeaders->setValue( QgsOwsConnection::settingsHeaders->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsUsername->setValue( QgsOwsConnection::settingsUsername->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsPassword->setValue( QgsOwsConnection::settingsPassword->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsAuthCfg->setValue( QgsOwsConnection::settingsAuthCfg->value( detailsParameters ), newDetailsParameters );
+
+  item->parent()->refreshConnections();
 }
 
 void QgsWcsDataItemGuiProvider::refreshConnection( QgsDataItem *item )

--- a/src/providers/wcs/qgswcsdataitemguiprovider.cpp
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.cpp
@@ -99,13 +99,7 @@ void QgsWcsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QString connectionName = item->name();
   const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( {QStringLiteral( "wcs" )} );
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   const QStringList detailsParameters { QStringLiteral( "wcs" ), connectionName };
   const QStringList newDetailsParameters { QStringLiteral( "wcs" ), newConnectionName };

--- a/src/providers/wcs/qgswcsdataitemguiprovider.h
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.h
@@ -31,6 +31,7 @@ class QgsWcsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/providers/wfs/qgswfsdataitemguiprovider.cpp
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.cpp
@@ -100,13 +100,7 @@ void QgsWfsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QString connectionName = item->name();
   const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( {QStringLiteral( "wfs" )} );
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   const QStringList detailsParameters { QStringLiteral( "wfs" ), connectionName };
   const QStringList newDetailsParameters { QStringLiteral( "wfs" ), newConnectionName };

--- a/src/providers/wfs/qgswfsdataitemguiprovider.cpp
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.cpp
@@ -55,6 +55,10 @@ void QgsWfsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
     menu->addAction( actionEdit );
 
+    QAction *actionDuplicate = new QAction( tr( "Duplicate Connection" ), menu );
+    connect( actionDuplicate, &QAction::triggered, this, [connItem] { duplicateConnection( connItem ); } );
+    menu->addAction( actionDuplicate );
+
     const QList< QgsWfsConnectionItem * > wfsConnectionItems = QgsDataItem::filteredItems<QgsWfsConnectionItem>( selection );
     QAction *actionDelete = new QAction( wfsConnectionItems.size() > 1 ? tr( "Remove Connections…" ) : tr( "Remove Connection…" ), menu );
     connect( actionDelete, &QAction::triggered, this, [wfsConnectionItems, context]
@@ -90,6 +94,43 @@ void QgsWfsDataItemGuiProvider::editConnection( QgsDataItem *item )
     item->parent()->refreshConnections();
   }
 }
+
+void QgsWfsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
+{
+  const QString connectionName = item->name();
+  const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( {QStringLiteral( "wfs" )} );
+
+  int i = 0;
+  QString newConnectionName( connectionName );
+  while ( connections.contains( newConnectionName ) )
+  {
+    ++i;
+    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
+  }
+
+  const QStringList detailsParameters { QStringLiteral( "wfs" ), connectionName };
+  const QStringList newDetailsParameters { QStringLiteral( "wfs" ), newConnectionName };
+
+  QgsOwsConnection::settingsUrl->setValue( QgsOwsConnection::settingsUrl->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsIgnoreAxisOrientation->setValue( QgsOwsConnection::settingsIgnoreAxisOrientation->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsInvertAxisOrientation->setValue( QgsOwsConnection::settingsInvertAxisOrientation->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsPreferCoordinatesForWfsT11->setValue( QgsOwsConnection::settingsPreferCoordinatesForWfsT11->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsVersion->setValue( QgsOwsConnection::settingsVersion->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsMaxNumFeatures->setValue( QgsOwsConnection::settingsMaxNumFeatures->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsPagesize->setValue( QgsOwsConnection::settingsPagesize->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsPagingEnabled->setValue( QgsOwsConnection::settingsPagingEnabled->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsUsername->setValue( QgsOwsConnection::settingsUsername->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsPassword->setValue( QgsOwsConnection::settingsPassword->value( detailsParameters ), newDetailsParameters );
+  QgsOwsConnection::settingsAuthCfg->setValue( QgsOwsConnection::settingsAuthCfg->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsHeaders->setValue( QgsOwsConnection::settingsHeaders->value( detailsParameters ), newDetailsParameters );
+
+  item->parent()->refreshConnections();
+}
+
 
 void QgsWfsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
 {

--- a/src/providers/wfs/qgswfsdataitemguiprovider.h
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.h
@@ -31,6 +31,7 @@ class QgsWfsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );

--- a/src/providers/wms/qgswmsdataitemguiproviders.cpp
+++ b/src/providers/wms/qgswmsdataitemguiproviders.cpp
@@ -108,13 +108,7 @@ void QgsWmsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QString connectionName = item->name();
   const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( {QStringLiteral( "wms" )} );
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   const QStringList detailsParameters { QStringLiteral( "wms" ), connectionName };
   const QStringList newDetailsParameters { QStringLiteral( "wms" ), newConnectionName };
@@ -244,13 +238,7 @@ void QgsXyzDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   const QString connectionName = item->name();
   const QStringList connections = QgsXyzConnectionSettings::sTreeXyzConnections->items();
 
-  int i = 0;
-  QString newConnectionName( connectionName );
-  while ( connections.contains( newConnectionName ) )
-  {
-    ++i;
-    newConnectionName = QString( "%1 - copy %2" ).arg( connectionName ).arg( i );
-  }
+  const QString newConnectionName = QgsDataItemGuiProviderUtils::uniqueName( connectionName, connections );
 
   QgsXyzConnection connection =  QgsXyzConnectionUtils::connection( connectionName );
   connection.name = newConnectionName;

--- a/src/providers/wms/qgswmsdataitemguiproviders.h
+++ b/src/providers/wms/qgswmsdataitemguiproviders.h
@@ -36,6 +36,7 @@ class QgsWmsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
   private:
     static void refreshConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
@@ -57,6 +58,7 @@ class QgsXyzDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 
   private:
     static void editConnection( QgsDataItem *item );
+    static void duplicateConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
     static void saveXyzTilesServers();
     static void loadXyzTilesServers( QgsDataItem *item );


### PR DESCRIPTION
## Description

Add "Duplicate connection" action to the context menu of Browser connection items. This allows quickly make a copy of a connection to the same source when only a few details are differ (for example, different PostGIS database on the same server)

![image](https://github.com/user-attachments/assets/276e2d60-fa00-46e4-8601-b31c04403012)

Funded by [NaturalGIS](https://www.naturalgis.pt/).