### PR TITLE
qgsrectangle: Properly handle NaN coordinates in intersects method

### DIFF
--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -369,6 +369,11 @@ class CORE_EXPORT QgsRectangle
      */
     bool intersects( const QgsRectangle &rect ) const SIP_HOLDGIL
     {
+      if ( isNull() || rect.isNull() )
+      {
+        return false;
+      }
+
       const double x1 = ( mXmin > rect.mXmin ? mXmin : rect.mXmin );
       const double x2 = ( mXmax < rect.mXmax ? mXmax : rect.mXmax );
       if ( x1 > x2 )

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -32,6 +32,7 @@ class TestQgsRectangle: public QObject
     void set();
     void setXY();
     void fromCenter();
+    void intersects();
     void manipulate();
     void regression6194();
     void operators();
@@ -230,6 +231,38 @@ void TestQgsRectangle::fromCenter()
   QCOMPARE( rect.yMinimum(), 21.0 );
   QCOMPARE( rect.xMaximum(), 22.0 );
   QCOMPARE( rect.yMaximum(), 21.0 );
+}
+
+void TestQgsRectangle::intersects()
+{
+  QgsRectangle rect1, rect2;
+
+  // both rectangle are null - rects do not intersect
+  QVERIFY( rect1.isNull() );
+  QVERIFY( rect2.isNull() );
+  QVERIFY( !rect1.intersects( rect2 ) );
+  QVERIFY( !rect2.intersects( rect1 ) );
+
+  // rect2 is null - rects do not intersect
+  rect1.set( 1, 2, 3, 5 );
+  QVERIFY( !rect1.isNull() );
+  QVERIFY( rect2.isNull() );
+  QVERIFY( !rect1.intersects( rect2 ) );
+  QVERIFY( !rect2.intersects( rect1 ) );
+
+  // rect2 is still null - rects do not intersect
+  rect2.set( std::numeric_limits<double>::quiet_NaN(),  std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN() );
+  QVERIFY( !rect1.isNull() );
+  QVERIFY( rect2.isNull() );
+  QVERIFY( !rect1.intersects( rect2 ) );
+  QVERIFY( !rect2.intersects( rect1 ) );
+
+  // intersection
+  rect2.set( 1.5, 3.2, 2.5, 4 );
+  QVERIFY( !rect1.isNull() );
+  QVERIFY( !rect2.isNull() );
+  QVERIFY( rect1.intersects( rect2 ) );
+  QVERIFY( rect2.intersects( rect1 ) );
 }
 
 void TestQgsRectangle::manipulate()

--- a/tests/src/python/test_qgsrectangle.py
+++ b/tests/src/python/test_qgsrectangle.py
@@ -43,6 +43,14 @@ class TestQgsRectangle(QgisTestCase):
         self.assertEqual(rect.perimeter(), 58.0)
 
     def testIntersection(self):
+        rect1 = QgsRectangle()
+        rect2 = QgsRectangle()
+
+        # both rectangle are null, they do not intersect
+        self.assertTrue(rect1.isNull())
+        self.assertTrue(rect2.isNull())
+        self.assertFalse(rect2.intersects(rect1))
+
         rect1 = QgsRectangle(0.0, 0.0, 5.0, 5.0)
         rect2 = QgsRectangle(2.0, 2.0, 7.0, 7.0)
 


### PR DESCRIPTION
## Description

This brings two changes to the `intersects` method of `QgsRectangle`: 
- if one of the rectangles contains only `NaN` coordinate, intersects now returns `false`
- if one of the rectangles contains at least one `NaN` coordinate, intersects now returns `false`

## Update: september 4

Only one change is kept: `intersects` now returns false if at least one rectangle only contains `NaN` coordinates