### PR TITLE
[ColorWidget] Select color component as float

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgscolorwidgets.py
+++ b/python/PyQt6/gui/auto_additions/qgscolorwidgets.py
@@ -27,7 +27,7 @@ try:
 except NameError:
     pass
 try:
-    QgsColorRampWidget.__attribute_docs__ = {'valueChanged': "Emitted when the widget's color component value changes\n\n:param value: new value of color component\n"}
+    QgsColorRampWidget.__attribute_docs__ = {'valueChanged': "Emitted when the widget's color component value changes\n\n:param value: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorRampWidget.componentRange`\n\n.. deprecated:: QGIS 3.40.\n   Use :py:func:`~QgsColorRampWidget.valueChangedF` instead.\n", 'valueChangedF': "Emitted when the widget's color component value changes\n\n:param value: new value of color component in the range 0.0-1.0\n\n.. versionadded:: 3.40\n"}
 except NameError:
     pass
 QgsColorWidget.createDragIcon = staticmethod(QgsColorWidget.createDragIcon)

--- a/python/PyQt6/gui/auto_additions/qgscolorwidgets.py
+++ b/python/PyQt6/gui/auto_additions/qgscolorwidgets.py
@@ -32,3 +32,4 @@ except NameError:
     pass
 QgsColorWidget.createDragIcon = staticmethod(QgsColorWidget.createDragIcon)
 QgsColorWidget.alterColor = staticmethod(QgsColorWidget.alterColor)
+QgsColorWidget.alterColorF = staticmethod(QgsColorWidget.alterColorF)

--- a/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
@@ -246,7 +246,7 @@ as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the satu
 .. versionadded:: 3.40
 %End
 
-    static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue );
+ static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) /Deprecated/;
 %Docstring
 Alters a color by modifying the value of a specific color component
 

--- a/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
@@ -66,7 +66,7 @@ Returns the color component which the widget controls
 .. seealso:: :py:func:`setComponent`
 %End
 
-    int componentValue() const;
+ int componentValue() const;
 %Docstring
 Returns the current value of the widget's color component
 
@@ -76,6 +76,23 @@ Returns the current value of the widget's color component
 .. seealso:: :py:func:`setComponentValue`
 
 .. seealso:: :py:func:`component`
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.componentValueF` instead.
+%End
+
+    float componentValueF() const;
+%Docstring
+Returns the current value of the widget's color component
+
+:return: value of color component, or -1 if widget has multiple components or an invalid color
+         set
+
+.. seealso:: :py:func:`setComponentValueF`
+
+.. seealso:: :py:func:`component`
+
+.. versionadded:: 3.40
 %End
 
     static QPixmap createDragIcon( const QColor &color );
@@ -106,12 +123,12 @@ Sets the color component which the widget controls
 .. seealso:: :py:func:`component`
 %End
 
-    virtual void setComponentValue( int value );
+ virtual void setComponentValue( int value );
 %Docstring
 Alters the widget's color by setting the value for the widget's color component
 
-:param value: value for widget's color component. This value is automatically
-              clipped to the range of valid values for the color component.
+:param value: value for widget's color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`.
+              This value is automatically clipped to the range of valid values for the color component.
 
 .. seealso:: :py:func:`componentValue`
 
@@ -121,6 +138,28 @@ Alters the widget's color by setting the value for the widget's color component
 
    this method has no effect if the widget is set to the QgsColorWidget.Multiple
    component
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.setComponentValueF` instead.
+%End
+
+    virtual void setComponentValueF( float value );
+%Docstring
+Alters the widget's color by setting the value for the widget's color component
+
+:param value: value for widget's color component in the range 0.0-1.0.
+              This value is automatically clipped to the range 0.0-1.0.
+
+.. seealso:: :py:func:`componentValue`
+
+.. seealso:: :py:func:`setComponent`
+
+.. note::
+
+   this method has no effect if the widget is set to the QgsColorWidget.Multiple
+   component
+
+.. versionadded:: 3.40
 %End
 
   signals:
@@ -156,24 +195,55 @@ Returns the range of valid values a color component
 :return: maximum value allowed for color component
 %End
 
-    int componentValue( ColorComponent component ) const;
+ int componentValue( ColorComponent component ) const;
 %Docstring
 Returns the value of a component of the widget's current color. This method correctly
 handles hue values when the color has an ambiguous hue (e.g., black or white shades)
 
 :param component: color component to return
 
-:return: value of color component, or -1 if widget has an invalid color set
+:return: value of color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`,
+         or -1 if widget has an invalid color set
 
 .. seealso:: :py:func:`hue`
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.componentValueF` instead.
 %End
 
-    int hue() const;
+    float componentValueF( ColorComponent component ) const;
+%Docstring
+Returns the value of a component of the widget's current color. This method correctly
+handles hue values when the color has an ambiguous hue (e.g., black or white shades)
+
+:param component: color component to return
+
+:return: value of color component in the range 0-1.0, or -1 if widget has an invalid color set
+
+.. seealso:: :py:func:`hue`
+
+.. versionadded:: 3.40
+%End
+
+ int hue() const;
 %Docstring
 Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
 as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
 
-:return: explicitly set hue for widget
+:return: explicitly set hue for widget in the range 0-359
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.hueF` instead.
+%End
+
+    float hueF() const;
+%Docstring
+Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
+as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
+
+:return: explicitly set hue for widget in the range 0-1.0
+
+.. versionadded:: 3.40
 %End
 
     static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue );
@@ -182,8 +252,23 @@ Alters a color by modifying the value of a specific color component
 
 :param color: color to alter
 :param component: color component to alter
-:param newValue: new value of color component. Values are automatically clipped to a
+:param newValue: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`. Values are automatically clipped to a
                  valid range for the color component.
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.alterColorF` instead.
+%End
+
+    static void alterColorF( QColor &color, QgsColorWidget::ColorComponent component, float newValue );
+%Docstring
+Alters a color by modifying the value of a specific color component
+
+:param color: color to alter
+:param component: color component to alter
+:param newValue: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`. Values are automatically clipped to
+                 range 0.0-1.0
+
+.. versionadded:: 3.40
 %End
 
     QColor::Spec colorSpec() const;
@@ -476,11 +561,23 @@ Sets the size for drawing the triangular markers on the ramp
 
   signals:
 
-    void valueChanged( int value );
+ void valueChanged( int value );
 %Docstring
 Emitted when the widget's color component value changes
 
-:param value: new value of color component
+:param value: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorRampWidget.componentRange`
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorRampWidget.valueChangedF` instead.
+%End
+
+    void valueChangedF( float value );
+%Docstring
+Emitted when the widget's color component value changes
+
+:param value: new value of color component in the range 0.0-1.0
+
+.. versionadded:: 3.40
 %End
 
   protected:
@@ -521,7 +618,7 @@ Construct a new color slider widget.
 
     virtual void setComponent( ColorComponent component );
 
-    virtual void setComponentValue( int value );
+    virtual void setComponentValueF( float value );
 
     virtual void setColor( const QColor &color, bool emitSignals = false );
 

--- a/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
@@ -66,7 +66,7 @@ Returns the color component which the widget controls
 .. seealso:: :py:func:`setComponent`
 %End
 
- int componentValue() const;
+ int componentValue() const /Deprecated/;
 %Docstring
 Returns the current value of the widget's color component
 
@@ -123,7 +123,7 @@ Sets the color component which the widget controls
 .. seealso:: :py:func:`component`
 %End
 
- virtual void setComponentValue( int value );
+ virtual void setComponentValue( int value ) /Deprecated/;
 %Docstring
 Alters the widget's color by setting the value for the widget's color component
 
@@ -195,7 +195,7 @@ Returns the range of valid values a color component
 :return: maximum value allowed for color component
 %End
 
- int componentValue( ColorComponent component ) const;
+ int componentValue( ColorComponent component ) const /Deprecated/;
 %Docstring
 Returns the value of a component of the widget's current color. This method correctly
 handles hue values when the color has an ambiguous hue (e.g., black or white shades)
@@ -225,7 +225,7 @@ handles hue values when the color has an ambiguous hue (e.g., black or white sha
 .. versionadded:: 3.40
 %End
 
- int hue() const;
+ int hue() const /Deprecated/;
 %Docstring
 Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
 as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
@@ -561,7 +561,7 @@ Sets the size for drawing the triangular markers on the ramp
 
   signals:
 
- void valueChanged( int value );
+ void valueChanged( int value ) /Deprecated/;
 %Docstring
 Emitted when the widget's color component value changes
 

--- a/python/gui/auto_additions/qgscolorwidgets.py
+++ b/python/gui/auto_additions/qgscolorwidgets.py
@@ -14,3 +14,4 @@ except NameError:
     pass
 QgsColorWidget.createDragIcon = staticmethod(QgsColorWidget.createDragIcon)
 QgsColorWidget.alterColor = staticmethod(QgsColorWidget.alterColor)
+QgsColorWidget.alterColorF = staticmethod(QgsColorWidget.alterColorF)

--- a/python/gui/auto_additions/qgscolorwidgets.py
+++ b/python/gui/auto_additions/qgscolorwidgets.py
@@ -9,7 +9,7 @@ try:
 except NameError:
     pass
 try:
-    QgsColorRampWidget.__attribute_docs__ = {'valueChanged': "Emitted when the widget's color component value changes\n\n:param value: new value of color component\n"}
+    QgsColorRampWidget.__attribute_docs__ = {'valueChanged': "Emitted when the widget's color component value changes\n\n:param value: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorRampWidget.componentRange`\n\n.. deprecated:: QGIS 3.40.\n   Use :py:func:`~QgsColorRampWidget.valueChangedF` instead.\n", 'valueChangedF': "Emitted when the widget's color component value changes\n\n:param value: new value of color component in the range 0.0-1.0\n\n.. versionadded:: 3.40\n"}
 except NameError:
     pass
 QgsColorWidget.createDragIcon = staticmethod(QgsColorWidget.createDragIcon)

--- a/python/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/gui/auto_generated/qgscolorwidgets.sip.in
@@ -246,7 +246,7 @@ as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the satu
 .. versionadded:: 3.40
 %End
 
-    static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue );
+ static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) /Deprecated/;
 %Docstring
 Alters a color by modifying the value of a specific color component
 

--- a/python/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/gui/auto_generated/qgscolorwidgets.sip.in
@@ -66,7 +66,7 @@ Returns the color component which the widget controls
 .. seealso:: :py:func:`setComponent`
 %End
 
-    int componentValue() const;
+ int componentValue() const;
 %Docstring
 Returns the current value of the widget's color component
 
@@ -76,6 +76,23 @@ Returns the current value of the widget's color component
 .. seealso:: :py:func:`setComponentValue`
 
 .. seealso:: :py:func:`component`
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.componentValueF` instead.
+%End
+
+    float componentValueF() const;
+%Docstring
+Returns the current value of the widget's color component
+
+:return: value of color component, or -1 if widget has multiple components or an invalid color
+         set
+
+.. seealso:: :py:func:`setComponentValueF`
+
+.. seealso:: :py:func:`component`
+
+.. versionadded:: 3.40
 %End
 
     static QPixmap createDragIcon( const QColor &color );
@@ -106,12 +123,12 @@ Sets the color component which the widget controls
 .. seealso:: :py:func:`component`
 %End
 
-    virtual void setComponentValue( int value );
+ virtual void setComponentValue( int value );
 %Docstring
 Alters the widget's color by setting the value for the widget's color component
 
-:param value: value for widget's color component. This value is automatically
-              clipped to the range of valid values for the color component.
+:param value: value for widget's color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`.
+              This value is automatically clipped to the range of valid values for the color component.
 
 .. seealso:: :py:func:`componentValue`
 
@@ -121,6 +138,28 @@ Alters the widget's color by setting the value for the widget's color component
 
    this method has no effect if the widget is set to the QgsColorWidget.Multiple
    component
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.setComponentValueF` instead.
+%End
+
+    virtual void setComponentValueF( float value );
+%Docstring
+Alters the widget's color by setting the value for the widget's color component
+
+:param value: value for widget's color component in the range 0.0-1.0.
+              This value is automatically clipped to the range 0.0-1.0.
+
+.. seealso:: :py:func:`componentValue`
+
+.. seealso:: :py:func:`setComponent`
+
+.. note::
+
+   this method has no effect if the widget is set to the QgsColorWidget.Multiple
+   component
+
+.. versionadded:: 3.40
 %End
 
   signals:
@@ -156,24 +195,55 @@ Returns the range of valid values a color component
 :return: maximum value allowed for color component
 %End
 
-    int componentValue( ColorComponent component ) const;
+ int componentValue( ColorComponent component ) const;
 %Docstring
 Returns the value of a component of the widget's current color. This method correctly
 handles hue values when the color has an ambiguous hue (e.g., black or white shades)
 
 :param component: color component to return
 
-:return: value of color component, or -1 if widget has an invalid color set
+:return: value of color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`,
+         or -1 if widget has an invalid color set
 
 .. seealso:: :py:func:`hue`
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.componentValueF` instead.
 %End
 
-    int hue() const;
+    float componentValueF( ColorComponent component ) const;
+%Docstring
+Returns the value of a component of the widget's current color. This method correctly
+handles hue values when the color has an ambiguous hue (e.g., black or white shades)
+
+:param component: color component to return
+
+:return: value of color component in the range 0-1.0, or -1 if widget has an invalid color set
+
+.. seealso:: :py:func:`hue`
+
+.. versionadded:: 3.40
+%End
+
+ int hue() const;
 %Docstring
 Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
 as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
 
-:return: explicitly set hue for widget
+:return: explicitly set hue for widget in the range 0-359
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.hueF` instead.
+%End
+
+    float hueF() const;
+%Docstring
+Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
+as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
+
+:return: explicitly set hue for widget in the range 0-1.0
+
+.. versionadded:: 3.40
 %End
 
     static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue );
@@ -182,8 +252,23 @@ Alters a color by modifying the value of a specific color component
 
 :param color: color to alter
 :param component: color component to alter
-:param newValue: new value of color component. Values are automatically clipped to a
+:param newValue: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`. Values are automatically clipped to a
                  valid range for the color component.
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorWidget.alterColorF` instead.
+%End
+
+    static void alterColorF( QColor &color, QgsColorWidget::ColorComponent component, float newValue );
+%Docstring
+Alters a color by modifying the value of a specific color component
+
+:param color: color to alter
+:param component: color component to alter
+:param newValue: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorWidget.componentRange`. Values are automatically clipped to
+                 range 0.0-1.0
+
+.. versionadded:: 3.40
 %End
 
     QColor::Spec colorSpec() const;
@@ -476,11 +561,23 @@ Sets the size for drawing the triangular markers on the ramp
 
   signals:
 
-    void valueChanged( int value );
+ void valueChanged( int value );
 %Docstring
 Emitted when the widget's color component value changes
 
-:param value: new value of color component
+:param value: new value of color component in the range between 0 and the value returned by :py:func:`~QgsColorRampWidget.componentRange`
+
+.. deprecated:: QGIS 3.40.
+   Use :py:func:`~QgsColorRampWidget.valueChangedF` instead.
+%End
+
+    void valueChangedF( float value );
+%Docstring
+Emitted when the widget's color component value changes
+
+:param value: new value of color component in the range 0.0-1.0
+
+.. versionadded:: 3.40
 %End
 
   protected:
@@ -521,7 +618,7 @@ Construct a new color slider widget.
 
     virtual void setComponent( ColorComponent component );
 
-    virtual void setComponentValue( int value );
+    virtual void setComponentValueF( float value );
 
     virtual void setColor( const QColor &color, bool emitSignals = false );
 

--- a/python/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/gui/auto_generated/qgscolorwidgets.sip.in
@@ -66,7 +66,7 @@ Returns the color component which the widget controls
 .. seealso:: :py:func:`setComponent`
 %End
 
- int componentValue() const;
+ int componentValue() const /Deprecated/;
 %Docstring
 Returns the current value of the widget's color component
 
@@ -123,7 +123,7 @@ Sets the color component which the widget controls
 .. seealso:: :py:func:`component`
 %End
 
- virtual void setComponentValue( int value );
+ virtual void setComponentValue( int value ) /Deprecated/;
 %Docstring
 Alters the widget's color by setting the value for the widget's color component
 
@@ -195,7 +195,7 @@ Returns the range of valid values a color component
 :return: maximum value allowed for color component
 %End
 
- int componentValue( ColorComponent component ) const;
+ int componentValue( ColorComponent component ) const /Deprecated/;
 %Docstring
 Returns the value of a component of the widget's current color. This method correctly
 handles hue values when the color has an ambiguous hue (e.g., black or white shades)
@@ -225,7 +225,7 @@ handles hue values when the color has an ambiguous hue (e.g., black or white sha
 .. versionadded:: 3.40
 %End
 
- int hue() const;
+ int hue() const /Deprecated/;
 %Docstring
 Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
 as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
@@ -561,7 +561,7 @@ Sets the size for drawing the triangular markers on the ramp
 
   signals:
 
- void valueChanged( int value );
+ void valueChanged( int value ) /Deprecated/;
 %Docstring
 Emitted when the widget's color component value changes
 

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -862,18 +862,18 @@ void QgsColorBox::paintEvent( QPaintEvent *event )
   //draw cross lines
   const double h = height();
   const double w = width();
-  const int margin = static_cast<int>( mMargin );
-  const int xPos = static_cast<int>( mMargin + ( w - 2 * mMargin - 1 ) * static_cast<double>( xComponentValue() ) );
-  const int yPos = static_cast<int>( mMargin + ( h - 2 * mMargin - 1 ) - ( h - 2 * mMargin - 1 ) * static_cast<double>( yComponentValue() ) );
+  const double margin = mMargin;
+  const double xPos = ( mMargin + ( w - 2 * mMargin - 1 ) * xComponentValue() );
+  const double yPos = ( mMargin + ( h - 2 * mMargin - 1 ) - ( h - 2 * mMargin - 1 ) * yComponentValue() );
 
   painter.setBrush( Qt::white );
   painter.setPen( Qt::NoPen );
 
-  painter.drawRect( xPos - 1, mMargin, 3, height() - 2 * margin - 1 );
-  painter.drawRect( mMargin, yPos - 1, width() - 2 * margin - 1, 3 );
+  painter.drawRect( QRectF( xPos - 1, mMargin, 3, height() - 2 * margin - 1 ) );
+  painter.drawRect( QRectF( mMargin, yPos - 1, width() - 2 * margin - 1, 3 ) );
   painter.setPen( Qt::black );
-  painter.drawLine( xPos, mMargin, xPos, height() - margin - 1 );
-  painter.drawLine( mMargin, yPos, width() - margin - 1, yPos );
+  painter.drawLine( QLineF( xPos, mMargin, xPos, height() - margin - 1 ) );
+  painter.drawLine( QLineF( mMargin, yPos, width() - margin - 1, yPos ) );
 
   painter.end();
 }

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -29,7 +29,7 @@
 #endif
 #include <QPainter>
 #include <QHBoxLayout>
-#include <QSpinBox>
+#include <QDoubleSpinBox>
 #include <QLineEdit>
 #include <QFontMetrics>
 #include <QToolButton>
@@ -40,6 +40,7 @@
 
 #include <cmath>
 
+#define HUE_MAX 359
 
 //
 // QgsColorWidget
@@ -55,7 +56,12 @@ QgsColorWidget::QgsColorWidget( QWidget *parent, const ColorComponent component 
 
 int QgsColorWidget::componentValue() const
 {
-  return componentValue( mComponent );
+  return static_cast<int>( std::round( componentValueF( mComponent ) * static_cast<float>( componentRange() ) ) );
+}
+
+float QgsColorWidget::componentValueF() const
+{
+  return componentValueF( mComponent );
 }
 
 QPixmap QgsColorWidget::createDragIcon( const QColor &color )
@@ -80,6 +86,11 @@ QPixmap QgsColorWidget::createDragIcon( const QColor &color )
 
 int QgsColorWidget::componentValue( const QgsColorWidget::ColorComponent component ) const
 {
+  return static_cast<int>( std::round( componentValueF( component ) * static_cast<float>( componentRange( component ) ) ) );
+}
+
+float QgsColorWidget::componentValueF( const QgsColorWidget::ColorComponent component ) const
+{
   if ( !mCurrentColor.isValid() )
   {
     return -1;
@@ -88,28 +99,28 @@ int QgsColorWidget::componentValue( const QgsColorWidget::ColorComponent compone
   switch ( component )
   {
     case QgsColorWidget::Red:
-      return mCurrentColor.red();
+      return mCurrentColor.redF();
     case QgsColorWidget::Green:
-      return mCurrentColor.green();
+      return mCurrentColor.greenF();
     case QgsColorWidget::Blue:
-      return mCurrentColor.blue();
+      return mCurrentColor.blueF();
     case QgsColorWidget::Hue:
       //hue is treated specially, to avoid -1 hues values from QColor for ambiguous hues
-      return hue();
+      return hueF();
     case QgsColorWidget::Saturation:
-      return mCurrentColor.hsvSaturation();
+      return mCurrentColor.hsvSaturationF();
     case QgsColorWidget::Value:
-      return mCurrentColor.value();
+      return mCurrentColor.valueF();
     case QgsColorWidget::Alpha:
-      return mCurrentColor.alpha();
+      return mCurrentColor.alphaF();
     case QgsColorWidget::Cyan:
-      return mCurrentColor.cyan();
+      return mCurrentColor.cyanF();
     case QgsColorWidget::Yellow:
-      return mCurrentColor.yellow();
+      return mCurrentColor.yellowF();
     case QgsColorWidget::Magenta:
-      return mCurrentColor.magenta();
+      return mCurrentColor.magentaF();
     case QgsColorWidget::Black:
-      return mCurrentColor.black();
+      return mCurrentColor.blackF();
     default:
       return -1;
   }
@@ -130,8 +141,8 @@ int QgsColorWidget::componentRange( const QgsColorWidget::ColorComponent compone
 
   if ( component == QgsColorWidget::Hue )
   {
-    //hue ranges to 359
-    return 359;
+    //hue ranges to HUE_MAX
+    return HUE_MAX;
   }
   else
   {
@@ -142,9 +153,14 @@ int QgsColorWidget::componentRange( const QgsColorWidget::ColorComponent compone
 
 int QgsColorWidget::hue() const
 {
-  if ( mCurrentColor.hue() >= 0 )
+  return static_cast<int>( std::round( hueF() * HUE_MAX ) );
+}
+
+float QgsColorWidget::hueF() const
+{
+  if ( mCurrentColor.hueF() >= 0 )
   {
-    return mCurrentColor.hue();
+    return mCurrentColor.hueF();
   }
   else
   {
@@ -155,42 +171,32 @@ int QgsColorWidget::hue() const
 void QgsColorWidget::alterColor( QColor &color, const QgsColorWidget::ColorComponent component, const int newValue )
 {
   //clip value to sensible range
-  const int clippedValue = std::min( std::max( 0, newValue ), componentRange( component ) );
+  const float clippedValue = static_cast<float>( std::clamp( newValue, 0, componentRange( component ) ) ) / static_cast<float>( componentRange( component ) );
+  alterColorF( color, component, clippedValue );
+}
+
+void QgsColorWidget::alterColorF( QColor &color, const QgsColorWidget::ColorComponent component, const float newValue )
+{
+  float clippedValue = std::clamp( newValue, 0.f, 1.f );
 
   if ( colorSpec( component ) == QColor::Spec::Cmyk )
   {
-    int c, m, y, k, a;
-    color.getCmyk( &c, &m, &y, &k, &a );
+    float c, m, y, k, a;
+    color.getCmykF( &c, &m, &y, &k, &a );
 
     switch ( component )
     {
       case QgsColorWidget::Cyan:
-        if ( c == clippedValue )
-        {
-          return;
-        }
-        color.setCmyk( clippedValue, m, y, k, a );
+        color.setCmykF( clippedValue, m, y, k, a );
         break;
       case QgsColorWidget::Magenta:
-        if ( m == clippedValue )
-        {
-          return;
-        }
-        color.setCmyk( c, clippedValue, y, k, a );
+        color.setCmykF( c, clippedValue, y, k, a );
         break;
       case QgsColorWidget::Yellow:
-        if ( y == clippedValue )
-        {
-          return;
-        }
-        color.setCmyk( c, m, clippedValue, k, a );
+        color.setCmykF( c, m, clippedValue, k, a );
         break;
       case QgsColorWidget::Black:
-        if ( k == clippedValue )
-        {
-          return;
-        }
-        color.setCmyk( c, m, y, clippedValue, a );
+        color.setCmykF( c, m, y, clippedValue, a );
         break;
       default:
         return;
@@ -198,61 +204,33 @@ void QgsColorWidget::alterColor( QColor &color, const QgsColorWidget::ColorCompo
   }
   else
   {
-    int r, g, b, a;
-    color.getRgb( &r, &g, &b, &a );
-    int h, s, v;
-    color.getHsv( &h, &s, &v );
+    float r, g, b, a;
+    color.getRgbF( &r, &g, &b, &a );
+    float h, s, v;
+    color.getHsvF( &h, &s, &v );
 
     switch ( component )
     {
       case QgsColorWidget::Red:
-        if ( r == clippedValue )
-        {
-          return;
-        }
-        color.setRed( clippedValue );
+        color.setRedF( clippedValue );
         break;
       case QgsColorWidget::Green:
-        if ( g == clippedValue )
-        {
-          return;
-        }
-        color.setGreen( clippedValue );
+        color.setGreenF( clippedValue );
         break;
       case QgsColorWidget::Blue:
-        if ( b == clippedValue )
-        {
-          return;
-        }
-        color.setBlue( clippedValue );
+        color.setBlueF( clippedValue );
         break;
       case QgsColorWidget::Hue:
-        if ( h == clippedValue )
-        {
-          return;
-        }
-        color.setHsv( clippedValue, s, v, a );
+        color.setHsvF( clippedValue, s, v, a );
         break;
       case QgsColorWidget::Saturation:
-        if ( s == clippedValue )
-        {
-          return;
-        }
-        color.setHsv( h, clippedValue, v, a );
+        color.setHsvF( h, clippedValue, v, a );
         break;
       case QgsColorWidget::Value:
-        if ( v == clippedValue )
-        {
-          return;
-        }
-        color.setHsv( h, s, clippedValue, a );
+        color.setHsvF( h, s, clippedValue, a );
         break;
       case QgsColorWidget::Alpha:
-        if ( a == clippedValue )
-        {
-          return;
-        }
-        color.setAlpha( clippedValue );
+        color.setAlphaF( clippedValue );
         break;
       default:
         return;
@@ -374,6 +352,11 @@ void QgsColorWidget::setComponent( const QgsColorWidget::ColorComponent componen
 
 void QgsColorWidget::setComponentValue( const int value )
 {
+  setComponentValueF( static_cast<float>( value ) );
+}
+
+void QgsColorWidget::setComponentValueF( const float value )
+{
   if ( mComponent == QgsColorWidget::Multiple )
   {
     return;
@@ -382,20 +365,20 @@ void QgsColorWidget::setComponentValue( const int value )
   //overwrite hue with explicit hue if required
   if ( mComponent == QgsColorWidget::Saturation || mComponent == QgsColorWidget::Value )
   {
-    int h, s, v, a;
-    mCurrentColor.getHsv( &h, &s, &v, &a );
+    float h, s, v, a;
+    mCurrentColor.getHsvF( &h, &s, &v, &a );
 
-    h = hue();
+    h = hueF();
 
-    mCurrentColor.setHsv( h, s, v, a );
+    mCurrentColor.setHsvF( h, s, v, a );
   }
 
-  alterColor( mCurrentColor, mComponent, value );
+  alterColorF( mCurrentColor, mComponent, value );
 
   //update recorded hue
   if ( mCurrentColor.hue() >= 0 )
   {
-    mExplicitHue = mCurrentColor.hue();
+    mExplicitHue = mCurrentColor.hueF();
   }
 
   update();
@@ -413,7 +396,7 @@ void QgsColorWidget::setColor( const QColor &color, const bool emitSignals )
   //update recorded hue
   if ( color.hue() >= 0 )
   {
-    mExplicitHue = color.hue();
+    mExplicitHue = color.hueF();
   }
 
   if ( emitSignals )
@@ -479,7 +462,7 @@ void QgsColorWheel::paintEvent( QPaintEvent *event )
   imagePainter.drawImage( QPointF( center.x() - ( mWheelImage.width() / 2.0 ), center.y() - ( mWheelImage.height() / 2.0 ) ), mWheelImage );
 
   //draw hue marker
-  const int h = hue();
+  const float h = hueF() * HUE_MAX;
   const double length = mWheelImage.width() / 2.0;
   QLineF hueMarkerLine = QLineF( center.x(), center.y(), center.x() + length, center.y() );
   hueMarkerLine.setAngle( h );
@@ -534,7 +517,7 @@ void QgsColorWheel::paintEvent( QPaintEvent *event )
 
 void QgsColorWheel::setColor( const QColor &color, const bool emitSignals )
 {
-  if ( color.hue() >= 0 && color.hue() != hue() )
+  if ( color.hue() >= 0 && !qgsDoubleNear( color.hue(), hueF() ) )
   {
     //hue has changed, need to redraw the triangle
     mTriangleDirty = true;
@@ -594,10 +577,10 @@ void QgsColorWheel::setColorFromPos( const QPointF pos )
 
   QColor newColor = QColor();
 
-  int h, s, l, alpha;
-  mCurrentColor.getHsl( &h, &s, &l, &alpha );
+  float h, s, l, alpha;
+  mCurrentColor.getHslF( &h, &s, &l, &alpha );
   //override hue with explicit hue, so we don't get -1 values from QColor for hue
-  h = hue();
+  h = hueF();
 
   if ( mClickedPart == QgsColorWheel::Triangle )
   {
@@ -608,7 +591,7 @@ void QgsColorWheel::setColorFromPos( const QPointF pos )
     const double y = pos.y() - center.y();
 
     double eventAngleRadians = line.angle() * M_PI / 180.0;
-    const double hueRadians = h * M_PI / 180.0;
+    const double hueRadians = h * 2 * M_PI;
     double rad0 = std::fmod( eventAngleRadians + 2.0 * M_PI - hueRadians, 2.0 * M_PI );
     double rad1 = std::fmod( rad0, ( ( 2.0 / 3.0 ) * M_PI ) ) - ( M_PI / 3.0 );
     const double length = mWheelImage.width() / 2.0 / devicePixelRatioF();
@@ -636,19 +619,19 @@ void QgsColorWheel::setColorFromPos( const QPointF pos )
     const double newL = ( ( -std::sin( rad0 ) * r ) / triangleSideLength ) + 0.5;
     const double widthShare = 1.0 - ( std::fabs( newL - 0.5 ) * 2.0 );
     const double newS = ( ( ( std::cos( rad0 ) * r ) + ( triangleLength / 2.0 ) ) / ( 1.5 * triangleLength ) ) / widthShare;
-    s = std::min( static_cast< int >( std::round( std::max( 0.0, newS ) * 255.0 ) ), 255 );
-    l = std::min( static_cast< int >( std::round( std::max( 0.0, newL ) * 255.0 ) ), 255 );
-    newColor = QColor::fromHsl( h, s, l );
+    s = std::min( std::max( 0.f, static_cast<float>( newS ) ), 1.f );
+    l = std::min( std::max( 0.f, static_cast<float>( newL ) ), 1.f );
+    newColor = QColor::fromHslF( h, s, l );
     //explicitly set the hue again, so that it's exact
-    newColor.setHsv( h, newColor.hsvSaturation(), newColor.value(), alpha );
+    newColor.setHsvF( h, newColor.hsvSaturationF(), newColor.valueF(), alpha );
   }
   else if ( mClickedPart == QgsColorWheel::Wheel )
   {
     //use hue angle
-    s = mCurrentColor.hsvSaturation();
-    const int v = mCurrentColor.value();
-    const int newHue = line.angle();
-    newColor = QColor::fromHsv( newHue, s, v, alpha );
+    s = mCurrentColor.hsvSaturationF();
+    const float v = mCurrentColor.valueF();
+    const qreal newHue = line.angle() / HUE_MAX;
+    newColor = QColor::fromHsvF( static_cast<float>( newHue ), s, v, alpha );
     //hue has changed, need to redraw triangle
     mTriangleDirty = true;
   }
@@ -658,10 +641,10 @@ void QgsColorWheel::setColorFromPos( const QPointF pos )
     //color has changed
     mCurrentColor = QColor( newColor );
 
-    if ( mCurrentColor.hue() >= 0 )
+    if ( mCurrentColor.hueF() >= 0 )
     {
       //color has a valid hue, so update the QgsColorWidget's explicit hue
-      mExplicitHue = mCurrentColor.hue();
+      mExplicitHue = mCurrentColor.hueF();
     }
 
     update();
@@ -762,12 +745,13 @@ void QgsColorWheel::createTriangle()
   QPainter imagePainter( &mTriangleImage );
   imagePainter.setRenderHint( QPainter::Antialiasing );
 
-  const int angle = hue();
+  const float angle = hueF();
+  const float angleDegree = angle * HUE_MAX;
   const double wheelRadius = mWheelImage.width() / 2.0;
   const double triangleRadius = wheelRadius - mWheelThickness * devicePixelRatioF() - 1;
 
   //pure version of hue (at full saturation and value)
-  const QColor pureColor = QColor::fromHsv( angle, 255, 255 );
+  const QColor pureColor = QColor::fromHsvF( angle, 1., 1. );
   //create copy of color but with 0 alpha
   QColor alphaColor = QColor( pureColor );
   alphaColor.setAlpha( 0 );
@@ -778,11 +762,11 @@ void QgsColorWheel::createTriangle()
   QLineF line3 = QLineF( center.x(), center.y(), center.x() - triangleRadius * std::cos( M_PI / 3.0 ), center.y() + triangleRadius * std::sin( M_PI / 3.0 ) );
   QLineF line4 = QLineF( center.x(), center.y(), center.x() - triangleRadius * std::cos( M_PI / 3.0 ), center.y() );
   QLineF line5 = QLineF( center.x(), center.y(), ( line2.p2().x() + line1.p2().x() ) / 2.0, ( line2.p2().y() + line1.p2().y() ) / 2.0 );
-  line1.setAngle( line1.angle() + angle );
-  line2.setAngle( line2.angle() + angle );
-  line3.setAngle( line3.angle() + angle );
-  line4.setAngle( line4.angle() + angle );
-  line5.setAngle( line5.angle() + angle );
+  line1.setAngle( line1.angle() + angleDegree );
+  line2.setAngle( line2.angle() + angleDegree );
+  line3.setAngle( line3.angle() + angleDegree );
+  line4.setAngle( line4.angle() + angleDegree );
+  line5.setAngle( line5.angle() + angleDegree );
   const QPointF p1 = line1.p2();
   const QPointF p2 = line2.p2();
   const QPointF p3 = line3.p2();
@@ -868,17 +852,20 @@ void QgsColorBox::paintEvent( QPaintEvent *event )
   painter.drawImage( QPoint( mMargin, mMargin ), *mBoxImage );
 
   //draw cross lines
-  const double xPos = mMargin + ( width() - 2 * mMargin - 1 ) * static_cast<double>( xComponentValue() ) / static_cast<double>( valueRangeX() );
-  const double yPos = mMargin + ( height() - 2 * mMargin - 1 ) - ( height() - 2 * mMargin - 1 ) * static_cast<double>( yComponentValue() ) / static_cast<double>( valueRangeY() );
+  const double h = height();
+  const double w = width();
+  const int margin = static_cast<int>( mMargin );
+  const int xPos = static_cast<int>( mMargin + ( w - 2 * mMargin - 1 ) * static_cast<double>( xComponentValue() ) );
+  const int yPos = static_cast<int>( mMargin + ( h - 2 * mMargin - 1 ) - ( h - 2 * mMargin - 1 ) * static_cast<double>( yComponentValue() ) );
 
   painter.setBrush( Qt::white );
   painter.setPen( Qt::NoPen );
 
-  painter.drawRect( xPos - 1, mMargin, 3, height() - 2 * mMargin - 1 );
-  painter.drawRect( mMargin, yPos - 1, width() - 2 * mMargin - 1, 3 );
+  painter.drawRect( xPos - 1, mMargin, 3, height() - 2 * margin - 1 );
+  painter.drawRect( mMargin, yPos - 1, width() - 2 * margin - 1, 3 );
   painter.setPen( Qt::black );
-  painter.drawLine( xPos, mMargin, xPos, height() - mMargin - 1 );
-  painter.drawLine( mMargin, yPos, width() - mMargin - 1, yPos );
+  painter.drawLine( xPos, mMargin, xPos, height() - margin - 1 );
+  painter.drawLine( mMargin, yPos, width() - margin - 1, yPos );
 
   painter.end();
 }
@@ -897,16 +884,16 @@ void QgsColorBox::setColor( const QColor &color, const bool emitSignals )
 {
   //check if we need to redraw the box image
   mDirty |= (
-              ( mComponent == QgsColorWidget::Red && mCurrentColor.red() != color.red() ) ||
-              ( mComponent == QgsColorWidget::Green && mCurrentColor.green() != color.green() ) ||
-              ( mComponent == QgsColorWidget::Blue && mCurrentColor.blue() != color.blue() ) ||
-              ( mComponent == QgsColorWidget::Hue && color.hsvHue() >= 0 && hue() != color.hsvHue() ) ||
-              ( mComponent == QgsColorWidget::Saturation && mCurrentColor.hsvSaturation() != color.hsvSaturation() ) ||
-              ( mComponent == QgsColorWidget::Value && mCurrentColor.value() != color.value() ) ||
-              ( mComponent == QgsColorWidget::Cyan && mCurrentColor.cyan() != color.cyan() ) ||
-              ( mComponent == QgsColorWidget::Magenta && mCurrentColor.magenta() != color.magenta() ) ||
-              ( mComponent == QgsColorWidget::Yellow && mCurrentColor.yellow() != color.yellow() ) ||
-              ( mComponent == QgsColorWidget::Black && mCurrentColor.black() != color.black() )
+              ( mComponent == QgsColorWidget::Red && !qgsDoubleNear( mCurrentColor.redF(), color.redF() ) ) ||
+              ( mComponent == QgsColorWidget::Green && !qgsDoubleNear( mCurrentColor.greenF(), color.greenF() ) ) ||
+              ( mComponent == QgsColorWidget::Blue && !qgsDoubleNear( mCurrentColor.blueF(), color.blueF() ) ) ||
+              ( mComponent == QgsColorWidget::Hue && color.hsvHueF() >= 0 && !qgsDoubleNear( hueF(), color.hsvHueF() ) ) ||
+              ( mComponent == QgsColorWidget::Saturation && !qgsDoubleNear( mCurrentColor.hsvSaturationF(), color.hsvSaturationF() ) ) ||
+              ( mComponent == QgsColorWidget::Value && !qgsDoubleNear( mCurrentColor.valueF(), color.valueF() ) ) ||
+              ( mComponent == QgsColorWidget::Cyan && !qgsDoubleNear( mCurrentColor.cyanF(), color.cyanF() ) ) ||
+              ( mComponent == QgsColorWidget::Magenta && !qgsDoubleNear( mCurrentColor.magentaF(), color.magentaF() ) ) ||
+              ( mComponent == QgsColorWidget::Yellow && !qgsDoubleNear( mCurrentColor.yellowF(), color.yellowF() ) ) ||
+              ( mComponent == QgsColorWidget::Black && !qgsDoubleNear( mCurrentColor.blackF(), color.blackF() ) )
             );
 
   QgsColorWidget::setColor( color, emitSignals );
@@ -979,14 +966,14 @@ void QgsColorBox::createBox()
   mDirty = false;
 }
 
-int QgsColorBox::valueRangeX() const
+float QgsColorBox::valueRangeX() const
 {
-  return componentRange( xComponent() );
+  return static_cast<float>( componentRange( xComponent() ) );
 }
 
-int QgsColorBox::valueRangeY() const
+float QgsColorBox::valueRangeY() const
 {
-  return componentRange( yComponent() );
+  return static_cast<float>( componentRange( yComponent() ) );
 }
 
 QgsColorWidget::ColorComponent QgsColorBox::yComponent() const
@@ -1017,9 +1004,9 @@ QgsColorWidget::ColorComponent QgsColorBox::yComponent() const
   }
 }
 
-int QgsColorBox::yComponentValue() const
+float QgsColorBox::yComponentValue() const
 {
-  return componentValue( yComponent() );
+  return componentValueF( yComponent() );
 }
 
 QgsColorWidget::ColorComponent QgsColorBox::xComponent() const
@@ -1050,18 +1037,23 @@ QgsColorWidget::ColorComponent QgsColorBox::xComponent() const
   }
 }
 
-int QgsColorBox::xComponentValue() const
+float QgsColorBox::xComponentValue() const
 {
-  return componentValue( xComponent() );
+  return componentValueF( xComponent() );
 }
 
 void QgsColorBox::setColorFromPoint( QPoint point )
 {
-  int valX = valueRangeX() * ( point.x() - mMargin ) / ( width() - 2 * mMargin - 1 );
-  valX = std::min( std::max( valX, 0 ), valueRangeX() );
+  const float x = static_cast<float>( point.x() );
+  const float y = static_cast<float>( point.y() );
+  const float w = static_cast<float>( width() );
+  const float h = static_cast<float>( height() );
 
-  int valY = valueRangeY() - valueRangeY() * ( point.y() - mMargin ) / ( height() - 2 * mMargin - 1 );
-  valY = std::min( std::max( valY, 0 ), valueRangeY() );
+  float valX = valueRangeX() * ( x - mMargin ) / ( w - 2 * mMargin - 1 );
+  valX = std::min( std::max( valX, 0.f ), valueRangeX() );
+
+  float valY = valueRangeY() - valueRangeY() * ( y - mMargin ) / ( h - 2 * mMargin - 1 );
+  valY = std::min( std::max( valY, 0.f ), valueRangeY() );
 
   QColor color = QColor( mCurrentColor );
   alterColor( color, xComponent(), valX );
@@ -1072,9 +1064,9 @@ void QgsColorBox::setColorFromPoint( QPoint point )
     return;
   }
 
-  if ( color.hue() >= 0 )
+  if ( color.hueF() >= 0 )
   {
-    mExplicitHue = color.hue();
+    mExplicitHue = color.hueF();
   }
 
   mCurrentColor = color;
@@ -1136,11 +1128,14 @@ void QgsColorRampWidget::paintEvent( QPaintEvent *event )
     style()->drawPrimitive( QStyle::PE_FrameFocusRect, &option, &painter );
   }
 
+  float w = static_cast<float>( width() );
+  float h = static_cast<float>( height() );
+  float margin = static_cast<float>( mMargin );
   if ( mComponent != QgsColorWidget::Alpha )
   {
-    const int maxValue = ( mOrientation == QgsColorRampWidget::Horizontal ? width() : height() ) - 1 - 2 * mMargin;
+    const float maxValue = static_cast<float>( mOrientation == QgsColorRampWidget::Horizontal ? width() : height() ) - 1.f - 2.f * margin;
     QColor color = QColor( mCurrentColor );
-    color.setAlpha( 255 );
+    color.setAlphaF( 1.f );
     QPen pen;
     // we need to set pen width to 1,
     // since on retina displays
@@ -1151,30 +1146,30 @@ void QgsColorRampWidget::paintEvent( QPaintEvent *event )
     painter.setBrush( Qt::NoBrush );
 
     //draw background ramp
-    for ( int c = 0; c <= maxValue; ++c )
+    for ( float c = 0.f; c <= maxValue; ++c )
     {
-      int colorVal = static_cast<int>( componentRange() * static_cast<double>( c ) / maxValue );
+      float colorVal = c / maxValue;
       //vertical sliders are reversed
       if ( mOrientation == QgsColorRampWidget::Vertical )
       {
-        colorVal = componentRange() - colorVal;
+        colorVal = 1.f - colorVal;
       }
-      alterColor( color, mComponent, colorVal );
-      if ( color.hue() < 0 )
+      alterColorF( color, mComponent, colorVal );
+      if ( color.hueF() < 0 )
       {
-        color.setHsv( hue(), color.saturation(), color.value() );
+        color.setHsvF( hueF(), color.saturationF(), color.valueF() );
       }
       pen.setColor( color );
       painter.setPen( pen );
       if ( mOrientation == QgsColorRampWidget::Horizontal )
       {
         //horizontal
-        painter.drawLine( QLineF( c + mMargin, mMargin, c + mMargin, height() - mMargin - 1 ) );
+        painter.drawLine( QLineF( c + margin, margin, c + margin, h - margin - 1 ) );
       }
       else
       {
         //vertical
-        painter.drawLine( QLineF( mMargin, c + mMargin, width() - mMargin - 1, c + mMargin ) );
+        painter.drawLine( QLineF( margin, c + margin, w - margin - 1, c + margin ) );
       }
     }
   }
@@ -1185,17 +1180,17 @@ void QgsColorRampWidget::paintEvent( QPaintEvent *event )
     const QBrush checkBrush = QBrush( transparentBackground() );
     painter.setBrush( checkBrush );
     painter.setPen( Qt::NoPen );
-    painter.drawRect( QRectF( mMargin, mMargin, width() - 2 * mMargin - 1, height() - 2 * mMargin - 1 ) );
+    painter.drawRect( QRectF( margin, margin, w - 2 * margin - 1, h - 2 * margin - 1 ) );
     QLinearGradient colorGrad;
     if ( mOrientation == QgsColorRampWidget::Horizontal )
     {
       //horizontal
-      colorGrad = QLinearGradient( mMargin, 0, width() - mMargin - 1, 0 );
+      colorGrad = QLinearGradient( margin, 0, w - margin - 1, 0 );
     }
     else
     {
       //vertical
-      colorGrad = QLinearGradient( 0, mMargin, 0, height() - mMargin - 1 );
+      colorGrad = QLinearGradient( 0, margin, 0, h - margin - 1 );
     }
     QColor transparent = QColor( mCurrentColor );
     transparent.setAlpha( 0 );
@@ -1205,7 +1200,7 @@ void QgsColorRampWidget::paintEvent( QPaintEvent *event )
     colorGrad.setColorAt( 1, opaque );
     const QBrush colorBrush = QBrush( colorGrad );
     painter.setBrush( colorBrush );
-    painter.drawRect( QRectF( mMargin, mMargin, width() - 2 * mMargin - 1, height() - 2 * mMargin - 1 ) );
+    painter.drawRect( QRectF( margin, margin, w - 2 * margin - 1, h - 2 * margin - 1 ) );
   }
 
   if ( mOrientation == QgsColorRampWidget::Horizontal )
@@ -1214,9 +1209,9 @@ void QgsColorRampWidget::paintEvent( QPaintEvent *event )
     painter.setRenderHint( QPainter::Antialiasing );
     painter.setBrush( QBrush( Qt::black ) );
     painter.setPen( Qt::NoPen );
-    painter.translate( mMargin + ( width() - 2 * mMargin ) * static_cast<double>( componentValue() ) / componentRange(), mMargin - 1 );
+    painter.translate( margin + ( w - 2 * margin ) * componentValueF(), margin - 1 );
     painter.drawPolygon( mTopTriangle );
-    painter.translate( 0, height() - mMargin - 2 );
+    painter.translate( 0, h - margin - 2 );
     painter.setBrush( QBrush( Qt::white ) );
     painter.drawPolygon( mBottomTriangle );
     painter.end();
@@ -1224,12 +1219,12 @@ void QgsColorRampWidget::paintEvent( QPaintEvent *event )
   else
   {
     //draw cross lines for vertical ramps
-    const double ypos = mMargin + ( height() - 2 * mMargin - 1 ) - ( height() - 2 * mMargin - 1 ) * static_cast<double>( componentValue() ) / componentRange();
+    const double ypos = margin + ( h - 2 * margin - 1 ) - ( h - 2 * margin - 1 ) * componentValueF();
     painter.setBrush( Qt::white );
     painter.setPen( Qt::NoPen );
-    painter.drawRect( QRectF( mMargin, ypos - 1, width() - 2 * mMargin - 1, 3 ) );
+    painter.drawRect( QRectF( margin, ypos - 1, w - 2 * margin - 1, 3 ) );
     painter.setPen( Qt::black );
-    painter.drawLine( QLineF( mMargin, ypos, width() - mMargin - 1, ypos ) );
+    painter.drawLine( QLineF( margin, ypos, w - margin - 1, ypos ) );
   }
 }
 
@@ -1289,22 +1284,25 @@ void QgsColorRampWidget::mouseMoveEvent( QMouseEvent *event )
 
 void QgsColorRampWidget::wheelEvent( QWheelEvent *event )
 {
-  const int oldValue = componentValue();
-
+  const float oldValue = componentValueF();
+  const float delta = 1.f / static_cast<float>( componentRange() );
   if ( event->angleDelta().y() > 0 )
   {
-    setComponentValue( componentValue() + 1 );
+    setComponentValueF( oldValue + delta );
   }
   else
   {
-    setComponentValue( componentValue() - 1 );
+    setComponentValueF( oldValue - delta );
   }
 
-  if ( componentValue() != oldValue )
+  if ( !qgsDoubleNear( componentValueF(), oldValue ) )
   {
     //value has changed
     emit colorChanged( mCurrentColor );
+    Q_NOWARN_DEPRECATED_PUSH
     emit valueChanged( componentValue() );
+    Q_NOWARN_DEPRECATED_POP
+    emit valueChangedF( componentValueF() );
   }
 
   event->accept();
@@ -1337,37 +1335,38 @@ void QgsColorRampWidget::mouseReleaseEvent( QMouseEvent *event )
 
 void QgsColorRampWidget::keyPressEvent( QKeyEvent *event )
 {
-  const int oldValue = componentValue();
+  const float oldValue = componentValueF();
+  const float delta = 1.f / static_cast<float>( componentRange() );
   if ( ( mOrientation == QgsColorRampWidget::Horizontal && ( event->key() == Qt::Key_Right || event->key() == Qt::Key_Up ) )
        || ( mOrientation == QgsColorRampWidget::Vertical && ( event->key() == Qt::Key_Left || event->key() == Qt::Key_Up ) ) )
   {
-    setComponentValue( componentValue() + 1 );
+    setComponentValueF( oldValue + delta );
   }
   else if ( ( mOrientation == QgsColorRampWidget::Horizontal && ( event->key() == Qt::Key_Left || event->key() == Qt::Key_Down ) )
             || ( mOrientation == QgsColorRampWidget::Vertical && ( event->key() == Qt::Key_Right || event->key() == Qt::Key_Down ) ) )
   {
-    setComponentValue( componentValue() - 1 );
+    setComponentValueF( oldValue - delta );
   }
   else if ( ( mOrientation == QgsColorRampWidget::Horizontal && event->key() == Qt::Key_PageDown )
             || ( mOrientation == QgsColorRampWidget::Vertical && event->key() == Qt::Key_PageUp ) )
   {
-    setComponentValue( componentValue() + 10 );
+    setComponentValueF( oldValue + 10 * delta );
   }
   else if ( ( mOrientation == QgsColorRampWidget::Horizontal && event->key() == Qt::Key_PageUp )
             || ( mOrientation == QgsColorRampWidget::Vertical && event->key() == Qt::Key_PageDown ) )
   {
-    setComponentValue( componentValue() - 10 );
+    setComponentValueF( oldValue - 10 * delta );
   }
   else if ( ( mOrientation == QgsColorRampWidget::Horizontal && event->key() == Qt::Key_Home )
             || ( mOrientation == QgsColorRampWidget::Vertical && event->key() == Qt::Key_End ) )
   {
-    setComponentValue( 0 );
+    setComponentValueF( 0 );
   }
   else if ( ( mOrientation == QgsColorRampWidget::Horizontal && event->key() == Qt::Key_End )
             || ( mOrientation == QgsColorRampWidget::Vertical && event->key() == Qt::Key_Home ) )
   {
     //set to maximum value
-    setComponentValue( componentRange() );
+    setComponentValueF( 1.f );
   }
   else
   {
@@ -1375,34 +1374,43 @@ void QgsColorRampWidget::keyPressEvent( QKeyEvent *event )
     return;
   }
 
-  if ( componentValue() != oldValue )
+  if ( !qgsDoubleNear( componentValueF(), oldValue ) )
   {
     //value has changed
     emit colorChanged( mCurrentColor );
+    Q_NOWARN_DEPRECATED_PUSH
     emit valueChanged( componentValue() );
+    Q_NOWARN_DEPRECATED_POP
+    emit valueChangedF( componentValueF() );
   }
 }
 
 void QgsColorRampWidget::setColorFromPoint( QPointF point )
 {
-  const int oldValue = componentValue();
-  int val;
+  const float oldValue = componentValueF();
+  float val;
+  const float margin = static_cast<float>( mMargin );
+  const float w = static_cast<float>( width() );
+  const float h = static_cast<float>( height() );
+
   if ( mOrientation == QgsColorRampWidget::Horizontal )
   {
-    val = componentRange() * ( point.x() - mMargin ) / ( width() - 2 * mMargin );
+    val = ( static_cast<float>( point.x() ) - margin ) / ( w - 2 * margin );
   }
   else
   {
-    val = componentRange() - componentRange() * ( point.y() - mMargin ) / ( height() - 2 * mMargin );
+    val = 1.f - ( static_cast<float>( point.y() ) - margin ) / ( h - 2 * margin );
   }
-  val = std::max( 0, std::min( val, componentRange() ) );
-  setComponentValue( val );
+  setComponentValueF( val );
 
-  if ( componentValue() != oldValue )
+  if ( !qgsDoubleNear( componentValueF(), oldValue ) )
   {
     //value has changed
     emit colorChanged( mCurrentColor );
+    Q_NOWARN_DEPRECATED_PUSH
     emit valueChanged( componentValue() );
+    Q_NOWARN_DEPRECATED_POP
+    emit valueChangedF( componentValueF() );
   }
 }
 
@@ -1422,13 +1430,13 @@ QgsColorSliderWidget::QgsColorSliderWidget( QWidget *parent, const ColorComponen
   mRampWidget->setColor( mCurrentColor );
   hLayout->addWidget( mRampWidget, 1 );
 
-  mSpinBox = new QSpinBox();
+  mSpinBox = new QDoubleSpinBox();
   //set spinbox to a reasonable width
   const int largestCharWidth = mSpinBox->fontMetrics().horizontalAdvance( QStringLiteral( "888%" ) );
   mSpinBox->setMinimumWidth( largestCharWidth + 35 );
   mSpinBox->setMinimum( 0 );
-  mSpinBox->setMaximum( convertRealToDisplay( componentRange() ) );
-  mSpinBox->setValue( convertRealToDisplay( componentValue() ) );
+  mSpinBox->setMaximum( convertRealToDisplay( 1.f ) );
+  mSpinBox->setValue( convertRealToDisplay( componentValueF() ) );
   if ( component == QgsColorWidget::Hue )
   {
     //degrees suffix for hue
@@ -1441,9 +1449,9 @@ QgsColorSliderWidget::QgsColorSliderWidget( QWidget *parent, const ColorComponen
   hLayout->addWidget( mSpinBox );
   setLayout( hLayout );
 
-  connect( mRampWidget, &QgsColorRampWidget::valueChanged, this, &QgsColorSliderWidget::rampChanged );
+  connect( mRampWidget, &QgsColorRampWidget::valueChangedF, this, &QgsColorSliderWidget::rampChanged );
   connect( mRampWidget, &QgsColorWidget::colorChanged, this, &QgsColorSliderWidget::rampColorChanged );
-  connect( mSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsColorSliderWidget::spinChanged );
+  connect( mSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsColorSliderWidget::spinChanged );
 }
 
 void QgsColorSliderWidget::setComponent( const QgsColorWidget::ColorComponent component )
@@ -1468,11 +1476,11 @@ void QgsColorSliderWidget::setComponent( const QgsColorWidget::ColorComponent co
   }
 }
 
-void QgsColorSliderWidget::setComponentValue( const int value )
+void QgsColorSliderWidget::setComponentValueF( const float value )
 {
-  QgsColorWidget::setComponentValue( value );
+  QgsColorWidget::setComponentValueF( value );
   mRampWidget->blockSignals( true );
-  mRampWidget->setComponentValue( value );
+  mRampWidget->setComponentValueF( value );
   mRampWidget->blockSignals( false );
   mSpinBox->blockSignals( true );
   mSpinBox->setValue( convertRealToDisplay( value ) );
@@ -1484,7 +1492,7 @@ void QgsColorSliderWidget::setColor( const QColor &color, bool emitSignals )
   QgsColorWidget::setColor( color, emitSignals );
   mRampWidget->setColor( color );
   mSpinBox->blockSignals( true );
-  mSpinBox->setValue( convertRealToDisplay( componentValue() ) );
+  mSpinBox->setValue( convertRealToDisplay( componentValueF() ) );
   mSpinBox->blockSignals( false );
 }
 
@@ -1493,15 +1501,15 @@ void QgsColorSliderWidget::rampColorChanged( const QColor &color )
   emit colorChanged( color );
 }
 
-void QgsColorSliderWidget::spinChanged( int value )
+void QgsColorSliderWidget::spinChanged( double value )
 {
-  const int convertedValue = convertDisplayToReal( value );
-  QgsColorWidget::setComponentValue( convertedValue );
-  mRampWidget->setComponentValue( convertedValue );
+  const float convertedValue = convertDisplayToReal( static_cast<float>( value ) );
+  QgsColorWidget::setComponentValueF( convertedValue );
+  mRampWidget->setComponentValueF( convertedValue );
   emit colorChanged( mCurrentColor );
 }
 
-void QgsColorSliderWidget::rampChanged( int value )
+void QgsColorSliderWidget::rampChanged( float value )
 {
   mSpinBox->blockSignals( true );
   mSpinBox->setValue( convertRealToDisplay( value ) );
@@ -1509,29 +1517,38 @@ void QgsColorSliderWidget::rampChanged( int value )
 }
 
 
-int QgsColorSliderWidget::convertRealToDisplay( const int realValue ) const
+float QgsColorSliderWidget::convertRealToDisplay( const float realValue ) const
 {
   //scale saturation, value or alpha to 0->100 range. This makes more sense for users
   //for whom "255" is a totally arbitrary value!
   if ( mComponent == QgsColorWidget::Saturation || mComponent == QgsColorWidget::Value || mComponent == QgsColorWidget::Alpha )
   {
-    return std::round( 100.0 * realValue / 255.0 );
+    return realValue * 100.f;
   }
-
-  //leave all other values intact
-  return realValue;
+  else if ( mComponent == QgsColorWidget::Hue )
+  {
+    return realValue * HUE_MAX;
+  }
+  else
+  {
+    return realValue * 255.f;
+  }
 }
 
-int QgsColorSliderWidget::convertDisplayToReal( const int displayValue ) const
+float QgsColorSliderWidget::convertDisplayToReal( const float displayValue ) const
 {
-  //scale saturation, value or alpha from 0->100 range (see note in convertRealToDisplay)
   if ( mComponent == QgsColorWidget::Saturation || mComponent == QgsColorWidget::Value || mComponent == QgsColorWidget::Alpha )
   {
-    return std::round( 255.0 * displayValue / 100.0 );
+    return displayValue / 100.f;
   }
-
-  //leave all other values intact
-  return displayValue;
+  else if ( mComponent == QgsColorWidget::Hue )
+  {
+    return displayValue / HUE_MAX;
+  }
+  else
+  {
+    return displayValue / 255.f;
+  }
 }
 
 //

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -42,6 +42,14 @@
 
 #define HUE_MAX 359
 
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+typedef qreal float_type;
+#else
+typedef float float_type;
+#endif
+
+
 //
 // QgsColorWidget
 //
@@ -177,11 +185,11 @@ void QgsColorWidget::alterColor( QColor &color, const QgsColorWidget::ColorCompo
 
 void QgsColorWidget::alterColorF( QColor &color, const QgsColorWidget::ColorComponent component, const float newValue )
 {
-  float clippedValue = std::clamp( newValue, 0.f, 1.f );
+  float_type clippedValue = std::clamp( newValue, 0.f, 1.f );
 
   if ( colorSpec( component ) == QColor::Spec::Cmyk )
   {
-    float c, m, y, k, a;
+    float_type c, m, y, k, a;
     color.getCmykF( &c, &m, &y, &k, &a );
 
     switch ( component )
@@ -204,9 +212,9 @@ void QgsColorWidget::alterColorF( QColor &color, const QgsColorWidget::ColorComp
   }
   else
   {
-    float r, g, b, a;
+    float_type r, g, b, a;
     color.getRgbF( &r, &g, &b, &a );
-    float h, s, v;
+    float_type h, s, v;
     color.getHsvF( &h, &s, &v );
 
     switch ( component )
@@ -365,7 +373,7 @@ void QgsColorWidget::setComponentValueF( const float value )
   //overwrite hue with explicit hue if required
   if ( mComponent == QgsColorWidget::Saturation || mComponent == QgsColorWidget::Value )
   {
-    float h, s, v, a;
+    float_type h, s, v, a;
     mCurrentColor.getHsvF( &h, &s, &v, &a );
 
     h = hueF();
@@ -577,7 +585,7 @@ void QgsColorWheel::setColorFromPos( const QPointF pos )
 
   QColor newColor = QColor();
 
-  float h, s, l, alpha;
+  float_type h, s, l, alpha;
   mCurrentColor.getHslF( &h, &s, &l, &alpha );
   //override hue with explicit hue, so we don't get -1 values from QColor for hue
   h = hueF();

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -19,6 +19,7 @@
 #include "qgssettings.h"
 #include "qgslogger.h"
 #include "qgsguiutils.h"
+#include "qgsdoublespinbox.h"
 
 #include <QResizeEvent>
 
@@ -29,7 +30,6 @@
 #endif
 #include <QPainter>
 #include <QHBoxLayout>
-#include <QDoubleSpinBox>
 #include <QLineEdit>
 #include <QFontMetrics>
 #include <QToolButton>
@@ -1438,7 +1438,8 @@ QgsColorSliderWidget::QgsColorSliderWidget( QWidget *parent, const ColorComponen
   mRampWidget->setColor( mCurrentColor );
   hLayout->addWidget( mRampWidget, 1 );
 
-  mSpinBox = new QDoubleSpinBox();
+  mSpinBox = new QgsDoubleSpinBox();
+  mSpinBox->setShowClearButton( false );
   //set spinbox to a reasonable width
   const int largestCharWidth = mSpinBox->fontMetrics().horizontalAdvance( QStringLiteral( "888%" ) );
   mSpinBox->setMinimumWidth( largestCharWidth + 35 );

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -1173,12 +1173,12 @@ void QgsColorRampWidget::paintEvent( QPaintEvent *event )
       if ( mOrientation == QgsColorRampWidget::Horizontal )
       {
         //horizontal
-        painter.drawLine( c + mMargin, mMargin, c + mMargin, height() - mMargin - 1 );
+        painter.drawLine( QLineF( c + mMargin, mMargin, c + mMargin, height() - mMargin - 1 ) );
       }
       else
       {
         //vertical
-        painter.drawLine( mMargin, c + mMargin, width() - mMargin - 1, c + mMargin );
+        painter.drawLine( QLineF( mMargin, c + mMargin, width() - mMargin - 1, c + mMargin ) );
       }
     }
   }

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -672,6 +672,7 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      */
     void setColorFromPoint( QPointF point );
 
+    friend class TestQgsCompoundColorWidget;
 };
 
 
@@ -740,6 +741,7 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
      */
     void rampChanged( float value );
 
+    friend class TestQgsCompoundColorWidget;
 };
 
 

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -230,7 +230,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * valid range for the color component.
      * \deprecated since QGIS 3.40. Use alterColorF() instead.
      */
-    static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue );
+    Q_DECL_DEPRECATED static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) SIP_DEPRECATED;
 
     /**
      * Alters a color by modifying the value of a specific color component

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -22,7 +22,7 @@
 #include "qgis_sip.h"
 
 class QColor;
-class QSpinBox;
+class QDoubleSpinBox;
 class QLineEdit;
 class QToolButton;
 
@@ -87,8 +87,19 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * set
      * \see setComponentValue
      * \see component
+     * \deprecated since QGIS 3.40. Use componentValueF() instead.
      */
-    int componentValue() const;
+    Q_DECL_DEPRECATED int componentValue() const;
+
+    /**
+     * Returns the current value of the widget's color component
+     * \returns value of color component, or -1 if widget has multiple components or an invalid color
+     * set
+     * \see setComponentValueF
+     * \see component
+     * \since QGIS 3.40
+     */
+    float componentValueF() const;
 
     /**
      * Create an icon for dragging colors
@@ -115,14 +126,27 @@ class GUI_EXPORT QgsColorWidget : public QWidget
 
     /**
      * Alters the widget's color by setting the value for the widget's color component
-     * \param value value for widget's color component. This value is automatically
-     * clipped to the range of valid values for the color component.
+     * \param value value for widget's color component in the range between 0 and the value returned by componentRange().
+     * This value is automatically clipped to the range of valid values for the color component.
      * \see componentValue
      * \see setComponent
      * \note this method has no effect if the widget is set to the QgsColorWidget::Multiple
      * component
+     * \deprecated since QGIS 3.40. Use setComponentValueF() instead.
      */
-    virtual void setComponentValue( int value );
+    Q_DECL_DEPRECATED virtual void setComponentValue( int value );
+
+    /**
+     * Alters the widget's color by setting the value for the widget's color component
+     * \param value value for widget's color component in the range 0.0-1.0.
+     * This value is automatically clipped to the range 0.0-1.0.
+     * \see componentValue
+     * \see setComponent
+     * \note this method has no effect if the widget is set to the QgsColorWidget::Multiple
+     * component
+     * \since QGIS 3.40
+     */
+    virtual void setComponentValueF( float value );
 
   signals:
 
@@ -147,7 +171,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * QColor wipes the hue information when it is ambiguous (e.g., for saturation = 0). So
      * the hue is stored in mExplicit hue to keep it around, as it is useful when modifying colors
      */
-    int mExplicitHue = 0;
+    float mExplicitHue = 0;
 
     /**
      * Returns the range of valid values for the color widget's component
@@ -165,26 +189,58 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * Returns the value of a component of the widget's current color. This method correctly
      * handles hue values when the color has an ambiguous hue (e.g., black or white shades)
      * \param component color component to return
-     * \returns value of color component, or -1 if widget has an invalid color set
-     * \see hue
+     * \returns value of color component in the range between 0 and the value returned by componentRange(),
+     * or -1 if widget has an invalid color set
+     * \see hue()
+     * \deprecated since QGIS 3.40. Use componentValueF() instead.
      */
-    int componentValue( ColorComponent component ) const;
+    Q_DECL_DEPRECATED int componentValue( ColorComponent component ) const;
+
+    /**
+     * Returns the value of a component of the widget's current color. This method correctly
+     * handles hue values when the color has an ambiguous hue (e.g., black or white shades)
+     * \param component color component to return
+     * \returns value of color component in the range 0-1.0, or -1 if widget has an invalid color set
+     * \see hue()
+     * \since QGIS 3.40
+     */
+    float componentValueF( ColorComponent component ) const;
 
     /**
      * Returns the hue for the widget. This may differ from the hue for the QColor returned by color(),
      * as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
-     * \returns explicitly set hue for widget
+     * \returns explicitly set hue for widget in the range 0-359
+     * \deprecated since QGIS 3.40. Use hueF() instead.
      */
-    int hue() const;
+    Q_DECL_DEPRECATED int hue() const;
+
+    /**
+     * Returns the hue for the widget. This may differ from the hue for the QColor returned by color(),
+     * as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
+     * \returns explicitly set hue for widget in the range 0-1.0
+     * \since QGIS 3.40
+     */
+    float hueF() const;
 
     /**
      * Alters a color by modifying the value of a specific color component
      * \param color color to alter
      * \param component color component to alter
-     * \param newValue new value of color component. Values are automatically clipped to a
+     * \param newValue new value of color component in the range between 0 and the value returned by componentRange(). Values are automatically clipped to a
      * valid range for the color component.
+     * \deprecated since QGIS 3.40. Use alterColorF() instead.
      */
     static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue );
+
+    /**
+     * Alters a color by modifying the value of a specific color component
+     * \param color color to alter
+     * \param component color component to alter
+     * \param newValue new value of color component in the range between 0 and the value returned by componentRange(). Values are automatically clipped to
+     * range 0.0-1.0
+     * \since QGIS 3.40
+     */
+    static void alterColorF( QColor &color, QgsColorWidget::ColorComponent component, float newValue );
 
     /**
      * Returns color widget type of color, either RGB, HSV, CMYK, or Invalid if this component value is Multiple or Alpha
@@ -430,7 +486,7 @@ class GUI_EXPORT QgsColorBox : public QgsColorWidget
     bool mIsDragging = false;
 
     /*Margin between outer ring and edge of widget*/
-    int mMargin = 2;
+    static constexpr float mMargin = 2.;
 
     /*Cached image for color box*/
     QImage *mBoxImage = nullptr;
@@ -447,13 +503,13 @@ class GUI_EXPORT QgsColorBox : public QgsColorWidget
      * Returns the range of permissible values along the x axis
      * \returns maximum color component value for x axis
      */
-    int valueRangeX() const;
+    float valueRangeX() const;
 
     /**
      * Returns the range of permissible values along the y axis
      * \returns maximum color component value for y axis
      */
-    int valueRangeY() const;
+    float valueRangeY() const;
 
     /**
      * Returns the color component which varies along the y axis
@@ -463,7 +519,7 @@ class GUI_EXPORT QgsColorBox : public QgsColorWidget
     /**
      * Returns the value of the color component which varies along the y axis
      */
-    int yComponentValue() const;
+    float yComponentValue() const;
 
     /**
      * Returns the color component which varies along the x axis
@@ -473,7 +529,7 @@ class GUI_EXPORT QgsColorBox : public QgsColorWidget
     /**
      * Returns the value of the color component which varies along the x axis
      */
-    int xComponentValue() const;
+    float xComponentValue() const;
 
     /**
      * Updates the widget's color based on a point within the widget
@@ -571,9 +627,17 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
 
     /**
      * Emitted when the widget's color component value changes
-     * \param value new value of color component
+     * \param value new value of color component in the range between 0 and the value returned by componentRange()
+     * \deprecated since QGIS 3.40. Use valueChangedF() instead.
      */
-    void valueChanged( int value );
+    Q_DECL_DEPRECATED void valueChanged( int value );
+
+    /**
+     * Emitted when the widget's color component value changes
+     * \param value new value of color component in the range 0.0-1.0
+     * \since QGIS 3.40
+     */
+    void valueChangedF( float value );
 
   protected:
 
@@ -631,7 +695,7 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
     QgsColorSliderWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr, ColorComponent component = QgsColorWidget::Red );
 
     void setComponent( ColorComponent component ) override;
-    void setComponentValue( int value ) override;
+    void setComponentValueF( float value ) override;
     void setColor( const QColor &color, bool emitSignals = false ) override;
 
   private:
@@ -640,24 +704,24 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
     QgsColorRampWidget *mRampWidget = nullptr;
 
     /*Spin box widget*/
-    QSpinBox *mSpinBox = nullptr;
+    QDoubleSpinBox *mSpinBox = nullptr;
 
     /**
      * Converts the real value of a color component to a friendly display value. For instance,
      * alpha values from 0-255 have little meaning to users, so we translate them to 0-100%
-     * \param realValue actual value of the color component
+     * \param realValue actual value of the color component in the range 0.0-1.0
      * \returns display value of color component
      * \see convertDisplayToReal
      */
-    int convertRealToDisplay( int realValue ) const;
+    float convertRealToDisplay( float realValue ) const;
 
     /**
      * Converts the display value of a color component to a real value.
      * \param displayValue friendly display value of the color component
-     * \returns real value of color component
+     * \returns real value of color component in the range 0.0-1.0
      * \see convertRealToDisplay
      */
-    int convertDisplayToReal( int displayValue ) const;
+    float convertDisplayToReal( float displayValue ) const;
 
   private slots:
 
@@ -669,12 +733,12 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
     /**
      * Called when the value of the spin box changes
      */
-    void spinChanged( int value );
+    void spinChanged( double value );
 
     /**
      * Called when the value for the ramp changes
      */
-    void rampChanged( int value );
+    void rampChanged( float value );
 
 };
 

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -89,7 +89,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \see component
      * \deprecated since QGIS 3.40. Use componentValueF() instead.
      */
-    Q_DECL_DEPRECATED int componentValue() const;
+    Q_DECL_DEPRECATED int componentValue() const SIP_DEPRECATED;
 
     /**
      * Returns the current value of the widget's color component
@@ -134,7 +134,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * component
      * \deprecated since QGIS 3.40. Use setComponentValueF() instead.
      */
-    Q_DECL_DEPRECATED virtual void setComponentValue( int value );
+    Q_DECL_DEPRECATED virtual void setComponentValue( int value ) SIP_DEPRECATED;
 
     /**
      * Alters the widget's color by setting the value for the widget's color component
@@ -194,7 +194,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \see hue()
      * \deprecated since QGIS 3.40. Use componentValueF() instead.
      */
-    Q_DECL_DEPRECATED int componentValue( ColorComponent component ) const;
+    Q_DECL_DEPRECATED int componentValue( ColorComponent component ) const SIP_DEPRECATED;
 
     /**
      * Returns the value of a component of the widget's current color. This method correctly
@@ -212,7 +212,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \returns explicitly set hue for widget in the range 0-359
      * \deprecated since QGIS 3.40. Use hueF() instead.
      */
-    Q_DECL_DEPRECATED int hue() const;
+    Q_DECL_DEPRECATED int hue() const SIP_DEPRECATED;
 
     /**
      * Returns the hue for the widget. This may differ from the hue for the QColor returned by color(),
@@ -630,7 +630,7 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      * \param value new value of color component in the range between 0 and the value returned by componentRange()
      * \deprecated since QGIS 3.40. Use valueChangedF() instead.
      */
-    Q_DECL_DEPRECATED void valueChanged( int value );
+    Q_DECL_DEPRECATED void valueChanged( int value ) SIP_DEPRECATED;
 
     /**
      * Emitted when the widget's color component value changes

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -22,9 +22,9 @@
 #include "qgis_sip.h"
 
 class QColor;
-class QDoubleSpinBox;
 class QLineEdit;
 class QToolButton;
+class QgsDoubleSpinBox;
 
 /**
  * \ingroup gui
@@ -705,7 +705,7 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
     QgsColorRampWidget *mRampWidget = nullptr;
 
     /*Spin box widget*/
-    QDoubleSpinBox *mSpinBox = nullptr;
+    QgsDoubleSpinBox *mSpinBox = nullptr;
 
     /**
      * Converts the real value of a color component to a friendly display value. For instance,

--- a/tests/src/gui/testqgscompoundcolorwidget.cpp
+++ b/tests/src/gui/testqgscompoundcolorwidget.cpp
@@ -248,6 +248,8 @@ void TestQgsCompoundColorWidget::testSliderWidgets()
   QgsCompoundColorWidget w( nullptr, QColor::fromRgbF( 0.12f, 0.34f, 0.56, 0.78 ) );
   w.setVisible( true );
 
+  // TODO QGIS 4 remove the nolint instructions, QColor was qreal (double) and is now float
+  // NOLINTBEGIN(bugprone-narrowing-conversions)
   QCOMPARE( w.mRedSlider->mSpinBox->value(), 30.6 );
   compareFloat( w.mRedSlider->mRampWidget->color().redF(), 0.12f );
   QCOMPARE( w.mGreenSlider->mSpinBox->value(), 86.7 );
@@ -281,6 +283,7 @@ void TestQgsCompoundColorWidget::testSliderWidgets()
   compareFloat( w.mSaturationSlider->mRampWidget->color().saturationF(), 0.5f );
   QCOMPARE( w.mValueSlider->mSpinBox->value(), 50 );
   compareFloat( w.mValueSlider->mRampWidget->color().greenF(), 0.5f );
+  // NOLINTEND(bugprone-narrowing-conversions)
 }
 
 

--- a/tests/src/gui/testqgscompoundcolorwidget.cpp
+++ b/tests/src/gui/testqgscompoundcolorwidget.cpp
@@ -17,6 +17,7 @@
 
 #include "qgscompoundcolorwidget.h"
 #include "qgssettings.h"
+#include "qgsdoublespinbox.h"
 
 Q_DECLARE_METATYPE( QgsColorWidget::ColorComponent )
 

--- a/tests/src/gui/testqgscompoundcolorwidget.cpp
+++ b/tests/src/gui/testqgscompoundcolorwidget.cpp
@@ -20,6 +20,11 @@
 
 Q_DECLARE_METATYPE( QgsColorWidget::ColorComponent )
 
+void compareFloat( float a, float b )
+{
+  QVERIFY2( qgsDoubleNear( a, b, 0.00001 ), QString( "%1 != %2" ).arg( a ).arg( b ).toLatin1() );
+}
+
 class TestQgsCompoundColorWidget : public QgsTest
 {
     Q_OBJECT
@@ -40,6 +45,7 @@ class TestQgsCompoundColorWidget : public QgsTest
     void testModelChange();
     void testTabChange();
     void testInvalidColor();
+    void testSliderWidgets();
 };
 
 void TestQgsCompoundColorWidget::initTestCase()
@@ -234,6 +240,46 @@ void TestQgsCompoundColorWidget::testInvalidColor()
   QCOMPARE( w.mColorModel->currentIndex(), 0 );
   QVERIFY( w.mRGB->isVisible() );
   QVERIFY( !w.mCMYK->isVisible() );
+}
+
+void TestQgsCompoundColorWidget::testSliderWidgets()
+{
+  QgsCompoundColorWidget w( nullptr, QColor::fromRgbF( 0.12f, 0.34f, 0.56, 0.78 ) );
+  w.setVisible( true );
+
+  QCOMPARE( w.mRedSlider->mSpinBox->value(), 30.6 );
+  compareFloat( w.mRedSlider->mRampWidget->color().redF(), 0.12f );
+  QCOMPARE( w.mGreenSlider->mSpinBox->value(), 86.7 );
+  compareFloat( w.mGreenSlider->mRampWidget->color().greenF(), 0.34f );
+  QCOMPARE( w.mBlueSlider->mSpinBox->value(), 142.8 );
+  compareFloat( w.mBlueSlider->mRampWidget->color().blueF(), 0.56f );
+  QCOMPARE( w.mAlphaSlider->mSpinBox->value(), 78 );
+  compareFloat( w.mAlphaSlider->mRampWidget->color().alphaF(), 0.78f );
+
+  w.mRedSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mRedSlider->mRampWidget->width() ) / 2.f, 0.f ) );
+  w.mBlueSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mBlueSlider->mRampWidget->width() ) / 2.f, 0.f ) );
+  w.mGreenSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mGreenSlider->mRampWidget->width() ) / 2.f, 0.f ) );
+  w.mAlphaSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mAlphaSlider->mRampWidget->width() ) / 2.f, 0.f ) );
+
+  QCOMPARE( w.mRedSlider->mSpinBox->value(), 127.5 );
+  compareFloat( w.mRedSlider->mRampWidget->color().redF(), 0.5f );
+  QCOMPARE( w.mBlueSlider->mSpinBox->value(), 127.5 );
+  compareFloat( w.mBlueSlider->mRampWidget->color().blueF(), 0.5f );
+  QCOMPARE( w.mGreenSlider->mSpinBox->value(), 127.5 );
+  compareFloat( w.mGreenSlider->mRampWidget->color().greenF(), 0.5f );
+  QCOMPARE( w.mAlphaSlider->mSpinBox->value(), 50 );
+  compareFloat( w.mAlphaSlider->mRampWidget->color().greenF(), 0.5f );
+
+  w.mHueSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mHueSlider->mRampWidget->width() ) / 2.f, 0.f ) );
+  w.mSaturationSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mSaturationSlider->mRampWidget->width() ) / 2.f, 0.f ) );
+  w.mValueSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mValueSlider->mRampWidget->width() ) / 2.f, 0.f ) );
+
+  QCOMPARE( w.mHueSlider->mSpinBox->value(), 179.5 );
+  compareFloat( w.mHueSlider->mRampWidget->color().hueF(), 0.5f );
+  QCOMPARE( w.mSaturationSlider->mSpinBox->value(), 50 );
+  compareFloat( w.mSaturationSlider->mRampWidget->color().saturationF(), 0.5f );
+  QCOMPARE( w.mValueSlider->mSpinBox->value(), 50 );
+  compareFloat( w.mValueSlider->mRampWidget->color().greenF(), 0.5f );
 }
 
 


### PR DESCRIPTION
Allows to select color component as float with 2 decimals.

![color_float](https://github.com/user-attachments/assets/70c3b339-0121-4dcb-8996-9769dbd1d70c)

**Funded by Bordeaux Métropole**