### PR TITLE
[ServerWFS] Remove version from OGC urn

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1633,7 +1633,7 @@ QString QgsCoordinateReferenceSystem::toOgcUrn() const
   if ( parts.length() == 2 )
   {
     if ( parts[0] == QLatin1String( "EPSG" ) )
-      return  QStringLiteral( "urn:ogc:def:crs:EPSG:0:%1" ).arg( parts[1] );
+      return  QStringLiteral( "urn:ogc:def:crs:EPSG::%1" ).arg( parts[1] );
     else if ( parts[0] == QLatin1String( "OGC" ) )
     {
       return  QStringLiteral( "urn:ogc:def:crs:OGC:1.3:%1" ).arg( parts[1] );

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -787,7 +787,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         jdata['features'][0]['geometry']
         jdata['features'][0]['geometry']['coordinates']
         self.assertEqual(jdata['features'][0]['geometry']['coordinates'], [807305, 5592878])
-        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG:0:3857")
+        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG::3857")
 
         query_string = "?" + "&".join(["%s=%s" % i for i in list({
             "SERVICE": "WFS",
@@ -836,7 +836,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         jdata['features'][0]['geometry']
         jdata['features'][0]['geometry']['coordinates']
         self.assertEqual([int(i) for i in jdata['features'][0]['geometry']['coordinates']], [361806, 4964192])
-        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG:0:32632")
+        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG::32632")
 
         query_string = "?" + "&".join(["%s=%s" % i for i in list({
             "SERVICE": "WFS",
@@ -854,7 +854,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         jdata['features'][0]['geometry']
         jdata['features'][0]['geometry']['coordinates']
         self.assertEqual([int(i) for i in jdata['features'][0]['geometry']['coordinates']], [812191, 5589555])
-        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG:0:3857")
+        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG::3857")
 
     def test_insert_srsName(self):
         """Test srsName is respected when insering"""

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_alias_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_alias_json.txt
@@ -5,7 +5,7 @@ Content-Type: application/json; charset=utf-8
   "crs":
     {
       "properties": {
-        "name": "urn:ogc:def:crs:EPSG:0:3857"
+        "name": "urn:ogc:def:crs:EPSG::3857"
       },
       "type": "name"
     },

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_exclude_attribute_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_exclude_attribute_json.txt
@@ -5,7 +5,7 @@ Content-Type: application/json; charset=utf-8
   "crs":
     {
       "properties": {
-        "name": "urn:ogc:def:crs:EPSG:0:3857"
+        "name": "urn:ogc:def:crs:EPSG::3857"
       },
       "type": "name"
     },

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geojson.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geojson.txt
@@ -5,7 +5,7 @@ Content-Type: application/geo+json; charset=utf-8
   "crs":
     {
       "properties": {
-        "name": "urn:ogc:def:crs:EPSG:0:3857"
+        "name": "urn:ogc:def:crs:EPSG::3857"
       },
       "type": "name"
     },

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_json.txt
@@ -5,7 +5,7 @@ Content-Type: application/json; charset=utf-8
   "crs":
     {
       "properties": {
-        "name": "urn:ogc:def:crs:EPSG:0:3857"
+        "name": "urn:ogc:def:crs:EPSG::3857"
       },
       "type": "name"
     },

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_json.txt
@@ -5,7 +5,7 @@ Content-Type: application/json; charset=utf-8
   "crs":
     {
       "properties": {
-        "name": "urn:ogc:def:crs:EPSG:0:3857"
+        "name": "urn:ogc:def:crs:EPSG::3857"
       },
       "type": "name"
     },

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_multiple_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_multiple_json.txt
@@ -5,7 +5,7 @@ Content-Type: application/json; charset=utf-8
   "crs":
     {
       "properties": {
-        "name": "urn:ogc:def:crs:EPSG:0:3857"
+        "name": "urn:ogc:def:crs:EPSG::3857"
       },
       "type": "name"
     },


### PR DESCRIPTION
in order to stay consistent with the whole application (GeoJSON export for instance) where version is not set. Version is optionnal (see https://www.ogc.org/about-ogc/policies/ogc-urn-policy/).

Follows  #56600
