### PR TITLE
OAuth2 configuration: trim leading/trailing blanks from most parameters set from UI to avoid weird issues

### DIFF
--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -112,41 +112,40 @@ void QgsAuthOAuth2Config::setDescription( const QString &value )
 void QgsAuthOAuth2Config::setRequestUrl( const QString &value )
 {
   const QString preval( mRequestUrl );
-  mRequestUrl = value;
-  if ( preval != value )
+  mRequestUrl = value.trimmed();
+  if ( preval != mRequestUrl )
     emit requestUrlChanged( mRequestUrl );
 }
 
 void QgsAuthOAuth2Config::setTokenUrl( const QString &value )
 {
   const QString preval( mTokenUrl );
-  mTokenUrl = value;
-  if ( preval != value )
+  mTokenUrl = value.trimmed();
+  if ( preval != mTokenUrl )
     emit tokenUrlChanged( mTokenUrl );
 }
 
 void QgsAuthOAuth2Config::setRefreshTokenUrl( const QString &value )
 {
   const QString preval( mRefreshTokenUrl );
-  mRefreshTokenUrl = value;
-  if ( preval != value )
+  mRefreshTokenUrl = value.trimmed();
+  if ( preval != mRefreshTokenUrl )
     emit refreshTokenUrlChanged( mRefreshTokenUrl );
 }
 
 void QgsAuthOAuth2Config::setRedirectHost( const QString &host )
 {
-  if ( mRedirectHost != host )
-  {
-    mRedirectHost = host;
+  const QString preval( mRedirectHost );
+  mRedirectHost = host.trimmed();
+  if ( preval != mRedirectHost )
     emit redirectHostChanged( mRedirectHost );
-  }
 }
 
 void QgsAuthOAuth2Config::setRedirectUrl( const QString &value )
 {
   const QString preval( mRedirectURL );
-  mRedirectURL = value;
-  if ( preval != value )
+  mRedirectURL = value.trimmed();
+  if ( preval != mRedirectURL )
     emit redirectUrlChanged( mRedirectURL );
 }
 
@@ -154,23 +153,23 @@ void QgsAuthOAuth2Config::setRedirectPort( int value )
 {
   const int preval( mRedirectPort );
   mRedirectPort = value;
-  if ( preval != value )
+  if ( preval != mRedirectPort )
     emit redirectPortChanged( mRedirectPort );
 }
 
 void QgsAuthOAuth2Config::setClientId( const QString &value )
 {
   const QString preval( mClientId );
-  mClientId = value;
-  if ( preval != value )
+  mClientId = value.trimmed();
+  if ( preval != mClientId )
     emit clientIdChanged( mClientId );
 }
 
 void QgsAuthOAuth2Config::setClientSecret( const QString &value )
 {
   const QString preval( mClientSecret );
-  mClientSecret = value;
-  if ( preval != value )
+  mClientSecret = value.trimmed();
+  if ( preval != mClientSecret )
     emit clientSecretChanged( mClientSecret );
 }
 


### PR DESCRIPTION
I've been bitten by deadlock/crashes (in
src/auth/oauth2/core/qgsauthoauth2method.cpp, and with messages about O2ReplyServer parent thread not being the current one), when erroneously inserting a space character before the OAuth2 refresh token URL (' https://something'). Removing it makes things work nicely.

So while this doesn't fix a potential more fundamental threading issue in some scenarios, this at least avoids this weird error.
