### PR TITLE
[gui][code editor] Fix lack of styling for python lexer's unclosed strings and f-strings causing issues with dark themes

### DIFF
--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -120,6 +120,7 @@ void QgsCodeEditorPython::initializeLexer()
   pyLexer->setFont( font, QsciLexerPython::DoubleQuotedString );
 
   pyLexer->setColor( defaultColor, QsciLexerPython::Default );
+  pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Error ), QsciLexerPython::UnclosedString );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Class ), QsciLexerPython::ClassName );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Method ), QsciLexerPython::FunctionMethodName );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Number ), QsciLexerPython::Number );
@@ -130,7 +131,9 @@ void QgsCodeEditorPython::initializeLexer()
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Keyword ), QsciLexerPython::Keyword );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Decoration ), QsciLexerPython::Decorator );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::SingleQuote ), QsciLexerPython::SingleQuotedString );
+  pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::SingleQuote ), QsciLexerPython::SingleQuotedFString );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::DoubleQuote ), QsciLexerPython::DoubleQuotedString );
+  pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::DoubleQuote ), QsciLexerPython::DoubleQuotedFString );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::TripleSingleQuote ), QsciLexerPython::TripleSingleQuotedString );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::TripleDoubleQuote ), QsciLexerPython::TripleDoubleQuotedString );
 


### PR DESCRIPTION
Our python editor's lexer is missing color formatting for unclosed strings as well as f-strings. Using dark themes, the missing f-string coloring makes it nearly impossible to read these using the python editor (to edit a processing script for e.g.).

Before (barely to completely unreadable):

![Screenshot from 2024-08-16 11-01-20](https://github.com/user-attachments/assets/b9e3d6f0-2c36-46f4-9fa3-96047cf643cd)

After (I can read!):

![Screenshot from 2024-08-16 11-01-58](https://github.com/user-attachments/assets/56cc13ba-ead1-42fe-96a1-45eeea4e55e1)
