### PR TITLE
Multiple processing script editor dialog papercut fixes

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -104,6 +104,17 @@ Returns the widget's associated file path.
 .. seealso:: :py:func:`filePathChanged`
 %End
 
+    bool save( const QString &path = QString() );
+%Docstring
+Saves the code editor content into the file ``path``.
+
+.. note::
+
+   When the path is empty, the content will be saved to the current file path if not empty
+
+.. versionadded:: 3.38.2
+%End
+
   public slots:
 
     void showSearchBar();

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -108,9 +108,11 @@ Returns the widget's associated file path.
 %Docstring
 Saves the code editor content into the file ``path``.
 
+:return: ``False`` if the file path has not previously been set, or if writing the file fails.
+
 .. note::
 
-   When the path is empty, the content will be saved to the current file path if not empty
+   When the path is empty, the content will be saved to the current file path if not empty.
 
 .. versionadded:: 3.38.2
 %End

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -380,9 +380,7 @@ class Editor(QgsCodeEditorPython):
             self.reformatCode()
 
         index = self.tab_widget.indexOf(self.editor_tab)
-        if filename:
-            self.code_editor_widget.setFilePath(filename)
-        if not self.code_editor_widget.filePath():
+        if not filename and not self.code_editor_widget.filePath():
             saveTr = QCoreApplication.translate('PythonConsole',
                                                 'Python Console: Save file')
             folder = QgsSettings().value("pythonConsole/lastDirPath", QDir.homePath())
@@ -394,11 +392,13 @@ class Editor(QgsCodeEditorPython):
             if not path:
                 self.code_editor_widget.setFilePath(None)
                 return
-            self.code_editor_widget.setFilePath(path)
+            filename = path
 
-            msgText = QCoreApplication.translate('PythonConsole',
-                                                 'Script was correctly saved.')
-            self.showMessage(msgText)
+        self.code_editor_widget.save(filename)
+
+        msgText = QCoreApplication.translate('PythonConsole',
+                                             'Script was correctly saved.')
+        self.showMessage(msgText)
 
         # Save the new contents
         # Need to use newline='' to avoid adding extra \r characters on Windows

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -104,6 +104,17 @@ Returns the widget's associated file path.
 .. seealso:: :py:func:`filePathChanged`
 %End
 
+    bool save( const QString &path = QString() );
+%Docstring
+Saves the code editor content into the file ``path``.
+
+.. note::
+
+   When the path is empty, the content will be saved to the current file path if not empty
+
+.. versionadded:: 3.38.2
+%End
+
   public slots:
 
     void showSearchBar();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorwidget.sip.in
@@ -108,9 +108,11 @@ Returns the widget's associated file path.
 %Docstring
 Saves the code editor content into the file ``path``.
 
+:return: ``False`` if the file path has not previously been set, or if writing the file fails.
+
 .. note::
 
-   When the path is empty, the content will be saved to the current file path if not empty
+   When the path is empty, the content will be saved to the current file path if not empty.
 
 .. versionadded:: 3.38.2
 %End

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -230,23 +230,11 @@ class ScriptEditorDialog(BASE, WIDGET):
 
             if newPath:
                 newPath = QgsFileUtils.ensureFileNameHasExtension(newPath, ['py'])
-                self.code_editor_widget.setFilePath(newPath)
+                self.code_editor_widget.save(newPath)
+        elif self.code_editor_widget.filePath():
+            self.code_editor_widget.save()
 
-        if self.code_editor_widget.filePath():
-            text = self.editor.text()
-            try:
-                with codecs.open(self.code_editor_widget.filePath(),
-                                 "w", encoding="utf-8") as f:
-                    f.write(text)
-            except OSError as e:
-                QMessageBox.warning(self,
-                                    self.tr("I/O error"),
-                                    self.tr("Unable to save edits:\n{}").format(str(e))
-                                    )
-                return
-
-            self.setHasChanged(False)
-
+        self.setHasChanged(False)
         QgsApplication.processingRegistry().providerById("script").refreshAlgorithms()
 
     def _on_text_modified(self):

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -146,7 +146,7 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.actionIncreaseFontSize.triggered.connect(self.editor.zoomIn)
         self.actionDecreaseFontSize.triggered.connect(self.editor.zoomOut)
         self.actionToggleComment.triggered.connect(self.editor.toggleComment)
-        self.editor.textChanged.connect(self._on_text_modified)
+        self.editor.modificationChanged.connect(self._on_text_modified)
 
         self.run_dialog = None
 
@@ -237,8 +237,8 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.setHasChanged(False)
         QgsApplication.processingRegistry().providerById("script").refreshAlgorithms()
 
-    def _on_text_modified(self):
-        self.setHasChanged(True)
+    def _on_text_modified(self, modified):
+        self.setHasChanged(modified)
 
     def setHasChanged(self, hasChanged):
         self.hasChanged = hasChanged

--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -275,6 +275,12 @@ bool QgsCodeEditorWidget::eventFilter( QObject *obj, QEvent *event )
           QFile file( mFilePath );
           if ( file.open( QFile::ReadOnly ) )
           {
+            int currentLine = -1, currentColumn = -1;
+            if ( !mLastModified.isNull() )
+            {
+              mEditor->getCursorPosition( &currentLine, &currentColumn );
+            }
+
             const QString content = file.readAll();
 
             // don't clear, instead perform undoable actions:
@@ -287,6 +293,11 @@ bool QgsCodeEditorWidget::eventFilter( QObject *obj, QEvent *event )
             mEditor->endUndoAction();
 
             mLastModified = fi.lastModified();
+            if ( currentLine >= 0 && currentLine < mEditor->lines() )
+            {
+              mEditor->setCursorPosition( currentLine, currentColumn );
+            }
+
             emit loadedExternalChanges();
           }
         }
@@ -421,6 +432,8 @@ void QgsCodeEditorWidget::setFilePath( const QString &path )
     return;
 
   mFilePath = path;
+  mLastModified = QDateTime();
+
   emit filePathChanged( mFilePath );
 }
 

--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -424,6 +424,25 @@ void QgsCodeEditorWidget::setFilePath( const QString &path )
   emit filePathChanged( mFilePath );
 }
 
+bool QgsCodeEditorWidget::save( const QString &path )
+{
+  bool saved = false;
+  const QString filePath = !path.isEmpty() ? path : mFilePath;
+  if ( !filePath.isEmpty() )
+  {
+    QFile file( filePath );
+    if ( file.open( QFile::WriteOnly ) )
+    {
+      file.write( mEditor->text().toUtf8() );
+      file.close();
+      saved = true;
+    }
+    mLastModified = QFileInfo( filePath ).lastModified();
+    setFilePath( filePath );
+  }
+  return saved;
+}
+
 bool QgsCodeEditorWidget::openInExternalEditor( int line, int column )
 {
   if ( mFilePath.isEmpty() )

--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -439,7 +439,6 @@ void QgsCodeEditorWidget::setFilePath( const QString &path )
 
 bool QgsCodeEditorWidget::save( const QString &path )
 {
-  bool saved = false;
   const QString filePath = !path.isEmpty() ? path : mFilePath;
   if ( !filePath.isEmpty() )
   {
@@ -448,12 +447,15 @@ bool QgsCodeEditorWidget::save( const QString &path )
     {
       file.write( mEditor->text().toUtf8() );
       file.close();
-      saved = true;
+
+      mEditor->setModified( false );
+      mLastModified = QFileInfo( filePath ).lastModified();
+      setFilePath( filePath );
+
+      return true;
     }
-    mLastModified = QFileInfo( filePath ).lastModified();
-    setFilePath( filePath );
   }
-  return saved;
+  return false;
 }
 
 bool QgsCodeEditorWidget::openInExternalEditor( int line, int column )

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -119,7 +119,8 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
 
     /**
      * Saves the code editor content into the file \a path.
-     * \note When the path is empty, the content will be saved to the current file path if not empty
+     * \returns FALSE if the file path has not previously been set, or if writing the file fails.
+     * \note When the path is empty, the content will be saved to the current file path if not empty.
      * \since QGIS 3.38.2
      */
     bool save( const QString &path = QString() );

--- a/src/gui/codeeditors/qgscodeeditorwidget.h
+++ b/src/gui/codeeditors/qgscodeeditorwidget.h
@@ -117,6 +117,13 @@ class GUI_EXPORT QgsCodeEditorWidget : public QgsPanelWidget
      */
     QString filePath() const { return mFilePath; }
 
+    /**
+     * Saves the code editor content into the file \a path.
+     * \note When the path is empty, the content will be saved to the current file path if not empty
+     * \since QGIS 3.38.2
+     */
+    bool save( const QString &path = QString() );
+
   public slots:
 
     /**


### PR DESCRIPTION
## Description

Papercuts fixed by this PR:
- when a script is edited externally (e.g. an auto-formatting event through git commit), the script editor would always go back to the first line, which is a real PITA with large scripts
- when saving a script, focusing out and then back to the script dialog jumps back to the first line
- when opening a pre-existing script, it is marked as modified upon loading the content

Alongside the [dark theme fix](https://github.com/qgis/QGIS/pull/58406) in the previous PR, this makes the processing script editor dialog much, much nicer to use.