### PR TITLE
Layer styling live update UI tweaks

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -81,10 +81,6 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
 
   connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) > ( &QgsProject::layerWillBeRemoved ), this, &QgsLayerStylingWidget::layerAboutToBeRemoved );
 
-  QgsSettings settings;
-  mLiveApplyCheck->setChecked( settings.value( QStringLiteral( "UI/autoApplyStyling" ), true ).toBool() );
-  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !mLiveApplyCheck->isChecked() );
-
   mAutoApplyTimer = new QTimer( this );
   mAutoApplyTimer->setSingleShot( true );
 
@@ -104,9 +100,7 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
   connect( mAutoApplyTimer, &QTimer::timeout, this, &QgsLayerStylingWidget::apply );
 
   connect( mOptionsListWidget, &QListWidget::currentRowChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );
-  connect( mButtonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsLayerStylingWidget::apply );
   connect( mLayerCombo, &QgsMapLayerComboBox::layerChanged, this, &QgsLayerStylingWidget::setLayer );
-  connect( mLiveApplyCheck, &QAbstractButton::toggled, this, &QgsLayerStylingWidget::liveApplyToggled );
 
   mLayerCombo->setFilters( Qgis::LayerFilter::HasGeometry
                            | Qgis::LayerFilter::RasterLayer
@@ -397,7 +391,7 @@ void QgsLayerStylingWidget::apply()
 
 void QgsLayerStylingWidget::autoApply()
 {
-  if ( mLiveApplyCheck->isChecked() && !mBlockAutoApply )
+  if ( !mBlockAutoApply )
   {
     mAutoApplyTimer->start( 100 );
   }
@@ -850,14 +844,6 @@ void QgsLayerStylingWidget::layerAboutToBeRemoved( QgsMapLayer *layer )
     mAutoApplyTimer->stop();
     setLayer( nullptr );
   }
-}
-
-void QgsLayerStylingWidget::liveApplyToggled( bool liveUpdateEnabled )
-{
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "UI/autoApplyStyling" ), liveUpdateEnabled );
-
-  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !liveUpdateEnabled );
 }
 
 void QgsLayerStylingWidget::pushUndoItem( const QString &name, bool triggerRepaint )

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -83,6 +83,7 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
 
   QgsSettings settings;
   mLiveApplyCheck->setChecked( settings.value( QStringLiteral( "UI/autoApplyStyling" ), true ).toBool() );
+  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !mLiveApplyCheck->isChecked() );
 
   mAutoApplyTimer = new QTimer( this );
   mAutoApplyTimer->setSingleShot( true );
@@ -851,10 +852,12 @@ void QgsLayerStylingWidget::layerAboutToBeRemoved( QgsMapLayer *layer )
   }
 }
 
-void QgsLayerStylingWidget::liveApplyToggled( bool value )
+void QgsLayerStylingWidget::liveApplyToggled( bool liveUpdateEnabled )
 {
   QgsSettings settings;
-  settings.setValue( QStringLiteral( "UI/autoApplyStyling" ), value );
+  settings.setValue( QStringLiteral( "UI/autoApplyStyling" ), liveUpdateEnabled );
+
+  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !liveUpdateEnabled );
 }
 
 void QgsLayerStylingWidget::pushUndoItem( const QString &name, bool triggerRepaint )

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -81,6 +81,10 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
 
   connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) > ( &QgsProject::layerWillBeRemoved ), this, &QgsLayerStylingWidget::layerAboutToBeRemoved );
 
+  QgsSettings settings;
+  mLiveApplyCheck->setChecked( settings.value( QStringLiteral( "UI/autoApplyStyling" ), true ).toBool() );
+  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !mLiveApplyCheck->isChecked() );
+
   mAutoApplyTimer = new QTimer( this );
   mAutoApplyTimer->setSingleShot( true );
 
@@ -100,7 +104,9 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
   connect( mAutoApplyTimer, &QTimer::timeout, this, &QgsLayerStylingWidget::apply );
 
   connect( mOptionsListWidget, &QListWidget::currentRowChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );
+  connect( mButtonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsLayerStylingWidget::apply );
   connect( mLayerCombo, &QgsMapLayerComboBox::layerChanged, this, &QgsLayerStylingWidget::setLayer );
+  connect( mLiveApplyCheck, &QAbstractButton::toggled, this, &QgsLayerStylingWidget::liveApplyToggled );
 
   mLayerCombo->setFilters( Qgis::LayerFilter::HasGeometry
                            | Qgis::LayerFilter::RasterLayer
@@ -391,7 +397,7 @@ void QgsLayerStylingWidget::apply()
 
 void QgsLayerStylingWidget::autoApply()
 {
-  if ( !mBlockAutoApply )
+  if ( mLiveApplyCheck->isChecked() && !mBlockAutoApply )
   {
     mAutoApplyTimer->start( 100 );
   }
@@ -844,6 +850,14 @@ void QgsLayerStylingWidget::layerAboutToBeRemoved( QgsMapLayer *layer )
     mAutoApplyTimer->stop();
     setLayer( nullptr );
   }
+}
+
+void QgsLayerStylingWidget::liveApplyToggled( bool liveUpdateEnabled )
+{
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "UI/autoApplyStyling" ), liveUpdateEnabled );
+
+  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !liveUpdateEnabled );
 }
 
 void QgsLayerStylingWidget::pushUndoItem( const QString &name, bool triggerRepaint )

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -153,6 +153,7 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
   private slots:
 
     void layerAboutToBeRemoved( QgsMapLayer *layer );
+    void liveApplyToggled( bool liveUpdateEnabled );
 
   private:
     void pushUndoItem( const QString &name, bool triggerRepaint = true );

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -153,7 +153,6 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
   private slots:
 
     void layerAboutToBeRemoved( QgsMapLayer *layer );
-    void liveApplyToggled( bool liveUpdateEnabled );
 
   private:
     void pushUndoItem( const QString &name, bool triggerRepaint = true );

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -153,7 +153,7 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
   private slots:
 
     void layerAboutToBeRemoved( QgsMapLayer *layer );
-    void liveApplyToggled( bool value );
+    void liveApplyToggled( bool liveUpdateEnabled );
 
   private:
     void pushUndoItem( const QString &name, bool triggerRepaint = true );

--- a/src/ui/qgsmapstylingwidgetbase.ui
+++ b/src/ui/qgsmapstylingwidgetbase.ui
@@ -39,7 +39,7 @@
           <string>Not supported or no layer</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -76,7 +76,7 @@
             </sizepolicy>
            </property>
            <property name="sizeAdjustPolicy">
-            <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+            <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
            </property>
           </widget>
          </item>
@@ -121,7 +121,7 @@
          <item>
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -131,44 +131,15 @@
            </property>
           </spacer>
          </item>
-         <item>
-          <widget class="QCheckBox" name="mLiveApplyCheck">
-           <property name="toolTip">
-            <string>If checked, the map canvas will automatically update whenever an option has been changed without the requirement to click Apply</string>
-           </property>
-           <property name="text">
-            <string>Live update</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-           <property name="autoRepeat">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDialogButtonBox" name="mButtonBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="standardButtons">
-            <set>QDialogButtonBox::Apply</set>
-           </property>
-          </widget>
-         </item>
         </layout>
        </item>
        <item row="1" column="0" rowspan="2">
         <widget class="QFrame" name="mOptionsListFrame">
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Shadow::Raised</enum>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="spacing">
@@ -201,19 +172,19 @@
              </size>
             </property>
             <property name="frameShape">
-             <enum>QFrame::NoFrame</enum>
+             <enum>QFrame::Shape::NoFrame</enum>
             </property>
             <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
+             <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
             </property>
             <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
+             <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
             </property>
             <property name="textElideMode">
-             <enum>Qt::ElideNone</enum>
+             <enum>Qt::TextElideMode::ElideNone</enum>
             </property>
             <property name="resizeMode">
-             <enum>QListView::Adjust</enum>
+             <enum>QListView::ResizeMode::Adjust</enum>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -246,7 +217,6 @@
   <tabstop>mLayerCombo</tabstop>
   <tabstop>mUndoButton</tabstop>
   <tabstop>mRedoButton</tabstop>
-  <tabstop>mLiveApplyCheck</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsmapstylingwidgetbase.ui
+++ b/src/ui/qgsmapstylingwidgetbase.ui
@@ -39,7 +39,7 @@
           <string>Not supported or no layer</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
+          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -76,7 +76,7 @@
             </sizepolicy>
            </property>
            <property name="sizeAdjustPolicy">
-            <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
+            <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
            </property>
           </widget>
          </item>
@@ -121,7 +121,7 @@
          <item>
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -131,15 +131,44 @@
            </property>
           </spacer>
          </item>
+         <item>
+          <widget class="QCheckBox" name="mLiveApplyCheck">
+           <property name="toolTip">
+            <string>If checked, the map canvas will automatically update whenever an option has been changed without the requirement to click Apply</string>
+           </property>
+           <property name="text">
+            <string>Live update</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+           <property name="autoRepeat">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDialogButtonBox" name="mButtonBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="standardButtons">
+            <set>QDialogButtonBox::Apply</set>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="1" column="0" rowspan="2">
         <widget class="QFrame" name="mOptionsListFrame">
          <property name="frameShape">
-          <enum>QFrame::Shape::NoFrame</enum>
+          <enum>QFrame::NoFrame</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Shadow::Raised</enum>
+          <enum>QFrame::Raised</enum>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="spacing">
@@ -172,19 +201,19 @@
              </size>
             </property>
             <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+             <enum>Qt::ScrollBarAlwaysOff</enum>
             </property>
             <property name="editTriggers">
-             <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+             <set>QAbstractItemView::NoEditTriggers</set>
             </property>
             <property name="textElideMode">
-             <enum>Qt::TextElideMode::ElideNone</enum>
+             <enum>Qt::ElideNone</enum>
             </property>
             <property name="resizeMode">
-             <enum>QListView::ResizeMode::Adjust</enum>
+             <enum>QListView::Adjust</enum>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -217,6 +246,7 @@
   <tabstop>mLayerCombo</tabstop>
   <tabstop>mUndoButton</tabstop>
   <tabstop>mRedoButton</tabstop>
+  <tabstop>mLiveApplyCheck</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
There's two proposed changes here:

In the first I simply disable the "Apply" button when "Live update is enabled", fixing https://github.com/qgis/QGIS/issues/51894 . In the second I propose a more drastic change, and completely remove the "Live update" check and "Apply" button and just always consider live updates as enabled. 

The second can be reverted, but I don't believe there's any strong case left for disabling live update mode. If I recall correctly, it was originally in place for two reasons:

1. In case we miss any "changed" signals from the styling dock, so the updates aren't automatically applied. I'm confident there's none missing now, we've had years to catch them all and it's trivial to fix if there are any remaining missed ones.
2. For slow to redraw layers. This shouldn't be a factor anymore, there's no layer types which can cause hangs during redraws remaining.

Sponsored by QGIS User Group Denmark
