### PR TITLE
[Backport release-3_34] Fix PDF export size of elevation plots

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -769,7 +769,7 @@ void QgsElevationProfileWidget::exportAsPdf()
   printer.setPageMargins( QMarginsF( 0, 0, 0, 0 ) );
   printer.setFullPage( true );
   printer.setColorMode( QPrinter::Color );
-  printer.setResolution( 300 );
+  printer.setResolution( 1200 );
 
   QPainter p;
   if ( !p.begin( &printer ) )


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/58033 to release-3_34 branch after automatic backport failed.