### PR TITLE
Use a task instead of a progress dialog for wfs/oapif progress

### DIFF
--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -1211,10 +1211,10 @@ QgsOapifFeatureDownloaderImpl::~QgsOapifFeatureDownloaderImpl()
 {
 }
 
-void QgsOapifFeatureDownloaderImpl::createProgressDialog()
+void QgsOapifFeatureDownloaderImpl::createProgressTask()
 {
-  QgsFeatureDownloaderImpl::createProgressDialog( mNumberMatched );
-  CONNECT_PROGRESS_DIALOG( QgsOapifFeatureDownloaderImpl );
+  QgsFeatureDownloaderImpl::createProgressTask( mNumberMatched );
+  CONNECT_PROGRESS_TASK( QgsOapifFeatureDownloaderImpl );
 }
 
 void QgsOapifFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFeatures )
@@ -1387,7 +1387,7 @@ void QgsOapifFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFe
     if ( mNumberMatched < 0 && !mTimer && useProgressDialog && itemsRequest.numberMatched() > 0 )
     {
       mNumberMatched = itemsRequest.numberMatched();
-      CREATE_PROGRESS_DIALOG( QgsOapifFeatureDownloaderImpl );
+      CREATE_PROGRESS_TASK( QgsOapifFeatureDownloaderImpl );
     }
 
     totalDownloadedFeatureCount += itemsRequest.features().size();

--- a/src/providers/wfs/oapif/qgsoapifprovider.h
+++ b/src/providers/wfs/oapif/qgsoapifprovider.h
@@ -292,7 +292,7 @@ class QgsOapifFeatureDownloaderImpl final: public QObject, public QgsFeatureDown
     void run( bool serializeFeatures, long long maxFeatures ) override;
 
   private slots:
-    void createProgressDialog();
+    void createProgressTask();
 
   private:
 

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
@@ -32,6 +32,7 @@
 #include <QStyle>
 #include <QTimer>
 #include <QElapsedTimer>
+#include <QThreadPool>
 
 #include <sqlite3.h>
 
@@ -40,39 +41,54 @@ const QString QgsBackgroundCachedFeatureIteratorConstants::FIELD_UNIQUE_ID( QStr
 const QString QgsBackgroundCachedFeatureIteratorConstants::FIELD_HEXWKB_GEOM( QStringLiteral( "__qgis_hexwkb_geom" ) );
 const QString QgsBackgroundCachedFeatureIteratorConstants::FIELD_MD5( QStringLiteral( "__qgis_md5" ) );
 
-// -------------------------
 
+//
+// QgsFeatureDownloaderProgressTask
+//
 
-QgsFeatureDownloaderProgressDialog::QgsFeatureDownloaderProgressDialog( const QString &labelText,
-    const QString &cancelButtonText,
-    int minimum, int maximum, QWidget *parent )
-  : QProgressDialog( labelText, cancelButtonText, minimum, maximum, parent )
+QgsFeatureDownloaderProgressTask::QgsFeatureDownloaderProgressTask( const QString &description, long long totalCount )
+  : QgsTask( description,
+             QgsTask::CanCancel | QgsTask::CancelWithoutPrompt | QgsTask::Silent )
+  , mTotalCount( totalCount )
 {
-  mCancel = new QPushButton( cancelButtonText, this );
-  setCancelButton( mCancel );
-  mHide = new QPushButton( tr( "Hide" ), this );
-  connect( mHide, &QAbstractButton::clicked, this, &QgsFeatureDownloaderProgressDialog::hideRequest );
+
 }
 
-void QgsFeatureDownloaderProgressDialog::resizeEvent( QResizeEvent *ev )
+bool QgsFeatureDownloaderProgressTask::run()
 {
-  QProgressDialog::resizeEvent( ev );
-  // Note: this relies heavily on the details of the layout done in QProgressDialogPrivate::layout()
-  // Might be a bit fragile depending on QT versions.
-  QRect rect = geometry();
-  QRect cancelRect = mCancel->geometry();
-  QRect hideRect = mHide->geometry();
-  int mtb = style()->pixelMetric( QStyle::PM_LayoutRightMargin );
-  int mlr = std::min( width() / 10, mtb );
-  if ( rect.width() - cancelRect.x() - cancelRect.width() > mlr )
+  QgsApplication::taskManager()->threadPool()->releaseThread();
+  mNotFinishedMutex.lock();
+  if ( !mAlreadyFinished )
   {
-    // Force right alignment of cancel button
-    cancelRect.setX( rect.width() - cancelRect.width() - mlr );
-    mCancel->setGeometry( cancelRect );
+    mNotFinishedWaitCondition.wait( &mNotFinishedMutex );
   }
-  mHide->setGeometry( rect.width() - cancelRect.x() - cancelRect.width(),
-                      cancelRect.y(), hideRect.width(), cancelRect.height() );
+  mNotFinishedMutex.unlock();
+
+  QgsApplication::taskManager()->threadPool()->reserveThread();
+  return true;
 }
+
+void QgsFeatureDownloaderProgressTask::cancel()
+{
+  emit canceled();
+
+  QgsTask::cancel();
+}
+
+void QgsFeatureDownloaderProgressTask::finalize()
+{
+  const QMutexLocker lock( &mNotFinishedMutex );
+  mAlreadyFinished = true;
+
+  mNotFinishedWaitCondition.wakeAll();
+}
+
+void QgsFeatureDownloaderProgressTask::setDownloaded( long long count )
+{
+  setProgress( static_cast< double >( count ) / mTotalCount * 100 );
+}
+
+
 
 // -------------------------
 
@@ -84,8 +100,11 @@ QgsFeatureDownloaderImpl::QgsFeatureDownloaderImpl( QgsBackgroundCachedSharedDat
 
 QgsFeatureDownloaderImpl::~QgsFeatureDownloaderImpl()
 {
-  if ( mProgressDialog )
-    mProgressDialog->deleteLater();
+  if ( mProgressTask )
+  {
+    mProgressTask->finalize();
+    mProgressTask = nullptr;
+  }
 }
 
 void QgsFeatureDownloaderImpl::emitFeatureReceived( QVector<QgsFeatureUniqueIdPair> features )
@@ -121,50 +140,24 @@ void QgsFeatureDownloaderImpl::setStopFlag()
   mStop = true;
 }
 
-void QgsFeatureDownloaderImpl::hideProgressDialog()
-{
-  mSharedBase->setHideProgressDialog( true );
-  mProgressDialog->deleteLater();
-  mProgressDialog = nullptr;
-}
 
 // Called from GUI thread
-void QgsFeatureDownloaderImpl::createProgressDialog( int numberMatched )
+void QgsFeatureDownloaderImpl::createProgressTask( long long numberMatched )
 {
   Q_ASSERT( qApp->thread() == QThread::currentThread() );
 
   // Make sure that the creation is done in an atomic way, so that the
   // starting thread (running QgsFeatureDownloaderImpl::run()) can be sure that
   // this function has either run completely, or not at all (mStop == true),
-  // when it wants to destroy mProgressDialog
-  QMutexLocker locker( &mMutexCreateProgressDialog );
+  // when it wants to destroy mProgressTask
+  QMutexLocker locker( &mMutexCreateProgressTask );
 
   if ( mStop )
     return;
-  Q_ASSERT( !mProgressDialog );
+  Q_ASSERT( !mProgressTask );
 
-  if ( !mMainWindow )
-  {
-    const QWidgetList widgets = QgsApplication::topLevelWidgets();
-    for ( QWidget *widget : widgets )
-    {
-      if ( widget->objectName() == QLatin1String( "QgisApp" ) )
-      {
-        mMainWindow = widget;
-        break;
-      }
-    }
-  }
-
-  if ( !mMainWindow )
-    return;
-
-  mProgressDialog = new QgsFeatureDownloaderProgressDialog( QObject::tr( "Loading features for layer %1" ).arg( mSharedBase->layerName() ),
-      QObject::tr( "Abort" ), 0, numberMatched, mMainWindow );
-  mProgressDialog->setWindowTitle( QObject::tr( "QGIS" ) );
-  mProgressDialog->setValue( 0 );
-  if ( mProgressDialogShowImmediately )
-    mProgressDialog->show();
+  mProgressTask = new QgsFeatureDownloaderProgressTask( QObject::tr( "Loading features for layer %1" ).arg( mSharedBase->layerName() ), numberMatched );
+  QgsApplication::taskManager()->addTask( mProgressTask );
 }
 
 void QgsFeatureDownloaderImpl::endOfRun( bool serializeFeatures,
@@ -173,7 +166,7 @@ void QgsFeatureDownloaderImpl::endOfRun( bool serializeFeatures,
     const QString &errorMessage )
 {
   {
-    QMutexLocker locker( &mMutexCreateProgressDialog );
+    QMutexLocker locker( &mMutexCreateProgressTask );
     mStop = true;
   }
 
@@ -190,11 +183,12 @@ void QgsFeatureDownloaderImpl::endOfRun( bool serializeFeatures,
   // test suite.
   emitEndOfDownload( success );
 
-  if ( mProgressDialog )
+  if ( mProgressTask )
   {
-    mProgressDialog->deleteLater();
-    mProgressDialog = nullptr;
+    mProgressTask->finalize();
+    mProgressTask = nullptr;
   }
+
   if ( mTimer )
   {
     mTimer->deleteLater();

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
@@ -85,7 +85,7 @@ void QgsFeatureDownloaderProgressTask::finalize()
 
 void QgsFeatureDownloaderProgressTask::setDownloaded( long long count )
 {
-  setProgress( static_cast< double >( count ) / mTotalCount * 100 );
+  setProgress( static_cast< double >( count ) / static_cast< double >( mTotalCount ) * 100 );
 }
 
 

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -33,6 +33,7 @@
 #include <QDir>
 #include <QTimer>
 #include <QUrlQuery>
+#include <QTransform>
 
 QgsWFSFeatureHitsAsyncRequest::QgsWFSFeatureHitsAsyncRequest( QgsWFSDataSourceURI &uri )
   : QgsWfsRequest( uri )
@@ -348,13 +349,6 @@ void QgsWFSFeatureDownloaderImpl::gotHitsResponse()
   }
   if ( mNumberMatched >= 0 )
   {
-    if ( mTotalDownloadedFeatureCount == 0 )
-    {
-      // We get at this point after the 4 second delay to emit the hits request
-      // and the delay to get its response. If we don't still have downloaded
-      // any feature at this point, it is high time to give some visual feedback
-      mProgressDialogShowImmediately = true;
-    }
     // If the request didn't include any BBOX, then we can update the layer
     // feature count
     if ( mShared->currentRect().isNull() )
@@ -375,10 +369,10 @@ void QgsWFSFeatureDownloaderImpl::startHitsRequest()
   }
 }
 
-void QgsWFSFeatureDownloaderImpl::createProgressDialog()
+void QgsWFSFeatureDownloaderImpl::createProgressTask()
 {
-  QgsFeatureDownloaderImpl::createProgressDialog( mNumberMatched );
-  CONNECT_PROGRESS_DIALOG( QgsWFSFeatureDownloaderImpl );
+  QgsFeatureDownloaderImpl::createProgressTask( mNumberMatched );
+  CONNECT_PROGRESS_TASK( QgsWFSFeatureDownloaderImpl );
 }
 
 void QgsWFSFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFeatures )
@@ -582,7 +576,7 @@ void QgsWFSFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFeat
           if ( mShared->supportsFastFeatureCount() )
             disconnect( &timerForHits, &QTimer::timeout, this, &QgsWFSFeatureDownloaderImpl::startHitsRequest );
 
-          CREATE_PROGRESS_DIALOG( QgsWFSFeatureDownloaderImpl );
+          CREATE_PROGRESS_TASK( QgsWFSFeatureDownloaderImpl );
         }
       }
 

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -90,7 +90,7 @@ class QgsWFSFeatureDownloaderImpl final: public QgsWfsRequest, public QgsFeature
     void startHitsRequest();
     void gotHitsResponse();
 
-    void createProgressDialog();
+    void createProgressTask();
 
   private:
     QUrl buildURL( qint64 startIndex, long long maxFeatures, bool forHits );


### PR DESCRIPTION
Instead of firing up new progress dialogs for every wfs/oapif request, use the task manager to create loss obtrusive progress reports.

The download progress is now shown in the task manager, and cancel requests can be done via the standard means of canceling tasks.

Aside from avoiding the extra dialogs, this also means:

- Time estimates for downloads are shown in the task tooltip
- Operating system level feedback (ie task bar progress) is shown for wfs downloads

Sponsored by Dorset Council
