### PR TITLE
Set project color model to default color

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2621,7 +2621,11 @@ void QgsProjectProperties::setCurrentEllipsoid( const QString &ellipsoidAcronym 
 
 void QgsProjectProperties::mButtonAddColor_clicked()
 {
-  QColor newColor = QgsColorDialog::getColor( QColor(), this->parentWidget(), tr( "Select Color" ), true );
+  const Qgis::ColorModel colorModel = mColorModel->currentData().value<Qgis::ColorModel>();
+  const QColor defaultColor = colorModel == Qgis::ColorModel::Cmyk ?
+                              QColor::fromCmykF( 0., 1., 1., 0. ) : QColor::fromRgbF( 1., 0., 0. );
+
+  QColor newColor = QgsColorDialog::getColor( defaultColor, this->parentWidget(), tr( "Select Color" ), true );
   if ( !newColor.isValid() )
   {
     return;

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -864,6 +864,16 @@ QgsSymbol *QgsSymbol::defaultSymbol( Qgis::GeometryType geomType )
     s->setColor( QgsApplication::colorSchemeRegistry()->fetchRandomStyleColor() );
   }
 
+  const bool isCmyk = QgsProject::instance()->styleSettings() && QgsProject::instance()->styleSettings()->colorModel() == Qgis::ColorModel::Cmyk;
+  if ( s->color().spec() == QColor::Spec::Rgb && isCmyk )
+  {
+    s->setColor( s->color().toCmyk() );
+  }
+  else if ( s->color().spec() == QColor::Spec::Cmyk && !isCmyk )
+  {
+    s->setColor( s->color().toRgb() );
+  }
+
   return s.release();
 }
 

--- a/tests/src/python/test_qgssymbol.py
+++ b/tests/src/python/test_qgssymbol.py
@@ -1772,6 +1772,15 @@ class TestQgsFillSymbol(QgisTestCase):
 
         return image
 
+    def testDefaultSymbolColor(self):
+        s1 = QgsSymbol.defaultSymbol(Qgis.GeometryType.Point)
+        self.assertEqual(s1.color().spec(), QColor.Spec.Rgb)
+
+        self.assertTrue(QgsProject.instance().styleSettings())
+        QgsProject.instance().styleSettings().setColorModel(Qgis.ColorModel.Cmyk)
+        s1 = QgsSymbol.defaultSymbol(Qgis.GeometryType.Point)
+        self.assertEqual(s1.color().spec(), QColor.Spec.Cmyk)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Set new symbol color and project color model to project color model. 

Fixes https://github.com/qgis/QGIS/issues/58323

**Funded by Métropôle de Bordeaux**