### PR TITLE
fix(qgshttpheaders): add backward compatibility in setFromUrlQuery

### DIFF
--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -184,6 +184,10 @@ void QgsHttpHeaders::setFromUrlQuery( const QUrlQuery &uri )
       QString name = key.right( key.size() - QgsHttpHeaders::PARAM_PREFIX.size() );
       mHeaders[sanitizeKey( name )] = item.second;
     }
+    else if ( key == QgsHttpHeaders::KEY_REFERER ) // backward comptibility
+    {
+      mHeaders[QgsHttpHeaders::KEY_REFERER] = item.second;
+    }
   }
 }
 

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -713,7 +713,7 @@ void QgsDataSourceUri::setEncodedUri( const QByteArray &uri )
   const auto constQueryItems = query.queryItems();
   for ( const QPair<QString, QString> &item : constQueryItems )
   {
-    if ( !item.first.startsWith( QgsHttpHeaders::PARAM_PREFIX ) )
+    if ( !item.first.startsWith( QgsHttpHeaders::PARAM_PREFIX ) && item.first != QgsHttpHeaders::KEY_REFERER )
     {
       if ( item.first == QLatin1String( "username" ) )
         mUsername = query.queryItemValue( QStringLiteral( "username" ), QUrl::ComponentFormattingOption::FullyDecoded );

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -44,6 +44,7 @@ class TestQgsHttpheaders: public QObject
 
     void setFromSettingsGoodKey();
     void setFromSettingsBadKey();
+    void setFromUrlQuery();
     void updateSettings();
 
     void createQgsOwsConnection();
@@ -176,6 +177,37 @@ void TestQgsHttpheaders::updateNetworkRequest()
 
   QVERIFY( request.hasRawHeader( QByteArray::fromStdString( QgsHttpHeaders::KEY_REFERER.toStdString() ) ) );
   QCOMPARE( request.rawHeader( QByteArray::fromStdString( QgsHttpHeaders::KEY_REFERER.toStdString() ) ), "my_ref" );
+}
+
+
+void TestQgsHttpheaders::setFromUrlQuery()
+{
+  {
+    // with only new http-header:referer
+    QUrlQuery url( "https://www.ogc.org/?p1=v1&http-header:other_http_header=value&http-header:referer=http://test.new.com" );
+    QgsHttpHeaders h;
+    h.setFromUrlQuery( url );
+    QCOMPARE( h[QgsHttpHeaders::KEY_REFERER ].toString(), QStringLiteral( "http://test.new.com" ) );
+    QCOMPARE( h[ "other_http_header" ].toString(), QStringLiteral( "value" ) );
+  }
+
+  {
+    // with both new http-header:referer and old referer
+    QUrlQuery url( "https://www.ogc.org/?p1=v1&referer=http://test.old.com&http-header:other_http_header=value&http-header:referer=http://test.new.com" );
+    QgsHttpHeaders h;
+    h.setFromUrlQuery( url );
+    QCOMPARE( h[QgsHttpHeaders::KEY_REFERER ].toString(), QStringLiteral( "http://test.new.com" ) );
+    QCOMPARE( h[ "other_http_header" ].toString(), QStringLiteral( "value" ) );
+  }
+
+  {
+    // with only old referer
+    QUrlQuery url( "https://www.ogc.org/?p1=v1&referer=http://test.old.com&http-header:other_http_header=value" );
+    QgsHttpHeaders h;
+    h.setFromUrlQuery( url );
+    QCOMPARE( h[QgsHttpHeaders::KEY_REFERER ].toString(), QStringLiteral( "http://test.old.com" ) );
+    QCOMPARE( h[ "other_http_header" ].toString(), QStringLiteral( "value" ) );
+  }
 }
 
 


### PR DESCRIPTION
Add fix to HttpHeader to improve backward compatibility when setting values from url.

closes #58252 