### PR TITLE
Filter in Linking Dialogue of Relation Editor Widget

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -230,7 +230,7 @@ Delete a feature with given ``fid``
 %Docstring
 Links a new feature to the relation
 
-:param filterExpression: to filter the available features in the link dialog
+:param filterExpression: to filter the available features in the link dialog since QGIS 3.40
 %End
 
     void onLinkFeatureDlgAccepted();

--- a/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -226,9 +226,11 @@ Adds new features with given ``geometry``
 Delete a feature with given ``fid``
 %End
 
-    void linkFeature();
+    void linkFeature( const QString &filterExpression = QString() );
 %Docstring
 Links a new feature to the relation
+
+:param filterExpression: to filter the available features in the link dialog
 %End
 
     void onLinkFeatureDlgAccepted();

--- a/python/PyQt6/gui/auto_generated/qgsfeatureselectiondlg.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfeatureselectiondlg.sip.in
@@ -48,6 +48,11 @@ Set the selected features
 :param ids: The feature ids to select
 %End
 
+    void setFilterExpression( const QString &filter, QgsAttributeForm::FilterType type );
+%Docstring
+Set form filter expression
+%End
+
   protected:
 
     virtual void keyPressEvent( QKeyEvent *evt );

--- a/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -191,6 +191,10 @@ Update the configuration widget to represent the given configuration.
 :param config: The configuration which should be represented by this widget
 %End
 
+    void mEditExpression_clicked();
+%Docstring
+Opens an expression dialog and sets its value as filter expression for the linking dialog
+%End
 };
 
 

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -230,7 +230,7 @@ Delete a feature with given ``fid``
 %Docstring
 Links a new feature to the relation
 
-:param filterExpression: to filter the available features in the link dialog
+:param filterExpression: to filter the available features in the link dialog since QGIS 3.40
 %End
 
     void onLinkFeatureDlgAccepted();

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -226,9 +226,11 @@ Adds new features with given ``geometry``
 Delete a feature with given ``fid``
 %End
 
-    void linkFeature();
+    void linkFeature( const QString &filterExpression = QString() );
 %Docstring
 Links a new feature to the relation
+
+:param filterExpression: to filter the available features in the link dialog
 %End
 
     void onLinkFeatureDlgAccepted();

--- a/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
+++ b/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
@@ -48,6 +48,11 @@ Set the selected features
 :param ids: The feature ids to select
 %End
 
+    void setFilterExpression( const QString &filter, QgsAttributeForm::FilterType type );
+%Docstring
+Set form filter expression
+%End
+
   protected:
 
     virtual void keyPressEvent( QKeyEvent *evt );

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -191,6 +191,10 @@ Update the configuration widget to represent the given configuration.
 :param config: The configuration which should be represented by this widget
 %End
 
+    void mEditExpression_clicked();
+%Docstring
+Opens an expression dialog and sets its value as filter expression for the linking dialog
+%End
 };
 
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -447,7 +447,7 @@ void QgsAbstractRelationEditorWidget::deleteFeatures( const QgsFeatureIds &fids 
   }
 }
 
-void QgsAbstractRelationEditorWidget::linkFeature()
+void QgsAbstractRelationEditorWidget::linkFeature( const QString &filterExpression )
 {
   QgsVectorLayer *layer = nullptr;
 
@@ -474,6 +474,7 @@ void QgsAbstractRelationEditorWidget::linkFeature()
 
   const QString displayString = QgsVectorLayerUtils::getFeatureDisplayString( mRelation.referencedLayer(), mFeatureList.first() );
   selectionDlg->setWindowTitle( tr( "Link existing child features for parent %1 \"%2\"" ).arg( mRelation.referencedLayer()->name(), displayString ) );
+  selectionDlg->setFilterExpression( filterExpression, QgsAttributeForm::ReplaceFilter );
 
   connect( selectionDlg, &QDialog::accepted, this, &QgsAbstractRelationEditorWidget::onLinkFeatureDlgAccepted );
   selectionDlg->show();

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -234,8 +234,9 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Links a new feature to the relation
+     * \param filterExpression to filter the available features in the link dialog
      */
-    void linkFeature();
+    void linkFeature( const QString &filterExpression = QString() );
 
     /**
      * Called when the link feature dialog is confirmed by the user

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -234,7 +234,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Links a new feature to the relation
-     * \param filterExpression to filter the available features in the link dialog
+     * \param filterExpression to filter the available features in the link dialog since QGIS 3.40
      */
     void linkFeature( const QString &filterExpression = QString() );
 

--- a/src/gui/qgsfeatureselectiondlg.h
+++ b/src/gui/qgsfeatureselectiondlg.h
@@ -66,6 +66,11 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
      */
     void setSelectedFeatures( const QgsFeatureIds &ids );
 
+    /**
+     * Set form filter expression
+     */
+    void setFilterExpression( const QString &filter, QgsAttributeForm::FilterType type );
+
   protected:
 
     void keyPressEvent( QKeyEvent *evt ) override;
@@ -104,11 +109,6 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
      * Select feature using an expression
      */
     void mActionExpressionSelect_triggered();
-
-    /**
-     * Set form filter expression
-     */
-    void setFilterExpression( const QString &filter, QgsAttributeForm::FilterType type );
 
     /**
      * View mode has changed

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -954,6 +954,17 @@ QgsRelationEditorConfigWidget::QgsRelationEditorConfigWidget( const QgsRelation 
   setupUi( this );
   connect( mEditExpression, &QAbstractButton::clicked, this, &QgsRelationEditorConfigWidget::mEditExpression_clicked );
 
+  // Make filter depending on link button
+  filterExpressionLabel->setEnabled( mRelationShowLinkCheckBox->isChecked() );
+  mEditExpression->setEnabled( mRelationShowLinkCheckBox->isChecked() );
+  mFilterExpression->setEnabled( mRelationShowLinkCheckBox->isChecked() );
+  connect( mRelationShowLinkCheckBox, &QCheckBox::toggled, filterExpressionLabel, &QLabel::setEnabled );
+  connect( mRelationShowLinkCheckBox, &QCheckBox::toggled, mEditExpression, &QToolButton::setEnabled );
+  connect( mRelationShowLinkCheckBox, &QCheckBox::toggled, mFilterExpression, &QTextEdit::setEnabled );
+
+  // Make add feature with no geometry depending on add button
+  mAllowAddChildFeatureWithNoGeometry->setEnabled( mRelationShowAddChildCheckBox->isChecked() );
+  connect( mRelationShowAddChildCheckBox, &QCheckBox::toggled, mAllowAddChildFeatureWithNoGeometry, &QCheckBox::setEnabled );
 }
 
 void QgsRelationEditorConfigWidget::mEditExpression_clicked()

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -29,6 +29,8 @@
 #include "qgsmessagebar.h"
 #include "qgsmessagebaritem.h"
 #include "qgsactionmenu.h"
+#include "qgsexpressionbuilderdialog.h"
+#include "qgsexpressioncontextutils.h"
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -950,6 +952,32 @@ QgsRelationEditorConfigWidget::QgsRelationEditorConfigWidget( const QgsRelation 
   : QgsAbstractRelationEditorConfigWidget( relation, parent )
 {
   setupUi( this );
+  connect( mEditExpression, &QAbstractButton::clicked, this, &QgsRelationEditorConfigWidget::mEditExpression_clicked );
+
+}
+
+void QgsRelationEditorConfigWidget::mEditExpression_clicked()
+{
+  QgsVectorLayer *vl = nullptr;
+
+  if ( nmRelation().isValid() )
+  {
+    vl = nmRelation().referencedLayer();
+  }
+  else
+  {
+    vl = relation().referencingLayer();
+  }
+
+  // Show expression builder
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( vl ) );
+  QgsExpressionBuilderDialog dlg( vl, mFilterExpression->toPlainText(), this, QStringLiteral( "generic" ), context );
+  dlg.setWindowTitle( tr( "Edit Filter Expression of Target Layer" ) );
+
+  if ( dlg.exec() == QDialog::Accepted )
+  {
+    mFilterExpression->setPlainText( dlg.expressionBuilder()->expressionText() );
+  }
 }
 
 QVariantMap QgsRelationEditorConfigWidget::config()

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -93,6 +93,7 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
   , mButtonsVisibility( qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons ) )
   , mShowFirstFeature( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() )
   , mAllowAddChildFeatureWithNoGeometry( config.value( QStringLiteral( "allow_add_child_feature_with_no_geometry" ), false ).toBool() )
+  , mFilterExpression( config.value( QStringLiteral( "filter_expression" ) ).toString() )
 {
   QVBoxLayout *rootLayout = new QVBoxLayout( this );
   rootLayout->setContentsMargins( 0, 9, 0, 0 );
@@ -494,6 +495,11 @@ void QgsRelationEditorWidget::multiEditItemSelectionChanged()
   updateButtons();
 }
 
+void QgsRelationEditorWidget::linkFeature()
+{
+  QgsAbstractRelationEditorWidget::linkFeature( mFilterExpression );
+}
+
 void QgsRelationEditorWidget::toggleEditing( bool state )
 {
   QgsAbstractRelationEditorWidget::toggleEditing( state );
@@ -819,7 +825,8 @@ QVariantMap QgsRelationEditorWidget::config() const
 {
   return QVariantMap( {{"buttons", qgsFlagValueToKeys( visibleButtons() )},
     {"show_first_feature", mShowFirstFeature},
-    {"allow_add_child_feature_with_no_geometry", mAllowAddChildFeatureWithNoGeometry }
+    {"allow_add_child_feature_with_no_geometry", mAllowAddChildFeatureWithNoGeometry },
+    {"filter_expression", mFilterExpression }
   } );
 }
 
@@ -828,6 +835,7 @@ void QgsRelationEditorWidget::setConfig( const QVariantMap &config )
   mButtonsVisibility = qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons );
   mShowFirstFeature = config.value( QStringLiteral( "show_first_feature" ), true ).toBool();
   mAllowAddChildFeatureWithNoGeometry = config.value( QStringLiteral( "allow_add_child_feature_with_no_geometry" ), false ).toBool();
+  mFilterExpression = config.value( QStringLiteral( "filter_expression" ) ).toString();
   updateButtons();
 }
 
@@ -959,7 +967,8 @@ QVariantMap QgsRelationEditorConfigWidget::config()
   {
     {"buttons", qgsFlagValueToKeys( buttons )},
     {"show_first_feature", mShowFirstFeature->isChecked()},
-    {"allow_add_child_feature_with_no_geometry", mAllowAddChildFeatureWithNoGeometry->isChecked()}
+    {"allow_add_child_feature_with_no_geometry", mAllowAddChildFeatureWithNoGeometry->isChecked()},
+    {"filter_expression", mFilterExpression->toPlainText()}
   } );
 }
 
@@ -976,6 +985,7 @@ void QgsRelationEditorConfigWidget::setConfig( const QVariantMap &config )
   mRelationShowSaveChildEditsCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::SaveChildEdits ) );
   mShowFirstFeature->setChecked( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() );
   mAllowAddChildFeatureWithNoGeometry->setChecked( config.value( QStringLiteral( "allow_add_child_feature_with_no_geometry" ), false ).toBool() );
+  mFilterExpression->setPlainText( config.value( QStringLiteral( "filter_expression" ) ).toString() );
 }
 
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -305,6 +305,10 @@ class GUI_EXPORT QgsRelationEditorConfigWidget : public QgsAbstractRelationEdito
      */
     void setConfig( const QVariantMap &config ) override;
 
+    /**
+     * Opens an expression dialog and sets its value as filter expression for the linking dialog
+     */
+    void mEditExpression_clicked();
 };
 
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -210,6 +210,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void onDigitizingCompleted( const QgsFeature &feature );
     void onDigitizingCanceled( );
     void multiEditItemSelectionChanged();
+    void linkFeature();
 
   private:
 
@@ -261,6 +262,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     Buttons mButtonsVisibility = Button::AllButtons;
     bool mShowFirstFeature = true;
     bool mAllowAddChildFeatureWithNoGeometry = true;
+    QString mFilterExpression;
 
     QList<QTreeWidgetItem *> mMultiEditPreviousSelectedItems;
     QgsFeatureIds mMultiEdit1NJustAddedIds;

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -277,7 +277,6 @@
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -277,6 +277,7 @@
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -6,15 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>422</width>
-    <height>272</height>
+    <width>486</width>
+    <height>494</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Attribute Widget Relation Edit Widget</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
     <widget class="QCheckBox" name="mShowFirstFeature">
      <property name="toolTip">
       <string>Unchecking this can lead to faster loading time of attribute forms and avoid unnecessary queries.</string>
@@ -24,7 +24,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QGroupBox" name="mButtonsVisibility">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -115,11 +115,52 @@
         </property>
        </widget>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="topMargin">
+         <number>10</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Filter expression</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mEditExpression">
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QTextEdit" name="mFilterExpression"/>
+      </item>
      </layout>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -121,7 +121,7 @@
          <number>10</number>
         </property>
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="filterExpressionLabel">
           <property name="text">
            <string>Filter expression</string>
           </property>


### PR DESCRIPTION
While it's quite common to filter the parent entries in the drop down of the relation reference widget, in the relation editor one needed to enter the filter manually every time when linking children.

With this implementation one can configure a filter expression (with the scope of the target layer) on the relation editor configuration. 

After that the link children dialogue is filtered accordingly.

[Screencast from 21.08.2024 09:43:10.webm](https://github.com/user-attachments/assets/caba222e-0b7e-491b-b94e-3580dc2cc243)

This resolves #58185

Some technical details:
- We pass the expression to `linkFeature` in `QgsAbstractRelationEditorWidget`
- The rest of the implementation (configuration etc.) are all done in the `QgsRelationEditorWidget`
- `QgsFeatureSelectionDlg::setFilterExpression` became public

PS. You might have seen that after the filter still the form of the first feature of the unfiltered list is shown - this is a minor bug that existed before and has nothing to do with this implementation.