### PR TITLE
[CMYK] Add a specific preview for CMYK color

### DIFF
--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -535,6 +535,8 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * Creates the drop-down menu entries
      */
     void prepareMenu();
+
+    friend class QgsColorTooltip;
 };
 
 #endif

--- a/src/gui/qgscolorswatchgrid.cpp
+++ b/src/gui/qgscolorswatchgrid.cpp
@@ -16,7 +16,7 @@
 #include "qgscolorswatchgrid.h"
 #include "qgsapplication.h"
 #include "qgssymbollayerutils.h"
-#include "qgslogger.h"
+#include "qgscolortooltip_p.h"
 #include <QPainter>
 #include <QMouseEvent>
 #include <QMenu>
@@ -121,44 +121,11 @@ void QgsColorSwatchGrid::updateTooltip( const int colorIdx )
     //if color has an associated name from the color scheme, use that
     const QString colorName = mColors.at( colorIdx ).second;
 
-    // create very large preview swatch, because the grid itself has only tiny preview icons
-    const int width = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 23 );
-    const int height = static_cast< int >( width / 1.61803398875 ); // golden ratio
-    const int margin = static_cast< int >( height * 0.1 );
-    QImage icon = QImage( width + 2 * margin, height + 2 * margin, QImage::Format_ARGB32 );
-    icon.fill( Qt::transparent );
-
-    QPainter p;
-    p.begin( &icon );
-
-    //start with checkboard pattern
-    const QBrush checkBrush = QBrush( transparentBackground() );
-    p.setPen( Qt::NoPen );
-    p.setBrush( checkBrush );
-    p.drawRect( margin, margin, width, height );
-
-    //draw color over pattern
-    p.setBrush( QBrush( mColors.at( colorIdx ).first ) );
-
-    //draw border
-    p.setPen( QColor( 197, 197, 197 ) );
-    p.drawRect( margin, margin, width, height );
-    p.end();
-
-    QByteArray data;
-    QBuffer buffer( &data );
-    icon.save( &buffer, "PNG", 100 );
-
     QString info;
     if ( !colorName.isEmpty() )
       info += QStringLiteral( "<h3>%1</h3><p>" ).arg( colorName );
 
-    info += QStringLiteral( "<b>HEX</b> %1<br>"
-                            "<b>RGB</b> %2<br>"
-                            "<b>HSV</b> %3,%4,%5<p>" ).arg( color.name(),
-                                QgsSymbolLayerUtils::encodeColor( color ) )
-            .arg( color.hue() ).arg( color.saturation() ).arg( color.value() );
-    info += QStringLiteral( "<img src='data:image/png;base64, %0'>" ).arg( QString( data.toBase64() ) );
+    info += QgsColorTooltip::htmlDescription( color, this );
 
     setToolTip( info );
 

--- a/src/gui/qgscolorswatchgrid.h
+++ b/src/gui/qgscolorswatchgrid.h
@@ -174,6 +174,8 @@ class GUI_EXPORT QgsColorSwatchGrid : public QWidget
      * \returns checkboard pixmap
      */
     QPixmap transparentBackground();
+
+    friend class QgsColorTooltip;
 };
 
 

--- a/src/gui/qgscolortooltip_p.h
+++ b/src/gui/qgscolortooltip_p.h
@@ -1,0 +1,94 @@
+/***************************************************************************
+    qgscolortooltip_p.h
+    ---------------------
+    begin                : 2024/08/21
+    copyright            : (C) 2024 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCOLORTOOLTIP_P_H
+#define QGSCOLORTOOLTIP_P_H
+
+#include <QPainter>
+#include <QBuffer>
+
+#include "qgssymbollayerutils.h"
+
+//! helper class to generate color tooltip
+class QgsColorTooltip
+{
+  public:
+
+    //! Returns an HTML desciption given a \a color with a preview image of the color
+    template<typename T>
+    static QString htmlDescription( QColor color, T *widget )
+    {
+      // create very large preview swatch
+      const int width = static_cast< int >( Qgis::UI_SCALE_FACTOR * widget->fontMetrics().horizontalAdvance( 'X' ) * 23 );
+      const int height = static_cast< int >( width / 1.61803398875 ); // golden ratio
+
+      const int margin = static_cast< int >( height * 0.1 );
+      QImage icon = QImage( width + 2 * margin, height + 2 * margin, QImage::Format_ARGB32 );
+      icon.fill( Qt::transparent );
+
+      QPainter p;
+      p.begin( &icon );
+
+      //start with checkboard pattern
+      const QBrush checkBrush = QBrush( widget->transparentBackground() );
+      p.setPen( Qt::NoPen );
+      p.setBrush( checkBrush );
+      p.drawRect( margin, margin, width, height );
+
+      //draw color over pattern
+      p.setBrush( QBrush( color ) );
+
+      //draw border
+      p.setPen( QColor( 197, 197, 197 ) );
+      p.drawRect( margin, margin, width, height );
+      p.end();
+
+      QByteArray data;
+      QBuffer buffer( &data );
+      icon.save( &buffer, "PNG", 100 );
+
+      QString info = QStringLiteral( "<b>HEX</b> %1<br>" ).arg( color.name() );
+
+      if ( color.spec() == QColor::Spec::Cmyk )
+      {
+        const float cyan = color.cyanF() * 100.f;
+        const float magenta = color.magentaF() * 100.f;
+        const float yellow = color.yellowF() * 100.f;
+        const float black = color.blackF() * 100.f;
+        const float alpha = color.alphaF() * 100.f;
+
+        info += QStringLiteral( "<b>CMYKA</b> %1,%2,%3,%4,%5<p>" )
+                .arg( cyan, 0, 'f', 2 ).arg( magenta, 0, 'f', 2 )
+                .arg( yellow, 0, 'f', 2 ).arg( black, 0, 'f', 2 )
+                .arg( alpha, 0, 'f', 2 );
+      }
+      else
+      {
+        const int hue = color.hue();
+        const int value = color.value();
+        const int saturation = color.saturation();
+
+        info += QStringLiteral( "<b>RGBA</b> %1<br>"
+                                "<b>HSV</b> %2,%3,%4<p>" ).arg( QgsSymbolLayerUtils::encodeColor( color ) )
+                .arg( hue ).arg( saturation ).arg( value );
+      }
+
+      info += QStringLiteral( "<img src='data:image/png;base64, %1'>" ).arg( QString( data.toBase64() ) );
+
+      return info;
+    }
+};
+
+#endif

--- a/src/gui/qgscolortooltip_p.h
+++ b/src/gui/qgscolortooltip_p.h
@@ -22,6 +22,11 @@
 #include "qgssymbollayerutils.h"
 
 //! helper class to generate color tooltip
+
+/**
+ * \ingroup gui
+ * \since QGIS 3.40
+ */
 class QgsColorTooltip
 {
   public:
@@ -63,11 +68,11 @@ class QgsColorTooltip
 
       if ( color.spec() == QColor::Spec::Cmyk )
       {
-        const float cyan = color.cyanF() * 100.f;
-        const float magenta = color.magentaF() * 100.f;
-        const float yellow = color.yellowF() * 100.f;
-        const float black = color.blackF() * 100.f;
-        const float alpha = color.alphaF() * 100.f;
+        const double cyan = color.cyanF() * 100.;
+        const double magenta = color.magentaF() * 100.;
+        const double yellow = color.yellowF() * 100.;
+        const double black = color.blackF() * 100.;
+        const double alpha = color.alphaF() * 100.;
 
         info += QStringLiteral( "<b>CMYKA</b> %1,%2,%3,%4,%5<p>" )
                 .arg( cyan, 0, 'f', 2 ).arg( magenta, 0, 'f', 2 )


### PR DESCRIPTION
I propose to display CMYK color with 2 decimal digit in percent like in the color widget

![cmyk_preview](https://github.com/user-attachments/assets/c3abbdf5-b97a-4523-aa7e-eafd3177720e)

while the RGB one stay unchanged except that I added the **A** to **RGB** (We could also put Alpha on its own line for both RGB and CMYK, I have no strong opinion on this)


![rgbpreview](https://github.com/user-attachments/assets/48f6d6b2-598b-4050-8132-02ad30dc8c9c)


**Funded by Bordeaux Métropole**
