### PR TITLE
[Expressions] add color_rgbf/color_cmykf/color_hsvf/color_hslf

### DIFF
--- a/resources/function_help/json/color_cmykf
+++ b/resources/function_help/json/color_cmykf
@@ -1,0 +1,29 @@
+{
+  "name": "color_cmykf",
+  "type": "function",
+  "groups": ["Color"],
+  "description": "Returns a color object based on its cyan, magenta, yellow, black and alpha components.",
+  "arguments": [{
+    "arg": "cyan",
+    "description": "cyan component as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "magenta",
+    "description": "magenta component as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "yellow",
+    "description": "yellow component as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "black",
+    "description": "black component as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "alpha",
+    "optional": true,
+    "default": "1.0",
+    "description": "alpha component as a float value from 0.0 to 1.0"
+  }],
+  "examples": [{
+    "expression": "color_cmykf(1,0.9,0.81,0.62)",
+    "returns": "CMYKA: 1.00,0.90,0.81,0.62,1.00"
+  }],
+  "tags": ["cyan", "magenta", "yellow", "black", "alpha", "color", "components"]
+}

--- a/resources/function_help/json/color_hslf
+++ b/resources/function_help/json/color_hslf
@@ -1,0 +1,26 @@
+{
+  "name": "color_hslf",
+  "type": "function",
+  "groups": ["Color"],
+  "description": "Returns a color object based on its hue, saturation, and lightness attributes.",
+  "arguments": [{
+    "arg": "hue",
+    "description": "hue of the color, as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "saturation",
+    "description": "saturation of the color as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "lightness",
+    "description": "lightness of the color as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "alpha",
+    "optional": true,
+    "default": "1.0",
+    "description": "alpha component as a float value from 0.0 to 1.0"
+  }],
+  "examples": [{
+    "expression": "color_hslf(0.3,0.52,0.7)",
+    "returns": "HSLA: 0.30,0.52,0.70,1.00"
+  }],
+  "tags": ["attributes", "lightness", "color", "hue", "saturation"]
+}

--- a/resources/function_help/json/color_hsvf
+++ b/resources/function_help/json/color_hsvf
@@ -1,0 +1,26 @@
+{
+  "name": "color_hsvf",
+  "type": "function",
+  "groups": ["Color"],
+  "description": "Returns a color object based on its hue, saturation, and value attributes.",
+  "arguments": [{
+    "arg": "hue",
+    "description": "hue of the color, as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "saturation",
+    "description": "saturation of the color as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "value",
+    "description": "value of the color as as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "alpha",
+    "optional": true,
+    "default": "1.0",
+    "description": "alpha component as a float value from 0.0 to 1.0"
+  }],
+  "examples": [{
+    "expression": "color_hsvf(0.4,1,0.6)",
+    "returns": "HSVA: 0.40,1.00,0.60,1.00"
+  }],
+  "tags": ["attributes", "color", "hue", "saturation"]
+}

--- a/resources/function_help/json/color_rgbf
+++ b/resources/function_help/json/color_rgbf
@@ -1,0 +1,26 @@
+{
+  "name": "color_rgbf",
+  "type": "function",
+  "groups": ["Color"],
+  "description": "Returns a color object based on its red, green, blue and alpha components.",
+  "arguments": [{
+    "arg": "red",
+    "description": "red component as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "green",
+    "description": "green component as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "blue",
+    "description": "blue component as a float value from 0.0 to 1.0"
+  }, {
+    "arg": "alpha",
+    "optional": true,
+    "default": "1.0",
+    "description": "alpha component as a float value from 0.0 to 1.0"
+  }],
+  "examples": [{
+    "expression": "color_rgbf(1.0,0.5,0)",
+    "returns": "RGBA: 1.00,0.50,0.00,1.00"
+  }],
+  "tags": ["green", "blue", "red", "alpha", "color", "components"]
+}

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -1147,18 +1147,33 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
     {
       return tr( "<i>Invalid</i>" );
     }
-    if ( color.spec() == QColor::Spec::Cmyk )
+
+    switch ( color.spec() )
     {
-      return QStringLiteral( "CMYKA: %1,%2,%3,%4,%5" )
-             .arg( color.cyanF(), 0, 'f', 2 ).arg( color.magentaF(), 0, 'f', 2 )
-             .arg( color.yellowF(), 0, 'f', 2 ).arg( color.blackF(), 0, 'f', 2 )
-             .arg( color.alphaF(), 0, 'f', 2 );
-    }
-    else
-    {
-      return QStringLiteral( "RGBA: %1,%2,%3,%4" )
-             .arg( color.redF(), 0, 'f', 2 ).arg( color.greenF(), 0, 'f', 2 )
-             .arg( color.blueF(), 0, 'f', 2 ).arg( color.alphaF(), 0, 'f', 2 );
+      case QColor::Spec::Cmyk:
+        return QStringLiteral( "CMYKA: %1,%2,%3,%4,%5" )
+               .arg( color.cyanF(), 0, 'f', 2 ).arg( color.magentaF(), 0, 'f', 2 )
+               .arg( color.yellowF(), 0, 'f', 2 ).arg( color.blackF(), 0, 'f', 2 )
+               .arg( color.alphaF(), 0, 'f', 2 );
+
+      case QColor::Spec::Hsv:
+        return QStringLiteral( "HSVA: %1,%2,%3,%4" )
+               .arg( color.hsvHueF(), 0, 'f', 2 ).arg( color.hsvSaturationF(), 0, 'f', 2 )
+               .arg( color.valueF(), 0, 'f', 2 ).arg( color.alphaF(), 0, 'f', 2 );
+
+      case QColor::Spec::Hsl:
+        return QStringLiteral( "HSLA: %1,%2,%3,%4" )
+               .arg( color.hslHueF(), 0, 'f', 2 ).arg( color.hslSaturationF(), 0, 'f', 2 )
+               .arg( color.lightnessF(), 0, 'f', 2 ).arg( color.alphaF(), 0, 'f', 2 );
+
+      case QColor::Spec::Rgb:
+      case QColor::Spec::ExtendedRgb:
+        return QStringLiteral( "RGBA: %1,%2,%3,%4" )
+               .arg( color.redF(), 0, 'f', 2 ).arg( color.greenF(), 0, 'f', 2 )
+               .arg( color.blueF(), 0, 'f', 2 ).arg( color.alphaF(), 0, 'f', 2 );
+
+      case QColor::Spec::Invalid:
+        return tr( "<i>Invalid</i>" );
     }
   }
   else if ( value.userType() == QMetaType::Type::Int ||

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -1139,6 +1139,28 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
     listStr += QLatin1Char( ']' );
     return listStr;
   }
+  else if ( value.type() == QVariant::Color )
+  {
+    const QColor color = value.value<QColor>();
+
+    if ( !color.isValid() )
+    {
+      return tr( "<i>Invalid</i>" );
+    }
+    if ( color.spec() == QColor::Spec::Cmyk )
+    {
+      return QStringLiteral( "CMYKA: %1,%2,%3,%4,%5" )
+             .arg( color.cyanF(), 0, 'f', 2 ).arg( color.magentaF(), 0, 'f', 2 )
+             .arg( color.yellowF(), 0, 'f', 2 ).arg( color.blackF(), 0, 'f', 2 )
+             .arg( color.alphaF(), 0, 'f', 2 );
+    }
+    else
+    {
+      return QStringLiteral( "RGBA: %1,%2,%3,%4" )
+             .arg( color.redF(), 0, 'f', 2 ).arg( color.greenF(), 0, 'f', 2 )
+             .arg( color.blueF(), 0, 'f', 2 ).arg( color.alphaF(), 0, 'f', 2 );
+    }
+  }
   else if ( value.userType() == QMetaType::Type::Int ||
             value.userType() == QMetaType::Type::UInt ||
             value.userType() == QMetaType::Type::LongLong ||

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5871,10 +5871,10 @@ static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionCont
 
 static QVariant fcnColorRgbF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const float red = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
-  const float green = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
-  const float blue = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
-  const float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
+  const float red = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) ), 0.f, 1.f );
+  const float green = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) ), 0.f, 1.f );
+  const float blue = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) ), 0.f, 1.f );
+  const float alpha = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) ), 0.f, 1.f );
   QColor color = QColor::fromRgbF( red, green, blue, alpha );
   if ( ! color.isValid() )
   {
@@ -6005,10 +6005,10 @@ static QVariant fncColorHsla( const QVariantList &values, const QgsExpressionCon
 
 static QVariant fcnColorHslF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  float hue = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
-  float saturation = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
-  float lightness = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
-  float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
+  float hue = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) ), 0.f, 1.f );
+  float saturation = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) ), 0.f, 1.f );
+  float lightness = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) ), 0.f, 1.f );
+  float alpha = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) ), 0.f, 1.f );
 
   QColor color = QColor::fromHslF( hue, saturation, lightness, alpha );
   if ( ! color.isValid() )
@@ -6062,10 +6062,10 @@ static QVariant fncColorHsva( const QVariantList &values, const QgsExpressionCon
 
 static QVariant fcnColorHsvF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  float hue = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
-  float saturation = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
-  float value = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
-  float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
+  float hue = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) ), 0.f, 1.f );
+  float saturation = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) ), 0.f, 1.f );
+  float value = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) ), 0.f, 1.f );
+  float alpha = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) ), 0.f, 1.f );
   QColor color = QColor::fromHsvF( hue, saturation, value, alpha );
 
   if ( ! color.isValid() )
@@ -6079,11 +6079,11 @@ static QVariant fcnColorHsvF( const QVariantList &values, const QgsExpressionCon
 
 static QVariant fcnColorCmykF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const float cyan = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
-  const float magenta = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
-  const float yellow = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
-  const float black = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
-  const float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 4 ), parent ) );
+  const float cyan = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) ), 0.f, 1.f );
+  const float magenta = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) ), 0.f, 1.f );
+  const float yellow = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) ), 0.f, 1.f );
+  const float black = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) ), 0.f, 1.f );
+  const float alpha = std::clamp( static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 4 ), parent ) ), 0.f, 1.f );
 
   QColor color = QColor::fromCmykF( cyan, magenta, yellow, black, alpha );
   if ( ! color.isValid() )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6060,6 +6060,23 @@ static QVariant fncColorHsva( const QVariantList &values, const QgsExpressionCon
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
+static QVariant fcnColorHsvF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  float hue = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
+  float saturation = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
+  float value = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
+  float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
+  QColor color = QColor::fromHsvF( hue, saturation, value, alpha );
+
+  if ( ! color.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4' to color" ).arg( hue ).arg( saturation ).arg( value ).arg( alpha ) );
+    color = QColor( 0, 0, 0 );
+  }
+
+  return color;
+}
+
 static QVariant fcnColorCmykF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const float cyan = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
@@ -8446,6 +8463,11 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "alpha" ) ),
                                             fncColorHsva, QStringLiteral( "Color" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "color_hsvf" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "hue" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "saturation" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "alpha" ), true, 1. ),
+                                            fcnColorHsvF, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_cmyk" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "cyan" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "magenta" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "yellow" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6043,6 +6043,24 @@ static QVariant fncColorHsva( const QVariantList &values, const QgsExpressionCon
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
+static QVariant fcnColorCmykF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const float cyan = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
+  const float magenta = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
+  const float yellow = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
+  const float black = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
+  const float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 4 ), parent ) );
+
+  QColor color = QColor::fromCmykF( cyan, magenta, yellow, black, alpha );
+  if ( ! color.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4:%5' to color" ).arg( cyan ).arg( magenta ).arg( yellow ).arg( black ).arg( alpha ) );
+    color = QColor( 0, 0, 0 );
+  }
+
+  return color;
+}
+
 static QVariant fcnColorCmyk( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Cyan ranges from 0 - 100
@@ -8417,6 +8435,12 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "black" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "alpha" ) ),
                                             fncColorCmyka, QStringLiteral( "Color" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "color_cmykf" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "cyan" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "magenta" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "yellow" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "black" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "alpha" ), true, 1. ),
+                                            fcnColorCmykF, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_part" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "color" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "component" ) ),
                                             fncColorPart, QStringLiteral( "Color" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5879,7 +5879,7 @@ static QVariant fcnColorRgbF( const QVariantList &values, const QgsExpressionCon
   if ( ! color.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4' to color" ).arg( red ).arg( green ).arg( blue ).arg( alpha ) );
-    color = QColor( 0, 0, 0 );
+    return QVariant();
   }
 
   return color;
@@ -6014,7 +6014,7 @@ static QVariant fcnColorHslF( const QVariantList &values, const QgsExpressionCon
   if ( ! color.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4' to color" ).arg( hue ).arg( saturation ).arg( lightness ).arg( alpha ) );
-    color = QColor( 0, 0, 0 );
+    return QVariant();
   }
 
   return color;
@@ -6071,7 +6071,7 @@ static QVariant fcnColorHsvF( const QVariantList &values, const QgsExpressionCon
   if ( ! color.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4' to color" ).arg( hue ).arg( saturation ).arg( value ).arg( alpha ) );
-    color = QColor( 0, 0, 0 );
+    return QVariant();
   }
 
   return color;
@@ -6089,7 +6089,7 @@ static QVariant fcnColorCmykF( const QVariantList &values, const QgsExpressionCo
   if ( ! color.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4:%5' to color" ).arg( cyan ).arg( magenta ).arg( yellow ).arg( black ).arg( alpha ) );
-    color = QColor( 0, 0, 0 );
+    return QVariant();
   }
 
   return color;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5869,6 +5869,22 @@ static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionCont
   return QStringLiteral( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
+static QVariant fcnColorRgbF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const float red = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
+  const float green = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
+  const float blue = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
+  const float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
+  QColor color = QColor::fromRgbF( red, green, blue, alpha );
+  if ( ! color.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4' to color" ).arg( red ).arg( green ).arg( blue ).arg( alpha ) );
+    color = QColor( 0, 0, 0 );
+  }
+
+  return color;
+}
+
 static QVariant fcnTry( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsExpressionNode *node = QgsExpressionUtils::getNode( values.at( 0 ), parent );
@@ -8356,6 +8372,11 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "green" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "blue" ) ),
                                             fcnColorRgb, QStringLiteral( "Color" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "color_rgbf" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "red" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "green" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "blue" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "alpha" ), true, 1. ),
+                                            fcnColorRgbF, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_rgba" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "red" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "green" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "blue" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6003,6 +6003,23 @@ static QVariant fncColorHsla( const QVariantList &values, const QgsExpressionCon
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
+static QVariant fcnColorHslF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  float hue = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
+  float saturation = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent ) );
+  float lightness = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ) );
+  float alpha = static_cast<float>( QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent ) );
+
+  QColor color = QColor::fromHslF( hue, saturation, lightness, alpha );
+  if ( ! color.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1:%2:%3:%4' to color" ).arg( hue ).arg( saturation ).arg( lightness ).arg( alpha ) );
+    color = QColor( 0, 0, 0 );
+  }
+
+  return color;
+}
+
 static QVariant fcnColorHsv( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Hue ranges from 0 - 360
@@ -8415,6 +8432,11 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "lightness" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "alpha" ) ),
                                             fncColorHsla, QStringLiteral( "Color" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "color_hslf" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "hue" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "saturation" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "lightness" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "alpha" ), true, 1. ),
+                                            fcnColorHslF, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_hsv" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "hue" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "saturation" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ),

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1940,13 +1940,13 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color rgba float" ) << "color_rgbf(1,0.4989,0,0.21)" << false << QVariant( QColor::fromRgbF( 1., 0.4989, 0, 0.21 ) );
       QTest::newRow( "color cmyk float" ) << "color_cmykf(1,0.9012,0,0.8034)" << false << QVariant( QColor::fromCmykF( 1., 0.9012, 0, 0.8034 ) );
       QTest::newRow( "color cmyka float" ) << "color_cmykf(1,0.9012,0,0.8034,0.5069)" << false << QVariant( QColor::fromCmykF( 1.f, 0.9012, 0, 0.8034, 0.5069 ) );
-      QTest::newRow( "color cmyk invalid float" ) << "color_cmykf(1.5,0.1,0,0)" << true << QVariant();
+      QTest::newRow( "color cmyk invalid float" ) << "color_cmykf(1.5,0.1,0,0)" << false << QVariant( QColor::fromCmykF( 1.f, 0.1, 0, 0 ) );
       QTest::newRow( "color hsl float" ) << "color_hslf(1,0.9012,0)" << false << QVariant( QColor::fromHslF( 1., 0.9012, 0 ) );
       QTest::newRow( "color hsla float" ) << "color_hslf(0.5,0.9012,0,0.8034)" << false << QVariant( QColor::fromHslF( 0.5f, 0.9012, 0, 0.8034 ) );
-      QTest::newRow( "color hsl invalid float" ) << "color_hslf(1.5,0.1,0,0)" << true << QVariant();
+      QTest::newRow( "color hsl invalid float" ) << "color_hslf(1.5,0.1,0,0)" << false << QVariant( QColor::fromHslF( 1., 0.1, 0, 0 ) );
       QTest::newRow( "color hsv float" ) << "color_hsvf(1,0.9012,0)" << false << QVariant( QColor::fromHsvF( 1., 0.9012, 0 ) );
       QTest::newRow( "color hsva float" ) << "color_hsvf(0.5,0.9012,0,0.8034)" << false << QVariant( QColor::fromHsvF( 0.5f, 0.9012, 0, 0.8034 ) );
-      QTest::newRow( "color hsv invalid float" ) << "color_hsvf(1.5,0.1,0,0)" << true << QVariant();
+      QTest::newRow( "color hsv invalid float" ) << "color_hsvf(1.5,0.1,0,0)" << false << QVariant( QColor::fromHsvF( 1, 0.1, 0, 0 ) );
 
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1944,6 +1944,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color hsl float" ) << "color_hslf(1,0.9012,0)" << false << QVariant( QColor::fromHslF( 1., 0.9012, 0 ) );
       QTest::newRow( "color hsla float" ) << "color_hslf(0.5,0.9012,0,0.8034)" << false << QVariant( QColor::fromHslF( 0.5f, 0.9012, 0, 0.8034 ) );
       QTest::newRow( "color hsl invalid float" ) << "color_hslf(1.5,0.1,0,0)" << true << QVariant();
+      QTest::newRow( "color hsv float" ) << "color_hsvf(1,0.9012,0)" << false << QVariant( QColor::fromHsvF( 1., 0.9012, 0 ) );
+      QTest::newRow( "color hsva float" ) << "color_hsvf(0.5,0.9012,0,0.8034)" << false << QVariant( QColor::fromHsvF( 0.5f, 0.9012, 0, 0.8034 ) );
+      QTest::newRow( "color hsv invalid float" ) << "color_hsvf(1.5,0.1,0,0)" << true << QVariant();
 
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );
@@ -5197,6 +5200,9 @@ class TestQgsExpression: public QObject
 
       color = QColor::fromHslF( 0.90, 0.5f, 0.25f, 0.1f );
       QCOMPARE( QgsExpression::formatPreviewString( QVariant( color ) ), "HSLA: 0.90,0.50,0.25,0.10" );
+
+      color = QColor::fromHsvF( 0.90, 0.5f, 0.25f, 0.1f );
+      QCOMPARE( QgsExpression::formatPreviewString( QVariant( color ) ), "HSVA: 0.90,0.50,0.25,0.10" );
     }
 
     void test_formatPreviewStringWithLocale()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1938,9 +1938,9 @@ class TestQgsExpression: public QObject
 
       QTest::newRow( "color rgb float" ) << "color_rgbf(1,0.4989,0)" << false << QVariant( QColor::fromRgbF( 1., 0.4989, 0 ) );
       QTest::newRow( "color rgba float" ) << "color_rgbf(1,0.4989,0,0.21)" << false << QVariant( QColor::fromRgbF( 1., 0.4989, 0, 0.21 ) );
-      QTest::newRow( "qcolor cmyk" ) << "qcolor_cmyk(100,90.12,0,80.34)" << false << QVariant( QColor::fromCmykF( 1., 0.9012, 0, 0.8034 ) );
-      QTest::newRow( "qcolor cmyka" ) << "qcolor_cmyk(100,90.12,0,80.34,50.69)" << false << QVariant( QColor::fromCmykF( 1.f, 0.9012, 0, 0.8034, 0.5069 ) );
-      QTest::newRow( "qcolor cmyk invalid" ) << "qcolor_cmyk(150,10,0,0)" << true << QVariant();
+      QTest::newRow( "color cmyk float" ) << "color_cmykf(1,0.9012,0,0.8034)" << false << QVariant( QColor::fromCmykF( 1., 0.9012, 0, 0.8034 ) );
+      QTest::newRow( "color cmyka float" ) << "color_cmykf(1,0.9012,0,0.8034,0.5069)" << false << QVariant( QColor::fromCmykF( 1.f, 0.9012, 0, 0.8034, 0.5069 ) );
+      QTest::newRow( "color cmyk invalid float" ) << "color_cmykf(1.5,0.1,0,0)" << true << QVariant();
 
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );
@@ -2305,10 +2305,21 @@ class TestQgsExpression: public QObject
           const QColor resultColor = result.value<QColor>();
           const QColor expectedColor = expected.value<QColor>();
           QCOMPARE( resultColor.spec(), expectedColor.spec() );
-          QVERIFY( qgsDoubleNear( resultColor.redF(), expectedColor.redF(), 0.001 ) );
-          QVERIFY( qgsDoubleNear( resultColor.greenF(), expectedColor.greenF(), 0.001 ) );
-          QVERIFY( qgsDoubleNear( resultColor.blueF(), expectedColor.blueF(), 0.001 ) );
-          QVERIFY( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ) );
+          if ( resultColor.spec() == QColor::Spec::Cmyk )
+          {
+            QVERIFY( qgsDoubleNear( resultColor.cyanF(), expectedColor.cyanF(), 0.001 ) );
+            QVERIFY( qgsDoubleNear( resultColor.magentaF(), expectedColor.magentaF(), 0.001 ) );
+            QVERIFY( qgsDoubleNear( resultColor.yellowF(), expectedColor.yellowF(), 0.001 ) );
+            QVERIFY( qgsDoubleNear( resultColor.blackF(), expectedColor.blackF(), 0.001 ) );
+            QVERIFY( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ) );
+          }
+          else
+          {
+            QVERIFY( qgsDoubleNear( resultColor.redF(), expectedColor.redF(), 0.001 ) );
+            QVERIFY( qgsDoubleNear( resultColor.greenF(), expectedColor.greenF(), 0.001 ) );
+            QVERIFY( qgsDoubleNear( resultColor.blueF(), expectedColor.blueF(), 0.001 ) );
+            QVERIFY( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ) );
+          }
           break;
         }
         default:


### PR DESCRIPTION
According to QEP #283 , I propose to add 2 new expression functions to load RGB and CMYK color

Contrary to color_cmyk/rgb, qcolor_cmyk/rgb allows to load a color from float component (and not int) into a QColor object (and not a string representation).

This allows to avoid color conversions so we can write PDF with native CMYK colors coming from expression.

This is a first PR, I'm planning to add other functions with the same goal.

So far, I didn't deprecate the old functions.

**Funded by Bordeaux Métropole**