### PR TITLE
Improve name and description of File Downloader Algorithm and fix failing SKIP OUTPUT

### DIFF
--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -40,7 +40,7 @@ QString QgsFileDownloaderAlgorithm::displayName() const
 
 QString QgsFileDownloaderAlgorithm::shortDescription() const
 {
-  return tr( "Downloads a URL on the file system with an HTTP(S) GET or POST request" );
+  return tr( "Downloads a URL to the file system with an HTTP(S) GET or POST request" );
 }
 
 QStringList QgsFileDownloaderAlgorithm::tags() const
@@ -60,7 +60,7 @@ QString QgsFileDownloaderAlgorithm::groupId() const
 
 QString QgsFileDownloaderAlgorithm::shortHelpString() const
 {
-  return tr( "This algorithm downloads a URL on the file system with an HTTP(S) GET or POST request" );
+  return tr( "This algorithm downloads a URL to the file system with an HTTP(S) GET or POST request" );
 }
 
 QgsFileDownloaderAlgorithm *QgsFileDownloaderAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -35,12 +35,12 @@ QString QgsFileDownloaderAlgorithm::name() const
 
 QString QgsFileDownloaderAlgorithm::displayName() const
 {
-  return tr( "Download file" );
+  return tr( "Download file (HTTP request)" );
 }
 
 QStringList QgsFileDownloaderAlgorithm::tags() const
 {
-  return tr( "file,downloader,internet,url,fetch,get,https" ).split( ',' );
+  return tr( "file,downloader,internet,url,fetch,get,post,request,https" ).split( ',' );
 }
 
 QString QgsFileDownloaderAlgorithm::group() const
@@ -55,7 +55,7 @@ QString QgsFileDownloaderAlgorithm::groupId() const
 
 QString QgsFileDownloaderAlgorithm::shortHelpString() const
 {
-  return tr( "This algorithm downloads a URL on the file system." );
+  return tr( "This algorithm downloads a URL on the file system with an HTTP GET or POST request" );
 }
 
 QgsFileDownloaderAlgorithm *QgsFileDownloaderAlgorithm::createInstance() const
@@ -85,9 +85,8 @@ void QgsFileDownloaderAlgorithm::initAlgorithm( const QVariantMap & )
   dataParam->setHelp( QObject::tr( "The data to add in the body if the request is a POST" ) );
   dataParam->setFlags( dataParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( dataParam.release() );
-
   addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ),
-                tr( "File destination" ), QObject::tr( "All files (*.*)" ), QVariant(), true ) );
+                tr( "File destination" ), QObject::tr( "All files (*.*)" ), QVariant(), false ) );
 }
 
 QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -35,7 +35,12 @@ QString QgsFileDownloaderAlgorithm::name() const
 
 QString QgsFileDownloaderAlgorithm::displayName() const
 {
-  return tr( "Download file (HTTP request)" );
+  return tr( "Download file via HTTP(S)" );
+}
+
+QString QgsFileDownloaderAlgorithm::shortDescription() const
+{
+  return tr( "Downloads a URL on the file system with an HTTP(S) GET or POST request" );
 }
 
 QStringList QgsFileDownloaderAlgorithm::tags() const
@@ -55,7 +60,7 @@ QString QgsFileDownloaderAlgorithm::groupId() const
 
 QString QgsFileDownloaderAlgorithm::shortHelpString() const
 {
-  return tr( "This algorithm downloads a URL on the file system with an HTTP GET or POST request" );
+  return tr( "This algorithm downloads a URL on the file system with an HTTP(S) GET or POST request" );
 }
 
 QgsFileDownloaderAlgorithm *QgsFileDownloaderAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmfiledownloader.h
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.h
@@ -39,6 +39,7 @@ class QgsFileDownloaderAlgorithm : public QObject, public QgsProcessingAlgorithm
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;
+    QString shortDescription() const override;
     QStringList tags() const override;
     QString group() const override;
     QString groupId() const override;


### PR DESCRIPTION
- Changed name to "Download file (HTTP request)" because it's not given that a file download is performed by HTTP, and this is what this algorithm is about. Even more one easily can use it to perform HTTP requests without caring about the file.
- Still the algorithm failed because of SKIP OUTPUT not passing a file path to the QgsFileDownloader why I set the parameter to mandatory instead
- Additionally I added some tags

One could think about other improvements (but not part of this PR):
- Allow not to download files and only perform requests
- Put responses and / or status code (even on error) to the output