### PR TITLE
[feature] Add 'Custom Expression' numeric format

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsexpressionbasednumericformat.py
+++ b/python/PyQt6/core/auto_additions/qgsexpressionbasednumericformat.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/numericformats/qgsexpressionbasednumericformat.h
+try:
+    QgsExpressionBasedNumericFormat.__group__ = ['numericformats']
+except NameError:
+    pass

--- a/python/PyQt6/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
@@ -53,13 +53,6 @@ Returns the expression used to calculate the text representation of a value.
 .. seealso:: :py:func:`setExpression`
 %End
 
-  protected:
-
-    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
-%Docstring
-Sets the format's ``configuration``.
-%End
-
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
@@ -1,0 +1,71 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/numericformats/qgsexpressionbasednumericformat.h            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+class QgsExpressionBasedNumericFormat : QgsNumericFormat
+{
+%Docstring(signature="appended")
+A numeric formatter which uses a :py:class:`QgsExpression` to calculate the text representation of a value.
+
+.. versionadded:: 3.40
+%End
+
+%TypeHeaderCode
+#include "qgsexpressionbasednumericformat.h"
+%End
+  public:
+
+    QgsExpressionBasedNumericFormat();
+
+    virtual QString id() const;
+
+    virtual QString visibleName() const;
+
+    virtual int sortKey();
+
+    virtual QString formatDouble( double value, const QgsNumericFormatContext &context ) const;
+
+    virtual QgsNumericFormat *clone() const /Factory/;
+
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
+
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
+
+
+    void setExpression( const QString &expression );
+%Docstring
+Sets the ``expression`` used to calculate the text representation of a value.
+
+The expression can utilize `@value` to retrieve the numeric value to represent.
+
+.. seealso:: :py:func:`expression`
+%End
+
+    QString expression() const;
+%Docstring
+Returns the expression used to calculate the text representation of a value.
+
+.. seealso:: :py:func:`setExpression`
+%End
+
+  protected:
+
+    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
+%Docstring
+Sets the format's ``configuration``.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/numericformats/qgsexpressionbasednumericformat.h            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/PyQt6/core/auto_generated/numericformats/qgsnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsnumericformat.sip.in
@@ -33,7 +33,6 @@ Constructor for QgsNumericFormatContext.
 The context will be populated based on the user's current locale settings.
 %End
 
-
     QChar thousandsSeparator() const;
 %Docstring
 Returns the thousands separator character.
@@ -157,6 +156,24 @@ Sets the ``interpretation`` of the numbers being converted.
 .. versionadded:: 3.26
 %End
 
+    QgsExpressionContext expressionContext() const;
+%Docstring
+Returns the expression context to use when evaluating :py:class:`QgsExpressions`.
+
+.. seealso:: :py:func:`setExpressionContext`
+
+.. versionadded:: 3.40
+%End
+
+    void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Sets the expression ``context`` to use when evaluating :py:class:`QgsExpressions`.
+
+.. seealso:: :py:func:`expressionContext`
+
+.. versionadded:: 3.40
+%End
+
 };
 
 %ModuleHeaderCode
@@ -167,6 +184,7 @@ Sets the ``interpretation`` of the numbers being converted.
 #include <qgspercentagenumericformat.h>
 #include <qgsscientificnumericformat.h>
 #include <qgscoordinatenumericformat.h>
+#include <qgsexpressionbasednumericformat.h>
 %End
 
 class QgsNumericFormat
@@ -201,6 +219,8 @@ This is an abstract base class and will always need to be subclassed.
       sipType = sipType_QgsBasicNumericFormat;
     else if ( dynamic_cast< QgsFractionNumericFormat * >( sipCpp ) )
       sipType = sipType_QgsFractionNumericFormat;
+    else if ( dynamic_cast< QgsExpressionBasedNumericFormat * >( sipCpp ) )
+      sipType = sipType_QgsExpressionBasedNumericFormat;
     else
       sipType = NULL;
 %End

--- a/python/PyQt6/core/core_auto.sip
+++ b/python/PyQt6/core/core_auto.sip
@@ -543,6 +543,7 @@
 %Include auto_generated/numericformats/qgsbearingnumericformat.sip
 %Include auto_generated/numericformats/qgscoordinatenumericformat.sip
 %Include auto_generated/numericformats/qgscurrencynumericformat.sip
+%Include auto_generated/numericformats/qgsexpressionbasednumericformat.sip
 %Include auto_generated/numericformats/qgsfallbacknumericformat.sip
 %Include auto_generated/numericformats/qgsfractionnumericformat.sip
 %Include auto_generated/numericformats/qgsnumericformat.sip

--- a/python/PyQt6/gui/auto_additions/qgsnumericformatwidget.py
+++ b/python/PyQt6/gui/auto_additions/qgsnumericformatwidget.py
@@ -43,3 +43,7 @@ try:
     QgsFractionNumericFormatWidget.__group__ = ['numericformats']
 except NameError:
     pass
+try:
+    QgsExpressionBasedNumericFormatWidget.__group__ = ['numericformats']
+except NameError:
+    pass

--- a/python/PyQt6/gui/auto_generated/numericformats/qgsnumericformatwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/numericformats/qgsnumericformatwidget.sip.in
@@ -73,11 +73,9 @@ Constructor for QgsBasicNumericFormatWidget, initially showing the specified ``f
 %End
     ~QgsBasicNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -102,11 +100,9 @@ Constructor for QgsBearingNumericFormatWidget, initially showing the specified `
 %End
     ~QgsBearingNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -160,11 +156,9 @@ Constructor for QgsGeographicCoordinateNumericFormatWidget, initially showing th
 %End
     ~QgsGeographicCoordinateNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -219,11 +213,9 @@ Constructor for QgsCurrencyNumericFormatWidget, initially showing the specified 
 %End
     ~QgsCurrencyNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -249,11 +241,9 @@ Constructor for QgsPercentageNumericFormatWidget, initially showing the specifie
 %End
     ~QgsPercentageNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -280,11 +270,9 @@ Constructor for QgsScientificNumericFormatWidget, initially showing the specifie
 %End
     ~QgsScientificNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -309,11 +297,38 @@ Constructor for QgsFractionNumericFormatWidget, initially showing the specified 
 %End
     ~QgsFractionNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
+
+    QgsNumericFormat *format() final /Factory/;
+
+};
 
 
-    virtual QgsNumericFormat *format() /Factory/;
 
+class QgsExpressionBasedNumericFormatWidget : QgsNumericFormatWidget, QgsExpressionContextGenerator
+{
+%Docstring(signature="appended")
+A widget which allow control over the properties of a :py:class:`QgsExpressionBasedNumericFormat`.
+
+.. versionadded:: 3.40
+%End
+
+%TypeHeaderCode
+#include "qgsnumericformatwidget.h"
+%End
+  public:
+
+    QgsExpressionBasedNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsExpressionBasedNumericFormatWidget, initially showing the specified ``format``.
+%End
+    ~QgsExpressionBasedNumericFormatWidget();
+
+    QgsExpressionContext createExpressionContext() const final;
+
+    void setFormat( QgsNumericFormat *format ) final;
+
+    QgsNumericFormat *format() final /Factory/;
 
 };
 /************************************************************************

--- a/python/core/auto_additions/qgsexpressionbasednumericformat.py
+++ b/python/core/auto_additions/qgsexpressionbasednumericformat.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/numericformats/qgsexpressionbasednumericformat.h
+try:
+    QgsExpressionBasedNumericFormat.__group__ = ['numericformats']
+except NameError:
+    pass

--- a/python/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
+++ b/python/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
@@ -53,13 +53,6 @@ Returns the expression used to calculate the text representation of a value.
 .. seealso:: :py:func:`setExpression`
 %End
 
-  protected:
-
-    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
-%Docstring
-Sets the format's ``configuration``.
-%End
-
 };
 
 /************************************************************************

--- a/python/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
+++ b/python/core/auto_generated/numericformats/qgsexpressionbasednumericformat.sip.in
@@ -1,0 +1,71 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/numericformats/qgsexpressionbasednumericformat.h            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+class QgsExpressionBasedNumericFormat : QgsNumericFormat
+{
+%Docstring(signature="appended")
+A numeric formatter which uses a :py:class:`QgsExpression` to calculate the text representation of a value.
+
+.. versionadded:: 3.40
+%End
+
+%TypeHeaderCode
+#include "qgsexpressionbasednumericformat.h"
+%End
+  public:
+
+    QgsExpressionBasedNumericFormat();
+
+    virtual QString id() const;
+
+    virtual QString visibleName() const;
+
+    virtual int sortKey();
+
+    virtual QString formatDouble( double value, const QgsNumericFormatContext &context ) const;
+
+    virtual QgsNumericFormat *clone() const /Factory/;
+
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
+
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
+
+
+    void setExpression( const QString &expression );
+%Docstring
+Sets the ``expression`` used to calculate the text representation of a value.
+
+The expression can utilize `@value` to retrieve the numeric value to represent.
+
+.. seealso:: :py:func:`expression`
+%End
+
+    QString expression() const;
+%Docstring
+Returns the expression used to calculate the text representation of a value.
+
+.. seealso:: :py:func:`setExpression`
+%End
+
+  protected:
+
+    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
+%Docstring
+Sets the format's ``configuration``.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/numericformats/qgsexpressionbasednumericformat.h            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/core/auto_generated/numericformats/qgsnumericformat.sip.in
+++ b/python/core/auto_generated/numericformats/qgsnumericformat.sip.in
@@ -33,7 +33,6 @@ Constructor for QgsNumericFormatContext.
 The context will be populated based on the user's current locale settings.
 %End
 
-
     QChar thousandsSeparator() const;
 %Docstring
 Returns the thousands separator character.
@@ -157,6 +156,24 @@ Sets the ``interpretation`` of the numbers being converted.
 .. versionadded:: 3.26
 %End
 
+    QgsExpressionContext expressionContext() const;
+%Docstring
+Returns the expression context to use when evaluating :py:class:`QgsExpressions`.
+
+.. seealso:: :py:func:`setExpressionContext`
+
+.. versionadded:: 3.40
+%End
+
+    void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Sets the expression ``context`` to use when evaluating :py:class:`QgsExpressions`.
+
+.. seealso:: :py:func:`expressionContext`
+
+.. versionadded:: 3.40
+%End
+
 };
 
 %ModuleHeaderCode
@@ -167,6 +184,7 @@ Sets the ``interpretation`` of the numbers being converted.
 #include <qgspercentagenumericformat.h>
 #include <qgsscientificnumericformat.h>
 #include <qgscoordinatenumericformat.h>
+#include <qgsexpressionbasednumericformat.h>
 %End
 
 class QgsNumericFormat
@@ -201,6 +219,8 @@ This is an abstract base class and will always need to be subclassed.
       sipType = sipType_QgsBasicNumericFormat;
     else if ( dynamic_cast< QgsFractionNumericFormat * >( sipCpp ) )
       sipType = sipType_QgsFractionNumericFormat;
+    else if ( dynamic_cast< QgsExpressionBasedNumericFormat * >( sipCpp ) )
+      sipType = sipType_QgsExpressionBasedNumericFormat;
     else
       sipType = NULL;
 %End

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -543,6 +543,7 @@
 %Include auto_generated/numericformats/qgsbearingnumericformat.sip
 %Include auto_generated/numericformats/qgscoordinatenumericformat.sip
 %Include auto_generated/numericformats/qgscurrencynumericformat.sip
+%Include auto_generated/numericformats/qgsexpressionbasednumericformat.sip
 %Include auto_generated/numericformats/qgsfallbacknumericformat.sip
 %Include auto_generated/numericformats/qgsfractionnumericformat.sip
 %Include auto_generated/numericformats/qgsnumericformat.sip

--- a/python/gui/auto_additions/qgsnumericformatwidget.py
+++ b/python/gui/auto_additions/qgsnumericformatwidget.py
@@ -43,3 +43,7 @@ try:
     QgsFractionNumericFormatWidget.__group__ = ['numericformats']
 except NameError:
     pass
+try:
+    QgsExpressionBasedNumericFormatWidget.__group__ = ['numericformats']
+except NameError:
+    pass

--- a/python/gui/auto_generated/numericformats/qgsnumericformatwidget.sip.in
+++ b/python/gui/auto_generated/numericformats/qgsnumericformatwidget.sip.in
@@ -73,11 +73,9 @@ Constructor for QgsBasicNumericFormatWidget, initially showing the specified ``f
 %End
     ~QgsBasicNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -102,11 +100,9 @@ Constructor for QgsBearingNumericFormatWidget, initially showing the specified `
 %End
     ~QgsBearingNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -160,11 +156,9 @@ Constructor for QgsGeographicCoordinateNumericFormatWidget, initially showing th
 %End
     ~QgsGeographicCoordinateNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -219,11 +213,9 @@ Constructor for QgsCurrencyNumericFormatWidget, initially showing the specified 
 %End
     ~QgsCurrencyNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -249,11 +241,9 @@ Constructor for QgsPercentageNumericFormatWidget, initially showing the specifie
 %End
     ~QgsPercentageNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -280,11 +270,9 @@ Constructor for QgsScientificNumericFormatWidget, initially showing the specifie
 %End
     ~QgsScientificNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
 
-
-    virtual QgsNumericFormat *format() /Factory/;
-
+    QgsNumericFormat *format() final /Factory/;
 
 };
 
@@ -309,11 +297,38 @@ Constructor for QgsFractionNumericFormatWidget, initially showing the specified 
 %End
     ~QgsFractionNumericFormatWidget();
 
-    virtual void setFormat( QgsNumericFormat *format );
+    void setFormat( QgsNumericFormat *format ) final;
+
+    QgsNumericFormat *format() final /Factory/;
+
+};
 
 
-    virtual QgsNumericFormat *format() /Factory/;
 
+class QgsExpressionBasedNumericFormatWidget : QgsNumericFormatWidget, QgsExpressionContextGenerator
+{
+%Docstring(signature="appended")
+A widget which allow control over the properties of a :py:class:`QgsExpressionBasedNumericFormat`.
+
+.. versionadded:: 3.40
+%End
+
+%TypeHeaderCode
+#include "qgsnumericformatwidget.h"
+%End
+  public:
+
+    QgsExpressionBasedNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsExpressionBasedNumericFormatWidget, initially showing the specified ``format``.
+%End
+    ~QgsExpressionBasedNumericFormatWidget();
+
+    QgsExpressionContext createExpressionContext() const final;
+
+    void setFormat( QgsNumericFormat *format ) final;
+
+    QgsNumericFormat *format() final /Factory/;
 
 };
 /************************************************************************

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -195,6 +195,7 @@ set(QGIS_CORE_SRCS
   numericformats/qgsbearingnumericformat.cpp
   numericformats/qgscoordinatenumericformat.cpp
   numericformats/qgscurrencynumericformat.cpp
+  numericformats/qgsexpressionbasednumericformat.cpp
   numericformats/qgsfallbacknumericformat.cpp
   numericformats/qgsfractionnumericformat.cpp
   numericformats/qgsnumericformat.cpp
@@ -1749,6 +1750,7 @@ set(QGIS_CORE_HDRS
   numericformats/qgsbearingnumericformat.h
   numericformats/qgscoordinatenumericformat.h
   numericformats/qgscurrencynumericformat.h
+  numericformats/qgsexpressionbasednumericformat.h
   numericformats/qgsfallbacknumericformat.h
   numericformats/qgsfractionnumericformat.h
   numericformats/qgsnumericformat.h

--- a/src/core/numericformats/qgsexpressionbasednumericformat.cpp
+++ b/src/core/numericformats/qgsexpressionbasednumericformat.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+                             qgsexpressionbasednumericformat.cpp
+                             --------------------------
+    begin                : August 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsexpressionbasednumericformat.h"
+#include "qgis.h"
+
+QgsExpressionBasedNumericFormat::QgsExpressionBasedNumericFormat()
+{
+  setExpression( QStringLiteral( "@value" ) );
+}
+
+QString QgsExpressionBasedNumericFormat::id() const
+{
+  return QStringLiteral( "expression" );
+}
+
+QString QgsExpressionBasedNumericFormat::visibleName() const
+{
+  return QObject::tr( "Custom Expression" );
+}
+
+int QgsExpressionBasedNumericFormat::sortKey()
+{
+  return 1;
+}
+
+QString QgsExpressionBasedNumericFormat::formatDouble( double value, const QgsNumericFormatContext &context ) const
+{
+  QgsExpressionContext expContext = context.expressionContext();
+  expContext.setOriginalValueVariable( value );
+
+  return mExpression.evaluate( &expContext ).toString();
+}
+
+QgsNumericFormat *QgsExpressionBasedNumericFormat::clone() const
+{
+  return new QgsExpressionBasedNumericFormat( *this );
+}
+
+QgsNumericFormat *QgsExpressionBasedNumericFormat::create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const
+{
+  std::unique_ptr< QgsExpressionBasedNumericFormat > res = std::make_unique< QgsExpressionBasedNumericFormat >();
+  res->setConfiguration( configuration, context );
+  return res.release();
+}
+
+QVariantMap QgsExpressionBasedNumericFormat::configuration( const QgsReadWriteContext & ) const
+{
+  QVariantMap res;
+  res.insert( QStringLiteral( "expression" ), mExpressionString );
+  return res;
+}
+
+void QgsExpressionBasedNumericFormat::setExpression( const QString &expression )
+{
+  mExpressionString = expression;
+  mExpression = QgsExpression( mExpressionString );
+}
+
+void QgsExpressionBasedNumericFormat::setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext & )
+{
+  mExpressionString = configuration.value( QStringLiteral( "expression" ), QStringLiteral( "@value" ) ).toString();
+  mExpression = QgsExpression( mExpressionString );
+}
+

--- a/src/core/numericformats/qgsexpressionbasednumericformat.cpp
+++ b/src/core/numericformats/qgsexpressionbasednumericformat.cpp
@@ -52,21 +52,18 @@ QgsNumericFormat *QgsExpressionBasedNumericFormat::clone() const
 QgsNumericFormat *QgsExpressionBasedNumericFormat::create( const QVariantMap &configuration, const QgsReadWriteContext & ) const
 {
   std::unique_ptr< QgsExpressionBasedNumericFormat > res = std::make_unique< QgsExpressionBasedNumericFormat >();
-  res->mExpressionString = configuration.value( QStringLiteral( "expression" ), QStringLiteral( "@value" ) ).toString();
-  res->mExpression = QgsExpression( mExpressionString );
-
+  res->mExpression = QgsExpression( configuration.value( QStringLiteral( "expression" ), QStringLiteral( "@value" ) ).toString() );
   return res.release();
 }
 
 QVariantMap QgsExpressionBasedNumericFormat::configuration( const QgsReadWriteContext & ) const
 {
   QVariantMap res;
-  res.insert( QStringLiteral( "expression" ), mExpressionString );
+  res.insert( QStringLiteral( "expression" ), mExpression.expression() );
   return res;
 }
 
 void QgsExpressionBasedNumericFormat::setExpression( const QString &expression )
 {
-  mExpressionString = expression;
-  mExpression = QgsExpression( mExpressionString );
+  mExpression = QgsExpression( expression );
 }

--- a/src/core/numericformats/qgsexpressionbasednumericformat.cpp
+++ b/src/core/numericformats/qgsexpressionbasednumericformat.cpp
@@ -49,10 +49,12 @@ QgsNumericFormat *QgsExpressionBasedNumericFormat::clone() const
   return new QgsExpressionBasedNumericFormat( *this );
 }
 
-QgsNumericFormat *QgsExpressionBasedNumericFormat::create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const
+QgsNumericFormat *QgsExpressionBasedNumericFormat::create( const QVariantMap &configuration, const QgsReadWriteContext & ) const
 {
   std::unique_ptr< QgsExpressionBasedNumericFormat > res = std::make_unique< QgsExpressionBasedNumericFormat >();
-  res->setConfiguration( configuration, context );
+  res->mExpressionString = configuration.value( QStringLiteral( "expression" ), QStringLiteral( "@value" ) ).toString();
+  res->mExpression = QgsExpression( mExpressionString );
+
   return res.release();
 }
 
@@ -68,10 +70,3 @@ void QgsExpressionBasedNumericFormat::setExpression( const QString &expression )
   mExpressionString = expression;
   mExpression = QgsExpression( mExpressionString );
 }
-
-void QgsExpressionBasedNumericFormat::setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext & )
-{
-  mExpressionString = configuration.value( QStringLiteral( "expression" ), QStringLiteral( "@value" ) ).toString();
-  mExpression = QgsExpression( mExpressionString );
-}
-

--- a/src/core/numericformats/qgsexpressionbasednumericformat.h
+++ b/src/core/numericformats/qgsexpressionbasednumericformat.h
@@ -47,7 +47,7 @@ class CORE_EXPORT QgsExpressionBasedNumericFormat : public QgsNumericFormat
      *
      * \see expression()
      */
-    void setExpression( const QString &expression );
+    void setExpression( const QString &expression ); // cppcheck-suppress functionConst
 
     /**
      * Returns the expression used to calculate the text representation of a value.

--- a/src/core/numericformats/qgsexpressionbasednumericformat.h
+++ b/src/core/numericformats/qgsexpressionbasednumericformat.h
@@ -56,13 +56,6 @@ class CORE_EXPORT QgsExpressionBasedNumericFormat : public QgsNumericFormat
      */
     QString expression() const { return mExpressionString; }
 
-  protected:
-
-    /**
-     * Sets the format's \a configuration.
-     */
-    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
-
   private:
 
     QString mExpressionString;

--- a/src/core/numericformats/qgsexpressionbasednumericformat.h
+++ b/src/core/numericformats/qgsexpressionbasednumericformat.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+                             qgsexpressionbasednumericformat.h
+                             --------------------------
+    begin                : August 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSEXPRESSIONBASEDNUMERICFORMAT_H
+#define QGSEXPRESSIONBASEDNUMERICFORMAT_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include "qgsnumericformat.h"
+#include "qgsexpression.h"
+
+/**
+ * \ingroup core
+ * \brief A numeric formatter which uses a QgsExpression to calculate the text representation of a value.
+ *
+ * \since QGIS 3.40
+ */
+class CORE_EXPORT QgsExpressionBasedNumericFormat : public QgsNumericFormat
+{
+  public:
+
+    QgsExpressionBasedNumericFormat();
+
+    QString id() const override;
+    QString visibleName() const override;
+    int sortKey() override;
+    QString formatDouble( double value, const QgsNumericFormatContext &context ) const override;
+    QgsNumericFormat *clone() const override SIP_FACTORY;
+    QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const override SIP_FACTORY;
+    QVariantMap configuration( const QgsReadWriteContext &context ) const override;
+
+    /**
+     * Sets the \a expression used to calculate the text representation of a value.
+     *
+     * The expression can utilize `@value` to retrieve the numeric value to represent.
+     *
+     * \see expression()
+     */
+    void setExpression( const QString &expression );
+
+    /**
+     * Returns the expression used to calculate the text representation of a value.
+     *
+     * \see setExpression()
+     */
+    QString expression() const { return mExpressionString; }
+
+  protected:
+
+    /**
+     * Sets the format's \a configuration.
+     */
+    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
+
+  private:
+
+    QString mExpressionString;
+    mutable QgsExpression mExpression;
+};
+
+#endif // QGSEXPRESSIONBASEDNUMERICFORMAT_H

--- a/src/core/numericformats/qgsexpressionbasednumericformat.h
+++ b/src/core/numericformats/qgsexpressionbasednumericformat.h
@@ -54,11 +54,10 @@ class CORE_EXPORT QgsExpressionBasedNumericFormat : public QgsNumericFormat
      *
      * \see setExpression()
      */
-    QString expression() const { return mExpressionString; }
+    QString expression() const { return mExpression.expression(); }
 
   private:
 
-    QString mExpressionString;
     mutable QgsExpression mExpression;
 };
 

--- a/src/core/numericformats/qgsnumericformat.cpp
+++ b/src/core/numericformats/qgsnumericformat.cpp
@@ -45,6 +45,16 @@ QgsNumericFormatContext::QgsNumericFormatContext()
 #endif
 }
 
+QgsExpressionContext QgsNumericFormatContext::expressionContext() const
+{
+  return mExpressionContext;
+}
+
+void QgsNumericFormatContext::setExpressionContext( const QgsExpressionContext &context )
+{
+  mExpressionContext = context;
+}
+
 int QgsNumericFormat::sortKey()
 {
   return DEFAULT_SORT_KEY;

--- a/src/core/numericformats/qgsnumericformat.h
+++ b/src/core/numericformats/qgsnumericformat.h
@@ -17,6 +17,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgsexpressioncontext.h"
 
 #include <QString>
 #include <QVariantMap>
@@ -43,7 +44,6 @@ class CORE_EXPORT QgsNumericFormatContext
      * The context will be populated based on the user's current locale settings.
      */
     QgsNumericFormatContext();
-
 
     /**
      * Returns the thousands separator character.
@@ -222,6 +222,22 @@ class CORE_EXPORT QgsNumericFormatContext
       mInterpretation = interpretation;
     }
 
+    /**
+     * Returns the expression context to use when evaluating QgsExpressions.
+     *
+     * \see setExpressionContext()
+     * \since QGIS 3.40
+     */
+    QgsExpressionContext expressionContext() const;
+
+    /**
+     * Sets the expression \a context to use when evaluating QgsExpressions.
+     *
+     * \see expressionContext()
+     * \since QGIS 3.40
+     */
+    void setExpressionContext( const QgsExpressionContext &context );
+
   private:
     QChar mThousandsSep;
     QChar mDecimalSep;
@@ -232,6 +248,8 @@ class CORE_EXPORT QgsNumericFormatContext
     QChar mExponential;
 
     Interpretation mInterpretation = Interpretation::Generic;
+
+    QgsExpressionContext mExpressionContext;
 };
 
 #ifdef SIP_RUN
@@ -243,6 +261,7 @@ class CORE_EXPORT QgsNumericFormatContext
 #include <qgspercentagenumericformat.h>
 #include <qgsscientificnumericformat.h>
 #include <qgscoordinatenumericformat.h>
+#include <qgsexpressionbasednumericformat.h>
 % End
 #endif
 
@@ -277,6 +296,8 @@ class CORE_EXPORT QgsNumericFormat
       sipType = sipType_QgsBasicNumericFormat;
     else if ( dynamic_cast< QgsFractionNumericFormat * >( sipCpp ) )
       sipType = sipType_QgsFractionNumericFormat;
+    else if ( dynamic_cast< QgsExpressionBasedNumericFormat * >( sipCpp ) )
+      sipType = sipType_QgsExpressionBasedNumericFormat;
     else
       sipType = NULL;
     SIP_END

--- a/src/core/numericformats/qgsnumericformatregistry.cpp
+++ b/src/core/numericformats/qgsnumericformatregistry.cpp
@@ -23,6 +23,7 @@
 #include "qgsscientificnumericformat.h"
 #include "qgsfractionnumericformat.h"
 #include "qgscoordinatenumericformat.h"
+#include "qgsexpressionbasednumericformat.h"
 #include "qgsxmlutils.h"
 
 QgsNumericFormatRegistry::QgsNumericFormatRegistry()
@@ -35,6 +36,7 @@ QgsNumericFormatRegistry::QgsNumericFormatRegistry()
   addFormat( new QgsPercentageNumericFormat() );
   addFormat( new QgsScientificNumericFormat() );
   addFormat( new QgsFractionNumericFormat() );
+  addFormat( new QgsExpressionBasedNumericFormat() );
 }
 
 QgsNumericFormatRegistry::~QgsNumericFormatRegistry()

--- a/src/gui/numericformats/qgsnumericformatguiregistry.cpp
+++ b/src/gui/numericformats/qgsnumericformatguiregistry.cpp
@@ -89,6 +89,17 @@ class QgsFractionNumericFormatConfigurationWidgetFactory : public QgsNumericForm
       return new QgsFractionNumericFormatWidget( format );
     }
 };
+
+class QgsExpressionBasedNumericFormatConfigurationWidgetFactory : public QgsNumericFormatConfigurationWidgetFactory
+{
+  public:
+
+    QgsNumericFormatWidget *create( const QgsNumericFormat *format ) const
+    {
+      return new QgsExpressionBasedNumericFormatWidget( format );
+    }
+};
+
 ///@endcond
 
 QgsNumericFormatGuiRegistry::QgsNumericFormatGuiRegistry()
@@ -100,6 +111,7 @@ QgsNumericFormatGuiRegistry::QgsNumericFormatGuiRegistry()
   addFormatConfigurationWidgetFactory( QStringLiteral( "scientific" ), new QgsScientificNumericFormatConfigurationWidgetFactory() );
   addFormatConfigurationWidgetFactory( QStringLiteral( "fraction" ), new QgsFractionNumericFormatConfigurationWidgetFactory() );
   addFormatConfigurationWidgetFactory( QStringLiteral( "geographiccoordinate" ), new QgsGeographicCoordinateNumericFormatConfigurationWidgetFactory() );
+  addFormatConfigurationWidgetFactory( QStringLiteral( "expression" ), new QgsExpressionBasedNumericFormatConfigurationWidgetFactory() );
 }
 
 QgsNumericFormatGuiRegistry::~QgsNumericFormatGuiRegistry()

--- a/src/gui/numericformats/qgsnumericformatwidget.h
+++ b/src/gui/numericformats/qgsnumericformatwidget.h
@@ -18,10 +18,12 @@
 #include "qgis_sip.h"
 #include "qgsnumericformat.h"
 #include "qgspanelwidget.h"
+#include "qgsexpressioncontextgenerator.h"
 #include <memory>
 #include <QDialog>
 
 class QgsFractionNumericFormat;
+class QgsExpressionBasedNumericFormat;
 
 /**
  * \ingroup gui
@@ -89,9 +91,9 @@ class GUI_EXPORT QgsBasicNumericFormatWidget : public QgsNumericFormatWidget, pr
     QgsBasicNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsBasicNumericFormatWidget() override;
 
-    void setFormat( QgsNumericFormat *format ) override;
+    void setFormat( QgsNumericFormat *format ) final;
 
-    QgsNumericFormat *format() override SIP_FACTORY;
+    QgsNumericFormat *format() final SIP_FACTORY;
 
   private:
     std::unique_ptr< QgsBasicNumericFormat > mFormat;
@@ -121,9 +123,9 @@ class GUI_EXPORT QgsBearingNumericFormatWidget : public QgsNumericFormatWidget, 
     QgsBearingNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsBearingNumericFormatWidget() override;
 
-    void setFormat( QgsNumericFormat *format ) override;
+    void setFormat( QgsNumericFormat *format ) final;
 
-    QgsNumericFormat *format() override SIP_FACTORY;
+    QgsNumericFormat *format() final SIP_FACTORY;
 
   private:
     std::unique_ptr< QgsBearingNumericFormat > mFormat;
@@ -184,9 +186,9 @@ class GUI_EXPORT QgsGeographicCoordinateNumericFormatWidget : public QgsNumericF
     QgsGeographicCoordinateNumericFormatWidget( const QgsNumericFormat *format, bool hidePrecisionControl = false, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsGeographicCoordinateNumericFormatWidget() override;
 
-    void setFormat( QgsNumericFormat *format ) override;
+    void setFormat( QgsNumericFormat *format ) final;
 
-    QgsNumericFormat *format() override SIP_FACTORY;
+    QgsNumericFormat *format() final SIP_FACTORY;
 
   private:
     std::unique_ptr< QgsGeographicCoordinateNumericFormat > mFormat;
@@ -248,9 +250,9 @@ class GUI_EXPORT QgsCurrencyNumericFormatWidget : public QgsNumericFormatWidget,
     QgsCurrencyNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsCurrencyNumericFormatWidget() override;
 
-    void setFormat( QgsNumericFormat *format ) override;
+    void setFormat( QgsNumericFormat *format ) final;
 
-    QgsNumericFormat *format() override SIP_FACTORY;
+    QgsNumericFormat *format() final SIP_FACTORY;
 
   private:
     std::unique_ptr< QgsCurrencyNumericFormat > mFormat;
@@ -281,9 +283,9 @@ class GUI_EXPORT QgsPercentageNumericFormatWidget : public QgsNumericFormatWidge
     QgsPercentageNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsPercentageNumericFormatWidget() override;
 
-    void setFormat( QgsNumericFormat *format ) override;
+    void setFormat( QgsNumericFormat *format ) final;
 
-    QgsNumericFormat *format() override SIP_FACTORY;
+    QgsNumericFormat *format() final SIP_FACTORY;
 
   private:
     std::unique_ptr< QgsPercentageNumericFormat > mFormat;
@@ -315,9 +317,9 @@ class GUI_EXPORT QgsScientificNumericFormatWidget : public QgsNumericFormatWidge
     QgsScientificNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsScientificNumericFormatWidget() override;
 
-    void setFormat( QgsNumericFormat *format ) override;
+    void setFormat( QgsNumericFormat *format ) final;
 
-    QgsNumericFormat *format() override SIP_FACTORY;
+    QgsNumericFormat *format() final SIP_FACTORY;
 
   private:
     std::unique_ptr< QgsScientificNumericFormat > mFormat;
@@ -346,12 +348,45 @@ class GUI_EXPORT QgsFractionNumericFormatWidget : public QgsNumericFormatWidget,
     QgsFractionNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsFractionNumericFormatWidget() override;
 
-    void setFormat( QgsNumericFormat *format ) override;
+    void setFormat( QgsNumericFormat *format ) final;
 
-    QgsNumericFormat *format() override SIP_FACTORY;
+    QgsNumericFormat *format() final SIP_FACTORY;
 
   private:
     std::unique_ptr< QgsFractionNumericFormat > mFormat;
+    bool mBlockSignals = false;
+
+};
+
+
+#include "ui_qgsexpressionbasednumericformatwidgetbase.h"
+
+/**
+ * \ingroup gui
+ * \class QgsExpressionBasedNumericFormatWidget
+ * \brief A widget which allow control over the properties of a QgsExpressionBasedNumericFormat.
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsExpressionBasedNumericFormatWidget : public QgsNumericFormatWidget, public QgsExpressionContextGenerator, private Ui::QgsExpressionBasedNumericFormatWidgetBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsExpressionBasedNumericFormatWidget, initially showing the specified \a format.
+     */
+    QgsExpressionBasedNumericFormatWidget( const QgsNumericFormat *format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    ~QgsExpressionBasedNumericFormatWidget() override;
+
+    QgsExpressionContext createExpressionContext() const final;
+
+    void setFormat( QgsNumericFormat *format ) final;
+
+    QgsNumericFormat *format() final SIP_FACTORY;
+
+  private:
+    std::unique_ptr< QgsExpressionBasedNumericFormat > mFormat;
     bool mBlockSignals = false;
 
 };

--- a/src/ui/numericformats/qgsexpressionbasednumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgsexpressionbasednumericformatwidgetbase.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsExpressionBasedNumericFormatWidgetBase</class>
+ <widget class="QgsPanelWidget" name="QgsExpressionBasedNumericFormatWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>288</width>
+    <height>289</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QgsExpressionLineEdit" name="mExpressionSelector" native="true"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExpressionLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgsexpressionlineedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This numeric format allows users to craft a custom QGIS expression to format numbers. The expression can use the @value variable to retrieve the value to be formatted, and then use any standard QGIS expression function to format this as desired.

It can be used anywhere QgsNumericFormat is accepted, eg layout scalebars, elevation plots, layout tables, and color ramp legends

Sponsored by the Swiss QGIS User Group
