### PR TITLE
Provide style categories for raster layers

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -632,7 +632,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         }
 
         QgisApp *app = QgisApp::instance();
-        if ( layer->type() == Qgis::LayerType::Vector )
+        if ( layer->type() == Qgis::LayerType::Vector || layer->type() == Qgis::LayerType::Raster )
         {
           QMenu *copyStyleMenu = menuStyleManager->addMenu( tr( "Copy Style" ) );
           copyStyleMenu->setToolTipsVisible( true );
@@ -660,7 +660,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         if ( layer && app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
         {
-          if ( layer->type() == Qgis::LayerType::Vector )
+          if ( layer->type() == Qgis::LayerType::Vector || layer->type() == Qgis::LayerType::Raster )
           {
             QDomDocument doc( QStringLiteral( "qgis" ) );
             QString errorMsg;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2298,6 +2298,7 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
   {
     readRasterAttributeTableExternalPaths( layer_node, context );
   }
+
   readCustomProperties( layer_node );
 
   emit rendererChanged();

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2293,6 +2293,11 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     setMapTipsEnabled( mapTipElem.attribute( QStringLiteral( "enabled" ), QStringLiteral( "1" ) ).toInt() == 1 );
   }
 
+  // read attribute table attribute table paths
+  if ( categories.testFlag( AttributeTable ) )
+  {
+    readRasterAttributeTableExternalPaths( layer_node, context );
+  }
   readCustomProperties( layer_node );
 
   emit rendererChanged();
@@ -2496,6 +2501,12 @@ bool QgsRasterLayer::writeSymbology( QDomNode &layer_node, QDomDocument &documen
     QDomText mapTipText = document.createTextNode( mapTipTemplate() );
     mapTipElem.appendChild( mapTipText );
     layer_node.toElement().appendChild( mapTipElem );
+  }
+
+  // save attribute table attribute table paths
+  if ( categories.testFlag( AttributeTable ) )
+  {
+    writeRasterAttributeTableExternalPaths( layer_node, document, context );
   }
 
   // Store pipe members into pipe element, in future, it will be

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2303,8 +2303,6 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     readRasterAttributeTableExternalPaths( layer_node, context );
   }
 
-  readCustomProperties( layer_node );
-
   emit rendererChanged();
   emitStyleChanged();
 

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -30,7 +30,16 @@ QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( Qgis::LayerTyp
       break;
 
     case Qgis::LayerType::Raster:
-      mCategoryList << QgsMapLayer::StyleCategory::Symbology << QgsMapLayer::StyleCategory::AllStyleCategories;
+      mCategoryList << QgsMapLayer::StyleCategory::LayerConfiguration
+                    << QgsMapLayer::StyleCategory::Symbology
+                    << QgsMapLayer::StyleCategory::MapTips
+                    << QgsMapLayer::StyleCategory::Rendering
+                    << QgsMapLayer::StyleCategory::CustomProperties
+                    << QgsMapLayer::StyleCategory::Temporal
+                    << QgsMapLayer::StyleCategory::Elevation
+                    << QgsMapLayer::StyleCategory::AttributeTable
+                    << QgsMapLayer::StyleCategory::Notes
+                    << QgsMapLayer::StyleCategory::AllStyleCategories;
       break;
     case Qgis::LayerType::Annotation:
     case Qgis::LayerType::Plugin:


### PR DESCRIPTION
### On copy/paste
Until now one only could **copy/paste** all categories (`AllStyleCategories`) on raster layer, what meant the following categories where considered:
- `LayerConfiguration`
- `Temporal`
- `Elevation`
- `MapTips`
- `Notes` (what means right click -> layer notes)
- `CustomProperties`
- `Symbology`
- `Rendering` (including Histogram stuff)

New you can choose what categories you want  to consider. 

![image](https://github.com/user-attachments/assets/42b78e3f-ea39-4800-b89a-c1d34d4cac10)

Additionally `AttributeTable` is available to store the path to `FileBasedAttributeTables`.

**Note:**  Symbology and Render are are melted together in the pipe object, they cannot be split. Means when `Symbology` is chosen as well Render parts are exported/imported and when `Render` is chosen as well Symbology parts are exported/imported - maybe one could split, but it would lead to backwards incompatibility.

### On save/load to file

Until now only those categories could be **stored and loaded with QML/SLD** file:
- Symbology
- Rendering
- CustomProperties

by selecting `Symbology` category only.

Now here the categories mentioned above are provided as well.

![image](https://github.com/user-attachments/assets/78f1cfd2-3ba9-47b4-ab9d-ff58ad3d42ce)


**Note** Not implemented are:
-  Categories `Symbology3D`, `Labeling`, `Fields`, `Forms`, `Actions`, `Diagrams`, `GeometryOptions` since they do not make sense for rasters
- `Legend` Category - because it has no effects yet. The ***Embedded Widgets*** are concerned by the `CustomProperties` and the ***Legend placeholder image*** is not yet handled at all (neither in the vector layers).
- Section ***QGIS Server*** is not yet handled at all (neither in the vector layers).
- Section ***Metadata*** is provided by QMD export separate

Additionally I removed the reading of `customProperties` in every case 613e83b2611191017f766b3304b8073ef5057016 since it was read double.


