### PR TITLE
Only require `qgis.gui` import when gui is built

### DIFF
--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -159,7 +159,11 @@ def run_startup_script(script_path):
 
   // import QGIS bindings
   QString error_msg = QObject::tr( "Couldn't load PyQGIS." ) + '\n' + QObject::tr( "Python support will be disabled." );
-  if ( !runString( QStringLiteral( "from qgis.core import *" ), error_msg ) || !runString( QStringLiteral( "from qgis.gui import *" ), error_msg ) )
+  if ( !runString( QStringLiteral( "from qgis.core import *" ), error_msg )
+#ifdef HAVE_GUI
+       || !runString( QStringLiteral( "from qgis.gui import *" ), error_msg )
+#endif
+     )
   {
     return false;
   }


### PR DESCRIPTION
Running `qgis_process` on a `WITH_GUI=OFF` build results in the following error
```
qgis_process run native:buffer
"<font color=\"red\">Couldn't load PyQGIS.<br>Python support will be disabled.</font><br><pre><br>Traceback (most recent call last):<br>&nbsp; File \"<string>\", line 1, in <module><br>ModuleNotFoundError: No module named 'qgis.gui'<br><br></pre>Python version:<br>3.10.12 (main, Jul 29 2024, 16:56:48) [GCC 11.4.0]<br><br>QGIS version:<br>3.34.10-Prizren 'Prizren', 113de9e1<br><br>Python path:<br>['/usr/share/qgis/python', '/home/qgis/.local/share/QGIS/QGIS3/profiles/default/python', '/home/qgis/.local/share/QGIS/QGIS3/profiles/default/python/plugins', '/usr/share/qgis/python/plugins', '/usr/share/qgis/python', '/usr/lib/python310.zip', '/usr/lib/python3.10', '/usr/lib/python3.10/lib-dynload', '/usr/local/lib/python3.10/dist-packages', '/usr/lib/python3/dist-packages']"
```

Refs https://github.com/opengisch/qgis-slim/issues/3