### PR TITLE
[Layer dependencies] Emit QgsVectorLayer::dataChanged on commitChanges

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -6116,15 +6116,6 @@ void QgsVectorLayer::emitDataChanged()
   mDataChangedFired = false;
 }
 
-void QgsVectorLayer::onAfterCommitChangesDependency()
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  mDataChangedFired = true;
-  reload();
-  mDataChangedFired = false;
-}
-
 bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -6152,7 +6143,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
       disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitChangesDependency );
+      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
     }
   }
 
@@ -6176,7 +6167,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-      connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitChangesDependency );
+      connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
     }
   }
 

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -6109,6 +6109,14 @@ void QgsVectorLayer::emitDataChanged()
   if ( mDataChangedFired )
     return;
 
+  // If we are asked to fire dataChanged from a layer we depend on,
+  // be sure that this layer is not in the process of committing its changes, because
+  // we will be asked to fire dataChanged at the end of his commit, and we don't
+  // want to fire this signal more than necessary.
+  if ( QgsVectorLayer *layerWeDependUpon = qobject_cast<QgsVectorLayer *>( sender() );
+       layerWeDependUpon && layerWeDependUpon->mCommitChangesActive )
+    return;
+
   updateExtents(); // reset cached extent to reflect data changes
 
   mDataChangedFired = true;
@@ -6143,7 +6151,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
       disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
+      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::emitDataChanged );
     }
   }
 
@@ -6167,7 +6175,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-      connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
+      connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::emitDataChanged );
     }
   }
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2802,7 +2802,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onSymbolsCounted();
     void onDirtyTransaction( const QString &sql, const QString &name );
     void emitDataChanged();
-    void onAfterCommitChangesDependency();
 
   private:
     void updateDefaultValues( QgsFeatureId fid, QgsFeature feature = QgsFeature(), QgsExpressionContext *context = nullptr );

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -26,7 +26,6 @@ from qgis.core import (
     QgsRectangle,
     QgsSnappingConfig,
     QgsSnappingUtils,
-    QgsTolerance,
     QgsVectorLayer,
 )
 import unittest
@@ -194,12 +193,12 @@ class TestLayerDependencies(QgisTestCase):
         self.assertEqual(len(spy_lines_data_changed), 2)
 
         # added feature is deleted and added with its new defined id
-        # (it was -1 before) so it fires 2 more signal dataChanged on
-        # depending line (on featureAdded and on featureDeleted)
+        # (it was -1 before) so it fires 3 more signal dataChanged on
+        # depending line (on featureAdded and on featureDeleted and on afterCommitChanges)
         # and so 2 more signal on points because it depends on line
         self.pointsLayer.commitChanges()
-        self.assertEqual(len(spy_points_data_changed), 5)
-        self.assertEqual(len(spy_lines_data_changed), 4)
+        self.assertEqual(len(spy_points_data_changed), 6)
+        self.assertEqual(len(spy_lines_data_changed), 5)
 
         # repaintRequested is called on commit changes on point
         # so it is on depending line
@@ -230,14 +229,22 @@ class TestLayerDependencies(QgisTestCase):
         self.assertEqual(len(spy_lines_data_changed), 2)
 
         # added feature is deleted and added with its new defined id
-        # (it was -1 before) so it fires 2 more signal dataChanged on
-        # depending line (on featureAdded and on featureDeleted)
-        self.linesLayer.commitChanges()
-        self.assertEqual(len(spy_lines_data_changed), 4)
+        # (it was -1 before) so it fires 3 more signal dataChanged on
+        # depending line (on featureAdded and on featureDeleted and on afterCommitChanges)
+        self.linesLayer.commitChanges(False)
+        self.assertEqual(len(spy_lines_data_changed), 5)
 
         # repaintRequested is called only once on commit changes on line
         # (ideally only one repaintRequested signal is fired, but it's harmless to fire multiple ones)
         self.assertGreaterEqual(len(spy_lines_repaint_requested), 2)
+
+        # line fire dataChanged on geometryChanged
+        self.linesLayer.changeGeometry(f.id(), QgsGeometry.fromWkt("LINESTRING(0 0, 2 2)"))
+        self.assertEqual(len(spy_lines_data_changed), 6)
+
+        # line fire dataChanged on commitChanges
+        self.linesLayer.commitChanges()
+        self.assertEqual(len(spy_lines_data_changed), 7)
 
     def test_layerDefinitionRewriteId(self):
         tmpfile = os.path.join(tempfile.tempdir, "test.qlr")


### PR DESCRIPTION
## Description

Fixes #57784 where even if the layer is checked as a dependency layer, there is no reloading of data when the layer is saved.

With this change, the dataChanged signal is emitted on commitChanges, so that when a feature is externally modified on save (database trigger for example) we have index and cache reconstruction.

---

Related PRs:
- https://github.com/qgis/QGIS/pull/37475
- https://github.com/qgis/QGIS/pull/41463

This change is kind of following this particular comment/discussion https://github.com/qgis/QGIS/pull/41463#issuecomment-777094703 

See the tests explaining the multiple emissions of `dataChanged`.

Ping @suricactus @m-kuhn @MorriganR @troopa81 @3nids for review