### PR TITLE
Change elevation profile name

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -420,7 +420,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
 
   mOptionsMenu->addSeparator();
 
-  mRenameProfileAction = new QAction( tr( "Rename profile" ), this );
+  mRenameProfileAction = new QAction( tr( "Rename Profile…" ), this );
   connect( mRenameProfileAction, &QAction::triggered, this, &QgsElevationProfileWidget::renameProfileTriggered );
   mOptionsMenu->addAction( mRenameProfileAction );
 
@@ -972,7 +972,7 @@ void QgsElevationProfileWidget::axisScaleLockToggled( bool active )
 void QgsElevationProfileWidget::renameProfileTriggered()
 {
   QgsNewNameDialog dlg( tr( "elevation profile" ), canvasName(), {}, {}, Qt::CaseSensitive, this );
-  dlg.setWindowTitle( tr( "Rename elevation profile" ) );
+  dlg.setWindowTitle( tr( "Rename Elevation Profile" ) );
   dlg.setHintString( tr( "Enter a new elevation profile title" ) );
   dlg.setAllowEmptyName( false );
   if ( dlg.exec() == QDialog::Accepted )

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -57,6 +57,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsterrainprovider.h"
 #include "qgsprofilesourceregistry.h"
+#include "qgsnewnamedialog.h"
 
 #include <QToolBar>
 #include <QProgressBar>
@@ -416,6 +417,12 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   } );
 
   mOptionsMenu->addAction( mSettingsAction );
+
+  mOptionsMenu->addSeparator();
+
+  mRenameProfileAction = new QAction( tr( "Rename profile" ), this );
+  connect( mRenameProfileAction, &QAction::triggered, this, &QgsElevationProfileWidget::renameProfileTriggered );
+  mOptionsMenu->addAction( mRenameProfileAction );
 
   mBtnOptions = new QToolButton();
   mBtnOptions->setAutoRaise( true );
@@ -960,6 +967,18 @@ void QgsElevationProfileWidget::axisScaleLockToggled( bool active )
 {
   settingLockAxis->setValue( active );
   mCanvas->setLockAxisScales( active );
+}
+
+void QgsElevationProfileWidget::renameProfileTriggered()
+{
+  QgsNewNameDialog dlg( tr( "elevation profile" ), canvasName(), {}, {}, Qt::CaseSensitive, this );
+  dlg.setWindowTitle( tr( "Rename elevation profile" ) );
+  dlg.setHintString( tr( "Enter a new elevation profile title" ) );
+  dlg.setAllowEmptyName( false );
+  if ( dlg.exec() == QDialog::Accepted )
+  {
+    setCanvasName( dlg.name() );
+  }
 }
 
 void QgsElevationProfileWidget::createOrUpdateRubberBands( )

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -135,6 +135,7 @@ class QgsElevationProfileWidget : public QWidget
     void nudgeRight();
     void nudgeCurve( Qgis::BufferSide side );
     void axisScaleLockToggled( bool active );
+    void renameProfileTriggered();
     void onProjectElevationPropertiesChanged();
 
   private:
@@ -155,6 +156,7 @@ class QgsElevationProfileWidget : public QWidget
     QAction *mCaptureCurveFromFeatureAction = nullptr;
     QAction *mNudgeLeftAction = nullptr;
     QAction *mNudgeRightAction = nullptr;
+    QAction *mRenameProfileAction = nullptr;
     QAction *mLockRatioAction = nullptr;
     QMenu *mDistanceUnitMenu = nullptr;
 


### PR DESCRIPTION
## Description

This PR is a simple proposal to answer #58455.
It adds a "Change Progile Name" menu item in the Options sub-menu of the Elevation Profile widget in order to allow the user to change the profile windows name to anything more meaningfull to him/her. The change is made through a modal QInputDialog.

![image](https://github.com/user-attachments/assets/4d59b94c-2d49-481f-b92a-27e6f32e6d17)

![image](https://github.com/user-attachments/assets/131a007c-259e-4d2b-b28e-165bdc69a1d4)


Fixes #58455