### PR TITLE
Fix inconsistent field name line edit focus behaviour when creating new vector layers

### DIFF
--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -181,7 +181,7 @@ void QgsNewSpatialiteLayerDialog::mAddAttributeButton_clicked()
 
     if ( !mNameEdit->hasFocus() )
     {
-      mNameEdit->setFocus( Qt::MouseFocusReason );
+      mNameEdit->setFocus();
     }
   }
 }

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -178,6 +178,11 @@ void QgsNewSpatialiteLayerDialog::mAddAttributeButton_clicked()
     checkOk();
 
     mNameEdit->clear();
+
+    if ( !mNameEdit->hasFocus() )
+    {
+      mNameEdit->setFocus( Qt::MouseFocusReason );
+    }
   }
 }
 

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -237,6 +237,11 @@ void QgsNewGeoPackageLayerDialog::mAddAttributeButton_clicked()
     checkOk();
 
     mFieldNameEdit->clear();
+
+    if ( !mFieldNameEdit->hasFocus() )
+    {
+      mFieldNameEdit->setFocus( Qt::MouseFocusReason );
+    }
   }
 }
 

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -240,7 +240,7 @@ void QgsNewGeoPackageLayerDialog::mAddAttributeButton_clicked()
 
     if ( !mFieldNameEdit->hasFocus() )
     {
-      mFieldNameEdit->setFocus( Qt::MouseFocusReason );
+      mFieldNameEdit->setFocus();
     }
   }
 }

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -355,7 +355,7 @@ void QgsNewMemoryLayerDialog::mAddAttributeButton_clicked()
 
     if ( !mFieldNameEdit->hasFocus() )
     {
-      mFieldNameEdit->setFocus( Qt::MouseFocusReason );
+      mFieldNameEdit->setFocus();
     }
   }
 }

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -352,6 +352,11 @@ void QgsNewMemoryLayerDialog::mAddAttributeButton_clicked()
     mAttributeView->addTopLevelItem( new QTreeWidgetItem( QStringList() << fieldName << fieldType << width << precision ) );
 
     mFieldNameEdit->clear();
+
+    if ( !mFieldNameEdit->hasFocus() )
+    {
+      mFieldNameEdit->setFocus( Qt::MouseFocusReason );
+    }
   }
 }
 

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -215,8 +215,15 @@ void QgsNewVectorLayerDialog::mAddAttributeButton_clicked()
   //use userrole to avoid translated type string
   const QString myType = mTypeBox->currentData( Qt::UserRole ).toString();
   mAttributeView->addTopLevelItem( new QTreeWidgetItem( QStringList() << myName << myType << myWidth << myPrecision ) );
+
   checkOk();
+
   mNameEdit->clear();
+
+  if ( !mNameEdit->hasFocus() )
+  {
+    mNameEdit->setFocus( Qt::MouseFocusReason );
+  }
 }
 
 void QgsNewVectorLayerDialog::mRemoveAttributeButton_clicked()

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -222,7 +222,7 @@ void QgsNewVectorLayerDialog::mAddAttributeButton_clicked()
 
   if ( !mNameEdit->hasFocus() )
   {
-    mNameEdit->setFocus( Qt::MouseFocusReason );
+    mNameEdit->setFocus();
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes inconsistent behavior when adding fields to new layers by returning focus to the field name line edits in the `mAddAttributeButton_clicked` slot methods of the create new layer dialogues when the <kbd>Add to fields list</kbd> button is clicked.

Fixes #58482

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
