### PR TITLE
[processing] Insure that processing algorithms are not used to breach the OSMF tile usage policy on bulk download

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmaplayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsmaplayerutils.py
@@ -5,3 +5,4 @@ QgsMapLayerUtils.layerSourceMatchesPath = staticmethod(QgsMapLayerUtils.layerSou
 QgsMapLayerUtils.updateLayerSourcePath = staticmethod(QgsMapLayerUtils.updateLayerSourcePath)
 QgsMapLayerUtils.sortLayersByType = staticmethod(QgsMapLayerUtils.sortLayersByType)
 QgsMapLayerUtils.launderLayerName = staticmethod(QgsMapLayerUtils.launderLayerName)
+QgsMapLayerUtils.isOpenStreetMapLayer = staticmethod(QgsMapLayerUtils.isOpenStreetMapLayer)

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -236,6 +236,13 @@ Returns the layer's data provider, it may be ``None``.
 %End
 
 
+    QgsProviderMetadata *providerMetadata() const;
+%Docstring
+Returns the layer data provider's metadata, it may be ``None``.
+
+.. versionadded:: 3.40
+%End
+
  void setShortName( const QString &shortName ) /Deprecated/;
 %Docstring
 Sets the short name of the layer used by QGIS Server to identify the layer.

--- a/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
@@ -80,6 +80,13 @@ Specifically this method:
 .. versionadded:: 3.28
 %End
 
+    static bool isOpenStreetMapLayer( QgsMapLayer *layer );
+%Docstring
+Returns ``True`` if the layer is served by OpenStreetMap server.
+
+.. versionadded:: 3.40
+%End
+
 };
 
 

--- a/python/core/auto_additions/qgsmaplayerutils.py
+++ b/python/core/auto_additions/qgsmaplayerutils.py
@@ -5,3 +5,4 @@ QgsMapLayerUtils.layerSourceMatchesPath = staticmethod(QgsMapLayerUtils.layerSou
 QgsMapLayerUtils.updateLayerSourcePath = staticmethod(QgsMapLayerUtils.updateLayerSourcePath)
 QgsMapLayerUtils.sortLayersByType = staticmethod(QgsMapLayerUtils.sortLayersByType)
 QgsMapLayerUtils.launderLayerName = staticmethod(QgsMapLayerUtils.launderLayerName)
+QgsMapLayerUtils.isOpenStreetMapLayer = staticmethod(QgsMapLayerUtils.isOpenStreetMapLayer)

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -236,6 +236,13 @@ Returns the layer's data provider, it may be ``None``.
 %End
 
 
+    QgsProviderMetadata *providerMetadata() const;
+%Docstring
+Returns the layer data provider's metadata, it may be ``None``.
+
+.. versionadded:: 3.40
+%End
+
  void setShortName( const QString &shortName ) /Deprecated/;
 %Docstring
 Sets the short name of the layer used by QGIS Server to identify the layer.

--- a/python/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/core/auto_generated/qgsmaplayerutils.sip.in
@@ -80,6 +80,13 @@ Specifically this method:
 .. versionadded:: 3.28
 %End
 
+    static bool isOpenStreetMapLayer( QgsMapLayer *layer );
+%Docstring
+Returns ``True`` if the layer is served by OpenStreetMap server.
+
+.. versionadded:: 3.40
+%End
+
 };
 
 

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -24,6 +24,8 @@
 
 #include "qgsalgorithmrasterize.h"
 #include "qgsprocessingparameters.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
 #include "qgsmapthemecollection.h"
 #include "qgsrasterfilewriter.h"
 #include "qgsmaprenderercustompainterjob.h"
@@ -149,6 +151,76 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
   int width { xTileCount * tileSize };
   int height { yTileCount * tileSize };
   int nBands { transparent ? 4 : 3 };
+
+  int totalTiles = 0;
+  for ( auto &layer : std::as_const( mMapLayers ) )
+  {
+    if ( QgsRasterLayer *rasterLayer = dynamic_cast<QgsRasterLayer *>( ( layer.get() ) ) )
+    {
+      if ( rasterLayer->dataProvider() )
+      {
+        QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( rasterLayer->dataProvider()->name() );
+        if ( metadata )
+        {
+          QVariantMap details = metadata->decodeUri( rasterLayer->source() );
+          if ( details.contains( QStringLiteral( "url" ) ) && details[QStringLiteral( "url" )].toString().startsWith( QStringLiteral( "https://tile.openstreetmap.org" ), Qt::CaseInsensitive ) )
+          {
+            const QList< double > resolutions = rasterLayer->dataProvider()->nativeResolutions();
+            if ( resolutions.isEmpty() )
+            {
+              continue;
+            }
+
+            if ( totalTiles == 0 )
+            {
+              const QgsCoordinateTransform ct( context.project()->crs(), rasterLayer->crs(), context.transformContext() );
+              QgsRectangle extentLayer;
+              try
+              {
+                extentLayer = ct.transform( extent );
+              }
+              catch ( QgsCsException & )
+              {
+                totalTiles = -1;
+                continue;
+              }
+
+              const double mapUnitsPerPixelLayer = extentLayer.width() / width;
+              int i;
+              for ( i = 0; i < resolutions.size() && resolutions.at( i ) < mapUnitsPerPixelLayer; i++ )
+              {
+              }
+
+              if ( i == resolutions.size() ||
+                   ( i > 0 && resolutions.at( i ) - mapUnitsPerPixelLayer > mapUnitsPerPixelLayer - resolutions.at( i - 1 ) ) )
+              {
+                i--;
+              }
+
+              const int nbTilesWidth = std::ceil( extentLayer.width() / resolutions.at( i ) / 256 );
+              const int nbTilesHeight = std::ceil( extentLayer.height() / resolutions.at( i ) / 256 );
+              totalTiles = nbTilesWidth * nbTilesHeight;
+            }
+            feedback->pushInfo( QStringLiteral( "%1" ).arg( totalTiles ) );
+
+            if ( totalTiles > 5000 )
+            {
+              // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
+              feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
+                                              QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QString(), QString() ) );
+
+              layer->deleteLater();
+              std::vector<std::unique_ptr<QgsMapLayer>>::iterator position = std::find( mMapLayers.begin(), mMapLayers.end(), layer );
+              if ( position != mMapLayers.end() )
+              {
+                mMapLayers.erase( position );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
   const QString driverName { QgsRasterFileWriter::driverForExtension( QFileInfo( outputLayerFileName ).suffix() ) };
   if ( driverName.isEmpty() )

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -25,6 +25,7 @@
 #include "qgsalgorithmrasterize.h"
 #include "qgsprocessingparameters.h"
 #include "qgsprovidermetadata.h"
+#include "qgsmaplayerutils.h"
 #include "qgsmapthemecollection.h"
 #include "qgsrasterfilewriter.h"
 #include "qgsmaprenderercustompainterjob.h"
@@ -154,63 +155,59 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
   int64_t totalTiles = 0;
   for ( auto &layer : std::as_const( mMapLayers ) )
   {
-    if ( QgsRasterLayer *rasterLayer = qobject_cast<QgsRasterLayer *>( ( layer.get() ) ) )
+    if ( QgsMapLayerUtils::isOpenStreetMapLayer( layer.get() ) )
     {
-      if ( const QgsProviderMetadata *metadata = rasterLayer->providerMetadata() )
+      if ( QgsRasterLayer *rasterLayer = qobject_cast<QgsRasterLayer *>( ( layer.get() ) ) )
       {
-        QVariantMap details = metadata->decodeUri( rasterLayer->source() );
-        if ( details.contains( QStringLiteral( "url" ) ) && QUrl( details[QStringLiteral( "url" )].toString() ).host() == QStringLiteral( "tile.openstreetmap.org" ) )
+        const QList< double > resolutions = rasterLayer->dataProvider()->nativeResolutions();
+        if ( resolutions.isEmpty() )
         {
-          const QList< double > resolutions = rasterLayer->dataProvider()->nativeResolutions();
-          if ( resolutions.isEmpty() )
+          continue;
+        }
+
+        if ( totalTiles == 0 )
+        {
+          const QgsCoordinateTransform ct( context.project()->crs(), rasterLayer->crs(), context.transformContext() );
+          QgsRectangle extentLayer;
+          try
           {
+            extentLayer = ct.transform( extent );
+          }
+          catch ( QgsCsException & )
+          {
+            totalTiles = -1;
             continue;
           }
 
-          if ( totalTiles == 0 )
+          const double mapUnitsPerPixelLayer = extentLayer.width() / width;
+          int i;
+          for ( i = 0; i < resolutions.size() && resolutions.at( i ) < mapUnitsPerPixelLayer; i++ )
           {
-            const QgsCoordinateTransform ct( context.project()->crs(), rasterLayer->crs(), context.transformContext() );
-            QgsRectangle extentLayer;
-            try
-            {
-              extentLayer = ct.transform( extent );
-            }
-            catch ( QgsCsException & )
-            {
-              totalTiles = -1;
-              continue;
-            }
-
-            const double mapUnitsPerPixelLayer = extentLayer.width() / width;
-            int i;
-            for ( i = 0; i < resolutions.size() && resolutions.at( i ) < mapUnitsPerPixelLayer; i++ )
-            {
-            }
-
-            if ( i == resolutions.size() ||
-                 ( i > 0 && resolutions.at( i ) - mapUnitsPerPixelLayer > mapUnitsPerPixelLayer - resolutions.at( i - 1 ) ) )
-            {
-              i--;
-            }
-
-            const int nbTilesWidth = std::ceil( extentLayer.width() / resolutions.at( i ) / 256 );
-            const int nbTilesHeight = std::ceil( extentLayer.height() / resolutions.at( i ) / 256 );
-            totalTiles = static_cast<int64_t>( nbTilesWidth ) * nbTilesHeight;
           }
-          feedback->pushInfo( QStringLiteral( "%1" ).arg( totalTiles ) );
 
-          if ( totalTiles > 5000 )
+          if ( i == resolutions.size() ||
+               ( i > 0 && resolutions.at( i ) - mapUnitsPerPixelLayer > mapUnitsPerPixelLayer - resolutions.at( i - 1 ) ) )
           {
-            // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
-            feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
-                                            QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QString(), QString() ) );
+            i--;
+          }
 
-            layer->deleteLater();
-            std::vector<std::unique_ptr<QgsMapLayer>>::iterator position = std::find( mMapLayers.begin(), mMapLayers.end(), layer );
-            if ( position != mMapLayers.end() )
-            {
-              mMapLayers.erase( position );
-            }
+          const int nbTilesWidth = std::ceil( extentLayer.width() / resolutions.at( i ) / 256 );
+          const int nbTilesHeight = std::ceil( extentLayer.height() / resolutions.at( i ) / 256 );
+          totalTiles = static_cast<int64_t>( nbTilesWidth ) * nbTilesHeight;
+        }
+        feedback->pushInfo( QStringLiteral( "%1" ).arg( totalTiles ) );
+
+        if ( totalTiles > 5000 )
+        {
+          // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
+          feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
+                                          QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QString(), QString() ) );
+
+          layer->deleteLater();
+          std::vector<std::unique_ptr<QgsMapLayer>>::iterator position = std::find( mMapLayers.begin(), mMapLayers.end(), layer );
+          if ( position != mMapLayers.end() )
+          {
+            mMapLayers.erase( position );
           }
         }
       }

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -25,7 +25,6 @@
 #include "qgsalgorithmrasterize.h"
 #include "qgsprocessingparameters.h"
 #include "qgsprovidermetadata.h"
-#include "qgsproviderregistry.h"
 #include "qgsmapthemecollection.h"
 #include "qgsrasterfilewriter.h"
 #include "qgsmaprenderercustompainterjob.h"
@@ -152,69 +151,65 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
   int height { yTileCount * tileSize };
   int nBands { transparent ? 4 : 3 };
 
-  int totalTiles = 0;
+  int64_t totalTiles = 0;
   for ( auto &layer : std::as_const( mMapLayers ) )
   {
-    if ( QgsRasterLayer *rasterLayer = dynamic_cast<QgsRasterLayer *>( ( layer.get() ) ) )
+    if ( QgsRasterLayer *rasterLayer = qobject_cast<QgsRasterLayer *>( ( layer.get() ) ) )
     {
-      if ( rasterLayer->dataProvider() )
+      if ( const QgsProviderMetadata *metadata = rasterLayer->providerMetadata() )
       {
-        QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( rasterLayer->dataProvider()->name() );
-        if ( metadata )
+        QVariantMap details = metadata->decodeUri( rasterLayer->source() );
+        if ( details.contains( QStringLiteral( "url" ) ) && QUrl( details[QStringLiteral( "url" )].toString() ).host() == QStringLiteral( "tile.openstreetmap.org" ) )
         {
-          QVariantMap details = metadata->decodeUri( rasterLayer->source() );
-          if ( details.contains( QStringLiteral( "url" ) ) && details[QStringLiteral( "url" )].toString().startsWith( QStringLiteral( "https://tile.openstreetmap.org" ), Qt::CaseInsensitive ) )
+          const QList< double > resolutions = rasterLayer->dataProvider()->nativeResolutions();
+          if ( resolutions.isEmpty() )
           {
-            const QList< double > resolutions = rasterLayer->dataProvider()->nativeResolutions();
-            if ( resolutions.isEmpty() )
+            continue;
+          }
+
+          if ( totalTiles == 0 )
+          {
+            const QgsCoordinateTransform ct( context.project()->crs(), rasterLayer->crs(), context.transformContext() );
+            QgsRectangle extentLayer;
+            try
             {
+              extentLayer = ct.transform( extent );
+            }
+            catch ( QgsCsException & )
+            {
+              totalTiles = -1;
               continue;
             }
 
-            if ( totalTiles == 0 )
+            const double mapUnitsPerPixelLayer = extentLayer.width() / width;
+            int i;
+            for ( i = 0; i < resolutions.size() && resolutions.at( i ) < mapUnitsPerPixelLayer; i++ )
             {
-              const QgsCoordinateTransform ct( context.project()->crs(), rasterLayer->crs(), context.transformContext() );
-              QgsRectangle extentLayer;
-              try
-              {
-                extentLayer = ct.transform( extent );
-              }
-              catch ( QgsCsException & )
-              {
-                totalTiles = -1;
-                continue;
-              }
-
-              const double mapUnitsPerPixelLayer = extentLayer.width() / width;
-              int i;
-              for ( i = 0; i < resolutions.size() && resolutions.at( i ) < mapUnitsPerPixelLayer; i++ )
-              {
-              }
-
-              if ( i == resolutions.size() ||
-                   ( i > 0 && resolutions.at( i ) - mapUnitsPerPixelLayer > mapUnitsPerPixelLayer - resolutions.at( i - 1 ) ) )
-              {
-                i--;
-              }
-
-              const int nbTilesWidth = std::ceil( extentLayer.width() / resolutions.at( i ) / 256 );
-              const int nbTilesHeight = std::ceil( extentLayer.height() / resolutions.at( i ) / 256 );
-              totalTiles = nbTilesWidth * nbTilesHeight;
             }
-            feedback->pushInfo( QStringLiteral( "%1" ).arg( totalTiles ) );
 
-            if ( totalTiles > 5000 )
+            if ( i == resolutions.size() ||
+                 ( i > 0 && resolutions.at( i ) - mapUnitsPerPixelLayer > mapUnitsPerPixelLayer - resolutions.at( i - 1 ) ) )
             {
-              // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
-              feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
-                                              QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QString(), QString() ) );
+              i--;
+            }
 
-              layer->deleteLater();
-              std::vector<std::unique_ptr<QgsMapLayer>>::iterator position = std::find( mMapLayers.begin(), mMapLayers.end(), layer );
-              if ( position != mMapLayers.end() )
-              {
-                mMapLayers.erase( position );
-              }
+            const int nbTilesWidth = std::ceil( extentLayer.width() / resolutions.at( i ) / 256 );
+            const int nbTilesHeight = std::ceil( extentLayer.height() / resolutions.at( i ) / 256 );
+            totalTiles = static_cast<int64_t>( nbTilesWidth ) * nbTilesHeight;
+          }
+          feedback->pushInfo( QStringLiteral( "%1" ).arg( totalTiles ) );
+
+          if ( totalTiles > 5000 )
+          {
+            // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
+            feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
+                                            QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QString(), QString() ) );
+
+            layer->deleteLater();
+            std::vector<std::unique_ptr<QgsMapLayer>>::iterator position = std::find( mMapLayers.begin(), mMapLayers.end(), layer );
+            if ( position != mMapLayers.end() )
+            {
+              mMapLayers.erase( position );
             }
           }
         }

--- a/src/analysis/processing/qgsalgorithmrasterize.h
+++ b/src/analysis/processing/qgsalgorithmrasterize.h
@@ -55,6 +55,8 @@ class QgsRasterizeAlgorithm : public QgsProcessingAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
+    void checkLayersUsagePolicy( QgsProcessingFeedback *feedback );
+
   private:
 
     QMap<QString, QString> mMapThemeStyleOverrides;

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -22,6 +22,7 @@
 #include "qgslayertree.h"
 #include "qgslayertreelayer.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsmaplayerutils.h"
 #include "qgsprovidermetadata.h"
 
 ///@cond PRIVATE
@@ -192,17 +193,13 @@ void QgsXyzTilesBaseAlgorithm::checkLayersUsagePolicy( QgsProcessingFeedback *fe
   {
     for ( QgsMapLayer *layer : std::as_const( mLayers ) )
     {
-      if ( const QgsProviderMetadata *metadata = layer->providerMetadata() )
+      if ( QgsMapLayerUtils::isOpenStreetMapLayer( layer ) )
       {
-        QVariantMap details = metadata->decodeUri( layer->source() );
-        if ( details.contains( QStringLiteral( "url" ) ) && QUrl( details[QStringLiteral( "url" )].toString() ).host() == QStringLiteral( "tile.openstreetmap.org" ) )
-        {
-          // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
-          feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( layer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
-                                          QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( layer->name(), QString(), QString() ) );
-          mLayers.removeAll( layer );
-          delete layer;
-        }
+        // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
+        feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( layer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
+                                        QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( layer->name(), QString(), QString() ) );
+        mLayers.removeAll( layer );
+        delete layer;
       }
     }
   }

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -281,20 +281,22 @@ QVariantMap QgsXyzTilesDirectoryAlgorithm::processAlgorithm( const QVariantMap &
   mOutputDir = outputDir;
   mTms = tms;
 
+  mTotalTiles = 0;
   for ( int z = mMinZoom; z <= mMaxZoom; z++ )
   {
     if ( feedback->isCanceled() )
       break;
 
     mMetaTiles += getMetatiles( mWgs84Extent, z, mMetaTileSize );
+    feedback->pushWarning( QObject::tr( "%1 tiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalTiles ).arg( z ) );
+    mTotalTiles = mMetaTiles.size();
   }
+  feedback->pushWarning( QObject::tr( "A total of %1 tiles will be created" ).arg( mTotalTiles ) );
 
   for ( QgsMapLayer *layer : std::as_const( mLayers ) )
   {
     layer->moveToThread( QThread::currentThread() );
   }
-
-  mTotalTiles = mMetaTiles.size();
 
   QEventLoop loop;
   // cppcheck-suppress danglingLifetime
@@ -470,15 +472,17 @@ QVariantMap QgsXyzTilesMbtilesAlgorithm::processAlgorithm( const QVariantMap &pa
                       .arg( mWgs84Extent.xMaximum() ).arg( mWgs84Extent.yMaximum() );
   mMbtilesWriter->setMetadataValue( "bounds",  boundsStr );
 
+  mTotalTiles = 0;
   for ( int z = mMinZoom; z <= mMaxZoom; z++ )
   {
     if ( feedback->isCanceled() )
       break;
 
     mMetaTiles += getMetatiles( mWgs84Extent, z, mMetaTileSize );
+    feedback->pushWarning( QObject::tr( "%1 tiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalTiles ).arg( z ) );
+    mTotalTiles = mMetaTiles.size();
   }
-
-  mTotalTiles = mMetaTiles.size();
+  feedback->pushWarning( QObject::tr( "A total of %1 tiles will be created" ).arg( mTotalTiles ) );
 
   QEventLoop loop;
   // cppcheck-suppress danglingLifetime

--- a/src/analysis/processing/qgsalgorithmxyztiles.h
+++ b/src/analysis/processing/qgsalgorithmxyztiles.h
@@ -104,6 +104,8 @@ class QgsXyzTilesBaseAlgorithm : public QgsProcessingAlgorithm
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
+    void checkLayersUsagePolicy( QgsProcessingFeedback *feedback );
+
     void startJobs();
     virtual void processMetaTile( QgsMapRendererSequentialJob *job ) = 0;
 
@@ -129,7 +131,7 @@ class QgsXyzTilesBaseAlgorithm : public QgsProcessingAlgorithm
     long long mTotalTiles = 0;
     long long mProcessedTiles = 0;
     QgsCoordinateTransformContext mTransformContext;
-    QEventLoop *mEventLoop;
+    QPointer<QEventLoop> mEventLoop;
     QList< MetaTile > mMetaTiles;
     QMap< QgsMapRendererSequentialJob *, MetaTile > mRendererJobs;
 };

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -33,6 +33,7 @@
 #include "qgsprojectfiletransform.h"
 #include "qgsproject.h"
 #include "qgsproviderregistry.h"
+#include "qgsprovidermetadata.h"
 #include "qgsrasterlayer.h"
 #include "qgsreadwritecontext.h"
 #include "qgsrectangle.h"
@@ -43,7 +44,6 @@
 #include "qgsmessagelog.h"
 #include "qgsmaplayertemporalproperties.h"
 #include "qgsmaplayerelevationproperties.h"
-#include "qgsprovidermetadata.h"
 #include "qgslayernotesutils.h"
 #include "qgsdatums.h"
 #include "qgsprojoperation.h"
@@ -252,6 +252,11 @@ const QgsDataProvider *QgsMapLayer::dataProvider() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return nullptr;
+}
+
+QgsProviderMetadata *QgsMapLayer::providerMetadata() const
+{
+  return QgsProviderRegistry::instance()->providerMetadata( providerType() );
 }
 
 void QgsMapLayer::setShortName( const QString &shortName )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -48,6 +48,7 @@ class QgsMapLayerLegend;
 class QgsMapLayerRenderer;
 class QgsMapLayerStyleManager;
 class QgsProject;
+class QgsProviderMetadata;
 class QgsStyleEntityVisitorInterface;
 class QgsMapLayerTemporalProperties;
 class QgsMapLayerElevationProperties;
@@ -304,6 +305,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \note not available in Python bindings
      */
     virtual const QgsDataProvider *dataProvider() const SIP_SKIP;
+
+    /**
+     * Returns the layer data provider's metadata, it may be NULLPTR.
+     * \since QGIS 3.40
+     */
+    QgsProviderMetadata *providerMetadata() const;
 
     /**
      * Sets the short name of the layer used by QGIS Server to identify the layer.

--- a/src/core/qgsmaplayerutils.cpp
+++ b/src/core/qgsmaplayerutils.cpp
@@ -166,3 +166,20 @@ QString QgsMapLayerUtils::launderLayerName( const QString &name )
 
   return laundered;
 }
+
+bool QgsMapLayerUtils::isOpenStreetMapLayer( QgsMapLayer *layer )
+{
+  if ( layer->providerType() == QStringLiteral( "wms" ) )
+  {
+    if ( const QgsProviderMetadata *metadata = layer->providerMetadata() )
+    {
+      QVariantMap details = metadata->decodeUri( layer->source() );
+      QUrl url( details.value( QStringLiteral( "url" ) ).toString() );
+      if ( url.host().endsWith( QStringLiteral( ".openstreetmap.org" ) ) || url.host().endsWith( QStringLiteral( ".osm.org" ) ) )
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/core/qgsmaplayerutils.h
+++ b/src/core/qgsmaplayerutils.h
@@ -94,6 +94,13 @@ class CORE_EXPORT QgsMapLayerUtils
      */
     static QString launderLayerName( const QString &name );
 
+    /**
+     * Returns TRUE if the layer is served by OpenStreetMap server.
+     *
+     * \since QGIS 3.40
+     */
+    static bool isOpenStreetMapLayer( QgsMapLayer *layer );
+
 };
 
 #endif // QGSMAPLAYERUTILS_H


### PR DESCRIPTION
## Description

This PR adds safeguards to three algorithms to insure QGIS users do not breach the OSMF tile usage policy with regards to bulk download. The three algorithms are:
- Generate XYZ tiles (MBTiles)
- Generate XYZ tiles (Directory)
- Convert map to raster

In all three algorithms, a new logic is set in place to check whether more than 5,000 tiles will be fetched from an OSM layer. If the threshold is triggered, the algorithm will remove the layer from the list of map layers being rendered and will inform the user through a message in the console that offers a link to the above-mentioned tile usage policy.