### PR TITLE
Fix default AllowNotNULL for relation ref wdgt

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrelation.sip.in
@@ -264,6 +264,13 @@ Returns a list of attributes used to form the referencing fields
 :return: A list of attributes
 %End
 
+    bool referencingFieldsAllowNull() const;
+%Docstring
+Returns ``True`` if none of the referencing fields has a NOT NULL constraint.
+
+.. versionadded:: 3.28
+%End
+
     bool isValid() const;
 %Docstring
 Returns the validity of this relation. Don't use the information if it's not valid.

--- a/python/core/auto_generated/qgsrelation.sip.in
+++ b/python/core/auto_generated/qgsrelation.sip.in
@@ -264,6 +264,13 @@ Returns a list of attributes used to form the referencing fields
 :return: A list of attributes
 %End
 
+    bool referencingFieldsAllowNull() const;
+%Docstring
+Returns ``True`` if none of the referencing fields has a NOT NULL constraint.
+
+.. versionadded:: 3.28
+%End
+
     bool isValid() const;
 %Docstring
 Returns the validity of this relation. Don't use the information if it's not valid.

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -356,6 +356,26 @@ QgsAttributeList QgsRelation::referencingFields() const
 
 }
 
+bool QgsRelation::referencingFieldsAllowNull() const
+{
+  if ( ! referencingLayer() )
+  {
+    return false;
+  }
+
+  const auto fields = referencingFields();
+
+  return std::find_if( fields.constBegin(), fields.constEnd(), [&]( const auto & fieldIdx )
+  {
+    if ( !referencingLayer()->fields().exists( fieldIdx ) )
+    {
+      return false;
+    }
+    const QgsField field = referencingLayer()->fields().field( fieldIdx );
+    return field.constraints().constraints().testFlag( QgsFieldConstraints::Constraint::ConstraintNotNull );
+  } ) == fields.constEnd();
+}
+
 bool QgsRelation::isValid() const
 {
   return d->mValid && !d->mReferencingLayer.isNull() && !d->mReferencedLayer.isNull() && d->mReferencingLayer.data()->isValid() && d->mReferencedLayer.data()->isValid();

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -333,6 +333,12 @@ class CORE_EXPORT QgsRelation
     QgsAttributeList referencingFields() const;
 
     /**
+     * Returns TRUE if none of the referencing fields has a NOT NULL constraint.
+     * \since QGIS 3.28
+     */
+    bool referencingFieldsAllowNull() const;
+
+    /**
      * Returns the validity of this relation. Don't use the information if it's not valid.
      * A relation is considered valid if both referenced and referencig layers are valid.
      *

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -155,17 +155,7 @@ void QgsRelationReferenceConfigDlg::relationChanged( int idx )
   // constraints of the referencing fields
   if ( ! mAllowNullWasSetByConfig )
   {
-    const QgsAttributeList referencingFields = rel.referencingFields();
-    const bool allowNull { std::find_if( referencingFields.constBegin(), referencingFields.constEnd(), [&]( const auto & fieldIdx )
-    {
-      if ( !rel.referencingLayer()->fields().exists( fieldIdx ) )
-      {
-        return false;
-      }
-      const QgsField field = rel.referencingLayer()->fields().field( fieldIdx );
-      return field.constraints().constraints().testFlag( QgsFieldConstraints::Constraint::ConstraintNotNull );
-    } ) == referencingFields.constEnd()};
-    mCbxAllowNull->setChecked( allowNull );
+    mCbxAllowNull->setChecked( rel.referencingFieldsAllowNull() );
   }
 
   loadFields();

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -151,7 +151,8 @@ void QgsRelationReferenceConfigDlg::relationChanged( int idx )
     mCbxMapIdentification->setEnabled( mReferencedLayer->isSpatial() );
   }
 
-  // Provide a default for AllowNull if it was not set by the config
+  // If AllowNULL is not set in the config, provide a default value based on the
+  // constraints of the referencing fields
   if ( ! mAllowNullWasSetByConfig )
   {
     const QgsAttributeList referencingFields = rel.referencingFields();

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -109,17 +109,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   // constraints of the referencing fields
   if ( !config( QStringLiteral( "AllowNULL" ) ).isValid() )
   {
-    const QgsAttributeList referencingFields = relation.referencingFields();
-    const bool allowNull { std::find_if( referencingFields.constBegin(), referencingFields.constEnd(), [&]( const auto & fieldIdx )
-    {
-      if ( !relation.referencingLayer()->fields().exists( fieldIdx ) )
-      {
-        return false;
-      }
-      const QgsField field = relation.referencingLayer()->fields().field( fieldIdx );
-      return field.constraints().constraints().testFlag( QgsFieldConstraints::Constraint::ConstraintNotNull );
-    } ) == referencingFields.constEnd()};
-    mWidget->setRelation( relation, allowNull );
+    mWidget->setRelation( relation, relation.referencingFieldsAllowNull() );
   }
   else
   {

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -19,6 +19,7 @@ from qgis.core import (
     QgsProject,
     QgsRelation,
     QgsVectorLayer,
+    QgsFieldConstraints,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -249,6 +250,24 @@ class TestQgsRelation(QgisTestCase):
         rel = QgsRelation()
         # Check that it does not crash
         rel.generateId()
+
+    def test_referencingFieldsAllowNull(self):
+        rel = QgsRelation()
+
+        rel.setId('rel1')
+        rel.setName('Relation Number One')
+        rel.setReferencingLayer(self.referencingLayer.id())
+        rel.setReferencedLayer(self.referencedLayer.id())
+        rel.addFieldPair('foreignkey', 'y')
+
+        self.assertTrue(rel.referencingFieldsAllowNull())
+
+        referencingLayer = rel.referencingLayer()
+
+        # Set Not Null constraint on the field
+        referencingLayer.setFieldConstraint(referencingLayer.fields().indexFromName('foreignkey'), QgsFieldConstraints.ConstraintNotNull)
+
+        self.assertFalse(rel.referencingFieldsAllowNull())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #52219

Followup #58361 , this fixes the default before the config is actually saved.

While #58361 fixed the default in the config dialog, the default was not effective if the config wasn't saved.

