### PR TITLE
[Expression] Make color functions compatible with color object

### DIFF
--- a/resources/function_help/json/color_grayscale_average
+++ b/resources/function_help/json/color_grayscale_average
@@ -2,14 +2,18 @@
   "name": "color_grayscale_average",
   "type": "function",
   "groups": ["Color"],
-  "description": "Applies a grayscale filter and returns a string representation from a provided color.",
+  "description": "Applies a grayscale filter to a color and returns it. Returned type is the same as color argument, i.e. a color string representation or a color object.",
   "arguments": [{
     "arg": "color",
-    "description": "a color string"
+    "description": "a color string representation or a color object"
   }],
   "examples": [{
     "expression": "color_grayscale_average('255,100,50')",
     "returns": "'135,135,135,255'"
+  },
+  {
+    "expression": "color_grayscale_average(color_cmykf(0.6,0.5,0.1,0.8))",
+    "returns": "CMYKA: 0.40,0.40,0.40,0.80,1.00"
   }],
   "tags": ["filter", "color", "provided", "applies", "grayscale", "representation"]
 }

--- a/resources/function_help/json/color_mix
+++ b/resources/function_help/json/color_mix
@@ -1,0 +1,25 @@
+{
+  "name": "color_mix",
+  "type": "function",
+  "groups": ["Color"],
+  "description": "Returns a color mixing the red, green, blue, and alpha values of two provided colors based on a given ratio. Returned type is the same as color arguments, i.e. a color string representation or a color object.",
+  "arguments": [{
+    "arg": "color1",
+    "description": "a color string or a color object"
+  }, {
+    "arg": "color2",
+    "description": "a color string or a color object"
+  }, {
+    "arg": "ratio",
+    "description": "a ratio"
+  }],
+  "examples": [{
+    "expression": "color_mix_rgb('0,0,0','255,255,255',0.5)",
+    "returns": "'127,127,127,255'"
+  },
+  {
+    "expression": "color_mix(color_cmykf(0.9,0.9,0.9,0.9),color_cmykf(0.1,0.1,0.1,0.1),0.5)",
+    "returns": "CMYKA: 0.50,0.50,0.50,0.50,1.00"
+  }],
+  "tags": ["green", "blue", "red", "alpha", "mixing", "color", "colors", "provided", "ratio"]
+}

--- a/resources/function_help/json/color_part
+++ b/resources/function_help/json/color_part
@@ -2,10 +2,10 @@
   "name": "color_part",
   "type": "function",
   "groups": ["Color"],
-  "description": "Returns a specific component from a color string, e.g., the red component or alpha component.",
+  "description": "Returns a specific component from a color string or color object, e.g., the red component or alpha component.",
   "arguments": [{
     "arg": "color",
-    "description": "a color string"
+    "description": "a color string or a color object"
   }, {
     "arg": "component",
     "description": "a string corresponding to the color component to return. Valid options are:<br /><ul><li>red: RGB red component (0-255)</li><li>green: RGB green component (0-255)</li><li>blue: RGB blue component (0-255)</li><li>alpha: alpha (transparency) value (0-255)</li><li>hue: HSV hue (0-360)</li><li>saturation: HSV saturation (0-100)</li><li>value: HSV value (0-100)</li><li>hsl_hue: HSL hue (0-360)</li><li>hsl_saturation: HSL saturation (0-100)</li><li>lightness: HSL lightness (0-100)</li><li>cyan: CMYK cyan component (0-100)</li><li>magenta: CMYK magenta component (0-100)</li><li>yellow: CMYK yellow component (0-100)</li><li>black: CMYK black component (0-100)</li></ul>"
@@ -13,6 +13,10 @@
   "examples": [{
     "expression": "color_part('200,10,30','green')",
     "returns": "10"
+  },
+  {
+    "expression": "to_int(color_part(color_cmykf(0.1,0.2,0.3,0.9),'black'))",
+    "returns": "90"
   }],
   "tags": ["red", "specific", "color", "component", "alpha"]
 }

--- a/resources/function_help/json/darker
+++ b/resources/function_help/json/darker
@@ -2,10 +2,10 @@
   "name": "darker",
   "type": "function",
   "groups": ["Color"],
-  "description": "Returns a darker (or lighter) color string",
+  "description": "Returns a darker (or lighter) color. Returned type is the same as color arguments, i.e. a color string representation or a color object.",
   "arguments": [{
     "arg": "color",
-    "description": "a color string"
+    "description": "a color string or a color object"
   }, {
     "arg": "factor",
     "description": "an integer corresponding to the darkening factor:<ul><li>if the factor is greater than 100, this function returns a darker color (e.g., setting factor to 200 returns a color that is half the brightness);</li><li>if the factor is less than 100, the return color is lighter, but using the lighter() function for this purpose is recommended;</li><li>if the factor is 0 or negative, the return value is unspecified.</li></ul>"

--- a/resources/function_help/json/lighter
+++ b/resources/function_help/json/lighter
@@ -2,10 +2,10 @@
   "name": "lighter",
   "type": "function",
   "groups": ["Color"],
-  "description": "Returns a lighter (or darker) color string",
+  "description": "Returns a lighter (or darker) color. Returned type is the same as color arguments, i.e. a color string representation or a color object.",
   "arguments": [{
     "arg": "color",
-    "description": "a color string"
+    "description": "a color string or a color object"
   }, {
     "arg": "factor",
     "description": "an integer corresponding to the lightening factor:<ul><li>if the factor is greater than 100, this function returns a lighter color (e.g., setting factor to 150 returns a color that is 50% brighter);</li><li>if the factor is less than 100, the return color is darker, but using the darker() function for this purpose is recommended;</li><li>if the factor is 0 or negative, the return value is unspecified.</li></ul>"

--- a/resources/function_help/json/set_color_part
+++ b/resources/function_help/json/set_color_part
@@ -2,10 +2,10 @@
   "name": "set_color_part",
   "type": "function",
   "groups": ["Color"],
-  "description": "Sets a specific color component for a color string, e.g., the red component or alpha component.",
+  "description": "Sets a specific color component for a color string or a color object, e.g., the red component or alpha component.",
   "arguments": [{
     "arg": "color",
-    "description": "a color string"
+    "description": "a color string or a color object"
   }, {
     "arg": "component",
     "description": "a string corresponding to the color component to set. Valid options are:<br /><ul><li>red: RGB red component (0-255)</li><li>green: RGB green component (0-255)</li><li>blue: RGB blue component (0-255)</li><li>alpha: alpha (transparency) value (0-255)</li><li>hue: HSV hue (0-360)</li><li>saturation: HSV saturation (0-100)</li><li>value: HSV value (0-100)</li><li>hsl_hue: HSL hue (0-360)</li><li>hsl_saturation: HSL saturation (0-100)</li><li>lightness: HSL lightness (0-100)</li><li>cyan: CMYK cyan component (0-100)</li><li>magenta: CMYK magenta component (0-100)</li><li>yellow: CMYK yellow component (0-100)</li><li>black: CMYK black component (0-100)</li></ul>"
@@ -16,6 +16,10 @@
   "examples": [{
     "expression": "set_color_part('200,10,30','green',50)",
     "returns": "'200,50,30,255'"
+  },
+  {
+    "expression": "set_color_part(color_cmykf(0.21,0,0.92,0.70),'black',100)",
+    "returns": "CMYKA: 0.21,0.00,0.92,1.00,1.00"
   }],
   "tags": ["alpha", "component", "specific", "red", "color", "sets"]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5819,11 +5819,13 @@ static QVariant fcnFormatDate( const QVariantList &values, const QgsExpressionCo
   return locale.toString( datetime, format );
 }
 
-static QVariant fcnColorGrayscaleAverage( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
+static QVariant fcnColorGrayscaleAverage( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariant variant = values.at( 0 );
-  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
-  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
+  bool isQColor;
+  QColor color = QgsExpressionUtils::getColorValue( variant, parent, isQColor );
+  if ( !color.isValid() )
+    return QVariant();
 
   const float alpha = color.alphaF();
   if ( color.spec() == QColor::Spec::Cmyk )
@@ -5875,9 +5877,15 @@ static QVariant fcnColorMix( const QVariantList &values, const QgsExpressionCont
     return QVariant();
   }
 
-  const bool isQColor = variant1.userType() == QMetaType::Type::QColor;
-  QColor color1 = isQColor ? variant1.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant1.toString() );
-  QColor color2 = isQColor ? variant2.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant2.toString() );
+  bool isQColor;
+  const QColor color1 = QgsExpressionUtils::getColorValue( variant1, parent, isQColor );
+  if ( !color1.isValid() )
+    return QVariant();
+
+  const QColor color2 = QgsExpressionUtils::getColorValue( variant2, parent, isQColor );
+  if ( !color2.isValid() )
+    return QVariant();
+
   if ( ( color1.spec() == QColor::Cmyk ) != ( color2.spec() == QColor::Cmyk ) )
   {
     parent->setEvalErrorString( QObject::tr( "Both color arguments must have compatible color type (CMYK or RGB/HSV/HSL)" ) );
@@ -6195,14 +6203,10 @@ static QVariant fncColorCmyka( const QVariantList &values, const QgsExpressionCo
 static QVariant fncColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariant variant = values.at( 0 );
-  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
-  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
-  if ( ! color.isValid() )
-  {
-    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
-                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
+  bool isQColor;
+  const QColor color = QgsExpressionUtils::getColorValue( variant, parent, isQColor );
+  if ( !color.isValid() )
     return QVariant();
-  }
 
   QString part = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   if ( part.compare( QLatin1String( "red" ), Qt::CaseInsensitive ) == 0 )
@@ -6285,14 +6289,10 @@ static QVariant fcnCreateRamp( const QVariantList &values, const QgsExpressionCo
 static QVariant fncSetColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariant variant = values.at( 0 );
-  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
-  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
-  if ( ! color.isValid() )
-  {
-    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
-                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
+  bool isQColor;
+  QColor color = QgsExpressionUtils::getColorValue( variant, parent, isQColor );
+  if ( !color.isValid() )
     return QVariant();
-  }
 
   QString part = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   int value = QgsExpressionUtils::getNativeIntValue( values.at( 2 ), parent );
@@ -6335,14 +6335,10 @@ static QVariant fncSetColorPart( const QVariantList &values, const QgsExpression
 static QVariant fncDarker( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariant variant = values.at( 0 );
-  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
-  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
-  if ( ! color.isValid() )
-  {
-    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
-                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
+  bool isQColor;
+  QColor color = QgsExpressionUtils::getColorValue( variant, parent, isQColor );
+  if ( !color.isValid() )
     return QVariant();
-  }
 
   color = color.darker( QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent ) );
 
@@ -6352,14 +6348,10 @@ static QVariant fncDarker( const QVariantList &values, const QgsExpressionContex
 static QVariant fncLighter( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariant variant = values.at( 0 );
-  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
-  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
-  if ( ! color.isValid() )
-  {
-    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
-                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
+  bool isQColor;
+  QColor color = QgsExpressionUtils::getColorValue( variant, parent, isQColor );
+  if ( !color.isValid() )
     return QVariant();
-  }
 
   color = color.lighter( QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent ) );
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6334,30 +6334,36 @@ static QVariant fncSetColorPart( const QVariantList &values, const QgsExpression
 
 static QVariant fncDarker( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
+  const QVariant variant = values.at( 0 );
+  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
+  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
   if ( ! color.isValid() )
   {
-    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to color" ).arg( values.at( 0 ).toString() ) );
+    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
+                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
     return QVariant();
   }
 
   color = color.darker( QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent ) );
 
-  return QgsSymbolLayerUtils::encodeColor( color );
+  return isQColor ? QVariant( color ) : QVariant( QgsSymbolLayerUtils::encodeColor( color ) );
 }
 
 static QVariant fncLighter( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
+  const QVariant variant = values.at( 0 );
+  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
+  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
   if ( ! color.isValid() )
   {
-    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to color" ).arg( values.at( 0 ).toString() ) );
+    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
+                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
     return QVariant();
   }
 
   color = color.lighter( QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent ) );
 
-  return QgsSymbolLayerUtils::encodeColor( color );
+  return isQColor ? QVariant( color ) : QVariant( QgsSymbolLayerUtils::encodeColor( color ) );
 }
 
 static QVariant fcnGetGeometry( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6194,10 +6194,13 @@ static QVariant fncColorCmyka( const QVariantList &values, const QgsExpressionCo
 
 static QVariant fncColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
+  const QVariant variant = values.at( 0 );
+  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
+  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
   if ( ! color.isValid() )
   {
-    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to color" ).arg( values.at( 0 ).toString() ) );
+    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
+                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
     return QVariant();
   }
 
@@ -6281,10 +6284,13 @@ static QVariant fcnCreateRamp( const QVariantList &values, const QgsExpressionCo
 
 static QVariant fncSetColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
+  const QVariant variant = values.at( 0 );
+  const bool isQColor = variant.userType() == QMetaType::Type::QColor;
+  QColor color = isQColor ? variant.value<QColor>() : QgsSymbolLayerUtils::decodeColor( variant.toString() );
   if ( ! color.isValid() )
   {
-    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to color" ).arg( values.at( 0 ).toString() ) );
+    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
+                                : QObject::tr( "Cannot convert '%1' to color" ).arg( variant.toString() ) );
     return QVariant();
   }
 
@@ -6323,7 +6329,7 @@ static QVariant fncSetColorPart( const QVariantList &values, const QgsExpression
     parent->setEvalErrorString( QObject::tr( "Unknown color component '%1'" ).arg( part ) );
     return QVariant();
   }
-  return QgsSymbolLayerUtils::encodeColor( color );
+  return isQColor ? QVariant( color ) : QVariant( QgsSymbolLayerUtils::encodeColor( color ) );
 }
 
 static QVariant fncDarker( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5827,15 +5827,15 @@ static QVariant fcnColorGrayscaleAverage( const QVariantList &values, const QgsE
   if ( !color.isValid() )
     return QVariant();
 
-  const float alpha = color.alphaF();
+  const float alpha = color.alphaF(); // NOLINT(bugprone-narrowing-conversions): TODO QGIS 4 remove the nolint instructions, QColor was qreal (double) and is now float
   if ( color.spec() == QColor::Spec::Cmyk )
   {
-    const float avg = ( color.cyanF() + color.magentaF() + color.yellowF() ) / 3;
+    const float avg = ( color.cyanF() + color.magentaF() + color.yellowF() ) / 3; // NOLINT(bugprone-narrowing-conversions): TODO QGIS 4 remove the nolint instructions, QColor was qreal (double) and is now float
     color = QColor::fromCmykF( avg, avg, avg, color.blackF(), alpha );
   }
   else
   {
-    const float avg = ( color.redF() + color.greenF() + color.blueF() ) / 3;
+    const float avg = ( color.redF() + color.greenF() + color.blueF() ) / 3; // NOLINT(bugprone-narrowing-conversions): TODO QGIS 4 remove the nolint instructions, QColor was qreal (double) and is now float
     color.setRgbF( avg, avg, avg, alpha );
   }
 
@@ -5894,6 +5894,9 @@ static QVariant fcnColorMix( const QVariantList &values, const QgsExpressionCont
 
   const float ratio = static_cast<float>( std::clamp( QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent ), 0., 1. ) );
 
+  // TODO QGIS 4 remove the nolint instructions, QColor was qreal (double) and is now float
+  // NOLINTBEGIN(bugprone-narrowing-conversions)
+
   QColor newColor;
   const float alpha = color1.alphaF() * ( 1 - ratio ) + color2.alphaF() * ratio;
   if ( color1.spec() == QColor::Spec::Cmyk )
@@ -5911,6 +5914,8 @@ static QVariant fcnColorMix( const QVariantList &values, const QgsExpressionCont
     float blue = color1.blueF() * ( 1 - ratio ) + color2.blueF() * ratio;
     newColor = QColor::fromRgbF( red, green, blue, alpha );
   }
+
+  // NOLINTEND(bugprone-narrowing-conversions)
 
   return isQColor ? QVariant( newColor ) : QVariant( QgsSymbolLayerUtils::encodeColor( newColor ) );
 }

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -20,6 +20,7 @@
 #include "qgsvariantutils.h"
 #include "qgsproject.h"
 #include "qgsvectorlayerfeatureiterator.h"
+#include "qgssymbollayerutils.h"
 
 ///@cond PRIVATE
 
@@ -39,6 +40,19 @@ QgsExpressionUtils::TVL QgsExpressionUtils::OR[3][3] =
 
 QgsExpressionUtils::TVL QgsExpressionUtils::NOT[3] = { True, False, Unknown };
 
+
+QColor QgsExpressionUtils::getColorValue( const QVariant &value, QgsExpression *parent, bool &isQColor )
+{
+  isQColor = value.userType() == QMetaType::Type::QColor;
+  QColor color = isQColor ? value.value<QColor>() : QgsSymbolLayerUtils::decodeColor( value.toString() );
+  if ( ! color.isValid() )
+  {
+    parent->setEvalErrorString( isQColor ? QObject::tr( "Input color is invalid" )
+                                : QObject::tr( "Cannot convert '%1' to color" ).arg( value.toString() ) );
+  }
+
+  return color;
+}
 
 QgsGradientColorRamp QgsExpressionUtils::getRamp( const QVariant &value, QgsExpression *parent, bool report_error )
 {

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -311,6 +311,8 @@ class CORE_EXPORT QgsExpressionUtils
       }
     }
 
+    static QColor getColorValue( const QVariant &value, QgsExpression *parent, bool &isQColor );
+
     static QgsInterval getInterval( const QVariant &value, QgsExpression *parent, bool report_error = false )
     {
       if ( value.userType() == qMetaTypeId<QgsInterval>() )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1897,7 +1897,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color grayscale average object" ) << "color_grayscale_average(color_rgbf(0.6,0.5,0.1))" << false << QVariant( QColor::fromRgbF( 0.4, 0.4, 0.4 ) );
       QTest::newRow( "color grayscale average cmyk" ) << "color_grayscale_average(color_cmykf(0.6,0.5,0.1,0.8))" << false << QVariant( QColor::fromCmykF( 0.4, 0.4, 0.4, 0.8 ) );
       QTest::newRow( "color mix rgb" ) << "color_mix_rgb('0,0,0,100','255,255,255',0.5)" << false << QVariant( "127,127,127,177" );
+
+// looks like way color are rounded has changed between Qt 5 and 6
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+      QTest::newRow( "color mix" ) << "color_mix('0,0,0,100','255,255,255',0.5)" << false << QVariant( "128,128,128,177" );
+#else
       QTest::newRow( "color mix" ) << "color_mix('0,0,0,100','255,255,255',0.5)" << false << QVariant( "128,128,128,178" );
+#endif
+
       QTest::newRow( "color mix mixed types" ) << "color_mix('0,0,0,100',color_rgbf(1.0,1.0,1.0),0.5)" << true << QVariant();
       QTest::newRow( "color mix mixed color types" ) << "color_mix(color_cmykf(1.0,1.0,1.0,1.0),color_rgbf(1.0,1.0,1.0),0.5)" << true << QVariant();
       QTest::newRow( "color mix cmyk" ) << "color_mix(color_cmykf(0.9,0.9,0.9,0.9),color_cmykf(0.1,0.1,0.1,0.1),0.5)" << false << QVariant( QColor::fromCmykF( 0.5, 0.5, 0.5, 0.5 ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1943,6 +1943,10 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color darker bad color" ) << "darker('notacolor',150)" << true << QVariant();
       QTest::newRow( "color lighter" ) << "lighter('200,100,30',150)" << false << QVariant( "255,154,83,255" );
       QTest::newRow( "color lighter bad color" ) << "lighter('notacolor',150)" << true << QVariant();
+      QTest::newRow( "color darker object " ) << "darker(color_cmykf(0.1,0.4,0.6,0.6),150)" << false << QVariant( QColor::fromCmykF( 0, 0.333, 0.5555, 0.76 ) );
+      QTest::newRow( "color darker bad color object" ) << "darker(color_cmykf(1.5,1.5,1.5,1.5),150)" << true << QVariant();
+      QTest::newRow( "color lighter object" ) << "lighter(color_cmykf(0.1,0.4,0.6,0.6),150)" << false << QVariant( QColor::fromCmykF( 0, 0.333, 0.5555, 0.46 ) );
+      QTest::newRow( "color lighter bad color object" ) << "lighter(color_cmykf(1.5,1.5,1.5,1.5),150)" << true << QVariant();
 
       QTest::newRow( "color rgb float" ) << "color_rgbf(1,0.4989,0)" << false << QVariant( QColor::fromRgbF( 1., 0.4989, 0 ) );
       QTest::newRow( "color rgba float" ) << "color_rgbf(1,0.4989,0,0.21)" << false << QVariant( QColor::fromRgbF( 1., 0.4989, 0, 0.21 ) );
@@ -2322,33 +2326,33 @@ class TestQgsExpression: public QObject
           switch ( resultColor.spec() )
           {
             case QColor::Spec::Cmyk:
-              QVERIFY( qgsDoubleNear( resultColor.cyanF(), expectedColor.cyanF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.magentaF(), expectedColor.magentaF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.yellowF(), expectedColor.yellowF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.blackF(), expectedColor.blackF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ) );
+              QVERIFY2( qgsDoubleNear( resultColor.cyanF(), expectedColor.cyanF(), 0.001 ), QString( "cyan: %2!=%3" ).arg( resultColor.cyanF(), 0, 'f', 3 ).arg( expectedColor.cyanF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.magentaF(), expectedColor.magentaF(), 0.001 ), QString( "magenta: %2!=%3" ).arg( resultColor.magentaF(), 0, 'f', 3 ).arg( expectedColor.magentaF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.yellowF(), expectedColor.yellowF(), 0.001 ), QString( "yellow: %2!=%3" ).arg( resultColor.yellowF(), 0, 'f', 3 ).arg( expectedColor.yellowF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.blackF(), expectedColor.blackF(), 0.001 ), QString( "black: %2!=%3" ).arg( resultColor.blackF(), 0, 'f', 3 ).arg( expectedColor.blackF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
               break;
 
             case QColor::Spec::Hsl:
-              QVERIFY( qgsDoubleNear( resultColor.hslHueF(), expectedColor.hslHueF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.hslSaturationF(), expectedColor.hslSaturationF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.lightnessF(), expectedColor.lightnessF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ) );
+              QVERIFY2( qgsDoubleNear( resultColor.hslHueF(), expectedColor.hslHueF(), 0.001 ), QString( "hslHue: %2!=%3" ).arg( resultColor.hslHueF(), 0, 'f', 3 ).arg( expectedColor.hslHueF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.hslSaturationF(), expectedColor.hslSaturationF(), 0.001 ), QString( "hslSaturation: %2!=%3" ).arg( resultColor.hslSaturationF(), 0, 'f', 3 ).arg( expectedColor.hslSaturationF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.lightnessF(), expectedColor.lightnessF(), 0.001 ), QString( "lightness: %2!=%3" ).arg( resultColor.lightnessF(), 0, 'f', 3 ).arg( expectedColor.lightnessF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
               break;
 
             case QColor::Spec::Hsv:
-              QVERIFY( qgsDoubleNear( resultColor.hsvHueF(), expectedColor.hsvHueF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.hsvSaturationF(), expectedColor.hsvSaturationF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.valueF(), expectedColor.valueF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ) );
+              QVERIFY2( qgsDoubleNear( resultColor.hsvHueF(), expectedColor.hsvHueF(), 0.001 ), QString( "hsvHue: %2!=%3" ).arg( resultColor.hsvHueF(), 0, 'f', 3 ).arg( expectedColor.hsvHueF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.hsvSaturationF(), expectedColor.hsvSaturationF(), 0.001 ), QString( "hsvSaturation: %2!=%3" ).arg( resultColor.hsvSaturationF(), 0, 'f', 3 ).arg( expectedColor.hsvSaturationF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.valueF(), expectedColor.valueF(), 0.001 ), QString( "value: %2!=%3" ).arg( resultColor.valueF(), 0, 'f', 3 ).arg( expectedColor.valueF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
               break;
 
             case QColor::Spec::ExtendedRgb:
             case QColor::Spec::Rgb:
-              QVERIFY( qgsDoubleNear( resultColor.redF(), expectedColor.redF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.greenF(), expectedColor.greenF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.blueF(), expectedColor.blueF(), 0.001 ) );
-              QVERIFY( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ) );
+              QVERIFY2( qgsDoubleNear( resultColor.redF(), expectedColor.redF(), 0.001 ), QString( "red: %2!=%3" ).arg( resultColor.redF(), 0, 'f', 3 ).arg( expectedColor.redF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.greenF(), expectedColor.greenF(), 0.001 ), QString( "green: %2!=%3" ).arg( resultColor.greenF(), 0, 'f', 3 ).arg( expectedColor.greenF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.blueF(), expectedColor.blueF(), 0.001 ), QString( "blue: %2!=%3" ).arg( resultColor.blueF(), 0, 'f', 3 ).arg( expectedColor.blueF(), 0, 'f', 3 ).toLatin1() );
+              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
               break;
 
             case QColor::Spec::Invalid:

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1894,6 +1894,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color cmyk" ) << "color_cmyk(100,50,33,10)" << false << QVariant( "0,115,154" );
       QTest::newRow( "color cmyka" ) << "color_cmyka(50,25,90,60,200)" << false << QVariant( "51,76,10,200" );
       QTest::newRow( "color grayscale average" ) << "color_grayscale_average('255,100,50')" << false << QVariant( "135,135,135,255" );
+      QTest::newRow( "color grayscale average object" ) << "color_grayscale_average(color_rgbf(0.6,0.5,0.1))" << false << QVariant( QColor::fromRgbF( 0.4, 0.4, 0.4 ) );
+      QTest::newRow( "color grayscale average cmyk" ) << "color_grayscale_average(color_cmykf(0.6,0.5,0.1,0.8))" << false << QVariant( QColor::fromCmykF( 0.4, 0.4, 0.4, 0.8 ) );
       QTest::newRow( "color mix rgb" ) << "color_mix_rgb('0,0,0,100','255,255,255',0.5)" << false << QVariant( "127,127,127,177" );
 
       QTest::newRow( "color part bad color" ) << "color_part('notacolor','red')" << true << QVariant();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2331,33 +2331,33 @@ class TestQgsExpression: public QObject
           switch ( resultColor.spec() )
           {
             case QColor::Spec::Cmyk:
-              QVERIFY2( qgsDoubleNear( resultColor.cyanF(), expectedColor.cyanF(), 0.001 ), QString( "cyan: %2!=%3" ).arg( resultColor.cyanF(), 0, 'f', 3 ).arg( expectedColor.cyanF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.magentaF(), expectedColor.magentaF(), 0.001 ), QString( "magenta: %2!=%3" ).arg( resultColor.magentaF(), 0, 'f', 3 ).arg( expectedColor.magentaF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.yellowF(), expectedColor.yellowF(), 0.001 ), QString( "yellow: %2!=%3" ).arg( resultColor.yellowF(), 0, 'f', 3 ).arg( expectedColor.yellowF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.blackF(), expectedColor.blackF(), 0.001 ), QString( "black: %2!=%3" ).arg( resultColor.blackF(), 0, 'f', 3 ).arg( expectedColor.blackF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
+              QGSCOMPARENEAR( resultColor.cyanF(), expectedColor.cyanF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.magentaF(), expectedColor.magentaF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.yellowF(), expectedColor.yellowF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.blackF(), expectedColor.blackF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.alphaF(), expectedColor.alphaF(), 0.001 );
               break;
 
             case QColor::Spec::Hsl:
-              QVERIFY2( qgsDoubleNear( resultColor.hslHueF(), expectedColor.hslHueF(), 0.001 ), QString( "hslHue: %2!=%3" ).arg( resultColor.hslHueF(), 0, 'f', 3 ).arg( expectedColor.hslHueF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.hslSaturationF(), expectedColor.hslSaturationF(), 0.001 ), QString( "hslSaturation: %2!=%3" ).arg( resultColor.hslSaturationF(), 0, 'f', 3 ).arg( expectedColor.hslSaturationF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.lightnessF(), expectedColor.lightnessF(), 0.001 ), QString( "lightness: %2!=%3" ).arg( resultColor.lightnessF(), 0, 'f', 3 ).arg( expectedColor.lightnessF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
+              QGSCOMPARENEAR( resultColor.hslHueF(), expectedColor.hslHueF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.hslSaturationF(), expectedColor.hslSaturationF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.lightnessF(), expectedColor.lightnessF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.alphaF(), expectedColor.alphaF(), 0.001 );
               break;
 
             case QColor::Spec::Hsv:
-              QVERIFY2( qgsDoubleNear( resultColor.hsvHueF(), expectedColor.hsvHueF(), 0.001 ), QString( "hsvHue: %2!=%3" ).arg( resultColor.hsvHueF(), 0, 'f', 3 ).arg( expectedColor.hsvHueF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.hsvSaturationF(), expectedColor.hsvSaturationF(), 0.001 ), QString( "hsvSaturation: %2!=%3" ).arg( resultColor.hsvSaturationF(), 0, 'f', 3 ).arg( expectedColor.hsvSaturationF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.valueF(), expectedColor.valueF(), 0.001 ), QString( "value: %2!=%3" ).arg( resultColor.valueF(), 0, 'f', 3 ).arg( expectedColor.valueF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
+              QGSCOMPARENEAR( resultColor.hsvHueF(), expectedColor.hsvHueF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.hsvSaturationF(), expectedColor.hsvSaturationF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.valueF(), expectedColor.valueF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.alphaF(), expectedColor.alphaF(), 0.001 );
               break;
 
             case QColor::Spec::ExtendedRgb:
             case QColor::Spec::Rgb:
-              QVERIFY2( qgsDoubleNear( resultColor.redF(), expectedColor.redF(), 0.001 ), QString( "red: %2!=%3" ).arg( resultColor.redF(), 0, 'f', 3 ).arg( expectedColor.redF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.greenF(), expectedColor.greenF(), 0.001 ), QString( "green: %2!=%3" ).arg( resultColor.greenF(), 0, 'f', 3 ).arg( expectedColor.greenF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.blueF(), expectedColor.blueF(), 0.001 ), QString( "blue: %2!=%3" ).arg( resultColor.blueF(), 0, 'f', 3 ).arg( expectedColor.blueF(), 0, 'f', 3 ).toLatin1() );
-              QVERIFY2( qgsDoubleNear( resultColor.alphaF(), expectedColor.alphaF(), 0.001 ), QString( "alpha: %2!=%3" ).arg( resultColor.alphaF(), 0, 'f', 3 ).arg( expectedColor.alphaF(), 0, 'f', 3 ).toLatin1() );
+              QGSCOMPARENEAR( resultColor.redF(), expectedColor.redF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.greenF(), expectedColor.greenF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.blueF(), expectedColor.blueF(), 0.001 );
+              QGSCOMPARENEAR( resultColor.alphaF(), expectedColor.alphaF(), 0.001 );
               break;
 
             case QColor::Spec::Invalid:

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1897,6 +1897,10 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color grayscale average object" ) << "color_grayscale_average(color_rgbf(0.6,0.5,0.1))" << false << QVariant( QColor::fromRgbF( 0.4, 0.4, 0.4 ) );
       QTest::newRow( "color grayscale average cmyk" ) << "color_grayscale_average(color_cmykf(0.6,0.5,0.1,0.8))" << false << QVariant( QColor::fromCmykF( 0.4, 0.4, 0.4, 0.8 ) );
       QTest::newRow( "color mix rgb" ) << "color_mix_rgb('0,0,0,100','255,255,255',0.5)" << false << QVariant( "127,127,127,177" );
+      QTest::newRow( "color mix" ) << "color_mix('0,0,0,100','255,255,255',0.5)" << false << QVariant( "128,128,128,178" );
+      QTest::newRow( "color mix mixed types" ) << "color_mix('0,0,0,100',color_rgbf(1.0,1.0,1.0),0.5)" << true << QVariant();
+      QTest::newRow( "color mix mixed color types" ) << "color_mix(color_cmykf(1.0,1.0,1.0,1.0),color_rgbf(1.0,1.0,1.0),0.5)" << true << QVariant();
+      QTest::newRow( "color mix cmyk" ) << "color_mix(color_cmykf(0.9,0.9,0.9,0.9),color_cmykf(0.1,0.1,0.1,0.1),0.5)" << false << QVariant( QColor::fromCmykF( 0.5, 0.5, 0.5, 0.5 ) );
 
       QTest::newRow( "color part bad color" ) << "color_part('notacolor','red')" << true << QVariant();
       QTest::newRow( "color part bad part" ) << "color_part(color_rgb(255,127,0),'bad')" << true << QVariant();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1944,9 +1944,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color lighter" ) << "lighter('200,100,30',150)" << false << QVariant( "255,154,83,255" );
       QTest::newRow( "color lighter bad color" ) << "lighter('notacolor',150)" << true << QVariant();
       QTest::newRow( "color darker object " ) << "darker(color_cmykf(0.1,0.4,0.6,0.6),150)" << false << QVariant( QColor::fromCmykF( 0, 0.333, 0.5555, 0.76 ) );
-      QTest::newRow( "color darker bad color object" ) << "darker(color_cmykf(1.5,1.5,1.5,1.5),150)" << true << QVariant();
       QTest::newRow( "color lighter object" ) << "lighter(color_cmykf(0.1,0.4,0.6,0.6),150)" << false << QVariant( QColor::fromCmykF( 0, 0.333, 0.5555, 0.46 ) );
-      QTest::newRow( "color lighter bad color object" ) << "lighter(color_cmykf(1.5,1.5,1.5,1.5),150)" << true << QVariant();
 
       QTest::newRow( "color rgb float" ) << "color_rgbf(1,0.4989,0)" << false << QVariant( QColor::fromRgbF( 1., 0.4989, 0 ) );
       QTest::newRow( "color rgba float" ) << "color_rgbf(1,0.4989,0,0.21)" << false << QVariant( QColor::fromRgbF( 1., 0.4989, 0, 0.21 ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1919,6 +1919,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color part magenta" ) << "to_int(color_part(color_cmyk(0,10,90,76),'magenta'))" << false << QVariant( 10 );
       QTest::newRow( "color part yellow" ) << "to_int(color_part(color_cmyk(21,0,92,70),'yellow'))" << false << QVariant( 92 );
       QTest::newRow( "color part black" ) << "to_int(color_part(color_cmyk(21,0,92,70),'black'))" << false << QVariant( 70 );
+      QTest::newRow( "color part object" ) << "to_int(color_part(color_cmykf(0.1,0.2,0.3,0.9),'black'))" << false << QVariant( 90 );
       QTest::newRow( "set color part bad color" ) << "set_color_part('notacolor','red', 5)" << true << QVariant();
       QTest::newRow( "set color part bad part" ) << "set_color_part(color_rgb(255,127,0),'bad', 5)" << true << QVariant();
       QTest::newRow( "set color part red" ) << "color_part(set_color_part(color_rgba(200,127,150,100),'red',100),'red')" << false << QVariant( 100 );
@@ -1936,6 +1937,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "set color part magenta" ) << "to_int(color_part(set_color_part(color_cmyk(0,10,90,76),'magenta',31),'magenta'))" << false << QVariant( 31 );
       QTest::newRow( "set color part yellow" ) << "to_int(color_part(set_color_part(color_cmyk(21,0,92,70),'yellow',96),'yellow'))" << false << QVariant( 96 );
       QTest::newRow( "set color part black" ) << "to_int(color_part(set_color_part(color_cmyk(21,0,92,70),'black',100),'black'))" << false << QVariant( 100 );
+      QTest::newRow( "set color part object" ) << "to_int(color_part(set_color_part(color_cmykf(0.21,0,0.92,0.70),'black',100),'black'))" << false << QVariant( 100 );
 
       QTest::newRow( "color darker" ) << "darker('200,100,30',150)" << false << QVariant( "133,67,20,255" );
       QTest::newRow( "color darker bad color" ) << "darker('notacolor',150)" << true << QVariant();


### PR DESCRIPTION
... and not only color string representation as it as been discussed in https://github.com/qgis/QGIS/pull/58458#issuecomment-2303538480

Concerned functions:
- color_grayscale_average
- color_mix
- set_color_part
- color_part
- darker
- lighter

**Funded by Bordeaux Métropôle**