### PR TITLE
Save edits button in fields properties tab

### DIFF
--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -40,12 +40,14 @@ QgsSourceFieldsProperties::QgsSourceFieldsProperties( QgsVectorLayer *layer, QWi
   mDeleteAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
   mToggleEditingButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionToggleEditing.svg" ) ) );
   mCalculateFieldButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionCalculateField.svg" ) ) );
+  mSaveLayerEditsButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionSaveAllEdits.svg" ) ) );
 
   //button signals
   connect( mToggleEditingButton, &QAbstractButton::clicked, this, &QgsSourceFieldsProperties::toggleEditing );
   connect( mAddAttributeButton, &QAbstractButton::clicked, this, &QgsSourceFieldsProperties::addAttributeClicked );
   connect( mDeleteAttributeButton, &QAbstractButton::clicked, this, &QgsSourceFieldsProperties::deleteAttributeClicked );
   connect( mCalculateFieldButton, &QAbstractButton::clicked, this, &QgsSourceFieldsProperties::calculateFieldClicked );
+  connect( mSaveLayerEditsButton, &QAbstractButton::clicked, this, &QgsSourceFieldsProperties::saveLayerEditsClicked );
 
   //slots
   connect( mLayer, &QgsVectorLayer::editingStarted, this, &QgsSourceFieldsProperties::editingToggled );
@@ -381,6 +383,11 @@ void QgsSourceFieldsProperties::calculateFieldClicked()
   }
 }
 
+void QgsSourceFieldsProperties::saveLayerEditsClicked()
+{
+  mLayer->commitChanges( false );
+}
+
 void QgsSourceFieldsProperties::attributesListCellChanged( int row, int column )
 {
   if ( column == AttrNameCol && mLayer && mLayer->isEditable() )
@@ -429,11 +436,14 @@ void QgsSourceFieldsProperties::updateButtons()
     mDeleteAttributeButton->setEnabled( cap & Qgis::VectorProviderCapability::DeleteAttributes );
     mAddAttributeButton->setEnabled( cap & Qgis::VectorProviderCapability::AddAttributes );
     mToggleEditingButton->setChecked( true );
+    mSaveLayerEditsButton->setEnabled( true );
+    mSaveLayerEditsButton->setChecked( true );
   }
   else
   {
     mToggleEditingButton->setChecked( false );
     mAddAttributeButton->setEnabled( false );
+    mSaveLayerEditsButton->setEnabled( false );
 
     // Enable delete button if items are selected
     mDeleteAttributeButton->setEnabled( !mFieldsList->selectedItems().isEmpty() );

--- a/src/gui/vector/qgssourcefieldsproperties.h
+++ b/src/gui/vector/qgssourcefieldsproperties.h
@@ -104,6 +104,7 @@ class GUI_EXPORT QgsSourceFieldsProperties : public QWidget, private Ui_QgsSourc
     void addAttributeClicked();
     void deleteAttributeClicked();
     void calculateFieldClicked();
+    void saveLayerEditsClicked();
 
     void attributeAdded( int idx );
     void attributeDeleted( int idx );

--- a/src/ui/qgssourcefieldsproperties.ui
+++ b/src/ui/qgssourcefieldsproperties.ui
@@ -27,9 +27,6 @@
        <property name="toolTip">
         <string>Field calculator</string>
        </property>
-       <property name="whatsThis">
-        <string>Click to toggle table editing</string>
-       </property>
        <property name="text">
         <string/>
        </property>
@@ -42,9 +39,6 @@
       <widget class="QToolButton" name="mToggleEditingButton">
        <property name="toolTip">
         <string>Toggle editing mode</string>
-       </property>
-       <property name="whatsThis">
-        <string>Click to toggle table editing</string>
        </property>
        <property name="text">
         <string/>
@@ -104,9 +98,6 @@
        <property name="toolTip">
         <string>Save Layer Edits</string>
        </property>
-       <property name="whatsThis">
-        <string>Click to toggle table editing</string>
-       </property>
        <property name="text">
         <string/>
        </property>
@@ -124,6 +115,7 @@
   <tabstop>mAddAttributeButton</tabstop>
   <tabstop>mDeleteAttributeButton</tabstop>
   <tabstop>mToggleEditingButton</tabstop>
+  <tabstop>mSaveLayerEditsButton</tabstop>
   <tabstop>mCalculateFieldButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgssourcefieldsproperties.ui
+++ b/src/ui/qgssourcefieldsproperties.ui
@@ -62,10 +62,6 @@
        <property name="text">
         <string/>
        </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../../../../.designer/backup/.designer/xpm/delete_attribute.png</normaloff>../../../../.designer/backup/.designer/xpm/delete_attribute.png</iconset>
-       </property>
        <property name="shortcut">
         <string>Ctrl+X</string>
        </property>
@@ -84,10 +80,6 @@
        </property>
        <property name="text">
         <string/>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</iconset>
        </property>
        <property name="shortcut">
         <string>Ctrl+N</string>

--- a/src/ui/qgssourcefieldsproperties.ui
+++ b/src/ui/qgssourcefieldsproperties.ui
@@ -22,35 +22,6 @@
      <property name="rightMargin">
       <number>0</number>
      </property>
-     <item row="0" column="4">
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="2">
-      <widget class="QToolButton" name="mToggleEditingButton">
-       <property name="toolTip">
-        <string>Toggle editing mode</string>
-       </property>
-       <property name="whatsThis">
-        <string>Click to toggle table editing</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QToolButton" name="mAddAttributeButton">
        <property name="sizePolicy">
@@ -74,6 +45,38 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="3">
+      <widget class="QToolButton" name="mCalculateFieldButton">
+       <property name="toolTip">
+        <string>Field calculator</string>
+       </property>
+       <property name="whatsThis">
+        <string>Click to toggle table editing</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QToolButton" name="mToggleEditingButton">
+       <property name="toolTip">
+        <string>Toggle editing mode</string>
+       </property>
+       <property name="whatsThis">
+        <string>Click to toggle table editing</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="QToolButton" name="mDeleteAttributeButton">
        <property name="toolTip">
@@ -91,10 +94,23 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
-      <widget class="QToolButton" name="mCalculateFieldButton">
+     <item row="0" column="5">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="4">
+      <widget class="QToolButton" name="mSaveLayerEditsButton">
        <property name="toolTip">
-        <string>Field calculator</string>
+        <string>Save Layer Edits</string>
        </property>
        <property name="whatsThis">
         <string>Click to toggle table editing</string>

--- a/src/ui/qgssourcefieldsproperties.ui
+++ b/src/ui/qgssourcefieldsproperties.ui
@@ -22,30 +22,7 @@
      <property name="rightMargin">
       <number>0</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QToolButton" name="mAddAttributeButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>New field</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</iconset>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+N</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
+     <item row="0" column="4">
       <widget class="QToolButton" name="mCalculateFieldButton">
        <property name="toolTip">
         <string>Field calculator</string>
@@ -94,7 +71,30 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="5">
+     <item row="0" column="0">
+      <widget class="QToolButton" name="mAddAttributeButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>New field</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</iconset>
+       </property>
+       <property name="shortcut">
+        <string>Ctrl+N</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -107,7 +107,7 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="4">
+     <item row="0" column="3">
       <widget class="QToolButton" name="mSaveLayerEditsButton">
        <property name="toolTip">
         <string>Save Layer Edits</string>


### PR DESCRIPTION
## Description

Adds the `Save Edits` button to the Field tab in the vector layer properties:

![image](https://github.com/user-attachments/assets/77e545cc-56b5-480c-88a2-f15627822881)
