### PR TITLE
[metasearch] Fix missing import

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -43,6 +43,11 @@ from qgis.core import (Qgis, QgsApplication, QgsCoordinateReferenceSystem,
 from qgis.gui import QgsRubberBand, QgsGui
 from qgis.utils import OverrideCursor
 
+try:
+    from owslib.util import Authentication
+except ImportError:
+    pass
+
 from MetaSearch import link_types
 from MetaSearch.dialogs.manageconnectionsdialog import ManageConnectionsDialog
 from MetaSearch.dialogs.newconnectiondialog import NewConnectionDialog


### PR DESCRIPTION
fix https://github.com/qgis/QGIS/issues/47823

The import got lost in https://github.com/qgis/QGIS/commit/e3a179680fc99d707641b858753ac81febf1e211#diff-69d6b132e78b6860b875c8bff3da27600b1ea9e2eff3056a4290a9a29878a533L55.

Should be backported.