### PR TITLE
Further safeguards from (perceived or actual) bulk download of OpenStreetMap tiles

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsMapLayerUtils
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/core/auto_generated/qgsmaplayerutils.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsMapLayerUtils
 {
 %Docstring(signature="appended")

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -48,6 +48,7 @@ xyz\items\OpenStreetMap\url=https://tile.openstreetmap.org/{z}/{x}/{y}.png
 xyz\items\OpenStreetMap\username=
 xyz\items\OpenStreetMap\zmax=19
 xyz\items\OpenStreetMap\zmin=0
+xyz\items\OpenStreetMap\tile-pixel-ratio=1
 
 xyz\items\Mapzen Global Terrain\authcfg=
 xyz\items\Mapzen Global Terrain\password=

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -197,7 +197,7 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
         }
         feedback->pushInfo( QStringLiteral( "%1" ).arg( totalTiles ) );
 
-        if ( totalTiles > 5000 )
+        if ( totalTiles > MAXIMUM_OPENSTREETMAP_TILES_FETCH )
         {
           // Prevent bulk downloading of tiles from openstreetmap.org as per OSMF tile usage policy
           feedback->pushFormattedMessage( QObject::tr( "Layer %1 will be skipped as the algorithm leads to bulk downloading behavior which is prohibited by the %2OpenStreetMap Foundation tile usage policy%3" ).arg( rasterLayer->name(), QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -189,7 +189,7 @@ bool QgsXyzTilesBaseAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
 
 void QgsXyzTilesBaseAlgorithm::checkLayersUsagePolicy( QgsProcessingFeedback *feedback )
 {
-  if ( mTotalTiles > 5000 )
+  if ( mTotalTiles > MAXIMUM_OPENSTREETMAP_TILES_FETCH )
   {
     for ( QgsMapLayer *layer : std::as_const( mLayers ) )
     {

--- a/src/core/qgsmaplayerutils.h
+++ b/src/core/qgsmaplayerutils.h
@@ -17,6 +17,8 @@
 #ifndef QGSMAPLAYERUTILS_H
 #define QGSMAPLAYERUTILS_H
 
+#define MAXIMUM_OPENSTREETMAP_TILES_FETCH  5000
+
 #include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgis.h"

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -971,10 +971,10 @@ void QgsRasterLayerSaveAsDialog::accept()
     const int nbTilesHeight = std::ceil( nRows() / 256 );
     int64_t totalTiles = static_cast<int64_t>( nbTilesWidth ) * nbTilesHeight;
 
-    if ( totalTiles > 5000 )
+    if ( totalTiles > MAXIMUM_OPENSTREETMAP_TILES_FETCH )
     {
       QMessageBox::warning( this, tr( "Save Raster Layer" ),
-                            tr( "The number of OpenStreetMap tiles needed to produce the raster layer is too large and will leads to bulk downloading behavior which is prohibited by the %1OpenStreetMap Foundation tile usage policy%2." ).arg( QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
+                            tr( "The number of OpenStreetMap tiles needed to produce the raster layer is too large and will lead to bulk downloading behavior which is prohibited by the %1OpenStreetMap Foundation tile usage policy%2." ).arg( QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
                             QMessageBox::Ok );
       return;
     }

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -12,10 +12,12 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #include "qgsapplication.h"
 #include "qgsgdalutils.h"
 #include "qgslogger.h"
 #include "qgscoordinatetransform.h"
+#include "qgsmaplayerutils.h"
 #include "qgsrasterlayer.h"
 #include "qgsrasterlayersaveasdialog.h"
 #include "qgsrasterdataprovider.h"
@@ -961,6 +963,21 @@ void QgsRasterLayerSaveAsDialog::accept()
   if ( !validate() )
   {
     return;
+  }
+
+  if ( QgsMapLayerUtils::isOpenStreetMapLayer( mRasterLayer ) )
+  {
+    const int nbTilesWidth = std::ceil( nColumns() / 256 );
+    const int nbTilesHeight = std::ceil( nRows() / 256 );
+    int64_t totalTiles = static_cast<int64_t>( nbTilesWidth ) * nbTilesHeight;
+
+    if ( totalTiles > 5000 )
+    {
+      QMessageBox::warning( this, tr( "Save Raster Layer" ),
+                            tr( "The number of OpenStreetMap tiles needed to produce the raster layer is too large and will leads to bulk downloading behavior which is prohibited by the %1OpenStreetMap Foundation tile usage policy%2." ).arg( QStringLiteral( "<a href=\"https://operations.osmfoundation.org/policies/tiles/\">" ), QStringLiteral( "</a>" ) ),
+                            QMessageBox::Ok );
+      return;
+    }
   }
 
   if ( outputFormat() == QLatin1String( "GPKG" ) && outputLayerExists() &&


### PR DESCRIPTION
## Description

First, the PR adds a logic in the Save Raster Layer dialog to prevent bulk download by capping the number of tiles deemed acceptable/reasonable. The number matches that used for the processing algorithms. If the nb of tiles being fetched exceeds the cap, users are warned:

![Screenshot from 2024-09-05 17-41-18](https://github.com/user-attachments/assets/fe1f647b-e2a4-494a-b214-eddd7a811cd1)

That action was available both from the layer tree as well as the browser panel, and were the two last remaining UI/UX unguarded.

Second, to further reduce the number of tiles requested, the OpenStreetMap layer QGIS ships by default now has a defined tile resolution (96DPI) which insures that layout map items will not download a large amount of tiles during layout design/preview when the layout DPI is set to 300DPI. 