### PR TITLE
Fix 'unused parameter' error

### DIFF
--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -918,6 +918,7 @@ bool QgsWmsRenderContext::checkLayerReadPermissions( QgsMapLayer *layer )
     return false;
   }
 #endif
+  Q_UNUSED( layer )
   return true;
 }
 


### PR DESCRIPTION
    Fix 'unused parameter' error when compiling without HAVE_SERVER_PYTHON_PLUGINS defined
