### PR TITLE
qgscurvepolygon: Fix clear in copy operator

### DIFF
--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -98,11 +98,11 @@ QgsCompoundCurve::QgsCompoundCurve( const QgsCompoundCurve &curve ): QgsCurve( c
   }
 }
 
+// cppcheck-suppress operatorEqVarError
 QgsCompoundCurve &QgsCompoundCurve::operator=( const QgsCompoundCurve &curve )
 {
   if ( &curve != this )
   {
-    clearCache();
     QgsCurve::operator=( curve );
     for ( const QgsCurve *c : curve.mCurves )
     {

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -80,11 +80,11 @@ QgsCurvePolygon::QgsCurvePolygon( const QgsCurvePolygon &p )
   mValidityFailureReason = p.mValidityFailureReason;
 }
 
+// cppcheck-suppress operatorEqVarError
 QgsCurvePolygon &QgsCurvePolygon::operator=( const QgsCurvePolygon &p )
 {
   if ( &p != this )
   {
-    clearCache();
     QgsSurface::operator=( p );
     if ( p.mExteriorRing )
     {

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -52,11 +52,11 @@ QgsGeometryCollection::QgsGeometryCollection( const QgsGeometryCollection &c ):
   }
 }
 
+// cppcheck-suppress operatorEqVarError
 QgsGeometryCollection &QgsGeometryCollection::operator=( const QgsGeometryCollection &c )
 {
   if ( &c != this )
   {
-    clearCache();
     QgsAbstractGeometry::operator=( c );
     int nGeoms = c.mGeometries.size();
     mGeometries.resize( nGeoms );

--- a/tests/src/core/geometry/testqgscompoundcurve.cpp
+++ b/tests/src/core/geometry/testqgscompoundcurve.cpp
@@ -619,6 +619,13 @@ void TestQgsCompoundCurve::assignment()
 
   QVERIFY( cc1 != cc2 );
 
+  QgsLineString ls2;
+  ls2.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointM, 3, 4, 5, 6 )
+                 << QgsPoint( Qgis::WkbType::PointM, 1 / 2.0, 5 / 7.0, 1, 3 )
+                 << QgsPoint( Qgis::WkbType::PointM, 2, 3, 5, 7 ) );
+  cc2.addCurve( ls2.clone() );
+  QVERIFY( cc1 != cc2 );
+
   cc2 = cc1;
   QCOMPARE( cc1, cc2 );
 }

--- a/tests/src/core/geometry/testqgscurvepolygon.cpp
+++ b/tests/src/core/geometry/testqgscurvepolygon.cpp
@@ -150,22 +150,37 @@ void TestQgsCurvePolygon::testCopyConstructor()
   QgsCurvePolygon poly2( poly1 );
   QCOMPARE( poly1, poly2 );
 
-  QgsCircularString *ext = new QgsCircularString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 5 )
-                  << QgsPoint( Qgis::WkbType::PointZM, 0, 10, 2, 6 ) << QgsPoint( Qgis::WkbType::PointZM, 10, 10, 3, 7 )
-                  << QgsPoint( Qgis::WkbType::PointZM, 10, 0, 4, 8 ) << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 9 ) );
-  poly1.setExteriorRing( ext );
+  QgsCircularString *ext1 = new QgsCircularString();
+  ext1->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 5 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 0, 10, 2, 6 ) << QgsPoint( Qgis::WkbType::PointZM, 10, 10, 3, 7 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 10, 0, 4, 8 ) << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 9 ) );
+  poly1.setExteriorRing( ext1 );
 
-  QgsCircularString *ring = new QgsCircularString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 2 )
-                   << QgsPoint( Qgis::WkbType::PointZM, 1, 9, 2, 3 ) << QgsPoint( Qgis::WkbType::PointZM, 9, 9, 3, 6 )
-                   << QgsPoint( Qgis::WkbType::PointZM, 9, 1, 4, 4 ) << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 7 ) );
-  poly1.addInteriorRing( ring );
+  QgsCircularString *ring1 = new QgsCircularString();
+  ring1->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 2 )
+                    << QgsPoint( Qgis::WkbType::PointZM, 1, 9, 2, 3 ) << QgsPoint( Qgis::WkbType::PointZM, 9, 9, 3, 6 )
+                    << QgsPoint( Qgis::WkbType::PointZM, 9, 1, 4, 4 ) << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 7 ) );
+  poly1.addInteriorRing( ring1 );
 
   QgsCurvePolygon poly3( poly1 );
   QCOMPARE( poly1, poly3 );
 
   QgsCurvePolygon poly4;
+  QgsCircularString *ext2 = new QgsCircularString();
+  ext2->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZ, 0, 0, 1 )
+                   << QgsPoint( Qgis::WkbType::PointZ, 0, 10, 2 ) << QgsPoint( Qgis::WkbType::PointZ, 10, 10, 3 )
+                   << QgsPoint( Qgis::WkbType::PointZ, 10, 0, 4 ) << QgsPoint( Qgis::WkbType::PointZ, 0, 0, 1 ) );
+  poly4.setExteriorRing( ext2 );
+  QgsCircularString *ring2 = new QgsCircularString();
+  ring2->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZ, 1, 1, 1 )
+                    << QgsPoint( Qgis::WkbType::PointZ, 1, 9, 2 ) << QgsPoint( Qgis::WkbType::PointZ, 9, 9, 3 )
+                    << QgsPoint( Qgis::WkbType::PointZ, 9, 1, 4 ) << QgsPoint( Qgis::WkbType::PointZ, 1, 1, 1 ) );
+  poly4.addInteriorRing( ring2 );
+  QVERIFY( poly4.exteriorRing() );
+  QCOMPARE( poly4.numInteriorRings(), 1 );
+  QVERIFY( poly4.interiorRing( 0 ) );
+  QVERIFY( poly2 != poly4 );
+
   poly4 = poly2;
   QCOMPARE( poly2, poly4 );
   poly4 = poly1;

--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -15,6 +15,7 @@
 #include "qgstest.h"
 #include <QObject>
 #include <QString>
+#include <qtestcase.h>
 
 #include "qgscircularstring.h"
 #include "qgsgeometrycollection.h"
@@ -33,6 +34,8 @@ class TestQgsGeometryCollection: public QObject
     Q_OBJECT
   private slots:
     void geometryCollection();
+    void testCopyConstructor();
+    void testAssignment();
 };
 
 void TestQgsGeometryCollection::geometryCollection()
@@ -196,36 +199,10 @@ void TestQgsGeometryCollection::geometryCollection()
   QCOMPARE( *static_cast< const QgsLineString * >( cloned->geometryN( 0 ) ), part );
   QCOMPARE( *static_cast< const QgsLineString * >( cloned->geometryN( 1 ) ), part2 );
 
-  //copy constructor
-  QgsGeometryCollection c12;
-  QgsGeometryCollection c13( c12 );
-  QVERIFY( c13.isEmpty() );
-  part.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 5 )
-                  << QgsPoint( Qgis::WkbType::PointZM, 0, 10, 2, 6 ) << QgsPoint( Qgis::WkbType::PointZM, 10, 10, 3, 7 )
-                  << QgsPoint( Qgis::WkbType::PointZM, 10, 0, 4, 8 ) << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 9 ) );
-  c12.addGeometry( part.clone() );
-  part2.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 2 )
-                   << QgsPoint( Qgis::WkbType::PointZM, 1, 9, 2, 3 ) << QgsPoint( Qgis::WkbType::PointZM, 9, 9, 3, 6 )
-                   << QgsPoint( Qgis::WkbType::PointZM, 9, 1, 4, 4 ) << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 7 ) );
-  c12.addGeometry( part2.clone() );
-  QgsGeometryCollection c14( c12 );
-  QCOMPARE( c14.numGeometries(), 2 );
-  QCOMPARE( *static_cast< const QgsLineString * >( c14.geometryN( 0 ) ), part );
-  QCOMPARE( *static_cast< const QgsLineString * >( c14.geometryN( 1 ) ), part2 );
-
-  //assignment operator
-  QgsGeometryCollection c15;
-  c15 = c13;
-  QCOMPARE( c15.numGeometries(), 0 );
-  c15 = c14;
-  QCOMPARE( c15.numGeometries(), 2 );
-  QCOMPARE( *static_cast< const QgsLineString * >( c15.geometryN( 0 ) ), part );
-  QCOMPARE( *static_cast< const QgsLineString * >( c15.geometryN( 1 ) ), part2 );
-
   //equality
   QgsGeometryCollection emptyCollection;
-  QVERIFY( !( emptyCollection == c15 ) );
-  QVERIFY( emptyCollection != c15 );
+  QVERIFY( !( emptyCollection == c11 ) );
+  QVERIFY( emptyCollection != c11 );
   QgsPoint notCollection;
   QVERIFY( !( emptyCollection == notCollection ) );
   QVERIFY( emptyCollection != notCollection );
@@ -249,7 +226,7 @@ void TestQgsGeometryCollection::geometryCollection()
   QVERIFY( ml2 == ml3 );
 
   //toCurveType
-  std::unique_ptr< QgsGeometryCollection > curveType( c12.toCurveType() );
+  std::unique_ptr< QgsGeometryCollection > curveType( c11.toCurveType() );
   QCOMPARE( curveType->wkbType(), Qgis::WkbType::GeometryCollection );
   QCOMPARE( curveType->numGeometries(), 2 );
   const QgsCompoundCurve *curve = static_cast< const QgsCompoundCurve * >( curveType->geometryN( 0 ) );
@@ -1503,6 +1480,69 @@ void TestQgsGeometryCollection::geometryCollection()
   QgsPolygon polygon2;
   QVERIFY( polygon2.fromWkt( "Polygon( (5 10 0, 5 15 5, 10 15 5, 10 10 5, 5 10 0) )" ) );
   QVERIFY( b2.boundingBoxIntersects( polygon2.boundingBox3D() ) );
+}
+
+void TestQgsGeometryCollection::testCopyConstructor()
+{
+  QgsGeometryCollection c1;
+  QgsLineString part;
+  QgsLineString part2;
+
+  part.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  c1.addGeometry( part.clone() );
+
+  QgsGeometryCollection c2;
+  QgsGeometryCollection c3( c2 );
+  QVERIFY( c3.isEmpty() );
+  part.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 5 )
+                  << QgsPoint( Qgis::WkbType::PointZM, 0, 10, 2, 6 ) << QgsPoint( Qgis::WkbType::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( Qgis::WkbType::PointZM, 10, 0, 4, 8 ) << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 1, 9 ) );
+  c2.addGeometry( part.clone() );
+  part2.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 2 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 1, 9, 2, 3 ) << QgsPoint( Qgis::WkbType::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 9, 1, 4, 4 ) << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 7 ) );
+  c2.addGeometry( part2.clone() );
+  QgsGeometryCollection c4( c2 );
+  QCOMPARE( c4.numGeometries(), 2 );
+  QCOMPARE( *static_cast< const QgsLineString * >( c4.geometryN( 0 ) ), part );
+  QCOMPARE( *static_cast< const QgsLineString * >( c4.geometryN( 1 ) ), part2 );
+}
+
+void TestQgsGeometryCollection::testAssignment()
+{
+  QgsGeometryCollection c1;
+  QgsLineString part;
+  QgsLineString part2;
+  QgsLineString part3;
+
+  part.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  c1.addGeometry( part.clone() );
+  QCOMPARE( c1.numGeometries(), 1 );
+
+  QgsGeometryCollection c2;
+  QCOMPARE( c2.numGeometries(), 0 );
+  QVERIFY( c1 != c2 );
+
+  part2.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 2 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 1, 9, 2, 3 ) << QgsPoint( Qgis::WkbType::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 9, 1, 4, 4 ) << QgsPoint( Qgis::WkbType::PointZM, 1, 1, 1, 7 ) );
+  c2.addGeometry( part2.clone() );
+  QCOMPARE( c2.numGeometries(), 1 );
+  QVERIFY( c1 != c2 );
+
+  part3.setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                   << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
+                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
+  c1.addGeometry( part3.clone() );
+
+  c2 = c1;
+  QCOMPARE( c1.numGeometries(), 2 );
+  QCOMPARE( c2.numGeometries(), 2 );
+  QCOMPARE( *static_cast< const QgsLineString * >( c2.geometryN( 0 ) ), part );
+  QCOMPARE( *static_cast< const QgsLineString * >( c2.geometryN( 1 ) ), part3 );
+  QVERIFY( c1 == c2 );
 }
 
 


### PR DESCRIPTION


## Description

Clearing the cache is not enough, a full clear is needed.

Based on the discussion from https://github.com/qgis/QGIS/pull/58583#discussion_r1745634447
