### PR TITLE
fix vector digitizing truncating geometry precision decimals

### DIFF
--- a/src/app/qgsvectorlayerdigitizingproperties.cpp
+++ b/src/app/qgsvectorlayerdigitizingproperties.cpp
@@ -43,9 +43,8 @@ QgsVectorLayerDigitizingPropertiesPage::QgsVectorLayerDigitizingPropertiesPage( 
     mGeometryPrecisionLineEdit->setValidator( new QDoubleValidator( mGeometryPrecisionLineEdit ) );
 
     const double precision( vlayer->geometryOptions()->geometryPrecision() );
-    const bool ok = true;
     QString precisionStr( QLocale().toString( precision, 'g', 15 ) );
-    if ( precision == 0.0 || ! ok )
+    if ( precision == 0.0 )
       precisionStr = QString();
     mGeometryPrecisionLineEdit->setText( precisionStr );
 

--- a/src/app/qgsvectorlayerdigitizingproperties.cpp
+++ b/src/app/qgsvectorlayerdigitizingproperties.cpp
@@ -44,7 +44,7 @@ QgsVectorLayerDigitizingPropertiesPage::QgsVectorLayerDigitizingPropertiesPage( 
 
     const double precision( vlayer->geometryOptions()->geometryPrecision() );
     const bool ok = true;
-    QString precisionStr( QLocale().toString( precision, ok ) );
+    QString precisionStr( QLocale().toString( precision, 'g', 15 ) );
     if ( precision == 0.0 || ! ok )
       precisionStr = QString();
     mGeometryPrecisionLineEdit->setText( precisionStr );

--- a/src/app/qgsvectorlayerdigitizingproperties.cpp
+++ b/src/app/qgsvectorlayerdigitizingproperties.cpp
@@ -43,7 +43,7 @@ QgsVectorLayerDigitizingPropertiesPage::QgsVectorLayerDigitizingPropertiesPage( 
     mGeometryPrecisionLineEdit->setValidator( new QDoubleValidator( mGeometryPrecisionLineEdit ) );
 
     const double precision( vlayer->geometryOptions()->geometryPrecision() );
-    QString precisionStr( QLocale().toString( precision, 'g', 15 ) );
+    QString precisionStr( QLocale().toString( precision, 'g', 17 ) );
     if ( precision == 0.0 )
       precisionStr = QString();
     mGeometryPrecisionLineEdit->setText( precisionStr );


### PR DESCRIPTION
#58351

Digitizing box still uses the same QLocale to show values, but instead of the default precision of 6, it now has a precision of 15. After 4 decimals, it changes to scientific notation, depending on the user set locale settings.
As the same object is used to convert values to and from, scientific notation is a valid representation, both for showing the actual values and for saving.