### PR TITLE
[settings] support direct connection from widget value change to upda…

### DIFF
--- a/python/PyQt6/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
@@ -82,6 +82,17 @@ Sets the ``value`` of the widget
 The wrapper must be configured before calling this medthod
 %End
 
+    void enableAutomaticUpdate();
+%Docstring
+Enables automatic update
+so that the setting gets update
+on value change in the widget and
+sets the widget to the current settings value.
+This must called after createEditor or configureEditor.
+
+.. versionadded:: 3.40
+%End
+
 
   protected:
     virtual QWidget *createEditorPrivate( QWidget *parent = 0 ) const = 0;
@@ -92,6 +103,15 @@ Creates the widgets
     virtual bool configureEditorPrivate( QWidget *editor, const QgsSettingsEntryBase *setting ) = 0;
 %Docstring
 Configures an existing ``editor`` widget
+%End
+
+    virtual void enableAutomaticUpdatePrivate() = 0;
+%Docstring
+Enables automatic update
+so that the setting gets update
+on value change in the widget.
+
+.. versionadded:: 3.40
 %End
 
 };

--- a/python/PyQt6/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsSettingsEditorWidgetWrapper : QObject
 {
 %Docstring(signature="appended")
@@ -82,13 +83,17 @@ Sets the ``value`` of the widget
 The wrapper must be configured before calling this medthod
 %End
 
-    void enableAutomaticUpdate();
+    void configureAutomaticUpdate( QDialog *dialog = 0 );
 %Docstring
-Enables automatic update
-so that the setting gets update
-on value change in the widget and
-sets the widget to the current settings value.
-This must called after createEditor or configureEditor.
+Enables automatic update, which causes the setting to be updated immediately when the widget
+value is changed.
+
+If a ``dialog`` is provided, the setting will be updated when the dialog is accepted.
+If not, the setting will be updated directly at each widget value change.
+
+.. note::
+
+   This must called after :py:func:`~QgsSettingsEditorWidgetWrapper.createEditor` or :py:func:`~QgsSettingsEditorWidgetWrapper.configureEditor`.
 
 .. versionadded:: 3.40
 %End
@@ -107,9 +112,8 @@ Configures an existing ``editor`` widget
 
     virtual void enableAutomaticUpdatePrivate() = 0;
 %Docstring
-Enables automatic update
-so that the setting gets update
-on value change in the widget.
+Enables automatic update, which causes the setting to be updated immediately when the widget
+value is changed.
 
 .. versionadded:: 3.40
 %End

--- a/python/PyQt6/gui/auto_generated/settings/qgssettingseditorwidgetwrapperimpl.sip.in
+++ b/python/PyQt6/gui/auto_generated/settings/qgssettingseditorwidgetwrapperimpl.sip.in
@@ -109,6 +109,9 @@ Constructor
 
     virtual bool setWidgetValue( const QString &value ) const;
 
+
+    virtual void enableAutomaticUpdatePrivate();
+
 };
 
 
@@ -144,6 +147,9 @@ Constructor
 
 
     virtual bool setWidgetValue( const bool &value ) const;
+
+
+    virtual void enableAutomaticUpdatePrivate();
 
 };
 
@@ -181,6 +187,9 @@ Constructor
 
     virtual bool setWidgetValue( const int &value ) const;
 
+
+    virtual void enableAutomaticUpdatePrivate();
+
 };
 
 
@@ -217,6 +226,9 @@ Constructor
 
 
     virtual bool setWidgetValue( const double &value ) const;
+
+
+    virtual void enableAutomaticUpdatePrivate();
 
 };
 
@@ -257,6 +269,9 @@ Constructor
 
 
     virtual void configureEditorPrivateImplementation();
+
+
+    virtual void enableAutomaticUpdatePrivate();
 
 };
 

--- a/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
@@ -82,6 +82,17 @@ Sets the ``value`` of the widget
 The wrapper must be configured before calling this medthod
 %End
 
+    void enableAutomaticUpdate();
+%Docstring
+Enables automatic update
+so that the setting gets update
+on value change in the widget and
+sets the widget to the current settings value.
+This must called after createEditor or configureEditor.
+
+.. versionadded:: 3.40
+%End
+
 
   protected:
     virtual QWidget *createEditorPrivate( QWidget *parent = 0 ) const = 0;
@@ -92,6 +103,15 @@ Creates the widgets
     virtual bool configureEditorPrivate( QWidget *editor, const QgsSettingsEntryBase *setting ) = 0;
 %Docstring
 Configures an existing ``editor`` widget
+%End
+
+    virtual void enableAutomaticUpdatePrivate() = 0;
+%Docstring
+Enables automatic update
+so that the setting gets update
+on value change in the widget.
+
+.. versionadded:: 3.40
 %End
 
 };

--- a/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
@@ -83,12 +83,12 @@ Sets the ``value`` of the widget
 The wrapper must be configured before calling this medthod
 %End
 
-    void enableAutomaticUpdate( QDialog *dialog = 0 );
+    void configureAutomaticUpdate( QDialog *dialog = 0 );
 %Docstring
 Enables automatic update, which causes the setting to be updated immediately when the widget
 value is changed.
 
-If a ``dialog`` is provided, the setting will be updated when the dialog is accpeted.
+If a ``dialog`` is provided, the setting will be updated when the dialog is accepted.
 If not, the setting will be updated directly at each widget value change.
 
 .. note::

--- a/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapper.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsSettingsEditorWidgetWrapper : QObject
 {
 %Docstring(signature="appended")
@@ -82,13 +83,17 @@ Sets the ``value`` of the widget
 The wrapper must be configured before calling this medthod
 %End
 
-    void enableAutomaticUpdate();
+    void enableAutomaticUpdate( QDialog *dialog = 0 );
 %Docstring
-Enables automatic update
-so that the setting gets update
-on value change in the widget and
-sets the widget to the current settings value.
-This must called after createEditor or configureEditor.
+Enables automatic update, which causes the setting to be updated immediately when the widget
+value is changed.
+
+If a ``dialog`` is provided, the setting will be updated when the dialog is accpeted.
+If not, the setting will be updated directly at each widget value change.
+
+.. note::
+
+   This must called after :py:func:`~QgsSettingsEditorWidgetWrapper.createEditor` or :py:func:`~QgsSettingsEditorWidgetWrapper.configureEditor`.
 
 .. versionadded:: 3.40
 %End
@@ -107,9 +112,8 @@ Configures an existing ``editor`` widget
 
     virtual void enableAutomaticUpdatePrivate() = 0;
 %Docstring
-Enables automatic update
-so that the setting gets update
-on value change in the widget.
+Enables automatic update, which causes the setting to be updated immediately when the widget
+value is changed.
 
 .. versionadded:: 3.40
 %End

--- a/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapperimpl.sip.in
+++ b/python/gui/auto_generated/settings/qgssettingseditorwidgetwrapperimpl.sip.in
@@ -109,6 +109,9 @@ Constructor
 
     virtual bool setWidgetValue( const QString &value ) const;
 
+
+    virtual void enableAutomaticUpdatePrivate();
+
 };
 
 
@@ -144,6 +147,9 @@ Constructor
 
 
     virtual bool setWidgetValue( const bool &value ) const;
+
+
+    virtual void enableAutomaticUpdatePrivate();
 
 };
 
@@ -181,6 +187,9 @@ Constructor
 
     virtual bool setWidgetValue( const int &value ) const;
 
+
+    virtual void enableAutomaticUpdatePrivate();
+
 };
 
 
@@ -217,6 +226,9 @@ Constructor
 
 
     virtual bool setWidgetValue( const double &value ) const;
+
+
+    virtual void enableAutomaticUpdatePrivate();
 
 };
 
@@ -257,6 +269,9 @@ Constructor
 
 
     virtual void configureEditorPrivateImplementation();
+
+
+    virtual void enableAutomaticUpdatePrivate();
 
 };
 

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -19,6 +19,7 @@
 #define QGSGUI_H
 
 #include "qgis_gui.h"
+#include "qgssettingstree.h"
 #include "qgis_sip.h"
 #include <QWidget>
 #include <memory>
@@ -63,6 +64,8 @@ class GUI_EXPORT QgsGui : public QObject
     Q_OBJECT
 
   public:
+
+    static inline QgsSettingsTreeNode *sTtreeWidgetLastUsedValues = QgsSettingsTree::sTreeApp->createChildNode( QStringLiteral( "widget-last-used-values" ) ) SIP_SKIP;
 
     /**
      * Defines the behavior to use when setting the CRS for a newly created project.

--- a/src/gui/settings/qgssettingseditorwidgetwrapper.cpp
+++ b/src/gui/settings/qgssettingseditorwidgetwrapper.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "qgssettingsentry.h"
 
+#include <QDialog>
 #include <QWidget>
 
 
@@ -58,4 +59,20 @@ bool QgsSettingsEditorWidgetWrapper::configureEditor( QWidget *editor, const Qgs
     editor->setProperty( "SETTING-EDITOR-WIDGET-WRAPPER", QVariant::fromValue( this ) );
 
   return ok;
+}
+
+void QgsSettingsEditorWidgetWrapper::enableAutomaticUpdate( QDialog *dialog )
+{
+  setWidgetFromSetting();
+  if ( dialog )
+  {
+    QObject::connect( dialog, &QDialog::accepted, this, [ = ]()
+    {
+      setSettingFromWidget();
+    } );
+  }
+  else
+  {
+    enableAutomaticUpdatePrivate();
+  }
 }

--- a/src/gui/settings/qgssettingseditorwidgetwrapper.cpp
+++ b/src/gui/settings/qgssettingseditorwidgetwrapper.cpp
@@ -61,7 +61,7 @@ bool QgsSettingsEditorWidgetWrapper::configureEditor( QWidget *editor, const Qgs
   return ok;
 }
 
-void QgsSettingsEditorWidgetWrapper::enableAutomaticUpdate( QDialog *dialog )
+void QgsSettingsEditorWidgetWrapper::configureAutomaticUpdate( QDialog *dialog )
 {
   setWidgetFromSetting();
   if ( dialog )

--- a/src/gui/settings/qgssettingseditorwidgetwrapper.h
+++ b/src/gui/settings/qgssettingseditorwidgetwrapper.h
@@ -23,6 +23,8 @@
 
 class QgsSettingsEntryBase;
 
+class QDialog;
+
 /**
  * \ingroup gui
  * \brief Base class for settings editor wrappers
@@ -84,18 +86,14 @@ class GUI_EXPORT QgsSettingsEditorWidgetWrapper : public QObject
      * Enables automatic update, which causes the setting to be updated immediately when the widget
      * value is changed.
      *
-     * Calling this method will set the widget's current value to match the current settings value.
+     * If a \a dialog is provided, the setting will be updated when the dialog is accpeted.
+     * If not, the setting will be updated directly at each widget value change.
      *
      * \note This must called after createEditor() or configureEditor().
-     * \warning Do NOT call this method from places where a widget is embedded in a dialog with a cancel button, as the auto-update logic will immediately overwrite the setting value and prevent rollback if the user cancels the dialog.
      *
      * \since QGIS 3.40
      */
-    void enableAutomaticUpdate()
-    {
-      setWidgetFromSetting();
-      enableAutomaticUpdatePrivate();
-    }
+    void enableAutomaticUpdate( QDialog *dialog = nullptr );
 
 
   protected:

--- a/src/gui/settings/qgssettingseditorwidgetwrapper.h
+++ b/src/gui/settings/qgssettingseditorwidgetwrapper.h
@@ -80,6 +80,23 @@ class GUI_EXPORT QgsSettingsEditorWidgetWrapper : public QObject
      */
     virtual void setWidgetFromVariant( const QVariant &value ) const = 0;
 
+    /**
+     * Enables automatic update, which causes the setting to be updated immediately when the widget
+     * value is changed.
+     *
+     * Calling this method will set the widget's current value to match the current settings value.
+     *
+     * \note This must called after createEditor() or configureEditor().
+     * \warning Do NOT call this method from places where a widget is embedded in a dialog with a cancel button, as the auto-update logic will immediately overwrite the setting value and prevent rollback if the user cancels the dialog.
+     *
+     * \since QGIS 3.40
+     */
+    void enableAutomaticUpdate()
+    {
+      setWidgetFromSetting();
+      enableAutomaticUpdatePrivate();
+    }
+
 
   protected:
     //! Creates the widgets
@@ -87,6 +104,13 @@ class GUI_EXPORT QgsSettingsEditorWidgetWrapper : public QObject
 
     //! Configures an existing \a editor widget
     virtual bool configureEditorPrivate( QWidget *editor, const QgsSettingsEntryBase *setting ) = 0;
+
+    /**
+     * Enables automatic update, which causes the setting to be updated immediately when the widget
+     * value is changed.
+     * \since QGIS 3.40
+     */
+    virtual void enableAutomaticUpdatePrivate() = 0;
 
     QStringList mDynamicKeyPartList;
 };

--- a/src/gui/settings/qgssettingseditorwidgetwrapper.h
+++ b/src/gui/settings/qgssettingseditorwidgetwrapper.h
@@ -83,8 +83,7 @@ class GUI_EXPORT QgsSettingsEditorWidgetWrapper : public QObject
     virtual void setWidgetFromVariant( const QVariant &value ) const = 0;
 
     /**
-     * Enables automatic update, which causes the setting to be updated immediately when the widget
-     * value is changed.
+     * Configure the settings update behavior when a widget value is changed.
      *
      * If a \a dialog is provided, the setting will be updated when the dialog is accepted.
      * If not, the setting will be updated directly at each widget value change.

--- a/src/gui/settings/qgssettingseditorwidgetwrapper.h
+++ b/src/gui/settings/qgssettingseditorwidgetwrapper.h
@@ -86,14 +86,14 @@ class GUI_EXPORT QgsSettingsEditorWidgetWrapper : public QObject
      * Enables automatic update, which causes the setting to be updated immediately when the widget
      * value is changed.
      *
-     * If a \a dialog is provided, the setting will be updated when the dialog is accpeted.
+     * If a \a dialog is provided, the setting will be updated when the dialog is accepted.
      * If not, the setting will be updated directly at each widget value change.
      *
      * \note This must called after createEditor() or configureEditor().
      *
      * \since QGIS 3.40
      */
-    void enableAutomaticUpdate( QDialog *dialog = nullptr );
+    void configureAutomaticUpdate( QDialog *dialog = nullptr );
 
 
   protected:

--- a/src/gui/settings/qgssettingseditorwidgetwrapperimpl.cpp
+++ b/src/gui/settings/qgssettingseditorwidgetwrapperimpl.cpp
@@ -46,6 +46,14 @@ bool QgsSettingsStringEditorWidgetWrapper::setWidgetValue( const QString &value 
   return false;
 }
 
+void QgsSettingsStringEditorWidgetWrapper::enableAutomaticUpdatePrivate()
+{
+  QObject::connect( this->mEditor, &QLineEdit::textChanged, this, [ = ]( const QString & text )
+  {
+    this->mSetting->setValue( text, this->mDynamicKeyPartList );
+  } );
+}
+
 bool QgsSettingsStringEditorWidgetWrapper::setSettingFromWidget() const
 {
   if ( mEditor )
@@ -94,6 +102,14 @@ bool QgsSettingsBoolEditorWidgetWrapper::setWidgetValue( const bool &value ) con
     QgsDebugError( QStringLiteral( "Settings editor not set for %1" ).arg( mSetting->definitionKey() ) );
   }
   return false;
+}
+
+void QgsSettingsBoolEditorWidgetWrapper::enableAutomaticUpdatePrivate()
+{
+  QObject::connect( this->mEditor, &QCheckBox::clicked, this, [ = ]( bool checked )
+  {
+    this->mSetting->setValue( checked, this->mDynamicKeyPartList );
+  } );
 }
 
 bool QgsSettingsBoolEditorWidgetWrapper::setSettingFromWidget() const
@@ -148,6 +164,14 @@ bool QgsSettingsIntegerEditorWidgetWrapper::setWidgetValue( const int &value ) c
   return false;
 }
 
+void QgsSettingsIntegerEditorWidgetWrapper::enableAutomaticUpdatePrivate()
+{
+  QObject::connect( this->mEditor, qOverload<int>( &QSpinBox::valueChanged ), this, [ = ]( int value )
+  {
+    this->mSetting->setValue( value, this->mDynamicKeyPartList );
+  } );
+}
+
 bool QgsSettingsIntegerEditorWidgetWrapper::setSettingFromWidget() const
 {
   if ( mEditor )
@@ -198,6 +222,14 @@ bool QgsSettingsDoubleEditorWidgetWrapper::setWidgetValue( const double &value )
     QgsDebugError( QStringLiteral( "Settings editor not set for %1" ).arg( mSetting->definitionKey() ) );
   }
   return false;
+}
+
+void QgsSettingsDoubleEditorWidgetWrapper::enableAutomaticUpdatePrivate()
+{
+  QObject::connect( this->mEditor, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [ = ]( double value )
+  {
+    this->mSetting->setValue( value, this->mDynamicKeyPartList );
+  } );
 }
 
 bool QgsSettingsDoubleEditorWidgetWrapper::setSettingFromWidget() const
@@ -260,6 +292,14 @@ void QgsSettingsColorEditorWidgetWrapper::configureEditorPrivateImplementation()
   {
     QgsDebugError( QStringLiteral( "Settings editor not set for %1" ).arg( mSetting->definitionKey() ) );
   }
+}
+
+void QgsSettingsColorEditorWidgetWrapper::enableAutomaticUpdatePrivate()
+{
+  QObject::connect( this->mEditor, &QgsColorButton::colorChanged, this, [ = ]( const QColor & color )
+  {
+    this->mSetting->setValue( color, this->mDynamicKeyPartList );
+  } );
 }
 
 bool QgsSettingsColorEditorWidgetWrapper::setSettingFromWidget() const

--- a/src/gui/settings/qgssettingseditorwidgetwrapperimpl.h
+++ b/src/gui/settings/qgssettingseditorwidgetwrapperimpl.h
@@ -139,6 +139,8 @@ class GUI_EXPORT QgsSettingsStringEditorWidgetWrapper : public QgsSettingsEditor
     QString valueFromWidget() const override;
 
     bool setWidgetValue( const QString &value ) const override;
+
+    void enableAutomaticUpdatePrivate() override;
 };
 
 /**
@@ -164,6 +166,8 @@ class GUI_EXPORT QgsSettingsBoolEditorWidgetWrapper : public QgsSettingsEditorWi
     bool valueFromWidget() const override;
 
     bool setWidgetValue( const bool &value ) const override;
+
+    void enableAutomaticUpdatePrivate() override;
 };
 
 /**
@@ -189,6 +193,8 @@ class GUI_EXPORT QgsSettingsIntegerEditorWidgetWrapper : public QgsSettingsEdito
     int valueFromWidget() const override;
 
     bool setWidgetValue( const int &value ) const override;
+
+    void enableAutomaticUpdatePrivate() override;
 };
 
 
@@ -215,6 +221,8 @@ class GUI_EXPORT QgsSettingsDoubleEditorWidgetWrapper : public QgsSettingsEditor
     double valueFromWidget() const override;
 
     bool setWidgetValue( const double &value ) const override;
+
+    void enableAutomaticUpdatePrivate() override;
 };
 
 
@@ -243,6 +251,8 @@ class GUI_EXPORT QgsSettingsColorEditorWidgetWrapper : public QgsSettingsEditorW
     bool setWidgetValue( const QColor &value ) const override;
 
     void configureEditorPrivateImplementation() override;
+
+    void enableAutomaticUpdatePrivate() override;
 };
 
 


### PR DESCRIPTION
…te setting value

This is useful to remember last used values for instance.

There is an API break in `QgsSettingsEditorWidgetWrapper`. I would prefer to make the method pure virtual from the beginning. Considering the recently solved ticket of settings unregistration from plugin (#58595), it is pretty sure no one ever implemented a custom `QgsSettingsEditorWidgetWrapper` in python.


For instance, this code will set a combobox to display options from an enum with translations and auto save the last used option:

```cpp
const auto *QgsVectorTileConnectionDialog::settingsLastLoadingMode = new QgsSettingsEntryEnumFlag<QgsVectorTileConnectionDialog::LoadingMode>( QStringLiteral( "vector-tile-loading-mode" ), QgsGui::sTtreeWidgetLastUsedValues, QgsVectorTileConnectionDialog::LoadingMode::Url, QString() ) ;

…

auto *settingsWidgetWrapper = new QgsSettingsEnumEditorWidgetWrapper<QgsVectorTileConnectionDialog::LoadingMode>( this );
settingsWidgetWrapper->setDisplayStrings(
{
  {LoadingMode::Style, tr( "Load from style" )},
  {LoadingMode::Url, tr( "Load from URL" )},
} );
settingsWidgetWrapper->configureEditor( mModeComboBox, settingsLastLoadingMode );
settingsWidgetWrapper->enableAutomaticUpdate();
```