### PR TITLE
[geometry] Handle exporting of empty interior ring as WKT in a manner that will allow for re-creating geometries afterwards

### DIFF
--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -305,13 +305,20 @@ QString QgsCurvePolygon::asWkt( int precision ) const
     }
     for ( const QgsCurve *curve : mInteriorRings )
     {
-      QString childWkt = curve->asWkt( precision );
-      if ( qgsgeometry_cast<const QgsLineString *>( curve ) )
+      if ( !curve->isEmpty() )
       {
-        // Type names of linear geometries are omitted
-        childWkt = childWkt.mid( childWkt.indexOf( '(' ) );
+        QString childWkt = curve->asWkt( precision );
+        if ( qgsgeometry_cast<const QgsLineString *>( curve ) )
+        {
+          // Type names of linear geometries are omitted
+          childWkt = childWkt.mid( childWkt.indexOf( '(' ) );
+        }
+        wkt += childWkt + ',';
       }
-      wkt += childWkt + ',';
+      else
+      {
+        wkt += QLatin1String( "()" );
+      }
     }
     if ( wkt.endsWith( ',' ) )
     {

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -315,10 +315,6 @@ QString QgsCurvePolygon::asWkt( int precision ) const
         }
         wkt += childWkt + ',';
       }
-      else
-      {
-        wkt += QLatin1String( "()" );
-      }
     }
     if ( wkt.endsWith( ',' ) )
     {

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -206,19 +206,26 @@ QString QgsPolygon::asWkt( int precision ) const
     }
     for ( const QgsCurve *curve : mInteriorRings )
     {
-      QString childWkt;
-      if ( ! qgsgeometry_cast<QgsLineString *>( curve ) )
+      if ( !curve->isEmpty() )
       {
-        std::unique_ptr<QgsLineString> line( curve->curveToLine() );
-        childWkt = line->asWkt( precision );
+        QString childWkt;
+        if ( ! qgsgeometry_cast<QgsLineString *>( curve ) )
+        {
+          std::unique_ptr<QgsLineString> line( curve->curveToLine() );
+          childWkt = line->asWkt( precision );
+        }
+        else
+        {
+          childWkt = curve->asWkt( precision );
+        }
+        // Type names of linear geometries are omitted
+        childWkt = childWkt.mid( childWkt.indexOf( '(' ) );
+        wkt += childWkt + ',';
       }
       else
       {
-        childWkt = curve->asWkt( precision );
+        wkt += QLatin1String( "()" );
       }
-      // Type names of linear geometries are omitted
-      childWkt = childWkt.mid( childWkt.indexOf( '(' ) );
-      wkt += childWkt + ',';
     }
     if ( wkt.endsWith( ',' ) )
     {

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -222,10 +222,6 @@ QString QgsPolygon::asWkt( int precision ) const
         childWkt = childWkt.mid( childWkt.indexOf( '(' ) );
         wkt += childWkt + ',';
       }
-      else
-      {
-        wkt += QLatin1String( "()" );
-      }
     }
     if ( wkt.endsWith( ',' ) )
     {

--- a/tests/src/core/geometry/testqgscurvepolygon.cpp
+++ b/tests/src/core/geometry/testqgscurvepolygon.cpp
@@ -1731,6 +1731,21 @@ void TestQgsCurvePolygon::testWKT()
   QVERIFY( !poly2.is3D() );
   QVERIFY( !poly2.isMeasure() );
   QCOMPARE( poly2.wkbType(), Qgis::WkbType::CurvePolygon );
+
+  // Test WKT export with empty interior ring
+  QgsCurvePolygon poly3;
+  QgsCircularString *ext2 = new QgsCircularString();
+  ext2->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 10, 1 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 10, 0, 11, 2 ) << QgsPoint( Qgis::WkbType::PointZM, 10, 10, 12, 3 )
+                   << QgsPoint( Qgis::WkbType::PointZM, 0, 10, 13, 4 ) << QgsPoint( Qgis::WkbType::PointZM, 0, 0, 10, 1 ) );
+  poly3.setExteriorRing( ext2 );
+  poly3.addInteriorRing( new QgsCircularString() );
+  wkt = poly3.asWkt();
+  QCOMPARE( wkt, QStringLiteral( "CurvePolygonZM (CircularStringZM (0 0 10 1, 10 0 11 2, 10 10 12 3, 0 10 13 4, 0 0 10 1),())" ) );
+
+  QgsCurvePolygon poly4;
+  QVERIFY( poly4.fromWkt( wkt ) );
+  QCOMPARE( wkt, poly4.asWkt() );
 }
 
 void TestQgsCurvePolygon::testExport()

--- a/tests/src/core/geometry/testqgscurvepolygon.cpp
+++ b/tests/src/core/geometry/testqgscurvepolygon.cpp
@@ -1741,11 +1741,7 @@ void TestQgsCurvePolygon::testWKT()
   poly3.setExteriorRing( ext2 );
   poly3.addInteriorRing( new QgsCircularString() );
   wkt = poly3.asWkt();
-  QCOMPARE( wkt, QStringLiteral( "CurvePolygonZM (CircularStringZM (0 0 10 1, 10 0 11 2, 10 10 12 3, 0 10 13 4, 0 0 10 1),())" ) );
-
-  QgsCurvePolygon poly4;
-  QVERIFY( poly4.fromWkt( wkt ) );
-  QCOMPARE( wkt, poly4.asWkt() );
+  QCOMPARE( wkt, QStringLiteral( "CurvePolygonZM (CircularStringZM (0 0 10 1, 10 0 11 2, 10 10 12 3, 0 10 13 4, 0 0 10 1))" ) );
 }
 
 void TestQgsCurvePolygon::testExport()

--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -2854,6 +2854,23 @@ void TestQgsPolygon::toFromWKT()
   pl3.addInteriorRing( compound );
   wkt = pl3.asWkt();
   QCOMPARE( wkt, QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),(1 1, 1 9, 9 9, 9 1, 1 1))" ) );
+
+  // Test WKT export with empty interior ring
+  QgsPolygon pl4;
+  QgsLineString *ext4 = new QgsLineString();
+  ext4->setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::Point, 0, 0 )
+                   << QgsPoint( Qgis::WkbType::Point, 0, 10 )
+                   << QgsPoint( Qgis::WkbType::Point, 10, 10 )
+                   << QgsPoint( Qgis::WkbType::Point, 10, 0 )
+                   << QgsPoint( Qgis::WkbType::Point, 0, 0 ) );
+  pl4.setExteriorRing( ext4 );
+  pl4.addInteriorRing( new QgsLineString() );
+  wkt = pl4.asWkt();
+  QCOMPARE( wkt, QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),())" ) );
+
+  QgsPolygon pl5;
+  QVERIFY( pl5.fromWkt( wkt ) );
+  QCOMPARE( pl4, pl5 );
 }
 
 void TestQgsPolygon::exportImport()

--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -2866,11 +2866,7 @@ void TestQgsPolygon::toFromWKT()
   pl4.setExteriorRing( ext4 );
   pl4.addInteriorRing( new QgsLineString() );
   wkt = pl4.asWkt();
-  QCOMPARE( wkt, QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),())" ) );
-
-  QgsPolygon pl5;
-  QVERIFY( pl5.fromWkt( wkt ) );
-  QCOMPARE( pl4, pl5 );
+  QCOMPARE( wkt, QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0))" ) );
 }
 
 void TestQgsPolygon::exportImport()


### PR DESCRIPTION
## Description

While working on fixing https://github.com/qgis/QGIS/pull/58602 , I ran into an issue with the way we export WKT of a polygon with an empty interior ring. This PR insures that a polygon's asWkt() -> string allows for the same string to re-create the polygon when calling fromWkt(string).