### PR TITLE
[processing] Fix points to path algorithm's handling of text folder output's temporary destination

### DIFF
--- a/src/analysis/processing/qgsalgorithmpointstopaths.cpp
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.cpp
@@ -331,7 +331,7 @@ QVariantMap QgsPointsToPathsAlgorithm::processAlgorithm( const QVariantMap &para
     if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
       throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
 
-    if ( ! textDir.isEmpty() )
+    if ( !textDir.isEmpty() )
     {
       const QString filename = QDir( textDir ).filePath( hit.key().toString() + QString( ".txt" ) );
       QFile textFile( filename );
@@ -364,6 +364,10 @@ QVariantMap QgsPointsToPathsAlgorithm::processAlgorithm( const QVariantMap &para
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), dest );
   outputs.insert( QStringLiteral( "NUM_PATHS" ), pathCount );
+  if ( !textDir.isEmpty() )
+  {
+    outputs.insert( QStringLiteral( "OUTPUT_TEXT_DIR" ), textDir );
+  }
   return outputs;
 }
 

--- a/src/analysis/processing/qgsalgorithmpointstopaths.cpp
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.cpp
@@ -210,9 +210,10 @@ QVariantMap QgsPointsToPathsAlgorithm::processAlgorithm( const QVariantMap &para
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
 
   const QString textDir = parameterAsString( parameters, QStringLiteral( "OUTPUT_TEXT_DIR" ), context );
-  if ( ! textDir.isEmpty() &&
-       ! QDir( textDir ).exists() )
-    throw QgsProcessingException( QObject::tr( "The text output directory does not exist" ) );
+  if ( !textDir.isEmpty() && !QDir().mkpath( textDir ) )
+  {
+    throw QgsProcessingException( QObject::tr( "Failed to create the text output directory" ) );
+  }
 
   QgsDistanceArea da = QgsDistanceArea();
   da.setSourceCrs( source->sourceCrs(), context.transformContext() );


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/58345 by insuring that the points to path algorithm attempts to create the text output folder if missing. Algorithms are in charge of insuring a given destination folder parameter exists.