### PR TITLE
[mvt] support concat expression

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -3227,6 +3227,18 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
   {
     return QStringLiteral( "@vector_tile_zoom" );
   }
+  else if ( op == QLatin1String( "concat" ) )
+  {
+    QString concatString = QStringLiteral( "concat(" );
+    for ( int i = 1; i < expression.size(); i++ )
+    {
+      if ( i > 1 )
+        concatString += QStringLiteral( ", " );
+      concatString += parseExpression( expression.value( i ).toList(), context );
+    }
+    concatString += QStringLiteral( ")" );
+    return concatString;
+  }
   else
   {
     context.pushWarning( QObject::tr( "%1: Skipping unsupported expression \"%2\"" ).arg( context.layerId(), op ) );

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -486,6 +486,8 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
 
         self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["case", ["==", ["%", ["to-number", ["get", "ele"]], 100], 0], 0.75, 0], conversion_context, False), '''CASE WHEN (to_real("ele") % 100 IS 0) THEN 0.75 ELSE 0 END''')
 
+        self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["concat", ["get", "numero"], ["get", "indice_de_repetition"]], conversion_context, False), '''concat("numero", "indice_de_repetition")''')
+
     def testConvertLabels(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {


### PR DESCRIPTION
fixes #58364

Regarding the layer from the ticket, it is now loaded in QGIS but nothing appears on the map. I didn't investigate more for now.
Worth mentionning that clicking on the layer `toponyme - parcellaire - adresse` in maputnik (web) makes it crash.