### PR TITLE
qgsvectorlayerprofilegenerator: Add support for polyhedralsurface

### DIFF
--- a/tests/src/python/test_qgsvectorlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsvectorlayerprofilegenerator.py
@@ -46,7 +46,7 @@ from qgis.core import (
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
-from utilities import unitTestDataPath
+from utilities import compareWkt, unitTestDataPath
 
 start_app()
 
@@ -2311,6 +2311,61 @@ class TestQgsVectorLayerProfileGenerator(QgisTestCase):
         elif Qgis.geosVersionMajor() == 3 and Qgis.geosVersionMinor() >= 12:
             self.doCheckLine(req, 10, vl, [168, 172, 206, 210, 231, 267, 275, 282, 283, 284, 306, 307, 319, 321], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], Qgis.GeometryType.Line)
             self.doCheckLine(req, 11, vl, [168, 172, 206, 210, 231, 237, 255, 267, 275, 282, 283, 284, 306, 307, 319, 321], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], Qgis.GeometryType.Line)
+
+    def testPolyhedralSurfaceGenerationFeature(self):
+        # Create a Vector Layer and add a polyhedralSurface feature
+        vl = QgsVectorLayer("PolyhedralSurfaceZ?crs=epsg:27700", "polyhedral_surface", "memory")
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.crs().authid(), 'EPSG:27700')
+        vl.elevationProperties().setClamping(Qgis.AltitudeClamping.Absolute)
+        vl.elevationProperties().setExtrusionEnabled(False)
+
+        wkt_str = 'POLYHEDRALSURFACE Z(((321474.91 129812.38 -20.00,322277.09 130348.29 -20.00,322631.00 129738.23 -20.00,321434.46 129266.36 -20.00,321474.91 129812.38 -20.00)),((321474.91 129812.38 30.00,321434.46 129266.36 30.00,322631.00 129738.23 30.00,322277.09 130348.29 30.00,321474.91 129812.38 30.00)),((321474.91 129812.38 -20.00,321474.91 129812.38 30.00,322277.09 130348.29 30.00,322277.09 130348.29 -20.00,321474.91 129812.38 -20.00)),((322277.09 130348.29 -20.00,322277.09 130348.29 30.00,322631.00 129738.23 30.00,322631.00 129738.23 -20.00,322277.09 130348.29 -20.00)),((322631.00 129738.23 -20.00,322631.00 129738.23 30.00,321434.46 129266.36 30.00,321434.46 129266.36 -20.00,322631.00 129738.23 -20.00)),((321434.46 129266.36 -20.00,321434.46 129266.36 30.00,321474.91 129812.38 30.00,321474.91 129812.38 -20.00,321434.46 129266.36 -20.00)))'
+        vl_feature = QgsFeature()
+        vl_feature.setGeometry(QgsGeometry.fromWkt(wkt_str))
+        self.assertTrue(vl.dataProvider().addFeature(vl_feature))
+
+        # Do an intersection
+        curve = QgsLineString()
+        curve.fromWkt(
+            'LineString (-346120 6631840, -346550 6632030, -346440 6632140, -347830 6632930)')
+        req = QgsProfileRequest(curve)
+
+        req.setCrs(QgsCoordinateReferenceSystem('EPSG:3857'))
+        req.setTolerance(10)
+        generator = vl.createProfileGenerator(req)
+        self.assertTrue(generator.generateProfile())
+
+        # Check the result
+        results = generator.takeResults().asGeometries()
+        self.assertEqual(len(results), 1)
+
+        result = results[0]
+        self.assertEqual(result.wkbType(), Qgis.WkbType.MultiLineStringZ)
+        multi_line = result.constGet()
+        self.assertEqual(multi_line.numGeometries(), 4)
+        self.assertTrue(multi_line.geometryN(0).numPoints(), 27)
+        wkts_results = [
+            {
+                'result': multi_line.geometryN(0).pointN(12),
+                'expected': 'PointZ (-347168.3 6632565.4 -20)'
+
+            },
+            {
+                'result': multi_line.geometryN(0).pointN(16),
+                'expected': 'PointZ (-346431 6632144.3 -20)'
+
+            },
+            {
+                'result': multi_line.geometryN(2),
+                'expected': 'LineStringZ (-347186.6 6632552.8 -6.3, -347168.3 6632565.4 -5.6)'
+            }
+        ]
+        for wkt in wkts_results:
+            expected = wkt['expected']
+            result = wkt['result'].asWkt(1)
+            error_message = f'Expected: {expected}\nGot: {result}\n'
+            self.assertTrue(compareWkt(expected, result, 0.1), error_message)
 
     def test_vertical_transformation_4978_to_4985(self):
         """


### PR DESCRIPTION
## Description

a `QgsPolyhedralSurface` contains a list of polygons. Each of them needs to be processed.
