### PR TITLE
[processing] Fix "Extract binary field" (native:extractbinary) algorithm's handling of the output folder

### DIFF
--- a/src/analysis/processing/qgsalgorithmextractbinary.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbinary.cpp
@@ -87,8 +87,8 @@ QVariantMap QgsExtractBinaryFieldAlgorithm::processAlgorithm( const QVariantMap 
     throw QgsProcessingException( QObject::tr( "Invalid binary field" ) );
 
   const QString folder = parameterAsString( parameters, QStringLiteral( "FOLDER" ), context );
-  if ( !QFileInfo::exists( folder ) )
-    throw QgsProcessingException( QObject::tr( "Destination folder %1 does not exist" ).arg( folder ) );
+  if ( !QDir().mkpath( folder ) )
+    throw QgsProcessingException( QObject::tr( "Failed to create output directory." ) );
 
   const QDir dir( folder );
   const QString filenameExpressionString = parameterAsString( parameters, QStringLiteral( "FILENAME" ), context );


### PR DESCRIPTION
## Description

Ensures that the output folder is created if missing.

Follows up https://github.com/qgis/QGIS/pull/58619. Fixes https://github.com/qgis/QGIS/issues/58345#issuecomment-2338016939.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
