### PR TITLE
Use @geometry instead of deprecated $geometry in user-facing places

### DIFF
--- a/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
@@ -87,7 +87,7 @@ void QgsGeometryByExpressionAlgorithm::initParameters( const QVariantMap & )
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "WITH_Z" ), QObject::tr( "Output geometry has z dimension" ), false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "WITH_M" ), QObject::tr( "Output geometry has m values" ), false ) );
   addParameter( new QgsProcessingParameterExpression( QStringLiteral( "EXPRESSION" ), QObject::tr( "Geometry expression" ),
-                QStringLiteral( "$geometry" ), QStringLiteral( "INPUT" ) ) );
+                QStringLiteral( "@geometry" ), QStringLiteral( "INPUT" ) ) );
 }
 
 bool QgsGeometryByExpressionAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/app/options/qgscodeeditoroptions.cpp
+++ b/src/app/options/qgscodeeditoroptions.cpp
@@ -220,7 +220,7 @@ class SomeClass:
 
   mExpressionPreview->setText( R"""(aggregate(layer:='rail_stations',
     aggregate:='collect', -- a comment
-    expression:=centroid($geometry), /* a comment */
+    expression:=centroid(@geometry), /* a comment */
     filter:="region_name" = attribute(@parent,'name') + 55 /* a search result */
 )
 )""");

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -32,7 +32,7 @@ QgsSymbolLayer *QgsGeometryGeneratorSymbolLayer::create( const QVariantMap &prop
   QString expression = properties.value( QStringLiteral( "geometryModifier" ) ).toString();
   if ( expression.isEmpty() )
   {
-    expression = QStringLiteral( "$geometry" );
+    expression = QStringLiteral( "@geometry" );
   }
   QgsGeometryGeneratorSymbolLayer *symbolLayer = new QgsGeometryGeneratorSymbolLayer( expression );
 


### PR DESCRIPTION
In many places the deprecated `$geometry` is still used instead of `@geometry`.

I decided to only change it in places where I was 100% certain that I knew what I was doing and what the implications are. So: a) where it inserts the text as initial expression in fields for the user to edit further and b) where it is shown in an example code snippet.

# Initial expression for Geometry Generator
![image](https://github.com/user-attachments/assets/f0092a13-4375-4328-be34-172493fee84f)

# Processing algorithm: Geometry by Expression
![image](https://github.com/user-attachments/assets/f33030ea-e9f4-428b-9c9a-57c3abf232af)

# Settings -> Options -> IDE -> Code Editor
![image](https://github.com/user-attachments/assets/b9547937-d4bb-44e1-99a8-9fae0f8e730a)

Compiled and tested successfully.

Fixes https://github.com/qgis/QGIS/issues/58655