### PR TITLE
Bump Python minimum version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1049,7 +1049,7 @@ set(QGIS_INSTALL_SYS_LIBS TRUE CACHE BOOL "If set to TRUE install all required s
 #############################################################
 # Python
 
-set(MIN_PYTHON_VERSION "3.7")
+set(MIN_PYTHON_VERSION "3.9")
 set(Python_FIND_FRAMEWORK "LAST")
 
 


### PR DESCRIPTION
See the discussion on https://github.com/qgis/QGIS/pull/56499

As the PR with Python 3.10 is currently blocked, let's try to upgrade at least to Python 3.9 for the next LTR version

CC @3nids, @lbartoletti 