### PR TITLE
S3 auth: Fix malformed `Authorization` header

### DIFF
--- a/src/auth/awss3/core/qgsauthawss3method.cpp
+++ b/src/auth/awss3/core/qgsauthawss3method.cpp
@@ -69,15 +69,15 @@ bool QgsAuthAwsS3Method::updateNetworkRequest( QNetworkRequest &request, const Q
     return false;
   }
 
-  const QByteArray username = config.config( QStringLiteral( "username" ) ).toLocal8Bit();
-  const QByteArray password = config.config( QStringLiteral( "password" ) ).toLocal8Bit();
-  const QByteArray region = config.config( QStringLiteral( "region" ) ).toLocal8Bit();
+  const QByteArray username = config.config( QStringLiteral( "username" ) ).toUtf8();
+  const QByteArray password = config.config( QStringLiteral( "password" ) ).toUtf8();
+  const QByteArray region = config.config( QStringLiteral( "region" ) ).toUtf8();
 
   const QByteArray headerList = "host;x-amz-content-sha256;x-amz-date";
   const QByteArray encryptionMethod = "AWS4-HMAC-SHA256";
   const QDateTime currentDateTime = QDateTime::currentDateTime().toUTC();
-  const QByteArray date = currentDateTime.toString( "yyyyMMdd" ).toLocal8Bit();
-  const QByteArray dateTime = currentDateTime.toString( "yyyyMMddThhmmssZ" ).toLocal8Bit();
+  const QByteArray date = currentDateTime.toString( "yyyyMMdd" ).toUtf8();
+  const QByteArray dateTime = currentDateTime.toString( "yyyyMMddThhmmssZ" ).toUtf8();
 
   QByteArray canonicalPath = QUrl::toPercentEncoding( request.url().path(), "/" );  // Don't encode slash
   if ( canonicalPath.isEmpty() )
@@ -102,7 +102,7 @@ bool QgsAuthAwsS3Method::updateNetworkRequest( QNetworkRequest &request, const Q
   const QByteArray canonicalRequest = method + '\n' +
                                       canonicalPath + '\n' +
                                       '\n' +
-                                      "host:" + request.url().host().toLocal8Bit() + '\n' +
+                                      "host:" + request.url().host().toUtf8() + '\n' +
                                       "x-amz-content-sha256:" + payloadHash + '\n' +
                                       "x-amz-date:" + dateTime + '\n' +
                                       '\n' +
@@ -127,9 +127,9 @@ bool QgsAuthAwsS3Method::updateNetworkRequest( QNetworkRequest &request, const Q
   const QByteArray signature = QMessageAuthenticationCode::hash( stringToSign, signingKey, QCryptographicHash::Sha256 ).toHex();
   const QByteArray authorizationHeader = QString("%1 Credential=%2/%3/%4/s3/aws4_request, SignedHeaders=%5, Signature=%6")
                                              .arg(encryptionMethod, username, date, region, headerList, signature)
-                                             .toLocal8Bit();
+                                             .toUtf8();
 
-  request.setRawHeader( QByteArray( "Host" ), request.url().host().toLocal8Bit() );
+  request.setRawHeader( QByteArray( "Host" ), request.url().host().toUtf8() );
   request.setRawHeader( QByteArray( "X-Amz-Date" ), dateTime );
   request.setRawHeader( QByteArray( "Authorization" ), authorizationHeader );
 

--- a/src/auth/awss3/core/qgsauthawss3method.cpp
+++ b/src/auth/awss3/core/qgsauthawss3method.cpp
@@ -129,7 +129,7 @@ bool QgsAuthAwsS3Method::updateNetworkRequest( QNetworkRequest &request, const Q
   request.setRawHeader( QByteArray( "Host" ), request.url().host().toLocal8Bit() );
   request.setRawHeader( QByteArray( "X-Amz-Date" ), dateTime );
   request.setRawHeader( QByteArray( "Authorization" ),
-                        encryptionMethod + "Credential=" + username + '/' + date + "/" + region + "/s3/aws4_request, SignedHeaders=" + headerList + ", Signature=" + signature );
+                        encryptionMethod + " Credential=" + username + '/' + date + "/" + region + "/s3/aws4_request, SignedHeaders=" + headerList + ", Signature=" + signature );
 
   return true;
 }

--- a/src/auth/awss3/core/qgsauthawss3method.cpp
+++ b/src/auth/awss3/core/qgsauthawss3method.cpp
@@ -125,11 +125,13 @@ bool QgsAuthAwsS3Method::updateNetworkRequest( QNetworkRequest &request, const Q
                                 QCryptographicHash::Sha256 );
 
   const QByteArray signature = QMessageAuthenticationCode::hash( stringToSign, signingKey, QCryptographicHash::Sha256 ).toHex();
+  const QByteArray authorizationHeader = QString("%1 Credential=%2/%3/%4/s3/aws4_request, SignedHeaders=%5, Signature=%6")
+                                             .arg(encryptionMethod, username, date, region, headerList, signature)
+                                             .toLocal8Bit();
 
   request.setRawHeader( QByteArray( "Host" ), request.url().host().toLocal8Bit() );
   request.setRawHeader( QByteArray( "X-Amz-Date" ), dateTime );
-  request.setRawHeader( QByteArray( "Authorization" ),
-                        encryptionMethod + " Credential=" + username + '/' + date + "/" + region + "/s3/aws4_request, SignedHeaders=" + headerList + ", Signature=" + signature );
+  request.setRawHeader( QByteArray( "Authorization" ), authorizationHeader );
 
   return true;
 }

--- a/src/auth/awss3/core/qgsauthawss3method.cpp
+++ b/src/auth/awss3/core/qgsauthawss3method.cpp
@@ -125,9 +125,9 @@ bool QgsAuthAwsS3Method::updateNetworkRequest( QNetworkRequest &request, const Q
                                 QCryptographicHash::Sha256 );
 
   const QByteArray signature = QMessageAuthenticationCode::hash( stringToSign, signingKey, QCryptographicHash::Sha256 ).toHex();
-  const QByteArray authorizationHeader = QString("%1 Credential=%2/%3/%4/s3/aws4_request, SignedHeaders=%5, Signature=%6")
-                                             .arg(encryptionMethod, username, date, region, headerList, signature)
-                                             .toUtf8();
+  const QByteArray authorizationHeader = QString( "%1 Credential=%2/%3/%4/s3/aws4_request, SignedHeaders=%5, Signature=%6" )
+                                         .arg( encryptionMethod, username, date, region, headerList, signature )
+                                         .toUtf8();
 
   request.setRawHeader( QByteArray( "Host" ), request.url().host().toUtf8() );
   request.setRawHeader( QByteArray( "X-Amz-Date" ), dateTime );


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/58643

This change fixes request authentication when loading a layer from a private S3 bucket by correcting the format of the `Authorization` header.

____

**Before**

The malformed `Authorization` header (note the missing space before `Credential=`) leads to failed requests (400 status code).

<img width="1406" alt="image" src="https://github.com/user-attachments/assets/eb2b580c-a89b-4ec0-8df1-3807ac8cd573">

____

**After**

![image](https://github.com/user-attachments/assets/d30a5d57-8ce2-4cf4-84f1-b3db9d9ce967)


The corrected `Authorization` header leads to successful requests (200 status code).

____

I tested the change by doing a local build on Mac, and repeating the reproduction steps described in https://github.com/qgis/QGIS/issues/58643.