### PR TITLE
Don't show font size preview in font button icons

### DIFF
--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -850,6 +850,13 @@ void QgsFontButton::updatePreview( const QColor &color, QgsTextFormat *format, Q
   if ( color.isValid() )
     tempFormat.setColor( color );
 
+  // always show font previews based on the standard font size for buttons. Otherwise large/small text
+  // will be unreadable, making the button very non-user-friendly.
+  // Note that we take away a few points here, as the text in these buttons is rendered with a fairly large
+  // margin and we'd like to avoid cropping the text.
+  tempFormat.setSize( QToolButton::font().pointSizeF() - 2 );
+  tempFormat.setSizeUnit( Qgis::RenderUnit::Points );
+
   QSize currentIconSize;
   //icon size is button size with a small margin
   if ( menu() )


### PR DESCRIPTION
Just reset the font size to a standard size when generating the preview, otherwise we end up with invisible text on the buttons if the font size is too big or too little.

Before (left), after (right):
![image](https://github.com/user-attachments/assets/e7ed0030-b89e-4c70-9e07-680a42f54a1f)
