### PR TITLE
[ui] Fix addition of geometryless feature not working after first click on add record toolbar action

### DIFF
--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
@@ -51,6 +51,8 @@ Change the layer edited by the map tool
 
     virtual void deactivate();
 
+    virtual void reactivate();
+
 
     virtual void keyPressEvent( QKeyEvent *e );
 

--- a/python/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
@@ -51,6 +51,8 @@ Change the layer edited by the map tool
 
     virtual void deactivate();
 
+    virtual void reactivate();
+
 
     virtual void keyPressEvent( QKeyEvent *e );
 

--- a/src/gui/maptools/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/maptools/qgsmaptooldigitizefeature.cpp
@@ -131,6 +131,18 @@ void QgsMapToolDigitizeFeature::deactivate()
   emit digitizingFinished();
 }
 
+void QgsMapToolDigitizeFeature::reactivate()
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mLayer );
+  if ( !vlayer )
+    vlayer = currentVectorLayer();
+
+  if ( vlayer && vlayer->geometryType() == Qgis::GeometryType::Null )
+  {
+    layerGeometryCaptured( QgsGeometry() );
+  }
+}
+
 void QgsMapToolDigitizeFeature::keyPressEvent( QKeyEvent *e )
 {
   if ( e->key() == Qt::Key_Escape )

--- a/src/gui/maptools/qgsmaptooldigitizefeature.h
+++ b/src/gui/maptools/qgsmaptooldigitizefeature.h
@@ -55,6 +55,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
 
     void activate() override;
     void deactivate() override;
+    void reactivate() override;
 
     // Overridden to emit digitizingCanceled when ESC is pressed
     void keyPressEvent( QKeyEvent *e ) override;


### PR DESCRIPTION
## Description

This PR fixes addition of geometry-less features via clicking on the add record toolbar action:

![image](https://github.com/user-attachments/assets/43550587-1fcb-4866-a7f6-a38f4a2bab16)

Before this PR, only the first click on the tool (i.e. activation) was resulting in a new feature form. Now every click produces a new feature form.