### PR TITLE
qgsrenderchecker.cpp, checks for env.var. QGIS_TEST_REPORT

### DIFF
--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -56,7 +56,7 @@ QDir QgsRenderChecker::testReportDir()
 {
   if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
     return QDir( QDir( "/root/QGIS" ).filePath( QStringLiteral( "qgis_test_report" ) ) );
-  else if ( qgetenv( "QGIS_TEST_REPORT" ) )
+  else if ( !qgetenv( "QGIS_TEST_REPORT" ).isEmpty() )
     return QDir( qgetenv( "QGIS_TEST_REPORT") );
   else
     return QDir( QDir::temp().filePath( QStringLiteral( "qgis_test_report" ) ) );

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -56,7 +56,7 @@ QDir QgsRenderChecker::testReportDir()
 {
   if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
     return QDir( QDir( "/root/QGIS" ).filePath( QStringLiteral( "qgis_test_report" ) ) );
-  else if ( qgetenv( "QGIS_TEST_REPORT" ) != NULL )
+  else if ( qgetenv( "QGIS_TEST_REPORT" ) )
     return QDir( qgetenv( "QGIS_TEST_REPORT") );
   else
     return QDir( QDir::temp().filePath( QStringLiteral( "qgis_test_report" ) ) );

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -57,7 +57,7 @@ QDir QgsRenderChecker::testReportDir()
   if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
     return QDir( QDir( "/root/QGIS" ).filePath( QStringLiteral( "qgis_test_report" ) ) );
   else if ( !qgetenv( "QGIS_TEST_REPORT" ).isEmpty() )
-    return QDir( qgetenv( "QGIS_TEST_REPORT") );
+    return QDir( qgetenv( "QGIS_TEST_REPORT" ) );
   else
     return QDir( QDir::temp().filePath( QStringLiteral( "qgis_test_report" ) ) );
 }

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -56,6 +56,8 @@ QDir QgsRenderChecker::testReportDir()
 {
   if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
     return QDir( QDir( "/root/QGIS" ).filePath( QStringLiteral( "qgis_test_report" ) ) );
+  else if ( qgetenv( "QGIS_TEST_REPORT" ) != NULL )
+    return QDir( qgetenv( "QGIS_TEST_REPORT") );
   else
     return QDir( QDir::temp().filePath( QStringLiteral( "qgis_test_report" ) ) );
 }


### PR DESCRIPTION
qgsrenderchecker.cpp, checks for env.var. QGIS_TEST_REPORT, and if set uses it instead of $TMPDIR/qgis_test_report. 

Solves: https://github.com/qgis/QGIS/issues/58631.


