### PR TITLE
added Page Properties qAction to layout main menu

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -753,6 +753,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
     mView->resizeSelectedItems( QgsLayoutAligner::ResizeToSquare );
   } );
 
+  connect( mActionPageProperties, &QAction::triggered, this, &QgsLayoutDesignerDialog::showPageProperties );
   connect( mActionAddPages, &QAction::triggered, this, &QgsLayoutDesignerDialog::addPages );
 
   connect( mActionUnlockAll, &QAction::triggered, this, &QgsLayoutDesignerDialog::unlockAllItems );
@@ -1918,6 +1919,16 @@ void QgsLayoutDesignerDialog::addPages()
     if ( dlg.numberPages() > 1 )
       mLayout->undoStack()->endMacro();
 
+  }
+}
+
+void QgsLayoutDesignerDialog::showPageProperties()
+{
+  QgsLayoutItemPage *page = mLayout->pageCollection()->page( 0 );
+
+  if ( page )
+  {
+    showItemOptions( page, true );
   }
 }
 

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -381,6 +381,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
     void toggleFullScreen( bool enabled );
 
     void addPages();
+    void showPageProperties();
     void statusMessageReceived( const QString &message );
     void dockVisibilityChanged( bool visible );
     void undoRedoOccurredForItems( const QSet< QString > &itemUuids );

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -182,7 +182,7 @@
      <x>0</x>
      <y>0</y>
      <width>2180</width>
-     <height>22</height>
+     <height>32</height>
     </rect>
    </property>
    <widget class="QMenu" name="mLayoutMenu">
@@ -204,6 +204,7 @@
     <addaction name="separator"/>
     <addaction name="mActionLayoutProperties"/>
     <addaction name="mActionRenameLayout"/>
+    <addaction name="mActionPageProperties"/>
     <addaction name="mActionAddPages"/>
     <addaction name="separator"/>
     <addaction name="mActionLoadFromTemplate"/>
@@ -1585,8 +1586,14 @@
     <string>&amp;Keyboard Shortcuts...</string>
    </property>
   </action>
+  <action name="mActionPageProperties">
+   <property name="text">
+    <string>Page Properties…</string>
+   </property>
+  </action>
  </widget>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
## Description

Adds a menu option to open Page Properties in main Layout menu (see image).

![qgis_page_properties](https://github.com/user-attachments/assets/59dab18b-9e65-4524-aa38-a292329c7f2a)

This was available only on right mouse click above empty paper - considered hidden by many users.

Fixes #26237

Fixes #27843 (already closed but this really fixes it)

See #27698 (solves first problem in a list - second is discussable (feature request), and third problem still exists - see bottom of this description)

It's kind of a improvement for #29033

See #35580 (solves point 2, according to @gioman ![comment](https://github.com/qgis/QGIS/issues/35580#issuecomment-609048874) we can also close this one, but I agree that we should entirely remove "Printer Page Setup..." option since it does nothing, whatever you set up there gets ignored and overridden by settings set up in "Page Properties", but this should be done by someone more experienced to left no traces behind.:

![qgis_printer_page_setup](https://github.com/user-attachments/assets/6c84c2d0-a646-4b6f-bc3f-a917bd8c506d)

If we remove this "Printer Page Setup..." we could also close other bug reports noted above.

This is my first contribution, greetings from Bratislava contributor meeting, special thanks to @uclaros for helping me.
