### PR TITLE
Update the 2.5D renderer to use @geometry instead of $geometry

### DIFF
--- a/src/core/symbology/qgs25drenderer.cpp
+++ b/src/core/symbology/qgs25drenderer.cpp
@@ -26,7 +26,7 @@
 
 #define ROOF_EXPRESSION \
   "translate(" \
-  "  $geometry," \
+  "  @geometry," \
   "  cos( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )," \
   "  sin( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )" \
   ")"
@@ -34,17 +34,17 @@
 #define WALL_EXPRESSION \
   "order_parts( "\
   "  extrude(" \
-  "    segments_to_lines( $geometry )," \
+  "    segments_to_lines( @geometry )," \
   "    cos( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )," \
   "    sin( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )" \
   "  )," \
-  "  'distance(  $geometry,  translate(    @map_extent_center,    1000 * @map_extent_width * cos( radians( @qgis_25d_angle + 180 ) ),    1000 * @map_extent_width * sin( radians( @qgis_25d_angle + 180 ) )  ))'," \
+  "  'distance(  @geometry,  translate(    @map_extent_center,    1000 * @map_extent_width * cos( radians( @qgis_25d_angle + 180 ) ),    1000 * @map_extent_width * sin( radians( @qgis_25d_angle + 180 ) )  ))'," \
   "  False" \
   ")"
 
 #define ORDER_BY_EXPRESSION \
   "distance(" \
-  "  $geometry," \
+  "  @geometry," \
   "  translate(" \
   "    @map_extent_center," \
   "    1000 * @map_extent_width * cos( radians( @qgis_25d_angle + 180 ) )," \
@@ -57,8 +57,8 @@
   "  @symbol_color," \
   " 'value'," \
   "  40 + 19 * abs( $pi - azimuth( " \
-  "    point_n( geometry_n($geometry, @geometry_part_num) , 1 ), " \
-  "    point_n( geometry_n($geometry, @geometry_part_num) , 2 )" \
+  "    point_n( geometry_n(@geometry, @geometry_part_num) , 1 ), " \
+  "    point_n( geometry_n(@geometry, @geometry_part_num) , 2 )" \
   "  ) ) " \
   ")"
 

--- a/src/gui/symbology/qgs25drendererwidget.cpp
+++ b/src/gui/symbology/qgs25drendererwidget.cpp
@@ -26,7 +26,7 @@ Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *sty
   if ( !layer )
     return;
 
-  // the renderer only applies to point vector layers
+  // the renderer only applies to polygon vector layers
   if ( layer->geometryType() != Qgis::GeometryType::Polygon )
   {
     //setup blank dialog


### PR DESCRIPTION
Update the 2.5D renderer to use @geometry instead of $geometry. This change should not really change anything, it's really just cosmetic ;) When doing https://github.com/qgis/QGIS/pull/58657 I noticed that this was another place where I could update an expression without danger.

I looked at the same map in previous and freshly compiled QGIS and see no differences.


# Before
![3381-Grenoble](https://github.com/user-attachments/assets/e4664087-8bed-4ef1-beb7-50c9161d0437)

# After
![after sipify](https://github.com/user-attachments/assets/fc8ee6b0-3e4b-4483-b2ce-33d704aa4b92)
