### PR TITLE
Removed the unused "Size of bar" widget

### DIFF
--- a/src/app/decorations/qgsdecorationscalebar.h
+++ b/src/app/decorations/qgsdecorationscalebar.h
@@ -52,8 +52,6 @@ class APP_EXPORT QgsDecorationScaleBar: public QgsDecorationItem
 
   private:
 
-    //! The size preferred size of the scale bar
-    int mPreferredSize;
     //! Should we snap to integer times power of 10?
     bool mSnapping;
     //! Style of scale bar. An index and the translated text

--- a/src/app/decorations/qgsdecorationscalebardialog.cpp
+++ b/src/app/decorations/qgsdecorationscalebardialog.cpp
@@ -20,7 +20,7 @@
 #include <QDialogButtonBox>
 #include <QPushButton>
 
-QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar &deco, Qgis::DistanceUnit units, QWidget *parent )
+QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar &deco, QWidget *parent )
   : QDialog( parent )
   , mDeco( deco )
 {
@@ -34,25 +34,6 @@ QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar 
 
   QPushButton *applyButton = buttonBox->button( QDialogButtonBox::Apply );
   connect( applyButton, &QAbstractButton::clicked, this, &QgsDecorationScaleBarDialog::apply );
-
-  // set the map units in the spin box
-  spnSize->setShowClearButton( false );
-  switch ( units )
-  {
-    case Qgis::DistanceUnit::Meters:
-      spnSize->setSuffix( tr( " meters/km" ) );
-      break;
-    case Qgis::DistanceUnit::Feet:
-    case Qgis::DistanceUnit::Miles:
-      spnSize->setSuffix( tr( " feet/miles" ) );
-      break;
-    case Qgis::DistanceUnit::Degrees:
-      spnSize->setSuffix( tr( " degrees" ) );
-      break;
-    default:
-      QgsDebugError( QStringLiteral( "Error: not picked up map units - actual value = %1" ).arg( qgsEnumValueToKey( units ) ) );
-  }
-  spnSize->setValue( mDeco.mPreferredSize );
 
   chkSnapping->setChecked( mDeco.mSnapping );
 
@@ -113,7 +94,6 @@ void QgsDecorationScaleBarDialog::apply()
   mDeco.mMarginUnit = wgtUnitSelection->unit();
   mDeco.mMarginHorizontal = spnHorizontal->value();
   mDeco.mMarginVertical = spnVertical->value();
-  mDeco.mPreferredSize = spnSize->value();
   mDeco.mSnapping = chkSnapping->isChecked();
   mDeco.setEnabled( grpEnable->isChecked() );
   mDeco.mStyleIndex = cboStyle->currentIndex();

--- a/src/app/decorations/qgsdecorationscalebardialog.h
+++ b/src/app/decorations/qgsdecorationscalebardialog.h
@@ -24,7 +24,7 @@ class APP_EXPORT QgsDecorationScaleBarDialog : public QDialog, private Ui::QgsDe
     Q_OBJECT
 
   public:
-    QgsDecorationScaleBarDialog( QgsDecorationScaleBar &deco, Qgis::DistanceUnit units, QWidget *parent = nullptr );
+    QgsDecorationScaleBarDialog( QgsDecorationScaleBar &deco, QWidget *parent = nullptr );
 
   private slots:
     void buttonBox_accepted();

--- a/src/ui/qgsdecorationscalebardialog.ui
+++ b/src/ui/qgsdecorationscalebardialog.ui
@@ -52,6 +52,74 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="4" column="0">
+       <widget class="QLabel" name="textLabel1_3_22">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Font of bar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="cboPlacement">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="lblLocation">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Placement</string>
+        </property>
+        <property name="buddy">
+         <cstring>cboPlacement</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QgsFontButton" name="mButtonFontStyle">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Font</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkSnapping">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Automatically snap to round number on resize</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
        <layout class="QHBoxLayout" name="colorLayout">
         <item>
@@ -124,8 +192,8 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="textLabel1_3">
+      <item row="3" column="0">
+       <widget class="QLabel" name="textLabel1_3_2">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
           <horstretch>0</horstretch>
@@ -133,10 +201,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Size of bar</string>
-        </property>
-        <property name="buddy">
-         <cstring>spnSize</cstring>
+         <string>Color of bar</string>
         </property>
        </widget>
       </item>
@@ -173,79 +238,7 @@
         </item>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="textLabel1_3_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Color of bar</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="textLabel1_3_22">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Font of bar</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QgsFontButton" name="mButtonFontStyle">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Font</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QgsSpinBox" name="spnSize">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item row="8" column="1">
+      <item row="7" column="1">
        <layout class="QHBoxLayout" name="hlytMargin" stretch="0,0,0,0,0">
         <property name="spacing">
          <number>10</number>
@@ -301,14 +294,14 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>Horizontal offset on the map canvas from the placement anchor</string>
+          </property>
           <property name="minimum">
            <number>0</number>
           </property>
           <property name="maximum">
            <number>100</number>
-          </property>
-          <property name="toolTip">
-           <string>Horizontal offset on the map canvas from the placement anchor</string>
           </property>
          </widget>
         </item>
@@ -351,11 +344,11 @@
             <height>16777215</height>
            </size>
           </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
           <property name="toolTip">
            <string>Vertical offset on the map canvas from the placement anchor</string>
+          </property>
+          <property name="maximum">
+           <number>100</number>
           </property>
          </widget>
         </item>
@@ -368,62 +361,7 @@
         </item>
        </layout>
       </item>
-      <item row="7" column="1">
-       <widget class="QComboBox" name="cboPlacement">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="lblMargin">
-        <property name="minimumSize">
-         <size>
-          <width>155</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Margin from edge</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="lblLocation">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Placement</string>
-        </property>
-        <property name="buddy">
-         <cstring>cboPlacement</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkSnapping">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Automatically snap to round number on resize</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -436,6 +374,19 @@
         </property>
        </spacer>
       </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="lblMargin">
+        <property name="minimumSize">
+         <size>
+          <width>155</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Margin from edge</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -444,26 +395,26 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -472,7 +423,6 @@
   <tabstop>pbnChangeColor</tabstop>
   <tabstop>pbnChangeOutlineColor</tabstop>
   <tabstop>mButtonFontStyle</tabstop>
-  <tabstop>spnSize</tabstop>
   <tabstop>chkSnapping</tabstop>
   <tabstop>cboPlacement</tabstop>
   <tabstop>spnHorizontal</tabstop>


### PR DESCRIPTION
## Description
I had a look at the code, the problem is, that the scale bar is always automatically resized between a quarter an a third of the width of the map canvas. So the given number in "Size of bar" has no influence on the size of the bar, because it gets always resized.
I deleted the option to enter the size of the bar, instead it is set to 25 % of the width of the map canvas. Some automatic adjustments are still made if the "Automatically snap to round number on resize" is checked.
Fixes #15647

Widget before
![image](https://github.com/user-attachments/assets/7f8818e9-bf0c-4281-89e2-79eb6afc1f39)

Widget after
![image](https://github.com/user-attachments/assets/8a5744b0-4ee6-434f-a321-368e6724520d)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
