### PR TITLE
QgsVectorLayerSaveAsDialog: use correct test for question

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -376,7 +376,7 @@ void QgsVectorLayerSaveAsDialog::accept()
         // should not reach here, layer does not exist and cannot add new layer
         if ( QMessageBox::question( this,
                                     tr( "Save Vector Layer As" ),
-                                    tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
+                                    tr( "The file already exists. Do you want to overwrite it?" ) ) != QMessageBox::Yes )
         {
           return;
         }


### PR DESCRIPTION
This doesn't fix a real issue, since that code path is unlikely to be taken, but when creating https://github.com/qgis/QGIS/pull/58705, I copied&pasted this wrong code, and was wondering why clicking on No had the same effect as Yes...
