### PR TITLE
QGIS Server: WMS render context const allowed

### DIFF
--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -53,7 +53,7 @@ void QgsWmsRenderContext::setParameters( const QgsWmsParameters &parameters )
 
 bool QgsWmsRenderContext::addLayerToRender( QgsMapLayer *layer )
 {
-  bool allowed = checkLayerReadPermissions( layer );
+  const bool allowed = checkLayerReadPermissions( layer );
   if ( allowed )
   {
     mLayersToRender.append( layer );


### PR DESCRIPTION
Based on @elpaso review on https://github.com/qgis/QGIS/pull/58530
