### PR TITLE
Add info about usable "expression dialect" to filter dialog

### DIFF
--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -93,14 +93,32 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   connect( layer, &QgsVectorLayer::subsetStringChanged, this, &QgsQueryBuilder::layerSubsetStringChanged );
   layerSubsetStringChanged();
 
-  lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name() ).arg( layer->dataProvider()->name() ) );
-
-  const QString subsetStringDialect = layer->dataProvider()->subsetStringDialect();
-  if ( !subsetStringDialect.isEmpty() )
+  QString subsetStringDialect;
+  QString subsetStringHelpUrl;
+  
+  if ( QgsDataProvider *provider = layer->dataProvider() )
   {
-    const QString subsetStringHelpUrl = layer->dataProvider()->subsetStringHelpUrl();
+    lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name(), provider()>name() ) );
+    subsetStringDialect = provider->subsetStringDialect();
+    subsetStringHelpUrl = provider->subsetStringHelpUrl();    
+  }
+  else
+  {
+    lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name(), layer->providerType() ) );
+  }
+  
+  if ( !subsetStringDialect.isEmpty() && !subsetStringHelpUrl.isEmpty() )
+  {
     lblProviderFilterInfo->setOpenExternalLinks( true );
     lblProviderFilterInfo->setText( tr( "Enter a <a href=\"%1\">%2</a> to filter the layer" ).arg( subsetStringHelpUrl ).arg( subsetStringDialect ) ) ;
+  }
+  else if ( !subsetStringDialect.isEmpty() )
+  {
+    lblProviderFilterInfo->setText( tr( "Enter a %1 to filter the layer" ).arg( subsetStringDialect ) ) ;  
+  }
+  else
+  {
+    lblProviderFilterInfo->hide();
   }
 
   mTxtSql->setText( mOrigSubsetString );

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -95,18 +95,18 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
 
   QString subsetStringDialect;
   QString subsetStringHelpUrl;
-  
+
   if ( QgsDataProvider *provider = layer->dataProvider() )
   {
     lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name(), provider->name() ) );
     subsetStringDialect = provider->subsetStringDialect();
-    subsetStringHelpUrl = provider->subsetStringHelpUrl();    
+    subsetStringHelpUrl = provider->subsetStringHelpUrl();
   }
   else
   {
     lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name(), layer->providerType() ) );
   }
-  
+
   if ( !subsetStringDialect.isEmpty() && !subsetStringHelpUrl.isEmpty() )
   {
     lblProviderFilterInfo->setOpenExternalLinks( true );
@@ -114,7 +114,7 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   }
   else if ( !subsetStringDialect.isEmpty() )
   {
-    lblProviderFilterInfo->setText( tr( "Enter a %1 to filter the layer" ).arg( subsetStringDialect ) ) ;  
+    lblProviderFilterInfo->setText( tr( "Enter a %1 to filter the layer" ).arg( subsetStringDialect ) ) ;
   }
   else
   {

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -96,7 +96,8 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name() ).arg( layer->dataProvider()->name() ) );
 
   const QString subsetStringDialect = layer->dataProvider()->subsetStringDialect();
-  if ( !subsetStringDialect.isEmpty() ) {
+  if ( !subsetStringDialect.isEmpty() )
+  {
     const QString subsetStringHelpUrl = layer->dataProvider()->subsetStringHelpUrl();
     lblProviderFilterInfo->setOpenExternalLinks( true );
     lblProviderFilterInfo->setText( tr( "Enter a <a href=\"%1\">%2</a> to filter the layer" ).arg( subsetStringHelpUrl ).arg( subsetStringDialect ) ) ;

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -93,7 +93,15 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   connect( layer, &QgsVectorLayer::subsetStringChanged, this, &QgsQueryBuilder::layerSubsetStringChanged );
   layerSubsetStringChanged();
 
-  lblDataUri->setText( tr( "Set provider filter on %1" ).arg( layer->name() ) );
+  lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name() ).arg( layer->dataProvider()->name() ) );
+
+  const QString subsetStringDialect = layer->dataProvider()->subsetStringDialect();
+  if ( !subsetStringDialect.isEmpty() ) {
+    const QString subsetStringHelpUrl = layer->dataProvider()->subsetStringHelpUrl();
+    lblProviderFilterInfo->setOpenExternalLinks( true );
+    lblProviderFilterInfo->setText( tr( "Enter a <a href=\"%1\">%2</a> to filter the layer" ).arg( subsetStringHelpUrl ).arg( subsetStringDialect ) ) ;
+  }
+
   mTxtSql->setText( mOrigSubsetString );
 
   mFilterLineEdit->setShowSearchIcon( true );

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -98,7 +98,7 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   
   if ( QgsDataProvider *provider = layer->dataProvider() )
   {
-    lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name(), provider()>name() ) );
+    lblDataUri->setText( tr( "Set provider filter on %1 (provider: %2)" ).arg( layer->name(), provider->name() ) );
     subsetStringDialect = provider->subsetStringDialect();
     subsetStringHelpUrl = provider->subsetStringHelpUrl();    
   }

--- a/src/ui/qgsquerybuilderbase.ui
+++ b/src/ui/qgsquerybuilderbase.ui
@@ -322,8 +322,15 @@ p, li { white-space: pre-wrap; }
           <property name="bottomMargin">
            <number>11</number>
           </property>
-          <item row="0" column="0">
+          <item row="1" column="0">
            <widget class="QgsCodeEditorSQL" name="mTxtSql" native="true"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblProviderFilterInfo">
+            <property name="text">
+             <string>Provider expression dialect</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
The query builder used for entering filter expressions on vector layers now shows the supported expression dialect. This uses the new data provider methods introduced in https://github.com/qgis/QGIS/pull/58781.

![asd](https://github.com/user-attachments/assets/efea9a9e-2493-45ed-8d1f-a4eda10e2bf8)

Sponsored by WhereGroup GmbH.