### PR TITLE
astyle: Replace sorting implementation

### DIFF
--- a/external/astyle/astyle_main.cpp
+++ b/external/astyle/astyle_main.cpp
@@ -1363,7 +1363,7 @@ void ASConsole::getFileNames(const string& directory, const vector<string>& wild
 
 	// sort the current entries for fileName
 	if (firstEntry < fileName.size())
-		sort(&fileName[firstEntry], &fileName[fileName.size()]);
+		sort(fileName.begin() + firstEntry, fileName.end());
 
 	// recurse into sub directories
 	// if not doing recursive, subDirectory is empty


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://cwe.mitre.org/data/definitions/125.html
- https://cwe.mitre.org/data/definitions/787.html

## Description

Replace the sorting implementation since the previous implementation might cause a buffer overread.