### PR TITLE
[OGR provider] Fix changeAttributeValues() on GeoJSON files for GDAL 3.9.1 and 3.9.2

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2651,10 +2651,12 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
   if ( useUpdate )
     it = attr_map.end();
 
-#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,9,1)
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,9,3)
+  // UpdateFeature is available since 3.7.0, but was broken for GeoJSON up to 3.9.3
+  // see https://github.com/OSGeo/gdal/pull/10197
+  // and https://github.com/OSGeo/gdal/pull/10794
   const bool useUpdateFeature = mOgrLayer->TestCapability( OLCUpdateFeature );
 #elif GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
-  // see https://github.com/OSGeo/gdal/pull/10197
   const bool useUpdateFeature = mOgrLayer->TestCapability( OLCUpdateFeature )
                                 && mGDALDriverName != QLatin1String( "ODS" )
                                 && mGDALDriverName != QLatin1String( "XLSX" )


### PR DESCRIPTION
Running the tests/src/python/test_provider_ogr.py tests against GDAL master raised a number of failures. I've now realized that the GeoJSON driver of GDAL 3.9.1 has still a broken implementation of UpdateFeature().
Now this will *really* fixed per
https://github.com/OSGeo/gdal/pull/10794 for 3.9.3 In the meantime disable using UpdateFeature for GeoJSON for GDAL < 3.9.3

Fixes https://github.com/qgis/QGIS/pull/57736#discussion_r1636226384

Affects release 3.38, but not 3.34

Fixes #58261