### PR TITLE
Fix handling of empty field name in QgsFields' lookupField function

### DIFF
--- a/src/core/qgsfields.cpp
+++ b/src/core/qgsfields.cpp
@@ -403,14 +403,14 @@ QIcon QgsFields::iconForFieldType( QVariant::Type type, QVariant::Type subType, 
 
 int QgsFields::lookupField( const QString &fieldName ) const
 {
-  if ( fieldName.isEmpty() ) //shortcut
-    return -1;
-
   for ( int idx = 0; idx < count(); ++idx )
   {
     if ( d->fields[idx].field.name() == fieldName )
       return idx;
   }
+
+  if ( fieldName.isEmpty() )
+    return -1;
 
   for ( int idx = 0; idx < count(); ++idx )
   {

--- a/tests/src/core/testqgsfields.cpp
+++ b/tests/src/core/testqgsfields.cpp
@@ -383,9 +383,11 @@ void TestQgsFields::indexFromName()
   QgsField field3( QStringLiteral( "testfield3" ) );
   field3.setAlias( QString() );
   fields.append( field3 );
+  QCOMPARE( fields.lookupField( QString() ), -1 );
 
-  QCOMPARE( fields.lookupField( QString() ), -1 );
-  QCOMPARE( fields.lookupField( QString() ), -1 );
+  const QgsField field4 = QgsField( QString() );
+  fields.append( field4 );
+  QCOMPARE( fields.lookupField( QString() ), 3 );
 
   QCOMPARE( fields.indexFromName( QString( "bad" ) ), -1 );
   QCOMPARE( fields.lookupField( QString( "bad" ) ), -1 );
@@ -401,7 +403,7 @@ void TestQgsFields::indexFromName()
   //test that fieldNameIndex prefers exact case matches over case insensitive matches
   const QgsField sameNameDifferentCase( QStringLiteral( "teStFielD" ) );  //#spellok
   fields.append( sameNameDifferentCase );
-  QCOMPARE( fields.lookupField( QString( "teStFielD" ) ), 3 );  //#spellok
+  QCOMPARE( fields.lookupField( QString( "teStFielD" ) ), 4 );  //#spellok
 
   //test that the alias is only matched with fieldNameIndex
   QCOMPARE( fields.indexFromName( "testfieldAlias" ), -1 );


### PR DESCRIPTION
## Description

This PR fixes a QGIS attribute table crash reported here (https://github.com/qgis/QGIS/issues/58738), whereas an empty field name (something our API does allow) leads to the attribute table's filter model mishandling that field index. 

The mix up happens due to a failure in QgsFields' lookupField function to return the proper index of that field on this line (https://github.com/qgis/QGIS/blob/master/src/gui/attributetable/qgsattributetablefiltermodel.cpp#L171).

