### PR TITLE
[layouts] Fix computation of atlas rectangle for rotated map items when no atlas geometry available

### DIFF
--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -3015,7 +3015,7 @@ QgsRectangle QgsLayoutItemMap::computeAtlasRectangle()
   // Note: we cannot directly take the transformation of the bounding box, since transformations are not linear
   QgsGeometry g = mLayout->reportContext().currentGeometry( crs() );
   // Rotating the geometry, so the bounding box is correct wrt map rotation
-  if ( mEvaluatedMapRotation != 0.0 )
+  if ( !g.boundingBox().isEmpty() && mEvaluatedMapRotation != 0.0 )
   {
     QgsPointXY prevCenter = g.boundingBox().center();
     g.rotate( mEvaluatedMapRotation, g.boundingBox().center() );


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/58245 , whereas enabling a map item's [x] controlled by atlas option would lead to a bogus rectangle when a/ it calculates margins around atlas feature + b/ the map item is rotated + c/ the atlas context provides no geometry (i.e. geometryless feature or atlas not yet enabled).