### PR TITLE
[processing] Avoid not needed warnings in postprocessing when `qgis._3d` is not available but the layer is not a PointCloud

### DIFF
--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -103,9 +103,9 @@ def post_process_layer(output_name: str,
     if style:
         layer.loadNamedStyle(style)
 
-    try:
-        from qgis._3d import QgsPointCloudLayer3DRenderer
-        if layer.type() == Qgis.LayerType.PointCloud:
+    if layer.type() == Qgis.LayerType.PointCloud:
+        try:
+            from qgis._3d import QgsPointCloudLayer3DRenderer
             if layer.renderer3D() is None:
                 # If the layer has no 3D renderer and syncing 3D to 2D
                 # renderer is enabled, we create a renderer and set it up
@@ -114,14 +114,14 @@ def post_process_layer(output_name: str,
                     renderer_3d = QgsPointCloudLayer3DRenderer()
                     renderer_3d.convertFrom2DRenderer(layer.renderer())
                     layer.setRenderer3D(renderer_3d)
-    except ImportError:
-        QgsMessageLog.logMessage(
-            QCoreApplication.translate(
-                "Postprocessing",
-                "3D library is not available, "
-                "can't assign a 3d renderer to a layer."
+        except ImportError:
+            QgsMessageLog.logMessage(
+                QCoreApplication.translate(
+                    "Postprocessing",
+                    "3D library is not available, "
+                    "can't assign a 3d renderer to a layer."
+                )
             )
-        )
 
 
 def create_layer_tree_layer(layer: QgsMapLayer,


### PR DESCRIPTION
## Description

Using a QGIS build with `qgis._3d` not available, the warning `WARNING    3D library is not available, can't assign a 3d renderer to a layer.` is displayed for every layer added by a processing algorithm, while it should only displayed for PointCloud layers.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
