### PR TITLE
[processing] Fix deprecated QgsField constructor and use QMetaType.Type in place of QVariant in various `qgis:` algorithms (Fix #57920)

### DIFF
--- a/python/plugins/processing/algs/qgis/CheckValidity.py
+++ b/python/plugins/processing/algs/qgis/CheckValidity.py
@@ -22,7 +22,7 @@ __copyright__ = '(C) 2015, Arnaud Morvan'
 import os
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 from qgis.core import (Qgis,
                        QgsApplication,
@@ -134,13 +134,13 @@ class CheckValidity(QgisAlgorithm):
         valid_count = 0
 
         invalid_fields = source.fields()
-        invalid_fields.append(QgsField('_errors', QVariant.String, 'string', 255))
+        invalid_fields.append(QgsField('_errors', QMetaType.Type.QString, 'string', 255))
         (invalid_output_sink, invalid_output_dest_id) = self.parameterAsSink(parameters, self.INVALID_OUTPUT, context,
                                                                              invalid_fields, source.wkbType(), source.sourceCrs())
         invalid_count = 0
 
         error_fields = QgsFields()
-        error_fields.append(QgsField('message', QVariant.String, 'string', 255))
+        error_fields.append(QgsField('message', QMetaType.Type.QString, 'string', 255))
         (error_output_sink, error_output_dest_id) = self.parameterAsSink(parameters, self.ERROR_OUTPUT, context,
                                                                          error_fields, QgsWkbTypes.Type.Point, source.sourceCrs())
         error_count = 0

--- a/python/plugins/processing/algs/qgis/Climb.py
+++ b/python/plugins/processing/algs/qgis/Climb.py
@@ -24,7 +24,7 @@ import os
 import math
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 from qgis.core import (QgsProcessing,
                        QgsFeatureSink,
@@ -137,10 +137,10 @@ class Climb(QgisAlgorithm):
         fieldnumber = 0
 
         # Create new fields for climb and descent
-        thefields.append(QgsField(self.CLIMBATTRIBUTE, QVariant.Double))
-        thefields.append(QgsField(self.DESCENTATTRIBUTE, QVariant.Double))
-        thefields.append(QgsField(self.MINELEVATTRIBUTE, QVariant.Double))
-        thefields.append(QgsField(self.MAXELEVATTRIBUTE, QVariant.Double))
+        thefields.append(QgsField(self.CLIMBATTRIBUTE, QMetaType.Type.Double))
+        thefields.append(QgsField(self.DESCENTATTRIBUTE, QMetaType.Type.Double))
+        thefields.append(QgsField(self.MINELEVATTRIBUTE, QMetaType.Type.Double))
+        thefields.append(QgsField(self.MAXELEVATTRIBUTE, QMetaType.Type.Double))
 
         # combine all the vector fields
         out_fields = QgsProcessingUtils.combineFields(thefields, source_fields)

--- a/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
+++ b/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
@@ -23,7 +23,7 @@ import os
 import math
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 from qgis.core import (NULL,
                        Qgis,
@@ -103,25 +103,25 @@ class ExportGeometryInfo(QgisAlgorithm):
 
         new_fields = QgsFields()
         if QgsWkbTypes.geometryType(wkb_type) == QgsWkbTypes.GeometryType.PolygonGeometry:
-            new_fields.append(QgsField('area', QVariant.Double))
-            new_fields.append(QgsField('perimeter', QVariant.Double))
+            new_fields.append(QgsField('area', QMetaType.Type.Double))
+            new_fields.append(QgsField('perimeter', QMetaType.Type.Double))
         elif QgsWkbTypes.geometryType(wkb_type) == QgsWkbTypes.GeometryType.LineGeometry:
-            new_fields.append(QgsField('length', QVariant.Double))
+            new_fields.append(QgsField('length', QMetaType.Type.Double))
             if not QgsWkbTypes.isMultiType(source.wkbType()):
-                new_fields.append(QgsField('straightdis', QVariant.Double))
-                new_fields.append(QgsField('sinuosity', QVariant.Double))
+                new_fields.append(QgsField('straightdis', QMetaType.Type.Double))
+                new_fields.append(QgsField('sinuosity', QMetaType.Type.Double))
         else:
             if QgsWkbTypes.isMultiType(source.wkbType()):
-                new_fields.append(QgsField('numparts', QVariant.Int))
+                new_fields.append(QgsField('numparts', QMetaType.Type.Int))
             else:
-                new_fields.append(QgsField('xcoord', QVariant.Double))
-                new_fields.append(QgsField('ycoord', QVariant.Double))
+                new_fields.append(QgsField('xcoord', QMetaType.Type.Double))
+                new_fields.append(QgsField('ycoord', QMetaType.Type.Double))
                 if QgsWkbTypes.hasZ(source.wkbType()):
                     self.export_z = True
-                    new_fields.append(QgsField('zcoord', QVariant.Double))
+                    new_fields.append(QgsField('zcoord', QMetaType.Type.Double))
                 if QgsWkbTypes.hasM(source.wkbType()):
                     self.export_m = True
-                    new_fields.append(QgsField('mvalue', QVariant.Double))
+                    new_fields.append(QgsField('mvalue', QMetaType.Type.Double))
 
         fields = QgsProcessingUtils.combineFields(fields, new_fields)
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,

--- a/python/plugins/processing/algs/qgis/FieldPyculator.py
+++ b/python/plugins/processing/algs/qgis/FieldPyculator.py
@@ -21,7 +21,7 @@ __copyright__ = '(C) 2012, Victor Olaya & NextGIS'
 
 import sys
 
-from qgis.PyQt.QtCore import QMetaType, QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (QgsProcessingException,
                        QgsField,
                        QgsFields,
@@ -46,8 +46,6 @@ class FieldsPyculator(QgisAlgorithm):
     FORMULA = 'FORMULA'
     OUTPUT = 'OUTPUT'
     RESULT_VAR_NAME = 'value'
-
-    TYPES = [QVariant.LongLong, QVariant.Double, QVariant.String]
 
     def group(self):
         return self.tr('Vector table')
@@ -110,34 +108,34 @@ class FieldsPyculator(QgisAlgorithm):
 
         field_name = self.parameterAsString(parameters, self.FIELD_NAME, context)
 
-        field_type = QVariant.Invalid
-        field_sub_type = QVariant.Invalid
+        field_type = QMetaType.Type.UnknownType
+        field_sub_type = QMetaType.Type.UnknownType
         field_type_parameter = self.parameterAsEnum(parameters, self.FIELD_TYPE, context)
         if field_type_parameter == 0:  # Integer
-            field_type = QVariant.Int
+            field_type = QMetaType.Type.Int
         elif field_type_parameter == 1:  # Float
-            field_type = QVariant.Double
+            field_type = QMetaType.Type.Double
         elif field_type_parameter == 2:  # String
-            field_type = QVariant.String
+            field_type = QMetaType.Type.QString
         elif field_type_parameter == 3:  # Boolean
-            field_type = QVariant.Bool
+            field_type = QMetaType.Type.Bool
         elif field_type_parameter == 4:  # Date
-            field_type = QVariant.Date
+            field_type = QMetaType.Type.QDate
         elif field_type_parameter == 5:  # Time
-            field_type = QVariant.Time
+            field_type = QMetaType.Type.QTime
         elif field_type_parameter == 6:  # DateTime
-            field_type = QVariant.DateTime
+            field_type = QMetaType.Type.QDateTime
         elif field_type_parameter == 7:  # Binary
-            field_type = QVariant.ByteArray
+            field_type = QMetaType.Type.QByteArray
         elif field_type_parameter == 8:  # StringList
-            field_type = QVariant.StringList
-            field_sub_type = QVariant.String
+            field_type = QMetaType.Type.QStringList
+            field_sub_type = QMetaType.Type.QString
         elif field_type_parameter == 9:  # IntegerList
-            field_type = QVariant.List
-            field_sub_type = QVariant.Int
+            field_type = QMetaType.Type.QVariantList
+            field_sub_type = QMetaType.Type.Int
         elif field_type_parameter == 10:  # DoubleList
-            field_type = QVariant.List
-            field_sub_type = QVariant.Double
+            field_type = QMetaType.Type.QVariantList
+            field_sub_type = QMetaType.Type.Double
 
         width = self.parameterAsInt(parameters, self.FIELD_LENGTH, context)
         precision = self.parameterAsInt(parameters, self.FIELD_PRECISION, context)

--- a/python/plugins/processing/algs/qgis/FindProjection.py
+++ b/python/plugins/processing/algs/qgis/FindProjection.py
@@ -36,7 +36,7 @@ from qgis.core import (QgsGeometry,
                        QgsProcessingParameterCrs,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterDefinition)
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -97,7 +97,7 @@ class FindProjection(QgisAlgorithm):
         target_geom = QgsGeometry.fromRect(extent)
 
         fields = QgsFields()
-        fields.append(QgsField('auth_id', QVariant.String, '', 20))
+        fields.append(QgsField('auth_id', QMetaType.Type.QString, '', 20))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.NoGeometry, QgsCoordinateReferenceSystem())

--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -19,7 +19,7 @@ __author__ = 'Michael Minn'
 __date__ = 'May 2010'
 __copyright__ = '(C) 2010, Michael Minn'
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (QgsField,
                        QgsGeometry,
                        QgsDistanceArea,
@@ -107,8 +107,8 @@ class HubDistanceLines(QgisAlgorithm):
         units = self.UNITS[self.parameterAsEnum(parameters, self.UNIT, context)]
 
         fields = point_source.fields()
-        fields.append(QgsField('HubName', QVariant.String))
-        fields.append(QgsField('HubDist', QVariant.Double))
+        fields.append(QgsField('HubName', QMetaType.Type.QString))
+        fields.append(QgsField('HubDist', QMetaType.Type.Double))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.LineString, point_source.sourceCrs())

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -19,7 +19,7 @@ __author__ = 'Michael Minn'
 __date__ = 'May 2010'
 __copyright__ = '(C) 2010, Michael Minn'
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (QgsField,
                        QgsGeometry,
                        QgsFeatureSink,
@@ -104,8 +104,8 @@ class HubDistancePoints(QgisAlgorithm):
         units = self.UNITS[self.parameterAsEnum(parameters, self.UNIT, context)]
 
         fields = point_source.fields()
-        fields.append(QgsField('HubName', QVariant.String))
-        fields.append(QgsField('HubDist', QVariant.Double))
+        fields.append(QgsField('HubName', QMetaType.Type.QString))
+        fields.append(QgsField('HubDist', QMetaType.Type.Double))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.Point, point_source.sourceCrs())

--- a/python/plugins/processing/algs/qgis/KNearestConcaveHull.py
+++ b/python/plugins/processing/algs/qgis/KNearestConcaveHull.py
@@ -26,7 +26,7 @@ import os.path
 import math
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 from qgis.core import (QgsApplication,
                        QgsExpression,
@@ -108,7 +108,7 @@ class KNearestConcaveHull(QgisAlgorithm):
         field_index = -1
 
         fields = QgsFields()
-        fields.append(QgsField('id', QVariant.Int, '', 20))
+        fields.append(QgsField('id', QMetaType.Type.Int, '', 20))
 
         current = 0
 

--- a/python/plugins/processing/algs/qgis/MinimumBoundingGeometry.py
+++ b/python/plugins/processing/algs/qgis/MinimumBoundingGeometry.py
@@ -23,7 +23,7 @@ import os
 import math
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 from qgis.core import (QgsApplication,
                        QgsField,
@@ -108,7 +108,7 @@ class MinimumBoundingGeometry(QgisAlgorithm):
         field_index = -1
 
         fields = QgsFields()
-        fields.append(QgsField('id', QVariant.Int, '', 20))
+        fields.append(QgsField('id', QMetaType.Type.Int, '', 20))
 
         if use_field:
             # keep original field type, name and parameters
@@ -117,25 +117,25 @@ class MinimumBoundingGeometry(QgisAlgorithm):
                 fields.append(source.fields()[field_index])
         if type == 0:
             # envelope
-            fields.append(QgsField('width', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('height', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('area', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('perimeter', QVariant.Double, '', 20, 6))
+            fields.append(QgsField('width', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('height', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('area', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('perimeter', QMetaType.Type.Double, '', 20, 6))
         elif type == 1:
             # oriented rect
-            fields.append(QgsField('width', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('height', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('angle', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('area', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('perimeter', QVariant.Double, '', 20, 6))
+            fields.append(QgsField('width', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('height', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('angle', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('area', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('perimeter', QMetaType.Type.Double, '', 20, 6))
         elif type == 2:
             # circle
-            fields.append(QgsField('radius', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('area', QVariant.Double, '', 20, 6))
+            fields.append(QgsField('radius', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('area', QMetaType.Type.Double, '', 20, 6))
         elif type == 3:
             # convex hull
-            fields.append(QgsField('area', QVariant.Double, '', 20, 6))
-            fields.append(QgsField('perimeter', QVariant.Double, '', 20, 6))
+            fields.append(QgsField('area', QMetaType.Type.Double, '', 20, 6))
+            fields.append(QgsField('perimeter', QMetaType.Type.Double, '', 20, 6))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.Polygon, source.sourceCrs())

--- a/python/plugins/processing/algs/qgis/PointDistance.py
+++ b/python/plugins/processing/algs/qgis/PointDistance.py
@@ -23,7 +23,7 @@ import os
 import math
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 from qgis.core import (QgsApplication,
                        QgsFeatureRequest,
@@ -161,12 +161,12 @@ class PointDistance(QgisAlgorithm):
             target_id_field = target_source.fields()[outIdx]
             target_id_field.setName('TargetID')
             fields.append(target_id_field)
-            fields.append(QgsField('Distance', QVariant.Double))
+            fields.append(QgsField('Distance', QMetaType.Type.Double))
         else:
-            fields.append(QgsField('MEAN', QVariant.Double))
-            fields.append(QgsField('STDDEV', QVariant.Double))
-            fields.append(QgsField('MIN', QVariant.Double))
-            fields.append(QgsField('MAX', QVariant.Double))
+            fields.append(QgsField('MEAN', QMetaType.Type.Double))
+            fields.append(QgsField('STDDEV', QMetaType.Type.Double))
+            fields.append(QgsField('MIN', QMetaType.Type.Double))
+            fields.append(QgsField('MAX', QMetaType.Type.Double))
 
         out_wkb = QgsWkbTypes.multiType(source.wkbType()) if matType == 0 else source.wkbType()
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
@@ -258,7 +258,7 @@ class PointDistance(QgisAlgorithm):
                 input_id_field.setName('ID')
                 fields.append(input_id_field)
                 for f in target_source.getFeatures(QgsFeatureRequest().setFilterFids(featList).setSubsetOfAttributes([targetIdx]).setDestinationCrs(source.sourceCrs(), context.transformContext())):
-                    fields.append(QgsField(str(f[targetField]), QVariant.Double))
+                    fields.append(QgsField(str(f[targetField]), QMetaType.Type.Double))
 
                 (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                        fields, source.wkbType(), source.sourceCrs())

--- a/python/plugins/processing/algs/qgis/PointsFromLines.py
+++ b/python/plugins/processing/algs/qgis/PointsFromLines.py
@@ -20,7 +20,7 @@ __date__ = 'August 2013'
 __copyright__ = '(C) 2013, Alexander Bruy'
 
 from osgeo import gdal
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (QgsFeature,
                        QgsFeatureSink,
                        QgsFields,
@@ -81,9 +81,9 @@ class PointsFromLines(QgisAlgorithm):
         rasterDS = None
 
         fields = QgsFields()
-        fields.append(QgsField('id', QVariant.Int, '', 10, 0))
-        fields.append(QgsField('line_id', QVariant.Int, '', 10, 0))
-        fields.append(QgsField('point_id', QVariant.Int, '', 10, 0))
+        fields.append(QgsField('id', QMetaType.Type.Int, '', 10, 0))
+        fields.append(QgsField('line_id', QMetaType.Type.Int, '', 10, 0))
+        fields.append(QgsField('point_id', QMetaType.Type.Int, '', 10, 0))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.Point, raster_layer.crs())

--- a/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
@@ -21,7 +21,7 @@ __copyright__ = '(C) 2014, Alexander Bruy'
 
 import random
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (Qgis,
                        QgsField,
                        QgsFeatureSink,
@@ -94,7 +94,7 @@ class RandomPointsAlongLines(QgisAlgorithm):
         minDistance = self.parameterAsDouble(parameters, self.MIN_DISTANCE, context)
 
         fields = QgsFields()
-        fields.append(QgsField('id', QVariant.Int, '', 10, 0))
+        fields.append(QgsField('id', QMetaType.Type.Int, '', 10, 0))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.Point, source.sourceCrs(), QgsFeatureSink.SinkFlag.RegeneratePrimaryKey)

--- a/python/plugins/processing/algs/qgis/RandomPointsLayer.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsLayer.py
@@ -23,7 +23,7 @@ import os
 import random
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (Qgis,
                        QgsApplication,
                        QgsField,
@@ -106,7 +106,7 @@ class RandomPointsLayer(QgisAlgorithm):
         sourceIndex = QgsSpatialIndex(source, feedback)
 
         fields = QgsFields()
-        fields.append(QgsField('id', QVariant.Int, '', 10, 0))
+        fields.append(QgsField('id', QMetaType.Type.Int, '', 10, 0))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.Point, source.sourceCrs(), QgsFeatureSink.SinkFlag.RegeneratePrimaryKey)

--- a/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
@@ -22,7 +22,7 @@ __copyright__ = '(C) 2014, Alexander Bruy'
 import os
 import random
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (Qgis,
                        QgsApplication,
                        QgsField,
@@ -149,7 +149,7 @@ class RandomPointsPolygons(QgisAlgorithm):
             value = self.parameterAsDouble(parameters, self.VALUE, context)
 
         fields = QgsFields()
-        fields.append(QgsField('id', QVariant.Int, '', 10, 0))
+        fields.append(QgsField('id', QMetaType.Type.Int, '', 10, 0))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.Point, source.sourceCrs(),

--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -24,7 +24,7 @@ from random import seed, uniform
 from math import sqrt
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (QgsApplication,
                        QgsFields,
                        QgsFeatureSink,
@@ -101,7 +101,7 @@ class RegularPoints(QgisAlgorithm):
         extent = self.parameterAsExtent(parameters, self.EXTENT, context, crs)
 
         fields = QgsFields()
-        fields.append(QgsField('id', QVariant.Int, '', 10, 0))
+        fields.append(QgsField('id', QMetaType.Type.Int, '', 10, 0))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, QgsWkbTypes.Type.Point, crs)

--- a/python/plugins/processing/algs/qgis/SelectByAttribute.py
+++ b/python/plugins/processing/algs/qgis/SelectByAttribute.py
@@ -19,7 +19,7 @@ __author__ = 'Michael Minn'
 __date__ = 'May 2010'
 __copyright__ = '(C) 2010, Michael Minn'
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (QgsExpression,
                        QgsVectorLayer,
                        QgsProcessing,
@@ -124,13 +124,13 @@ class SelectByAttribute(QgisAlgorithm):
 
         fields = layer.fields()
 
-        idx = layer.fields().lookupField(fieldName)
+        idx = fields.lookupField(fieldName)
         if idx < 0:
             raise QgsProcessingException(self.tr("Field '{}' was not found in layer").format(fieldName))
 
         fieldType = fields[idx].type()
 
-        if fieldType != QVariant.String and operator in self.STRING_OPERATORS:
+        if fieldType != QMetaType.Type.QString and operator in self.STRING_OPERATORS:
             op = ''.join('"%s", ' % o for o in self.STRING_OPERATORS)
             raise QgsProcessingException(
                 self.tr('Operators {0} can be used only with string fields.').format(op))

--- a/python/plugins/processing/algs/qgis/StatisticsByCategories.py
+++ b/python/plugins/processing/algs/qgis/StatisticsByCategories.py
@@ -37,7 +37,7 @@ from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessing,
                        QgsProcessingFeatureSource,
                        NULL)
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 from collections import defaultdict
@@ -123,44 +123,44 @@ class StatisticsByCategories(QgisAlgorithm):
 
         if value_field is None:
             field_type = 'none'
-            fields.append(QgsField('count', QVariant.Int))
+            fields.append(QgsField('count', QMetaType.Type.Int))
         elif value_field.isNumeric():
             field_type = 'numeric'
-            fields.append(QgsField('count', QVariant.Int))
-            fields.append(QgsField('unique', QVariant.Int))
-            fields.append(QgsField('min', QVariant.Double))
-            fields.append(QgsField('max', QVariant.Double))
-            fields.append(QgsField('range', QVariant.Double))
-            fields.append(QgsField('sum', QVariant.Double))
-            fields.append(QgsField('mean', QVariant.Double))
-            fields.append(QgsField('median', QVariant.Double))
-            fields.append(QgsField('stddev', QVariant.Double))
-            fields.append(QgsField('minority', QVariant.Double))
-            fields.append(QgsField('majority', QVariant.Double))
-            fields.append(QgsField('q1', QVariant.Double))
-            fields.append(QgsField('q3', QVariant.Double))
-            fields.append(QgsField('iqr', QVariant.Double))
-        elif value_field.type() in (QVariant.Date, QVariant.Time, QVariant.DateTime):
+            fields.append(QgsField('count', QMetaType.Type.Int))
+            fields.append(QgsField('unique', QMetaType.Type.Int))
+            fields.append(QgsField('min', QMetaType.Type.Double))
+            fields.append(QgsField('max', QMetaType.Type.Double))
+            fields.append(QgsField('range', QMetaType.Type.Double))
+            fields.append(QgsField('sum', QMetaType.Type.Double))
+            fields.append(QgsField('mean', QMetaType.Type.Double))
+            fields.append(QgsField('median', QMetaType.Type.Double))
+            fields.append(QgsField('stddev', QMetaType.Type.Double))
+            fields.append(QgsField('minority', QMetaType.Type.Double))
+            fields.append(QgsField('majority', QMetaType.Type.Double))
+            fields.append(QgsField('q1', QMetaType.Type.Double))
+            fields.append(QgsField('q3', QMetaType.Type.Double))
+            fields.append(QgsField('iqr', QMetaType.Type.Double))
+        elif value_field.type() in (QMetaType.Type.QDate, QMetaType.QTime, QMetaType.QDateTime):
             field_type = 'datetime'
-            fields.append(QgsField('count', QVariant.Int))
-            fields.append(QgsField('unique', QVariant.Int))
-            fields.append(QgsField('empty', QVariant.Int))
-            fields.append(QgsField('filled', QVariant.Int))
+            fields.append(QgsField('count', QMetaType.Type.Int))
+            fields.append(QgsField('unique', QMetaType.Type.Int))
+            fields.append(QgsField('empty', QMetaType.Type.Int))
+            fields.append(QgsField('filled', QMetaType.Type.Int))
             # keep same data type for these fields
             addField('min')
             addField('max')
         else:
             field_type = 'string'
-            fields.append(QgsField('count', QVariant.Int))
-            fields.append(QgsField('unique', QVariant.Int))
-            fields.append(QgsField('empty', QVariant.Int))
-            fields.append(QgsField('filled', QVariant.Int))
+            fields.append(QgsField('count', QMetaType.Type.Int))
+            fields.append(QgsField('unique', QMetaType.Type.Int))
+            fields.append(QgsField('empty', QMetaType.Type.Int))
+            fields.append(QgsField('filled', QMetaType.Type.Int))
             # keep same data type for these fields
             addField('min')
             addField('max')
-            fields.append(QgsField('min_length', QVariant.Int))
-            fields.append(QgsField('max_length', QVariant.Int))
-            fields.append(QgsField('mean_length', QVariant.Double))
+            fields.append(QgsField('min_length', QMetaType.Type.Int))
+            fields.append(QgsField('max_length', QMetaType.Type.Int))
+            fields.append(QgsField('mean_length', QMetaType.Type.Double))
 
         request = QgsFeatureRequest().setFlags(QgsFeatureRequest.Flag.NoGeometry)
         if value_field is not None:

--- a/python/plugins/processing/algs/qgis/TextToFloat.py
+++ b/python/plugins/processing/algs/qgis/TextToFloat.py
@@ -19,7 +19,7 @@ __author__ = 'Michael Minn'
 __date__ = 'May 2010'
 __copyright__ = '(C) 2010, Michael Minn'
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (QgsField,
                        QgsProcessing,
                        QgsProcessingParameterField,
@@ -63,7 +63,7 @@ class TextToFloat(QgisFeatureBasedAlgorithm):
     def outputFields(self, inputFields):
         self.field_idx = inputFields.lookupField(self.field_name)
         if self.field_idx >= 0:
-            inputFields[self.field_idx] = QgsField(self.field_name, QVariant.Double, '', 24, 15)
+            inputFields[self.field_idx] = QgsField(self.field_name, QMetaType.Type.Double, '', 24, 15)
         return inputFields
 
     def prepareAlgorithm(self, parameters, context, feedback):

--- a/python/plugins/processing/algs/qgis/TopoColors.py
+++ b/python/plugins/processing/algs/qgis/TopoColors.py
@@ -39,7 +39,7 @@ from qgis.core import (QgsField,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterFeatureSink)
 
-from qgis.PyQt.QtCore import (QVariant)
+from qgis.PyQt.QtCore import QMetaType
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -104,7 +104,7 @@ class TopoColor(QgisAlgorithm):
         min_distance = self.parameterAsDouble(parameters, self.MIN_DISTANCE, context)
 
         fields = source.fields()
-        fields.append(QgsField('color_id', QVariant.Int))
+        fields.append(QgsField('color_id', QMetaType.Type.Int))
 
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                fields, source.wkbType(), source.sourceCrs())


### PR DESCRIPTION
## Description

Fixes #57920 for various processing algorithms:

"Check validity" `qgis:checkvalidity`
"Climb along line" `qgis:climbalongline`
"Add geometry attributes" `qgis:exportaddgeometrycolumns`
"Advanced Python field calculator" `qgis:advancedpythonfieldcalculator`
"Find projection" `qgis:findprojection`
"Distance to nearest hub (line to hub)" `qgis:distancetonearesthublinetohub`
"Distance to nearest hub (points)"  `qgis:distancetonearesthubpoints`
"Concave hull (k-nearest neighbor)" `qgis:knearestconcavehull`
"Minimum bounding geometry" `qgis:minimumboundinggeometry`
"Distance matrix" `qgis:distancematrix`
"Generate points (pixel centroids) along line" `qgis:generatepointspixelcentroidsalongline`
"Random points along line" `qgis:randompointsalongline`
"Random points in layer bounds" `qgis:randompointsinlayerbounds`
"Random points inside polygons" `qgis:randompointsinsidepolygons`
"Regular points" `qgis:regularpoints`
"Statistics by categories" `qgis:statisticsbycategories`
"Text to float" `qgis:texttofloat`
"Topological coloring" `qgis:topologicalcoloring`

 "Select by attribute" `qgis:selectbyattribute` was also updated to use QMetaType.Type in place of QVariant, although not used in a QgsField constructor.

Not to be backported to 3.34.

Ref: https://github.com/qgis/QGIS/pull/57272.

Side note: while fixing the code of the "Advanced Python field calculator" algorithm I noticed that, years ago, there was a shift from `Int` to `LongLong` field type https://github.com/qgis/QGIS/commit/0ac02497b9cb7d13294e239dacebbe3f882548fc (https://github.com/qgis/QGIS/pull/5143) by @m-kuhn, but more recently the field type has been reverted to `Int` from `LongLong` 835fe144cc9d8aa3e3c03ce5dda375a54a3626ad (https://github.com/qgis/QGIS/pull/47094) by @nirvn. Is it intentional or an oversight?

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
