### PR TITLE
Enable QgsClipper::trimFeature on arm architectures

### DIFF
--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -89,8 +89,6 @@ class CORE_EXPORT QgsClipper
       ZMin, //!< Minimum Z \since QGIS 3.26
     };
 
-    SIP_IF_FEATURE( !ARM ) // Not available on ARM sip bindings because of qreal issues
-
     /**
      * Trims the given feature to a rectangular box. Returns the trimmed
      * feature in x and y. The shapeOpen parameter determines whether
@@ -102,8 +100,6 @@ class CORE_EXPORT QgsClipper
     static void trimFeature( QVector<double> &x,
                              QVector<double> &y,
                              bool shapeOpen );
-
-    SIP_END
 
     /**
      * Trims the given polygon to a rectangular box, by modifying the given polygon in place.


### PR DESCRIPTION
This was apparently a left over from android build on 32 bits.

@nyalldawson worth mentioning that I came on this due to sipify auto additions not considering the the sip if feature.

![unnamed (3)](https://github.com/user-attachments/assets/fecee0a4-e661-4a40-b71b-a42c4ff856c8)

you might want to add an AttributeError too in the exception?