### PR TITLE
Add option to delete user profile in Profile Selector (adds #38243)

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1099,7 +1099,7 @@ int main( int argc, char *argv[] )
             profileName = manager.allProfiles()[0];
             break;
           }
-          QgsUserProfileSelectionDialog dlg( &manager );
+          QgsUserProfileSelectionDialog dlg( &manager, QString() );
           if ( dlg.exec() == QDialog::Accepted )
           {
             profileName = dlg.selectedProfileName();

--- a/src/app/options/qgsuserprofileselectiondialog.cpp
+++ b/src/app/options/qgsuserprofileselectiondialog.cpp
@@ -122,7 +122,7 @@ void QgsUserProfileSelectionDialog::onRemoveProfile()
     return;
   }
 
-  QMessageBox::StandardButton response = QMessageBox::warning( this, tr( "Remove profile" ), QString( "Are you sure you want to delete profile '%1'?" ).arg( selectedProfile ), QMessageBox::Yes | QMessageBox::No );
+  QMessageBox::StandardButton response = QMessageBox::warning( this, tr( "Remove profile" ), QString( "Are you sure you want to delete profile '%1'? This action cannot be undone!" ).arg( selectedProfile ), QMessageBox::Yes | QMessageBox::No );
 
   if ( response == QMessageBox::No )
     return;

--- a/src/app/options/qgsuserprofileselectiondialog.cpp
+++ b/src/app/options/qgsuserprofileselectiondialog.cpp
@@ -21,11 +21,12 @@
 #include "qgsapplication.h"
 #include "qgsuserprofilemanager.h"
 #include "qgsnewnamedialog.h"
+#include "qnamespace.h"
 
 #include "qgsuserprofileselectiondialog.h"
 
-QgsUserProfileSelectionDialog::QgsUserProfileSelectionDialog( QgsUserProfileManager *manager, QWidget *parent )
-  : QDialog( parent ), mManager( manager )
+QgsUserProfileSelectionDialog::QgsUserProfileSelectionDialog( QgsUserProfileManager *manager, const QString &activeProfile, QWidget *parent )
+  : QDialog( parent ), mManager( manager ), mActiveProfile( activeProfile )
 
 {
   setupUi( this );
@@ -53,6 +54,9 @@ void QgsUserProfileSelectionDialog::populateProfileList()
   for ( auto profile : mManager->allProfiles() )
   {
     auto item = new QListWidgetItem( mManager->profileForName( profile )->icon(), profile );
+    if ( profile == mActiveProfile )
+      item->setBackground( Qt::lightGray );
+
     mProfileListWidget->addItem( item );
 
     // If the profile is the last used one, select it
@@ -71,8 +75,8 @@ QString QgsUserProfileSelectionDialog::selectedProfileName() const
 
 void QgsUserProfileSelectionDialog::accept()
 {
-  // Accept only if an item is selected
-  if ( mProfileListWidget->currentItem() && mProfileListWidget->currentItem()->isSelected() )
+  // Accept only if an item is selected and not the already active profile
+  if ( mProfileListWidget->currentItem() != nullptr && mProfileListWidget->currentItem()->isSelected() && mProfileListWidget->currentItem()->text() != mActiveProfile )
   {
     QDialog::accept();
   }

--- a/src/app/options/qgsuserprofileselectiondialog.cpp
+++ b/src/app/options/qgsuserprofileselectiondialog.cpp
@@ -44,7 +44,12 @@ QgsUserProfileSelectionDialog::QgsUserProfileSelectionDialog( QgsUserProfileMana
   mProfileListWidget->setIconSize( QSize( iconSize, iconSize ) );
 
   // Fill the list of profiles
-  mProfileListWidget->clear();  // Clear bogus profiles in the Ui form
+  populateProfileList();
+}
+
+void QgsUserProfileSelectionDialog::populateProfileList()
+{
+  mProfileListWidget->clear();
   for ( auto profile : mManager->allProfiles() )
   {
     auto item = new QListWidgetItem( mManager->profileForName( profile )->icon(), profile );
@@ -111,7 +116,26 @@ void QgsUserProfileSelectionDialog::onRemoveProfile()
 {
   QString selectedProfile = selectedProfileName();
 
+  if ( selectedProfile == QStringLiteral( "default" ) )
+  {
+    QMessageBox::warning( this, tr( "Remove profile" ), QString( "Cannot delete default profile" ), QMessageBox::Ok );
+    return;
+  }
+
+  QMessageBox::StandardButton response = QMessageBox::warning( this, tr( "Remove profile" ), QString( "Are you sure you want to delete profile '%1'?" ).arg( selectedProfile ), QMessageBox::Ok | QMessageBox::Cancel );
+
+  if ( response == QMessageBox::Cancel )
+    return;
+
   QgsError error = mManager->deleteProfile( selectedProfile );
+  if ( error.isEmpty() )
+  {
+    populateProfileList();
+  }
+  else
+  {
+    QMessageBox::warning( this, tr( "Remove profile" ), tr( "Profile '%1' could not be deleted!" ).arg( selectedProfile ) );
+  }
 }
 
 QgsUserProfileSelectionDialog::~QgsUserProfileSelectionDialog() {}

--- a/src/app/options/qgsuserprofileselectiondialog.cpp
+++ b/src/app/options/qgsuserprofileselectiondialog.cpp
@@ -122,9 +122,9 @@ void QgsUserProfileSelectionDialog::onRemoveProfile()
     return;
   }
 
-  QMessageBox::StandardButton response = QMessageBox::warning( this, tr( "Remove profile" ), QString( "Are you sure you want to delete profile '%1'?" ).arg( selectedProfile ), QMessageBox::Ok | QMessageBox::Cancel );
+  QMessageBox::StandardButton response = QMessageBox::warning( this, tr( "Remove profile" ), QString( "Are you sure you want to delete profile '%1'?" ).arg( selectedProfile ), QMessageBox::Yes | QMessageBox::No );
 
-  if ( response == QMessageBox::Cancel )
+  if ( response == QMessageBox::No )
     return;
 
   QgsError error = mManager->deleteProfile( selectedProfile );

--- a/src/app/options/qgsuserprofileselectiondialog.cpp
+++ b/src/app/options/qgsuserprofileselectiondialog.cpp
@@ -37,6 +37,9 @@ QgsUserProfileSelectionDialog::QgsUserProfileSelectionDialog( QgsUserProfileMana
   // Add a new profile on button click
   connect( mAddProfileButton, &QPushButton::clicked, this, &QgsUserProfileSelectionDialog::onAddProfile );
 
+  // Remove selected profile on button click
+  connect( mRemoveProfileButton, &QPushButton::clicked, this, &QgsUserProfileSelectionDialog::onRemoveProfile );
+
   const int iconSize = mManager->settings()->value( QStringLiteral( "/selector/iconSize" ), 24 ).toInt();
   mProfileListWidget->setIconSize( QSize( iconSize, iconSize ) );
 
@@ -102,6 +105,13 @@ void QgsUserProfileSelectionDialog::onAddProfile()
     QMessageBox::warning( this, tr( "New Profile" ), tr( "Cannot create folder '%1'" ).arg( profileName ) );
     return;
   }
+}
+
+void QgsUserProfileSelectionDialog::onRemoveProfile()
+{
+  QString selectedProfile = selectedProfileName();
+
+  QgsError error = mManager->deleteProfile( selectedProfile );
 }
 
 QgsUserProfileSelectionDialog::~QgsUserProfileSelectionDialog() {}

--- a/src/app/options/qgsuserprofileselectiondialog.cpp
+++ b/src/app/options/qgsuserprofileselectiondialog.cpp
@@ -120,12 +120,6 @@ void QgsUserProfileSelectionDialog::onDeleteProfile()
 {
   QString selectedProfile = selectedProfileName();
 
-  if ( selectedProfile == QStringLiteral( "default" ) )
-  {
-    QMessageBox::warning( this, tr( "Delete Profile" ), tr( "The default profile cannot be deleted." ), QMessageBox::Ok );
-    return;
-  }
-
   if ( selectedProfile == mActiveProfile )
   {
     QMessageBox::warning( this, tr( "Delete Profile" ), tr( "The active profile cannot be deleted." ), QMessageBox::Ok );

--- a/src/app/options/qgsuserprofileselectiondialog.cpp
+++ b/src/app/options/qgsuserprofileselectiondialog.cpp
@@ -38,8 +38,8 @@ QgsUserProfileSelectionDialog::QgsUserProfileSelectionDialog( QgsUserProfileMana
   // Add a new profile on button click
   connect( mAddProfileButton, &QPushButton::clicked, this, &QgsUserProfileSelectionDialog::onAddProfile );
 
-  // Remove selected profile on button click
-  connect( mRemoveProfileButton, &QPushButton::clicked, this, &QgsUserProfileSelectionDialog::onRemoveProfile );
+  // Delete selected profile on button click
+  connect( mDeleteProfileButton, &QPushButton::clicked, this, &QgsUserProfileSelectionDialog::onDeleteProfile );
 
   const int iconSize = mManager->settings()->value( QStringLiteral( "/selector/iconSize" ), 24 ).toInt();
   mProfileListWidget->setIconSize( QSize( iconSize, iconSize ) );
@@ -53,9 +53,9 @@ void QgsUserProfileSelectionDialog::populateProfileList()
   mProfileListWidget->clear();
   for ( auto profile : mManager->allProfiles() )
   {
-    auto item = new QListWidgetItem( mManager->profileForName( profile )->icon(), profile );
+    QListWidgetItem *item = new QListWidgetItem( mManager->profileForName( profile )->icon(), profile );
     if ( profile == mActiveProfile )
-      item->setBackground( Qt::lightGray );
+      item->setBackground( mProfileListWidget->palette().color( QPalette::Mid ) );
 
     mProfileListWidget->addItem( item );
 
@@ -76,7 +76,7 @@ QString QgsUserProfileSelectionDialog::selectedProfileName() const
 void QgsUserProfileSelectionDialog::accept()
 {
   // Accept only if an item is selected and not the already active profile
-  if ( mProfileListWidget->currentItem() != nullptr && mProfileListWidget->currentItem()->isSelected() && mProfileListWidget->currentItem()->text() != mActiveProfile )
+  if ( mProfileListWidget->currentItem() && mProfileListWidget->currentItem()->isSelected() && mProfileListWidget->currentItem()->text() != mActiveProfile )
   {
     QDialog::accept();
   }
@@ -116,17 +116,23 @@ void QgsUserProfileSelectionDialog::onAddProfile()
   }
 }
 
-void QgsUserProfileSelectionDialog::onRemoveProfile()
+void QgsUserProfileSelectionDialog::onDeleteProfile()
 {
   QString selectedProfile = selectedProfileName();
 
   if ( selectedProfile == QStringLiteral( "default" ) )
   {
-    QMessageBox::warning( this, tr( "Remove profile" ), QString( "Cannot delete default profile" ), QMessageBox::Ok );
+    QMessageBox::warning( this, tr( "Delete Profile" ), tr( "The default profile cannot be deleted." ), QMessageBox::Ok );
     return;
   }
 
-  QMessageBox::StandardButton response = QMessageBox::warning( this, tr( "Remove profile" ), QString( "Are you sure you want to delete profile '%1'? This action cannot be undone!" ).arg( selectedProfile ), QMessageBox::Yes | QMessageBox::No );
+  if ( selectedProfile == mActiveProfile )
+  {
+    QMessageBox::warning( this, tr( "Delete Profile" ), tr( "The active profile cannot be deleted." ), QMessageBox::Ok );
+    return;
+  }
+
+  QMessageBox::StandardButton response = QMessageBox::warning( this, tr( "Delete Profile" ), tr( "Are you sure you want to delete profile '%1'? This action cannot be undone!" ).arg( selectedProfile ), QMessageBox::Yes | QMessageBox::No );
 
   if ( response == QMessageBox::No )
     return;
@@ -138,7 +144,7 @@ void QgsUserProfileSelectionDialog::onRemoveProfile()
   }
   else
   {
-    QMessageBox::warning( this, tr( "Remove profile" ), tr( "Profile '%1' could not be deleted!" ).arg( selectedProfile ) );
+    QMessageBox::warning( this, tr( "Delete Profile" ), tr( "Profile '%1' could not be deleted!" ).arg( selectedProfile ) );
   }
 }
 

--- a/src/app/options/qgsuserprofileselectiondialog.h
+++ b/src/app/options/qgsuserprofileselectiondialog.h
@@ -54,6 +54,7 @@ class APP_EXPORT QgsUserProfileSelectionDialog : public QDialog, private Ui::Qgs
 
   private slots:
     void onAddProfile();
+    void onRemoveProfile();
 
   private:
     QgsUserProfileManager *mManager = nullptr;

--- a/src/app/options/qgsuserprofileselectiondialog.h
+++ b/src/app/options/qgsuserprofileselectiondialog.h
@@ -58,6 +58,7 @@ class APP_EXPORT QgsUserProfileSelectionDialog : public QDialog, private Ui::Qgs
 
   private:
     QgsUserProfileManager *mManager = nullptr;
+    void populateProfileList();
 
 
 };

--- a/src/app/options/qgsuserprofileselectiondialog.h
+++ b/src/app/options/qgsuserprofileselectiondialog.h
@@ -40,9 +40,10 @@ class APP_EXPORT QgsUserProfileSelectionDialog : public QDialog, private Ui::Qgs
     /**
      * Constructor for QgsUserProfileSelectionDialog.
      * \param manager QgsUserProfileManager manager that will be used to fill the list of profiles
+     * \param activeProfile QString current profile
      * \param parent parent widget
      */
-    explicit QgsUserProfileSelectionDialog( QgsUserProfileManager *manager, QWidget *parent = nullptr );
+    explicit QgsUserProfileSelectionDialog( QgsUserProfileManager *manager, const QString &activeProfile, QWidget *parent = nullptr );
     virtual ~QgsUserProfileSelectionDialog();
 
 
@@ -58,6 +59,7 @@ class APP_EXPORT QgsUserProfileSelectionDialog : public QDialog, private Ui::Qgs
 
   private:
     QgsUserProfileManager *mManager = nullptr;
+    QString mActiveProfile;
     void populateProfileList();
 
 

--- a/src/app/options/qgsuserprofileselectiondialog.h
+++ b/src/app/options/qgsuserprofileselectiondialog.h
@@ -55,7 +55,7 @@ class APP_EXPORT QgsUserProfileSelectionDialog : public QDialog, private Ui::Qgs
 
   private slots:
     void onAddProfile();
-    void onRemoveProfile();
+    void onDeleteProfile();
 
   private:
     QgsUserProfileManager *mManager = nullptr;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3536,17 +3536,6 @@ void QgisApp::refreshProfileMenu()
 
   mConfigMenu->addSeparator( );
 
-  QAction *openProfileSelectionDialog = mConfigMenu->addAction( tr( "Open Profile Selector" ) );
-  openProfileSelectionDialog->setObjectName( "mActionOpenProfileSelector" );
-  connect( openProfileSelectionDialog, &QAction::triggered, this, [this]()
-  {
-    auto dlg = QgsUserProfileSelectionDialog( userProfileManager() );
-    if ( dlg.exec() == QDialog::Accepted )
-    {
-      userProfileManager()->loadUserProfile( dlg.selectedProfileName() );
-    }
-  } );
-
   QAction *openProfileFolderAction = mConfigMenu->addAction( tr( "Open Active Profile Folder" ) );
   openProfileFolderAction->setObjectName( "mActionOpenActiveProfileFolder" );
   connect( openProfileFolderAction, &QAction::triggered, this, [this]()
@@ -3557,6 +3546,19 @@ void QgisApp::refreshProfileMenu()
   QAction *newProfileAction = mConfigMenu->addAction( tr( "New Profile…" ) );
   newProfileAction->setObjectName( "mActionNewProfile" );
   connect( newProfileAction, &QAction::triggered, this, &QgisApp::newProfile );
+
+  mConfigMenu->addSeparator( );
+
+  QAction *openProfileSelectionDialog = mConfigMenu->addAction( tr( "Open Profile Selector" ) );
+  openProfileSelectionDialog->setObjectName( "mActionOpenProfileSelector" );
+  connect( openProfileSelectionDialog, &QAction::triggered, this, [this]()
+  {
+    auto dlg = QgsUserProfileSelectionDialog( userProfileManager() );
+    if ( dlg.exec() == QDialog::Accepted )
+    {
+      userProfileManager()->loadUserProfile( dlg.selectedProfileName() );
+    }
+  } );
 }
 
 void QgisApp::createProfileMenu()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3549,11 +3549,12 @@ void QgisApp::refreshProfileMenu()
 
   mConfigMenu->addSeparator( );
 
-  QAction *openProfileSelectionDialog = mConfigMenu->addAction( tr( "Open Profile Selector" ) );
+  QAction *openProfileSelectionDialog = mConfigMenu->addAction( tr( "Open Profile Selector…" ) );
   openProfileSelectionDialog->setObjectName( "mActionOpenProfileSelector" );
-  connect( openProfileSelectionDialog, &QAction::triggered, this, [this]()
+  connect( openProfileSelectionDialog, &QAction::triggered, this, [this, activeName]()
   {
-    auto dlg = QgsUserProfileSelectionDialog( userProfileManager() );
+    auto dlg = QgsUserProfileSelectionDialog( userProfileManager(), activeName );
+
     if ( dlg.exec() == QDialog::Accepted )
     {
       userProfileManager()->loadUserProfile( dlg.selectedProfileName() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -74,6 +74,7 @@
 #include <QWindow>
 #include <QActionGroup>
 
+#include "qgsuserprofileselectiondialog.h"
 #include "qgsscreenhelper.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsnetworkaccessmanager.h"
@@ -3534,6 +3535,17 @@ void QgisApp::refreshProfileMenu()
   }
 
   mConfigMenu->addSeparator( );
+
+  QAction *openProfileSelectionDialog = mConfigMenu->addAction( tr( "Open Profile Selector" ) );
+  openProfileSelectionDialog->setObjectName( "mActionOpenProfileSelector" );
+  connect( openProfileSelectionDialog, &QAction::triggered, this, [this]()
+  {
+    auto dlg = QgsUserProfileSelectionDialog( userProfileManager() );
+    if ( dlg.exec() == QDialog::Accepted )
+    {
+      userProfileManager()->loadUserProfile( dlg.selectedProfileName() );
+    }
+  } );
 
   QAction *openProfileFolderAction = mConfigMenu->addAction( tr( "Open Active Profile Folder" ) );
   openProfileFolderAction->setObjectName( "mActionOpenActiveProfileFolder" );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3553,7 +3553,7 @@ void QgisApp::refreshProfileMenu()
   openProfileSelectionDialog->setObjectName( "mActionOpenProfileSelector" );
   connect( openProfileSelectionDialog, &QAction::triggered, this, [this, activeName]()
   {
-    auto dlg = QgsUserProfileSelectionDialog( userProfileManager(), activeName );
+    QgsUserProfileSelectionDialog dlg = QgsUserProfileSelectionDialog( userProfileManager(), activeName );
 
     if ( dlg.exec() == QDialog::Accepted )
     {

--- a/src/ui/qgsuserprofileselectiondialog.ui
+++ b/src/ui/qgsuserprofileselectiondialog.ui
@@ -173,9 +173,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="mRemoveProfileButton">
+      <widget class="QToolButton" name="mDeleteProfileButton">
        <property name="text">
-        <string>Remove profile</string>
+        <string>Delete profile</string>
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">

--- a/src/ui/qgsuserprofileselectiondialog.ui
+++ b/src/ui/qgsuserprofileselectiondialog.ui
@@ -148,50 +148,54 @@
     </widget>
    </item>
    <item>
-    <widget class="QToolButton" name="mAddProfileButton">
-     <property name="text">
-      <string>Add new profile</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../../images/images.qrc">
-       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>24</width>
-       <height>24</height>
-      </size>
-     </property>
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonTextBesideIcon</enum>
-     </property>
-     <property name="autoRaise">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QToolButton" name="mRemoveProfileButton">
-     <property name="text">
-      <string>Remove profile</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../../images/images.qrc">
-       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>24</width>
-       <height>24</height>
-      </size>
-     </property>
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonTextBesideIcon</enum>
-     </property>
-     <property name="autoRaise">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="mAddProfileButton">
+       <property name="text">
+        <string>Add new profile</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mRemoveProfileButton">
+       <property name="text">
+        <string>Remove profile</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/ui/qgsuserprofileselectiondialog.ui
+++ b/src/ui/qgsuserprofileselectiondialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>332</width>
-    <height>417</height>
+    <height>471</height>
    </rect>
   </property>
   <property name="palette">
@@ -83,10 +83,10 @@
      <item>
       <widget class="QLabel" name="label_2">
        <property name="maximumSize">
-       <size>
+        <size>
          <width>100</width>
          <height>100</height>
-       </size>
+        </size>
        </property>
        <property name="text">
         <string/>
@@ -171,10 +171,33 @@
     </widget>
    </item>
    <item>
+    <widget class="QToolButton" name="mRemoveProfileButton">
+     <property name="text">
+      <string>Remove profile</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../images/images.qrc">
+       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextBesideIcon</enum>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
-      </property>
+     </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>


### PR DESCRIPTION
This is my implementation of this somewhat old feature request #38243 to be able to remove user profiles in the GUI without having to manually delete the folder.

* I figured that a logical place to add this feature is the recently added QgsUserProfileSelectionDialog.

![](https://github.com/user-attachments/assets/911702bc-e708-421a-a7ab-ca4637ed74b0)

* Since not everyone has the selection dialog enabled I thought I'd add a button to open the Selector from **Settings** > **User Profiles**

![image](https://github.com/user-attachments/assets/17f452df-b334-400a-8920-1e42c8b77d5b)

* I've also disabled deleting the default profile, although I'm not sure it's necessary

---
If this is at all an okay direction for the Profile Selector, personally I'd like for it to have even more features:
* Being able to select and delete multiple profiles
* Being able to add profiles without immediately starting a new process
* Being able to rename profiles
* Maybe being able to reset a profile?
* Maybe being able to edit the profile icons?