### PR TITLE
[ReshapeMapTool] Fix snapping matches with tracing

### DIFF
--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -317,7 +317,6 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
   mSnappingMatches.append( QgsPointLocator::Match() );
 
   addCurve( new QgsLineString( mapPoints ) );
-  int pointBefore = mCaptureCurve.numPoints();
 
   resetRubberBand();
 
@@ -343,12 +342,13 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
         mCaptureCurve = *qgsgeometry_cast<QgsCompoundCurve *>( curved.constGet() );
       }
     }
-  }
 
-  // sync the snapping matches list
-  const int pointAfter = mCaptureCurve.numPoints();
-  for ( ; pointBefore < pointAfter; ++pointBefore )
-    mSnappingMatches.append( QgsPointLocator::Match() );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    mSnappingMatches = QVector( mCaptureCurve.numPoints(), QgsPointLocator::Match() ).toList();
+#else
+    mSnappingMatches.resize( mCaptureCurve.numPoints() );
+#endif
+  }
 
   tracer->reportError( QgsTracer::ErrNone, true ); // clear messagebar if there was any error
 

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -316,8 +316,8 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
   mSnappingMatches.removeLast();
   mSnappingMatches.append( QgsPointLocator::Match() );
 
-  int pointBefore = mCaptureCurve.numPoints();
   addCurve( new QgsLineString( mapPoints ) );
+  int pointBefore = mCaptureCurve.numPoints();
 
   resetRubberBand();
 

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -323,6 +323,10 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
   // Curves de-approximation
   if ( QgsSettingsRegistryCore::settingsDigitizingConvertToCurve->value() )
   {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    int pointBefore = mCaptureCurve.numPoints();
+#endif
+
     // If the tool and the layer support curves
     QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer() );
     if ( vlayer && capabilities().testFlag( QgsMapToolCapture::Capability::SupportsCurves ) && vlayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::CircularGeometries ) )
@@ -344,7 +348,14 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
     }
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    mSnappingMatches = QVector( mCaptureCurve.numPoints(), QgsPointLocator::Match() ).toList();
+    // sync the snapping matches list
+    const int pointAfter = mCaptureCurve.numPoints();
+
+    for ( ; pointBefore < pointAfter; ++pointBefore )
+      mSnappingMatches.append( QgsPointLocator::Match() );
+
+    for ( ; pointBefore > pointAfter; --pointBefore )
+      mSnappingMatches.removeLast();
 #else
     mSnappingMatches.resize( mCaptureCurve.numPoints() );
 #endif

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -16,17 +16,15 @@
 #include "qgstest.h"
 
 #include "qgisapp.h"
-#include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
-#include "qgsmapcanvassnappingutils.h"
 #include "qgssnappingconfig.h"
 #include "qgssnappingutils.h"
 #include "qgsmaptoolreshape.h"
 #include "qgsproject.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsvectorlayer.h"
-#include "qgsmapmouseevent.h"
+#include "qgsmapcanvastracer.h"
 #include "testqgsmaptoolutils.h"
 
 
@@ -48,6 +46,7 @@ class TestQgsMapToolReshape: public QObject
     void testTopologicalEditing();
     void testAvoidIntersectionAndTopoEdit();
     void reshapeWithBindingLine();
+    void testWithTracing();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -376,6 +375,38 @@ void TestQgsMapToolReshape::reshapeWithBindingLine()
   QCOMPARE( f1.geometry().asWkt(), QStringLiteral( "LineString (1 2, 2 1, 3 2, 3 3, 2 2)" ) );
 
   vl->rollBack();
+}
+
+void TestQgsMapToolReshape::testWithTracing()
+{
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerTopo );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerTopo );
+
+  std::unique_ptr<QgsMapCanvasTracer> tracer( new QgsMapCanvasTracer( mCanvas, nullptr ) );
+
+  const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  QgsProject::instance()->setTopologicalEditing( true );
+  mCanvas->setCurrentLayer( mLayerTopo );
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  // test with default Z value = 333
+  QgsSettingsRegistryCore::settingsDigitizingDefaultZValue->setValue( 333 );
+
+  utils.mouseClick( 7, 0, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 4, 0, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 4, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 7, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 8, 5, Qt::RightButton );
+
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), "Polygon ((0 0, 4 0, 4 4, 0 4))" );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), "Polygon ((7 0, 8 0, 8 4, 7 4, 4 4, 4 0, 7 0))" );
+
+  mLayerTopo->undoStack()->undo();
+
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 4 0, 4 4, 0 4))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon ((7 0, 8 0, 8 4, 7 4))" ) );
+
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
 }
 
 


### PR DESCRIPTION
`addCurve()` method already update the `mSnappingMatches ` variable so we need to update `pointBefore` variable after the `addCurve()` call

Fixes #57225

