### PR TITLE
[pyqt5To6] Avoid endless recursion because of baseClass

### DIFF
--- a/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
+++ b/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
@@ -614,6 +614,10 @@ def get_class_enums(item):
     matched_classes = {item}.union(all_subclasses(item))
 
     for key, value in item.__dict__.items():
+
+        if key == 'baseClass':
+            continue
+
         if inspect.isclass(value) and type(value).__name__ == 'EnumType':
             for ekey, evalue in value.__dict__.items():
                 for matched_class in matched_classes:


### PR DESCRIPTION
baseClass is an attribute added by sipify script.

Fixes https://github.com/qgis/QGIS/issues/58659
