### PR TITLE
QgsDistanceArea methods should raise QgsCsException when errors occur

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsdistancearea.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdistancearea.sip.in
@@ -148,7 +148,7 @@ The inverse flattening is calculated with invf = a/(a-b).
 .. seealso:: :py:func:`ellipsoidSemiMinor`
 %End
 
-    double measureArea( const QgsGeometry &geometry ) const;
+    double measureArea( const QgsGeometry &geometry ) const throw( QgsCsException );
 %Docstring
 Measures the area of a geometry.
 
@@ -162,9 +162,11 @@ Measures the area of a geometry.
 .. seealso:: :py:func:`measurePerimeter`
 
 .. seealso:: :py:func:`areaUnits`
+
+:raises QgsCsException: if a transformation error occurs while calculating the area
 %End
 
-    double measureLength( const QgsGeometry &geometry ) const;
+    double measureLength( const QgsGeometry &geometry ) const throw( QgsCsException );
 %Docstring
 Measures the length of a geometry.
 
@@ -178,9 +180,11 @@ Measures the length of a geometry.
 .. seealso:: :py:func:`measureArea`
 
 .. seealso:: :py:func:`measurePerimeter`
+
+:raises QgsCsException: if a transformation error occurs while calculating the length
 %End
 
-    double measurePerimeter( const QgsGeometry &geometry ) const;
+    double measurePerimeter( const QgsGeometry &geometry ) const throw( QgsCsException );
 %Docstring
 Measures the perimeter of a polygon geometry.
 
@@ -194,9 +198,11 @@ Measures the perimeter of a polygon geometry.
 .. seealso:: :py:func:`measureArea`
 
 .. seealso:: :py:func:`measurePerimeter`
+
+:raises QgsCsException: if a transformation error occurs while calculating the perimeter
 %End
 
-    double measureLine( const QVector<QgsPointXY> &points ) const;
+    double measureLine( const QVector<QgsPointXY> &points ) const throw( QgsCsException );
 %Docstring
 Measures the length of a line with multiple segments.
 
@@ -204,10 +210,12 @@ Measures the length of a line with multiple segments.
 
 :return: length of line. The units for the returned length can be retrieved by calling :py:func:`~QgsDistanceArea.lengthUnits`.
 
+:raises QgsCsException: if a transformation error occurs while calculating the length
+
 .. seealso:: :py:func:`lengthUnits`
 %End
 
-    double measureLine( const QgsPointXY &p1, const QgsPointXY &p2 ) const;
+    double measureLine( const QgsPointXY &p1, const QgsPointXY &p2 ) const throw( QgsCsException );
 %Docstring
 Measures the distance between two points.
 
@@ -215,6 +223,8 @@ Measures the distance between two points.
 :param p2: end of line
 
 :return: distance between points. The units for the returned distance can be retrieved by calling :py:func:`~QgsDistanceArea.lengthUnits`.
+
+:raises QgsCsException: if a transformation error occurs while calculating the length
 
 .. seealso:: :py:func:`lengthUnits`
 %End
@@ -255,9 +265,11 @@ Returns the units of area for areal calculations made by this object.
 .. seealso:: :py:func:`lengthUnits`
 %End
 
-    double measurePolygon( const QVector<QgsPointXY> &points ) const;
+    double measurePolygon( const QVector<QgsPointXY> &points ) const throw( QgsCsException );
 %Docstring
 Measures the area of the polygon described by a set of points.
+
+:raises QgsCsException: if a transformation error occurs while calculating the area.
 %End
 
     double bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) const throw( QgsCsException );

--- a/python/core/auto_generated/qgsdistancearea.sip.in
+++ b/python/core/auto_generated/qgsdistancearea.sip.in
@@ -148,7 +148,7 @@ The inverse flattening is calculated with invf = a/(a-b).
 .. seealso:: :py:func:`ellipsoidSemiMinor`
 %End
 
-    double measureArea( const QgsGeometry &geometry ) const;
+    double measureArea( const QgsGeometry &geometry ) const throw( QgsCsException );
 %Docstring
 Measures the area of a geometry.
 
@@ -162,9 +162,11 @@ Measures the area of a geometry.
 .. seealso:: :py:func:`measurePerimeter`
 
 .. seealso:: :py:func:`areaUnits`
+
+:raises QgsCsException: if a transformation error occurs while calculating the area
 %End
 
-    double measureLength( const QgsGeometry &geometry ) const;
+    double measureLength( const QgsGeometry &geometry ) const throw( QgsCsException );
 %Docstring
 Measures the length of a geometry.
 
@@ -178,9 +180,11 @@ Measures the length of a geometry.
 .. seealso:: :py:func:`measureArea`
 
 .. seealso:: :py:func:`measurePerimeter`
+
+:raises QgsCsException: if a transformation error occurs while calculating the length
 %End
 
-    double measurePerimeter( const QgsGeometry &geometry ) const;
+    double measurePerimeter( const QgsGeometry &geometry ) const throw( QgsCsException );
 %Docstring
 Measures the perimeter of a polygon geometry.
 
@@ -194,9 +198,11 @@ Measures the perimeter of a polygon geometry.
 .. seealso:: :py:func:`measureArea`
 
 .. seealso:: :py:func:`measurePerimeter`
+
+:raises QgsCsException: if a transformation error occurs while calculating the perimeter
 %End
 
-    double measureLine( const QVector<QgsPointXY> &points ) const;
+    double measureLine( const QVector<QgsPointXY> &points ) const throw( QgsCsException );
 %Docstring
 Measures the length of a line with multiple segments.
 
@@ -204,10 +210,12 @@ Measures the length of a line with multiple segments.
 
 :return: length of line. The units for the returned length can be retrieved by calling :py:func:`~QgsDistanceArea.lengthUnits`.
 
+:raises QgsCsException: if a transformation error occurs while calculating the length
+
 .. seealso:: :py:func:`lengthUnits`
 %End
 
-    double measureLine( const QgsPointXY &p1, const QgsPointXY &p2 ) const;
+    double measureLine( const QgsPointXY &p1, const QgsPointXY &p2 ) const throw( QgsCsException );
 %Docstring
 Measures the distance between two points.
 
@@ -215,6 +223,8 @@ Measures the distance between two points.
 :param p2: end of line
 
 :return: distance between points. The units for the returned distance can be retrieved by calling :py:func:`~QgsDistanceArea.lengthUnits`.
+
+:raises QgsCsException: if a transformation error occurs while calculating the length
 
 .. seealso:: :py:func:`lengthUnits`
 %End
@@ -255,9 +265,11 @@ Returns the units of area for areal calculations made by this object.
 .. seealso:: :py:func:`lengthUnits`
 %End
 
-    double measurePolygon( const QVector<QgsPointXY> &points ) const;
+    double measurePolygon( const QVector<QgsPointXY> &points ) const throw( QgsCsException );
 %Docstring
 Measures the area of the polygon described by a set of points.
+
+:raises QgsCsException: if a transformation error occurs while calculating the area.
 %End
 
     double bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) const throw( QgsCsException );

--- a/src/analysis/network/qgsvectorlayerdirector.cpp
+++ b/src/analysis/network/qgsvectorlayerdirector.cpp
@@ -27,7 +27,7 @@
 #include "qgsgeometry.h"
 #include "qgsdistancearea.h"
 #include "qgswkbtypes.h"
-
+#include "qgslogger.h"
 #include <QString>
 #include <QtAlgorithms>
 
@@ -381,7 +381,17 @@ void QgsVectorLayerDirector::makeGraph( QgsGraphBuilderInterface *builder, const
 
             if ( !isFirstPoint && arcPt1 != arcPt2 )
             {
-              double distance = builder->distanceArea()->measureLine( arcPt1, arcPt2 );
+              double distance = 0;
+              try
+              {
+                distance = builder->distanceArea()->measureLine( arcPt1, arcPt2 );
+              }
+              catch ( QgsCsException & )
+              {
+                // TODO report errors to user
+                QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+              }
+
               QVector< QVariant > prop;
               prop.reserve( mStrategies.size() );
               for ( QgsNetworkStrategy *strategy : mStrategies )

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
@@ -155,7 +155,16 @@ QVariantMap QgsCalculateVectorOverlapsAlgorithm::processAlgorithm( const QVarian
     if ( feature.hasGeometry() && !qgsDoubleNear( feature.geometry().area(), 0.0 ) )
     {
       const QgsGeometry inputGeom = feature.geometry();
-      const double inputArea = da.measureArea( inputGeom );
+
+      double inputArea = 0;
+      try
+      {
+        inputArea = da.measureArea( inputGeom );
+      }
+      catch ( QgsCsException & )
+      {
+        throw QgsProcessingException( QObject::tr( "An error occurred while calculating feature area" ) );
+      }
 
       // prepare for lots of intersection tests (for speed)
       std::unique_ptr< QgsGeometryEngine > bufferGeomEngine( QgsGeometry::createGeometryEngine( inputGeom.constGet() ) );
@@ -195,7 +204,16 @@ QVariantMap QgsCalculateVectorOverlapsAlgorithm::processAlgorithm( const QVarian
 
         const QgsGeometry overlayIntersection = inputGeom.intersection( overlayDissolved, geometryParameters );
 
-        const double overlayArea = da.measureArea( overlayIntersection );
+        double overlayArea = 0;
+        try
+        {
+          overlayArea = da.measureArea( overlayIntersection );
+        }
+        catch ( QgsCsException & )
+        {
+          throw QgsProcessingException( QObject::tr( "An error occurred while calculating feature area" ) );
+        }
+
         outAttributes.append( overlayArea );
         outAttributes.append( 100 * overlayArea / inputArea );
       }

--- a/src/analysis/processing/qgsalgorithmlinedensity.cpp
+++ b/src/analysis/processing/qgsalgorithmlinedensity.cpp
@@ -190,7 +190,16 @@ QVariantMap QgsLineDensityAlgorithm::processAlgorithm( const QVariantMap &parame
 
           if ( engine->intersects( lineGeom.constGet() ) )
           {
-            const double analysisLineLength =  mDa.measureLength( QgsGeometry( engine->intersection( mIndex.geometry( id ).constGet() ) ) );
+            double analysisLineLength = 0;
+            try
+            {
+              analysisLineLength =  mDa.measureLength( QgsGeometry( engine->intersection( mIndex.geometry( id ).constGet() ) ) );
+            }
+            catch ( QgsCsException & )
+            {
+              throw QgsProcessingException( QObject::tr( "An error occurred while calculating feature length" ) );
+            }
+
             double weight = 1;
 
             if ( !mWeightField.isEmpty() )
@@ -206,7 +215,16 @@ QVariantMap QgsLineDensityAlgorithm::processAlgorithm( const QVariantMap &parame
         if ( absDensity > 0 )
         {
           //only calculate ellipsoidal area if abs density is greater 0
-          const double analysisSearchGeometryArea = mDa.measureArea( mSearchGeometry );
+          double analysisSearchGeometryArea = 0;
+          try
+          {
+            analysisSearchGeometryArea = mDa.measureArea( mSearchGeometry );
+          }
+          catch ( QgsCsException & )
+          {
+            throw QgsProcessingException( QObject::tr( "An error occurred while calculating feature area" ) );
+          }
+
           lineDensity = absDensity / analysisSearchGeometryArea;
         }
         rasterDataLine->setValue( 0, col, lineDensity );

--- a/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
+++ b/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
@@ -113,7 +113,14 @@ QVariantMap QgsNearestNeighbourAnalysisAlgorithm::processAlgorithm( const QVaria
     }
 
     const QgsFeatureId neighbourId = spatialIndex.nearestNeighbor( f.geometry().asPoint(), 2 ).at( 1 );
-    sumDist += da.measureLine( spatialIndex.geometry( neighbourId ).asPoint(), f.geometry().asPoint() );
+    try
+    {
+      sumDist += da.measureLine( spatialIndex.geometry( neighbourId ).asPoint(), f.geometry().asPoint() );
+    }
+    catch ( QgsCsException & )
+    {
+      throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+    }
 
     i++;
     feedback->setProgress( i * step );

--- a/src/analysis/processing/qgsalgorithmpointstopaths.cpp
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.cpp
@@ -353,7 +353,15 @@ QVariantMap QgsPointsToPathsAlgorithm::processAlgorithm( const QVariantMap &para
       for ( int i = 1; i < pathPoints.size(); ++i )
       {
         const double angle = pathPoints.at( i - 1 ).azimuth( pathPoints.at( i ) );
-        const double distance = da.measureLine( pathPoints.at( i - 1 ), pathPoints.at( i ) );
+        double distance = 0;
+        try
+        {
+          distance = da.measureLine( pathPoints.at( i - 1 ), pathPoints.at( i ) );
+        }
+        catch ( QgsCsException & )
+        {
+          throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+        }
         out << QString( "%1;%2;90\n" ).arg( angle ).arg( distance );
       }
     }

--- a/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
@@ -165,7 +165,16 @@ QVariantMap QgsServiceAreaFromLayerAlgorithm::processAlgorithm( const QVariantMa
 
     if ( pointDistanceThreshold >= 0 )
     {
-      const double distancePointToNetwork = mBuilder->distanceArea()->measureLine( originalPoint, snappedPoint );
+      double distancePointToNetwork = 0;
+      try
+      {
+        distancePointToNetwork = mBuilder->distanceArea()->measureLine( originalPoint, snappedPoint );
+      }
+      catch ( QgsCsException & )
+      {
+        throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+      }
+
       if ( distancePointToNetwork > pointDistanceThreshold )
       {
         feedback->pushWarning( QObject::tr( "Point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distancePointToNetwork ).arg( pointDistanceThreshold ) );

--- a/src/analysis/processing/qgsalgorithmserviceareafrompoint.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafrompoint.cpp
@@ -113,7 +113,17 @@ QVariantMap QgsServiceAreaFromPointAlgorithm::processAlgorithm( const QVariantMa
   {
     const double pointDistanceThreshold = parameterAsDouble( parameters, QStringLiteral( "POINT_TOLERANCE" ), context );
 
-    const double distancePointToNetwork = mBuilder->distanceArea()->measureLine( startPoint, snappedStartPoint );
+    double distancePointToNetwork = 0;
+    try
+    {
+      distancePointToNetwork = mBuilder->distanceArea()->measureLine( startPoint, snappedStartPoint );
+    }
+    catch ( QgsCsException & )
+    {
+      throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+    }
+
+
     if ( distancePointToNetwork > pointDistanceThreshold )
     {
       throw QgsProcessingException( QObject::tr( "Point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distancePointToNetwork ).arg( pointDistanceThreshold ) );

--- a/src/analysis/processing/qgsalgorithmshortestline.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestline.cpp
@@ -155,7 +155,16 @@ QVariantMap QgsShortestLineAlgorithm::processAlgorithm( const QVariantMap &param
       }
 
       const QgsGeometry shortestLine = sourceGeom.shortestLine( destinationGeom );
-      double dist = da.measureLength( shortestLine );
+      double dist = 0;
+      try
+      {
+        dist = da.measureLength( shortestLine );
+      }
+      catch ( QgsCsException & )
+      {
+        throw QgsProcessingException( QObject::tr( "An error occurred while calculating shortest line length" ) );
+      }
+
       QgsFeature f;
       QgsAttributes attrs = sourceFeature.attributes();
       attrs << destinationAttributeCache.value( id ) << dist;

--- a/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.cpp
@@ -107,7 +107,16 @@ QVariantMap QgsShortestPathLayerToPointAlgorithm::processAlgorithm( const QVaria
 
   if ( pointDistanceThreshold >= 0 )
   {
-    const double distanceEndPointToNetwork = mBuilder->distanceArea()->measureLine( endPoint, snappedEndPoint );
+    double distanceEndPointToNetwork = 0;
+    try
+    {
+      distanceEndPointToNetwork = mBuilder->distanceArea()->measureLine( endPoint, snappedEndPoint );
+    }
+    catch ( QgsCsException & )
+    {
+      throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+    }
+
     if ( distanceEndPointToNetwork > pointDistanceThreshold )
     {
       throw QgsProcessingException( QObject::tr( "End point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distanceEndPointToNetwork ).arg( pointDistanceThreshold ) );
@@ -143,7 +152,16 @@ QVariantMap QgsShortestPathLayerToPointAlgorithm::processAlgorithm( const QVaria
 
     if ( pointDistanceThreshold >= 0 )
     {
-      const double distancePointToNetwork = mBuilder->distanceArea()->measureLine( originalPoint, snappedPoint );
+      double distancePointToNetwork = 0;
+      try
+      {
+        distancePointToNetwork = mBuilder->distanceArea()->measureLine( originalPoint, snappedPoint );
+      }
+      catch ( QgsCsException & )
+      {
+        throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+      }
+
       if ( distancePointToNetwork > pointDistanceThreshold )
       {
         feedback->pushWarning( QObject::tr( "Point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distancePointToNetwork ).arg( pointDistanceThreshold ) );

--- a/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.cpp
@@ -112,7 +112,16 @@ QVariantMap QgsShortestPathPointToLayerAlgorithm::processAlgorithm( const QVaria
 
   if ( pointDistanceThreshold >= 0 )
   {
-    const double distanceStartPointToNetwork = mBuilder->distanceArea()->measureLine( startPoint, snappedStartPoint );
+    double distanceStartPointToNetwork = 0;
+    try
+    {
+      distanceStartPointToNetwork = mBuilder->distanceArea()->measureLine( startPoint, snappedStartPoint );
+    }
+    catch ( QgsCsException & )
+    {
+      throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+    }
+
     if ( distanceStartPointToNetwork > pointDistanceThreshold )
     {
       throw QgsProcessingException( QObject::tr( "Start point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distanceStartPointToNetwork ).arg( pointDistanceThreshold ) );
@@ -148,7 +157,16 @@ QVariantMap QgsShortestPathPointToLayerAlgorithm::processAlgorithm( const QVaria
 
     if ( pointDistanceThreshold >= 0 )
     {
-      const double distancePointToNetwork = mBuilder->distanceArea()->measureLine( originalPoint, snappedPoint );
+      double distancePointToNetwork = 0;
+      try
+      {
+        distancePointToNetwork = mBuilder->distanceArea()->measureLine( originalPoint, snappedPoint );
+      }
+      catch ( QgsCsException & )
+      {
+        throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+      }
+
       if ( distancePointToNetwork > pointDistanceThreshold )
       {
         feedback->pushWarning( QObject::tr( "Point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distancePointToNetwork ).arg( pointDistanceThreshold ) );

--- a/src/analysis/processing/qgsalgorithmshortestpathpointtopoint.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathpointtopoint.cpp
@@ -90,13 +90,31 @@ QVariantMap QgsShortestPathPointToPointAlgorithm::processAlgorithm( const QVaria
   {
     const double pointDistanceThreshold = parameterAsDouble( parameters, QStringLiteral( "POINT_TOLERANCE" ), context );
 
-    const double distanceStartPointToNetwork = mBuilder->distanceArea()->measureLine( startPoint, snappedStartPoint );
+    double distanceStartPointToNetwork = 0;
+    try
+    {
+      distanceStartPointToNetwork = mBuilder->distanceArea()->measureLine( startPoint, snappedStartPoint );
+    }
+    catch ( QgsCsException & )
+    {
+      throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+    }
+
     if ( distanceStartPointToNetwork > pointDistanceThreshold )
     {
       throw QgsProcessingException( QObject::tr( "Start point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distanceStartPointToNetwork ).arg( pointDistanceThreshold ) );
     }
 
-    const double distanceEndPointToNetwork = mBuilder->distanceArea()->measureLine( endPoint, snappedEndPoint );
+    double distanceEndPointToNetwork = 0;
+    try
+    {
+      distanceEndPointToNetwork = mBuilder->distanceArea()->measureLine( endPoint, snappedEndPoint );
+    }
+    catch ( QgsCsException & )
+    {
+      throw QgsProcessingException( QObject::tr( "An error occurred while calculating length" ) );
+    }
+
     if ( distanceEndPointToNetwork > pointDistanceThreshold )
     {
       throw QgsProcessingException( QObject::tr( "End point is too far from the network layer (%1, maximum permitted is %2)" ).arg( distanceEndPointToNetwork ).arg( pointDistanceThreshold ) );

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -220,7 +220,14 @@ QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feat
       if ( engine->intersects( lineFeature.geometry().constGet() ) )
       {
         const QgsGeometry outGeom = polyGeom.intersection( lineFeature.geometry() );
-        length += mDa.measureLength( outGeom );
+        try
+        {
+          length += mDa.measureLength( outGeom );
+        }
+        catch ( QgsCsException & )
+        {
+          throw QgsProcessingException( QObject::tr( "An error occurred while calculating feature length" ) );
+        }
         count++;
       }
     }

--- a/src/app/decorations/qgsdecorationscalebar.cpp
+++ b/src/app/decorations/qgsdecorationscalebar.cpp
@@ -225,8 +225,17 @@ double QgsDecorationScaleBar::mapWidth( const QgsMapSettings &settings ) const
 
     // we measure the horizontal distance across the vertical center of the map
     const double yPosition = 0.5 * ( mapExtent.yMinimum() + mapExtent.yMaximum() );
-    double measure = da.measureLine( QgsPointXY( mapExtent.xMinimum(), yPosition ),
-                                     QgsPointXY( mapExtent.xMaximum(), yPosition ) );
+    double measure = 0;
+    try
+    {
+      measure = da.measureLine( QgsPointXY( mapExtent.xMinimum(), yPosition ),
+                                QgsPointXY( mapExtent.xMaximum(), yPosition ) );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    }
 
     measure /= QgsUnitTypes::fromUnitToUnitFactor( mSettings.units(), units );
     return measure;

--- a/src/app/gps/qgsgpsbearingitem.cpp
+++ b/src/app/gps/qgsgpsbearingitem.cpp
@@ -87,8 +87,17 @@ void QgsGpsBearingItem::updateLine()
     QgsDistanceArea da1;
     da1.setSourceCrs( mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
     da1.setEllipsoid( QgsProject::instance()->ellipsoid() );
-    const double totalLength = 2 * da1.measureLine( mMapCanvas->mapSettings().extent().center(), QgsPointXY( mMapCanvas->mapSettings().extent().xMaximum(),
-                               mMapCanvas->mapSettings().extent().yMaximum() ) );
+    double totalLength = 0;
+    try
+    {
+      totalLength = 2 * da1.measureLine( mMapCanvas->mapSettings().extent().center(), QgsPointXY( mMapCanvas->mapSettings().extent().xMaximum(),
+                                         mMapCanvas->mapSettings().extent().yMaximum() ) );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    }
 
     QgsDistanceArea da;
     da.setSourceCrs( mWgs84CRS, QgsProject::instance()->transformContext() );

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -238,14 +238,33 @@ void QgsMeasureDialog::mouseMove( const QgsPointXY &point )
   {
     QVector<QgsPointXY> tmpPoints = mTool->points();
     tmpPoints.append( point );
-    const double area = mDa.measurePolygon( tmpPoints );
+    double area = 0;
+    try
+    {
+      area = mDa.measurePolygon( tmpPoints );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating area" ) );
+    }
+
     editTotal->setText( formatArea( area ) );
   }
   else if ( !mMeasureArea && !mTool->points().empty() )
   {
     const QVector< QgsPointXY > tmpPoints = mTool->points();
     QgsPointXY p1( tmpPoints.at( tmpPoints.size() - 1 ) ), p2( point );
-    double d = mDa.measureLine( p1, p2 );
+    double d = 0;
+    try
+    {
+      d = mDa.measureLine( p1, p2 );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    }
     editTotal->setText( formatDistance( mTotal + d, mConvertToDisplayUnits ) );
     d = convertLength( d, mDistanceUnits );
 
@@ -265,7 +284,17 @@ void QgsMeasureDialog::addPoint()
   const int numPoints = mTool->points().size();
   if ( mMeasureArea && numPoints > 2 )
   {
-    const double area = mDa.measurePolygon( mTool->points() );
+    double area = 0;
+    try
+    {
+      area = mDa.measurePolygon( mTool->points() );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating area" ) );
+    }
+
     editTotal->setText( formatArea( area ) );
   }
   else if ( !mMeasureArea && numPoints >= 1 )
@@ -292,7 +321,16 @@ void QgsMeasureDialog::addPoint()
     }
     if ( numPoints > 1 )
     {
-      mTotal = mDa.measureLine( mTool->points() );
+      try
+      {
+        mTotal = mDa.measureLine( mTool->points() );
+      }
+      catch ( QgsCsException & )
+      {
+        // TODO report errors to user
+        QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+      }
+
       editTotal->setText( formatDistance( mTotal, mConvertToDisplayUnits ) );
     }
   }
@@ -308,7 +346,16 @@ void QgsMeasureDialog::removeLastPoint()
       QVector<QgsPointXY> tmpPoints = mTool->points();
       if ( !mTool->done() )
         tmpPoints.append( mLastMousePoint );
-      const double area = mDa.measurePolygon( tmpPoints );
+      double area = 0;
+      try
+      {
+        area = mDa.measurePolygon( tmpPoints );
+      }
+      catch ( QgsCsException & )
+      {
+        // TODO report errors to user
+        QgsDebugError( QStringLiteral( "An error occurred while calculating area" ) );
+      }
       editTotal->setText( formatArea( area ) );
     }
     else
@@ -321,14 +368,31 @@ void QgsMeasureDialog::removeLastPoint()
     //remove final row
     delete mTable->takeTopLevelItem( mTable->topLevelItemCount() - 1 );
 
-    mTotal = mDa.measureLine( mTool->points() );
+    try
+    {
+      mTotal = mDa.measureLine( mTool->points() );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    }
 
     if ( !mTool->done() )
     {
       // need to add the distance for the temporary mouse cursor point
       const QVector< QgsPointXY > tmpPoints = mTool->points();
       const QgsPointXY p1( tmpPoints.at( tmpPoints.size() - 1 ) );
-      double d = mDa.measureLine( p1, mLastMousePoint );
+      double d = 0;
+      try
+      {
+        d = mDa.measureLine( p1, mLastMousePoint );
+      }
+      catch ( QgsCsException & )
+      {
+        // TODO report errors to user
+        QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+      }
 
       d = convertLength( d, mDistanceUnits );
 
@@ -628,7 +692,15 @@ void QgsMeasureDialog::updateUi()
     double area = 0.0;
     if ( mTool->points().size() > 1 )
     {
-      area = mDa.measurePolygon( mTool->points() );
+      try
+      {
+        area = mDa.measurePolygon( mTool->points() );
+      }
+      catch ( QgsCsException & )
+      {
+        // TODO report errors to user
+        QgsDebugError( QStringLiteral( "An error occurred while calculating area" ) );
+      }
     }
     mTable->hide(); // Hide the table, only show summary
     mSpacer->changeSize( 40, 5, QSizePolicy::Fixed, QSizePolicy::Expanding );
@@ -654,7 +726,16 @@ void QgsMeasureDialog::updateUi()
       if ( !firstPoint )
       {
         double d = -1;
-        d = mDa.measureLine( previousPoint, point );
+        try
+        {
+          d = mDa.measureLine( previousPoint, point );
+        }
+        catch ( QgsCsException & )
+        {
+          // TODO report errors to user
+          QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+        }
+
         if ( mConvertToDisplayUnits )
         {
           if ( mDistanceUnits == Qgis::DistanceUnit::Unknown && mMapDistanceUnits != Qgis::DistanceUnit::Unknown )

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -1231,9 +1231,17 @@ class CurrentFaceAreaExpressionFunction: public QgsScopedExpressionFunction
           QgsGeometry geom = QgsMeshUtils::toGeometry( nativeMesh.face( faceIndex ), nativeMesh.vertices );
           if ( calc )
           {
-            double area = calc->measureArea( geom );
-            area = calc->convertAreaMeasurement( area, parent->areaUnits() );
-            return QVariant( area );
+            try
+            {
+              double area = calc->measureArea( geom );
+              area = calc->convertAreaMeasurement( area, parent->areaUnits() );
+              return QVariant( area );
+            }
+            catch ( QgsCsException & )
+            {
+              parent->setEvalErrorString( QObject::tr( "An error occurred while calculating area" ) );
+              return QVariant();
+            }
           }
           else
           {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4266,9 +4266,17 @@ static QVariant fcnGeomArea( const QVariantList &, const QgsExpressionContext *c
   QgsDistanceArea *calc = parent->geomCalculator();
   if ( calc )
   {
-    double area = calc->measureArea( f.geometry() );
-    area = calc->convertAreaMeasurement( area, parent->areaUnits() );
-    return QVariant( area );
+    try
+    {
+      double area = calc->measureArea( f.geometry() );
+      area = calc->convertAreaMeasurement( area, parent->areaUnits() );
+      return QVariant( area );
+    }
+    catch ( QgsCsException & )
+    {
+      parent->setEvalErrorString( QObject::tr( "An error occurred while calculating area" ) );
+      return QVariant();
+    }
   }
   else
   {
@@ -4293,9 +4301,17 @@ static QVariant fcnGeomLength( const QVariantList &, const QgsExpressionContext 
   QgsDistanceArea *calc = parent->geomCalculator();
   if ( calc )
   {
-    double len = calc->measureLength( f.geometry() );
-    len = calc->convertLengthMeasurement( len, parent->distanceUnits() );
-    return QVariant( len );
+    try
+    {
+      double len = calc->measureLength( f.geometry() );
+      len = calc->convertLengthMeasurement( len, parent->distanceUnits() );
+      return QVariant( len );
+    }
+    catch ( QgsCsException & )
+    {
+      parent->setEvalErrorString( QObject::tr( "An error occurred while calculating length" ) );
+      return QVariant();
+    }
   }
   else
   {
@@ -4310,9 +4326,17 @@ static QVariant fcnGeomPerimeter( const QVariantList &, const QgsExpressionConte
   QgsDistanceArea *calc = parent->geomCalculator();
   if ( calc )
   {
-    double len = calc->measurePerimeter( f.geometry() );
-    len = calc->convertLengthMeasurement( len, parent->distanceUnits() );
-    return QVariant( len );
+    try
+    {
+      double len = calc->measurePerimeter( f.geometry() );
+      len = calc->convertLengthMeasurement( len, parent->distanceUnits() );
+      return QVariant( len );
+    }
+    catch ( QgsCsException & )
+    {
+      parent->setEvalErrorString( QObject::tr( "An error occurred while calculating perimeter" ) );
+      return QVariant();
+    }
   }
   else
   {

--- a/src/core/gps/qgsgpslogger.cpp
+++ b/src/core/gps/qgsgpslogger.cpp
@@ -267,7 +267,16 @@ double QgsGpsLogger::totalTrackLength() const
 {
   QVector<QgsPointXY> points;
   QgsGeometry::convertPointList( mCaptureListWgs84, points );
-  return mDistanceCalculator.measureLine( points );
+  try
+  {
+    return mDistanceCalculator.measureLine( points );
+  }
+  catch ( QgsCsException & )
+  {
+    // TODO report errors to user
+    QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    return 0;
+  }
 }
 
 double QgsGpsLogger::trackDistanceFromStart() const
@@ -275,7 +284,16 @@ double QgsGpsLogger::trackDistanceFromStart() const
   if ( mCaptureListWgs84.empty() )
     return 0;
 
-  return mDistanceCalculator.measureLine( { QgsPointXY( mCaptureListWgs84.constFirst() ), QgsPointXY( mCaptureListWgs84.constLast() )} );
+  try
+  {
+    return mDistanceCalculator.measureLine( { QgsPointXY( mCaptureListWgs84.constFirst() ), QgsPointXY( mCaptureListWgs84.constLast() )} );
+  }
+  catch ( QgsCsException & )
+  {
+    // TODO report errors to user
+    QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    return 0;
+  }
 }
 
 QVariant QgsGpsLogger::componentValue( Qgis::GpsInformationComponent component ) const
@@ -313,7 +331,17 @@ QVariant QgsGpsLogger::componentValue( Qgis::GpsInformationComponent component )
       return lastTimestamp();
 
     case Qgis::GpsInformationComponent::TrackDistanceSinceLastPoint:
-      return mPreviousTrackPoint.isEmpty() ? QVariant() : distanceArea().measureLine( mPreviousTrackPoint, lastPosition() );
+      try
+      {
+        return mPreviousTrackPoint.isEmpty() ? QVariant() : distanceArea().measureLine( mPreviousTrackPoint, lastPosition() );
+      }
+      catch ( QgsCsException & )
+      {
+        // TODO report errors to user
+        QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+        return 0;
+      }
+
     case Qgis::GpsInformationComponent::TrackTimeSinceLastPoint:
       return mPreviousTrackPointTime.isValid() ? static_cast< double >( mPreviousTrackPointTime.msecsTo( lastTimestamp() ) ) / 1000 : QVariant();
   }

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -2007,9 +2007,18 @@ double QgsLayoutItemMapGrid::mapWidth() const
     da.setEllipsoid( mLayout->project()->ellipsoid() );
 
     const Qgis::DistanceUnit units = da.lengthUnits();
-    double measure = da.measureLine( QgsPointXY( mapExtent.xMinimum(), mapExtent.yMinimum() ),
-                                     QgsPointXY( mapExtent.xMaximum(), mapExtent.yMinimum() ) );
-    measure /= QgsUnitTypes::fromUnitToUnitFactor( distanceUnit, units );
+    double measure = 0;
+    try
+    {
+      measure = da.measureLine( QgsPointXY( mapExtent.xMinimum(), mapExtent.yMinimum() ),
+                                QgsPointXY( mapExtent.xMaximum(), mapExtent.yMinimum() ) );
+      measure /= QgsUnitTypes::fromUnitToUnitFactor( distanceUnit, units );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    }
     return measure;
   }
 }

--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -570,9 +570,18 @@ double QgsLayoutItemScaleBar::mapWidth() const
     da.setEllipsoid( mLayout->project()->ellipsoid() );
 
     const Qgis::DistanceUnit units = da.lengthUnits();
-    double measure = da.measureLine( QgsPointXY( mapExtent.xMinimum(), mapExtent.yMinimum() ),
-                                     QgsPointXY( mapExtent.xMaximum(), mapExtent.yMinimum() ) );
-    measure /= QgsUnitTypes::fromUnitToUnitFactor( mSettings.units(), units );
+    double measure = 0;
+    try
+    {
+      measure = da.measureLine( QgsPointXY( mapExtent.xMinimum(), mapExtent.yMinimum() ),
+                                QgsPointXY( mapExtent.xMaximum(), mapExtent.yMinimum() ) );
+      measure /= QgsUnitTypes::fromUnitToUnitFactor( mSettings.units(), units );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    }
     return measure;
   }
 }

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -320,43 +320,33 @@ double QgsDistanceArea::measureLine( const QVector<QgsPointXY> &points ) const
       return 0;
   }
 
-  try
+  if ( willUseEllipsoid() )
+    p1 = mCoordTransform.transform( points[0] );
+  else
+    p1 = points[0];
+
+  for ( QVector<QgsPointXY>::const_iterator i = points.constBegin(); i != points.constEnd(); ++i )
   {
     if ( willUseEllipsoid() )
-      p1 = mCoordTransform.transform( points[0] );
-    else
-      p1 = points[0];
-
-    for ( QVector<QgsPointXY>::const_iterator i = points.constBegin(); i != points.constEnd(); ++i )
     {
-      if ( willUseEllipsoid() )
-      {
-        p2 = mCoordTransform.transform( *i );
+      p2 = mCoordTransform.transform( *i );
 
-        double distance = 0;
-        double azimuth1 = 0;
-        double azimuth2 = 0;
-        geod_inverse( mGeod.get(), p1.y(), p1.x(), p2.y(), p2.x(), &distance, &azimuth1, &azimuth2 );
-        total += distance;
-      }
-      else
-      {
-        p2 = *i;
-        total += measureLine( p1, p2 );
-      }
-
-      p1 = p2;
+      double distance = 0;
+      double azimuth1 = 0;
+      double azimuth2 = 0;
+      geod_inverse( mGeod.get(), p1.y(), p1.x(), p2.y(), p2.x(), &distance, &azimuth1, &azimuth2 );
+      total += distance;
+    }
+    else
+    {
+      p2 = *i;
+      total += measureLine( p1, p2 );
     }
 
-    return total;
-  }
-  catch ( QgsCsException &cse )
-  {
-    Q_UNUSED( cse )
-    QgsMessageLog::logMessage( QObject::tr( "Caught a coordinate system exception while trying to transform a point. Unable to calculate line length." ) );
-    return 0.0;
+    p1 = p2;
   }
 
+  return total;
 }
 
 double QgsDistanceArea::measureLine( const QgsPointXY &p1, const QgsPointXY &p2 ) const
@@ -372,36 +362,28 @@ double QgsDistanceArea::measureLine( const QgsPointXY &p1, const QgsPointXY &p2 
       return 0;
   }
 
-  try
-  {
-    QgsPointXY pp1 = p1, pp2 = p2;
+  QgsPointXY pp1 = p1, pp2 = p2;
 
-    QgsDebugMsgLevel( QStringLiteral( "Measuring from %1 to %2" ).arg( p1.toString( 4 ), p2.toString( 4 ) ), 3 );
-    if ( willUseEllipsoid() )
-    {
-      QgsDebugMsgLevel( QStringLiteral( "Ellipsoidal calculations is enabled, using ellipsoid %1" ).arg( mEllipsoid ), 4 );
-      QgsDebugMsgLevel( QStringLiteral( "From proj4 : %1" ).arg( mCoordTransform.sourceCrs().toProj() ), 4 );
-      QgsDebugMsgLevel( QStringLiteral( "To   proj4 : %1" ).arg( mCoordTransform.destinationCrs().toProj() ), 4 );
-      pp1 = mCoordTransform.transform( p1 );
-      pp2 = mCoordTransform.transform( p2 );
-      QgsDebugMsgLevel( QStringLiteral( "New points are %1 and %2, calculating..." ).arg( pp1.toString( 4 ), pp2.toString( 4 ) ), 4 );
-
-      double azimuth1 = 0;
-      double azimuth2 = 0;
-      geod_inverse( mGeod.get(), pp1.y(), pp1.x(), pp2.y(), pp2.x(), &result, &azimuth1, &azimuth2 );
-    }
-    else
-    {
-      QgsDebugMsgLevel( QStringLiteral( "Cartesian calculation on canvas coordinates" ), 4 );
-      result = p2.distance( p1 );
-    }
-  }
-  catch ( QgsCsException &cse )
+  QgsDebugMsgLevel( QStringLiteral( "Measuring from %1 to %2" ).arg( p1.toString( 4 ), p2.toString( 4 ) ), 3 );
+  if ( willUseEllipsoid() )
   {
-    Q_UNUSED( cse )
-    QgsMessageLog::logMessage( QObject::tr( "Caught a coordinate system exception while trying to transform a point. Unable to calculate line length." ) );
-    result = 0.0;
+    QgsDebugMsgLevel( QStringLiteral( "Ellipsoidal calculations is enabled, using ellipsoid %1" ).arg( mEllipsoid ), 4 );
+    QgsDebugMsgLevel( QStringLiteral( "From proj4 : %1" ).arg( mCoordTransform.sourceCrs().toProj() ), 4 );
+    QgsDebugMsgLevel( QStringLiteral( "To   proj4 : %1" ).arg( mCoordTransform.destinationCrs().toProj() ), 4 );
+    pp1 = mCoordTransform.transform( p1 );
+    pp2 = mCoordTransform.transform( p2 );
+    QgsDebugMsgLevel( QStringLiteral( "New points are %1 and %2, calculating..." ).arg( pp1.toString( 4 ), pp2.toString( 4 ) ), 4 );
+
+    double azimuth1 = 0;
+    double azimuth2 = 0;
+    geod_inverse( mGeod.get(), pp1.y(), pp1.x(), pp2.y(), pp2.x(), &result, &azimuth1, &azimuth2 );
   }
+  else
+  {
+    QgsDebugMsgLevel( QStringLiteral( "Cartesian calculation on canvas coordinates" ), 4 );
+    result = p2.distance( p1 );
+  }
+
   QgsDebugMsgLevel( QStringLiteral( "The result was %1" ).arg( result ), 3 );
   return result;
 }
@@ -823,27 +805,18 @@ double QgsDistanceArea::measurePolygon( const QgsCurve *curve ) const
 
 double QgsDistanceArea::measurePolygon( const QVector<QgsPointXY> &points ) const
 {
-  try
+  if ( willUseEllipsoid() )
   {
-    if ( willUseEllipsoid() )
+    QVector<QgsPointXY> pts;
+    for ( QVector<QgsPointXY>::const_iterator i = points.constBegin(); i != points.constEnd(); ++i )
     {
-      QVector<QgsPointXY> pts;
-      for ( QVector<QgsPointXY>::const_iterator i = points.constBegin(); i != points.constEnd(); ++i )
-      {
-        pts.append( mCoordTransform.transform( *i ) );
-      }
-      return computePolygonArea( pts );
+      pts.append( mCoordTransform.transform( *i ) );
     }
-    else
-    {
-      return computePolygonArea( points );
-    }
+    return computePolygonArea( pts );
   }
-  catch ( QgsCsException &cse )
+  else
   {
-    Q_UNUSED( cse )
-    QgsMessageLog::logMessage( QObject::tr( "Caught a coordinate system exception while trying to transform a point. Unable to calculate polygon area." ) );
-    return 0.0;
+    return computePolygonArea( points );
   }
 }
 

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -148,8 +148,9 @@ class CORE_EXPORT QgsDistanceArea
      * \see measureLength()
      * \see measurePerimeter()
      * \see areaUnits()
+     * \throws QgsCsException if a transformation error occurs while calculating the area
      */
-    double measureArea( const QgsGeometry &geometry ) const;
+    double measureArea( const QgsGeometry &geometry ) const SIP_THROW( QgsCsException );
 
     /**
      * Measures the length of a geometry.
@@ -159,8 +160,9 @@ class CORE_EXPORT QgsDistanceArea
      * \see lengthUnits()
      * \see measureArea()
      * \see measurePerimeter()
+     * \throws QgsCsException if a transformation error occurs while calculating the length
      */
-    double measureLength( const QgsGeometry &geometry ) const;
+    double measureLength( const QgsGeometry &geometry ) const SIP_THROW( QgsCsException );
 
     /**
      * Measures the perimeter of a polygon geometry.
@@ -170,25 +172,28 @@ class CORE_EXPORT QgsDistanceArea
      * \see lengthUnits()
      * \see measureArea()
      * \see measurePerimeter()
+     * \throws QgsCsException if a transformation error occurs while calculating the perimeter
      */
-    double measurePerimeter( const QgsGeometry &geometry ) const;
+    double measurePerimeter( const QgsGeometry &geometry ) const SIP_THROW( QgsCsException );
 
     /**
      * Measures the length of a line with multiple segments.
      * \param points list of points in line
      * \returns length of line. The units for the returned length can be retrieved by calling lengthUnits().
+     * \throws QgsCsException if a transformation error occurs while calculating the length
      * \see lengthUnits()
      */
-    double measureLine( const QVector<QgsPointXY> &points ) const;
+    double measureLine( const QVector<QgsPointXY> &points ) const SIP_THROW( QgsCsException );
 
     /**
      * Measures the distance between two points.
      * \param p1 start of line
      * \param p2 end of line
      * \returns distance between points. The units for the returned distance can be retrieved by calling lengthUnits().
+     * \throws QgsCsException if a transformation error occurs while calculating the length
      * \see lengthUnits()
      */
-    double measureLine( const QgsPointXY &p1, const QgsPointXY &p2 ) const;
+    double measureLine( const QgsPointXY &p1, const QgsPointXY &p2 ) const SIP_THROW( QgsCsException );
 
     /**
      * Calculates the distance from one point with distance in meters and azimuth (direction)
@@ -219,8 +224,10 @@ class CORE_EXPORT QgsDistanceArea
 
     /**
      * Measures the area of the polygon described by a set of points.
+     *
+     * \throws QgsCsException if a transformation error occurs while calculating the area.
      */
-    double measurePolygon( const QVector<QgsPointXY> &points ) const;
+    double measurePolygon( const QVector<QgsPointXY> &points ) const SIP_THROW( QgsCsException );
 
     /**
      * Computes the bearing (in radians) between two points.

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -153,10 +153,20 @@ QgsTiledSceneRequest QgsTiledSceneLayerRenderer::createBaseRequest()
   const double maximumErrorPixels = context->convertToPainterUnits( mRenderer->maximumScreenError(), mRenderer->maximumScreenErrorUnit() );
   // calculate width in meters across the middle of the map
   const double mapYCenter = 0.5 * ( mapExtent.yMinimum() + mapExtent.yMaximum() );
-  const double mapWidthMeters = context->distanceArea().measureLine(
-                                  QgsPointXY( mapExtent.xMinimum(), mapYCenter ),
-                                  QgsPointXY( mapExtent.xMaximum(), mapYCenter )
-                                );
+  double mapWidthMeters = 0;
+  try
+  {
+    mapWidthMeters = context->distanceArea().measureLine(
+                       QgsPointXY( mapExtent.xMinimum(), mapYCenter ),
+                       QgsPointXY( mapExtent.xMaximum(), mapYCenter )
+                     );
+  }
+  catch ( QgsCsException & )
+  {
+    // TODO report errors to user
+    QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+  }
+
   const double mapMetersPerPixel = mapWidthMeters / context->outputSize().width();
   const double maximumErrorInMeters = maximumErrorPixels * mapMetersPerPixel;
 

--- a/src/gui/maptools/qgsmaptoolidentify.cpp
+++ b/src/gui/maptools/qgsmaptoolidentify.cpp
@@ -919,8 +919,18 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
   {
     const QgsAbstractGeometry *layerCrsGeom = layerCrsGeometry.constGet();
 
-    double dist = calc.measureLength( feature.geometry() );
-    dist = calc.convertLengthMeasurement( dist, displayDistanceUnits() );
+    double dist = 0;
+    try
+    {
+      dist = calc.measureLength( feature.geometry() );
+      dist = calc.convertLengthMeasurement( dist, displayDistanceUnits() );
+    }
+    catch ( QgsCsException & )
+    {
+      //TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating length" ) );
+    }
+
     QString str;
     if ( ellipsoid != geoNone() )
     {
@@ -975,8 +985,18 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
   }
   else if ( geometryType == Qgis::GeometryType::Polygon )
   {
-    double area = calc.measureArea( layerCrsGeometry );
-    area = calc.convertAreaMeasurement( area, displayAreaUnits() );
+    double area = 0;
+    try
+    {
+      area = calc.measureArea( layerCrsGeometry );
+      area = calc.convertAreaMeasurement( area, displayAreaUnits() );
+    }
+    catch ( QgsCsException & )
+    {
+      // TODO report errors to user
+      QgsDebugError( QStringLiteral( "An error occurred while calculating area" ) );
+    }
+
     QString str;
     if ( ellipsoid != geoNone() )
     {
@@ -989,8 +1009,17 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
 
     if ( ellipsoid != geoNone() )
     {
-      double perimeter = calc.measurePerimeter( layerCrsGeometry );
-      perimeter = calc.convertLengthMeasurement( perimeter, displayDistanceUnits() );
+      double perimeter = 0;
+      try
+      {
+        perimeter = calc.measurePerimeter( layerCrsGeometry );
+        perimeter = calc.convertLengthMeasurement( perimeter, displayDistanceUnits() );
+      }
+      catch ( QgsCsException & )
+      {
+        // TODO report errors to user
+        QgsDebugError( QStringLiteral( "An error occurred while calculating perimeter" ) );
+      }
       str = formatDistance( perimeter );
       derivedAttributes.insert( tr( "Perimeter (Ellipsoidal — %1)" ).arg( ellipsoid ), str );
     }


### PR DESCRIPTION
Instead of just silently return "0", which is misleading and can result in data corruption/incorrect analysis results. Better to be safe and force callers to handle transformation errors appropriately.

In this case we:

- raise QgsProcessingExceptions when the failed measurement is coming from a processing tool, so that the user is forced to deal with the issue and we aren't providing meaningless/misleading measurements
- report evaluation errors if the measurement is coming from a QGIS expression, so the user must appropriately handle the situation
- for all other cases we currently just write a console error and maintain the current behavior of treating the measurement length as 0. TODO notes have been added to handle this cases better.
