### PR TITLE
[TaskManager] Release "not started" semaphore on waitForFinished

### DIFF
--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -170,6 +170,7 @@ bool QgsTask::waitForFinished( int timeout )
 {
   // We wait the task to be started
   mNotStartedMutex.acquire();
+  mNotStartedMutex.release();
 
   bool rv = true;
   if ( mOverallStatus == Complete || mOverallStatus == Terminated )

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -902,6 +902,10 @@ void TestQgsTaskManager::waitForFinished()
   QCOMPARE( finishedTask->waitForFinished(), true );
   QCOMPARE( finishedTask->status(), QgsTask::Complete );
 
+  // check we can call waitForFinished several times
+  QCOMPARE( finishedTask->waitForFinished(), true );
+  QCOMPARE( finishedTask->status(), QgsTask::Complete );
+
   timerThread->quit();
 
   ProgressReportingTask *failedTask = new ProgressReportingTask();


### PR DESCRIPTION
If not, several call to waitForFinished would be blocking

I stumbled on this while working on #58798. It is not possible to call 2 times the same export when you set a legend filter because the 2 paint() method call would wait for the same HitMapTestTask to finished, and so you end up in a deadlock.

Even though I'm quite confident on the fix, I'd rather not backporting it regarding the criticity of task manager