### PR TITLE
[processing] Random points in polygons: fix NULL exp returning 1

### DIFF
--- a/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
@@ -255,7 +255,18 @@ QVariantMap QgsRandomPointsInPolygonsAlgorithm::processAlgorithm( const QVariant
     // Get data defined parameters
     int numberPointsForThisFeature = mNumPoints;
     if ( mDynamicNumPoints )
-      numberPointsForThisFeature = mNumPointsProperty.valueAsInt( expressionContext, numberPointsForThisFeature );
+    {
+      bool ok;
+      const int numPointsFromProperty { mNumPointsProperty.valueAsInt( expressionContext, numberPointsForThisFeature, &ok ) };
+      if ( ok )
+      {
+        numberPointsForThisFeature = numPointsFromProperty;
+      }
+      else
+      {
+        numberPointsForThisFeature = 0;
+      }
+    }
     desiredNumberOfPoints += numberPointsForThisFeature;
     int maxAttemptsForThisFeature = mMaxAttempts;
     if ( mDynamicMaxAttempts )

--- a/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
@@ -256,16 +256,7 @@ QVariantMap QgsRandomPointsInPolygonsAlgorithm::processAlgorithm( const QVariant
     int numberPointsForThisFeature = mNumPoints;
     if ( mDynamicNumPoints )
     {
-      bool ok;
-      const int numPointsFromProperty { mNumPointsProperty.valueAsInt( expressionContext, numberPointsForThisFeature, &ok ) };
-      if ( ok )
-      {
-        numberPointsForThisFeature = numPointsFromProperty;
-      }
-      else
-      {
-        numberPointsForThisFeature = 0;
-      }
+      numberPointsForThisFeature = mNumPointsProperty.valueAsInt( expressionContext, 0 );
     }
     desiredNumberOfPoints += numberPointsForThisFeature;
     int maxAttemptsForThisFeature = mMaxAttempts;


### PR DESCRIPTION
When POINTS_NUMBER is set to an expression and the expression evaluation returns an invalid value, set the value to 0 instead of 1 (which is logically the min value for the fixed number option).

Fix #58737
