### PR TITLE
add setCurrentNode to qgslayertreeview

### DIFF
--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -139,7 +139,7 @@ for mapping the view indexes through the view's proxy model to the source model.
 
     QModelIndex node2index( QgsLayerTreeNode *node ) const;
 %Docstring
-Returns proxy model index for a given node. If the node does not belong to the layer tree, the result is undefined
+Returns proxy model index for a given node. If the node does not belong to the layer tree, the result is undefined   
 
 Unlike :py:func:`QgsLayerTreeModel.node2index()`, calling this method correctly accounts
 for mapping the view indexes through the view's proxy model to the source model.
@@ -150,7 +150,7 @@ for mapping the view indexes through the view's proxy model to the source model.
 
     QModelIndex node2sourceIndex( QgsLayerTreeNode *node ) const;
 %Docstring
-Returns source model index for a given node. If the node does not belong to the layer tree, the result is undefined
+Returns source model index for a given node. If the node does not belong to the layer tree, the result is undefined  
 
 .. versionadded:: 3.18
 %End
@@ -233,15 +233,6 @@ Sets the currently selected ``layer``.
 If ``layer`` is ``None`` then all layers will be deselected.
 
 .. seealso:: :py:func:`currentLayer`
-%End
-
-    void setCurrentGroup( QgsLayerTreeGroup *group);
-%Docstring
-Sets the currently selected ``group``
-
-If ``group`` is ``None`` then all nodes will be deselected.
-
-.. versionadded:: 3.40
 %End
 
     QgsLayerTreeNode *currentNode() const;
@@ -381,7 +372,7 @@ Returns if valid layers should be hidden (i.e. only invalid layers are shown).
   public slots:
     void refreshLayerSymbology( const QString &layerId );
 %Docstring
-Force refresh of layer symbology. Normally not needed as the changes of layer's renderer are monitored by the model
+Force refresh of layer symbology. Normally not needed as the changes of layer's renderer are monitored by the model  
 %End
 
     void expandAllNodes();

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -215,6 +215,17 @@ Convenience methods which sets the visible state of the specified map ``layer``.
 .. versionadded:: 3.10
 %End
 
+    void setCurrentNode( QgsLayerTreeNode *node );
+%Docstring
+Sets the currently selected ``node``.
+
+If ``node`` is ``None`` then all nodes will be deselected.
+
+.. seealso:: :py:func:`currentNode`
+
+.. versionadded:: 3.40
+%End
+
     void setCurrentLayer( QgsMapLayer *layer );
 %Docstring
 Sets the currently selected ``layer``.
@@ -222,6 +233,15 @@ Sets the currently selected ``layer``.
 If ``layer`` is ``None`` then all layers will be deselected.
 
 .. seealso:: :py:func:`currentLayer`
+%End
+
+    void setCurrentGroup( QgsLayerTreeGroup *group);
+%Docstring
+Sets the currently selected ``group``
+
+If ``group`` is ``None`` then all nodes will be deselected.
+
+.. versionadded:: 3.40
 %End
 
     QgsLayerTreeNode *currentNode() const;

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -177,6 +177,11 @@ void QgsLayerTreeView::setCurrentLayer( QgsMapLayer *layer )
   setCurrentIndex( node2index( nodeLayer ) );
 }
 
+void QgsLayerTreeView::setCurrentGroup( QgsLayerTreeGroup *group )
+{
+  setCurrentNode( group );
+}
+
 void QgsLayerTreeView::setLayerVisible( QgsMapLayer *layer, bool visible )
 {
   if ( !layer )

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -174,7 +174,7 @@ void QgsLayerTreeView::setCurrentLayer( QgsMapLayer *layer )
   if ( !nodeLayer )
     return;
 
-  setCurrentIndex( node2index( nodeLayer ) );
+  setCurrentNode( nodeLayer );
 }
 
 void QgsLayerTreeView::setCurrentGroup( QgsLayerTreeGroup *group )

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -177,11 +177,6 @@ void QgsLayerTreeView::setCurrentLayer( QgsMapLayer *layer )
   setCurrentNode( nodeLayer );
 }
 
-void QgsLayerTreeView::setCurrentGroup( QgsLayerTreeGroup *group )
-{
-  setCurrentNode( group );
-}
-
 void QgsLayerTreeView::setLayerVisible( QgsMapLayer *layer, bool visible )
 {
   if ( !layer )

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -151,6 +151,17 @@ QgsMapLayer *QgsLayerTreeView::currentLayer() const
   return layerForIndex( currentIndex() );
 }
 
+void QgsLayerTreeView::setCurrentNode( QgsLayerTreeNode *node )
+{
+  if ( !node )
+  {
+    setCurrentIndex( QModelIndex() );
+    return;
+  }
+
+  setCurrentIndex( node2index( node ) );
+}   
+
 void QgsLayerTreeView::setCurrentLayer( QgsMapLayer *layer )
 {
   if ( !layer )

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -234,6 +234,16 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     void setLayerVisible( QgsMapLayer *layer, bool visible );
 
     /**
+     * Sets the currently selected \a node.
+     *
+     * If \a node is NULLPTR then all nodes will be deselected.
+     *
+     * \see currentNode()
+     * \since QGIS 3.40
+     */
+    void setCurrentNode( QgsLayerTreeNode *node );
+
+    /**
      * Sets the currently selected \a layer.
      *
      * If \a layer is NULLPTR then all layers will be deselected.

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -252,14 +252,6 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      */
     void setCurrentLayer( QgsMapLayer *layer );
 
-    /** 
-     * Sets the currently selected \a group
-     * 
-     * If \a group is NULLPTR then all nodes will be deselected.
-     * \since QGIS 3.40
-     */
-    void setCurrentGroup( QgsLayerTreeGroup *group);
-
     //! Gets current node. May be NULLPTR
     QgsLayerTreeNode *currentNode() const;
     //! Gets current group node. If a layer is current node, the function will return parent group. May be NULLPTR.

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -252,6 +252,14 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      */
     void setCurrentLayer( QgsMapLayer *layer );
 
+    /** 
+     * Sets the currently selected \a group
+     * 
+     * If \a group is NULLPTR then all nodes will be deselected.
+     * \since QGIS 3.40
+     */
+    void setCurrentGroup( QgsLayerTreeGroup *group);
+
     //! Gets current node. May be NULLPTR
     QgsLayerTreeNode *currentNode() const;
     //! Gets current group node. If a layer is current node, the function will return parent group. May be NULLPTR.


### PR DESCRIPTION
QgsLayerTreeView has a method (setCurrentLayer) for setting the QgsLayerNode as active in the tree by passing the layer to it.

There is no method for selecting groups the same way, even though the method setCurrentLayer finds the QgsLayerTreeNode and passes it to a function which selects the node.

2 new methods are added:

setCurrentNode - a general way of setting active nodes, which both setCurrentGroup and setCurrentLayer will call. Also, since a layerTreeView.selectedNodes() method returns selected nodes, it would make sense to have a method for selecting them as well.

setCurrentGroup - to have an exact way of setting active groups alongside active layers, even though maybe having setCurrentNode only would be ideal. Removing setCurrentLayer would not make sense now, so adding this as well.

Would close #47337
