### PR TITLE
Don't apply reset-to-zero step size logic in spin boxes when no special value text is set

### DIFF
--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -118,7 +118,7 @@ void QgsDoubleSpinBox::paintEvent( QPaintEvent *event )
 void QgsDoubleSpinBox::stepBy( int steps )
 {
   const bool wasNull = mShowClearButton && value() == clearValue();
-  if ( wasNull && minimum() < 0 && maximum() > 0 )
+  if ( wasNull && minimum() < 0 && maximum() > 0 && !( specialValueText().isEmpty() || specialValueText() == SPECIAL_TEXT_WHEN_EMPTY ) )
   {
     // value is currently null, and range allows both positive and negative numbers
     // in this case we DON'T do the default step, as that would add one step to the NULL value,

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -221,7 +221,7 @@ QValidator::State QgsSpinBox::validate( QString &input, int &pos ) const
 void QgsSpinBox::stepBy( int steps )
 {
   const bool wasNull = mShowClearButton && value() == clearValue();
-  if ( wasNull && minimum() < 0 && maximum() > 0 )
+  if ( wasNull && minimum() < 0 && maximum() > 0 && !( specialValueText().isEmpty() || specialValueText() == SPECIAL_TEXT_WHEN_EMPTY ) )
   {
     // value is currently null, and range allows both positive and negative numbers
     // in this case we DON'T do the default step, as that would add one step to the NULL value,

--- a/tests/src/gui/testqgsdoublespinbox.cpp
+++ b/tests/src/gui/testqgsdoublespinbox.cpp
@@ -181,6 +181,25 @@ void TestQgsDoubleSpinBox::step()
   QCOMPARE( spin.value(), -1000 );
   spin.stepBy( -1 );
   QCOMPARE( spin.value(), -1 );
+
+  // with clear value, but no special value text. In this case we should NOT reset to 0 when incrementing up from the clear value
+  spin.setSpecialValueText( QString() );
+  spin.setClearValue( -1000 );
+  spin.setValue( 0 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), 0 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), -999 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1000 );
 }
 
 QGSTEST_MAIN( TestQgsDoubleSpinBox )

--- a/tests/src/gui/testqgsspinbox.cpp
+++ b/tests/src/gui/testqgsspinbox.cpp
@@ -181,6 +181,25 @@ void TestQgsSpinBox::step()
   QCOMPARE( spin.value(), -1000 );
   spin.stepBy( -1 );
   QCOMPARE( spin.value(), -1 );
+
+  // with clear value, but no special value text. In this case we should NOT reset to 0 when incrementing up from the clear value
+  spin.setSpecialValueText( QString() );
+  spin.setClearValue( -1000 );
+  spin.setValue( 0 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), 1 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), 0 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  spin.stepBy( 1 );
+  QCOMPARE( spin.value(), -999 );
+  spin.clear();
+  QCOMPARE( spin.value(), -1000 );
+  spin.stepBy( -1 );
+  QCOMPARE( spin.value(), -1000 );
 }
 
 QGSTEST_MAIN( TestQgsSpinBox )


### PR DESCRIPTION
In these cases it's odd to jump from a negative number to a positive one when we're actually showing the numeric clear value

Followup 87d9a3e
