### PR TITLE
[digitizing] Advanced: fix distance input with non-meter CRSs

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -987,6 +987,15 @@ double QgsAdvancedDigitizingDockWidget::parseUserInput( const QString &inputValu
       value = result.toDouble( &ok );
     }
   }
+
+  if ( ok && type == Qgis::CadConstraintType::Distance )
+  {
+    const Qgis::DistanceUnit displayUnits { QgsProject::instance()->distanceUnits() };
+    // Convert to canvas units
+    const Qgis::DistanceUnit canvasUnits { mMapCanvas->mapSettings().mapUnits() };
+    value *= QgsUnitTypes::fromUnitToUnitFactor( displayUnits, canvasUnits );
+  }
+
   return value;
 }
 
@@ -2324,8 +2333,11 @@ QString QgsAdvancedDigitizingDockWidget::CadConstraint::displayValue() const
     }
     case Qgis::CadConstraintType::Distance:
     {
-      const Qgis::DistanceUnit units { QgsProject::instance()->distanceUnits() };
-      return QgsDistanceArea::formatDistance( mValue, mPrecision, units, true );
+      const Qgis::DistanceUnit displayUnits { QgsProject::instance()->distanceUnits() };
+      // Convert from canvas units
+      const Qgis::DistanceUnit canvasUnits { mMapCanvas->mapSettings().mapUnits() };
+      const double value { QgsUnitTypes::fromUnitToUnitFactor( canvasUnits, displayUnits ) *mValue };
+      return QgsDistanceArea::formatDistance( value, mPrecision, displayUnits, true );
     }
     case Qgis::CadConstraintType::Generic:
     case Qgis::CadConstraintType::ZValue:

--- a/tests/src/gui/testqgsadvanceddigitizingdockwidget.cpp
+++ b/tests/src/gui/testqgsadvanceddigitizingdockwidget.cpp
@@ -119,16 +119,24 @@ void TestQgsAdvancedDigitizingDockWidget::parseUserInput()
   QgsProject::instance()->setDistanceUnits( Qgis::DistanceUnit::NauticalMiles );
 
   result = widget.parseUserInput( QStringLiteral( "120.123" ), Qgis::CadConstraintType::Distance, ok );
-  QCOMPARE( result,  120.123 );
+  QCOMPARE( result, 120.123 );
   QVERIFY( ok );
 
   result = widget.parseUserInput( QStringLiteral( "120.123 NM" ), Qgis::CadConstraintType::Distance, ok );
-  QCOMPARE( result,  120.123 );
+  QCOMPARE( result, 120.123 );
   QVERIFY( ok );
 
   result = widget.parseUserInput( QStringLiteral( "120.123NM" ), Qgis::CadConstraintType::Distance, ok );
   QCOMPARE( result,  120.123 );
   QVERIFY( ok );
+
+  // Set a CRS using feet as units
+  QgsProject::instance()->setDistanceUnits( Qgis::DistanceUnit::Meters );
+  widget.mMapCanvas->mapSettings().setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3739" ) ) );
+  result = widget.parseUserInput( QStringLiteral( "100" ), Qgis::CadConstraintType::Distance, ok );
+  QCOMPARE( result, 100.0 * QgsUnitTypes::fromUnitToUnitFactor( Qgis::DistanceUnit::Meters, Qgis::DistanceUnit::FeetUSSurvey ) );
+  QVERIFY( ok );
+
 
 }
 


### PR DESCRIPTION
Always internally store the distance in canvas's CRS units, transform for display.

Fix #58620 where the CRS units are US Feet.
