### PR TITLE
fix .dbf fields allowed length and num

### DIFF
--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -35,6 +35,20 @@
 #include <QFileDialog>
 #include <QMessageBox>
 
+namespace
+{
+  // ESRI shapefile field width specification is taken from here
+  // https://webhelp.esri.com/arcgisdesktop/9.3/index.cfm?TopicName=Geoprocessing%20considerations%20for%20shapefile%20output
+
+  constexpr int ESRI_SHPF_TEXT_MAX_WIDTH_INCLUSIVE = 254;
+  constexpr int ESRI_SHPF_SHORT_INTEGER_MAX_WIDTH_INCLUSIVE = 4;
+  // constexpr int ESRI_SHPF_LONG_INTEGER_MAX_WIDTH_INCLUSIVE = 9;
+  // constexpr int ESRI_SHPF_FLOAT_MAX_WIDTH_INCLUSIVE = 13;
+  constexpr int ESRI_SHPF_DOUBLE_MAX_WIDTH_INCLUSIVE = 13;
+  constexpr int ESRI_SHPF_DATE_MAX_WIDTH_INCLUSIVE = 8;
+  constexpr int ESRI_SHPF_MAX_FIELD_NUM = 255;
+}
+
 QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
 {
@@ -57,9 +71,6 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
   mTypeBox->addItem( QgsFields::iconForFieldType( QMetaType::Type::Double ), QgsVariantUtils::typeToDisplayString( QMetaType::Type::Double ), "Real" );
   mTypeBox->addItem( QgsFields::iconForFieldType( QMetaType::Type::QDate ), QgsVariantUtils::typeToDisplayString( QMetaType::Type::QDate ), "Date" );
 
-  mWidth->setValidator( new QIntValidator( 1, 255, this ) );
-  mPrecision->setValidator( new QIntValidator( 0, 15, this ) );
-
   const Qgis::WkbType geomTypes[] =
   {
     Qgis::WkbType::NoGeometry,
@@ -76,6 +87,7 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
   mOkButton = buttonBox->button( QDialogButtonBox::Ok );
   mOkButton->setEnabled( false );
 
+  // (?) Create ENUM for formats?
   mFileFormatComboBox->addItem( tr( "ESRI Shapefile" ), "ESRI Shapefile" );
 #if 0
   // Disabled until provider properly supports editing the created file formats
@@ -94,6 +106,16 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
 
   mFileFormatComboBox->setCurrentIndex( 0 );
 
+  mPrecision->setMinimum( 1 );
+  mPrecision->setClearValue( 6 );
+  mPrecision->setMaximum( 15 );
+  mPrecision->setExpressionsEnabled( false );
+
+  mWidth->setMinimum( 1 );
+  mWidth->setExpressionsEnabled( false );
+
+  mTypeBox->setCurrentIndex( 0 );
+
   mFileEncoding->addItems( QgsVectorDataProvider::availableEncodings() );
 
   // Use default encoding if none supplied
@@ -109,7 +131,8 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
   }
   mFileEncoding->setCurrentIndex( encindex );
 
-  mAttributeView->addTopLevelItem( new QTreeWidgetItem( QStringList() << QStringLiteral( "id" ) << QStringLiteral( "Integer" ) << QStringLiteral( "10" ) << QString() ) );
+  QString firstItemLength = QString::number( ESRI_SHPF_SHORT_INTEGER_MAX_WIDTH_INCLUSIVE );
+  mAttributeView->addTopLevelItem( new QTreeWidgetItem( QStringList() << QStringLiteral( "id" ) << QStringLiteral( "Integer" ) << firstItemLength << QString() ) );
   connect( mNameEdit, &QLineEdit::textChanged, this, &QgsNewVectorLayerDialog::nameChanged );
   connect( mAttributeView, &QTreeWidget::itemSelectionChanged, this, &QgsNewVectorLayerDialog::selectionChanged );
   connect( mGeometryTypeBox, static_cast<void( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [ = ]( int )
@@ -150,36 +173,9 @@ void QgsNewVectorLayerDialog::mFileFormatComboBox_currentIndexChanged( int index
 void QgsNewVectorLayerDialog::mTypeBox_currentIndexChanged( int index )
 {
   // FIXME: sync with providers/ogr/qgsogrprovider.cpp
-  switch ( index )
-  {
-    case 0: // Text data
-      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 255 )
-        mWidth->setText( QStringLiteral( "80" ) );
-      mPrecision->setEnabled( false );
-      mWidth->setValidator( new QIntValidator( 1, 255, this ) );
-      break;
 
-    case 1: // Whole number
-      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 10 )
-        mWidth->setText( QStringLiteral( "10" ) );
-      mPrecision->setEnabled( false );
-      mWidth->setValidator( new QIntValidator( 1, 10, this ) );
-      break;
-
-    case 2: // Decimal number
-      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 20 )
-        mWidth->setText( QStringLiteral( "20" ) );
-      if ( mPrecision->text().toInt() < 1 || mPrecision->text().toInt() > 15 )
-        mPrecision->setText( QStringLiteral( "6" ) );
-
-      mPrecision->setEnabled( true );
-      mWidth->setValidator( new QIntValidator( 1, 20, this ) );
-      break;
-
-    default:
-      QgsDebugError( QStringLiteral( "unexpected index" ) );
-      break;
-  }
+  if ( mFileFormatComboBox->currentText() == tr( "ESRI Shapefile" ) )
+    mTypeBox_currentIndexChanged_formatShapeESRI( index );
 }
 
 Qgis::WkbType QgsNewVectorLayerDialog::selectedType() const
@@ -289,6 +285,44 @@ void QgsNewVectorLayerDialog::moveFieldsDown()
   mAttributeView->setCurrentIndex( mAttributeView->model()->index( currentRow + 1, 0 ) );
 }
 
+void QgsNewVectorLayerDialog::mTypeBox_currentIndexChanged_formatShapeESRI( int index )
+{
+  switch ( index )
+  {
+    case 0: // Text data
+      mWidth->setMaximum( ESRI_SHPF_TEXT_MAX_WIDTH_INCLUSIVE );
+      mWidth->setClearValue( 80 );
+
+      mPrecision->setEnabled( false );
+      break;
+
+    case 1: // Whole number
+      mWidth->setMaximum( ESRI_SHPF_SHORT_INTEGER_MAX_WIDTH_INCLUSIVE );
+      mWidth->setClearValueMode( QgsSpinBox::ClearValueMode::MaximumValue );
+
+      mPrecision->setEnabled( false );
+      break;
+
+    case 2: // Decimal number
+      mWidth->setMaximum( ESRI_SHPF_DOUBLE_MAX_WIDTH_INCLUSIVE );
+      mWidth->setClearValueMode( QgsSpinBox::ClearValueMode::MaximumValue );
+
+      mPrecision->setEnabled( true );
+      break;
+
+    case 3: // Date
+      mWidth->setMaximum( ESRI_SHPF_DATE_MAX_WIDTH_INCLUSIVE );
+      mWidth->setClearValueMode( QgsSpinBox::ClearValueMode::MaximumValue );
+
+      mPrecision->setEnabled( false );
+      break;
+
+    default:
+      QgsDebugError( QStringLiteral( "unexpected index (ESRI format)" ) );
+      break;
+  }
+}
+
 QString QgsNewVectorLayerDialog::filename() const
 {
   return mFileName->filePath();
@@ -301,7 +335,10 @@ void QgsNewVectorLayerDialog::setFilename( const QString &filename )
 
 void QgsNewVectorLayerDialog::checkOk()
 {
-  const bool ok = ( !mFileName->filePath().isEmpty() && mAttributeView->topLevelItemCount() > 0 && mGeometryTypeBox->currentIndex() != -1 );
+  bool ok = ( !mFileName->filePath().isEmpty() && mAttributeView->topLevelItemCount() > 0 && mGeometryTypeBox->currentIndex() != -1 );
+  if ( mFileFormatComboBox->currentText() == tr( "ESRI Shapefile" ) )
+    ok = ok && ( mAttributeView->topLevelItemCount() < ESRI_SHPF_MAX_FIELD_NUM ) ;
+
   mOkButton->setEnabled( ok );
 }
 

--- a/src/gui/qgsnewvectorlayerdialog.h
+++ b/src/gui/qgsnewvectorlayerdialog.h
@@ -129,6 +129,9 @@ class GUI_EXPORT QgsNewVectorLayerDialog: public QDialog, private Ui::QgsNewVect
     void moveFieldsDown();
 
   private:
+    void mTypeBox_currentIndexChanged_formatShapeESRI( int index );
+
+  private:
     QPushButton *mOkButton = nullptr;
 
     void updateExtension();

--- a/src/ui/qgsnewvectorlayerdialogbase.ui
+++ b/src/ui/qgsnewvectorlayerdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>867</width>
-    <height>993</height>
+    <width>712</width>
+    <height>573</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,150 +17,63 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout">
-   <item row="11" column="0" colspan="3">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Fields List</string>
-     </property>
-     <layout class="QGridLayout" columnstretch="1,0,0,0">
-      <item row="3" column="0">
-       <spacer name="spacer">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>121</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="1">
-       <widget class="QToolButton" name="mRemoveAttributeButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Delete selected field</string>
-        </property>
-        <property name="text">
-         <string>Remove Field</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../images/images.qrc">
-          <normaloff>:/images/themes/default/mActionDeleteAttribute.svg</normaloff>:/images/themes/default/mActionDeleteAttribute.svg</iconset>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
-       <widget class="QTreeWidget" name="mAttributeView">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="alternatingRowColors">
-         <bool>true</bool>
-        </property>
-        <property name="rootIsDecorated">
-         <bool>false</bool>
-        </property>
-        <property name="columnCount">
-         <number>4</number>
-        </property>
-        <column>
-         <property name="text">
-          <string>Name</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Type</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Length</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Precision</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <layout class="QVBoxLayout" name="pushBtnBox_3" stretch="0,0,1">
-        <property name="spacing">
-         <number>4</number>
-        </property>
-        <item>
-         <widget class="QPushButton" name="mButtonUp">
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Move up</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mActionArrowUp.svg</normaloff>:/images/themes/default/mActionArrowUp.svg</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="mButtonDown">
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Move down</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mActionArrowDown.svg</normaloff>:/images/themes/default/mActionArrowDown.svg</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="10" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>New Field</string>
      </property>
      <layout class="QGridLayout">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QgsSpinBox" name="mWidth">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>254</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Precision</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsSpinBox" name="mPrecision">
+          <property name="maximum">
+           <number>254</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="textLabel1">
         <property name="text">
@@ -171,50 +84,11 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1" colspan="4">
-       <widget class="QLineEdit" name="mNameEdit"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel2">
-        <property name="text">
-         <string>Type</string>
-        </property>
-        <property name="buddy">
-         <cstring>mTypeBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="4">
-       <widget class="QComboBox" name="mTypeBox"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Length</string>
-        </property>
-        <property name="buddy">
-         <cstring>mWidth</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QLineEdit" name="mWidth"/>
-      </item>
-      <item row="2" column="3">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Precision</string>
-        </property>
-        <property name="buddy">
-         <cstring>mPrecision</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <widget class="QLineEdit" name="mPrecision"/>
-      </item>
-      <item row="4" column="4">
+      <item row="3" column="2">
        <widget class="QToolButton" name="mAddAttributeButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -225,7 +99,7 @@
          <string>Add field to list</string>
         </property>
         <property name="layoutDirection">
-         <enum>Qt::LayoutDirection::LeftToRight</enum>
+         <enum>Qt::LeftToRight</enum>
         </property>
         <property name="text">
          <string>Add to Fields List</string>
@@ -235,14 +109,17 @@
           <normaloff>:/images/themes/default/mActionNewAttribute.svg</normaloff>:/images/themes/default/mActionNewAttribute.svg</iconset>
         </property>
         <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
+         <enum>Qt::ToolButtonTextBesideIcon</enum>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="4">
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="mNameEdit"/>
+      </item>
+      <item row="8" column="0" colspan="5">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -251,6 +128,19 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="1" column="2">
+       <widget class="QComboBox" name="mTypeBox"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="textLabel2">
+        <property name="text">
+         <string>Type</string>
+        </property>
+        <property name="buddy">
+         <cstring>mTypeBox</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -360,7 +250,7 @@
         </size>
        </property>
        <property name="focusPolicy">
-        <enum>Qt::FocusPolicy::StrongFocus</enum>
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>
@@ -405,12 +295,147 @@
    </item>
    <item row="13" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Fields List</string>
+     </property>
+     <layout class="QGridLayout" columnstretch="1,0,0,0">
+      <item row="3" column="0">
+       <spacer name="spacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>121</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="1">
+       <widget class="QToolButton" name="mRemoveAttributeButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Delete selected field</string>
+        </property>
+        <property name="text">
+         <string>Remove Field</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionDeleteAttribute.svg</normaloff>:/images/themes/default/mActionDeleteAttribute.svg</iconset>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextBesideIcon</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QTreeWidget" name="mAttributeView">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="columnCount">
+         <number>4</number>
+        </property>
+        <column>
+         <property name="text">
+          <string>Name</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Type</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Length</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Precision</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <layout class="QVBoxLayout" name="pushBtnBox_3" stretch="0,0,1">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="mButtonUp">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Move up</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionArrowUp.svg</normaloff>:/images/themes/default/mActionArrowUp.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="mButtonDown">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Move down</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionArrowDown.svg</normaloff>:/images/themes/default/mActionArrowDown.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -418,16 +443,21 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">qgsprojectionselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -438,17 +468,13 @@
   <tabstop>mGeometryWithZRadioButton</tabstop>
   <tabstop>mGeometryWithMRadioButton</tabstop>
   <tabstop>mCrsSelector</tabstop>
-  <tabstop>mNameEdit</tabstop>
-  <tabstop>mTypeBox</tabstop>
-  <tabstop>mWidth</tabstop>
-  <tabstop>mPrecision</tabstop>
-  <tabstop>mAddAttributeButton</tabstop>
   <tabstop>mAttributeView</tabstop>
   <tabstop>mButtonUp</tabstop>
   <tabstop>mButtonDown</tabstop>
   <tabstop>mRemoveAttributeButton</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
## Description

Fix dbf-format allowed field width and maximum number of fields 

1. Shapefile format is using dbf-tables to store geometry attributes, which, according to specification, has a set number of max fields and each field has a max width, depending on its type. Width numbers and max number are taken from here:

    https://webhelp.esri.com/arcgisdesktop/9.3/index.cfm?TopicName=Geoprocessing%20considerations%20for%20shapefile%20output

    Thus in the shapefile layer creation menu width-text-edit field changed to int spinbox and it would have it's max value changed according to chosen field type.

    Origin version
    ![qgis_shapefile_dlg_origin](https://github.com/user-attachments/assets/e1bd7b04-4859-4b76-9aa0-6f9a7d6de8c6)

    Fix version
    ![image](https://github.com/user-attachments/assets/1890b645-f5b5-4c8f-b965-f723023fa022)

2. It may be advised to double-check width-values since dbf has several versions. Here ESRI was chosen as the first guideline, but there still may be nuances, which were not understood/confused/interpreted incorrectly during our research and fix
