### PR TITLE
Handle wrap mode in calltips

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -366,6 +366,17 @@ Convenience function to set the selection using linear indexes
 .. versionadded:: 3.36
 %End
 
+    virtual void callTip();
+
+    int wrapPosition( int line = -1 );
+%Docstring
+Returns the linear position of the start of the last wrapped part for the specified line, or
+for the current line if line = -1
+If wrapping is disabled, returns -1 instead
+
+.. versionadded:: 3.42
+%End
+
   public slots:
 
     void runCommand( const QString &command, bool skipHistory = false );

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -374,7 +374,7 @@ Returns the linear position of the start of the last wrapped part for the specif
 for the current line if line = -1
 If wrapping is disabled, returns -1 instead
 
-.. versionadded:: 3.42
+.. versionadded:: 3.40
 %End
 
   public slots:

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -366,6 +366,17 @@ Convenience function to set the selection using linear indexes
 .. versionadded:: 3.36
 %End
 
+    virtual void callTip();
+
+    int wrapPosition( int line = -1 );
+%Docstring
+Returns the linear position of the start of the last wrapped part for the specified line, or
+for the current line if line = -1
+If wrapping is disabled, returns -1 instead
+
+.. versionadded:: 3.42
+%End
+
   public slots:
 
     void runCommand( const QString &command, bool skipHistory = false );

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -374,7 +374,7 @@ Returns the linear position of the start of the last wrapped part for the specif
 for the current line if line = -1
 If wrapping is disabled, returns -1 instead
 
-.. versionadded:: 3.42
+.. versionadded:: 3.40
 %End
 
   public slots:

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -407,6 +407,18 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void setLinearSelection( int start, int end );
 
+    // Override QsciScintilla::callTip to handle wrapping
+    virtual void callTip() override;
+
+    /**
+     * Returns the linear position of the start of the last wrapped part for the specified line, or
+     * for the current line if line = -1
+     * If wrapping is disabled, returns -1 instead
+     *
+     * \since QGIS 3.42
+     */
+    int wrapPosition( int line = -1 );
+
   public slots:
 
     /**
@@ -633,6 +645,7 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     bool readHistoryFile();
     void syncSoftHistory();
     void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
+    char getCharacter( int &pos ) const;
 
     QString mWidgetTitle;
     bool mMargin = false;

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -415,7 +415,7 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      * for the current line if line = -1
      * If wrapping is disabled, returns -1 instead
      *
-     * \since QGIS 3.42
+     * \since QGIS 3.40
      */
     int wrapPosition( int line = -1 );
 

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -236,17 +236,6 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
   bool autoSurround = settings.value( QStringLiteral( "/pythonConsole/autoSurround" ), true ).toBool();
   bool autoInsertImport = settings.value( QStringLiteral( "/pythonConsole/autoInsertImport" ), false ).toBool();
 
-  // Update calltips when cursor position changes with left and right keys
-  if ( event->key() == Qt::Key_Left  ||
-       event->key() == Qt::Key_Right ||
-       event->key() == Qt::Key_Up ||
-       event->key() == Qt::Key_Down )
-  {
-    QgsCodeEditor::keyPressEvent( event );
-    callTip();
-    return;
-  }
-
   // Get entered text and cursor position
   const QString eText = event->text();
   int line, column;
@@ -322,14 +311,13 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
           setSelection( line, column - 1, line, column + 1 );
           removeSelectedText();
           event->accept();
+          // Update calltips (cursor position has changed)
+          callTip();
         }
         else
         {
           QgsCodeEditor::keyPressEvent( event );
         }
-
-        // Update calltips (cursor position has changed)
-        callTip();
         return;
       }
 


### PR DESCRIPTION
- Fix #58720

## Description

Fix the call tips in `QgsCodeEditor` to handle word wrap.
When wrap mode is enabled (in the python console or expression editor for instance), and the current line is wrapped, the call tips no longer hides the text being typed.

### In the Expression Editor
![fix_calltips](https://github.com/user-attachments/assets/1f537224-0c18-427d-b00a-64960ea29a28)

### In the Python Console
![fix_calltips_console](https://github.com/user-attachments/assets/9b7c611b-cb48-4617-adfa-a1911334dc1b)
