### PR TITLE
Quantized Mesh fixes

### DIFF
--- a/src/3d/terrain/qgsdemterraingenerator.cpp
+++ b/src/3d/terrain/qgsdemterraingenerator.cpp
@@ -125,7 +125,7 @@ void QgsDemTerrainGenerator::setExtent( const QgsRectangle &extent )
 void QgsDemTerrainGenerator::updateGenerator()
 {
   QgsRasterLayer *dem = layer();
-  if ( dem )
+  if ( dem && mCrs.isValid() )
   {
     mTerrainTilingScheme = QgsTilingScheme( mExtent, mCrs );
     delete mHeightMapGenerator;

--- a/src/3d/terrain/qgsdemterraingenerator.h
+++ b/src/3d/terrain/qgsdemterraingenerator.h
@@ -49,6 +49,7 @@ class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator
 
     //! Sets CRS of the terrain
     void setCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
+    QgsCoordinateReferenceSystem crs() const override { return mCrs; }
 
     //! Sets resolution of the generator (how many elevation samples on one side of a terrain tile)
     void setResolution( int resolution ) { mResolution = resolution; updateGenerator(); }

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -146,13 +146,6 @@ void QgsFlatTerrainGenerator::setExtent( const QgsRectangle &extent )
 
 void QgsFlatTerrainGenerator::updateTilingScheme()
 {
-  if ( mExtent.isNull() )
-  {
-    mTerrainTilingScheme = QgsTilingScheme();
-  }
-  else
-  {
-    // the real extent will be a square where the given extent fully fits
-    mTerrainTilingScheme = QgsTilingScheme( mExtent, mCrs );
-  }
+  // the real extent will be a square where the given extent fully fits
+  mTerrainTilingScheme = QgsTilingScheme( mExtent, mCrs );
 }

--- a/src/3d/terrain/qgsflatterraingenerator.h
+++ b/src/3d/terrain/qgsflatterraingenerator.h
@@ -68,7 +68,7 @@ class _3D_EXPORT QgsFlatTerrainGenerator : public QgsTerrainGenerator
     //! Sets CRS of the terrain
     void setCrs( const QgsCoordinateReferenceSystem &crs );
     //! Returns CRS of the terrain
-    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+    QgsCoordinateReferenceSystem crs() const override { return mCrs; }
 
   private:
 

--- a/src/3d/terrain/qgsonlineterraingenerator.h
+++ b/src/3d/terrain/qgsonlineterraingenerator.h
@@ -44,7 +44,7 @@ class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
     //! Sets CRS of the terrain
     void setCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
     //! Returns CRS of the terrain
-    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+    QgsCoordinateReferenceSystem crs() const override { return mCrs; }
 
     //! Sets resolution of the generator (how many elevation samples on one side of a terrain tile)
     void setResolution( int resolution ) { mResolution = resolution; updateGenerator(); }

--- a/src/3d/terrain/qgsquantizedmeshterraingenerator.cpp
+++ b/src/3d/terrain/qgsquantizedmeshterraingenerator.cpp
@@ -225,6 +225,11 @@ QgsTerrainGenerator::Type QgsQuantizedMeshTerrainGenerator::type() const
   return QgsTerrainGenerator::QuantizedMesh;
 }
 
+void QgsQuantizedMeshTerrainGenerator::setExtent( const QgsRectangle &extent )
+{
+  mMapExtent = extent;
+}
+
 QgsRectangle QgsQuantizedMeshTerrainGenerator::rootChunkExtent() const
 {
   return mMetadata->mBoundingVolume.bounds().toRectangle();
@@ -303,6 +308,8 @@ QVector<QgsChunkNode *> QgsQuantizedMeshTerrainGenerator::createChildren( QgsChu
 
     QgsTileMatrix zoomedTileMatrix = QgsTileMatrix::fromTileMatrix( tile.zoomLevel(), mMetadata->mTileMatrix );
     QgsRectangle extent2d = mTileCrsToMapCrs.transform( zoomedTileMatrix.tileExtent( tile ) );
+    if ( !extent2d.intersects( mMapExtent ) )
+      continue; // Don't render terrain inside layer extent, but outside map extent
     Q_ASSERT( mTerrain );
     QgsVector3D corner1 = mTerrain->mapSettings()->mapToWorldCoordinates(
     {extent2d.xMinimum(), extent2d.yMinimum(), mMetadata->dummyZRange.lower()} );

--- a/src/3d/terrain/qgsquantizedmeshterraingenerator.cpp
+++ b/src/3d/terrain/qgsquantizedmeshterraingenerator.cpp
@@ -307,14 +307,15 @@ QVector<QgsChunkNode *> QgsQuantizedMeshTerrainGenerator::createChildren( QgsChu
       continue;
 
     QgsTileMatrix zoomedTileMatrix = QgsTileMatrix::fromTileMatrix( tile.zoomLevel(), mMetadata->mTileMatrix );
-    QgsRectangle extent2d = mTileCrsToMapCrs.transform( zoomedTileMatrix.tileExtent( tile ) );
+    QgsRectangle extent2d = zoomedTileMatrix.tileExtent( tile );
     if ( !extent2d.intersects( mMapExtent ) )
       continue; // Don't render terrain inside layer extent, but outside map extent
     Q_ASSERT( mTerrain );
+    QgsRectangle mapExtent2d = mTileCrsToMapCrs.transform( extent2d );
     QgsVector3D corner1 = mTerrain->mapSettings()->mapToWorldCoordinates(
-    {extent2d.xMinimum(), extent2d.yMinimum(), mMetadata->dummyZRange.lower()} );
+    {mapExtent2d.xMinimum(), mapExtent2d.yMinimum(), mMetadata->dummyZRange.lower()} );
     QgsVector3D corner2 = mTerrain->mapSettings()->mapToWorldCoordinates(
-    {extent2d.xMaximum(), extent2d.yMaximum(), mMetadata->dummyZRange.upper()} );
+    {mapExtent2d.xMaximum(), mapExtent2d.yMaximum(), mMetadata->dummyZRange.upper()} );
     children.push_back(
       new QgsChunkNode(
         childId,

--- a/src/3d/terrain/qgsquantizedmeshterraingenerator.h
+++ b/src/3d/terrain/qgsquantizedmeshterraingenerator.h
@@ -18,6 +18,7 @@
 #include "qgschunknode_p.h"
 #include "qgscoordinatetransform.h"
 #include "qgsmaplayerref.h"
+#include "qgsrectangle.h"
 #include "qgsterrainentity_p.h"
 #include "qgsterraingenerator.h"
 #include "qgsquantizedmeshdataprovider.h"
@@ -41,6 +42,7 @@ class _3D_EXPORT QgsQuantizedMeshTerrainGenerator : public QgsTerrainGenerator
     virtual void setTerrain( QgsTerrainEntity *t ) override;
     virtual QgsTerrainGenerator *clone() const override SIP_FACTORY;
     virtual QgsTerrainGenerator::Type type() const override;
+    virtual void setExtent( const QgsRectangle &extent ) override;
     virtual QgsRectangle rootChunkExtent() const override;
     virtual float rootChunkError( const Qgs3DMapSettings &map ) const override;
     virtual void rootChunkHeightRange( float &hMin, float &hMax ) const override;
@@ -67,6 +69,7 @@ class _3D_EXPORT QgsQuantizedMeshTerrainGenerator : public QgsTerrainGenerator
     std::optional<QgsQuantizedMeshMetadata> mMetadata;
     QgsCoordinateTransform mTileCrsToMapCrs;
     QgsTiledSceneIndex mIndex;
+    QgsRectangle mMapExtent;
 
     QgsQuantizedMeshTerrainGenerator( QgsMapLayerRef layerRef, const QgsQuantizedMeshMetadata &metadata );
     QgsTileXYZ nodeIdToTile( QgsChunkNodeId nodeId ) const;

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -107,7 +107,7 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsQuadtreeChunkLoaderFactory
     const QgsTilingScheme &tilingScheme() const { return mTerrainTilingScheme; }
 
     //! Returns CRS of the terrain
-    QgsCoordinateReferenceSystem crs() const { return mTerrainTilingScheme.crs(); }
+    virtual QgsCoordinateReferenceSystem crs() const { return mTerrainTilingScheme.crs(); }
 
     //! Returns whether the terrain generator is valid
     bool isValid() const;

--- a/src/core/tiledscene/qgsquantizedmeshdataprovider.cpp
+++ b/src/core/tiledscene/qgsquantizedmeshdataprovider.cpp
@@ -86,7 +86,8 @@ QgsQuantizedMeshMetadata::QgsQuantizedMeshMetadata(
   QgsSetRequestInitiatorClass( requestData,
                                QStringLiteral( "QgsQuantizedMeshDataProvider" ) );
   QgsBlockingNetworkRequest request;
-  request.setAuthCfg( mAuthCfg );
+  if ( !mAuthCfg.isEmpty() )
+    request.setAuthCfg( mAuthCfg );
   auto respCode = request.get( requestData );
   if ( respCode != QgsBlockingNetworkRequest::ErrorCode::NoError )
   {
@@ -413,7 +414,8 @@ QByteArray QgsQuantizedMeshIndex::fetchContent( const QString &uri,
   requestData.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
   requestData.setRawHeader( "Accept", "application/vnd.quantized-mesh,application/octet-stream;q=0.9" );
   mMetadata.mHeaders.updateNetworkRequest( requestData );
-  QgsApplication::authManager()->updateNetworkRequest( requestData, mMetadata.mAuthCfg );
+  if ( !mMetadata.mAuthCfg.isEmpty() )
+    QgsApplication::authManager()->updateNetworkRequest( requestData, mMetadata.mAuthCfg );
   QgsSetRequestInitiatorClass( requestData,
                                QStringLiteral( "QgsQuantizedMeshIndex" ) );
 

--- a/src/core/tiledscene/qgsquantizedmeshdataprovider.cpp
+++ b/src/core/tiledscene/qgsquantizedmeshdataprovider.cpp
@@ -429,7 +429,7 @@ QByteArray QgsQuantizedMeshIndex::fetchContent( const QString &uri,
 
   if ( reply->error() != QNetworkReply::NoError )
   {
-    QgsDebugError( QStringLiteral( "Request failed: %1" ).arg( uri ) );
+    QgsDebugError( QStringLiteral( "Request failed (%1): %2" ).arg( uri ).arg( reply->errorString() ) );
     return {};
   }
   return reply->data();

--- a/src/core/tiledscene/qgsquantizedmeshtiles.cpp
+++ b/src/core/tiledscene/qgsquantizedmeshtiles.cpp
@@ -469,23 +469,53 @@ tinygltf::Model QgsQuantizedMeshTile::toGltf( bool addSkirt, double skirtDepth, 
     // Create texture coordinates matching X, Y
 
     tinygltf::Buffer textureCoordBuffer;
-    textureCoordBuffer.data.resize( mVertexCoords.size() / 3 * 2 * sizeof( float ) );
+    textureCoordBuffer.data.resize( vertexBuffer.data.size() / 3 * 2 );
     std::vector<double> texCoordMinimums = {1.0, 1.0};
     std::vector<double> texCoordMaximums = {0.0, 0.0};
     auto textureCoordFloats = reinterpret_cast<float *>( textureCoordBuffer.data.data() );
 
-    for ( size_t i = 0; i < mVertexCoords.size() / 3; i++ )
+    auto addTexCoordForVertex = [&]( size_t vertexIdx )
     {
-      double u = mVertexCoords[i * 3] / 32767.0;
+      double u = mVertexCoords[vertexIdx * 3] / 32767.0;
       // V coord needs to be flipped for terrain for some reason
-      double v = 1.0 - ( mVertexCoords[i * 3 + 1] / 32767.0 );
+      double v = 1.0 - ( mVertexCoords[vertexIdx * 3 + 1] / 32767.0 );
       if ( texCoordMinimums[0] > u ) texCoordMinimums[0] = u;
       if ( texCoordMinimums[1] > v ) texCoordMinimums[1] = v;
       if ( texCoordMaximums[0] < u ) texCoordMaximums[0] = u;
       if ( texCoordMaximums[1] < v ) texCoordMaximums[1] = v;
-      textureCoordFloats[i * 2] = u;
-      textureCoordFloats[i * 2 + 1] = v;
+      *textureCoordFloats++ = u;
+      *textureCoordFloats++ = v;
+    };
+
+    for ( size_t i = 0; i < mVertexCoords.size() / 3; i++ )
+    {
+      addTexCoordForVertex( i );
     }
+
+    if ( addSkirt )
+    {
+      // Add UV for generated bottom vertices matching the top edge vertices
+      auto addSkirtVertexUVs = [&]( const std::vector<uint32_t> &idxs )
+      {
+        for ( uint32_t idx : idxs )
+        {
+          addTexCoordForVertex( idx );
+        }
+
+        if ( idxs.size() > 1 )
+        {
+          // The two bottom corner vertices get UVs too
+          addTexCoordForVertex( idxs[0] );
+          addTexCoordForVertex( idxs[idxs.size() - 1] );
+        }
+      };
+      addSkirtVertexUVs( mWestVertices );
+      addSkirtVertexUVs( mSouthVertices );
+      addSkirtVertexUVs( mEastVertices );
+      addSkirtVertexUVs( mNorthVertices );
+    }
+
+    Q_ASSERT( textureCoordFloats == ( float * )( textureCoordBuffer.data.data() + textureCoordBuffer.data.size() ) );
 
     model.buffers.push_back( textureCoordBuffer );
 

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -325,9 +325,11 @@ void TestQgs3DRendering::testDemTerrain()
   map->setLayers( QList<QgsMapLayer *>() << mLayerRgb );
 
   QgsDemTerrainGenerator *demTerrain = new QgsDemTerrainGenerator;
+  demTerrain->setCrs( mProject->crs(), mProject->transformContext() );
   demTerrain->setLayer( mLayerDtm );
   map->setTerrainGenerator( demTerrain );
   map->setTerrainVerticalScale( 3 );
+  QVERIFY( demTerrain->isValid() );
 
   QgsOffscreen3DEngine engine;
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
@@ -358,9 +360,11 @@ void TestQgs3DRendering::testTerrainShading()
   // no terrain layers set!
 
   QgsDemTerrainGenerator *demTerrain = new QgsDemTerrainGenerator;
+  demTerrain->setCrs( mProject->crs(), mProject->transformContext() );
   demTerrain->setLayer( mLayerDtm );
   map->setTerrainGenerator( demTerrain );
   map->setTerrainVerticalScale( 3 );
+  QVERIFY( demTerrain->isValid() );
 
   QgsPhongMaterialSettings terrainMaterial;
   terrainMaterial.setAmbient( QColor( 0, 0, 0 ) );
@@ -1452,9 +1456,11 @@ void TestQgs3DRendering::testFilteredDemTerrain()
   map->setLayers( QList<QgsMapLayer *>() << mLayerRgb );
 
   QgsDemTerrainGenerator *demTerrain = new QgsDemTerrainGenerator;
+  demTerrain->setCrs( mProject->crs(), mProject->transformContext() );
   demTerrain->setLayer( mLayerDtm );
   map->setTerrainGenerator( demTerrain );
   map->setTerrainVerticalScale( 3 );
+  QVERIFY( demTerrain->isValid() );
 
   QgsOffscreen3DEngine engine;
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
@@ -1550,9 +1556,11 @@ void TestQgs3DRendering::testAmbientOcclusion()
   mapSettings.setMapThemeCollection( project.mapThemeCollection() );
 
   QgsDemTerrainGenerator *demTerrain = new QgsDemTerrainGenerator;
+  demTerrain->setCrs( mProject->crs(), mProject->transformContext() );
   demTerrain->setLayer( layerDtm );
   mapSettings.setTerrainGenerator( demTerrain );
   mapSettings.setTerrainVerticalScale( 3 );
+  QVERIFY( demTerrain->isValid() );
 
   QgsPointLightSettings defaultPointLight;
   defaultPointLight.setPosition( QgsVector3D( 0, 400, 0 ) );
@@ -1615,9 +1623,11 @@ void TestQgs3DRendering::testDepthBuffer()
   mapSettings.setMapThemeCollection( project.mapThemeCollection() );
 
   QgsDemTerrainGenerator *demTerrain = new QgsDemTerrainGenerator;
+  demTerrain->setCrs( mProject->crs(), mProject->transformContext() );
   demTerrain->setLayer( layerDtm );
   mapSettings.setTerrainGenerator( demTerrain );
   mapSettings.setTerrainVerticalScale( 3 );
+  QVERIFY( demTerrain->isValid() );
 
   QgsPointLightSettings defaultPointLight;
   defaultPointLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
@@ -1943,10 +1953,12 @@ void TestQgs3DRendering::test3DSceneExporterBig()
   mapSettings.setPathResolver( project.pathResolver() );
   mapSettings.setMapThemeCollection( project.mapThemeCollection() );
 
-  QgsDemTerrainGenerator *demTerrain = new QgsDemTerrainGenerator();
+  QgsDemTerrainGenerator *demTerrain = new QgsDemTerrainGenerator;
+  demTerrain->setCrs( mProject->crs(), mProject->transformContext() );
   demTerrain->setLayer( layerDtm );
   mapSettings.setTerrainGenerator( demTerrain );
   mapSettings.setTerrainVerticalScale( 3 );
+  QVERIFY( demTerrain->isValid() );
 
   QgsPointLightSettings defaultPointLight;
   defaultPointLight.setPosition( QgsVector3D( 0, 400, 0 ) );


### PR DESCRIPTION
## Description

This PR fixes some small issues introduced by the implementation of Quantized Mesh support into QGIS (mainly #58591):

- Tile skirts now have texture coordinates that mirror the nearest terrain vertex.
- Only tiles inside the map view extent are loaded.
- Some console warnings are fixed.

Funded by: Swiss QGIS user group

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
