### PR TITLE
delays `PYQGIS_STARTUP` logs until `qgis` module is loaded

### DIFF
--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -64,35 +64,47 @@ bool QgsPythonUtilsImpl::checkSystemImports()
 exec(
     compile(
         """
-def run_startup_script(script_path):
-    script_executed = False
-    if not script_path:
+class StartupScriptRunner:
+    def __init__(self):
+        self.info_messages: list[str] = []
+        self.warning_messages: list[str] = []
+
+    def run_startup_script(self, script_path: pathlib.Path | str | None) -> bool:
+        script_executed = False
+        if not script_path:
+            return script_executed
+
+        p1 = pathlib.Path(script_path)
+        if p1.exists():
+            self.info_messages.append(f"Executed startup script: {p1}")
+            code = compile(p1.read_text(), p1, 'exec')
+            exec(code, globals())
+            script_executed = True
+
+        p2 = pathlib.Path('%1') / script_path
+        if p2.exists() and p2 != p1:
+            self.info_messages.append(f"Executed startup script: {p2}")
+            code = compile(p2.read_text(), p2, 'exec')
+            exec(code, globals())
+            script_executed = True
+
+        if not script_executed:
+            self.warning_messages.append(
+                f"Startup script not executed - neither {p1} nor {p2} exist!"
+            )
+
         return script_executed
 
-    from qgis.core import Qgis, QgsMessageLog
+    def log_messages(self):
+        from qgis.core import Qgis, QgsMessageLog
 
-    p1 = pathlib.Path(script_path)
-    if p1.exists():
-        QgsMessageLog.logMessage(f"Running {p1}", "QGIS", Qgis.MessageLevel.Info)
-        code = compile(p1.read_text(), p1, 'exec')
-        exec(code, globals())
-        script_executed = True
+        for msg in self.info_messages:
+            QgsMessageLog.logMessage(msg, "QGIS", Qgis.MessageLevel.Info)
 
-    p2 = pathlib.Path('%1') / script_path
-    if p2.exists() and p2 != p1:
-        QgsMessageLog.logMessage(f"Running {p2}", "QGIS", Qgis.MessageLevel.Info)
-        code = compile(p2.read_text(), p2, 'exec')
-        exec(code, globals())
-        script_executed = True
+        for msg in self.warning_messages:
+            QgsMessageLog.logMessage(msg, "QGIS", Qgis.MessageLevel.Warning)
 
-    if not script_executed:
-        QgsMessageLog.logMessage(
-            f"Startup script not executed - neither {p1} nor {p2} exist!",
-            "QGIS",
-            Qgis.MessageLevel.Warning,
-        )
-
-    return script_executed
+_ssr = StartupScriptRunner()
         """,
         'QgsPythonUtilsImpl::checkSystemImports [run_startup_script]',
         'exec',
@@ -100,7 +112,7 @@ def run_startup_script(script_path):
     globals(),
 )
 )"""" ).arg( pythonPath() ), QObject::tr( "Couldn't create run_startup_script." ), true );
-  runString( QStringLiteral( "is_startup_script_executed = run_startup_script(pyqgstart)" ) );
+  runString( QStringLiteral( "is_startup_script_executed = _ssr.run_startup_script(pyqgstart)" ) );
 
 #ifdef Q_OS_WIN
   runString( "oldhome=None" );
@@ -183,6 +195,9 @@ def run_startup_script(script_path):
 #ifdef Q_OS_WIN
   runString( "if oldhome: os.environ['HOME']=oldhome\n" );
 #endif
+
+  // now, after successful import of `qgis` module, we can show logs from `StartupScriptRunner`
+  runString( QStringLiteral( "_ssr.log_messages()" ));
 
   return true;
 }


### PR DESCRIPTION
## Description
This pull request change location for logging messages for `PYQGIS_STARTUP`. 

### Problem
There is a problem on windows installation using `OSGeo4W network installer`, because some search path for python import system (`sys.path`) are not yet configured, so we cannot import `qgis` module at that moment.

These paths are configured as soon as the code provided in `PYQGIS_STARTUP` is executed. According to docs, this is by design:
> [1.3.2. The PYQGIS_STARTUP environment variable](https://docs.qgis.org/3.34/en/docs/pyqgis_developer_cookbook/intro.html#the-pyqgis-startup-environment-variable)
> You can run Python code just before QGIS initialization completes by setting the PYQGIS_STARTUP environment variable to the path of an existing Python file.
>
> This code will run before QGIS initialization is complete. This method is very useful for cleaning sys.path, which may have undesireable paths, or for isolating/loading the initial environment without requiring a virtual environment, e.g. homebrew or MacPorts installs on Mac.

### Solution
I decided to solve this by storing log messages in lists and log them at later stage (after path configuration and import validation are successful).

The only situation, when we do not show these logs, is when we cannot import  `qgis` module. 
I consider this a very rare situation, so it is not included in this pull request (I am not sure if it would even be possible).

I changed a previous function to a class, because we need to store a state (messages). 
Also, I assigned a new object to a variable prefixed by `_`, because the object is not intended to be used anywhere.
However, I keep this object forever for possible debug purposes.

### Tests
I tested this on my dev build. Unfortunately, the reported issue never happened there, because python `sys.path` are configured there differently.
The error exists only when installed from `OSGeo4W network installer`, which I did __NOT__ tested.
If there are any instructions how one can test "dev build" installed from `OSGeo4W network installer`, please provide it to me and I will test it.

### About backport
This problem exists from this pull request #56827 (first tag 3.38.0). 
I believe it would enough to include these changes only in the newest Windows installation.

closes #57996

<!--

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
