### PR TITLE
PolarPlot: Fix AttributeError: module 'plotly.graph_objs' has no attribute 'Area'

### DIFF
--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -52,7 +52,9 @@ class PolarPlot(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterField(self.NAME_FIELD,
                                                       self.tr('Category name field'), parentLayerParameterName=self.INPUT))  # FIXME unused?
         self.addParameter(QgsProcessingParameterField(self.VALUE_FIELD,
-                                                      self.tr('Value field'), parentLayerParameterName=self.INPUT))
+                                                      self.tr('Value field'),
+                                                      parentLayerParameterName=self.INPUT,
+                                                      type=QgsProcessingParameterField.DataType.Numeric))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Polar plot'), self.tr('HTML files (*.html)')))
 

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -89,8 +89,9 @@ class PolarPlot(QgisAlgorithm):
 
         values = vector.values(source, valuefieldname)
 
-        data = [go.Area(r=values[valuefieldname],
-                        t=np.degrees(np.arange(0.0, 2 * np.pi, 2 * np.pi / len(values[valuefieldname]))))]
+        data = [go.Barpolar(r=values[valuefieldname],
+                        theta=np.degrees(np.arange(0.0, 2 * np.pi, 2 * np.pi / len(values[valuefieldname]))))]
+
         plt.offline.plot(data, filename=output, auto_open=False)
 
         return {self.OUTPUT: output}

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -92,7 +92,7 @@ class PolarPlot(QgisAlgorithm):
         values = vector.values(source, valuefieldname)
 
         data = [go.Barpolar(r=values[valuefieldname],
-                        theta=np.degrees(np.arange(0.0, 2 * np.pi, 2 * np.pi / len(values[valuefieldname]))))]
+                            theta=np.degrees(np.arange(0.0, 2 * np.pi, 2 * np.pi / len(values[valuefieldname]))))]
 
         plt.offline.plot(data, filename=output, auto_open=False)
 


### PR DESCRIPTION
The PolarPlot crashes with:

AttributeError: module 'plotly.graph_objs' has no attribute 'Area'

The old polar plots `go.Area()` have been replaced by `go.Barplot()` in Plotly 4.0 and removed in Plotly 5.0. 

The pull request fixes the bug by using go.Barplot instead. It also forces the type of the value field to be numeric.
 