### PR TITLE
Save Raster Layer as: do not propose PDF as possible format, which is not supported

### DIFF
--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -162,7 +162,8 @@ QList<QgsGdalOption> QgsGdalOption::optionsFromXml( const CPLXMLNode *node )
 bool QgsGdalUtils::supportsRasterCreate( GDALDriverH driver )
 {
   const QString driverShortName = GDALGetDriverShortName( driver );
-  if ( driverShortName == QLatin1String( "SQLite" ) )
+  if ( driverShortName == QLatin1String( "SQLite" ) ||
+       driverShortName == QLatin1String( "PDF" ) )
   {
     // it supports Create() but only for vector side
     return false;


### PR DESCRIPTION
The PDF driver only supports 'random' creation for vectors, not raster. For raster, it only supports CreateCopy() mode

Refs #58891
