### PR TITLE
Default map canvas color based on theme color palette 

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -797,6 +797,14 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   pbnSelectionColor->setDefaultColor( QColor( 255, 255, 0, 255 ) );
 
   //set the default color for canvas background
+  if ( mSettings->value( QStringLiteral( "/qgis/default_canvas_theme_color" ), true ).toBool() )
+  {
+    radCanvasThemeColor->setChecked( true );
+  }
+  else
+  {
+    radCanvasSpecificColor->setChecked( true );
+  }
   red = mSettings->value( QStringLiteral( "/qgis/default_canvas_color_red" ), 255 ).toInt();
   green = mSettings->value( QStringLiteral( "/qgis/default_canvas_color_green" ), 255 ).toInt();
   blue = mSettings->value( QStringLiteral( "/qgis/default_canvas_color_blue" ), 255 ).toInt();
@@ -1742,6 +1750,8 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/default_selection_color_alpha" ), myColor.alpha() );
 
   //set the default color for canvas background
+  mSettings->setValue( QStringLiteral( "/qgis/default_canvas_theme_color" ), radCanvasThemeColor->isChecked() );
+
   myColor = pbnCanvasColor->color();
   mSettings->setValue( QStringLiteral( "/qgis/default_canvas_color_red" ), myColor.red() );
   mSettings->setValue( QStringLiteral( "/qgis/default_canvas_color_green" ), myColor.green() );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -89,6 +89,7 @@
 #include <QUuid>
 #include <QRegularExpression>
 #include <QThreadPool>
+#include <QPalette>
 
 #ifdef _MSC_VER
 #include <sys/utime.h>
@@ -1262,14 +1263,23 @@ void QgsProject::clear()
   const bool defaultRelativePaths = mSettings.value( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), true ).toBool();
   setFilePathStorage( defaultRelativePaths ? Qgis::FilePathType::Relative : Qgis::FilePathType::Absolute );
 
-  int red = mSettings.value( QStringLiteral( "qgis/default_canvas_color_red" ), 255 ).toInt();
-  int green = mSettings.value( QStringLiteral( "qgis/default_canvas_color_green" ), 255 ).toInt();
-  int blue = mSettings.value( QStringLiteral( "qgis/default_canvas_color_blue" ), 255 ).toInt();
-  setBackgroundColor( QColor( red, green, blue ) );
+  if ( mSettings.value( QStringLiteral( "qgis/default_canvas_theme_color" ), true ).toBool() )
+  {
+    QPalette pal = qApp->palette();
+    QColor canvasColor = pal.color( QPalette::Base );
+    setBackgroundColor( canvasColor );
+  }
+  else
+  {
+    int red = mSettings.value( QStringLiteral( "qgis/default_canvas_color_red" ), 255 ).toInt();
+    int green = mSettings.value( QStringLiteral( "qgis/default_canvas_color_green" ), 255 ).toInt();
+    int blue = mSettings.value( QStringLiteral( "qgis/default_canvas_color_blue" ), 255 ).toInt();
+    setBackgroundColor( QColor( red, green, blue ) );
+  }
 
-  red = mSettings.value( QStringLiteral( "qgis/default_selection_color_red" ), 255 ).toInt();
-  green = mSettings.value( QStringLiteral( "qgis/default_selection_color_green" ), 255 ).toInt();
-  blue = mSettings.value( QStringLiteral( "qgis/default_selection_color_blue" ), 0 ).toInt();
+  int red = mSettings.value( QStringLiteral( "qgis/default_selection_color_red" ), 255 ).toInt();
+  int green = mSettings.value( QStringLiteral( "qgis/default_selection_color_green" ), 255 ).toInt();
+  int blue = mSettings.value( QStringLiteral( "qgis/default_selection_color_blue" ), 0 ).toInt();
   const int alpha = mSettings.value( QStringLiteral( "qgis/default_selection_color_alpha" ), 255 ).toInt();
   setSelectionColor( QColor( red, green, blue, alpha ) );
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2447,8 +2447,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>508</width>
-                <height>487</height>
+                <width>855</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -2470,7 +2470,78 @@
                   <string>Default Map Appearance (overridden by project properties)</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
-                  <item row="0" column="4">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Background color</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QgsColorButton" name="pbnSelectionColor">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>120</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>120</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="7">
+                   <spacer name="horizontalSpacer_28">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="textLabel1_9">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Selection color</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QRadioButton" name="radCanvasThemeColor">
+                    <property name="text">
+                     <string>Theme color</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="2">
                    <widget class="QgsColorButton" name="pbnCanvasColor">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -2495,67 +2566,10 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="6">
-                   <spacer name="horizontalSpacer_28">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="3">
-                   <widget class="QLabel" name="label">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
+                  <item row="4" column="1">
+                   <widget class="QRadioButton" name="radCanvasSpecificColor">
                     <property name="text">
-                     <string>Background color</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="textLabel1_9">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>Selection color</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QgsColorButton" name="pbnSelectionColor">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>120</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>120</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string/>
+                     <string>Specific color</string>
                     </property>
                    </widget>
                   </item>
@@ -5519,8 +5533,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>lstRasterDrivers</tabstop>
   <tabstop>lstVectorDrivers</tabstop>
   <tabstop>mOptionsScrollArea_06</tabstop>
-  <tabstop>pbnSelectionColor</tabstop>
-  <tabstop>pbnCanvasColor</tabstop>
   <tabstop>cmbLegendDoubleClickAction</tabstop>
   <tabstop>mShowFeatureCountByDefaultCheckBox</tabstop>
   <tabstop>cbxLegendClassifiers</tabstop>


### PR DESCRIPTION
This PR adds the option to have the background color of the map canvas determined by the current theme:
- In the "Night Mapping" theme, this prevents glaring map canvas in new projects
- This setting only refers to the default setting in the profile when creating new projects
- Existing projects are not affected by this change
- Affects all map views 2D and 3D

Before:
<img src="https://github.com/user-attachments/assets/12ba5391-47b4-4c21-b357-12e1af0cf504" width="40%">
After:
<img src="https://github.com/user-attachments/assets/9a9c9eba-172c-4048-97a8-72403d05d8d1" width="40%">
</table>

Result:
![grafik](https://github.com/user-attachments/assets/4d44c5a4-de82-4deb-9089-e069db150c4b)
