### PR TITLE
Fix 'Move selected to top' breaks attribute table sorting

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -281,7 +281,7 @@ void QgsAttributeTableFilterModel::setSelectedOnTop( bool selectedOnTop )
     if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
       order = Qt::AscendingOrder;
 
-    sort( 0, Qt::AscendingOrder );
+    sort( column, order );
     invalidate();
   }
 }

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -398,6 +398,19 @@ void TestQgsAttributeTable::testSelectedOnTop()
   QCOMPARE( dlg->mMainView->mFilterModel->index( 1, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 1 ) );
   QCOMPARE( dlg->mMainView->mFilterModel->index( 2, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 2 ) );
 
+  dlg->mMainView->setSelectedOnTop( false );
+  dlg->mMainView->tableView()->sortByColumn( 1, Qt::DescendingOrder );
+
+  QCOMPARE( dlg->mMainView->mFilterModel->index( 0, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 3 ) );
+  QCOMPARE( dlg->mMainView->mFilterModel->index( 1, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 1 ) );
+  QCOMPARE( dlg->mMainView->mFilterModel->index( 2, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 2 ) );
+
+  tempLayer->selectByIds( QgsFeatureIds() << 2 );
+  dlg->mMainView->setSelectedOnTop( true );
+
+  QCOMPARE( dlg->mMainView->mFilterModel->index( 0, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 2 ) );
+  QCOMPARE( dlg->mMainView->mFilterModel->index( 1, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 3 ) );
+  QCOMPARE( dlg->mMainView->mFilterModel->index( 2, 0 ).data( static_cast< int >( QgsAttributeTableModel::CustomRole::FeatureId ) ), QVariant( 1 ) );
 }
 
 void TestQgsAttributeTable::testSortByDisplayExpression()


### PR DESCRIPTION
## Description

Recently I noticed that toggling the 'Move selected to top' action in the attribute table dialog, breaks any existing sort column and sort order; the sorting is always reset to ascending on the first column.

Looking at the code, it seems that the sort column and order was hard-coded to 0 and `Qt::AscendingOrder` respectively. The existing sort column and order is retrieved but not used:

![Screenshot from 2024-09-29 16-56-50](https://github.com/user-attachments/assets/56e98cf4-d6e7-4994-b8ba-d37edb2b13a6)

Unless I'm missing something, shouldn't we be passing the `column` and `order` values to the `sort()` call?

Screencast before:

![selected-to-top-bug-1](https://github.com/user-attachments/assets/a44993b9-f4ba-4de2-adb2-d9ef37a50b22)

Screencast after proposed fix:

![selected-to-top-bug-2](https://github.com/user-attachments/assets/46de7e2e-efe0-4ce6-99bd-1ebbc2e38867)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
