### PR TITLE
Fix buttons tab order and vertical expansion

### DIFF
--- a/src/ui/qgssensorthingssubseteditorbase.ui
+++ b/src/ui/qgssensorthingssubseteditorbase.ui
@@ -235,6 +235,19 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
+      <item row="6" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
@@ -248,6 +261,25 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>lstFields</tabstop>
+  <tabstop>groupBox4</tabstop>
+  <tabstop>mButtonEq</tabstop>
+  <tabstop>mButtonNe</tabstop>
+  <tabstop>mButtonGt</tabstop>
+  <tabstop>mButtonGe</tabstop>
+  <tabstop>mButtonLt</tabstop>
+  <tabstop>mButtonLe</tabstop>
+  <tabstop>mButtonAnd</tabstop>
+  <tabstop>mButtonOr</tabstop>
+  <tabstop>mButtonNot</tabstop>
+  <tabstop>mButtonNow</tabstop>
+  <tabstop>mButtonAdd</tabstop>
+  <tabstop>mButtonSub</tabstop>
+  <tabstop>mButtonMul</tabstop>
+  <tabstop>mButtonDiv</tabstop>
+  <tabstop>mButtonMod</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Current situation 
![sensorthings](https://github.com/user-attachments/assets/a0cec0b7-b14c-440a-86c3-b2d84a968eaf)


PR (Qt Designer)
![image](https://github.com/user-attachments/assets/cfe22d09-f731-40e2-9e0d-f71d8f078a30)

Note:: I couldn't find why some strings were in bold while "Date" isn't.