### PR TITLE
Show warning in help for algorithms for known issues or security risk

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6228,6 +6228,9 @@ QgsProcessingAlgorithm.FlagRequiresProject = Qgis.ProcessingAlgorithmFlag.Requir
 QgsProcessingAlgorithm.Flag.FlagRequiresProject = Qgis.ProcessingAlgorithmFlag.RequiresProject
 QgsProcessingAlgorithm.FlagRequiresProject.is_monkey_patched = True
 QgsProcessingAlgorithm.FlagRequiresProject.__doc__ = "The algorithm requires that a valid QgsProject is available from the processing context in order to execute"
+QgsProcessingAlgorithm.SecurityRisk = Qgis.ProcessingAlgorithmFlag.SecurityRisk
+QgsProcessingAlgorithm.SecurityRisk.is_monkey_patched = True
+QgsProcessingAlgorithm.SecurityRisk.__doc__ = "The algorithm represents a potential security risk if executed with untrusted inputs. \n.. versionadded:: 3.40"
 QgsProcessingAlgorithm.FlagDeprecated = Qgis.ProcessingAlgorithmFlag.Deprecated
 QgsProcessingAlgorithm.Flag.FlagDeprecated = Qgis.ProcessingAlgorithmFlag.Deprecated
 QgsProcessingAlgorithm.FlagDeprecated.is_monkey_patched = True
@@ -6295,6 +6298,10 @@ Qgis.ProcessingAlgorithmFlag.__doc__ = """Flags indicating how and when an algor
 * ``RequiresProject``: The algorithm requires that a valid QgsProject is available from the processing context in order to execute
 
   Available as ``QgsProcessingAlgorithm.FlagRequiresProject`` in older QGIS releases.
+
+* ``SecurityRisk``: The algorithm represents a potential security risk if executed with untrusted inputs.
+
+  .. versionadded:: 3.40
 
 * ``Deprecated``: Algorithm is deprecated
 

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -32,6 +32,8 @@ Constructor for QgsProcessingModelAlgorithm.
     virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );  //#spellok
 
 
+    virtual Qgis::ProcessingAlgorithmFlags flags() const;
+
     virtual QString name() const;
 
     virtual QString displayName() const;

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1922,6 +1922,7 @@ The development version
       SkipGenericModelLogging,
       NotAvailableInStandaloneTool,
       RequiresProject,
+      SecurityRisk,
       Deprecated,
     };
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6171,6 +6171,9 @@ QgsProcessingAlgorithm.FlagRequiresProject = Qgis.ProcessingAlgorithmFlag.Requir
 QgsProcessingAlgorithm.Flag.FlagRequiresProject = Qgis.ProcessingAlgorithmFlag.RequiresProject
 QgsProcessingAlgorithm.FlagRequiresProject.is_monkey_patched = True
 QgsProcessingAlgorithm.FlagRequiresProject.__doc__ = "The algorithm requires that a valid QgsProject is available from the processing context in order to execute"
+QgsProcessingAlgorithm.SecurityRisk = Qgis.ProcessingAlgorithmFlag.SecurityRisk
+QgsProcessingAlgorithm.SecurityRisk.is_monkey_patched = True
+QgsProcessingAlgorithm.SecurityRisk.__doc__ = "The algorithm represents a potential security risk if executed with untrusted inputs. \n.. versionadded:: 3.40"
 QgsProcessingAlgorithm.FlagDeprecated = Qgis.ProcessingAlgorithmFlag.Deprecated
 QgsProcessingAlgorithm.Flag.FlagDeprecated = Qgis.ProcessingAlgorithmFlag.Deprecated
 QgsProcessingAlgorithm.FlagDeprecated.is_monkey_patched = True
@@ -6238,6 +6241,10 @@ Qgis.ProcessingAlgorithmFlag.__doc__ = """Flags indicating how and when an algor
 * ``RequiresProject``: The algorithm requires that a valid QgsProject is available from the processing context in order to execute
 
   Available as ``QgsProcessingAlgorithm.FlagRequiresProject`` in older QGIS releases.
+
+* ``SecurityRisk``: The algorithm represents a potential security risk if executed with untrusted inputs.
+
+  .. versionadded:: 3.40
 
 * ``Deprecated``: Algorithm is deprecated
 

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -32,6 +32,8 @@ Constructor for QgsProcessingModelAlgorithm.
     virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );  //#spellok
 
 
+    virtual Qgis::ProcessingAlgorithmFlags flags() const;
+
     virtual QString name() const;
 
     virtual QString displayName() const;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1922,6 +1922,7 @@ The development version
       SkipGenericModelLogging,
       NotAvailableInStandaloneTool,
       RequiresProject,
+      SecurityRisk,
       Deprecated,
     };
 

--- a/python/plugins/processing/algs/qgis/FieldPyculator.py
+++ b/python/plugins/processing/algs/qgis/FieldPyculator.py
@@ -22,7 +22,8 @@ __copyright__ = '(C) 2012, Victor Olaya & NextGIS'
 import sys
 
 from qgis.PyQt.QtCore import QMetaType
-from qgis.core import (QgsProcessingException,
+from qgis.core import (Qgis,
+                       QgsProcessingException,
                        QgsField,
                        QgsFields,
                        QgsFeatureSink,
@@ -46,6 +47,11 @@ class FieldsPyculator(QgisAlgorithm):
     FORMULA = 'FORMULA'
     OUTPUT = 'OUTPUT'
     RESULT_VAR_NAME = 'value'
+
+    def flags(self):
+        # This algorithm represents a security risk, due to the use
+        # of the Python "exec" function
+        return super().flags() | Qgis.ProcessingAlgorithmFlag.SecurityRisk
 
     def group(self):
         return self.tr('Vector table')

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -547,6 +547,20 @@ class BatchPanel(QgsPanelWidget, WIDGET):
         self.wrappers = []
 
     def load(self):
+        if self.alg.flags() & Qgis.ProcessingAlgorithmFlag.SecurityRisk:
+            message_box = QMessageBox()
+            message_box.setWindowTitle(self.tr("Security warning"))
+            message_box.setText(
+                self.tr(
+                    "This algorithm is a potential security risk if executed with unchecked inputs, and may result in system damage or data leaks. Only continue if you trust the source of the file. Continue?"))
+            message_box.setIcon(QMessageBox.Icon.Warning)
+            message_box.addButton(QMessageBox.StandardButton.Yes)
+            message_box.addButton(QMessageBox.StandardButton.No)
+            message_box.setDefaultButton(QMessageBox.StandardButton.No)
+            message_box.exec()
+            if message_box.result() != QMessageBox.StandardButton.Yes:
+                return
+
         settings = QgsSettings()
         last_path = settings.value("/Processing/LastBatchPath", QDir.homePath())
         filters = ';;'.join([self.tr('Batch Processing files (*.batch)'),

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -45,6 +45,23 @@ void QgsProcessingModelAlgorithm::initAlgorithm( const QVariantMap & )
 {
 }
 
+Qgis::ProcessingAlgorithmFlags QgsProcessingModelAlgorithm::flags() const
+{
+  Qgis::ProcessingAlgorithmFlags res = QgsProcessingAlgorithm::flags();
+
+  // don't force algorithm attachment here, that's potentially too expensive
+  QMap< QString, QgsProcessingModelChildAlgorithm >::const_iterator childIt = mChildAlgorithms.constBegin();
+  for ( ; childIt != mChildAlgorithms.constEnd(); ++childIt )
+  {
+    if ( childIt->algorithm() && childIt->algorithm()->flags().testFlag( Qgis::ProcessingAlgorithmFlag::SecurityRisk ) )
+    {
+      // security risk flag propagates from child algorithms to model
+      res |= Qgis::ProcessingAlgorithmFlag::SecurityRisk;
+    }
+  }
+  return res;
+}
+
 QString QgsProcessingModelAlgorithm::name() const
 {
   return mModelName;

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -47,6 +47,7 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
 
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;  //#spellok
 
+    Qgis::ProcessingAlgorithmFlags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QString group() const override;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3303,6 +3303,7 @@ class CORE_EXPORT Qgis
       SkipGenericModelLogging SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGenericModelLogging ) = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
       NotAvailableInStandaloneTool SIP_MONKEYPATCH_COMPAT_NAME( FlagNotAvailableInStandaloneTool ) = 1 << 13, //!< Algorithm should not be available from the standalone "qgis_process" tool. Used to flag algorithms which make no sense outside of the QGIS application, such as "select by..." style algorithms.
       RequiresProject SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresProject ) = 1 << 14, //!< The algorithm requires that a valid QgsProject is available from the processing context in order to execute
+      SecurityRisk = 1 << 15, //!< The algorithm represents a potential security risk if executed with untrusted inputs. \since QGIS 3.40
       Deprecated SIP_MONKEYPATCH_COMPAT_NAME( FlagDeprecated ) = HideFromToolbox | HideFromModeler, //!< Algorithm is deprecated
     };
     Q_ENUM( ProcessingAlgorithmFlag );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -796,6 +796,19 @@ QString QgsProcessingAlgorithmDialogBase::formatHelp( QgsProcessingAlgorithm *al
     }
     result += QStringLiteral( "<ul><li><i>%1</i></li></ul>" ).arg( flags.join( QLatin1String( "</i></li><li><i>" ) ) );
   }
+  if ( algorithm->flags() & Qgis::ProcessingAlgorithmFlag::SecurityRisk )
+  {
+    result += QStringLiteral( "<p><b>%1</b></p>" ).arg(
+                tr( "Warning: This algorithm is a potential security risk if executed with unchecked inputs, and may result in system damage or data leaks." )
+              );
+  }
+  if ( algorithm->flags() & Qgis::ProcessingAlgorithmFlag::KnownIssues )
+  {
+    result += QStringLiteral( "<p><b>%1</b></p>" ).arg(
+                tr( "Warning: This algorithm has known issues. The results must be carefully validated by the user." )
+              );
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Add processing algorithm flag for SecurityRisk, and add to "Advanced Python field calculator" algorithm, as that algorithm uses the Python exec() function and is a security risk if run with untrusted/unchecked inputs

Require users to opt in before loading batch parameters for algorithms which represent a security risk
