### PR TITLE
Only use threaded legend hit test for preview renders

### DIFF
--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -116,14 +116,6 @@ void QgsLayoutItemLegend::paint( QPainter *painter, const QStyleOptionGraphicsIt
     doUpdateFilterByMap();
   }
 
-  if ( mLayout )
-  {
-    if ( !mLayout->renderContext().isPreviewRender() && mLegendModel->hitTestInProgress() )
-    {
-      mLegendModel->waitForHitTestBlocking();
-    }
-  }
-
   const int dpi = painter->device()->logicalDpiX();
   const double dotsPerMM = dpi / 25.4;
 
@@ -1140,6 +1132,10 @@ void QgsLayoutItemLegend::doUpdateFilterByMap()
   {
     mLegendModel->setLayerStyleOverrides( QMap<QString, QString>() );
   }
+
+  // only use thread hit tests for preview renders. In other cases we'll need a blocking hit test anyway, and we run a risk
+  // of deadlocks if a non-preview render is then started on the main thread.
+  mLegendModel->setFlag( QgsLayerTreeModel::UseThreadedHitTest, mLayout->renderContext().isPreviewRender() );
 
   const bool filterByExpression = QgsLayerTreeUtils::hasLegendFilterExpression( *( mCustomLayerTree ? mCustomLayerTree.get() : mLayout->project()->layerTreeRoot() ) );
 


### PR DESCRIPTION
In other cases we'll need a blocking hit test anyway, and we run a risk of deadlocks if a non-preview render is then started on the main thread.

Fixes #58496
