### PR TITLE
make create annotation map tools available in public API

### DIFF
--- a/python/PyQt6/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
+++ b/python/PyQt6/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
@@ -88,7 +88,7 @@ whenever this signal is emitted.
 
     virtual ~QgsCreateAnnotationItemMapToolInterface();
 
-    virtual QgsCreateAnnotationItemMapToolHandler *handler() = 0;
+    virtual QgsCreateAnnotationItemMapToolHandler *handler() const = 0;
 %Docstring
 Returns the handler object for the map tool.
 %End

--- a/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
+++ b/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
@@ -88,7 +88,7 @@ whenever this signal is emitted.
 
     virtual ~QgsCreateAnnotationItemMapToolInterface();
 
-    virtual QgsCreateAnnotationItemMapToolHandler *handler() = 0;
+    virtual QgsCreateAnnotationItemMapToolHandler *handler() const = 0;
 %Docstring
 Returns the handler object for the map tool.
 %End

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1062,6 +1062,7 @@ set(QGIS_GUI_HDRS
   annotations/qgsannotationitemguiregistry.h
   annotations/qgsannotationitemwidget.h
   annotations/qgscreateannotationitemmaptool.h
+  annotations/qgscreateannotationitemmaptool_impl.h
   annotations/qgsmaptoolmodifyannotation.h
 
   attributeformconfig/qgsattributeformcontaineredit.h

--- a/src/gui/annotations/qgscreateannotationitemmaptool.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool.h
@@ -113,7 +113,7 @@ class GUI_EXPORT QgsCreateAnnotationItemMapToolInterface
     /**
      * Returns the handler object for the map tool.
      */
-    virtual QgsCreateAnnotationItemMapToolHandler *handler() = 0;
+    virtual QgsCreateAnnotationItemMapToolHandler *handler() const = 0;
 
     /**
      * Returns a reference to the associated map tool.

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -52,7 +52,7 @@ QgsMapToolCaptureAnnotationItem::QgsMapToolCaptureAnnotationItem( QgsMapCanvas *
   mToolName = tr( "Annotation tool" );
 }
 
-QgsCreateAnnotationItemMapToolHandler *QgsMapToolCaptureAnnotationItem::handler()
+QgsCreateAnnotationItemMapToolHandler *QgsMapToolCaptureAnnotationItem::handler() const
 {
   return mHandler;
 }
@@ -120,7 +120,7 @@ void QgsCreatePointTextItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event
   mHandler->pushCreatedItem( createdItem.release() );
 }
 
-QgsCreateAnnotationItemMapToolHandler *QgsCreatePointTextItemMapTool::handler()
+QgsCreateAnnotationItemMapToolHandler *QgsCreatePointTextItemMapTool::handler() const
 {
   return mHandler;
 }
@@ -369,7 +369,7 @@ void QgsCreatePictureItemMapTool::keyPressEvent( QKeyEvent *event )
   }
 }
 
-QgsCreateAnnotationItemMapToolHandler *QgsCreatePictureItemMapTool::handler()
+QgsCreateAnnotationItemMapToolHandler *QgsCreatePictureItemMapTool::handler() const
 {
   return mHandler;
 }
@@ -472,7 +472,7 @@ void QgsCreateRectangleTextItemMapTool::keyPressEvent( QKeyEvent *event )
   }
 }
 
-QgsCreateAnnotationItemMapToolHandler *QgsCreateRectangleTextItemMapTool::handler()
+QgsCreateAnnotationItemMapToolHandler *QgsCreateRectangleTextItemMapTool::handler() const
 {
   return mHandler;
 }

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -41,7 +41,7 @@ class GUI_EXPORT QgsMapToolCaptureAnnotationItem: public QgsMapToolCapture, publ
   public:
     //! Constructor
     QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
-    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsCreateAnnotationItemMapToolHandler *handler() const override;
     QgsMapTool *mapTool() override;
     QgsMapLayer *layer() const override;
     QgsMapToolCapture::Capabilities capabilities() const override;
@@ -71,7 +71,7 @@ class GUI_EXPORT QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitiz
     ~QgsCreatePointTextItemMapTool() override;
 
     void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
-    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsCreateAnnotationItemMapToolHandler *handler() const override;
     QgsMapTool *mapTool() override;
 
   private:
@@ -161,7 +161,7 @@ class GUI_EXPORT QgsCreateRectangleTextItemMapTool: public QgsMapToolAdvancedDig
     void cadCanvasMoveEvent( QgsMapMouseEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
 
-    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsCreateAnnotationItemMapToolHandler *handler() const override;
     QgsMapTool *mapTool() override;
 
   private:
@@ -195,7 +195,7 @@ class GUI_EXPORT QgsCreatePictureItemMapTool: public QgsMapToolAdvancedDigitizin
     void cadCanvasMoveEvent( QgsMapMouseEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
 
-    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsCreateAnnotationItemMapToolHandler *handler() const override;
     QgsMapTool *mapTool() override;
 
   private:

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -16,22 +16,30 @@
 #define QGSCREATEANNOTATIONITEMMAPTOOLIMPL_H
 
 #include "qgis_gui.h"
-#include "qgis_sip.h"
 #include "qgscreateannotationitemmaptool.h"
 #include "qgsmaptoolcapture.h"
-#include "qgssettingstree.h"
 
 #define SIP_NO_FILE
 
 class QgsSettingsEntryString;
 class QgsSettingsTreeNode;
 
-///@cond PRIVATE
 
-class QgsMapToolCaptureAnnotationItem: public QgsMapToolCapture, public QgsCreateAnnotationItemMapToolInterface
+/**
+ * \class QgsMapToolCaptureAnnotationItem
+ * \ingroup gui
+ *
+ * \brief A base class to digitize annotation items using QgsMapToolCapture
+ *
+ * \note Not available in Python bindings.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsMapToolCaptureAnnotationItem: public QgsMapToolCapture, public QgsCreateAnnotationItemMapToolInterface
 {
     Q_OBJECT
   public:
+    //! Constructor
     QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
     QgsCreateAnnotationItemMapToolHandler *handler() override;
     QgsMapTool *mapTool() override;
@@ -45,12 +53,20 @@ class QgsMapToolCaptureAnnotationItem: public QgsMapToolCapture, public QgsCreat
 
 };
 
-class QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
+/**
+ * \class QgsCreatePointTextItemMapTool
+ * \ingroup gui
+ *
+ * \brief A map tool to digitize point text items.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
 {
     Q_OBJECT
 
   public:
-
+    //! Constructor
     QgsCreatePointTextItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
     ~QgsCreatePointTextItemMapTool() override;
 
@@ -65,49 +81,80 @@ class QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public
 };
 
 
-class QgsCreateMarkerItemMapTool: public QgsMapToolCaptureAnnotationItem
+/**
+ * \class QgsCreateMarkerItemMapTool
+ * \ingroup gui
+ *
+ * \brief A map tool to digitize marker items.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsCreateMarkerItemMapTool: public QgsMapToolCaptureAnnotationItem
 {
     Q_OBJECT
 
   public:
-
+    //! Constructor
     QgsCreateMarkerItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
     void cadCanvasReleaseEvent( QgsMapMouseEvent *event ) override;
 
 };
 
-class QgsCreateLineItemMapTool: public QgsMapToolCaptureAnnotationItem
+/**
+ * \class QgsCreateLineItemMapTool
+ * \ingroup gui
+ *
+ * \brief A map tool to digitize line items.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsCreateLineItemMapTool: public QgsMapToolCaptureAnnotationItem
 {
     Q_OBJECT
 
   public:
-
+    //! Constructor
     QgsCreateLineItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
   private slots:
     void lineCaptured( const QgsCurve *line ) override;
 };
 
-class QgsCreatePolygonItemMapTool: public QgsMapToolCaptureAnnotationItem
+/**
+ * \class QgsCreatePolygonItemMapTool
+ * \ingroup gui
+ *
+ * \brief A map tool to digitize polygon items.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsCreatePolygonItemMapTool: public QgsMapToolCaptureAnnotationItem
 {
     Q_OBJECT
 
   public:
-
+    //! Constructor
     QgsCreatePolygonItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
   private slots:
     void polygonCaptured( const QgsCurvePolygon *polygon ) override;
 };
 
-
-class QgsCreateRectangleTextItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
+/**
+ * \class QgsCreateRectangleTextItemMapTool
+ * \ingroup gui
+ *
+ * \brief A map tool to digitize rectangle text items.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsCreateRectangleTextItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
 {
     Q_OBJECT
 
   public:
-
+    //! Constructor
     QgsCreateRectangleTextItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
     void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
@@ -118,7 +165,6 @@ class QgsCreateRectangleTextItemMapTool: public QgsMapToolAdvancedDigitizing, pu
     QgsMapTool *mapTool() override;
 
   private:
-
     QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
     QRectF mRect;
@@ -126,8 +172,15 @@ class QgsCreateRectangleTextItemMapTool: public QgsMapToolAdvancedDigitizing, pu
     QObjectUniquePtr< QgsRubberBand > mRubberBand;
 };
 
-
-class QgsCreatePictureItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
+/**
+ * \class QgsCreatePictureItemMapTool
+ * \ingroup gui
+ *
+ * \brief A map tool to digitize picture items.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsCreatePictureItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
 {
     Q_OBJECT
 
@@ -135,6 +188,7 @@ class QgsCreatePictureItemMapTool: public QgsMapToolAdvancedDigitizing, public Q
     static inline QgsSettingsTreeNode *sTreePicture = QgsCreateAnnotationItemMapToolInterface::sTreeAnnotationTools->createChildNode( QStringLiteral( "picture-item" ) );
     static const QgsSettingsEntryString *settingLastSourceFolder;
 
+    //! Constructor
     QgsCreatePictureItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
     void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
@@ -145,7 +199,7 @@ class QgsCreatePictureItemMapTool: public QgsMapToolAdvancedDigitizing, public Q
     QgsMapTool *mapTool() override;
 
   private:
-
+    //! Constructor
     QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
     QRectF mRect;
@@ -153,19 +207,25 @@ class QgsCreatePictureItemMapTool: public QgsMapToolAdvancedDigitizing, public Q
     QObjectUniquePtr< QgsRubberBand > mRubberBand;
 };
 
-
-class QgsCreateLineTextItemMapTool: public QgsMapToolCaptureAnnotationItem
+/**
+ * \class QgsCreateLineTextItemMapTool
+ * \ingroup gui
+ *
+ * \brief A map tool to digitize line text items.
+ *
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsCreateLineTextItemMapTool: public QgsMapToolCaptureAnnotationItem
 {
     Q_OBJECT
 
   public:
-
+    //! Constructor
     QgsCreateLineTextItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
   private slots:
     void lineCaptured( const QgsCurve *line ) override;
 };
 
-///@endcond PRIVATE
 
 #endif // QGSCREATEANNOTATIONITEMMAPTOOLIMPL_H


### PR DESCRIPTION
We use annotation in a third application (Kadas) and I would like to reuse the map tools.

I made them available in the API but not in Python bindings for now.

