### PR TITLE
[server] Fix sub-optimal checks in wms access control

### DIFF
--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -299,7 +299,7 @@ namespace QgsWms
        * Check layer read permissions
        * Returns true if the layer is readable, false otherwise
        */
-      bool checkLayerReadPermissions( QgsMapLayer *layer );
+      bool checkLayerReadPermissions( QgsMapLayer *layer ) const;
 
       bool layerScaleVisibility( const QString &name ) const;
 


### PR DESCRIPTION
## Description

Fix suboptimal check in wms access control.

[This PR](https://github.com/qgis/QGIS/pull/58073) introduced changes in WMS access control management by checking availability of layer groups and this was done by prior checking all layers from all groups.

This is sub-optimal as every layers or groups need to be checked even if not requested and may lead to performance penalty with project with many layers.

This PR fixe the issue by checking only requested groups and layers and preserving behavior of the original PR.
