### PR TITLE
Add API to temporarily disable updates in 3D map scene

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -114,6 +114,24 @@ Returns the 3D map settings.
 .. versionadded:: 3.30
 %End
 
+    bool hasSceneUpdatesEnabled() const;
+%Docstring
+Returns whether updates of the 3D scene's entities are allowed.
+Normally, scene updates are enabled. But for debugging purposes,
+it may be useful to temporarily disable scene updates.
+
+.. versionadded:: 3.40
+%End
+
+    void setSceneUpdatesEnabled( bool enabled );
+%Docstring
+Sets whether updates of the 3D scene's entities are allowed.
+Normally, scene updates are enabled. But for debugging purposes,
+it may be useful to temporarily disable scene updates.
+
+.. versionadded:: 3.40
+%End
+
  static QMap< QString, Qgs3DMapScene * > openScenes() /Deprecated/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -114,6 +114,24 @@ Returns the 3D map settings.
 .. versionadded:: 3.30
 %End
 
+    bool hasSceneUpdatesEnabled() const;
+%Docstring
+Returns whether updates of the 3D scene's entities are allowed.
+Normally, scene updates are enabled. But for debugging purposes,
+it may be useful to temporarily disable scene updates.
+
+.. versionadded:: 3.40
+%End
+
+    void setSceneUpdatesEnabled( bool enabled );
+%Docstring
+Sets whether updates of the 3D scene's entities are allowed.
+Normally, scene updates are enabled. But for debugging purposes,
+it may be useful to temporarily disable scene updates.
+
+.. versionadded:: 3.40
+%End
+
  static QMap< QString, Qgs3DMapScene * > openScenes() /Deprecated/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -322,6 +322,12 @@ void Qgs3DMapScene::onCameraChanged()
 
 void Qgs3DMapScene::updateScene( bool forceUpdate )
 {
+  if ( !mSceneUpdatesEnabled )
+  {
+    QgsDebugMsgLevel( "Scene update skipped", 2 );
+    return;
+  }
+
   if ( forceUpdate )
     QgsEventTracing::addEvent( QgsEventTracing::Instant, QStringLiteral( "3D" ), QStringLiteral( "Update Scene" ) );
 

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -188,6 +188,24 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     Qgs3DMapSettings *mapSettings() const { return &mMap; }
 
     /**
+     * Returns whether updates of the 3D scene's entities are allowed.
+     * Normally, scene updates are enabled. But for debugging purposes,
+     * it may be useful to temporarily disable scene updates.
+     *
+     * \since QGIS 3.40
+     */
+    bool hasSceneUpdatesEnabled() const { return mSceneUpdatesEnabled; }
+
+    /**
+     * Sets whether updates of the 3D scene's entities are allowed.
+     * Normally, scene updates are enabled. But for debugging purposes,
+     * it may be useful to temporarily disable scene updates.
+     *
+     * \since QGIS 3.40
+     */
+    void setSceneUpdatesEnabled( bool enabled ) { mSceneUpdatesEnabled = enabled; }
+
+    /**
      * Returns a map of 3D map scenes (by name) open in the QGIS application.
      *
      * \note Only available from the QGIS desktop application.
@@ -301,6 +319,8 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
 
     //! 3d axis visualization
     Qgs3DAxis *m3DAxis = nullptr;
+
+    bool mSceneUpdatesEnabled = true;
 
 };
 #endif // QGS3DMAPSCENE_H


### PR DESCRIPTION
This is useful for debugging 3D views, to pause scene updates and inspect some parts of the scene in detail.
