### PR TITLE
QgsMapLayer::setDataSource don't require layer name, provider

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -1327,7 +1327,7 @@ Write just the symbology information for the layer into the document
 %End
 
 
-    void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false );
+    void setDataSource( const QString &dataSource, const QString &baseName = QString(), const QString &provider = QString(), bool loadDefaultStyleFlag = false );
 %Docstring
 Updates the data source of the layer.
 
@@ -1335,11 +1335,12 @@ The ``dataSource`` argument must specify the new data source string for the laye
 the specified data ``provider`` in use. See :py:class:`QgsDataSourceUri` and the documentation for the various :py:class:`QgsMapLayer`
 subclasses for further details on data source strings.
 
-The ``baseName`` argument specifies the user-visible name to use for the layer. (See :py:func:`~QgsMapLayer.name` or :py:func:`~QgsMapLayer.setName`).
+The ``baseName`` argument specifies the user-visible name to use for the layer. (See :py:func:`~QgsMapLayer.name` or :py:func:`~QgsMapLayer.setName`). If not
+specified, then the current name will be left unchanged (since QGIS 3.40).
 
 The ``provider`` argument is used to specify the unique key of the data provider to use for
 the layer. This must match one of the values returned by :py:func:`QgsProviderRegistry.instance()`->:py:func:`~QgsMapLayer.providerList`.
-(See :py:func:`~QgsMapLayer.providerType`).
+(See :py:func:`~QgsMapLayer.providerType`). If not specified, then the current data provider will be used (since QGIS 3.40).
 
 If ``loadDefaultStyleFlag`` is set to ``True`` then the layer's existing style will be reset to the default
 for the data source.

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1327,7 +1327,7 @@ Write just the symbology information for the layer into the document
 %End
 
 
-    void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false );
+    void setDataSource( const QString &dataSource, const QString &baseName = QString(), const QString &provider = QString(), bool loadDefaultStyleFlag = false );
 %Docstring
 Updates the data source of the layer.
 
@@ -1335,11 +1335,12 @@ The ``dataSource`` argument must specify the new data source string for the laye
 the specified data ``provider`` in use. See :py:class:`QgsDataSourceUri` and the documentation for the various :py:class:`QgsMapLayer`
 subclasses for further details on data source strings.
 
-The ``baseName`` argument specifies the user-visible name to use for the layer. (See :py:func:`~QgsMapLayer.name` or :py:func:`~QgsMapLayer.setName`).
+The ``baseName`` argument specifies the user-visible name to use for the layer. (See :py:func:`~QgsMapLayer.name` or :py:func:`~QgsMapLayer.setName`). If not
+specified, then the current name will be left unchanged (since QGIS 3.40).
 
 The ``provider`` argument is used to specify the unique key of the data provider to use for
 the layer. This must match one of the values returned by :py:func:`QgsProviderRegistry.instance()`->:py:func:`~QgsMapLayer.providerList`.
-(See :py:func:`~QgsMapLayer.providerType`).
+(See :py:func:`~QgsMapLayer.providerType`). If not specified, then the current data provider will be used (since QGIS 3.40).
 
 If ``loadDefaultStyleFlag`` is set to ``True`` then the layer's existing style will be reset to the default
 for the data source.

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2444,7 +2444,10 @@ void QgsMapLayer::setDataSource( const QString &dataSource, const QString &baseN
   {
     flags |= Qgis::DataProviderReadFlag::TrustDataSource;
   }
-  setDataSource( dataSource, baseName, provider, options, flags );
+  setDataSource( dataSource,
+                 baseName.isEmpty() ? mLayerName : baseName,
+                 provider.isEmpty() ? mProviderKey : provider,
+                 options, flags );
 }
 
 void QgsMapLayer::setDataSource( const QString &dataSource, const QString &baseName, const QString &provider,

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1399,11 +1399,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * the specified data \a provider in use. See QgsDataSourceUri and the documentation for the various QgsMapLayer
      * subclasses for further details on data source strings.
      *
-     * The \a baseName argument specifies the user-visible name to use for the layer. (See name() or setName()).
+     * The \a baseName argument specifies the user-visible name to use for the layer. (See name() or setName()). If not
+     * specified, then the current name will be left unchanged (since QGIS 3.40).
      *
      * The \a provider argument is used to specify the unique key of the data provider to use for
      * the layer. This must match one of the values returned by QgsProviderRegistry::instance()->providerList().
-     * (See providerType()).
+     * (See providerType()). If not specified, then the current data provider will be used (since QGIS 3.40).
      *
      * If \a loadDefaultStyleFlag is set to TRUE then the layer's existing style will be reset to the default
      * for the data source.
@@ -1421,7 +1422,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see dataSourceChanged()
      * \since QGIS 3.20
      */
-    void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false );
+    void setDataSource( const QString &dataSource, const QString &baseName = QString(), const QString &provider = QString(), bool loadDefaultStyleFlag = false );
 
     /**
      * Updates the data source of the layer.


### PR DESCRIPTION
Make them optional, and default to current layer name/provider when not specified
