### PR TITLE
Regenerate primary key when making layer permanent if layer property set

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsvectorfilewritertask.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewritertask.sip.in
@@ -28,10 +28,13 @@ QGIS interface.
 
     QgsVectorFileWriterTask( QgsVectorLayer *layer,
                              const QString &fileName,
-                             const QgsVectorFileWriter::SaveVectorOptions &options );
+                             const QgsVectorFileWriter::SaveVectorOptions &options,
+                             QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 %Docstring
 Constructor for QgsVectorFileWriterTask. Takes a source ``layer``, destination ``fileName``
 and save ``options``.
+
+Since QGIS 3.40 the ``sinkFlags`` can be specified.
 %End
 
     virtual void cancel();

--- a/python/core/auto_generated/qgsvectorfilewritertask.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewritertask.sip.in
@@ -28,10 +28,13 @@ QGIS interface.
 
     QgsVectorFileWriterTask( QgsVectorLayer *layer,
                              const QString &fileName,
-                             const QgsVectorFileWriter::SaveVectorOptions &options );
+                             const QgsVectorFileWriter::SaveVectorOptions &options,
+                             QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 %Docstring
 Constructor for QgsVectorFileWriterTask. Takes a source ``layer``, destination ``fileName``
 and save ``options``.
+
+Since QGIS 3.40 the ``sinkFlags`` can be specified.
 %End
 
     virtual void cancel();

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -3477,7 +3477,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( Prepa
   return writeAsVectorFormatV2( details, fileName, QgsCoordinateTransformContext(), options, newFilename, newLayer, errorMessage );
 }
 
-QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( PreparedWriterDetails &details, const QString &fileName, const QgsCoordinateTransformContext &transformContext, const QgsVectorFileWriter::SaveVectorOptions &options, QString *newFilename, QString *newLayer, QString *errorMessage )
+QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( PreparedWriterDetails &details, const QString &fileName, const QgsCoordinateTransformContext &transformContext, const QgsVectorFileWriter::SaveVectorOptions &options, QString *newFilename, QString *newLayer, QString *errorMessage, SinkFlags sinkFlags )
 {
   Qgis::WkbType destWkbType = details.destWkbType;
 
@@ -3545,7 +3545,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( Pre
     newOptions.sourceDatabaseProviderConnection = details.sourceDatabaseProviderConnection.get();
   }
 
-  std::unique_ptr< QgsVectorFileWriter > writer( create( fileName, details.outputFields, destWkbType, details.outputCrs, transformContext, newOptions, QgsFeatureSink::SinkFlags(), &tempNewFilename, &tempNewLayer ) );
+  std::unique_ptr< QgsVectorFileWriter > writer( create( fileName, details.outputFields, destWkbType, details.outputCrs, transformContext, newOptions, sinkFlags, &tempNewFilename, &tempNewLayer ) );
   writer->setSymbologyScale( options.symbologyScale );
 
   if ( newFilename )

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -1045,6 +1045,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param newFilename potentially modified file name (output parameter)
      * \param newLayer potentially modified layer name (output parameter)
      * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
+     * \param sinkFlags optional sink flags (since QGIS 3.40)
      * \returns Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
      * \since QGIS 3.10.3
      */
@@ -1054,7 +1055,8 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = nullptr,
         QString *newLayer = nullptr,
-        QString *errorMessage SIP_OUT = nullptr );
+        QString *errorMessage SIP_OUT = nullptr,
+        QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 
     /**
      * Writes a previously prepared PreparedWriterDetails \a details object.

--- a/src/core/qgsvectorfilewritertask.cpp
+++ b/src/core/qgsvectorfilewritertask.cpp
@@ -18,9 +18,10 @@
 #include "qgsvectorfilewritertask.h"
 #include "qgsvectorlayer.h"
 
-QgsVectorFileWriterTask::QgsVectorFileWriterTask( QgsVectorLayer *layer, const QString &fileName, const QgsVectorFileWriter::SaveVectorOptions &options )
+QgsVectorFileWriterTask::QgsVectorFileWriterTask( QgsVectorLayer *layer, const QString &fileName, const QgsVectorFileWriter::SaveVectorOptions &options, QgsFeatureSink::SinkFlags sinkFlags )
   : QgsTask( tr( "Saving %1" ).arg( fileName ), QgsTask::CanCancel )
   , mDestFileName( fileName )
+  , mSinkFlags( sinkFlags )
   , mOptions( options )
 {
   if ( mOptions.fieldValueConverter )
@@ -59,7 +60,7 @@ bool QgsVectorFileWriterTask::run()
 
 
   mError = QgsVectorFileWriter::writeAsVectorFormatV2(
-             mWriterDetails, mDestFileName, mTransformContext, mOptions, &mNewFilename, &mNewLayer, &mErrorMessage );
+             mWriterDetails, mDestFileName, mTransformContext, mOptions, &mNewFilename, &mNewLayer, &mErrorMessage, mSinkFlags );
   return mError == QgsVectorFileWriter::NoError;
 }
 

--- a/src/core/qgsvectorfilewritertask.h
+++ b/src/core/qgsvectorfilewritertask.h
@@ -40,10 +40,13 @@ class CORE_EXPORT QgsVectorFileWriterTask : public QgsTask
     /**
      * Constructor for QgsVectorFileWriterTask. Takes a source \a layer, destination \a fileName
      * and save \a options.
+     *
+     * Since QGIS 3.40 the \a sinkFlags can be specified.
      */
     QgsVectorFileWriterTask( QgsVectorLayer *layer,
                              const QString &fileName,
-                             const QgsVectorFileWriter::SaveVectorOptions &options );
+                             const QgsVectorFileWriter::SaveVectorOptions &options,
+                             QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 
     void cancel() override;
 
@@ -79,6 +82,7 @@ class CORE_EXPORT QgsVectorFileWriterTask : public QgsTask
     QString mDestFileName;
 
     std::unique_ptr< QgsFeedback > mOwnedFeedback;
+    QgsFeatureSink::SinkFlags mSinkFlags;
     QgsVectorFileWriter::WriterError mError = QgsVectorFileWriter::NoError;
 
     QString mNewFilename;


### PR DESCRIPTION
Respect the OnConvertFormatRegeneratePrimaryKey layer property when
making a temporary layer permanent.

This ensures that processing outputs which require primary key
regeneration will correctly get new primary keys when they are
initially run with a memory layer output, and then later that
memory layer is made permanent

Fixes https://github.com/qgis/QGIS/issues/58942