### PR TITLE
Fix issue with vertical lines not visible in the elevation profile tool

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -26,6 +26,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgspolygon.h"
 #include "qgsgeometryeditutils.h"
 #include "qgspolyhedralsurface.h"
+#include "qgsgeometryutils_base.h"
 #include <limits>
 #include <cstdio>
 
@@ -540,6 +541,43 @@ QgsAbstractGeometry *QgsGeos::symDifference( const QgsAbstractGeometry *geom, QS
   return overlay( geom, OverlaySymDifference, errorMsg, parameters ).release();
 }
 
+static bool isZVerticalLine( const QgsAbstractGeometry *geom, double tolerance = 4 * std::numeric_limits<double>::epsilon() )
+{
+  // checks if the Geometry if a purely vertical 3D line LineString Z((X Y Z1, X Y Z2, ..., X Y Zn))
+  // This is needed because QgsGeos is not able to handle this type of geometry on distance computation.
+
+  if ( geom->wkbType() != Qgis::WkbType::LineStringZ && geom->wkbType() != Qgis::WkbType::LineStringZM )
+  {
+    return false;
+  }
+
+  bool isVertical = true;
+  if ( const QgsLineString *line = qgsgeometry_cast<const QgsLineString *>( geom ) )
+  {
+    const int nrPoints = line->numPoints();
+    if ( nrPoints == 1 )
+    {
+      return true;
+    }
+
+    // if the 2D part of two points of the line are different, this means
+    // that the line is not purely vertical
+    const double sqrTolerance = tolerance * tolerance;
+    const double *lineX = line->xData();
+    const double *lineY = line->yData();
+    for ( int iVert = nrPoints - 1, jVert = 0; jVert < nrPoints; iVert = jVert++ )
+    {
+      if ( QgsGeometryUtilsBase::sqrDistance2D( lineX[iVert], lineY[iVert], lineX[jVert], lineY[jVert] ) > sqrTolerance )
+      {
+        isVertical = false;
+        break;
+      }
+    }
+  }
+
+  return isVertical;
+}
+
 double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   double distance = -1.0;
@@ -548,7 +586,22 @@ double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) c
     return distance;
   }
 
-  geos::unique_ptr otherGeosGeom( asGeos( geom, mPrecision ) );
+  geos::unique_ptr otherGeosGeom;
+
+  // GEOSPreparedDistance_r is not able to properly compute the distance if one
+  // of the geometries if a vertical line (LineString Z((X Y Z1, X Y Z2, ..., X Y Zn))).
+  // In that case, replace `geom` by a single point.
+  // However, GEOSDistance_r works.
+  if ( mGeosPrepared && isZVerticalLine( geom->simplifiedTypeRef() ) )
+  {
+    QgsPoint firstPoint = geom->vertexAt( QgsVertexId( 0, 0, 0 ) );
+    otherGeosGeom = asGeos( &firstPoint, mPrecision );
+  }
+  else
+  {
+    otherGeosGeom = asGeos( geom, mPrecision );
+  }
+
   if ( !otherGeosGeom )
   {
     return distance;
@@ -557,7 +610,7 @@ double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) c
   GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
-    if ( mGeosPrepared )
+    if ( mGeosPrepared && !isZVerticalLine( mGeometry->simplifiedTypeRef() ) )
     {
       GEOSPreparedDistance_r( context, mGeosPrepared.get(), otherGeosGeom.get(), &distance );
     }

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -134,6 +134,7 @@ class TestQgsGeometry : public QgsTest
     void bufferCheck();
     void smoothCheck();
     void shortestLineEmptyGeometry();
+    void distanceCheck();
 
     void unaryUnion();
 
@@ -1677,6 +1678,73 @@ void TestQgsGeometry::shortestLineEmptyGeometry()
   QgsGeometry geom2( new QgsPoint() );
   QgsGeos geos( geom1.constGet() );
   QVERIFY( geos.shortestLine( geom2.constGet() ).isNull() );
+}
+
+void TestQgsGeometry::distanceCheck()
+{
+  QgsGeometry polygon( QgsGeometry::fromWkt( QStringLiteral( "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0 ))" ) ) );
+  std::unique_ptr< QgsGeometryEngine > polygonEngine( QgsGeometry::createGeometryEngine( polygon.constGet() ) );
+  polygonEngine->prepareGeometry();
+
+  /**
+   * Test polygon and 2D line
+   */
+  QgsGeometry line2D( QgsGeometry::fromWkt( QStringLiteral( "LineString (15.05 25.2, 13.2 14.1, 17.05 18.1, 15.5 25.2)" ) ) );
+  std::unique_ptr< QgsGeometryEngine > line2DEngine( QgsGeometry::createGeometryEngine( line2D.constGet() ) );
+  line2DEngine->prepareGeometry();
+
+  const double distanceToLine2D = 5.20;
+  QGSCOMPARENEAR( polygonEngine->distance( line2D.constGet() ), distanceToLine2D, 0.01 );
+  QGSCOMPARENEAR( line2DEngine->distance( polygon.constGet() ), distanceToLine2D, 0.01 );
+  QGSCOMPARENEAR( polygon.distance( line2D ), distanceToLine2D, 0.01 );
+  QGSCOMPARENEAR( line2D.distance( polygon ), distanceToLine2D, 0.01 );
+
+  /**
+   * Test polygon and 3D line
+   */
+  QgsGeometry line3D( QgsGeometry::fromWkt( QStringLiteral( "LineString Z(40 50 1, -30 10 30, -70 80 20, 40 50 1)" ) ) );
+  std::unique_ptr< QgsGeometryEngine > line3DEngine( QgsGeometry::createGeometryEngine( line3D.constGet() ) );
+  line3DEngine->prepareGeometry();
+
+  const double distanceToLine3D = 14.88;
+  QGSCOMPARENEAR( polygonEngine->distance( line3D.constGet() ), distanceToLine3D, 0.01 );
+  QGSCOMPARENEAR( line3DEngine->distance( polygon.constGet() ), distanceToLine3D, 0.01 );
+  QGSCOMPARENEAR( polygon.distance( line3D ), distanceToLine3D, 0.01 );
+  QGSCOMPARENEAR( line3D.distance( polygon ), distanceToLine3D, 0.01 );
+
+  /**
+   * Test polygon and 3D point
+   */
+  QgsGeometry point3D( QgsGeometry::fromWkt( QStringLiteral( "Point Z(40.3 50.1 10.2)" ) ) );
+  std::unique_ptr< QgsGeometryEngine > point3DEngine( QgsGeometry::createGeometryEngine( point3D.constGet() ) );
+  point3DEngine->prepareGeometry();
+  const double distanceToPoint3D = 50.26;
+  QGSCOMPARENEAR( polygonEngine->distance( point3D.constGet() ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( point3DEngine->distance( polygon.constGet() ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( polygon.distance( point3D ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( point3D.distance( polygon ), distanceToPoint3D, 0.01 );
+
+  /**
+   * Test polygon and 3D vertical line ((X Y Z1, X Y Z2, ..., X Y ZN, X Y Z1))
+   */
+  QgsGeometry line3DVertical( QgsGeometry::fromWkt( QStringLiteral( "LineString Z(40.3 50.1 10, 40.3 50.1 -2, 40.3 50.1 -46, 40.3 50.1 10)" ) ) );
+  std::unique_ptr< QgsGeometryEngine > line3DVerticalEngine( QgsGeometry::createGeometryEngine( line3DVertical.constGet() ) );
+  line3DVerticalEngine->prepareGeometry();
+  QGSCOMPARENEAR( polygonEngine->distance( line3DVertical.constGet() ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( line3DVerticalEngine->distance( polygon.constGet() ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( polygon.distance( line3DVertical ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( line3DVertical.distance( polygon ), distanceToPoint3D, 0.01 );
+
+  /**
+   * Test polygon and 3D vertical line of two points ((X Y Z1, X Y Z2))
+   */
+  QgsGeometry line3DVertical2( QgsGeometry::fromWkt( QStringLiteral( "LineString Z(40.3 50.1 10, 40.3 50.1 -2)" ) ) );
+  std::unique_ptr< QgsGeometryEngine > line3DVertical2Engine( QgsGeometry::createGeometryEngine( line3DVertical2.constGet() ) );
+  line3DVertical2Engine->prepareGeometry();
+  QGSCOMPARENEAR( polygonEngine->distance( line3DVertical2.constGet() ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( line3DVertical2Engine->distance( polygon.constGet() ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( polygon.distance( line3DVertical2 ), distanceToPoint3D, 0.01 );
+  QGSCOMPARENEAR( line3DVertical2.distance( polygon ), distanceToPoint3D, 0.01 );
 }
 
 void TestQgsGeometry::unaryUnion()

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -1698,6 +1698,8 @@ void TestQgsGeometry::distanceCheck()
   QGSCOMPARENEAR( line2DEngine->distance( polygon.constGet() ), distanceToLine2D, 0.01 );
   QGSCOMPARENEAR( polygon.distance( line2D ), distanceToLine2D, 0.01 );
   QGSCOMPARENEAR( line2D.distance( polygon ), distanceToLine2D, 0.01 );
+  QVERIFY( polygonEngine->distanceWithin( line2D.constGet(), distanceToLine2D + 0.01 ) );
+  QVERIFY( line2DEngine->distanceWithin( polygon.constGet(), distanceToLine2D + 0.01 ) );
 
   /**
    * Test polygon and 3D line
@@ -1711,6 +1713,8 @@ void TestQgsGeometry::distanceCheck()
   QGSCOMPARENEAR( line3DEngine->distance( polygon.constGet() ), distanceToLine3D, 0.01 );
   QGSCOMPARENEAR( polygon.distance( line3D ), distanceToLine3D, 0.01 );
   QGSCOMPARENEAR( line3D.distance( polygon ), distanceToLine3D, 0.01 );
+  QVERIFY( polygonEngine->distanceWithin( line3D.constGet(), distanceToLine3D + 0.01 ) );
+  QVERIFY( line3DEngine->distanceWithin( polygon.constGet(), distanceToLine3D + 0.01 ) );
 
   /**
    * Test polygon and 3D point
@@ -1723,6 +1727,8 @@ void TestQgsGeometry::distanceCheck()
   QGSCOMPARENEAR( point3DEngine->distance( polygon.constGet() ), distanceToPoint3D, 0.01 );
   QGSCOMPARENEAR( polygon.distance( point3D ), distanceToPoint3D, 0.01 );
   QGSCOMPARENEAR( point3D.distance( polygon ), distanceToPoint3D, 0.01 );
+  QVERIFY( polygonEngine->distanceWithin( point3D.constGet(), distanceToPoint3D + 0.01 ) );
+  QVERIFY( point3DEngine->distanceWithin( polygon.constGet(), distanceToPoint3D + 0.01 ) );
 
   /**
    * Test polygon and 3D vertical line ((X Y Z1, X Y Z2, ..., X Y ZN, X Y Z1))
@@ -1734,6 +1740,8 @@ void TestQgsGeometry::distanceCheck()
   QGSCOMPARENEAR( line3DVerticalEngine->distance( polygon.constGet() ), distanceToPoint3D, 0.01 );
   QGSCOMPARENEAR( polygon.distance( line3DVertical ), distanceToPoint3D, 0.01 );
   QGSCOMPARENEAR( line3DVertical.distance( polygon ), distanceToPoint3D, 0.01 );
+  QVERIFY( polygonEngine->distanceWithin( line3DVertical.constGet(), distanceToPoint3D + 0.01 ) );
+  QVERIFY( line3DVerticalEngine->distanceWithin( polygon.constGet(), distanceToPoint3D + 0.01 ) );
 
   /**
    * Test polygon and 3D vertical line of two points ((X Y Z1, X Y Z2))
@@ -1745,6 +1753,8 @@ void TestQgsGeometry::distanceCheck()
   QGSCOMPARENEAR( line3DVertical2Engine->distance( polygon.constGet() ), distanceToPoint3D, 0.01 );
   QGSCOMPARENEAR( polygon.distance( line3DVertical2 ), distanceToPoint3D, 0.01 );
   QGSCOMPARENEAR( line3DVertical2.distance( polygon ), distanceToPoint3D, 0.01 );
+  QVERIFY( polygonEngine->distanceWithin( line3DVertical2.constGet(), distanceToPoint3D + 0.01 ) );
+  QVERIFY( line3DVertical2Engine->distanceWithin( polygon.constGet(), distanceToPoint3D + 0.01 ) );
 }
 
 void TestQgsGeometry::unaryUnion()


### PR DESCRIPTION
## Description

This PR reverts commit ce96dee6b517bc19a84c9394e48d6cb30e80c1f7.

This commit was introduced to gain some performance when the
`tolerance` is set by using `request.setDistanceWithin` instead of
`request.setFilterRect`. However, in that case, the providers either
use `GEOS::distance` or `GEOS::distanceWithin` which is not able to
handle the Z component of a Geometry.
For example, a purely vertical line, i.e.: `LineString(X Y Z1, X Y
Z2)` will always be to an infinite distance of any geometry according
to GEOS.

In practice, this means that a purely vertical line will never be
visible in the elevation profile when the tolerance is set. Indeed,
the provider will always discard such geometry because of the usage
of `setDistanceWithin`. This issue is fixed by always using
`setFilterRect`. This might introduce a performance penalty but this
ensures that the result is always correct.

## Update October 10

```
`GEOSPreparedDistance_r` is not able to properly handle a purely
vertical line (LineString Z((X Y Z1, X Y Z2, ..., X Y Zn))). In that
case, it always `inf`. However, `GEOSDistance_r` works.

This issue is fixed by checking if one of the geometry is vertical 3d
line by introducing `isZVerticalLine`. This function checks if a
geometry is a 3d line. If that's the case, it loops through the points
of the line. If two points do not have the same X Y corrdinates, it
means that the line is not purely vertical.

If `geom` is a vertical line, it is replaced by its first point.
It the prepared geometry is a vertical line, fallback to the non
prepared case.
```