### PR TITLE
Fix parsing 2-byte LAS scan angle (fix #58451)

### DIFF
--- a/src/core/pointcloud/qgslazdecoder.cpp
+++ b/src/core/pointcloud/qgslazdecoder.cpp
@@ -315,7 +315,9 @@ void decodePoint( char *buf, int lasPointFormat, char *dataBuffer, std::size_t &
   lazperf::las::nir14 nir;
   lazperf::las::point14 p14;
 
-  bool isLas14 = ( lasPointFormat == 6 || lasPointFormat == 7 || lasPointFormat == 8 );
+  // Does the point record start with the common fields for formats introduced
+  // in the LAS 1.4 spec?
+  const bool isLas14 = ( lasPointFormat == 6 || lasPointFormat == 7 || lasPointFormat == 8 || lasPointFormat == 9 || lasPointFormat == 10 );
 
   switch ( lasPointFormat )
   {
@@ -397,7 +399,12 @@ void decodePoint( char *buf, int lasPointFormat, char *dataBuffer, std::size_t &
         lazStoreToStream_<unsigned char>( dataBuffer, outputOffset, requestedAttribute.type, isLas14 ? p14.eofFlag() : p10.edge_of_flight_line );
         break;
       case QgsLazDecoder::LazAttribute::ScanAngleRank:
-        lazStoreToStream_<char>( dataBuffer, outputOffset, requestedAttribute.type, char( isLas14 ? p14.scanAngle() : p10.scan_angle_rank ) );
+        lazStoreToStream_<float>( dataBuffer, outputOffset, requestedAttribute.type,
+                                  isLas14
+                                  // Formats from LAS 1.4 spec store the angle in 0.006 degree increments
+                                  ? p14.scanAngle() * 0.006f
+                                  // Older formats store integer values
+                                  : p10.scan_angle_rank );
         break;
       case QgsLazDecoder::LazAttribute::UserData:
         lazStoreToStream_<unsigned char>( dataBuffer, outputOffset, requestedAttribute.type, isLas14 ? p14.userData() : p10.user_data );

--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -168,7 +168,7 @@ void QgsLazInfo::parseLazAttributes()
   mAttributes.push_back( QgsPointCloudAttribute( "ScanDirectionFlag", QgsPointCloudAttribute::Char ) );
   mAttributes.push_back( QgsPointCloudAttribute( "EdgeOfFlightLine", QgsPointCloudAttribute::Char ) );
   mAttributes.push_back( QgsPointCloudAttribute( "Classification", QgsPointCloudAttribute::UChar ) );
-  mAttributes.push_back( QgsPointCloudAttribute( "ScanAngleRank", QgsPointCloudAttribute::Short ) );
+  mAttributes.push_back( QgsPointCloudAttribute( "ScanAngleRank", QgsPointCloudAttribute::Float ) );
   mAttributes.push_back( QgsPointCloudAttribute( "UserData", QgsPointCloudAttribute::UChar ) );
   mAttributes.push_back( QgsPointCloudAttribute( "PointSourceId", QgsPointCloudAttribute::UShort ) );
   mAttributes.push_back( QgsPointCloudAttribute( "Synthetic", QgsPointCloudAttribute::UChar ) );

--- a/src/core/pointcloud/qgspointcloudlayerexporter.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.cpp
@@ -587,7 +587,7 @@ void QgsPointCloudLayerExporter::ExporterPdal::handlePoint( double x, double y, 
   mView->setField( pdal::Dimension::Id::NumberOfReturns, pointNumber, map[ QStringLiteral( "NumberOfReturns" ) ].toInt() );
   mView->setField( pdal::Dimension::Id::ScanDirectionFlag, pointNumber, map[ QStringLiteral( "ScanDirectionFlag" ) ].toInt() );
   mView->setField( pdal::Dimension::Id::EdgeOfFlightLine, pointNumber, map[ QStringLiteral( "EdgeOfFlightLine" ) ].toInt() );
-  mView->setField( pdal::Dimension::Id::ScanAngleRank, pointNumber, map[ QStringLiteral( "ScanAngleRank" ) ].toInt() );
+  mView->setField( pdal::Dimension::Id::ScanAngleRank, pointNumber, map[ QStringLiteral( "ScanAngleRank" ) ].toFloat() );
   mView->setField( pdal::Dimension::Id::UserData, pointNumber, map[ QStringLiteral( "UserData" ) ].toInt() );
   mView->setField( pdal::Dimension::Id::PointSourceId, pointNumber, map[ QStringLiteral( "PointSourceId" ) ].toInt() );
 

--- a/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
+++ b/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
@@ -437,7 +437,7 @@ void QgsVirtualPointCloudProvider::populateAttributeCollection( QSet<QString> na
   if ( names.contains( QLatin1String( "Classification" ) ) )
     mAttributes.push_back( QgsPointCloudAttribute( QStringLiteral( "Classification" ), QgsPointCloudAttribute::UChar ) );
   if ( names.contains( QLatin1String( "ScanAngleRank" ) ) )
-    mAttributes.push_back( QgsPointCloudAttribute( QStringLiteral( "ScanAngleRank" ), QgsPointCloudAttribute::Short ) );
+    mAttributes.push_back( QgsPointCloudAttribute( QStringLiteral( "ScanAngleRank" ), QgsPointCloudAttribute::Float ) );
   if ( names.contains( QLatin1String( "UserData" ) ) )
     mAttributes.push_back( QgsPointCloudAttribute( QStringLiteral( "UserData" ), QgsPointCloudAttribute::Char ) );
   if ( names.contains( QLatin1String( "PointSourceId" ) ) )

--- a/tests/src/providers/testqgscopcprovider.cpp
+++ b/tests/src/providers/testqgscopcprovider.cpp
@@ -317,7 +317,7 @@ void TestQgsCopcProvider::attributes()
   QCOMPARE( attributes.at( 8 ).name(), QStringLiteral( "Classification" ) );
   QCOMPARE( attributes.at( 8 ).type(), QgsPointCloudAttribute::UChar );
   QCOMPARE( attributes.at( 9 ).name(), QStringLiteral( "ScanAngleRank" ) );
-  QCOMPARE( attributes.at( 9 ).type(), QgsPointCloudAttribute::Short );
+  QCOMPARE( attributes.at( 9 ).type(), QgsPointCloudAttribute::Float );
   QCOMPARE( attributes.at( 10 ).name(), QStringLiteral( "UserData" ) );
   QCOMPARE( attributes.at( 10 ).type(), QgsPointCloudAttribute::UChar );
   QCOMPARE( attributes.at( 11 ).name(), QStringLiteral( "PointSourceId" ) );
@@ -404,7 +404,7 @@ void TestQgsCopcProvider::testIdentify()
     expected[ QStringLiteral( "PointSourceId" ) ] = 7041;
     expected[ QStringLiteral( "Red" ) ] = 0;
     expected[ QStringLiteral( "ReturnNumber" ) ] = 1;
-    expected[ QStringLiteral( "ScanAngleRank" ) ] = -59;
+    expected[ QStringLiteral( "ScanAngleRank" ) ] = -28.0020008087;
     expected[ QStringLiteral( "ScanDirectionFlag" ) ] = 1;
     expected[ QStringLiteral( "UserData" ) ] = 17;
     expected[ QStringLiteral( "X" ) ] = 498062.52;
@@ -443,7 +443,7 @@ void TestQgsCopcProvider::testIdentify()
       point[ QStringLiteral( "PointSourceId" ) ] =  "7041" ;
       point[ QStringLiteral( "Red" ) ] =  "0" ;
       point[ QStringLiteral( "ReturnNumber" ) ] =  "1" ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =  "-59" ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =  "-28.0020008087" ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =  "1" ;
       point[ QStringLiteral( "UserData" ) ] =  "17" ;
       point[ QStringLiteral( "X" ) ] =  "498066.27" ;
@@ -486,7 +486,7 @@ void TestQgsCopcProvider::testIdentify()
       point[ QStringLiteral( "PointSourceId" ) ] =  "7041" ;
       point[ QStringLiteral( "Red" ) ] =  "0" ;
       point[ QStringLiteral( "ReturnNumber" ) ] =  "1" ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =  "-59" ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =  "-28.0020008087" ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =  "1" ;
       point[ QStringLiteral( "UserData" ) ] =  "17" ;
       point[ QStringLiteral( "X" ) ] =  "498063.14" ;
@@ -506,7 +506,7 @@ void TestQgsCopcProvider::testIdentify()
       point[ QStringLiteral( "PointSourceId" ) ] =  "7042" ;
       point[ QStringLiteral( "Red" ) ] =  "0" ;
       point[ QStringLiteral( "ReturnNumber" ) ] =  "1" ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =  "48" ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =  "-12" ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =  "1" ;
       point[ QStringLiteral( "UserData" ) ] =  "17" ;
       point[ QStringLiteral( "X" ) ] =  "498063.11" ;
@@ -597,7 +597,7 @@ void TestQgsCopcProvider::testExtraBytesAttributesValues()
       point[ QStringLiteral( "Red" ) ] =   "0"  ;
       point[ QStringLiteral( "Reflectance" ) ] =   "-8.050000190734863"  ;
       point[ QStringLiteral( "ReturnNumber" ) ] =   "3"  ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =   "24"  ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =   "-6"  ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =   "0"  ;
       point[ QStringLiteral( "UserData" ) ] =   "0"  ;
       point[ QStringLiteral( "X" ) ] =   "527919.11"  ;
@@ -620,7 +620,7 @@ void TestQgsCopcProvider::testExtraBytesAttributesValues()
       point[ QStringLiteral( "Red" ) ] =   "0"  ;
       point[ QStringLiteral( "Reflectance" ) ] =   "-17.829999923706055"  ;
       point[ QStringLiteral( "ReturnNumber" ) ] =   "2"  ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =   "24"  ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =   "-6"  ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =   "0"  ;
       point[ QStringLiteral( "UserData" ) ] =   "0"  ;
       point[ QStringLiteral( "X" ) ] =   "527919.1799999999"  ;
@@ -681,7 +681,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Red" ) ] =   "0"  ;
       point[ QStringLiteral( "Reflectance" ) ] =   "-8.050000190734863"  ;
       point[ QStringLiteral( "ReturnNumber" ) ] =   "3"  ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =   "24"  ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =   "-6"  ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =   "0"  ;
       point[ QStringLiteral( "UserData" ) ] =   "0"  ;
       point[ QStringLiteral( "Synthetic" ) ] =   "1"  ;
@@ -708,7 +708,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Red" ) ] =   "0"  ;
       point[ QStringLiteral( "Reflectance" ) ] =   "-17.829999923706055"  ;
       point[ QStringLiteral( "ReturnNumber" ) ] =   "2"  ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =   "24"  ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =   "-6"  ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =   "0"  ;
       point[ QStringLiteral( "UserData" ) ] =   "0"  ;
       point[ QStringLiteral( "Synthetic" ) ] =   "1"  ;
@@ -735,7 +735,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Red" ) ] =   "0"  ;
       point[ QStringLiteral( "Reflectance" ) ] =   "-14.720000267028809"  ;
       point[ QStringLiteral( "ReturnNumber" ) ] =   "2"  ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =   "24"  ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =   "-6"  ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =   "0"  ;
       point[ QStringLiteral( "UserData" ) ] =   "0"  ;
       point[ QStringLiteral( "Synthetic" ) ] =   "1"  ;
@@ -762,7 +762,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Red" ) ] =   "0"  ;
       point[ QStringLiteral( "Reflectance" ) ] =   "-6.829999923706055"  ;
       point[ QStringLiteral( "ReturnNumber" ) ] =   "3"  ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =   "24"  ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =   "-6"  ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =   "0"  ;
       point[ QStringLiteral( "UserData" ) ] =   "0"  ;
       point[ QStringLiteral( "Synthetic" ) ] =   "1"  ;
@@ -789,7 +789,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Red" ) ] =   "0"  ;
       point[ QStringLiteral( "Reflectance" ) ] =   "-10.550000190734863"  ;
       point[ QStringLiteral( "ReturnNumber" ) ] =   "1"  ;
-      point[ QStringLiteral( "ScanAngleRank" ) ] =   "24"  ;
+      point[ QStringLiteral( "ScanAngleRank" ) ] =   "-6"  ;
       point[ QStringLiteral( "ScanDirectionFlag" ) ] =   "0"  ;
       point[ QStringLiteral( "UserData" ) ] =   "0"  ;
       point[ QStringLiteral( "Synthetic" ) ] =   "0"  ;
@@ -1035,8 +1035,8 @@ void TestQgsCopcProvider::testStatsCalculator()
 
   {
     QgsPointCloudAttributeStatistics s = stats.statisticsOf( QStringLiteral( "ScanAngleRank" ) );
-    QCOMPARE( ( float )s.minimum, -65 );
-    QCOMPARE( ( float )s.maximum, 125 );
+    QCOMPARE( ( float )s.minimum, -10.998000145f );
+    QCOMPARE( ( float )s.maximum, -4.001999855f );
   }
 
   {

--- a/tests/src/providers/testqgsvirtualpointcloudprovider.cpp
+++ b/tests/src/providers/testqgsvirtualpointcloudprovider.cpp
@@ -252,7 +252,7 @@ void TestQgsVirtualPointCloudProvider::attributes()
   QCOMPARE( attributes.at( 8 ).name(), QStringLiteral( "Classification" ) );
   QCOMPARE( attributes.at( 8 ).type(), QgsPointCloudAttribute::UChar );
   QCOMPARE( attributes.at( 9 ).name(), QStringLiteral( "ScanAngleRank" ) );
-  QCOMPARE( attributes.at( 9 ).type(), QgsPointCloudAttribute::Short );
+  QCOMPARE( attributes.at( 9 ).type(), QgsPointCloudAttribute::Float );
   QCOMPARE( attributes.at( 10 ).name(), QStringLiteral( "UserData" ) );
   QCOMPARE( attributes.at( 10 ).type(), QgsPointCloudAttribute::Char );
   QCOMPARE( attributes.at( 11 ).name(), QStringLiteral( "PointSourceId" ) );


### PR DESCRIPTION
## Description

Currently in QGIS the `ScanAngleRank` LAS(/LAZ) field is typed as a short and is read as a single signed byte. The LAS 1.4 specification introduced a new field, `ScanAngle`, which is logically a two-byte fixed-point number, to replace `ScanAngleRank` in new formats. Right now QGIS tries to read this field as `ScanAngleRank`, so the result is an incorrect integer value.

This PR changes the type of `ScanAngleRank` to `float` and fixes parsing the new LAS 1.4 formats, unifying `ScanAngleRank` and `ScanAngle` into one general property, just as PDAL does.

Will fix #58451.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
