### PR TITLE
Only render main annotation layer in main map canvas or docked maps

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -5958,6 +5958,20 @@ Qgis.RendererUsage.__doc__ = """Usage of the renderer.
 # --
 Qgis.RendererUsage.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.MapCanvasFlag.ShowMainAnnotationLayer.__doc__ = "The project's main annotation layer should be rendered in the canvas"
+Qgis.MapCanvasFlag.__doc__ = """Flags controlling behavior of map canvases.
+
+.. versionadded:: 3.40
+
+* ``ShowMainAnnotationLayer``: The project's main annotation layer should be rendered in the canvas
+
+"""
+# --
+Qgis.MapCanvasFlag.baseClass = Qgis
+Qgis.MapCanvasFlags = lambda flags=0: Qgis.MapCanvasFlag(flags)
+Qgis.MapCanvasFlags.baseClass = Qgis
+MapCanvasFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.ViewSyncModeFlag.Sync3DTo2D.__doc__ = "Synchronize 3D view camera to the main map canvas extent"
 Qgis.ViewSyncModeFlag.Sync2DTo3D.__doc__ = "Update the 2D main canvas extent to include the viewed area from the 3D view"
 Qgis.ViewSyncModeFlag.__doc__ = """Synchronization of 2D map canvas and 3D view

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1856,6 +1856,14 @@ The development version
       Unknown,
     };
 
+    enum class MapCanvasFlag /BaseType=IntFlag/
+    {
+      ShowMainAnnotationLayer,
+    };
+
+    typedef QFlags<Qgis::MapCanvasFlag> MapCanvasFlags;
+
+
     enum class ViewSyncModeFlag /BaseType=IntFlag/
     {
       Sync3DTo2D,
@@ -3373,6 +3381,8 @@ QFlags<Qgis::VectorRenderingSimplificationFlag> operator|(Qgis::VectorRenderingS
 QFlags<Qgis::DataProviderReadFlag> operator|(Qgis::DataProviderReadFlag f1, QFlags<Qgis::DataProviderReadFlag> f2);
 
 QFlags<Qgis::VectorProviderCapability> operator|(Qgis::VectorProviderCapability f1, QFlags<Qgis::VectorProviderCapability> f2);
+
+QFlags<Qgis::MapCanvasFlag> operator|(Qgis::MapCanvasFlag f1, QFlags<Qgis::MapCanvasFlag> f2);
 
 
 

--- a/python/PyQt6/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmapcanvas.sip.in
@@ -78,6 +78,24 @@ empty string before :py:func:`~QgsMapCanvas.setLayers` calls can be made.
 .. seealso:: :py:func:`layers`
 %End
 
+    void setFlags( Qgis::MapCanvasFlags flags );
+%Docstring
+Sets ``flags`` which control how the map canvas behaves.
+
+.. seealso:: :py:func:`flags`
+
+.. versionadded:: 3.40
+%End
+
+    Qgis::MapCanvasFlags flags() const;
+%Docstring
+Returns flags which control how the map canvas behaves.
+
+.. seealso:: :py:func:`setFlags`
+
+.. versionadded:: 3.40
+%End
+
     void setCurrentLayer( QgsMapLayer *layer );
 
     const QgsMapSettings &mapSettings() const /KeepReference/;

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -5904,6 +5904,19 @@ Qgis.RendererUsage.__doc__ = """Usage of the renderer.
 # --
 Qgis.RendererUsage.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.MapCanvasFlag.ShowMainAnnotationLayer.__doc__ = "The project's main annotation layer should be rendered in the canvas"
+Qgis.MapCanvasFlag.__doc__ = """Flags controlling behavior of map canvases.
+
+.. versionadded:: 3.40
+
+* ``ShowMainAnnotationLayer``: The project's main annotation layer should be rendered in the canvas
+
+"""
+# --
+Qgis.MapCanvasFlag.baseClass = Qgis
+Qgis.MapCanvasFlags.baseClass = Qgis
+MapCanvasFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.ViewSyncModeFlag.Sync3DTo2D.__doc__ = "Synchronize 3D view camera to the main map canvas extent"
 Qgis.ViewSyncModeFlag.Sync2DTo3D.__doc__ = "Update the 2D main canvas extent to include the viewed area from the 3D view"
 Qgis.ViewSyncModeFlag.__doc__ = """Synchronization of 2D map canvas and 3D view

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1856,6 +1856,14 @@ The development version
       Unknown,
     };
 
+    enum class MapCanvasFlag
+    {
+      ShowMainAnnotationLayer,
+    };
+
+    typedef QFlags<Qgis::MapCanvasFlag> MapCanvasFlags;
+
+
     enum class ViewSyncModeFlag
     {
       Sync3DTo2D,
@@ -3373,6 +3381,8 @@ QFlags<Qgis::VectorRenderingSimplificationFlag> operator|(Qgis::VectorRenderingS
 QFlags<Qgis::DataProviderReadFlag> operator|(Qgis::DataProviderReadFlag f1, QFlags<Qgis::DataProviderReadFlag> f2);
 
 QFlags<Qgis::VectorProviderCapability> operator|(Qgis::VectorProviderCapability f1, QFlags<Qgis::VectorProviderCapability> f2);
+
+QFlags<Qgis::MapCanvasFlag> operator|(Qgis::MapCanvasFlag f1, QFlags<Qgis::MapCanvasFlag> f2);
 
 
 

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -78,6 +78,24 @@ empty string before :py:func:`~QgsMapCanvas.setLayers` calls can be made.
 .. seealso:: :py:func:`layers`
 %End
 
+    void setFlags( Qgis::MapCanvasFlags flags );
+%Docstring
+Sets ``flags`` which control how the map canvas behaves.
+
+.. seealso:: :py:func:`flags`
+
+.. versionadded:: 3.40
+%End
+
+    Qgis::MapCanvasFlags flags() const;
+%Docstring
+Returns flags which control how the map canvas behaves.
+
+.. seealso:: :py:func:`setFlags`
+
+.. versionadded:: 3.40
+%End
+
     void setCurrentLayer( QgsMapLayer *layer );
 
     const QgsMapSettings &mapSettings() const /KeepReference/;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1066,6 +1066,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   startProfile( tr( "Creating map canvas" ) );
   mMapCanvas = new QgsMapCanvas( centralWidget );
   mMapCanvas->setObjectName( QStringLiteral( "theMapCanvas" ) );
+  mMapCanvas->setFlags( Qgis::MapCanvasFlag::ShowMainAnnotationLayer );
 
   // before anything, let's freeze canvas redraws
   QgsCanvasRefreshBlocker refreshBlocker;
@@ -2083,6 +2084,7 @@ QgisApp::QgisApp()
 
   mInternalClipboard = new QgsClipboard;
   mMapCanvas = new QgsMapCanvas();
+  mMapCanvas->setFlags( Qgis::MapCanvasFlag::ShowMainAnnotationLayer );
   connect( mMapCanvas, &QgsMapCanvas::messageEmitted, this, &QgisApp::displayMessage );
   QgsCanvasRefreshBlocker refreshBlocker;
   mLayerTreeView = new QgsLayerTreeView( this );

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -54,6 +54,7 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   mToolbar->setIconSize( QgisApp::instance()->iconSize( true ) );
 
   mMapCanvas = new QgsMapCanvas( this );
+  mMapCanvas->setFlags( Qgis::MapCanvasFlag::ShowMainAnnotationLayer );
   mXyMarker = new QgsVertexMarker( mMapCanvas );
   mXyMarker->setIconType( QgsVertexMarker::ICON_CIRCLE );
   mXyMarker->setIconSize( 6 );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3191,6 +3191,25 @@ class CORE_EXPORT Qgis
     Q_ENUM( RendererUsage )
 
     /**
+     * Flags controlling behavior of map canvases.
+     *
+     * \since QGIS 3.40
+     */
+    enum class MapCanvasFlag : int SIP_ENUM_BASETYPE( IntFlag )
+    {
+      ShowMainAnnotationLayer = 1 << 0, //!< The project's main annotation layer should be rendered in the canvas
+    };
+    Q_ENUM( MapCanvasFlag )
+
+    /**
+     * Flags controlling behavior of map canvases.
+     *
+     * \since QGIS 3.40
+     */
+    Q_DECLARE_FLAGS( MapCanvasFlags, MapCanvasFlag )
+    Q_FLAG( MapCanvasFlags )
+
+    /**
      * Synchronization of 2D map canvas and 3D view
      *
      * \since QGIS 3.26
@@ -5724,6 +5743,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::DataItemProviderCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::VectorRenderingSimplificationFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::DataProviderReadFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::VectorProviderCapabilities )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapCanvasFlags )
 
 // hack to workaround warnings when casting void pointers
 // retrieved from QLibrary::resolve to function pointers.

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -408,6 +408,16 @@ void QgsMapCanvas::setLayers( const QList<QgsMapLayer *> &layers )
   setLayersPrivate( layers );
 }
 
+void QgsMapCanvas::setFlags( Qgis::MapCanvasFlags flags )
+{
+  mFlags = flags;
+}
+
+Qgis::MapCanvasFlags QgsMapCanvas::flags() const
+{
+  return mFlags;
+}
+
 void QgsMapCanvas::setLayersPrivate( const QList<QgsMapLayer *> &layers )
 {
   const QList<QgsMapLayer *> oldLayers = mSettings.layers();
@@ -825,7 +835,8 @@ void QgsMapCanvas::refreshMap()
   // render main annotation layer above all other layers
   QgsMapSettings renderSettings = mSettings;
   QList<QgsMapLayer *> allLayers = renderSettings.layers();
-  allLayers.insert( 0, QgsProject::instance()->mainAnnotationLayer() );
+  if ( mFlags & Qgis::MapCanvasFlag::ShowMainAnnotationLayer )
+    allLayers.insert( 0, QgsProject::instance()->mainAnnotationLayer() );
 
   renderSettings.setLayers( filterLayersForRender( allLayers ) );
 
@@ -3590,7 +3601,8 @@ void QgsMapCanvas::startPreviewJob( int number )
 
     previewLayers << layer;
   }
-  if ( QgsProject::instance()->mainAnnotationLayer()->dataProvider()->renderInPreview( context ) )
+  if ( ( mFlags & Qgis::MapCanvasFlag::ShowMainAnnotationLayer )
+       && QgsProject::instance()->mainAnnotationLayer()->dataProvider()->renderInPreview( context ) )
   {
     previewLayers.insert( 0, QgsProject::instance()->mainAnnotationLayer() );
   }

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -141,6 +141,22 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
      */
     void setLayers( const QList<QgsMapLayer *> &layers );
 
+    /**
+     * Sets \a flags which control how the map canvas behaves.
+     *
+     * \see flags()
+     * \since QGIS 3.40
+     */
+    void setFlags( Qgis::MapCanvasFlags flags );
+
+    /**
+     * Returns flags which control how the map canvas behaves.
+     *
+     * \see setFlags()
+     * \since QGIS 3.40
+     */
+    Qgis::MapCanvasFlags flags() const;
+
     void setCurrentLayer( QgsMapLayer *layer );
 
     /**
@@ -1305,6 +1321,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     };
 
     QgsOverlayWidgetLayout *mLayout = nullptr;
+
+    Qgis::MapCanvasFlags mFlags;
 
     //! encompases all map settings necessary for map rendering
     QgsMapSettings mSettings;

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -17,6 +17,7 @@ from qgis.PyQt.QtCore import QDate, QDateTime, QTime, Qt
 from qgis.PyQt.QtGui import QImage
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
+    Qgis,
     QgsAnnotationLayer,
     QgsAnnotationLineItem,
     QgsAnnotationMarkerItem,
@@ -509,6 +510,20 @@ class TestQgsMapCanvas(QgisTestCase):
 
         # annotation must be rendered over other layers
         rendered_image = self.canvas_to_image(canvas)
+
+        # should NOT be shown, as ShowMainAnnotationLayer flag not set
+        self.assertFalse(
+            self.image_check('main_annotation_layer', 'main_annotation_layer', rendered_image,
+                             color_tolerance=2,
+                             allowed_mismatch=20,
+                             expect_fail=True)
+        )
+
+        canvas.setFlags(Qgis.MapCanvasFlag.ShowMainAnnotationLayer)
+        canvas.refresh()
+        canvas.waitWhileRendering()
+        rendered_image = self.canvas_to_image(canvas)
+        # now annotation should be rendered
         self.assertTrue(
             self.image_check('main_annotation_layer', 'main_annotation_layer', rendered_image,
                              color_tolerance=2,


### PR DESCRIPTION
Don't show it in other map canvas instances, eg the coordinate bounds preview map

Fixes #58766
