### PR TITLE
Non-default blend mode should force raster render of layer

### DIFF
--- a/src/core/annotations/qgsannotationlayerrenderer.cpp
+++ b/src/core/annotations/qgsannotationlayerrenderer.cpp
@@ -26,6 +26,7 @@ QgsAnnotationLayerRenderer::QgsAnnotationLayerRenderer( QgsAnnotationLayer *laye
   : QgsMapLayerRenderer( layer->id(), &context )
   , mFeedback( std::make_unique< QgsFeedback >() )
   , mLayerOpacity( layer->opacity() )
+  , mLayerBlendMode( layer->blendMode() )
 {
   if ( QgsMapLayer *linkedLayer = layer->linkedVisibilityLayer() )
   {
@@ -123,5 +124,14 @@ bool QgsAnnotationLayerRenderer::render()
 
 bool QgsAnnotationLayerRenderer::forceRasterRender() const
 {
-  return renderContext()->testFlag( Qgis::RenderContextFlag::UseAdvancedEffects ) && ( !qgsDoubleNear( mLayerOpacity, 1.0 ) );
+  if ( !renderContext()->testFlag( Qgis::RenderContextFlag::UseAdvancedEffects ) )
+    return false;
+
+  if ( !qgsDoubleNear( mLayerOpacity, 1.0 ) )
+    return true;
+
+  if ( mLayerBlendMode != QPainter::CompositionMode_SourceOver )
+    return true;
+
+  return false;
 }

--- a/src/core/annotations/qgsannotationlayerrenderer.h
+++ b/src/core/annotations/qgsannotationlayerrenderer.h
@@ -54,6 +54,7 @@ class CORE_EXPORT QgsAnnotationLayerRenderer : public QgsMapLayerRenderer
     std::vector < std::pair< QString, std::unique_ptr< QgsAnnotationItem > > > mItems;
     std::unique_ptr< QgsFeedback > mFeedback;
     double mLayerOpacity = 1.0;
+    QPainter::CompositionMode mLayerBlendMode = QPainter::CompositionMode::CompositionMode_SourceOver;
     std::unique_ptr< QgsPaintEffect > mPaintEffect;
 
 };

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -38,6 +38,7 @@ QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *laye
   , mLayerName( layer->name() )
   , mDataProvider( qgis::down_cast< const QgsVectorTileDataProvider* >( layer->dataProvider() )->clone() )
   , mRenderer( layer->renderer()->clone() )
+  , mLayerBlendMode( layer->blendMode() )
   , mDrawTileBoundaries( layer->isTileBorderRenderingEnabled() )
   , mLabelsEnabled( layer->labelsEnabled() )
   , mFeedback( new QgsFeedback )
@@ -237,7 +238,16 @@ bool QgsVectorTileLayerRenderer::render()
 
 bool QgsVectorTileLayerRenderer::forceRasterRender() const
 {
-  return renderContext()->testFlag( Qgis::RenderContextFlag::UseAdvancedEffects ) && ( !qgsDoubleNear( mLayerOpacity, 1.0 ) );
+  if ( !renderContext()->testFlag( Qgis::RenderContextFlag::UseAdvancedEffects ) )
+    return false;
+
+  if ( !qgsDoubleNear( mLayerOpacity, 1.0 ) )
+    return true;
+
+  if ( mLayerBlendMode != QPainter::CompositionMode_SourceOver )
+    return true;
+
+  return false;
 }
 
 void QgsVectorTileLayerRenderer::decodeAndDrawTile( const QgsVectorTileRawData &rawTile )

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -63,6 +63,8 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
     //! Tile renderer object to do rendering of individual tiles
     std::unique_ptr<QgsVectorTileRenderer> mRenderer;
 
+    QPainter::CompositionMode mLayerBlendMode = QPainter::CompositionMode::CompositionMode_SourceOver;
+
     /**
      * Label provider that handles registration of labels.
      * No need to delete: if exists it is owned by labeling engine.

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -678,6 +678,25 @@ class TestQgsAnnotationLayer(QgisTestCase):
         self.assertTrue(compareWkt(result, expected, tol=1000), "mismatch Expected:\n{}\nGot:\n{}\n".format(expected,
                                                                                                             result))
 
+    def test_force_raster_render(self):
+        layer = QgsAnnotationLayer('test', QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()))
+        self.assertTrue(layer.isValid())
+        settings = QgsMapSettings()
+        rc = QgsRenderContext.fromMapSettings(settings)
+        renderer = layer.createMapRenderer(rc)
+        self.assertFalse(renderer.forceRasterRender())
+
+        # layer opacity should force raster render
+        layer.setOpacity(0.5)
+        renderer = layer.createMapRenderer(rc)
+        self.assertTrue(renderer.forceRasterRender())
+        layer.setOpacity(1.0)
+
+        # alternate blend mode should force raster render
+        layer.setBlendMode(QPainter.CompositionMode.CompositionMode_Multiply)
+        renderer = layer.createMapRenderer(rc)
+        self.assertTrue(renderer.forceRasterRender())
+
     def testRenderWithDisabledItems(self):
         layer = QgsAnnotationLayer('test', QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()))
         self.assertTrue(layer.isValid())


### PR DESCRIPTION
Fixes rendering of vector tile and annotation layers with non default blend modes in layouts

Fixes #55629
