### PR TITLE
Fixes #35767 to allow for view creation into specified schema from [ Create a view ] in DBManager

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -1015,14 +1015,14 @@ class PostGisDBConnector(DBConnector):
 
     def createView(self, view, query):
         view_name_parts = view.split('.')
-        
+
         if len(view_name_parts) > 2:
             # Raise an error when more than one period is used.
             raise ValueError("Invalid view name: Please use the format 'schema.viewname', or enter only the viewname for the public schema.")
-        elif len(view_name_parts) == 2: # To allow view creation into specified schema
+        elif len(view_name_parts) == 2:  # To allow view creation into specified schema
             schema, view_name = view_name_parts
             sql = "CREATE VIEW %s AS %s" % (self.quoteId([schema, view_name]), query)
-        else: # No specific schema specified
+        else:  # No specific schema specified
             sql = "CREATE VIEW %s AS %s" % (self.quoteId(view), query)
         self._execute_and_commit(sql)
 

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -1014,7 +1014,13 @@ class PostGisDBConnector(DBConnector):
         self._commit()
 
     def createView(self, view, query):
-        sql = "CREATE VIEW %s AS %s" % (self.quoteId(view), query)
+        user_input = view
+        
+        if '.' in user_input: # To allow view creation into specified schema
+            schema, view_name = user_input.split('.')
+            sql = "CREATE VIEW %s AS %s" % (self.quoteId([schema, view_name]), query)
+        else: # No schema specified; uses public
+            sql = "CREATE VIEW %s AS %s" % (self.quoteId(view), query)
         self._execute_and_commit(sql)
 
     def createSpatialView(self, view, query):

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -1018,7 +1018,7 @@ class PostGisDBConnector(DBConnector):
 
         if len(view_name_parts) > 2:
             # Raise an error when more than one period is used.
-            raise ValueError("Invalid view name: Please use the format 'schema.viewname', or enter only the viewname for the public schema.")
+            raise DbError("Invalid view name: Please use the format 'schema.viewname', or enter only the viewname for the public schema.")
         elif len(view_name_parts) == 2:  # To allow view creation into specified schema
             schema, view_name = view_name_parts
             sql = "CREATE VIEW %s AS %s" % (self.quoteId([schema, view_name]), query)

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -1014,12 +1014,15 @@ class PostGisDBConnector(DBConnector):
         self._commit()
 
     def createView(self, view, query):
-        user_input = view
+        view_name_parts = view.split('.')
         
-        if '.' in user_input: # To allow view creation into specified schema
-            schema, view_name = user_input.split('.')
+        if len(view_name_parts) > 2:
+            # Raise an error when more than one period is used.
+            raise ValueError("Invalid view name: Please use the format 'schema.viewname', or enter only the viewname for the public schema.")
+        elif len(view_name_parts) == 2: # To allow view creation into specified schema
+            schema, view_name = view_name_parts
             sql = "CREATE VIEW %s AS %s" % (self.quoteId([schema, view_name]), query)
-        else: # No schema specified; uses public
+        else: # No specific schema specified
             sql = "CREATE VIEW %s AS %s" % (self.quoteId(view), query)
         self._execute_and_commit(sql)
 


### PR DESCRIPTION
Fixes #35767 to allow for view creation into specified schema from [ Create a view ] in DBManager

## Description

Currently, using [ Create a view ] from DBManager for postgres automatically loads the view into the public schema named the entire string. It is reasonable for the user to assume that specifying the schema name as schema.view will create the view into the schema specified. Instead, it's creates a view called schema.view in the public schema. This is generally warned against.

Tested

In order to meet users' expectations, allowed for testing if the string has a "." in the name and to separate the string into two parts to feed into the quoteId which is already set up to accept schema and viewname as a list to process appropriately.

Recommended documentation:
"The Create a View button opens a dialog where you can enter the name for the new view. By default, the view is created in the public schema of the PostgreSQL database. However, you can specify a different schema by using the schema.viewname naming convention."

Backporting is recommended to meet user expectations.

Fixes #35767 to allow for view creation into specified schema from [ Create a view ] in DBManager