### PR TITLE
Fix style constraint save when strength is NotSet

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsfieldconstraints.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldconstraints.sip.in
@@ -73,7 +73,7 @@ is not present on this field.
 %Docstring
 Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
 is not present on this field. If the strength is not set returns ConstraintStrengthNotSet
-for anything but ConstraintExpression when returns ConstraintStrengthHard.
+for anything but ConstraintExpression which returns ConstraintStrengthHard.
 
 .. seealso:: :py:func:`constraints`
 

--- a/python/PyQt6/core/auto_generated/qgsfieldconstraints.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldconstraints.sip.in
@@ -72,7 +72,8 @@ is not present on this field.
     ConstraintStrength constraintStrength( Constraint constraint ) const;
 %Docstring
 Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
-is not present on this field.
+is not present on this field. If the strength is not set returns ConstraintStrengthNotSet
+for anything but ConstraintExpression when returns ConstraintStrengthHard.
 
 .. seealso:: :py:func:`constraints`
 

--- a/python/core/auto_generated/qgsfieldconstraints.sip.in
+++ b/python/core/auto_generated/qgsfieldconstraints.sip.in
@@ -73,7 +73,7 @@ is not present on this field.
 %Docstring
 Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
 is not present on this field. If the strength is not set returns ConstraintStrengthNotSet
-for anything but ConstraintExpression when returns ConstraintStrengthHard.
+for anything but ConstraintExpression which returns ConstraintStrengthHard.
 
 .. seealso:: :py:func:`constraints`
 

--- a/python/core/auto_generated/qgsfieldconstraints.sip.in
+++ b/python/core/auto_generated/qgsfieldconstraints.sip.in
@@ -72,7 +72,8 @@ is not present on this field.
     ConstraintStrength constraintStrength( Constraint constraint ) const;
 %Docstring
 Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
-is not present on this field.
+is not present on this field. If the strength is not set returns ConstraintStrengthNotSet
+for anything but ConstraintExpression when returns ConstraintStrengthHard.
 
 .. seealso:: :py:func:`constraints`
 

--- a/src/core/qgsfieldconstraints.cpp
+++ b/src/core/qgsfieldconstraints.cpp
@@ -29,8 +29,8 @@ QgsFieldConstraints::ConstraintStrength QgsFieldConstraints::constraintStrength(
   if ( !( mConstraints & constraint ) )
     return ConstraintStrengthNotSet;
 
-  // defaults to hard strength unless explicitly set
-  return mConstraintStrengths.value( constraint, ConstraintStrengthHard );
+  // defaults to not set
+  return mConstraintStrengths.value( constraint, ConstraintStrengthNotSet );
 }
 
 void QgsFieldConstraints::setConstraintStrength( QgsFieldConstraints::Constraint constraint, QgsFieldConstraints::ConstraintStrength strength )

--- a/src/core/qgsfieldconstraints.cpp
+++ b/src/core/qgsfieldconstraints.cpp
@@ -29,8 +29,8 @@ QgsFieldConstraints::ConstraintStrength QgsFieldConstraints::constraintStrength(
   if ( !( mConstraints & constraint ) )
     return ConstraintStrengthNotSet;
 
-  // defaults to not set
-  return mConstraintStrengths.value( constraint, ConstraintStrengthNotSet );
+  // defaults to not set for all but expressions (which does not use strength)
+  return mConstraintStrengths.value( constraint, constraint == ConstraintExpression ? ConstraintStrengthHard : ConstraintStrengthNotSet );
 }
 
 void QgsFieldConstraints::setConstraintStrength( QgsFieldConstraints::Constraint constraint, QgsFieldConstraints::ConstraintStrength strength )

--- a/src/core/qgsfieldconstraints.h
+++ b/src/core/qgsfieldconstraints.h
@@ -89,7 +89,8 @@ class CORE_EXPORT QgsFieldConstraints
 
     /**
      * Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
-     * is not present on this field.
+     * is not present on this field. If the strength is not set returns ConstraintStrengthNotSet
+     * for anything but ConstraintExpression when returns ConstraintStrengthHard.
      * \see constraints()
      * \see setConstraintStrength()
      */

--- a/src/core/qgsfieldconstraints.h
+++ b/src/core/qgsfieldconstraints.h
@@ -90,7 +90,7 @@ class CORE_EXPORT QgsFieldConstraints
     /**
      * Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
      * is not present on this field. If the strength is not set returns ConstraintStrengthNotSet
-     * for anything but ConstraintExpression when returns ConstraintStrengthHard.
+     * for anything but ConstraintExpression which returns ConstraintStrengthHard.
      * \see constraints()
      * \see setConstraintStrength()
      */

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -3141,53 +3141,11 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
     {
       QDomElement constraintElem = doc.createElement( QStringLiteral( "constraint" ) );
       constraintElem.setAttribute( QStringLiteral( "field" ), field.name() );
+      constraintElem.setAttribute( QStringLiteral( "constraints" ), field.constraints().constraints() );
+      constraintElem.setAttribute( QStringLiteral( "unique_strength" ), field.constraints().constraintStrength( QgsFieldConstraints::ConstraintUnique ) );
+      constraintElem.setAttribute( QStringLiteral( "notnull_strength" ), field.constraints().constraintStrength( QgsFieldConstraints::ConstraintNotNull ) );
+      constraintElem.setAttribute( QStringLiteral( "exp_strength" ), field.constraints().constraintStrength( QgsFieldConstraints::ConstraintExpression ) );
 
-      // This manipulation is required because when the strength is set to NotSet the constraint is removed from
-      // the field but when the field is queried for the strength of a not-existing constraint it returns Hard by default,
-      // see issue #58431
-      QgsFieldConstraints::Constraints constraints { mFieldConstraints.value( field.name() ) };
-      QgsFieldConstraints::ConstraintStrength uniqueStrength { QgsFieldConstraints::ConstraintStrength::ConstraintStrengthNotSet };
-      QgsFieldConstraints::ConstraintStrength notNullStrength { QgsFieldConstraints::ConstraintStrength::ConstraintStrengthNotSet };
-      QgsFieldConstraints::ConstraintStrength expressionStrength { QgsFieldConstraints::ConstraintStrength::ConstraintStrengthNotSet };
-
-      QPair<QString, QgsFieldConstraints::Constraint> strengthKey { qMakePair( field.name(), QgsFieldConstraints::ConstraintUnique ) };
-
-      if ( mFieldConstraintStrength.contains( strengthKey ) && mFieldConstraintStrength.value( strengthKey ) == QgsFieldConstraints::ConstraintStrength::ConstraintStrengthNotSet )
-      {
-        constraints.setFlag( QgsFieldConstraints::Constraint::ConstraintUnique, false );
-      }
-      else
-      {
-        uniqueStrength = mFieldConstraintStrength.value( strengthKey );
-      }
-
-      strengthKey = qMakePair( field.name(), QgsFieldConstraints::ConstraintNotNull );
-
-      if ( mFieldConstraintStrength.contains( strengthKey ) && mFieldConstraintStrength.value( strengthKey ) == QgsFieldConstraints::ConstraintStrength::ConstraintStrengthNotSet )
-      {
-        constraints.setFlag( QgsFieldConstraints::Constraint::ConstraintNotNull, false );
-      }
-      else
-      {
-        notNullStrength = mFieldConstraintStrength.value( strengthKey );
-      }
-
-      strengthKey = qMakePair( field.name(), QgsFieldConstraints::ConstraintExpression );
-
-      if ( mFieldConstraintStrength.contains( strengthKey ) && mFieldConstraintStrength.value( strengthKey ) == QgsFieldConstraints::ConstraintStrength::ConstraintStrengthNotSet )
-      {
-        constraints.setFlag( QgsFieldConstraints::Constraint::ConstraintExpression, false );
-      }
-      else
-      {
-        expressionStrength = mFieldConstraintStrength.value( strengthKey );
-      }
-
-
-      constraintElem.setAttribute( QStringLiteral( "constraints" ), constraints );
-      constraintElem.setAttribute( QStringLiteral( "unique_strength" ), uniqueStrength );
-      constraintElem.setAttribute( QStringLiteral( "notnull_strength" ), notNullStrength );
-      constraintElem.setAttribute( QStringLiteral( "exp_strength" ), expressionStrength );
       constraintsElem.appendChild( constraintElem );
     }
     node.appendChild( constraintsElem );

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -4675,6 +4675,35 @@ class TestQgsVectorLayerTransformContext(QgisTestCase):
             self.assertEqual(vl2.selectionProperties().selectionColor(),
                              QColor(255, 0, 0))
 
+    def testConstraintsStrengthNotSet(self):
+        """Test issue GH #58431 when strength NotSet becomes Hard"""
+
+        # Create a memory layer with unique constraints
+        layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer", "test_unique", "memory")
+        self.assertTrue(layer.isValid())
+
+        # Se not constraint on fldtxt
+        layer.setFieldConstraint(0, QgsFieldConstraints.Constraint.ConstraintNotNull, QgsFieldConstraints.ConstraintStrength.ConstraintStrengthSoft)
+        layer.setFieldConstraint(0, QgsFieldConstraints.Constraint.ConstraintUnique, QgsFieldConstraints.ConstraintStrength.ConstraintStrengthNotSet)
+
+        # Export the style to QML
+        style = QgsMapLayerStyle()
+        temp_file = tempfile.mktemp(suffix='.qml')
+        layer.saveNamedStyle(temp_file)
+        layer.loadNamedStyle(temp_file)
+
+        # Check constraints at the field level
+        field = layer.fields().at(0)
+        constraints = field.constraints()
+        self.assertEqual(constraints.constraintStrength(QgsFieldConstraints.Constraint.ConstraintNotNull), QgsFieldConstraints.ConstraintStrength.ConstraintStrengthSoft)
+        self.assertEqual(constraints.constraintStrength(QgsFieldConstraints.Constraint.ConstraintUnique), QgsFieldConstraints.ConstraintStrength.ConstraintStrengthNotSet)
+
+        # Check constraints at the layer level
+        constraints = layer.fieldConstraintsAndStrength(0)
+        self.assertEqual(constraints[QgsFieldConstraints.Constraint.ConstraintNotNull], QgsFieldConstraints.ConstraintStrength.ConstraintStrengthSoft)
+        self.assertEqual(constraints[QgsFieldConstraints.Constraint.ConstraintUnique], QgsFieldConstraints.ConstraintStrength.ConstraintStrengthNotSet)
+
+
 # TODO:
 # - fetch rect: feat with changed geometry: 1. in rect, 2. out of rect
 # - more join tests

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -4695,8 +4695,8 @@ class TestQgsVectorLayerTransformContext(QgisTestCase):
 
         # Check constraints at the layer level
         constraints = layer.fieldConstraintsAndStrength(0)
-        self.assertEquals(constraints[QgsFieldConstraints.Constraint.ConstraintNotNull], QgsFieldConstraints.ConstraintStrength.ConstraintStrengthSoft)
-        self.assertEquals(constraints[QgsFieldConstraints.Constraint.ConstraintUnique], QgsFieldConstraints.ConstraintStrength.ConstraintStrengthNotSet)
+        self.assertEqual(constraints[QgsFieldConstraints.Constraint.ConstraintNotNull], QgsFieldConstraints.ConstraintStrength.ConstraintStrengthSoft)
+        self.assertEqual(constraints[QgsFieldConstraints.Constraint.ConstraintUnique], QgsFieldConstraints.ConstraintStrength.ConstraintStrengthNotSet)
 
         # Export the style to QML and reload it
         style = QgsMapLayerStyle()


### PR DESCRIPTION
Fix #58431

I feel that the underlying issue remains (which is that setting the strength to NotSet removes it from the field but not from the layer and that the default strength is Hard) but since it was clearly made in purpose 8 years ago I am not keen to change it lightly.
