### PR TITLE
Add user-friendly warnings when built without webkit and opening layouts with html items

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1734,6 +1734,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutNorthArrowValidityCheck() );
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutOverviewValidityCheck() );
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutPictureSourceValidityCheck() );
+#ifndef WITH_QTWEBKIT
+  QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutHtmlItemValidityCheck() );
+#endif
 
   mSplash->showMessage( tr( "Initializing file filters" ), Qt::AlignHCenter | Qt::AlignBottom, splashTextColor );
   qApp->processEvents();

--- a/src/core/layout/qgslayoutitemhtml.cpp
+++ b/src/core/layout/qgslayoutitemhtml.cpp
@@ -339,6 +339,7 @@ QSizeF QgsLayoutItemHtml::totalSize() const
 void QgsLayoutItemHtml::render( QgsLayoutItemRenderContext &context, const QRectF &renderExtent, const int frameIndex )
 {
 #ifdef WITH_QTWEBKIT
+  Q_UNUSED( frameIndex )
   if ( !mWebPage )
     return;
 

--- a/src/core/layout/qgslayoutitemhtml.cpp
+++ b/src/core/layout/qgslayoutitemhtml.cpp
@@ -39,6 +39,7 @@
 #include <QNetworkReply>
 #include <QThread>
 #include <QUrl>
+#include <QAbstractTextDocumentLayout>
 
 // clazy:excludeall=lambda-in-connect
 
@@ -335,8 +336,9 @@ QSizeF QgsLayoutItemHtml::totalSize() const
   return mSize;
 }
 
-void QgsLayoutItemHtml::render( QgsLayoutItemRenderContext &context, const QRectF &renderExtent, const int )
+void QgsLayoutItemHtml::render( QgsLayoutItemRenderContext &context, const QRectF &renderExtent, const int frameIndex )
 {
+#ifdef WITH_QTWEBKIT
   if ( !mWebPage )
     return;
 
@@ -346,6 +348,38 @@ void QgsLayoutItemHtml::render( QgsLayoutItemRenderContext &context, const QRect
   painter->scale( context.renderContext().scaleFactor() / mHtmlUnitsToLayoutUnits, context.renderContext().scaleFactor() / mHtmlUnitsToLayoutUnits );
   painter->translate( 0.0, -renderExtent.top() * mHtmlUnitsToLayoutUnits );
   mWebPage->mainFrame()->render( painter, QRegion( renderExtent.left(), renderExtent.top() * mHtmlUnitsToLayoutUnits, renderExtent.width() * mHtmlUnitsToLayoutUnits, renderExtent.height() * mHtmlUnitsToLayoutUnits ) );
+#else
+  Q_UNUSED( renderExtent )
+  if ( mLayout->renderContext().isPreviewRender() )
+  {
+    if ( QgsLayoutFrame *currentFrame = frame( frameIndex ) )
+    {
+      QPainter *painter = context.renderContext().painter();
+
+      // painter is scaled to dots, so scale back to layout units
+      const QRectF painterRect = QRectF( currentFrame->rect().left() * context.renderContext().scaleFactor(),
+                                         currentFrame->rect().top() * context.renderContext().scaleFactor(),
+                                         currentFrame->rect().width() * context.renderContext().scaleFactor(),
+                                         currentFrame->rect().height() * context.renderContext().scaleFactor()
+                                       );
+
+      painter->setBrush( QBrush( QColor( 255, 125, 125, 125 ) ) );
+      painter->setPen( Qt::NoPen );
+      painter->drawRect( painterRect );
+      painter->setBrush( Qt::NoBrush );
+
+      painter->setPen( QColor( 200, 0, 0, 255 ) );
+      QTextDocument td;
+      td.setTextWidth( painterRect.width() );
+      td.setHtml( QStringLiteral( "<span style=\"color: rgb(200,0,0);\"><b>%1</b><br>%2</span>" ).arg(
+                    tr( "WebKit not available!" ),
+                    tr( "The item cannot be rendered because this QGIS install was built without WebKit support." ) ) );
+      painter->setClipRect( painterRect );
+      QAbstractTextDocumentLayout::PaintContext ctx;
+      td.documentLayout()->draw( painter, ctx );
+    }
+  }
+#endif
 }
 
 double QgsLayoutItemHtml::htmlUnitsToLayoutUnits()

--- a/src/gui/layout/qgslayoutvaliditychecks.h
+++ b/src/gui/layout/qgslayoutvaliditychecks.h
@@ -110,4 +110,27 @@ class GUI_EXPORT QgsLayoutPictureSourceValidityCheck : public QgsAbstractValidit
     QList<QgsValidityCheckResult> mResults;
 };
 
+#ifndef WITH_QTWEBKIT
+/**
+ * \ingroup gui
+ * \brief Layout HTML item validity check
+ *
+ * \note This class is not a part of public API
+ * \since QGIS 3.40
+ */
+class GUI_EXPORT QgsLayoutHtmlItemValidityCheck : public QgsAbstractValidityCheck
+{
+  public:
+    //! constructor
+    QgsLayoutHtmlItemValidityCheck *create() const override;
+    QString id() const override;
+    int checkType() const override;
+    bool prepareCheck( const QgsValidityCheckContext *context, QgsFeedback *feedback ) override;
+    QList< QgsValidityCheckResult > runCheck( const QgsValidityCheckContext *context, QgsFeedback *feedback ) override;
+
+  private:
+    QList<QgsValidityCheckResult> mResults;
+};
+#endif
+
 #endif // QGSLAYOUTVALIDITYCHECKS_H


### PR DESCRIPTION
Adds a warning in the preview render:

![image](https://github.com/user-attachments/assets/c7c6acf2-105c-45d7-947f-81d129d24438)

and an export-time check too:

![image](https://github.com/user-attachments/assets/29be3210-5d4f-4610-99aa-c25a21381d29)

Fixes https://github.com/qgis/QGIS/issues/58975