### PR TITLE
Fix aggregate function returns incorrect results 

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsexpressioncontext.sip.in
@@ -946,6 +946,18 @@ if evaluation should be canceled, if set.
 .. versionadded:: 3.20
 %End
 
+    QString uniqueHash( bool &ok /Out/, const QSet<QString> &variables = QSet<QString>() ) const;
+%Docstring
+Returns a unique hash representing the current state of the context.
+
+:param variables: optional names of a subset of variables to include in the hash. If not specified, all variables will be considered.
+
+:return: - calculated hash
+         - ok: ``True`` if the hash could be generated, or false if e.g. a variable value is of a type which cannot be hashed
+
+.. versionadded:: 3.40
+%End
+
     static const QString EXPR_FIELDS;
     static const QString EXPR_ORIGINAL_VALUE;
     static const QString EXPR_SYMBOL_COLOR;

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -946,6 +946,18 @@ if evaluation should be canceled, if set.
 .. versionadded:: 3.20
 %End
 
+    QString uniqueHash( bool &ok /Out/, const QSet<QString> &variables = QSet<QString>() ) const;
+%Docstring
+Returns a unique hash representing the current state of the context.
+
+:param variables: optional names of a subset of variables to include in the hash. If not specified, all variables will be considered.
+
+:return: - calculated hash
+         - ok: ``True`` if the hash could be generated, or false if e.g. a variable value is of a type which cannot be hashed
+
+.. versionadded:: 3.40
+%End
+
     static const QString EXPR_FIELDS;
     static const QString EXPR_ORIGINAL_VALUE;
     static const QString EXPR_SYMBOL_COLOR;

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -789,6 +789,7 @@ QString QgsExpressionContext::uniqueHash( bool &ok, const QSet<QString> &variabl
   for ( const QString &variableName : std::as_const( sortedVars ) )
   {
     const QVariant value = variable( variableName );
+    hash.append( variableName + "=" );
     if ( QgsVariantUtils::isNull( value ) )
     {
       hash.append( delimiter );

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -769,3 +769,45 @@ QgsFeedback *QgsExpressionContext::feedback() const
 {
   return mFeedback;
 }
+
+QString QgsExpressionContext::uniqueHash( bool &ok, const QSet<QString> &variables ) const
+{
+  QString hash;
+  ok = true;
+  const QString delimiter( QStringLiteral( "||~~||" ) );
+
+  if ( hasFeature() )
+  {
+    hash.append( QString::number( feature().id() ) + delimiter + QString::number( qHash( feature() ) ) + delimiter );
+  }
+
+  QStringList sortedVars = qgis::setToList( variables );
+  if ( sortedVars.empty() )
+    sortedVars = variableNames();
+  std::sort( sortedVars.begin(), sortedVars.end() );
+
+  for ( const QString &variableName : std::as_const( sortedVars ) )
+  {
+    const QVariant value = variable( variableName );
+    if ( QgsVariantUtils::isNull( value ) )
+    {
+      hash.append( delimiter );
+    }
+    else if ( value.type() == QVariant::String )
+    {
+      hash.append( value.toString() + delimiter );
+    }
+    else
+    {
+      const QString variantString = value.toString();
+      if ( variantString.isEmpty() )
+      {
+        ok = false;
+        return QString();
+      }
+      hash.append( variantString + delimiter );
+    }
+  }
+
+  return hash;
+}

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -876,6 +876,18 @@ class CORE_EXPORT QgsExpressionContext
      */
     QgsFeedback *feedback() const;
 
+    /**
+     * Returns a unique hash representing the current state of the context.
+     *
+     * \param ok will be set to TRUE if the hash could be generated, or false if e.g. a variable value is of a type which cannot be hashed
+     * \param variables optional names of a subset of variables to include in the hash. If not specified, all variables will be considered.
+     *
+     * \returns calculated hash
+     *
+     * \since QGIS 3.40
+     */
+    QString uniqueHash( bool &ok SIP_OUT, const QSet<QString> &variables = QSet<QString>() ) const;
+
     //! Inbuilt variable name for fields storage
     static const QString EXPR_FIELDS;
     //! Inbuilt variable name for value original value variable

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2707,7 +2707,7 @@ class TestQgsExpression: public QObject
       QCOMPARE( res.toInt(), 1 );
     }
 
-    void test_aggregate_with_variable()
+    void test_aggregate_with_variable_feature()
     {
       // this checks that a variable can be non static in a aggregate, i.e. the result will change across the fetched features
       // see https://github.com/qgis/QGIS/issues/33382
@@ -2729,6 +2729,23 @@ class TestQgsExpression: public QObject
         int res2 = exp.evaluate( &context ).toInt();
         QCOMPARE( res2, f.attribute( "col1" ).toInt() );
       }
+    }
+
+    void test_aggregate_with_variables()
+    {
+      // this checks that a variable can be non static in a aggregate, i.e. the result will change across the fetched features
+      // see https://github.com/qgis/QGIS/issues/58221
+      QgsExpressionContext context;
+      context.appendScope( QgsExpressionContextUtils::layerScope( mAggregatesLayer ) );
+      context.lastScope()->setVariable( QStringLiteral( "my_var" ), QStringLiteral( "3" ) );
+
+      QgsExpression exp( QString( "aggregate(layer:='aggregate_layer', aggregate:='concatenate_unique', expression:=\"col2\", filter:=\"col1\"=@my_var)" ) );
+      QString res = exp.evaluate( &context ).toString();
+      QCOMPARE( res, QStringLiteral( "test333" ) );
+
+      context.lastScope()->setVariable( QStringLiteral( "my_var" ), QStringLiteral( "4" ) );
+      res = exp.evaluate( &context ).toString();
+      QCOMPARE( res, QStringLiteral( "test" ) );
     }
 
     void aggregate_data()

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -1063,27 +1063,27 @@ void TestQgsExpressionContext::uniqueHash()
   QSet< QString > vars;
   vars.insert( QStringLiteral( "var1" ) );
   vars.insert( QStringLiteral( "var2" ) );
-  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "||~~||||~~||" ) );
+  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "var1=||~~||var2=||~~||" ) );
   QVERIFY( ok );
 
   QgsExpressionContextScope *scope1 = new QgsExpressionContextScope();
   context.appendScope( scope1 );
   scope1->setVariable( QStringLiteral( "var1" ), QStringLiteral( "a string" ) );
   scope1->setVariable( QStringLiteral( "var2" ), 5 );
-  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "a string||~~||5||~~||" ) );
+  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "var1=a string||~~||var2=5||~~||" ) );
   QVERIFY( ok );
 
   QgsExpressionContextScope *scope2 = new QgsExpressionContextScope();
   context.appendScope( scope2 );
   scope2->setVariable( QStringLiteral( "var1" ), QStringLiteral( "b string" ) );
-  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "b string||~~||5||~~||" ) );
+  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "var1=b string||~~||var2=5||~~||" ) );
   QVERIFY( ok );
 
   QgsFeature feature;
   feature.setId( 11 );
   feature.setAttributes( QgsAttributes() << 5 << 11 );
   context.setFeature( feature );
-  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "11||~~||1566||~~||b string||~~||5||~~||" ) );
+  QCOMPARE( context.uniqueHash( ok, vars ), QStringLiteral( "11||~~||1566||~~||var1=b string||~~||var2=5||~~||" ) );
   QVERIFY( ok );
 
   // a value which can't be converted to string


### PR DESCRIPTION
When the aggregate uses variables, we need to ensure that the
cache key correctly considers the current value of ALL those
variables. Otherwise we'll return incorrect results when
an expression is re-evaluated after changing the variable
value for the context.

Fixes use of aggregate function with @symbol_label in legends.

Fixes https://github.com/qgis/QGIS/issues/58221

(Possibly also fixes https://github.com/qgis/QGIS/issues/58315, but untested)