### PR TITLE
make QgsSettingsTree::treeRoot() available in Python bindings

### DIFF
--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -29,6 +29,7 @@
  */
 class CORE_EXPORT QgsSettingsTree
 {
+
   public:
     /**
      * Returns the tree root node for the settings tree

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -31,6 +31,7 @@ class CORE_EXPORT QgsSettingsTree
 {
 
   public:
+
     /**
      * Returns the tree root node for the settings tree
      */

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -29,15 +29,13 @@
  */
 class CORE_EXPORT QgsSettingsTree
 {
-
   public:
-
-#ifndef SIP_RUN
-
     /**
      * Returns the tree root node for the settings tree
      */
     static QgsSettingsTreeNode *treeRoot();
+
+#ifndef SIP_RUN
 
     // only create first level here
     static inline QgsSettingsTreeNode *sTreeApp = treeRoot()->createChildNode( QStringLiteral( "app" ) );


### PR DESCRIPTION
@Guts following our discussion to access main settings node