### PR TITLE
use directly relation id from private variables

### DIFF
--- a/src/core/editform/qgsattributeeditorrelation.cpp
+++ b/src/core/editform/qgsattributeeditorrelation.cpp
@@ -40,7 +40,7 @@ QgsAttributeEditorElement *QgsAttributeEditorRelation::clone( QgsAttributeEditor
 
 void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
-  elem.setAttribute( QStringLiteral( "relation" ), mRelation.id() );
+  elem.setAttribute( QStringLiteral( "relation" ), mRelationId );
   elem.setAttribute( QStringLiteral( "forceSuppressFormPopup" ), mForceSuppressFormPopup );
   elem.setAttribute( QStringLiteral( "nmRelationId" ), mNmRelationId.toString() );
   elem.setAttribute( QStringLiteral( "label" ), mLabel );


### PR DESCRIPTION
## Description

This PR changes usage of potentially invalid object `QgsRelation` to private variable with relation ID (`mRelationId`).


Variable `mRelation` always has assigned object, but before all relations are loaded, this object is invalid.
We should not use this object until it is initialized by `QgsAttributeEditorRelation::init` (actually, it still may use invalid `QgsRelation`).
As show in stack trace in #59007 description, there is a possible path to use this invalid object.
Instead, we can always use available variable `mRelationId` that is provided in constructor.

I believe that all QGIS 3 versions are affected by this. Probably this is a result of refactoring print layout/composers (see stack trace). My test `.qgs` file has worked in QGIS 2.
I cannot find info about backport policy, but I would like this change to be backported to QGIS 3.28 :pray: .

closes #59007

<!--
[Replace this with some text explaining the rationale and details about this pull request]
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
