### PR TITLE
[fix] Make scale dependent visibility more robust for labels

### DIFF
--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -23,6 +23,7 @@
 #include "qgsapplication.h"
 #include "qgsstyle.h"
 #include "qgstextrenderer.h"
+#include "qgsscaleutils.h"
 
 #include "pal/labelposition.h"
 
@@ -1895,7 +1896,8 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
       maxScale = 1 / std::fabs( maxScale );
     }
 
-    if ( !qgsDoubleNear( maxScale, 0.0 ) && context.rendererScale() < maxScale )
+    // maxScale is inclusive ( < --> no label )
+    if ( !qgsDoubleNear( maxScale, 0.0 ) && QgsScaleUtils::lessThanMaximumScale( context.rendererScale(), maxScale ) )
     {
       return nullptr;
     }
@@ -1914,7 +1916,8 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
       minScale = 1 / std::fabs( minScale );
     }
 
-    if ( !qgsDoubleNear( minScale, 0.0 ) && context.rendererScale() > minScale )
+    // minScale is exclusive ( >= --> no label )
+    if ( !qgsDoubleNear( minScale, 0.0 ) && QgsScaleUtils::equalToOrGreaterThanMinimumScale( context.rendererScale(), minScale ) )
     {
       return nullptr;
     }

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -6045,7 +6045,8 @@ font-style: italic;</string>
                                  <enum>Qt::StrongFocus</enum>
                                 </property>
                                 <property name="toolTip">
-                                 <string>Maximum scale, i.e. most &quot;zoomed in&quot;.</string>
+                                 <string>Maximum scale, i.e. most &quot;zoomed in&quot;.
+This limit is inclusive, that means the label will be displayed on this scale.</string>
                                 </property>
                                </widget>
                               </item>
@@ -6062,7 +6063,8 @@ font-style: italic;</string>
                                  <enum>Qt::StrongFocus</enum>
                                 </property>
                                 <property name="toolTip">
-                                 <string>Minimum scale, i.e. most &quot;zoomed out&quot;.</string>
+                                 <string>Minimum scale, i.e. most &quot;zoomed out&quot;.
+This limit is exclusive, that means the label will not be displayed on this scale.</string>
                                 </property>
                                </widget>
                               </item>
@@ -6076,7 +6078,8 @@ font-style: italic;</string>
                               <item row="0" column="0">
                                <widget class="QLabel" name="mLabelMinScale">
                                 <property name="toolTip">
-                                 <string>Minimum scale, i.e. most &quot;zoomed out&quot;.</string>
+                                 <string>Minimum scale, i.e. most &quot;zoomed out&quot;.
+This limit is exclusive, that means the label will not be displayed on this scale.</string>
                                 </property>
                                 <property name="text">
                                  <string/>
@@ -6089,7 +6092,8 @@ font-style: italic;</string>
                               <item row="1" column="0">
                                <widget class="QLabel" name="mLabelMaxScale">
                                 <property name="toolTip">
-                                 <string>Maximum scale, i.e. most &quot;zoomed in&quot;.</string>
+                                 <string>Maximum scale, i.e. most &quot;zoomed in&quot;.
+This limit is inclusive, that means the label will be displayed on this scale.</string>
                                 </property>
                                 <property name="text">
                                  <string/>


### PR DESCRIPTION
Followup https://github.com/qgis/QGIS/pull/58968

Make labeling more robust when handling scale dependent visibility: handle exclusive/inclusive behavior on edge cases (non-round numbers).

Also, add tooltip for scale dependent visibility widgets (labeling) to indicate that min scale is exclusive and max scale is inclusive.

![image](https://github.com/user-attachments/assets/b063664c-6368-4b07-a22b-f342c112919b)


------

Fix https://github.com/qgis/QGIS/issues/42443