### PR TITLE
Delete equality operator from QgsMapLayerRef

### DIFF
--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -31,6 +31,7 @@
 #include "qgsdirectionallightsettings.h"
 #include "qgs3drendercontext.h"
 #include "qgsthreadingutils.h"
+#include "qgsmaplayerlistutils_p.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -643,17 +644,12 @@ void Qgs3DMapSettings::setLayers( const QList<QgsMapLayer *> &layers )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  QList<QgsMapLayerRef> lst;
-  lst.reserve( layers.count() );
-  for ( QgsMapLayer *layer : layers )
-  {
-    lst.append( layer );
-  }
+  const QList<QgsMapLayer *> raw = _qgis_listRefToRaw( mLayers );
 
-  if ( mLayers == lst )
+  if ( layers == raw )
     return;
 
-  mLayers = lst;
+  mLayers = _qgis_listRawToRef( layers );
   emit layersChanged();
 }
 

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -86,10 +86,15 @@ struct _LayerRef
   }
 
   /**
+   * Equality operator is deleted to avoid confusion as there are multiple ways two _LayerRef objects can be considered equal.
+   */
+  bool operator==( const _LayerRef &other ) = delete;
+
+  /**
    * Returns TRUE if the layer reference is resolved and contains a reference to an existing
    * map layer.
    */
-  operator bool() const
+  explicit operator bool() const
   {
     return static_cast< bool >( layer.data() );
   }


### PR DESCRIPTION
## Description
Without an equality operator, `QgsMapLayerRef` was implicitly using its `bool()` operator when compared. This resulted in all unresolved or resolved refs pointing to different layers appear as equal, for example when `QList<QgsMapLayerRef>`s were compared in https://github.com/qgis/QGIS/blob/756083c293201d50d7ddf1b4cc26b560bf0e6df9/src/3d/qgs3dmapsettings.cpp#L642-L658


Fixes #51291

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
