### PR TITLE
[ValueRelation] Update on widget value change when multi mode

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -456,9 +456,10 @@ void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const Q
 
 void QgsValueRelationWidgetWrapper::widgetValueChanged( const QString &attribute, const QVariant &newValue, bool attributeChanged )
 {
-
-  // Do nothing if the value has not changed
-  if ( attributeChanged )
+  // Do nothing if the value has not changed except for multi edit mode
+  // In multi edit mode feature is not updated (so attributeChanged is false) until user validate it but we need to update the
+  // value relation which could have an expression depending on another modified field
+  if ( attributeChanged || context().attributeFormMode() == QgsAttributeEditorContext::Mode::MultiEditMode )
   {
     QVariant oldValue( value( ) );
     setFormFeatureAttribute( attribute, newValue );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -566,6 +566,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     friend class TestQgsDualView;
     friend class TestQgsAttributeForm;
+    friend class TestQgsValueRelationWidgetWrapper;
 };
 
 #endif // QGSATTRIBUTEFORM_H


### PR DESCRIPTION
In multi edit mode feature is not updated (so `attributeChanged` is false) until user validate it but we need to update the value relation which could have an expression depending on another modified field

**Funded by [Coforet](https://www.coforet.com/)**