### PR TITLE
qgspolyhedralsurface: Implement isValid

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgspolyhedralsurface.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgspolyhedralsurface.sip.in
@@ -58,6 +58,9 @@ Creates a polyhedral surface from a multiPolygon.
     virtual bool fromWkt( const QString &wkt );
 
 
+    virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
+
+
     virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;

--- a/python/core/auto_generated/geometry/qgspolyhedralsurface.sip.in
+++ b/python/core/auto_generated/geometry/qgspolyhedralsurface.sip.in
@@ -58,6 +58,9 @@ Creates a polyhedral surface from a multiPolygon.
     virtual bool fromWkt( const QString &wkt );
 
 
+    virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
+
+
     virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;

--- a/src/core/geometry/qgspolyhedralsurface.cpp
+++ b/src/core/geometry/qgspolyhedralsurface.cpp
@@ -28,6 +28,7 @@
 #include "qgsvertexid.h"
 #include "qgswkbptr.h"
 #include "qgsmultilinestring.h"
+#include "qgsgeos.h"
 
 #include <QPainter>
 #include <QPainterPath>
@@ -993,4 +994,44 @@ int QgsPolyhedralSurface::compareToSameClass( const QgsAbstractGeometry *other )
   }
 
   return 0;
+}
+
+bool QgsPolyhedralSurface::isValid( QString &error, Qgis::GeometryValidityFlags flags ) const
+{
+  if ( flags == 0 && mHasCachedValidity )
+  {
+    // use cached validity results
+    error = mValidityFailureReason;
+    return error.isEmpty();
+  }
+
+  if ( isEmpty() )
+    return true;
+
+  error.clear();
+
+  // GEOS does not handle PolyhedralSurface, check the polygons one by one
+  for ( int i = 0; i < mPatches.size(); ++i )
+  {
+    const QgsGeos geos( mPatches.at( i ) );
+    const bool valid = geos.isValid( &error, flags & Qgis::GeometryValidityFlag::AllowSelfTouchingHoles, nullptr );
+    if ( !valid )
+    {
+      error = QStringLiteral( "Polygon %1 is invalid: %2" ).arg( QString::number( i ), error );
+      break;
+    }
+  }
+
+  //TODO: Also check that the polyhedral surface is connected
+  // For example, see SFCGAL implementation:
+  // https://gitlab.com/sfcgal/SFCGAL/-/blob/19e3ff0c9057542a0e271edfee873d5f8b220871/src/algorithm/isValid.cpp#L469
+
+  const bool valid = error.isEmpty();
+  if ( flags == 0 )
+  {
+    mValidityFailureReason = !valid ? error : QString();
+    mHasCachedValidity = true;
+  }
+
+  return valid;
 }

--- a/src/core/geometry/qgspolyhedralsurface.h
+++ b/src/core/geometry/qgspolyhedralsurface.h
@@ -117,6 +117,8 @@ class CORE_EXPORT QgsPolyhedralSurface: public QgsSurface
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
+    bool isValid( QString &error SIP_OUT, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const override;
+
     int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QString asWkt( int precision = 17 ) const override;

--- a/tests/src/core/geometry/testqgspolyhedralsurface.cpp
+++ b/tests/src/core/geometry/testqgspolyhedralsurface.cpp
@@ -61,6 +61,7 @@ class TestQgsPolyhedralSurface: public QObject
     void testWKT();
     void testExport();
     void testCast();
+    void testIsValid();
 };
 
 void TestQgsPolyhedralSurface::testConstructor()
@@ -1689,6 +1690,48 @@ void TestQgsPolyhedralSurface::testCast()
   QVERIFY( QgsPolyhedralSurface().cast( &pCast2 ) );
 
   QVERIFY( !pCast2.fromWkt( QStringLiteral( "PolyhedralSurfaceZ((111111))" ) ) );
+}
+
+void TestQgsPolyhedralSurface::testIsValid()
+{
+  QString error;
+  bool isValid;
+
+  // an empty QgsPolyhedralSurface is valid
+  QgsPolyhedralSurface polySurfaceEmpty;
+  isValid = polySurfaceEmpty.isValid( error );
+  QVERIFY( error.isEmpty() );
+  QVERIFY( isValid );
+
+  // a QgsPolyhedralSurface with a valid QgsPolygon is valid
+  QgsPolyhedralSurface polySurface1;
+  polySurface1.fromWkt( QStringLiteral( "PolyhedralSurfaceZ((0 0 0, 0 1 1, 1 0 2, 0 0 0))" ) );
+  isValid = polySurface1.isValid( error );
+  QVERIFY( error.isEmpty() );
+  QVERIFY( isValid );
+
+  // a QgsPolyhedralSurface with an invalid QgsPolygon is not valid
+  QgsPolyhedralSurface polySurface2;
+  QgsPolygon patch;
+  QgsLineString lineString;
+
+  lineString.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZ, 11, 2, 3 )
+                        << QgsPoint( Qgis::WkbType::PointZ, 4, 12, 13 )
+                        << QgsPoint( Qgis::WkbType::PointZ, 11, 12, 13 )
+                        << QgsPoint( Qgis::WkbType::PointZ, 11, 22, 23 )
+                        << QgsPoint( Qgis::WkbType::PointZ, 11, 2, 3 ) );
+  patch.setExteriorRing( lineString.clone() );
+
+  lineString.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZ, 10, 2, 5 )
+                        << QgsPoint( Qgis::WkbType::PointZ, 11, 2, 5 )
+                        << QgsPoint( Qgis::WkbType::PointZ, 10, 2, 5 ) );
+  patch.addInteriorRing( lineString.clone() );
+
+  polySurface2.addPatch( patch.clone() );
+
+  isValid = polySurface2.isValid( error );
+  QCOMPARE( error, "Polygon 0 is invalid: Too few points in geometry component" );
+  QVERIFY( !isValid );
 }
 
 


### PR DESCRIPTION
## Description

`QgsPolyhedralSurface` inherits from `QgsSurface` which implements `QgsAbstractgeometry::isValid` by calling `isValid` from GEOS. However, GEOS does not handle polyhedral surface. This means that `isValid` will always return False even if the polyhedral surface is valid.

This issue is fixed by implementing
`QgsPolyhedralSurface::isValid`. It checks that all the polygons of the polyhedral surface are valid.

