### PR TITLE
Don't override cursor in pin labels map tool

### DIFF
--- a/src/app/labeling/qgsmaptoolpinlabels.cpp
+++ b/src/app/labeling/qgsmaptoolpinlabels.cpp
@@ -190,7 +190,6 @@ void QgsMapToolPinLabels::highlightPinnedLabels()
 
   const QList<QgsLabelPosition> labelPosList = labelingResults->labelsWithinRect( ext );
 
-  QApplication::setOverrideCursor( Qt::WaitCursor );
   for ( const QgsLabelPosition &pos : labelPosList )
   {
     mCurrentLabel = LabelDetails( pos, canvas() );
@@ -254,18 +253,15 @@ void QgsMapToolPinLabels::highlightPinnedLabels()
       highlightCallout( false, callout, calloutStringID, calloutColor );
     }
   }
-  QApplication::restoreOverrideCursor();
 }
 
 void QgsMapToolPinLabels::removePinnedHighlights()
 {
-  QApplication::setOverrideCursor( Qt::BusyCursor );
   for ( QgsRubberBand *rb : std::as_const( mHighlights ) )
   {
     delete rb;
   }
   mHighlights.clear();
-  QApplication::restoreOverrideCursor();
 }
 
 void QgsMapToolPinLabels::pinUnpinLabels( const QgsRectangle &ext, QMouseEvent *e )


### PR DESCRIPTION
This tool was setting the application cursor after every map render. It's unnecessary and impolite, and causes bad UX.

Fixes #59016
