### PR TITLE
Qgspolyhedralsurface fix is valid

### DIFF
--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -150,7 +150,7 @@ void QgsGeometryValidator::validatePolyline( int i, const QgsLineString *line, b
 
   // test for duplicate nodes, and if we find any flag errors and then remove them so that the subsequent
   // tests work OK.
-  const QVector< QgsVertexId > duplicateNodes = line->collectDuplicateNodes( 1E-8 );
+  const QVector< QgsVertexId > duplicateNodes = line->collectDuplicateNodes( 1E-8, line->is3D() );
   if ( !duplicateNodes.empty() )
   {
     noDupes.reset( line->clone() );

--- a/tests/src/core/geometry/testqgspolyhedralsurface.cpp
+++ b/tests/src/core/geometry/testqgspolyhedralsurface.cpp
@@ -1710,8 +1710,22 @@ void TestQgsPolyhedralSurface::testIsValid()
   QVERIFY( error.isEmpty() );
   QVERIFY( isValid );
 
-  // a QgsPolyhedralSurface with an invalid QgsPolygon is not valid
+  // a QgsPolyhedralSurface invalid according to Geos because it does not handle the Z component
+  // Still valid
   QgsPolyhedralSurface polySurface2;
+  polySurface2.fromWkt( "POLYHEDRALSURFACE Z"
+                        "(((0.0 0.0 0.0,0.0 5.0 0.0,5.0 5.0 0.0,5.0 0.0 0.0,0.0 0.0 0.0)),"
+                        "((0.0 0.0 7.0,5.0 0.0 7.0,5.0 5.0 7.0,0.0 5.0 7.0,0.0 0.0 7.0)),"
+                        "((0.0 0.0 0.0,0.0 0.0 7.0,0.0 5.0 7.0,0.0 5.0 0.0,0.0 0.0 0.0)),"
+                        "((0.0 5.0 0.0,0.0 5.0 7.0,5.0 5.0 7.0,5.0 5.0 0.0,0.0 5.0 0.0)),"
+                        "((5.0 5.0 0.0,5.0 5.0 7.0,5.0 0.0 7.0,5.0 0.0 0.0,5.0 5.0 0.0)),"
+                        "((5.0 0.0 0.0,5.0 0.0 7.0,0.0 0.0 7.0,0.0 0.0 0.0,5.0 0.0 0.0)))" );
+  isValid = polySurface2.isValid( error );
+  QVERIFY( error.isEmpty() );
+  QVERIFY( isValid );
+
+  // a QgsPolyhedralSurface with an invalid QgsPolygon is not valid
+  QgsPolyhedralSurface polySurface3;
   QgsPolygon patch;
   QgsLineString lineString;
 
@@ -1727,9 +1741,9 @@ void TestQgsPolyhedralSurface::testIsValid()
                         << QgsPoint( Qgis::WkbType::PointZ, 10, 2, 5 ) );
   patch.addInteriorRing( lineString.clone() );
 
-  polySurface2.addPatch( patch.clone() );
+  polySurface3.addPatch( patch.clone() );
 
-  isValid = polySurface2.isValid( error );
+  isValid = polySurface3.isValid( error );
   QCOMPARE( error, "Polygon 0 is invalid: Too few points in geometry component" );
   QVERIFY( !isValid );
 }

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -152,6 +152,13 @@ class TestQgsGeometryValidator(QgisTestCase):
         self.assertEqual(spy[1][0].where(), QgsPointXY(2, 7))
         self.assertEqual(spy[1][0].what(), 'segment 1 of ring 1 of polygon 0 intersects segment 2 of ring 2 of polygon 0 at 2, 7')
 
+    def test_polygon_3d(self):
+        geom = QgsGeometry.fromWkt("Polygon Z((0 0 0,0 0 7,0 5 7,0 5 0,0 0 0))")
+        validator = QgsGeometryValidator(geom)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 0)
+
     def test_line_vertices(self):
         # valid line
         g = QgsGeometry.fromWkt("LineString (0 0, 10 0)")
@@ -181,6 +188,19 @@ class TestQgsGeometryValidator(QgisTestCase):
 
         self.assertEqual(spy[0][0].where(), QgsPointXY())
         self.assertEqual(spy[0][0].what(), 'line 0 with less than two points')
+
+    def test_line_3d(self):
+        geom1 = QgsGeometry.fromWkt("LineString Z(0 0 5, 10 0 5, 0 0 5)")
+        validator = QgsGeometryValidator(geom1)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 0)
+
+        geom2 = QgsGeometry.fromWkt("LineString Z(0 0 5, 10 0 7, 15 3 14, 0 0 5)")
+        validator = QgsGeometryValidator(geom2)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 0)
 
     def test_ring_vertex_count(self):
         # valid ring


### PR DESCRIPTION
## Description

`QgsPolyhedralSurface::isValid` checks that all its polygon are valid
with GEOS. However, GEOS is not able to properly handle 3D polygons
because it drops the Z component.

For example, "Polygon Z((0 0 0,0 0 7,0 5 7,0 5 0,0 0 0))" is
wrongly considered as an invalid polygon because it contains duplicate
nodes when the Z component is dropped.

This issue is fixed by calling QGIS internal geometry validator which
is able to handle 3D polygons.

Fixes: 721b0459c462821a811c2dc5229eeaec618ef8f1