### PR TITLE
qgsgeometryvalidator: Properly handle 3d lines

### DIFF
--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -150,7 +150,7 @@ void QgsGeometryValidator::validatePolyline( int i, const QgsLineString *line, b
 
   // test for duplicate nodes, and if we find any flag errors and then remove them so that the subsequent
   // tests work OK.
-  const QVector< QgsVertexId > duplicateNodes = line->collectDuplicateNodes( 1E-8 );
+  const QVector< QgsVertexId > duplicateNodes = line->collectDuplicateNodes( 1E-8, line->is3D() );
   if ( !duplicateNodes.empty() )
   {
     noDupes.reset( line->clone() );

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -152,6 +152,13 @@ class TestQgsGeometryValidator(QgisTestCase):
         self.assertEqual(spy[1][0].where(), QgsPointXY(2, 7))
         self.assertEqual(spy[1][0].what(), 'segment 1 of ring 1 of polygon 0 intersects segment 2 of ring 2 of polygon 0 at 2, 7')
 
+    def test_polygon_3d(self):
+        geom = QgsGeometry.fromWkt("Polygon Z((0 0 0,0 0 7,0 5 7,0 5 0,0 0 0))")
+        validator = QgsGeometryValidator(geom)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 0)
+
     def test_line_vertices(self):
         # valid line
         g = QgsGeometry.fromWkt("LineString (0 0, 10 0)")
@@ -181,6 +188,19 @@ class TestQgsGeometryValidator(QgisTestCase):
 
         self.assertEqual(spy[0][0].where(), QgsPointXY())
         self.assertEqual(spy[0][0].what(), 'line 0 with less than two points')
+
+    def test_line_3d(self):
+        geom1 = QgsGeometry.fromWkt("LineString Z(0 0 5, 10 0 5, 0 0 5)")
+        validator = QgsGeometryValidator(geom1)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 0)
+
+        geom2 = QgsGeometry.fromWkt("LineString Z(0 0 5, 10 0 7, 15 3 14, 0 0 5)")
+        validator = QgsGeometryValidator(geom2)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 0)
 
     def test_ring_vertex_count(self):
         # valid ring


### PR DESCRIPTION
## Description

When validating a line, `QgsGeometryValidator` checks in particular that there are no duplicate nodes by calling
`QgsGeometry::duplicateNodes`. However, this method does not handle the 3D component of a line by default.
