### PR TITLE
Fix elevation profile on virtual point cloud

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -389,11 +389,22 @@ bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenera
   // this is not AT ALL thread safe, but it's what QgsPointCloudLayerRenderer does !
   // TODO: fix when QgsPointCloudLayerRenderer is made thread safe to use same approach
 
-  QgsPointCloudIndex *pc = mLayer->dataProvider()->index();
-  if ( !pc || !pc->isValid() )
+  QVector<QgsPointCloudIndex *> indexes;
+  QgsPointCloudIndex *mainIndex = mLayer->dataProvider()->index();
+  if ( mainIndex && mainIndex->isValid() )
+    indexes.append( mainIndex );
+
+  // Gather all relevant sub-indexes
+  const QgsRectangle profileCurveBbox = mProfileCurve->boundingBox();
+  for ( const QgsPointCloudSubIndex &subidx : mLayer->dataProvider()->subIndexes() )
   {
-    return false;
+    QgsPointCloudIndex *index = subidx.index();
+    if ( index && index->isValid() && subidx.polygonBounds().intersects( profileCurveBbox ) )
+      indexes.append( subidx.index() );
   }
+
+  if ( indexes.empty() )
+    return false;
 
   const double startDistanceOffset = std::max( !context.distanceRange().isInfinite() ? context.distanceRange().lower() : 0, 0.0 );
   const double endDistance = context.distanceRange().upper();
@@ -433,9 +444,13 @@ bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenera
   mSearchGeometryInLayerCrsGeometryEngine->prepareGeometry();
   mMaxSearchExtentInLayerCrs = mSearchGeometryInLayerCrs->boundingBox();
 
-  const IndexedPointCloudNode root = pc->root();
-
   double maximumErrorPixels = context.convertDistanceToPixels( mMaximumScreenError, mMaximumScreenErrorUnit );
+  if ( maximumErrorPixels < 0.0 )
+  {
+    QgsDebugError( QStringLiteral( "Invalid maximum error in pixels" ) );
+    return false;
+  }
+
   const double toleranceInPixels = context.convertDistanceToPixels( mTolerance, Qgis::RenderUnit::MapUnits );
   // ensure that the maximum error is compatible with the tolerance size -- otherwise if the tolerance size
   // is much smaller than the maximum error, we don't dig deep enough into the point cloud nodes to find
@@ -443,42 +458,6 @@ bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenera
   // "4" is a magic number here, based purely on what "looks good" in the profile results!
   if ( toleranceInPixels / 4 < maximumErrorPixels )
     maximumErrorPixels = toleranceInPixels / 4;
-
-  const QgsRectangle rootNodeExtentLayerCoords = pc->nodeMapExtent( root );
-  QgsRectangle rootNodeExtentInCurveCrs;
-  try
-  {
-    QgsCoordinateTransform extentTransform = mLayerToTargetTransform;
-    extentTransform.setBallparkTransformsAreAppropriate( true );
-    rootNodeExtentInCurveCrs = extentTransform.transformBoundingBox( rootNodeExtentLayerCoords );
-  }
-  catch ( QgsCsException & )
-  {
-    QgsDebugError( QStringLiteral( "Could not transform node extent to curve CRS" ) );
-    rootNodeExtentInCurveCrs = rootNodeExtentLayerCoords;
-  }
-
-  const double rootErrorInMapCoordinates = rootNodeExtentInCurveCrs.width() / pc->span(); // in curve coords
-
-  const double mapUnitsPerPixel = context.mapUnitsPerDistancePixel();
-  if ( ( rootErrorInMapCoordinates < 0.0 ) || ( mapUnitsPerPixel < 0.0 ) || ( maximumErrorPixels < 0.0 ) )
-  {
-    QgsDebugError( QStringLiteral( "invalid screen error" ) );
-    return false;
-  }
-  double rootErrorPixels = rootErrorInMapCoordinates / mapUnitsPerPixel; // in pixels
-  const QVector<IndexedPointCloudNode> nodes = traverseTree( pc, pc->root(), maximumErrorPixels, rootErrorPixels, context.elevationRange() );
-  if ( nodes.empty() )
-  {
-    return false;
-  }
-
-  const double rootErrorInLayerCoordinates = rootNodeExtentLayerCoords.width() / pc->span();
-  const double maxErrorInMapCoordinates = maximumErrorPixels * mapUnitsPerPixel;
-
-  mResults = std::make_unique< QgsPointCloudLayerProfileResults >();
-  mResults->copyPropertiesFromGenerator( this );
-  mResults->mMaxErrorInLayerCoordinates = maxErrorInMapCoordinates * rootErrorInLayerCoordinates / rootErrorInMapCoordinates;
 
   QgsPointCloudRequest request;
   QgsPointCloudAttributeCollection attributes;
@@ -515,22 +494,75 @@ bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenera
 
   request.setAttributes( attributes );
 
-  switch ( pc->accessType() )
+  mResults = std::make_unique< QgsPointCloudLayerProfileResults >();
+  mResults->copyPropertiesFromGenerator( this );
+  mResults->mMaxErrorInLayerCoordinates = 0;
+
+  QgsCoordinateTransform extentTransform = mLayerToTargetTransform;
+  extentTransform.setBallparkTransformsAreAppropriate( true );
+
+  const double mapUnitsPerPixel = context.mapUnitsPerDistancePixel();
+  if ( mapUnitsPerPixel < 0.0 )
   {
-    case QgsPointCloudIndex::AccessType::Local:
-    {
-      visitNodesSync( nodes, pc, request, context.elevationRange() );
-      break;
-    }
-    case QgsPointCloudIndex::AccessType::Remote:
-    {
-      visitNodesAsync( nodes, pc, request, context.elevationRange() );
-      break;
-    }
+    QgsDebugError( QStringLiteral( "Invalid map units per pixel ratio" ) );
+    return false;
   }
 
-  if ( mFeedback->isCanceled() )
+  for ( QgsPointCloudIndex *pc : indexes )
+  {
+    const IndexedPointCloudNode root = pc->root();
+    const QgsRectangle rootNodeExtentLayerCoords = pc->nodeMapExtent( root );
+    QgsRectangle rootNodeExtentInCurveCrs;
+    try
+    {
+      rootNodeExtentInCurveCrs = extentTransform.transformBoundingBox( rootNodeExtentLayerCoords );
+    }
+    catch ( QgsCsException & )
+    {
+      QgsDebugError( QStringLiteral( "Could not transform node extent to curve CRS" ) );
+      rootNodeExtentInCurveCrs = rootNodeExtentLayerCoords;
+    }
+
+    const double rootErrorInMapCoordinates = rootNodeExtentInCurveCrs.width() / pc->span(); // in curve coords
+    if ( rootErrorInMapCoordinates < 0.0 )
+    {
+      QgsDebugError( QStringLiteral( "Invalid root node error" ) );
+      return false;
+    }
+
+    double rootErrorPixels = rootErrorInMapCoordinates / mapUnitsPerPixel; // in pixels
+    const QVector<IndexedPointCloudNode> nodes = traverseTree( pc, pc->root(), maximumErrorPixels, rootErrorPixels, context.elevationRange() );
+
+    const double rootErrorInLayerCoordinates = rootNodeExtentLayerCoords.width() / pc->span();
+    const double maxErrorInMapCoordinates = maximumErrorPixels * mapUnitsPerPixel;
+
+    mResults->mMaxErrorInLayerCoordinates = std::max(
+        mResults->mMaxErrorInLayerCoordinates,
+        maxErrorInMapCoordinates * rootErrorInLayerCoordinates / rootErrorInMapCoordinates );
+
+    switch ( pc->accessType() )
+    {
+      case QgsPointCloudIndex::AccessType::Local:
+      {
+        visitNodesSync( nodes, pc, request, context.elevationRange() );
+        break;
+      }
+      case QgsPointCloudIndex::AccessType::Remote:
+      {
+        visitNodesAsync( nodes, pc, request, context.elevationRange() );
+        break;
+      }
+    }
+
+    if ( mFeedback->isCanceled() )
+      return false;
+  }
+
+  if ( mGatheredPoints.empty() )
+  {
+    mResults = nullptr;
     return false;
+  }
 
   // convert x/y values back to distance/height values
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -508,7 +508,7 @@ bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenera
     return false;
   }
 
-  for ( QgsPointCloudIndex *pc : indexes )
+  for ( QgsPointCloudIndex *pc : std::as_const( indexes ) )
   {
     const IndexedPointCloudNode root = pc->root();
     const QgsRectangle rootNodeExtentLayerCoords = pc->nodeMapExtent( root );


### PR DESCRIPTION
## Description

This PR fixes elevation profile generation on virtual point cloud (VPC) layers by changing `QgsPointCloudLayerProfileGenerator::generateProfile()` to consider sub-indexes.

Will fix #54728

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
