### PR TITLE
Use a scoped proj logger to avoid user data lifetime issues

### DIFF
--- a/src/core/proj/qgscoordinatetransform_p.cpp
+++ b/src/core/proj/qgscoordinatetransform_p.cpp
@@ -247,36 +247,6 @@ void QgsCoordinateTransformPrivate::calculateTransforms( const QgsCoordinateTran
   }
 }
 
-static void proj_collecting_logger( void *user_data, int /*level*/, const char *message )
-{
-  QStringList *dest = reinterpret_cast< QStringList * >( user_data );
-  dest->append( QString( message ) );
-}
-
-static void proj_logger( void *, int level, const char *message )
-{
-#ifndef QGISDEBUG
-  Q_UNUSED( message )
-#endif
-  if ( level == PJ_LOG_ERROR )
-  {
-    const QString messageString( message );
-    if ( messageString == QLatin1String( "push: Invalid latitude" ) )
-    {
-      // these messages tend to spam the console as they can be repeated 1000s of times
-      QgsDebugMsgLevel( messageString, 3 );
-    }
-    else
-    {
-      QgsDebugError( messageString );
-    }
-  }
-  else if ( level == PJ_LOG_DEBUG )
-  {
-    QgsDebugMsgLevel( QString( message ), 3 );
-  }
-}
-
 ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
 {
   QgsReadWriteLocker locker( mProjLock, QgsReadWriteLocker::Read );
@@ -295,7 +265,7 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
 
   // use a temporary proj error collector
   QStringList projErrors;
-  proj_log_func( context, &projErrors, proj_collecting_logger );
+  proj_log_func( context, &projErrors, QgsProjUtils::proj_collecting_logger );
 
   mIsReversed = false;
 
@@ -533,7 +503,7 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
   }
 
   // reset logger to terminal output
-  proj_log_func( context, nullptr, proj_logger );
+  proj_log_func( context, nullptr, QgsProjUtils::proj_logger );
 
   if ( !transform )
   {

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -355,18 +355,29 @@ QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToDatumEnsemble( const PJ *crs
 #endif
 }
 
-static void proj_collecting_logger( void *user_data, int /*level*/, const char *message )
+void QgsProjUtils::proj_collecting_logger( void *user_data, int /*level*/, const char *message )
 {
   QStringList *dest = reinterpret_cast< QStringList * >( user_data );
-  dest->append( QString( message ) );
+  QString messageString( message );
+  messageString.replace( QLatin1String( "internal_proj_create: " ), QString() );
+  dest->append( messageString );
 }
 
-static void proj_logger( void *, int level, const char *message )
+void QgsProjUtils::proj_logger( void *, int level, const char *message )
 {
 #ifdef QGISDEBUG
   if ( level == PJ_LOG_ERROR )
   {
-    QgsDebugError( QString( message ) );
+    const QString messageString( message );
+    if ( messageString == QLatin1String( "push: Invalid latitude" ) )
+    {
+      // these messages tend to spam the console as they can be repeated 1000s of times
+      QgsDebugMsgLevel( messageString, 3 );
+    }
+    else
+    {
+      QgsDebugError( messageString );
+    }
   }
   else if ( level == PJ_LOG_DEBUG )
   {

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -311,6 +311,46 @@ class CORE_EXPORT QgsProjContext
 #endif
 };
 
+
+/**
+ * \ingroup core
+ *
+ * \brief Scoped object for temporary swapping to an error-collecting PROJ log function.
+ *
+ * Temporarily sets the PROJ log function to one which collects errors for the lifetime of the object,
+ * before returning it to the default QGIS proj logging function on destruction.
+ *
+ * \note The collecting logger ONLY applies to the current thread.
+ *
+ * \note Not available in Python bindings
+ * \since QGIS 3.40
+ */
+class CORE_EXPORT QgsScopedProjCollectingLogger
+{
+  public:
+
+    /**
+     * Constructor for QgsScopedProjCollectingLogger.
+     *
+     * PROJ errors will be collected, and can be retrieved by calling errors().
+     */
+    QgsScopedProjCollectingLogger();
+
+    /**
+     * Returns the PROJ logger back to the default QGIS PROJ logger.
+     */
+    ~QgsScopedProjCollectingLogger();
+
+    /**
+     * Returns the (possibly empty) list of collected errors.
+     */
+    QStringList errors() const { return mProjErrors; }
+
+  private:
+
+    QStringList mProjErrors;
+};
+
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProjUtils::IdentifyFlags )
 #endif
 #endif // QGSPROJUTILS_H

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -241,6 +241,22 @@ class CORE_EXPORT QgsProjUtils
      */
     static QList< QgsDatumTransform::GridDetails > gridsUsed( const QString &proj );
 
+    /**
+     * Default QGIS proj log function.
+     *
+     * Uses QgsDebugError or QgsDebugMsgLevel to report errors in debug builds only.
+     */
+    static void proj_logger( void *user_data, int level, const char *message );
+
+    /**
+     * QGIS proj log function which collects errors to a QStringList.
+     *
+     * \warning The user_data argument passed to proj_log_func MUST be a QStringList object,
+     * and must exist for the duration where proj_collecting_logger is used. You MUST reset
+     * the proj_log_func to proj_logger before the user data QStringList is destroyed.
+     */
+    static void proj_collecting_logger( void *user_data, int level, const char *message );
+
 #if 0 // not possible in current Proj 6 API
 
     /**

--- a/src/gui/proj/qgscrsdefinitionwidget.cpp
+++ b/src/gui/proj/qgscrsdefinitionwidget.cpp
@@ -114,10 +114,9 @@ void QgsCrsDefinitionWidget::validateCurrent()
 {
   const QString projDef = mTextEditParameters->toPlainText();
 
-  PJ_CONTEXT *context = proj_context_create();
+  PJ_CONTEXT *context = QgsProjContext::get();
 
-  QStringList projErrors;
-  proj_log_func( context, &projErrors, QgsProjUtils::proj_collecting_logger );
+  QgsScopedProjCollectingLogger projLogger;
   QgsProjUtils::proj_pj_unique_ptr crs;
 
   switch ( static_cast< Qgis::CrsDefinitionFormat >( mFormatComboBox->currentData().toInt() ) )
@@ -161,16 +160,11 @@ void QgsCrsDefinitionWidget::validateCurrent()
       else
       {
         QMessageBox::warning( this, tr( "Custom Coordinate Reference System" ),
-                              tr( "This proj projection definition is not valid:" ) + QStringLiteral( "\n\n" ) + projErrors.join( '\n' ) );
+                              tr( "This proj projection definition is not valid:" ) + QStringLiteral( "\n\n" ) + projLogger.errors().join( '\n' ) );
       }
       break;
     }
   }
-
-  // reset logger to terminal output
-  proj_log_func( context, nullptr, nullptr );
-  proj_context_destroy( context );
-  context = nullptr;
 }
 
 void QgsCrsDefinitionWidget::formatChanged()

--- a/src/gui/proj/qgscrsdefinitionwidget.cpp
+++ b/src/gui/proj/qgscrsdefinitionwidget.cpp
@@ -110,14 +110,6 @@ void QgsCrsDefinitionWidget::pbnCopyCRS_clicked()
   }
 }
 
-static void proj_collecting_logger( void *user_data, int /*level*/, const char *message )
-{
-  QStringList *dest = reinterpret_cast< QStringList * >( user_data );
-  QString messageString( message );
-  messageString.replace( QLatin1String( "internal_proj_create: " ), QString() );
-  dest->append( messageString );
-}
-
 void QgsCrsDefinitionWidget::validateCurrent()
 {
   const QString projDef = mTextEditParameters->toPlainText();
@@ -125,7 +117,7 @@ void QgsCrsDefinitionWidget::validateCurrent()
   PJ_CONTEXT *context = proj_context_create();
 
   QStringList projErrors;
-  proj_log_func( context, &projErrors, proj_collecting_logger );
+  proj_log_func( context, &projErrors, QgsProjUtils::proj_collecting_logger );
   QgsProjUtils::proj_pj_unique_ptr crs;
 
   switch ( static_cast< Qgis::CrsDefinitionFormat >( mFormatComboBox->currentData().toInt() ) )


### PR DESCRIPTION
Previously we incorrectly tried to reset the proj logger by calling proj_log_func with a nullptr function in some exit
paths. This leads to crashes, as the nullptr arg makes proj_log_func a no-op, and then later proj tries to
log using the now destroyed user data string list.

Make all this more robust by switching to a scoped QgsScopedProjCollectingLogger class, which automatically
correctly restores the default QGIS proj logger on destruction and ensures there's no object lifetime
issues for the log function vs the user data object.

Fixes https://github.com/qgis/QGIS/issues/36125, other crashes seen in the wild

I've tagged this for immediate backport as it's a crash fix, but if consensus is that it's too risky then i'll swap to a queued backport instead...