### PR TITLE
[processing] Fix clipping of long WKT strings for geometry parameters by using our geometry widget

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -68,6 +68,8 @@
 #include "qgsprocessingpointcloudexpressionlineedit.h"
 #include "qgsprocessingrastercalculatorexpressionlineedit.h"
 #include "qgsunittypes.h"
+#include "qgsgeometrywidget.h"
+
 #include <QToolButton>
 #include <QLabel>
 #include <QHBoxLayout>
@@ -4405,23 +4407,24 @@ QgsProcessingGeometryParameterDefinitionWidget::QgsProcessingGeometryParameterDe
 
   vlayout->addWidget( new QLabel( tr( "Default value" ) ) );
 
-  mDefaultLineEdit = new QLineEdit();
-  mDefaultLineEdit->setToolTip( tr( "Geometry as WKT" ) );
-  mDefaultLineEdit->setPlaceholderText( tr( "Geometry as WKT" ) );
+  mGeometryWidget = new QgsGeometryWidget();
   if ( const QgsProcessingParameterGeometry *geometryParam = dynamic_cast<const QgsProcessingParameterGeometry *>( definition ) )
   {
     QgsGeometry g = QgsProcessingParameters::parameterAsGeometry( geometryParam, geometryParam->defaultValueForGui(), context );
     if ( !g.isNull() )
-      mDefaultLineEdit->setText( g.asWkt() );
+    {
+      mGeometryWidget->setGeometryValue( QgsReferencedGeometry( g, QgsCoordinateReferenceSystem() ) );
+    }
   }
 
-  vlayout->addWidget( mDefaultLineEdit );
+  vlayout->addWidget( mGeometryWidget );
   setLayout( vlayout );
 }
 
 QgsProcessingParameterDefinition *QgsProcessingGeometryParameterDefinitionWidget::createParameter( const QString &name, const QString &description, Qgis::ProcessingParameterFlags flags ) const
 {
-  auto param = std::make_unique< QgsProcessingParameterGeometry >( name, description, mDefaultLineEdit->text() );
+  const QgsReferencedGeometry geometry = mGeometryWidget->geometryValue();
+  auto param = std::make_unique< QgsProcessingParameterGeometry >( name, description, geometry.isEmpty() ? QVariant() : geometry.asWkt() );
   param->setFlags( flags );
   return param.release();
 }
@@ -4440,13 +4443,13 @@ QWidget *QgsProcessingGeometryWidgetWrapper::createWidget()
     case QgsProcessingGui::Modeler:
     case QgsProcessingGui::Batch:
     {
-      mLineEdit = new QLineEdit();
-      mLineEdit->setToolTip( parameterDefinition()->toolTip() );
-      connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]
+      mGeometryWidget = new QgsGeometryWidget();
+      mGeometryWidget->setToolTip( parameterDefinition()->toolTip() );
+      connect( mGeometryWidget, &QgsGeometryWidget::geometryValueChanged, this, [ = ]( const QgsReferencedGeometry & )
       {
         emit widgetValueHasChanged( this );
       } );
-      return mLineEdit;
+      return mGeometryWidget;
     }
   }
   return nullptr;
@@ -4454,22 +4457,31 @@ QWidget *QgsProcessingGeometryWidgetWrapper::createWidget()
 
 void QgsProcessingGeometryWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )
 {
-  if ( mLineEdit )
+  if ( mGeometryWidget )
   {
     QgsGeometry g = QgsProcessingParameters::parameterAsGeometry( parameterDefinition(), value, context );
     if ( !g.isNull() )
-      mLineEdit->setText( g.asWkt() );
+    {
+      mGeometryWidget->setGeometryValue( QgsReferencedGeometry( g, QgsCoordinateReferenceSystem() ) );
+    }
     else
-      mLineEdit->clear();
+    {
+      mGeometryWidget->clearGeometry();
+    }
   }
 }
 
 QVariant QgsProcessingGeometryWidgetWrapper::widgetValue() const
 {
-  if ( mLineEdit )
-    return mLineEdit->text().isEmpty() ? QVariant() : mLineEdit->text();
+  if ( mGeometryWidget )
+  {
+    const QgsReferencedGeometry geometry = mGeometryWidget->geometryValue();
+    return geometry.isEmpty() ? QVariant() : geometry.asWkt();
+  }
   else
+  {
     return QVariant();
+  }
 }
 
 QStringList QgsProcessingGeometryWidgetWrapper::compatibleParameterTypes() const

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -75,6 +75,7 @@ class QgsProcessingPointCloudExpressionLineEdit;
 class QgsProcessingRasterCalculatorExpressionLineEdit;
 class QgsRubberBand;
 class QgsHighlightableLineEdit;
+class QgsGeometryWidget;
 
 ///@cond PRIVATE
 
@@ -1234,7 +1235,7 @@ class GUI_EXPORT QgsProcessingGeometryParameterDefinitionWidget : public QgsProc
 
   private:
 
-    QLineEdit *mDefaultLineEdit = nullptr;
+    QgsGeometryWidget *mGeometryWidget = nullptr;
 
 };
 
@@ -1270,7 +1271,7 @@ class GUI_EXPORT QgsProcessingGeometryWidgetWrapper : public QgsAbstractProcessi
     QString modelerExpressionFormatString() const override;
   private:
 
-    QLineEdit *mLineEdit = nullptr;
+    QgsGeometryWidget *mGeometryWidget = nullptr;
 
     friend class TestProcessingGui;
 };


### PR DESCRIPTION
## Description

This PR fixes a serious issue with the processing geometry parameter widget whereas long geometry WKT strings are clipped (due to QLineEdit's maximum characters limit), making it impossible to pass on complex geometries through GUI.

The fix is to replace the line edit with QgsGeometryWidget , which handles long geometry WKT strings. 

As a collateral benefit here, we gain the possibility to copy a feature on the map canvas and make use of its geometry value as geometry parameter via the widget's paste geometry logic.