### PR TITLE
Remove duplicate equality operator for QgsPointXY

### DIFF
--- a/python/PyQt6/core/auto_generated/qgspointxy.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspointxy.sip.in
@@ -220,7 +220,7 @@ Compares this point with another point with a fuzzy tolerance using distance com
 .. versionadded:: 3.36
 %End
 
-    bool operator==( const QgsPointXY &other ) /HoldGIL/;
+    bool operator==( const QgsPointXY &other ) const /HoldGIL/;
 
     bool operator!=( const QgsPointXY &other ) const /HoldGIL/;
 
@@ -285,7 +285,6 @@ Multiply x and y by the given value
 %End
 
 }; // class QgsPointXY
-
 
 
 

--- a/python/core/auto_generated/qgspointxy.sip.in
+++ b/python/core/auto_generated/qgspointxy.sip.in
@@ -220,7 +220,7 @@ Compares this point with another point with a fuzzy tolerance using distance com
 .. versionadded:: 3.36
 %End
 
-    bool operator==( const QgsPointXY &other ) /HoldGIL/;
+    bool operator==( const QgsPointXY &other ) const /HoldGIL/;
 
     bool operator!=( const QgsPointXY &other ) const /HoldGIL/;
 
@@ -285,7 +285,6 @@ Multiply x and y by the given value
 %End
 
 }; // class QgsPointXY
-
 
 
 

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -270,7 +270,7 @@ class CORE_EXPORT QgsPointXY
       return QgsGeometryUtilsBase::fuzzyDistanceEqual( epsilon, mX, mY, other.x(), other.y() );
     }
 
-    bool operator==( const QgsPointXY &other ) SIP_HOLDGIL
+    bool operator==( const QgsPointXY &other ) const SIP_HOLDGIL
     {
       if ( isEmpty() && other.isEmpty() )
         return true;
@@ -398,26 +398,6 @@ class CORE_EXPORT QgsPointXY
 }; // class QgsPointXY
 
 Q_DECLARE_METATYPE( QgsPointXY )
-
-inline bool operator==( const QgsPointXY &p1, const QgsPointXY &p2 ) SIP_SKIP
-{
-  const bool nan1X = std::isnan( p1.x() );
-  const bool nan2X = std::isnan( p2.x() );
-  if ( nan1X != nan2X )
-    return false;
-  if ( !nan1X && !qgsDoubleNear( p1.x(), p2.x(), 1E-8 ) )
-    return false;
-
-  const bool nan1Y = std::isnan( p1.y() );
-  const bool nan2Y = std::isnan( p2.y() );
-  if ( nan1Y != nan2Y )
-    return false;
-
-  if ( !nan1Y && !qgsDoubleNear( p1.y(), p2.y(), 1E-8 ) )
-    return false;
-
-  return true;
-}
 
 inline std::ostream &operator << ( std::ostream &os, const QgsPointXY &p ) SIP_SKIP
 {

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1391,9 +1391,9 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   mSnapMatch = context.snappingUtils->snapToMap( point, nullptr, true );
   if ( mSnapMatch.layer() )
   {
-      // note ND: I'm not 100% sure if the point == mSnapMatch.point() comparison was intended be done using QgsPointXY or QgsPoint objects here!
-      // I'm using QgsPointXY here to keep the behavior the same from before a duplicate QgsPointXY == operator was removed...
-      if ( ( ( mSnapMatch.hasVertex() || mSnapMatch.hasLineEndpoint() ) && ( QgsPointXY( point ) == mSnapMatch.point() ) )
+    // note ND: I'm not 100% sure if the point == mSnapMatch.point() comparison was intended be done using QgsPointXY or QgsPoint objects here!
+    // I'm using QgsPointXY here to keep the behavior the same from before a duplicate QgsPointXY == operator was removed...
+    if ( ( ( mSnapMatch.hasVertex() || mSnapMatch.hasLineEndpoint() ) && ( QgsPointXY( point ) == mSnapMatch.point() ) )
          || ( mSnapMatch.hasEdge() && QgsProject::instance()->topologicalEditing() ) )
     {
       e->snapPoint();

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1391,7 +1391,9 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   mSnapMatch = context.snappingUtils->snapToMap( point, nullptr, true );
   if ( mSnapMatch.layer() )
   {
-    if ( ( ( mSnapMatch.hasVertex() || mSnapMatch.hasLineEndpoint() ) && ( point == mSnapMatch.point() ) )
+      // note ND: I'm not 100% sure if the point == mSnapMatch.point() comparison was intended be done using QgsPointXY or QgsPoint objects here!
+      // I'm using QgsPointXY here to keep the behavior the same from before a duplicate QgsPointXY == operator was removed...
+      if ( ( ( mSnapMatch.hasVertex() || mSnapMatch.hasLineEndpoint() ) && ( QgsPointXY( point ) == mSnapMatch.point() ) )
          || ( mSnapMatch.hasEdge() && QgsProject::instance()->topologicalEditing() ) )
     {
       e->snapPoint();


### PR DESCRIPTION
We had two different(!!!!) implementations for equality operator for QgsPointXY, with different logic (one handled empty points, the other didn't). This compiled only because one was not marked as const. So we'd get a DIFFERENT equality check logic depending on whether or not the first point was const... eeek!

Remove the duplicate one, mark the better one as const
