### PR TITLE
[gui] Fix enable/disable diagrams (as well as subdiagrams of a stacked diagram)

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1040,7 +1040,7 @@ the left (horizontal mode) or more to the top (vertical mode).
 %Docstring
 Returns the renderer at the given ``index``.
 
-:param index: index of the disired renderer in the stacked renderer
+:param index: index of the desired renderer in the stacked renderer
 %End
 
   protected:

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1040,7 +1040,7 @@ the left (horizontal mode) or more to the top (vertical mode).
 %Docstring
 Returns the renderer at the given ``index``.
 
-:param index: index of the disired renderer in the stacked renderer
+:param index: index of the desired renderer in the stacked renderer
 %End
 
   protected:

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -1062,7 +1062,7 @@ class CORE_EXPORT QgsStackedDiagramRenderer : public QgsDiagramRenderer
     /**
      * Returns the renderer at the given \a index.
      *
-     * \param index index of the disired renderer in the stacked renderer
+     * \param index index of the desired renderer in the stacked renderer
      */
     const QgsDiagramRenderer *renderer( const int index ) const;
 

--- a/src/gui/vector/qgsdiagramproperties.cpp
+++ b/src/gui/vector/qgsdiagramproperties.cpp
@@ -878,7 +878,7 @@ std::unique_ptr< QgsDiagram > QgsDiagramProperties::createDiagramObject()
 std::unique_ptr<QgsDiagramSettings> QgsDiagramProperties::createDiagramSettings()
 {
   std::unique_ptr< QgsDiagramSettings > ds = std::make_unique< QgsDiagramSettings>();
-  ds->enabled = enabledDiagram();
+  ds->enabled = isDiagramEnabled();
   ds->font = mDiagramFontButton->currentFont();
   ds->opacity = mOpacityWidget->opacity();
 
@@ -1046,7 +1046,7 @@ void QgsDiagramProperties::apply()
   QgsSettings settings;
   if ( !dockMode() || !settings.value( QStringLiteral( "UI/autoApplyStyling" ), true ).toBool() )
   {
-    if ( enabledDiagram() && 0 == mDiagramAttributesTreeWidget->topLevelItemCount() )
+    if ( isDiagramEnabled() && 0 == mDiagramAttributesTreeWidget->topLevelItemCount() )
     {
       QMessageBox::warning( this, tr( "Diagrams: No attributes added." ),
                             tr( "You did not add any attributes to this diagram layer. Please specify the attributes to visualize on the diagrams or disable diagrams." ) );
@@ -1325,7 +1325,7 @@ void QgsDiagramProperties::setDiagramEnabled( bool enabled )
   mEnableDiagramCheckBox->setChecked( enabled );
 }
 
-bool QgsDiagramProperties::enabledDiagram() const
+bool QgsDiagramProperties::isDiagramEnabled() const
 {
   return mEnableDiagramCheckBox->isChecked();
 }

--- a/src/gui/vector/qgsdiagramproperties.h
+++ b/src/gui/vector/qgsdiagramproperties.h
@@ -210,12 +210,20 @@ class GUI_EXPORT QgsDiagramProperties : public QgsPanelWidget, private Ui::QgsDi
     /**
      * Sets widgets to reflect the \a enabled status of the diagram.
      * \param enabled Whether the diagram is enabled or not.
+     *
+     * \see isDiagramEnabled()
+     *
+     * \since QGIS 3.40
      */
     void setDiagramEnabled( const bool enabled );
 
     /**
      * Returns whether the current diagram should be enabled or not,
      * according to changes in the corresponding widgets.
+     *
+     * \see setDiagramEnabled()
+     *
+     * \since QGIS 3.40
      */
     bool isDiagramEnabled() const;
 

--- a/src/gui/vector/qgsdiagramproperties.h
+++ b/src/gui/vector/qgsdiagramproperties.h
@@ -207,6 +207,18 @@ class GUI_EXPORT QgsDiagramProperties : public QgsPanelWidget, private Ui::QgsDi
      */
     void insertDefaults();
 
+    /**
+     * Sets widgets to reflect the \a enabled status of the diagram.
+     * @param enabled Whether the diagram is enabled or not.
+     */
+    void setDiagramEnabled( const bool enabled );
+
+    /**
+     * Returns whether the current diagram should be enabled or not,
+     * according to changes in the corresponding widgets.
+     */
+    bool enabledDiagram() const;
+
     friend class QgsStackedDiagramProperties;
     friend class QgsStackedDiagramPropertiesDialog;
 };

--- a/src/gui/vector/qgsdiagramproperties.h
+++ b/src/gui/vector/qgsdiagramproperties.h
@@ -209,7 +209,7 @@ class GUI_EXPORT QgsDiagramProperties : public QgsPanelWidget, private Ui::QgsDi
 
     /**
      * Sets widgets to reflect the \a enabled status of the diagram.
-     * @param enabled Whether the diagram is enabled or not.
+     * \param enabled Whether the diagram is enabled or not.
      */
     void setDiagramEnabled( const bool enabled );
 
@@ -217,7 +217,7 @@ class GUI_EXPORT QgsDiagramProperties : public QgsPanelWidget, private Ui::QgsDi
      * Returns whether the current diagram should be enabled or not,
      * according to changes in the corresponding widgets.
      */
-    bool enabledDiagram() const;
+    bool isDiagramEnabled() const;
 
     friend class QgsStackedDiagramProperties;
     friend class QgsStackedDiagramPropertiesDialog;

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -10,7 +10,7 @@
     <height>491</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,1">
+  <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,0,1">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -49,6 +49,13 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="mEnableDiagramCheckBox">
+     <property name="text">
+      <string>Enable diagram</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -2411,6 +2418,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>mDiagramTypeComboBox</tabstop>
+  <tabstop>mEnableDiagramCheckBox</tabstop>
+  <tabstop>mOptionsTab</tabstop>
   <tabstop>mDiagramOptionsListWidget</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>mAttributesTreeWidget</tabstop>


### PR DESCRIPTION
Followup #58568 

New checkbox `Enable diagram`:

![image](https://github.com/user-attachments/assets/6cadbfc1-4eb9-4104-bc0a-ea4dabd12d3d)


**Current situation**: The diagram's enabled setting cannot be set manually.
**This PR**: Adds a checkbox to read and set such a setting in the diagram properties dialog/panel.

**Current situation**: Subdiagrams can be disabled in the main panel of a stacked diagram. However, once a subdiagram is being edited, its disabled setting is no longer kept and there is no visual clue for the user about the enabled/disabled setting status.
**This PR**: Adds consistency to handling the enabled setting, i.e., changes in the status are visible and easily toggled via the new checkbox.

GUI consistency: I'm adhering here to similar widgets that have been employed in several QGIS modules before. For instance, for enabling/disabling labels in a `rule-based labeling` or in the `Layout map grid` widget. 

Screencast:

https://github.com/user-attachments/assets/ff1accbd-9e53-4d18-a94f-e9f5a7ab2e21


