### PR TITLE
Fix hang when picking point/extent for algorithm from model designer dialog

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsextentwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsextentwidget.sip.in
@@ -238,6 +238,8 @@ to permit access to the map canvas)
 
     virtual void dropEvent( QDropEvent *event );
 
+    virtual void showEvent( QShowEvent *event );
+
 
 };
 

--- a/python/gui/auto_generated/qgsextentwidget.sip.in
+++ b/python/gui/auto_generated/qgsextentwidget.sip.in
@@ -238,6 +238,8 @@ to permit access to the map canvas)
 
     virtual void dropEvent( QDropEvent *event );
 
+    virtual void showEvent( QShowEvent *event );
+
 
 };
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -1130,10 +1130,12 @@ class GUI_EXPORT QgsProcessingPointPanel : public QWidget
     void setMapCanvas( QgsMapCanvas *canvas );
     void setAllowNull( bool allowNull );
     void setShowPointOnCanvas( bool show );
+    void setAllowSelectOnCanvas( bool allow );
 
     QVariant value() const;
     void clear();
     void setValue( const QgsPointXY &point, const QgsCoordinateReferenceSystem &crs );
+    void showEvent( QShowEvent *event ) override;
 
   signals:
 
@@ -1152,6 +1154,8 @@ class GUI_EXPORT QgsProcessingPointPanel : public QWidget
 
     QgsFilterLineEdit *mLineEdit = nullptr;
     bool mShowPointOnCanvas = false;
+    bool mFirstShow = true;
+    bool mAllowSelectOnCanvas = true;
     QToolButton *mButton = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
     QgsCoordinateReferenceSystem mCrs;

--- a/src/gui/qgsextentwidget.cpp
+++ b/src/gui/qgsextentwidget.cpp
@@ -585,8 +585,7 @@ void QgsExtentWidget::setMapCanvas( QgsMapCanvas *canvas, bool drawOnCanvasOptio
     mCurrentExtentButton->setVisible( true );
 
     mUseCanvasExtentAction->setVisible( true );
-    if ( drawOnCanvasOption )
-      mDrawOnCanvasAction->setVisible( true );
+    mDrawOnCanvasAction->setVisible( drawOnCanvasOption && !mBlockDrawOnCanvas );
 
     mCondensedToolButton->setToolTip( tr( "Set to current map canvas extent" ) );
     mCondensedToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapIdentification.svg" ) ) );
@@ -666,4 +665,21 @@ void QgsExtentWidget::dropEvent( QDropEvent *event )
   }
   mCondensedLineEdit->setHighlighted( false );
   update();
+}
+
+void QgsExtentWidget::showEvent( QShowEvent * )
+{
+  if ( mFirstShow )
+  {
+    // we don't support select on canvas if the dialog is modal
+    if ( QWidget *parentWindow = window() )
+    {
+      if ( parentWindow->isModal() )
+      {
+        mBlockDrawOnCanvas = true;
+        mDrawOnCanvasAction->setVisible( false );
+      }
+    }
+    mFirstShow = false;
+  }
 }

--- a/src/gui/qgsextentwidget.h
+++ b/src/gui/qgsextentwidget.h
@@ -241,6 +241,7 @@ class GUI_EXPORT QgsExtentWidget : public QWidget, private Ui::QgsExtentGroupBox
     void dragEnterEvent( QDragEnterEvent *event ) override;
     void dragLeaveEvent( QDragLeaveEvent *event ) override;
     void dropEvent( QDropEvent *event ) override;
+    void showEvent( QShowEvent *event ) override;
 
   private slots:
 
@@ -292,6 +293,10 @@ class GUI_EXPORT QgsExtentWidget : public QWidget, private Ui::QgsExtentGroupBox
     bool mHasFixedOutputCrs = false;
 
     QRegularExpression mCondensedRe;
+
+    bool mFirstShow = true;
+    bool mBlockDrawOnCanvas = false;
+
     void setValid( bool valid );
 
     void setExtentToLayerExtent( const QString &layerId );


### PR DESCRIPTION
When a processing widget is shown in a modal dialog, we can't offer the actions to draw the point/extent on the canvas. So hide in these contexts.

Fixes #59063