### PR TITLE
Make OAuth2 HTML brower page translatable

### DIFF
--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -139,7 +139,11 @@ void QgsO2::setVerificationResponseContent()
   QFile verhtml( QStringLiteral( ":/oauth2method/oauth2_verification_finished.html" ) );
   if ( verhtml.open( QIODevice::ReadOnly | QIODevice::Text ) )
   {
-    setReplyContent( verhtml.readAll() );
+    setReplyContent( QString::fromUtf8( verhtml.readAll() )
+                     .replace( QStringLiteral( "{{ H2_TITLE }}" ), tr( "QGIS OAuth2 verification has finished" ) )
+                     .replace( QStringLiteral( "{{ H3_TITLE }}" ), tr( "If you have not been returned to QGIS, bring the application to the forefront." ) )
+                     .replace( QStringLiteral( "{{ CLOSE_WINDOW }}" ), tr( "Close window" ) ).toUtf8()
+                   );
   }
 }
 

--- a/src/auth/oauth2/resources/oauth2_verification_finished.html
+++ b/src/auth/oauth2/resources/oauth2_verification_finished.html
@@ -15,11 +15,13 @@ window.onload = function hashFunction() {
 </head>
 <body>
 
-<h2>QGIS OAuth2 verification has finished</h2>
+<!-- Replacement of below placeholders is done by src/auth/oauth2/core/qgso2.cpp -->
 
-<h3>If you have not been returned to QGIS, bring the application to the forefront.</h3>
+<h2>{{ H2_TITLE }}</h2>
 
-<p><a href="#" onclick="window.close()">Close window</a></p>
+<h3>{{ H3_TITLE }}</h3>
+
+<p><a href="#" onclick="window.close()">{{ CLOSE_WINDOW }}</a></p>
 
 </body>
 </html>


### PR DESCRIPTION
Currently the HTML page returned after logging in to the authentication server is hardcoded in English. Let's make it translatable.

Funded by Régie de Gestion des Données Savoie Mont Blanc (rgd.fr)
