### PR TITLE
QgsRasterLayer: readXml(): read layer notes even when opening with FlagDontResolveLayers (backport)

### DIFF
--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2211,9 +2211,9 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
   {
     const QString rendererType = rasterRendererElem.attribute( QStringLiteral( "type" ) );
     QgsRasterRendererRegistryEntry rendererEntry;
-    if ( QgsApplication::rasterRendererRegistry()->rendererData( rendererType, rendererEntry ) )
+    if ( mDataProvider && QgsApplication::rasterRendererRegistry()->rendererData( rendererType, rendererEntry ) )
     {
-      QgsRasterRenderer *renderer = rendererEntry.rendererCreateFunction( rasterRendererElem, dataProvider() );
+      QgsRasterRenderer *renderer = rendererEntry.rendererCreateFunction( rasterRendererElem, mDataProvider );
       mPipe->set( renderer );
     }
   }
@@ -2402,8 +2402,8 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     if ( !( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) )
     {
       QgsDebugError( QStringLiteral( "Raster data provider could not be created for %1" ).arg( mDataSource ) );
+      return false;
     }
-    return false;
   }
 
   QString error;
@@ -2442,7 +2442,7 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
 
   const QDomNodeList noDataBandList = noDataElement.elementsByTagName( QStringLiteral( "noDataList" ) );
 
-  for ( int i = 0; i < noDataBandList.size(); ++i )
+  for ( int i = 0; mDataProvider && i < noDataBandList.size(); ++i )
   {
     const QDomElement bandElement = noDataBandList.at( i ).toElement();
     bool ok;

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -33,6 +33,7 @@ from qgis.core import (
     QgsExpressionContextUtils,
     QgsFeature,
     QgsGeometry,
+    QgsLayerNotesUtils,
     QgsLabelingEngineSettings,
     QgsMapLayer,
     QgsProject,
@@ -1610,6 +1611,31 @@ class TestQgsProject(QgisTestCase):
         self.assertTrue(project2.flags() & Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide)
         self.assertEqual(layers[0].dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
         self.assertEqual(layers[1].dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
+
+    def testRasterLayerFlagDontResolveLayers(self):
+        """
+        Test that we can read layer notes from a raster layer when opening with FlagDontResolveLayers
+        """
+        tmpDir = QTemporaryDir()
+        tmpFile = f"{tmpDir.path()}/project.qgs"
+        copyfile(os.path.join(TEST_DATA_DIR, "landsat_4326.tif"), os.path.join(tmpDir.path(), "landsat_4326.tif"))
+
+        project = QgsProject()
+
+        l = QgsRasterLayer(os.path.join(tmpDir.path(), "landsat_4326.tif"), "landsat", "gdal")
+        self.assertTrue(l.isValid())
+        QgsLayerNotesUtils.setLayerNotes(l, 'my notes')
+        self.assertTrue(project.addMapLayers([l]))
+        self.assertTrue(project.write(tmpFile))
+        del project
+
+        # Read the project with FlagDontResolveLayers
+        project = QgsProject()
+        self.assertTrue(project.read(tmpFile, QgsProject.FlagDontResolveLayers))
+        layers = list(project.mapLayers().values())
+        self.assertEqual(QgsLayerNotesUtils.layerNotes(layers[0]), "my notes")
+
+        del project
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/58835