### PR TITLE
[PdfExport] Set output condition

### DIFF
--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1311,6 +1311,12 @@ void QgsLayoutExporter::preparePrintAsPdf( QgsLayout *layout, QPdfWriter *device
     {
       QPdfOutputIntent outputIntent;
       outputIntent.setOutputProfile( colorSpace );
+      outputIntent.setOutputCondition( colorSpace.description() );
+
+      // There is no way to actually get the color space registry identifier or even
+      // the registry it comes from.
+      outputIntent.setOutputConditionIdentifier( QStringLiteral( "Unknown identifier" ) );
+      outputIntent.setRegistryName( QStringLiteral( "Unknown registry" ) );
       device->setOutputIntent( outputIntent );
 
       // PDF/X-4 standard allows PDF to be printing ready and is only possible if a color space has been set


### PR DESCRIPTION
If not, Qt sRGB default is automatically set

This gives us in Adobe Acrobat preflight control tool the following


![outputintent](https://github.com/user-attachments/assets/23a7f71d-9bf7-42d8-bf45-6cdc88da9724)
