### PR TITLE
QgsRasterFileWriter::driverForExtension(): make sure querying the tif…

### DIFF
--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -1072,6 +1072,16 @@ QString QgsRasterFileWriter::driverForExtension( const QString &extension )
   if ( ext.startsWith( '.' ) )
     ext.remove( 0, 1 );
 
+  if ( ext.compare( QLatin1String( "tif" ), Qt::CaseInsensitive ) == 0 ||
+       ext.compare( QLatin1String( "tiff" ), Qt::CaseInsensitive ) == 0 )
+  {
+    // Be robust to GDAL drivers potentially recognizing the tif/tiff extensions
+    // but being registered before the GTiff one.
+    // Cf https://github.com/qgis/QGIS/issues/59112
+    if ( GDALGetDriverByName( "GTiff" ) )
+      return "GTiff";
+  }
+
   GDALAllRegister();
   int const drvCount = GDALGetDriverCount();
 


### PR DESCRIPTION
…/tiff extension returns the GTiff driver

Not strictly necessary since has been adressed on GDAL side per https://github.com/OSGeo/gdal/pull/11037 but might be prudent for future similar situations.

Fixes #59112

Already tested per https://github.com/qgis/QGIS/blob/94411b5fcd0c670767332a1ba23ca12786c46118/tests/src/python/test_qgsrasterfilewriter.py#L108