### PR TITLE
[fix] Improve ownership handling and documentation for Stacked Diagrams

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -970,6 +970,9 @@ the rendered diagram is given by a combination of subrenderers.
     QgsStackedDiagramRenderer();
     ~QgsStackedDiagramRenderer();
 
+    QgsStackedDiagramRenderer( const QgsStackedDiagramRenderer &other );
+
+
     virtual QgsStackedDiagramRenderer *clone() const /Factory/;
 
 

--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1041,13 +1041,6 @@ the left (horizontal mode) or more to the top (vertical mode).
 :param renderer: diagram renderer to be added to the stacked renderer
 %End
 
-    const QgsDiagramRenderer *renderer( const int index ) const;
-%Docstring
-Returns the renderer at the given ``index``.
-
-:param index: index of the desired renderer in the stacked renderer
-%End
-
   protected:
     virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext &c, QgsDiagramSettings &s ) const;
 

--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1041,6 +1041,18 @@ the left (horizontal mode) or more to the top (vertical mode).
 :param renderer: diagram renderer to be added to the stacked renderer
 %End
 
+    const QgsDiagramRenderer *renderer( const int index ) const;
+%Docstring
+Returns the renderer at the given ``index``. Does not transfer ownership.
+
+:param index: index of the desired renderer in the stacked renderer
+%End
+
+    int rendererCount() const;
+%Docstring
+Returns the number of sub renderers in the stacked diagram renderer
+%End
+
   protected:
     virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext &c, QgsDiagramSettings &s ) const;
 

--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -968,6 +968,7 @@ the rendered diagram is given by a combination of subrenderers.
   public:
 
     QgsStackedDiagramRenderer();
+    ~QgsStackedDiagramRenderer();
 
     virtual QgsStackedDiagramRenderer *clone() const /Factory/;
 
@@ -1026,9 +1027,9 @@ Returns an ordered list with the renderers of the stacked renderer object.
 :param sortByDiagramMode: If true, the list is returned backwards for vertical orientation.
 %End
 
-    void addRenderer( QgsDiagramRenderer *renderer );
+    void addRenderer( QgsDiagramRenderer *renderer /Transfer/ );
 %Docstring
-Adds a renderer to the stacked renderer object.
+Adds a renderer to the stacked renderer object. Takes ownership.
 
 Renderers added first will render their diagrams first, i.e., more to
 the left (horizontal mode) or more to the top (vertical mode).

--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1026,6 +1026,7 @@ Writes stacked renderers state to a DOM element.
     QList< QgsDiagramRenderer * > renderers( bool sortByDiagramMode = false ) const;
 %Docstring
 Returns an ordered list with the renderers of the stacked renderer object.
+Does not transfer ownership.
 
 :param sortByDiagramMode: If true, the list is returned backwards for vertical orientation.
 %End

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -970,6 +970,9 @@ the rendered diagram is given by a combination of subrenderers.
     QgsStackedDiagramRenderer();
     ~QgsStackedDiagramRenderer();
 
+    QgsStackedDiagramRenderer( const QgsStackedDiagramRenderer &other );
+
+
     virtual QgsStackedDiagramRenderer *clone() const /Factory/;
 
 

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1041,13 +1041,6 @@ the left (horizontal mode) or more to the top (vertical mode).
 :param renderer: diagram renderer to be added to the stacked renderer
 %End
 
-    const QgsDiagramRenderer *renderer( const int index ) const;
-%Docstring
-Returns the renderer at the given ``index``.
-
-:param index: index of the desired renderer in the stacked renderer
-%End
-
   protected:
     virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext &c, QgsDiagramSettings &s ) const;
 

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1041,6 +1041,18 @@ the left (horizontal mode) or more to the top (vertical mode).
 :param renderer: diagram renderer to be added to the stacked renderer
 %End
 
+    const QgsDiagramRenderer *renderer( const int index ) const;
+%Docstring
+Returns the renderer at the given ``index``. Does not transfer ownership.
+
+:param index: index of the desired renderer in the stacked renderer
+%End
+
+    int rendererCount() const;
+%Docstring
+Returns the number of sub renderers in the stacked diagram renderer
+%End
+
   protected:
     virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext &c, QgsDiagramSettings &s ) const;
 

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -968,6 +968,7 @@ the rendered diagram is given by a combination of subrenderers.
   public:
 
     QgsStackedDiagramRenderer();
+    ~QgsStackedDiagramRenderer();
 
     virtual QgsStackedDiagramRenderer *clone() const /Factory/;
 
@@ -1026,9 +1027,9 @@ Returns an ordered list with the renderers of the stacked renderer object.
 :param sortByDiagramMode: If true, the list is returned backwards for vertical orientation.
 %End
 
-    void addRenderer( QgsDiagramRenderer *renderer );
+    void addRenderer( QgsDiagramRenderer *renderer /Transfer/ );
 %Docstring
-Adds a renderer to the stacked renderer object.
+Adds a renderer to the stacked renderer object. Takes ownership.
 
 Renderers added first will render their diagrams first, i.e., more to
 the left (horizontal mode) or more to the top (vertical mode).

--- a/python/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -1026,6 +1026,7 @@ Writes stacked renderers state to a DOM element.
     QList< QgsDiagramRenderer * > renderers( bool sortByDiagramMode = false ) const;
 %Docstring
 Returns an ordered list with the renderers of the stacked renderer object.
+Does not transfer ownership.
 
 :param sortByDiagramMode: If true, the list is returned backwards for vertical orientation.
 %End

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -864,6 +864,31 @@ void QgsLinearlyInterpolatedDiagramRenderer::writeXml( QDomElement &layerElem, Q
 
 const QString QgsStackedDiagramRenderer::DIAGRAM_RENDERER_NAME_STACKED = QStringLiteral( "Stacked" );
 
+QgsStackedDiagramRenderer::QgsStackedDiagramRenderer( const QgsStackedDiagramRenderer &other )
+  : QgsDiagramRenderer( other )
+  , mSettings( other.mSettings )
+{
+  for ( QgsDiagramRenderer *renderer : std::as_const( other.mDiagramRenderers ) )
+  {
+    if ( renderer )
+      mDiagramRenderers << renderer->clone();
+  }
+}
+
+QgsStackedDiagramRenderer &QgsStackedDiagramRenderer::operator=( const QgsStackedDiagramRenderer &other )
+{
+  mSettings = other.mSettings;
+  qDeleteAll( mDiagramRenderers );
+  mDiagramRenderers.clear();
+  for ( QgsDiagramRenderer *renderer : std::as_const( other.mDiagramRenderers ) )
+  {
+    if ( renderer )
+      mDiagramRenderers << renderer->clone();
+  }
+
+  return *this;
+}
+
 QgsStackedDiagramRenderer::~QgsStackedDiagramRenderer()
 {
   qDeleteAll( mDiagramRenderers );
@@ -1078,6 +1103,9 @@ void QgsStackedDiagramRenderer::readXml( const QDomElement &elem, const QgsReadW
 
 void QgsStackedDiagramRenderer::_readXmlSubRenderers( const QDomElement &elem, const QgsReadWriteContext &context )
 {
+  qDeleteAll( mDiagramRenderers );
+  mDiagramRenderers.clear();
+
   const QDomElement subRenderersElem = elem.firstChildElement( QStringLiteral( "DiagramRenderers" ) );
 
   if ( !subRenderersElem.isNull() )

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -867,6 +867,7 @@ const QString QgsStackedDiagramRenderer::DIAGRAM_RENDERER_NAME_STACKED = QString
 QgsStackedDiagramRenderer::QgsStackedDiagramRenderer( const QgsStackedDiagramRenderer &other )
   : QgsDiagramRenderer( other )
   , mSettings( other.mSettings )
+  , mDiagramRenderers()
 {
   for ( QgsDiagramRenderer *renderer : std::as_const( other.mDiagramRenderers ) )
   {

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -1083,11 +1083,6 @@ void QgsStackedDiagramRenderer::addRenderer( QgsDiagramRenderer *renderer )
   }
 }
 
-const QgsDiagramRenderer *QgsStackedDiagramRenderer::renderer( const int index ) const
-{
-  return mDiagramRenderers.value( index );
-}
-
 void QgsStackedDiagramRenderer::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
 {
   const QDomElement categoryElem = elem.firstChildElement( QStringLiteral( "DiagramCategory" ) );

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -1084,6 +1084,16 @@ void QgsStackedDiagramRenderer::addRenderer( QgsDiagramRenderer *renderer )
   }
 }
 
+const QgsDiagramRenderer *QgsStackedDiagramRenderer::renderer( const int index ) const
+{
+  return mDiagramRenderers.value( index );
+}
+
+int QgsStackedDiagramRenderer::rendererCount() const
+{
+  return mDiagramRenderers.size();
+}
+
 void QgsStackedDiagramRenderer::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
 {
   const QDomElement categoryElem = elem.firstChildElement( QStringLiteral( "DiagramCategory" ) );

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -864,6 +864,11 @@ void QgsLinearlyInterpolatedDiagramRenderer::writeXml( QDomElement &layerElem, Q
 
 const QString QgsStackedDiagramRenderer::DIAGRAM_RENDERER_NAME_STACKED = QStringLiteral( "Stacked" );
 
+QgsStackedDiagramRenderer::~QgsStackedDiagramRenderer()
+{
+  qDeleteAll( mDiagramRenderers );
+}
+
 QgsStackedDiagramRenderer *QgsStackedDiagramRenderer::clone() const
 {
   return new QgsStackedDiagramRenderer( *this );

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -907,7 +907,7 @@ QSizeF QgsStackedDiagramRenderer::sizeMapUnits( const QgsFeature &feature, const
   // Iterate renderers. For each renderer, get the diagram
   // size for the feature and add it to the total size
   // accounting for stacked diagram defined spacing
-  for ( const auto &subRenderer : std::as_const( mDiagramRenderers ) )
+  for ( const QgsDiagramRenderer *subRenderer : std::as_const( mDiagramRenderers ) )
   {
     QSizeF size = subRenderer->sizeMapUnits( feature, c );
 
@@ -959,7 +959,7 @@ void QgsStackedDiagramRenderer::renderDiagram( const QgsFeature &feature, QgsRen
   // Get subrenderers sorted by mode (vertical diagrams are returned backwards)
   const QList< QgsDiagramRenderer * > stackedRenderers = renderers( true );
 
-  for ( const auto &stackedRenderer : stackedRenderers )
+  for ( const QgsDiagramRenderer *stackedRenderer : stackedRenderers )
   {
     if ( stackedRenderer->rendererName() == QgsStackedDiagramRenderer::DIAGRAM_RENDERER_NAME_STACKED )
     {
@@ -1054,7 +1054,7 @@ QList<QString> QgsStackedDiagramRenderer::diagramAttributes() const
 QList< QgsLayerTreeModelLegendNode * > QgsStackedDiagramRenderer::legendItems( QgsLayerTreeLayer *nodeLayer ) const
 {
   QList< QgsLayerTreeModelLegendNode * > nodes;
-  for ( const auto &renderer : std::as_const( mDiagramRenderers ) )
+  for ( const QgsDiagramRenderer *renderer : std::as_const( mDiagramRenderers ) )
   {
     nodes << renderer->legendItems( nodeLayer );
   }

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -1065,13 +1065,6 @@ class CORE_EXPORT QgsStackedDiagramRenderer : public QgsDiagramRenderer
      */
     void addRenderer( QgsDiagramRenderer *renderer SIP_TRANSFER );
 
-    /**
-     * Returns the renderer at the given \a index.
-     *
-     * \param index index of the desired renderer in the stacked renderer
-     */
-    const QgsDiagramRenderer *renderer( const int index ) const;
-
   protected:
     bool diagramSettings( const QgsFeature &feature, const QgsRenderContext &c, QgsDiagramSettings &s ) const override;
     QSizeF diagramSize( const QgsFeature &, const QgsRenderContext &c ) const override;

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -1065,6 +1065,16 @@ class CORE_EXPORT QgsStackedDiagramRenderer : public QgsDiagramRenderer
      */
     void addRenderer( QgsDiagramRenderer *renderer SIP_TRANSFER );
 
+    /**
+     * Returns the renderer at the given \a index. Does not transfer ownership.
+     *
+     * \param index index of the desired renderer in the stacked renderer
+     */
+    const QgsDiagramRenderer *renderer( const int index ) const;
+
+    //! Returns the number of sub renderers in the stacked diagram renderer
+    int rendererCount() const;
+
   protected:
     bool diagramSettings( const QgsFeature &feature, const QgsRenderContext &c, QgsDiagramSettings &s ) const override;
     QSizeF diagramSize( const QgsFeature &, const QgsRenderContext &c ) const override;

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -1005,6 +1005,10 @@ class CORE_EXPORT QgsStackedDiagramRenderer : public QgsDiagramRenderer
     QgsStackedDiagramRenderer() = default;
     ~QgsStackedDiagramRenderer() override;
 
+    QgsStackedDiagramRenderer( const QgsStackedDiagramRenderer &other );
+
+    QgsStackedDiagramRenderer &operator=( const QgsStackedDiagramRenderer &other );
+
     QgsStackedDiagramRenderer *clone() const override SIP_FACTORY;
 
     //! Returns size of the diagram for a feature in map units. Returns an invalid QSizeF in case of error

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -1003,6 +1003,7 @@ class CORE_EXPORT QgsStackedDiagramRenderer : public QgsDiagramRenderer
     static const QString DIAGRAM_RENDERER_NAME_STACKED SIP_SKIP;
 
     QgsStackedDiagramRenderer() = default;
+    ~QgsStackedDiagramRenderer() override;
 
     QgsStackedDiagramRenderer *clone() const override SIP_FACTORY;
 
@@ -1050,14 +1051,14 @@ class CORE_EXPORT QgsStackedDiagramRenderer : public QgsDiagramRenderer
     QList< QgsDiagramRenderer * > renderers( bool sortByDiagramMode = false ) const;
 
     /**
-     * Adds a renderer to the stacked renderer object.
+     * Adds a renderer to the stacked renderer object. Takes ownership.
      *
      * Renderers added first will render their diagrams first, i.e., more to
      * the left (horizontal mode) or more to the top (vertical mode).
      *
      * \param renderer diagram renderer to be added to the stacked renderer
      */
-    void addRenderer( QgsDiagramRenderer *renderer );
+    void addRenderer( QgsDiagramRenderer *renderer SIP_TRANSFER );
 
     /**
      * Returns the renderer at the given \a index.

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -1049,6 +1049,7 @@ class CORE_EXPORT QgsStackedDiagramRenderer : public QgsDiagramRenderer
 
     /**
      * Returns an ordered list with the renderers of the stacked renderer object.
+     * Does not transfer ownership.
      *
      * \param sortByDiagramMode If true, the list is returned backwards for vertical orientation.
      */

--- a/src/gui/vector/qgsdiagramproperties.cpp
+++ b/src/gui/vector/qgsdiagramproperties.cpp
@@ -421,6 +421,16 @@ void QgsDiagramProperties::insertDefaults()
 void QgsDiagramProperties::syncToLayer()
 {
   const QgsDiagramRenderer *renderer = mLayer->diagramRenderer();
+  if ( renderer->rendererName() == QgsStackedDiagramRenderer::DIAGRAM_RENDERER_NAME_STACKED )
+  {
+    const QgsStackedDiagramRenderer *stackedRenderer = static_cast< const QgsStackedDiagramRenderer *>( renderer );
+    if ( stackedRenderer->rendererCount() > 0 )
+    {
+      // If layer has a stacked diagram renderer, take its first sub
+      // renderer as the basis for the new single one being created
+      renderer = stackedRenderer->renderer( 0 );
+    }
+  }
   syncToRenderer( renderer );
 
   const QgsDiagramLayerSettings *layerDls = mLayer->diagramLayerSettings();

--- a/src/gui/vector/qgsdiagramproperties.h
+++ b/src/gui/vector/qgsdiagramproperties.h
@@ -55,7 +55,7 @@ class GUI_EXPORT QgsDiagramProperties : public QgsPanelWidget, private Ui::QgsDi
     void syncToLayer();
 
     /**
-     * Updates the widget to reflect the diagram renderer.
+     * Updates the widget to reflect the diagram renderer. Does not take ownership.
      * \param dr Diagram renderer where settings are taken from.
      *
      * \since QGIS 3.40
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsDiagramProperties : public QgsPanelWidget, private Ui::QgsDi
     void syncToRenderer( const QgsDiagramRenderer *dr );
 
     /**
-     * Updates the widget to reflect the diagram layer settings.
+     * Updates the widget to reflect the diagram layer settings. Does not take ownership.
      * \param dls Diagram Layer Settings to update the widget.
      *
      * \since QGIS 3.40

--- a/src/gui/vector/qgsdiagramwidget.cpp
+++ b/src/gui/vector/qgsdiagramwidget.cpp
@@ -131,8 +131,6 @@ void QgsDiagramWidget::syncToOwnLayer()
         // Play safe and set to histogram by default if the diagram name is unknown
         mDiagramTypeComboBox->setCurrentIndex( ModeHistogram );
       }
-      // TODO: if we get a stacked diagram, take the first subdiagram,
-      // Set its diagram type and sync to its settings
 
       // Delegate to single diagram's syncToLayer
       static_cast<QgsDiagramProperties *>( mWidget )->syncToLayer();

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -393,7 +393,37 @@ QVariant QgsStackedDiagramPropertiesModel::data( const QModelIndex &index, int r
     switch ( index.column() )
     {
       case 1:
-        return ( !dr || !dr->diagram() ) ? tr( "(no diagram)" ) : dr->diagram()->diagramName();
+        if ( dr && dr->diagram() )
+        {
+          if ( dr->diagram()->diagramName() == QgsPieDiagram::DIAGRAM_NAME_PIE )
+          {
+            return tr( "Pie Chart" );
+          }
+          else if ( dr->diagram()->diagramName() == QgsTextDiagram::DIAGRAM_NAME_TEXT )
+          {
+            return tr( "Text Diagram" );
+          }
+          else if ( dr->diagram()->diagramName() == QgsHistogramDiagram::DIAGRAM_NAME_HISTOGRAM )
+          {
+            return tr( "Histogram" );
+          }
+          else if ( dr->diagram()->diagramName() == QgsStackedBarDiagram::DIAGRAM_NAME_STACKED_BAR )
+          {
+            return tr( "Stacked Bars" );
+          }
+          else if ( dr->diagram()->diagramName() == QgsStackedDiagram::DIAGRAM_NAME_STACKED )
+          {
+            return tr( "Stacked Diagram" );
+          }
+          else
+          {
+            return dr->diagram()->diagramName();
+          }
+        }
+        else
+        {
+          return tr( "(no diagram)" );
+        }
       case 2:
         if ( !dr )
         {

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -40,11 +40,11 @@ QgsStackedDiagramProperties::QgsStackedDiagramProperties( QgsVectorLayer *layer,
   }
 
   setupUi( this );
-  connect( mSubDiagramsView, &QAbstractItemView::doubleClicked, this, static_cast<void ( QgsStackedDiagramProperties::* )( const QModelIndex & )>( &QgsStackedDiagramProperties::editSubDiagram ) );
+  connect( mSubDiagramsView, &QAbstractItemView::doubleClicked, this, static_cast<void ( QgsStackedDiagramProperties::* )( const QModelIndex & )>( &QgsStackedDiagramProperties::editSubDiagramRenderer ) );
 
-  connect( mAddSubDiagramButton, &QPushButton::clicked, this, &QgsStackedDiagramProperties::addSubDiagram );
-  connect( mEditSubDiagramButton, &QAbstractButton::clicked, this, static_cast<void ( QgsStackedDiagramProperties::* )()>( &QgsStackedDiagramProperties::editSubDiagram ) );
-  connect( mRemoveSubDiagramButton, &QPushButton::clicked, this, &QgsStackedDiagramProperties::removeSubDiagram );
+  connect( mAddSubDiagramButton, &QPushButton::clicked, this, &QgsStackedDiagramProperties::addSubDiagramRenderer );
+  connect( mEditSubDiagramButton, &QAbstractButton::clicked, this, static_cast<void ( QgsStackedDiagramProperties::* )()>( &QgsStackedDiagramProperties::editSubDiagramRenderer ) );
+  connect( mRemoveSubDiagramButton, &QPushButton::clicked, this, &QgsStackedDiagramProperties::removeSubDiagramRenderer );
 
   // Initialize stacked diagram controls
   mStackedDiagramModeComboBox->addItem( tr( "Horizontal" ), QgsDiagramSettings::Horizontal );
@@ -73,7 +73,7 @@ QgsStackedDiagramProperties::QgsStackedDiagramProperties( QgsVectorLayer *layer,
   syncToLayer();
 }
 
-void QgsStackedDiagramProperties::addSubDiagram()
+void QgsStackedDiagramProperties::addSubDiagramRenderer()
 {
   // Create a single category renderer by default
   std::unique_ptr< QgsDiagramRenderer > renderer;
@@ -94,12 +94,12 @@ void QgsStackedDiagramProperties::addSubDiagram()
   else
   {
     // append to root
-    appendSubDiagram( renderer.release() );
+    appendSubDiagramRenderer( renderer.release() );
   }
-  editSubDiagram();
+  editSubDiagramRenderer();
 }
 
-void QgsStackedDiagramProperties::appendSubDiagram( QgsDiagramRenderer *dr )
+void QgsStackedDiagramProperties::appendSubDiagramRenderer( QgsDiagramRenderer *dr )
 {
   const int rows = mModel->rowCount();
   mModel->insertSubDiagram( rows, dr ); // Transfers ownership
@@ -107,12 +107,12 @@ void QgsStackedDiagramProperties::appendSubDiagram( QgsDiagramRenderer *dr )
   mSubDiagramsView->selectionModel()->setCurrentIndex( newIndex, QItemSelectionModel::ClearAndSelect );
 }
 
-void QgsStackedDiagramProperties::editSubDiagram()
+void QgsStackedDiagramProperties::editSubDiagramRenderer()
 {
-  editSubDiagram( mSubDiagramsView->selectionModel()->currentIndex() );
+  editSubDiagramRenderer( mSubDiagramsView->selectionModel()->currentIndex() );
 }
 
-void QgsStackedDiagramProperties::editSubDiagram( const QModelIndex &index )
+void QgsStackedDiagramProperties::editSubDiagramRenderer( const QModelIndex &index )
 {
   if ( !index.isValid() )
     return;
@@ -159,7 +159,7 @@ void QgsStackedDiagramProperties::editSubDiagram( const QModelIndex &index )
   }
 }
 
-void QgsStackedDiagramProperties::removeSubDiagram()
+void QgsStackedDiagramProperties::removeSubDiagramRenderer()
 {
   const QItemSelection sel = mSubDiagramsView->selectionModel()->selection();
   const auto constSel = sel;
@@ -189,13 +189,13 @@ void QgsStackedDiagramProperties::syncToLayer()
       const auto renderers = stackedDiagramRenderer->renderers();
       for ( const auto &renderer : renderers )
       {
-        appendSubDiagram( renderer->clone() );
+        appendSubDiagramRenderer( renderer->clone() );
       }
     }
     else
     {
       // Take this single renderer as the first stacked renderer
-      appendSubDiagram( dr->clone() );
+      appendSubDiagramRenderer( dr->clone() );
     }
 
     const QgsDiagramLayerSettings *dls = mLayer->diagramLayerSettings();

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -225,7 +225,7 @@ void QgsStackedDiagramProperties::apply()
       ds->categoryLabels += ds1.at( 0 ).categoryLabels;
       ds->categoryColors += ds1.at( 0 ).categoryColors;
     }
-    dr->addRenderer( renderer );
+    dr->addRenderer( renderer->clone() );
   }
 
   dr->setDiagramSettings( *ds );

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -186,8 +186,8 @@ void QgsStackedDiagramProperties::syncToLayer()
     if ( dr->rendererName() == QgsStackedDiagramRenderer::DIAGRAM_RENDERER_NAME_STACKED )
     {
       const QgsStackedDiagramRenderer *stackedDiagramRenderer = static_cast< const QgsStackedDiagramRenderer * >( dr );
-      const auto renderers = stackedDiagramRenderer->renderers();
-      for ( const auto &renderer : renderers )
+      const QList< QgsDiagramRenderer * > renderers = stackedDiagramRenderer->renderers();
+      for ( const QgsDiagramRenderer *renderer : renderers )
       {
         appendSubDiagramRenderer( renderer->clone() );
       }
@@ -216,7 +216,7 @@ void QgsStackedDiagramProperties::apply()
 
   // Get DiagramSettings from each subdiagram
   const QList< QgsDiagramRenderer *> renderers = mModel->subRenderers();
-  for ( const auto &renderer : renderers )
+  for ( const QgsDiagramRenderer *renderer : renderers )
   {
     const QList< QgsDiagramSettings > ds1 = renderer->diagramSettings();
     if ( !ds1.isEmpty() )
@@ -254,7 +254,7 @@ bool QgsStackedDiagramProperties::couldBeFirstSubDiagram( const QModelIndex &ind
 
   for ( int i = 0; i < index.row(); i++ )
   {
-    const auto &renderer = renderers.at( i );
+    const QgsDiagramRenderer *renderer = renderers.at( i );
     const QList< QgsDiagramSettings > ds = renderer->diagramSettings();
     if ( !ds.isEmpty() && ds.at( 0 ).enabled )
     {

--- a/src/gui/vector/qgsstackeddiagramproperties.h
+++ b/src/gui/vector/qgsstackeddiagramproperties.h
@@ -50,6 +50,8 @@ class GUI_EXPORT QgsStackedDiagramPropertiesModel : public QAbstractTableModel
     //! constructor
     QgsStackedDiagramPropertiesModel( QObject *parent = nullptr );
 
+    ~QgsStackedDiagramPropertiesModel() override;
+
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
     QVariant headerData( int section, Qt::Orientation orientation,
@@ -63,15 +65,15 @@ class GUI_EXPORT QgsStackedDiagramPropertiesModel : public QAbstractTableModel
 
     // new methods
 
-    //! Returns the diagram renderer at the specified index
+    //! Returns the diagram renderer at the specified index. Does not transfer ownership.
     QgsDiagramRenderer *subDiagramForIndex( const QModelIndex &index ) const;
 
-    //! Inserts a new diagram at the specified position
+    //! Inserts a new diagram at the specified position. Takes ownership.
     void insertSubDiagram( const int index, QgsDiagramRenderer *newSubDiagram );
-    //! Replaces the diagram located at \a index by \a dr
+    //! Replaces the diagram located at \a index by \a dr. Takes ownership.
     void updateSubDiagram( const QModelIndex &index, QgsDiagramRenderer *dr );
 
-    //! Returns the list of diagram renderers from the model
+    //! Returns the list of diagram renderers from the model. Does not transfer ownership.
     QList< QgsDiagramRenderer *> subRenderers() const;
 
     //! Returns the diagram layer settings from the model
@@ -121,6 +123,7 @@ class GUI_EXPORT QgsStackedDiagramProperties : public QgsPanelWidget, private Ui
 
     /**
      * Appends a diagram to the current QgsStackedDiagramProperties.
+     * Takes ownership.
      */
     void appendSubDiagram( QgsDiagramRenderer *dr );
 
@@ -192,6 +195,7 @@ class GUI_EXPORT QgsStackedDiagramPropertiesDialog : public QDialog
 
     /**
      * Gets a renderer object built from the diagram properties widget.
+     * Transfers ownership.
      */
     QgsDiagramRenderer *renderer();
 

--- a/src/gui/vector/qgsstackeddiagramproperties.h
+++ b/src/gui/vector/qgsstackeddiagramproperties.h
@@ -117,30 +117,30 @@ class GUI_EXPORT QgsStackedDiagramProperties : public QgsPanelWidget, private Ui
   private slots:
 
     /**
-     * Adds a diagram to the current QgsStackedDiagramProperties.
+     * Adds a sub diagram renderer to the current QgsStackedDiagramProperties.
      */
-    void addSubDiagram();
+    void addSubDiagramRenderer();
 
     /**
-     * Appends a diagram to the current QgsStackedDiagramProperties.
+     * Appends a sub diagram renderer to the current QgsStackedDiagramProperties.
      * Takes ownership.
      */
-    void appendSubDiagram( QgsDiagramRenderer *dr );
+    void appendSubDiagramRenderer( QgsDiagramRenderer *dr );
 
     /**
-     * Edits the properties of the current diagram.
+     * Edits the properties of the current diagram renderer.
      */
-    void editSubDiagram();
+    void editSubDiagramRenderer();
 
     /**
-     * Edits the properties of a diagram located at a given \a index.
+     * Edits the properties of a diagram renderer located at a given \a index.
      */
-    void editSubDiagram( const QModelIndex &index );
+    void editSubDiagramRenderer( const QModelIndex &index );
 
     /**
      * Removes a diagram from the current QgsStackedDiagramProperties.
      */
-    void removeSubDiagram();
+    void removeSubDiagramRenderer();
 
   private:
     QgsVectorLayer *mLayer = nullptr;


### PR DESCRIPTION
Followup #58568 (probably the last one in this series)

Improves ownership handling of sub renderers in `QgsStackedDiagramRenderer` and `QgsStackedDiagramPropertiesModel`.

Adds documentation on ownership transfer when receiving or returning sub renderers.

Other adjustments:
 + Replaces `subDiagram` by `subDiagramRenderer` when we actually refer to renderers.
 + Avoids `auto` for non-complex types.
 + Passing from stacked to single diagram: take first stacked diagram as the basis for the new single one.
 + Stacked diagram list in GUI: Match `Diagram type` column to names from the main diagram combobox. This helps us to better differentiate between a stacked bars diagram and a stacked diagram (using the diagram name alone was a bit confusing: e.g., `Stacked`).
