### PR TITLE
[gps] Be tolerant to talker IDs which don't start with 'G'

### DIFF
--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -237,29 +237,21 @@ int nmea_parse_GPGGA( const char *buff, int buff_sz, nmeaGPGGA *pack )
 
   nmea_trace_buff( buff, buff_sz );
 
-  char type;
-
-  if ( 15 != nmea_scanf( buff, buff_sz,
-                         "$G%CGGA,%s,%f,%C,%f,%C,%d,%d,%f,%f,%C,%f,%C,%f,%d*",
-                         &( type ),
+  if ( 16 != nmea_scanf( buff, buff_sz,
+                         "$%C%CGGA,%s,%f,%C,%f,%C,%d,%d,%f,%f,%C,%f,%C,%f,%d*",
+                         &( pack->talkerId[0] ), &( pack->talkerId[1] ),
                          &( time_buff[0] ),
                          &( pack->lat ), &( pack->ns ), &( pack->lon ), &( pack->ew ),
                          &( pack->sig ), &( pack->satinuse ), &( pack->HDOP ), &( pack->elv ), &( pack->elv_units ),
                          &( pack->diff ), &( pack->diff_units ), &( pack->dgps_age ), &( pack->dgps_sid ) ) )
   {
-    nmea_error( "G?GGA parse error!" );
-    return 0;
-  }
-
-  if ( type != 'P' && type != 'N' )
-  {
-    nmea_error( "G?GGA invalid type " );
+    nmea_error( "GGA parse error!" );
     return 0;
   }
 
   if ( 0 != _nmea_parse_time( &time_buff[0], ( int )strlen( &time_buff[0] ), &( pack->utc ) ) )
   {
-    nmea_error( "GPGGA time parse error!" );
+    nmea_error( "GGA time parse error!" );
     return 0;
   }
 
@@ -283,28 +275,20 @@ int nmea_parse_GPGST( const char *buff, int buff_sz, nmeaGPGST *pack )
 
   nmea_trace_buff( buff, buff_sz );
 
-  char type;
-
-  if ( 9 != nmea_scanf( buff, buff_sz,
-                        "$G%CGST,%s,%f,%f,%f,%f,%f,%f,%f*",
-                        &( type ),
-                        &( time_buff[0] ),
-                        &( pack->rms_pr ), &( pack->err_major ), &( pack->err_minor ), &( pack->err_ori ),
-                        &( pack->sig_lat ), &( pack->sig_lon ), &( pack->sig_alt ) ) )
+  if ( 10 != nmea_scanf( buff, buff_sz,
+                         "$%C%CGST,%s,%f,%f,%f,%f,%f,%f,%f*",
+                         &( pack->talkerId[0] ), &( pack->talkerId[1] ),
+                         &( time_buff[0] ),
+                         &( pack->rms_pr ), &( pack->err_major ), &( pack->err_minor ), &( pack->err_ori ),
+                         &( pack->sig_lat ), &( pack->sig_lon ), &( pack->sig_alt ) ) )
   {
-    nmea_error( "G?GST parse error!" );
-    return 0;
-  }
-
-  if ( type != 'P' && type != 'N' )
-  {
-    nmea_error( "G?GST invalid type " );
+    nmea_error( "GST parse error!" );
     return 0;
   }
 
   if ( 0 != _nmea_parse_time( &time_buff[0], ( int )strlen( &time_buff[0] ), &( pack->utc ) ) )
   {
-    nmea_error( "G?GST time parse error!" );
+    nmea_error( "GST time parse error!" );
     return 0;
   }
 
@@ -326,20 +310,15 @@ int nmea_parse_GPGSA( const char *buff, int buff_sz, nmeaGPGSA *pack )
 
   nmea_trace_buff( buff, buff_sz );
 
-  if ( 18 != nmea_scanf( buff, buff_sz,
-                         "$G%CGSA,%C,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%f,%f*",
-                         &( pack->pack_type ), &( pack->fix_mode ), &( pack->fix_type ),
+  if ( 19 != nmea_scanf( buff, buff_sz,
+                         "$%C%CGSA,%C,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%f,%f*",
+                         &( pack->talkerId[0] ), &( pack->talkerId[1] ),
+                         &( pack->fix_mode ), &( pack->fix_type ),
                          &( pack->sat_prn[0] ), &( pack->sat_prn[1] ), &( pack->sat_prn[2] ), &( pack->sat_prn[3] ), &( pack->sat_prn[4] ), &( pack->sat_prn[5] ),
                          &( pack->sat_prn[6] ), &( pack->sat_prn[7] ), &( pack->sat_prn[8] ), &( pack->sat_prn[9] ), &( pack->sat_prn[10] ), &( pack->sat_prn[11] ),
                          &( pack->PDOP ), &( pack->HDOP ), &( pack->VDOP ) ) )
   {
-    nmea_error( "G?GSA parse error!" );
-    return 0;
-  }
-
-  if ( pack->pack_type != 'P' && pack->pack_type != 'N' && pack->pack_type != 'L' )
-  {
-    nmea_error( "G?GSA invalid type " );
+    nmea_error( "GSA parse error!" );
     return 0;
   }
 
@@ -364,12 +343,12 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
   nmea_trace_buff( buff, buff_sz );
 
   nsen = nmea_scanf( buff, buff_sz,
-                     "$G%CGSV,%d,%d,%d,"
+                     "$%C%CGSV,%d,%d,%d,"
                      "%d,%d,%d,%d,"
                      "%d,%d,%d,%d,"
                      "%d,%d,%d,%d,"
                      "%d,%d,%d,%d*",
-                     &( pack->pack_type ),
+                     &( pack->talkerId[0] ), &( pack->talkerId[1] ),
                      &( pack->pack_count ), &( pack->pack_index ), &( pack->sat_count ),
                      &( pack->sat_data[0].id ), &( pack->sat_data[0].elv ), &( pack->sat_data[0].azimuth ), &( pack->sat_data[0].sig ),
                      &( pack->sat_data[1].id ), &( pack->sat_data[1].elv ), &( pack->sat_data[1].azimuth ), &( pack->sat_data[1].sig ),
@@ -380,15 +359,9 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
   nsat = ( nsat + NMEA_SATINPACK > pack->sat_count ) ? pack->sat_count - nsat : NMEA_SATINPACK;
   nsat = nsat * 4 + 3 /* first three sentence`s */;
 
-  if ( nsen - 1 < nsat || nsen - 1 > ( NMEA_SATINPACK * 4 + 3 ) )
+  if ( nsen - 2 < nsat || nsen - 2 > ( NMEA_SATINPACK * 4 + 3 ) )
   {
-    nmea_error( "G?GSV parse error!" );
-    return 0;
-  }
-
-  if ( pack->pack_type != 'P' && pack->pack_type != 'N' && pack->pack_type != 'L' && pack->pack_type != 'A' && pack->pack_type != 'B' && pack->pack_type != 'Q' )
-  {
-    nmea_error( "G?GSV invalid type " );
+    nmea_error( "GSV parse error!" );
     return 0;
   }
 
@@ -405,7 +378,6 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
 int nmea_parse_GPRMC( const char *buff, int buff_sz, nmeaGPRMC *pack )
 {
   int nsen;
-  char type;
   char time_buff[NMEA_TIMEPARSE_BUF];
 
   NMEA_ASSERT( buff && pack );
@@ -415,28 +387,22 @@ int nmea_parse_GPRMC( const char *buff, int buff_sz, nmeaGPRMC *pack )
   nmea_trace_buff( buff, buff_sz );
 
   nsen = nmea_scanf( buff, buff_sz,
-                     "$G%CRMC,%s,%C,%f,%C,%f,%C,%f,%f,%2d%2d%2d,%f,%C,%C,%C*",
-                     &( type ), &( time_buff[0] ),
+                     "$%C%CRMC,%s,%C,%f,%C,%f,%C,%f,%f,%2d%2d%2d,%f,%C,%C,%C*",
+                     &( pack->talkerId[0] ), &( pack->talkerId[1] ), &( time_buff[0] ),
                      &( pack->status ), &( pack->lat ), &( pack->ns ), &( pack->lon ), &( pack->ew ),
                      &( pack->speed ), &( pack->direction ),
                      &( pack->utc.day ), &( pack->utc.mon ), &( pack->utc.year ),
                      &( pack->declination ), &( pack->declin_ew ), &( pack->mode ), &( pack->navstatus ) );
 
-  if ( nsen < 14 || nsen > 16 )
+  if ( nsen < 15 || nsen > 17 )
   {
-    nmea_error( "G?RMC parse error!" );
-    return 0;
-  }
-
-  if ( type != 'P' && type != 'N' )
-  {
-    nmea_error( "G?RMC invalid type " );
+    nmea_error( "RMC parse error!" );
     return 0;
   }
 
   if ( 0 != _nmea_parse_time( &time_buff[0], ( int )strlen( &time_buff[0] ), &( pack->utc ) ) )
   {
-    nmea_error( "GPRMC time parse error!" );
+    nmea_error( "RMC time parse error!" );
     return 0;
   }
 
@@ -463,26 +429,19 @@ int nmea_parse_GPHDT( const char *buff, int buff_sz, nmeaGPHDT *pack )
   nmea_trace_buff( buff, buff_sz );
 
   char type;
-  char talker_id;
 
-  if ( 3 != nmea_scanf( buff, buff_sz,
-                        "$G%CHDT,%f,%C*",
-                        &( talker_id ),
+  if ( 4 != nmea_scanf( buff, buff_sz,
+                        "$%C%CHDT,%f,%C*",
+                        &( pack->talkerId[0] ), &( pack->talkerId[1] ),
                         &( pack->heading ), &( type ) ) )
   {
-    nmea_error( "G?HDT parse error!" );
-    return 0;
-  }
-
-  if ( talker_id != 'P' && talker_id != 'N' )
-  {
-    nmea_error( "G?HDT invalid type " );
+    nmea_error( "HDT parse error!" );
     return 0;
   }
 
   if ( type != 'T' )
   {
-    nmea_error( "G?HDT invalid type " );
+    nmea_error( "HDT invalid type " );
     return 0;
   }
 
@@ -504,23 +463,15 @@ int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack )
 
   nmea_trace_buff( buff, buff_sz );
 
-  char type;
-
-  if ( 9 != nmea_scanf( buff, buff_sz,
-                        "$G%CVTG,%f,%C,%f,%C,%f,%C,%f,%C*",
-                        &type,
-                        &( pack->dir ), &( pack->dir_t ),
-                        &( pack->dec ), &( pack->dec_m ),
-                        &( pack->spn ), &( pack->spn_n ),
-                        &( pack->spk ), &( pack->spk_k ) ) )
+  if ( 10 != nmea_scanf( buff, buff_sz,
+                         "$%C%CVTG,%f,%C,%f,%C,%f,%C,%f,%C*",
+                         &pack->talkerId[0], &pack->talkerId[1],
+                         &( pack->dir ), &( pack->dir_t ),
+                         &( pack->dec ), &( pack->dec_m ),
+                         &( pack->spn ), &( pack->spn_n ),
+                         &( pack->spk ), &( pack->spk_k ) ) )
   {
-    nmea_error( "G?VTG parse error!" );
-    return 0;
-  }
-
-  if ( type != 'P' && type != 'N' )
-  {
-    nmea_error( "G?VTG invalid type " );
+    nmea_error( "VTG parse error!" );
     return 0;
   }
 
@@ -529,7 +480,7 @@ int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack )
        pack->spn_n != 'N' ||
        pack->spk_k != 'K' )
   {
-    nmea_error( "G?VTG parse error (format error)!" );
+    nmea_error( "VTG parse error (format error)!" );
     return 0;
   }
 
@@ -537,7 +488,7 @@ int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack )
 }
 
 /**
- * \brief Parse HCHDG packet from buffer.
+ * \brief Parse HDG packet from buffer.
  * @param buff a constant character pointer of packet buffer.
  * @param buff_sz buffer size.
  * @param pack a pointer of packet which will filled by function.
@@ -551,51 +502,26 @@ int nmea_parse_HCHDG( const char *buff, int buff_sz, nmeaHCHDG *pack )
 
   nmea_trace_buff( buff, buff_sz );
 
-  if ( 5 != nmea_scanf( buff, buff_sz,
-                        "$HCHDG,%f,%f,%C,%f,%C*",
+  if ( 7 != nmea_scanf( buff, buff_sz,
+                        "$%C%CHDG,%f,%f,%C,%f,%C*",
+                        &pack->talkerId[0], &pack->talkerId[1],
                         &( pack->mag_heading ), &( pack->mag_deviation ),
                         &( pack->ew_deviation ), &( pack->mag_variation ),
                         &( pack->ew_variation ) ) )
   {
-    nmea_error( "HCHDG parse error!" );
+    nmea_error( "HDG parse error!" );
     return 0;
   }
 
   if ( pack->ew_deviation != 'E' && pack->ew_deviation != 'W' )
   {
-    nmea_error( "HCHDG invalid deviation direction" );
+    nmea_error( "HDG invalid deviation direction" );
     return 0;
   }
 
   if ( pack->ew_variation != 'E' && pack->ew_variation != 'W' )
   {
-    nmea_error( "HCHDG invalid variation direction" );
-    return 0;
-  }
-
-  return 1;
-}
-
-/**
- * \brief Parse HDT packet from buffer.
- * @param buff a constant character pointer of packet buffer.
- * @param buff_sz buffer size.
- * @param pack a pointer of packet which will filled by function.
- * @return 1 (true) - if parsed successfully or 0 (false) - if fail.
- */
-int nmea_parse_HCHDT( const char *buff, int buff_sz, nmeaHCHDT *pack )
-{
-  NMEA_ASSERT( buff && pack );
-
-  memset( pack, 0, sizeof( nmeaHCHDT ) );
-
-  nmea_trace_buff( buff, buff_sz );
-
-  if ( 2 != nmea_scanf( buff, buff_sz,
-                        "$HCHDT,%f,%C*",
-                        &( pack->direction ), &( pack->t_flag ) ) )
-  {
-    nmea_error( "HCHDT parse error!" );
+    nmea_error( "HDG invalid variation direction" );
     return 0;
   }
 

--- a/external/nmea/parse.h
+++ b/external/nmea/parse.h
@@ -43,7 +43,6 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack );
 int nmea_parse_GPRMC( const char *buff, int buff_sz, nmeaGPRMC *pack );
 int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack );
 int nmea_parse_HCHDG( const char *buff, int buff_sz, nmeaHCHDG *pack );
-int nmea_parse_HCHDT( const char *buff, int buff_sz, nmeaHCHDT *pack );
 int nmea_parse_GPGST( const char *buff, int buff_sz, nmeaGPGST *pack );
 int nmea_parse_GPHDT( const char *buff, int buff_sz, nmeaGPHDT *pack );
 

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -41,6 +41,7 @@ enum nmeaPACKTYPE
  */
 typedef struct _nmeaGPGGA
 {
+  char talkerId[2];   //!< Talker ID
   nmeaTIME utc;       //!< UTC of position (just time)
   double  lat;        //!< Latitude in NDEG - [degree][min].[sec/60]
   char    ns;         //!< [N]orth or [S]outh
@@ -63,6 +64,7 @@ typedef struct _nmeaGPGGA
  */
 typedef struct _nmeaGPGST
 {
+  char talkerId[2];   //!< Talker ID
   nmeaTIME utc;       //!< UTC of position fix
   double  rms_pr;     //!< RMS value of the pseudorange residuals; Includes carrier phase residuals during periods of RTK (float) and RTK (fixed) processing
   double  err_major;  //!< Error ellipse semi-major axis 1 sigma error, in meters
@@ -79,14 +81,13 @@ typedef struct _nmeaGPGST
  */
 typedef struct _nmeaGPGSA
 {
+  char talkerId[2];   //!< Talker ID
   char    fix_mode;   //!< Mode (M = Manual, forced to operate in 2D or 3D; A = Automatic, 3D/2D)
   int     fix_type;   //!< Type, used for navigation (1 = Fix not available; 2 = 2D; 3 = 3D)
   int     sat_prn[NMEA_MAXSAT]; //!< PRNs of satellites used in position fix (null for unused fields)
   double  PDOP;       //!< Dilution of precision
   double  HDOP;       //!< Horizontal dilution of precision
   double  VDOP;       //!< Vertical dilution of precision
-  char    pack_type;  //!< P=GPS, N=generic, L=GLONASS
-
 } nmeaGPGSA;
 
 /**
@@ -94,10 +95,10 @@ typedef struct _nmeaGPGSA
  */
 typedef struct _nmeaGPGSV
 {
+  char talkerId[2];   //!< Talker ID
   int     pack_count; //!< Total number of messages of this type in this cycle
   int     pack_index; //!< Message number
   int     sat_count;  //!< Total number of satellites in view
-  char    pack_type;  //!< P=GPS - S=SBas - N=generic - L=GLONAS - A=GALILEO - B=BEIDOU - Q=QZSS
   nmeaSATELLITE sat_data[NMEA_SATINPACK];
 
 } nmeaGPGSV;
@@ -107,6 +108,7 @@ typedef struct _nmeaGPGSV
  */
 typedef struct _nmeaGPRMC
 {
+  char talkerId[2];   //!< Talker ID
   nmeaTIME utc;       //!< UTC of position
   char    status;     //!< Status (A = active or V = void)
   double  lat;        //!< Latitude in NDEG - [degree][min].[sec/60]
@@ -126,6 +128,7 @@ typedef struct _nmeaGPRMC
  */
 typedef struct _nmeaGPVTG
 {
+  char talkerId[2];   //!< Talker ID
   double  dir;        //!< True track made good (degrees)
   char    dir_t;      //!< Fixed text 'T' indicates that track made good is relative to true north
   double  dec;        //!< Magnetic track made good
@@ -142,6 +145,7 @@ typedef struct _nmeaGPVTG
  */
 typedef struct _nmeaGPHDT
 {
+  char talkerId[2];   //!< Talker ID
   double  heading;    //!< Heading in degrees
   char    t_flag;      //!< Fixed text 'T' indicates that heading is relative to true north
 
@@ -152,6 +156,7 @@ typedef struct _nmeaGPHDT
  */
 typedef struct _nmeaHCHDG
 {
+  char talkerId[2];   //!< Talker ID
   double mag_heading;   //!< Magnetic sensor heading (degrees)
   double mag_deviation; //!< Magnetic deviation (degrees)
   char ew_deviation;     //!< [E]ast or [W]est
@@ -159,14 +164,6 @@ typedef struct _nmeaHCHDG
   char ew_variation;    //!< [E]ast or [W]est
 } nmeaHCHDG;
 
-/**
- * HDT packet information structure (Heading, )
- */
-typedef struct _nmeaHCHDT
-{
-  double direction;   //!< Heading respect to true north (degrees)
-  char t_flag;    //!< Static text [T]
-} nmeaHCHDT;
 
 void nmea_zero_GPGGA( nmeaGPGGA *pack );
 void nmea_zero_GPGST( nmeaGPGST *pack );

--- a/python/PyQt6/core/auto_generated/gps/qgsnmeaconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgsnmeaconnection.sip.in
@@ -71,10 +71,6 @@ process HDT sentence
 %Docstring
 process HCHDG sentence
 %End
-    void processHchdtSentence( const char *data, int len );
-%Docstring
-process HCHDT sentence
-%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/gps/qgsnmeaconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsnmeaconnection.sip.in
@@ -71,10 +71,6 @@ process HDT sentence
 %Docstring
 process HCHDG sentence
 %End
-    void processHchdtSentence( const char *data, int len );
-%Docstring
-process HCHDT sentence
-%End
 };
 
 /************************************************************************

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -21,6 +21,7 @@
 #include <QIODevice>
 #include <QApplication>
 #include <QStringList>
+#include <QRegularExpression>
 
 
 //from libnmea
@@ -102,7 +103,10 @@ void QgsNmeaConnection::processStringBuffer()
       {
         const QString substring = mStringBuffer.mid( dollarIndex, endSentenceIndex );
         QByteArray ba = substring.toLocal8Bit();
-        if ( substring.startsWith( QLatin1String( "$GPGGA" ) ) || substring.startsWith( QLatin1String( "$GNGGA" ) ) )
+        const thread_local QRegularExpression rxSentence( QStringLiteral( "^\\$([A-Z]{2})([A-Z]{3})" ) );
+        const QRegularExpressionMatch sentenceMatch = rxSentence.match( substring );
+        const QString sentenceId = sentenceMatch.captured( 2 );
+        if ( sentenceId == QLatin1String( "GGA" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           mLastGPSInformation.satInfoComplete = true;
@@ -110,7 +114,7 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        else if ( substring.startsWith( QLatin1String( "$GPRMC" ) ) || substring.startsWith( QLatin1String( "$GNRMC" ) ) )
+        else if ( sentenceId == QLatin1String( "RMC" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           mLastGPSInformation.satInfoComplete = true;
@@ -118,8 +122,7 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        // GPS+SBAS GLONASS GALILEO BEIDOU QZSS;
-        else if ( substring.startsWith( QLatin1String( "$GPGSV" ) ) || substring.startsWith( QLatin1String( "$GNGSV" ) ) || substring.startsWith( QLatin1String( "$GLGSV" ) ) || substring.startsWith( QLatin1String( "$GAGSV" ) ) || substring.startsWith( QLatin1String( "$GBGSV" ) ) || substring.startsWith( QLatin1String( "$GQGSV" ) ) )
+        else if ( sentenceId == QLatin1String( "GSV" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           mLastGPSInformation.satInfoComplete = false;
@@ -127,7 +130,7 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        else if ( substring.startsWith( QLatin1String( "$GPVTG" ) ) || substring.startsWith( QLatin1String( "$GNVTG" ) ) )
+        else if ( sentenceId == QLatin1String( "VTG" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           mLastGPSInformation.satInfoComplete = true;
@@ -135,14 +138,14 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        else if ( substring.startsWith( QLatin1String( "$GPGSA" ) ) || substring.startsWith( QLatin1String( "$GNGSA" ) ) || substring.startsWith( QLatin1String( "$GLGSA" ) ) )
+        else if ( sentenceId == QLatin1String( "GSA" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           processGsaSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        else if ( substring.startsWith( QLatin1String( "$GPGST" ) ) || substring.startsWith( QLatin1String( "$GNGST" ) ) )
+        else if ( sentenceId == QLatin1String( "GST" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           mLastGPSInformation.satInfoComplete = true;
@@ -150,7 +153,7 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        else if ( substring.startsWith( QLatin1String( "$GPHDT" ) ) || substring.startsWith( QLatin1String( "$GNHDT" ) ) )
+        else if ( sentenceId == QLatin1String( "HDT" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           mLastGPSInformation.satInfoComplete = true;
@@ -158,19 +161,11 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        else if ( substring.startsWith( QLatin1String( "$HCHDG" ) ) )
+        else if ( sentenceId == QLatin1String( "HDG" ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           mLastGPSInformation.satInfoComplete = true;
           processHchdgSentence( ba.data(), ba.length() );
-          mStatus = GPSDataReceived;
-          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
-        }
-        else if ( substring.startsWith( QLatin1String( "$HCHDT" ) ) )
-        {
-          QgsDebugMsgLevel( substring, 2 );
-          mLastGPSInformation.satInfoComplete = true;
-          processHchdtSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
@@ -273,15 +268,6 @@ void QgsNmeaConnection::processHchdgSentence( const char *data, int len )
       mLastGPSInformation.direction += result.mag_variation;
     else
       mLastGPSInformation.direction -= result.mag_variation;
-  }
-}
-
-void QgsNmeaConnection::processHchdtSentence( const char *data, int len )
-{
-  nmeaHCHDT result;
-  if ( nmea_parse_HCHDT( data, len, &result ) )
-  {
-    mLastGPSInformation.direction = result.direction;
   }
 }
 
@@ -418,27 +404,30 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
         }
       }
       satelliteInfo.signal = currentSatellite.sig;
-      satelliteInfo.satType = result.pack_type;
+      satelliteInfo.satType = result.talkerId[1];
 
-      if ( result.pack_type == 'P' )
+      if ( result.talkerId[0] == 'G' )
       {
-        satelliteInfo.mConstellation = Qgis::GnssConstellation::Gps;
-      }
-      else if ( result.pack_type == 'L' )
-      {
-        satelliteInfo.mConstellation = Qgis::GnssConstellation::Glonass;
-      }
-      else if ( result.pack_type == 'A' )
-      {
-        satelliteInfo.mConstellation = Qgis::GnssConstellation::Galileo;
-      }
-      else if ( result.pack_type == 'B' )
-      {
-        satelliteInfo.mConstellation = Qgis::GnssConstellation::BeiDou;
-      }
-      else if ( result.pack_type == 'Q' )
-      {
-        satelliteInfo.mConstellation = Qgis::GnssConstellation::Qzss;
+        if ( result.talkerId[1] == 'P' )
+        {
+          satelliteInfo.mConstellation = Qgis::GnssConstellation::Gps;
+        }
+        else if ( result.talkerId[1] == 'L' )
+        {
+          satelliteInfo.mConstellation = Qgis::GnssConstellation::Glonass;
+        }
+        else if ( result.talkerId[1] == 'A' )
+        {
+          satelliteInfo.mConstellation = Qgis::GnssConstellation::Galileo;
+        }
+        else if ( result.talkerId[1] == 'B' )
+        {
+          satelliteInfo.mConstellation = Qgis::GnssConstellation::BeiDou;
+        }
+        else if ( result.talkerId[1] == 'Q' )
+        {
+          satelliteInfo.mConstellation = Qgis::GnssConstellation::Qzss;
+        }
       }
 
       if ( satelliteInfo.satType == 'P' && satelliteInfo.id > 32 )
@@ -511,7 +500,7 @@ void QgsNmeaConnection::processGsaSentence( const char *data, int len )
         mLastGPSInformation.satellitesUsed += 1;
 
         Qgis::GnssConstellation constellation = Qgis::GnssConstellation::Unknown;
-        if ( result.pack_type == 'L' || result.sat_prn[i] > 64 )
+        if ( ( result.talkerId[0] == 'G' && result.talkerId[1] == 'L' ) || result.sat_prn[i] > 64 )
           constellation = Qgis::GnssConstellation::Glonass;
         else if ( result.sat_prn[i] >= 1 && result.sat_prn[i] <= 32 )
           constellation = Qgis::GnssConstellation::Gps;

--- a/src/core/gps/qgsnmeaconnection.h
+++ b/src/core/gps/qgsnmeaconnection.h
@@ -63,8 +63,6 @@ class CORE_EXPORT QgsNmeaConnection: public QgsGpsConnection
     void processHdtSentence( const char *data, int len );
     //! process HCHDG sentence
     void processHchdgSentence( const char *data, int len );
-    //! process HCHDT sentence
-    void processHchdtSentence( const char *data, int len );
 };
 
 #endif // QGSNMEACONNECTION_H

--- a/tests/src/core/testqgsnmeaconnection.cpp
+++ b/tests/src/core/testqgsnmeaconnection.cpp
@@ -75,12 +75,17 @@ class TestQgsNmeaConnection : public QgsTest
   private slots:
     void initTestCase();
     void cleanupTestCase();
+    void testBasic_data();
     void testBasic();
+    void testVtg_data();
     void testVtg();
+    void testFixStatus_data();
     void testFixStatus();
     void testFixStatusAcrossConstellations();
     void testConstellation();
+    void testPosition_data();
     void testPosition();
+    void testComponent_data();
     void testComponent();
     void testIncompleteMessage();
 
@@ -98,11 +103,22 @@ void TestQgsNmeaConnection::cleanupTestCase()
   QgsApplication::exitQgis();
 }
 
+void TestQgsNmeaConnection::testBasic_data()
+{
+  QTest::addColumn<QString>( "talkerId" );
+
+  QTest::newRow( "GPS" ) << "GP";
+  QTest::newRow( "GN" ) << "GN";
+  QTest::newRow( "IN" ) << "IN";
+}
+
 void TestQgsNmeaConnection::testBasic()
 {
+  QFETCH( QString, talkerId );
+
   ReplayNmeaConnection connection;
 
-  QgsGpsInformation info = connection.push( QStringLiteral( "$GPGSV,3,1,12,07,41,181,26,05,34,292,30,16,34,060,36,26,24,031,24*7B" ) );
+  QgsGpsInformation info = connection.push( QStringLiteral( "$%1GSV,3,1,12,07,41,181,26,05,34,292,30,16,34,060,36,26,24,031,24*7B" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( !info.satInfoComplete );
   Qgis::GnssConstellation constellation = Qgis::GnssConstellation::Unknown;
@@ -114,7 +130,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.elevation, 0 );
   QVERIFY( std::isnan( info.direction ) );
 
-  info = connection.push( QStringLiteral( "$GPGSV,3,2,12,02,61,115,,21,53,099,,03,51,111,,19,32,276,*72" ) );
+  info = connection.push( QStringLiteral( "$%1GSV,3,2,12,02,61,115,,21,53,099,,03,51,111,,19,32,276,*72" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( !info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::NoData );
@@ -124,7 +140,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.elevation, 0 );
   QVERIFY( std::isnan( info.direction ) );
 
-  info =  connection.push( QStringLiteral( "$GPGSV,3,3,12,17,31,279,,28,27,320,,23,23,026,,14,22,060,*7B" ) );
+  info =  connection.push( QStringLiteral( "$%1GSV,3,3,12,17,31,279,,28,27,320,,23,23,026,,14,22,060,*7B" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( !info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::NoData );
@@ -134,7 +150,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.elevation, 0 );
   QVERIFY( std::isnan( info.direction ) );
 
-  info = connection.push( QStringLiteral( "$GPGGA,084112.185,6938.6532,N,01856.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ) );
+  info = connection.push( QStringLiteral( "$%1GGA,084112.185,6938.6532,N,01856.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::NoData );
@@ -148,7 +164,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.utcDateTime, QDateTime() );
   QCOMPARE( info.utcTime, QTime( 8, 41, 12, 185 ) );
 
-  info = connection.push( QStringLiteral( "$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::NoData );
@@ -165,7 +181,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.utcDateTime, dateTime );
   QCOMPARE( info.utcTime, dateTime.time() );
 
-  info = connection.push( QStringLiteral( "$GPGSA,A,3,07,05,16,26,,,,,,,,,3.4,1.4,3.1*33" ) );
+  info = connection.push( QStringLiteral( "$%1GSA,A,3,07,05,16,26,,,,,,,,,3.4,1.4,3.1*33" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( !info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::Fix3D );
@@ -176,7 +192,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.elevation, 35 );
   QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
 
-  info = connection.push( QStringLiteral( "$GPRMC,084112.185,A,6938.6532,N,01856.8526,E,0.08,2.00,220120,,,A*60" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,084112.185,A,6938.6532,N,01856.8526,E,0.08,2.00,220120,,,A*60" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::Fix3D );
@@ -186,7 +202,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.elevation, 35 );
   QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
 
-  info = connection.push( QStringLiteral( "$GPGGA,084113.185,6938.6532,N,01856.8526,E,1,04,1.4,34.0,M,29.4,M,,0000*63" ) );
+  info = connection.push( QStringLiteral( "$%1GGA,084113.185,6938.6532,N,01856.8526,E,1,04,1.4,34.0,M,29.4,M,,0000*63" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::Fix3D );
@@ -196,7 +212,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.elevation, 34 );
   QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
 
-  info = connection.push( QStringLiteral( "$GPGSA,A,3,07,05,16,26,,,,,,,,,3.4,1.4,3.1*33" ) );
+  info = connection.push( QStringLiteral( "$%1GSA,A,3,07,05,16,26,,,,,,,,,3.4,1.4,3.1*33" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( !info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::Fix3D );
@@ -206,7 +222,7 @@ void TestQgsNmeaConnection::testBasic()
   QCOMPARE( info.elevation, 34 );
   QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
 
-  info = connection.push( QStringLiteral( "$GPRMC,084113.185,A,6938.6532,N,01856.8526,E,0.05,2.00,220120,,,A*6C" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,084113.185,A,6938.6532,N,01856.8526,E,0.05,2.00,220120,,,A*6C" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( info.satInfoComplete );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::Fix3D );
@@ -217,40 +233,62 @@ void TestQgsNmeaConnection::testBasic()
   QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
 }
 
+void TestQgsNmeaConnection::testVtg_data()
+{
+  QTest::addColumn<QString>( "talkerId" );
+
+  QTest::newRow( "GPS" ) << "GP";
+  QTest::newRow( "GN" ) << "GN";
+  QTest::newRow( "IN" ) << "IN";
+}
+
 void TestQgsNmeaConnection::testVtg()
 {
+  QFETCH( QString, talkerId );
+
   ReplayNmeaConnection connection;
 
   QSignalSpy statusSpy( &connection, &QgsGpsConnection::fixStatusChanged );
 
   // try initially with no direction
-  QgsGpsInformation info = connection.push( QStringLiteral( "$GPVTG,,T,,M,0.003,N,0.005,K,D*20" ) );
+  QgsGpsInformation info = connection.push( QStringLiteral( "$%1VTG,,T,,M,0.003,N,0.005,K,D*20" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QVERIFY( std::isnan( info.direction ) );
   QCOMPARE( info.speed, 0.005 );
-  info = connection.push( QStringLiteral( "$GPVTG,224.592,T,224.492,M,0.003,N,0.006,K,D*20" ) );
+  info = connection.push( QStringLiteral( "$%1VTG,224.592,T,224.492,M,0.003,N,0.006,K,D*20" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   // must be direction to true north, not magnetic north
   QCOMPARE( info.direction, 224.592 );
   QCOMPARE( info.speed, 0.006 );
-  info = connection.push( QStringLiteral( "$GNVTG,139.969,T,139.969,M,0.007,N,0.013,K,D*3D" ) );
+  info = connection.push( QStringLiteral( "$%1VTG,139.969,T,139.969,M,0.007,N,0.013,K,D*3D" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QCOMPARE( info.direction, 139.969 );
   QCOMPARE( info.speed, 0.013 );
   // direction should not be overwritten with nan
-  info = connection.push( QStringLiteral( "$GPVTG,,T,,M,0.003,N,0.005,K,D*20" ) );
+  info = connection.push( QStringLiteral( "$%1VTG,,T,,M,0.003,N,0.005,K,D*20" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QCOMPARE( info.direction, 139.969 );
   QCOMPARE( info.speed, 0.005 );
 }
 
+void TestQgsNmeaConnection::testFixStatus_data()
+{
+  QTest::addColumn<QString>( "talkerId" );
+
+  QTest::newRow( "GPS" ) << "GP";
+  QTest::newRow( "GN" ) << "GN";
+  QTest::newRow( "IN" ) << "IN";
+}
+
 void TestQgsNmeaConnection::testFixStatus()
 {
+  QFETCH( QString, talkerId );
+
   ReplayNmeaConnection connection;
 
   QSignalSpy statusSpy( &connection, &QgsGpsConnection::fixStatusChanged );
 
-  QgsGpsInformation info = connection.push( QStringLiteral( "$GPRMC,220516,V,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QgsGpsInformation info = connection.push( QStringLiteral( "$%1RMC,220516,V,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QVERIFY( !info.isValid() );
   Qgis::GnssConstellation constellation = Qgis::GnssConstellation::Unknown;
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::NoData );
@@ -258,49 +296,49 @@ void TestQgsNmeaConnection::testFixStatus()
   QCOMPARE( statusSpy.count(), 0 );
 
   // no fix status change
-  connection.push( QStringLiteral( "$GPRMC,220516,V,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  connection.push( QStringLiteral( "$%1RMC,220516,V,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QCOMPARE( statusSpy.count(), 0 );
 
   // simulate 3d fix
-  connection.push( QStringLiteral( "$GPGSA,A,3,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
-  info = connection.push( QStringLiteral( "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  connection.push( QStringLiteral( "$%1GSA,A,3,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ).arg( talkerId ) );
+  info = connection.push( QStringLiteral( "$%1RMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::Fix3D );
   QCOMPARE( statusSpy.count(), 1 );
   QCOMPARE( statusSpy.constLast().at( 0 ).value< Qgis::GpsFixStatus >(), Qgis::GpsFixStatus::Fix3D );
 
   // no fix status change
-  connection.push( QStringLiteral( "$GPGSA,A,3,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  connection.push( QStringLiteral( "$%1GSA,A,3,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ).arg( talkerId ) );
   QCOMPARE( statusSpy.count(), 1 );
 
   // simulate 2d fix
-  connection.push( QStringLiteral( "$GPGSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
-  info = connection.push( QStringLiteral( "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  connection.push( QStringLiteral( "$%1GSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ).arg( talkerId ) );
+  info = connection.push( QStringLiteral( "$%1RMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QVERIFY( info.isValid() );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::Fix2D );
   QCOMPARE( statusSpy.count(), 2 );
   QCOMPARE( statusSpy.constLast().at( 0 ).value< Qgis::GpsFixStatus >(), Qgis::GpsFixStatus::Fix2D );
 
   // no fix status change
-  connection.push( QStringLiteral( "$GPGSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  connection.push( QStringLiteral( "$%1GSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ).arg( talkerId ) );
   QCOMPARE( statusSpy.count(), 2 );
 
   // simulate fix not available
-  connection.push( QStringLiteral( "$GPGSA,A,1,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
-  info = connection.push( QStringLiteral( "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  connection.push( QStringLiteral( "$%1GSA,A,1,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ).arg( talkerId ) );
+  info = connection.push( QStringLiteral( "$%1RMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QVERIFY( !info.isValid() );
   QCOMPARE( info.bestFixStatus( constellation ), Qgis::GpsFixStatus::NoFix );
   QCOMPARE( statusSpy.count(), 3 );
   QCOMPARE( statusSpy.constLast().at( 0 ).value< Qgis::GpsFixStatus >(), Qgis::GpsFixStatus::NoFix );
 
   // no fix status change
-  connection.push( QStringLiteral( "$GPGSA,A,1,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  connection.push( QStringLiteral( "$%1GSA,A,1,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ).arg( talkerId ) );
   QCOMPARE( statusSpy.count(), 3 );
 
   // invalid fix due to bad lat / long values
-  connection.push( QStringLiteral( "$GPGSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  connection.push( QStringLiteral( "$%1GSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ).arg( talkerId ) );
   // latitude 99 degrees => out of range
-  info = connection.push( QStringLiteral( "$GPRMC,220516,A,9933.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,220516,A,9933.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QGSCOMPARENEAR( info.latitude, 99.563666, 0.00001 );
   QGSCOMPARENEAR( info.longitude, -0.70400000, 0.00001 );
   QVERIFY( !info.isValid() );
@@ -308,18 +346,18 @@ void TestQgsNmeaConnection::testFixStatus()
   QCOMPARE( statusSpy.count(), 4 );
   QCOMPARE( statusSpy.constLast().at( 0 ).value< Qgis::GpsFixStatus >(), Qgis::GpsFixStatus::Fix2D );
 
-  info = connection.push( QStringLiteral( "$GPRMC,220516,A,9933.82,S,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,220516,A,9933.82,S,00042.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QGSCOMPARENEAR( info.latitude, -99.563666, 0.00001 );
   QGSCOMPARENEAR( info.longitude, -0.70400000, 0.00001 );
   QVERIFY( !info.isValid() );
 
   // longitude 192 degrees => out of range
-  info = connection.push( QStringLiteral( "$GPRMC,220516,A,1933.82,N,19192.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,220516,A,1933.82,N,19192.24,W,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QGSCOMPARENEAR( info.latitude, 19.5636666667, 0.00001 );
   QGSCOMPARENEAR( info.longitude, -192.5373333333, 0.00001 );
   QVERIFY( !info.isValid() );
 
-  info = connection.push( QStringLiteral( "$GPRMC,220516,A,1933.82,N,19192.24,E,173.8,231.8,130694,004.2,W*70" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,220516,A,1933.82,N,19192.24,E,173.8,231.8,130694,004.2,W*70" ).arg( talkerId ) );
   QGSCOMPARENEAR( info.latitude, 19.5636666667, 0.00001 );
   QGSCOMPARENEAR( info.longitude, 192.5373333333, 0.00001 );
   QVERIFY( !info.isValid() );
@@ -431,46 +469,68 @@ void TestQgsNmeaConnection::testConstellation()
   QCOMPARE( info.satellitesInView.at( 7 ).constellation(), Qgis::GnssConstellation::BeiDou );
 }
 
+void TestQgsNmeaConnection::testPosition_data()
+{
+  QTest::addColumn<QString>( "talkerId" );
+
+  QTest::newRow( "GPS" ) << "GP";
+  QTest::newRow( "GN" ) << "GN";
+  QTest::newRow( "IN" ) << "IN";
+}
+
 void TestQgsNmeaConnection::testPosition()
 {
+  QFETCH( QString, talkerId );
+
   ReplayNmeaConnection connection;
 
   QSignalSpy spy( &connection, &QgsGpsConnection::positionChanged );
 
-  connection.push( QStringLiteral( "$GPGGA,084112.185,6900.0,N,01800.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ) );
+  connection.push( QStringLiteral( "$%1GGA,084112.185,6900.0,N,01800.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ).arg( talkerId ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.constLast().at( 0 ).value< QgsPoint>(), QgsPoint( 18, 69, 35 ) );
   QCOMPARE( connection.lastValidLocation(), QgsPoint( 18, 69, 35 ) );
   // push same location, should be no new signal
-  connection.push( QStringLiteral( "$GPGGA,084112.185,6900.0,N,01800.0,E,1,04,1.4,35.0,M,29.6,M,,0000*63" ) );
+  connection.push( QStringLiteral( "$%1GGA,084112.185,6900.0,N,01800.0,E,1,04,1.4,35.0,M,29.6,M,,0000*63" ).arg( talkerId ) );
   QCOMPARE( spy.count(), 1 );
 
   // new location
-  connection.push( QStringLiteral( "$GPGGA,084112.185,6900.0,N,01900.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ) );
+  connection.push( QStringLiteral( "$%1GGA,084112.185,6900.0,N,01900.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ).arg( talkerId ) );
   QCOMPARE( spy.count(), 2 );
   QCOMPARE( spy.constLast().at( 0 ).value< QgsPoint>(), QgsPoint( 19, 69, 35 ) );
   QCOMPARE( connection.lastValidLocation(), QgsPoint( 19, 69, 35 ) );
 
   // invalid location (latitude > 90 degrees)
-  connection.push( QStringLiteral( "$GPGGA,084112.185,9900.0,N,01900.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ) );
+  connection.push( QStringLiteral( "$%1GGA,084112.185,9900.0,N,01900.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ).arg( talkerId ) );
   // signal will NOT be emitted
   QCOMPARE( spy.count(), 2 );
   // last valid location remains unchanged
   QCOMPARE( connection.lastValidLocation(), QgsPoint( 19, 69, 35 ) );
 }
 
+void TestQgsNmeaConnection::testComponent_data()
+{
+  QTest::addColumn<QString>( "talkerId" );
+
+  QTest::newRow( "GPS" ) << "GP";
+  QTest::newRow( "GN" ) << "GN";
+  QTest::newRow( "IN" ) << "IN";
+}
+
 void TestQgsNmeaConnection::testComponent()
 {
+  QFETCH( QString, talkerId );
+
   ReplayNmeaConnection connection;
 
-  QgsGpsInformation info = connection.push( QStringLiteral( "$GPGGA,084112.185,6900.0,N,01800.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ) );
+  QgsGpsInformation info = connection.push( QStringLiteral( "$%1GGA,084112.185,6900.0,N,01800.0,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ).arg( talkerId ) );
 
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::Location ).value< QgsPointXY >(), QgsPointXY( 18, 69 ) );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::Altitude ).toDouble(), 35 );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::GroundSpeed ).toDouble(), 0 );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::Bearing ).toDouble(), 0 );
 
-  info = connection.push( QStringLiteral( "$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E" ) );
+  info = connection.push( QStringLiteral( "$%1RMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E" ).arg( talkerId ) );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::Location ).value< QgsPointXY >(), QgsPointXY( 18.94754499999999808, 69.644218333333341779 ) );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::Altitude ).toDouble(), 35 );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::GroundSpeed ).toDouble(),  0.29632 );


### PR DESCRIPTION
From the nmea specifications it is clear that the talker ID does not have to start with 'G'. Accordingly remove ALL these incorrect hardcoded checks against (a very small subset) of known talker IDs, and permit any two-character string as a valid talker ID

Fixes connection to NMEA devices which use "IN" for talker ID (and others)
