### PR TITLE
[fix] Avoid locator searches in current layer if it has been marked as not searchable

### DIFF
--- a/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp
+++ b/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp
@@ -67,6 +67,9 @@ QStringList QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string,
   if ( !layer )
     return QStringList();
 
+  if ( !layer->flags().testFlag( QgsMapLayer::Searchable ) )
+    return QStringList();
+
   mLayerIsSpatial = layer->isSpatial();
   mDispExpression = QgsExpression( layer->displayExpression() );
   mContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );


### PR DESCRIPTION
Followup #41397, which partially addressed https://github.com/qgis/QGIS/issues/40357 (i.e., fixed identifiable, forgot searchable).

Followup #38688, which dealt with fields.

This PR adds consistency with e.g., `Identifiable` behavior, which when disabled, makes a layer impossible to identify even by setting the identify mode to `Current Layer` in the `Identify Results` panel.

![image](https://github.com/user-attachments/assets/ae22e7a0-0ff4-4689-9d9f-7508fa6e90d0)


Fix #40357