### PR TITLE
Handle addition of quantized mesh layers from Cesium ion

### DIFF
--- a/src/core/tiledscene/qgsquantizedmeshdataprovider.h
+++ b/src/core/tiledscene/qgsquantizedmeshdataprovider.h
@@ -119,6 +119,8 @@ class CORE_EXPORT QgsQuantizedMeshDataProvider: public QgsTiledSceneDataProvider
     static constexpr const char *providerName = "quantizedmesh";
     static constexpr const char *providerDescription = "Cesium Quantized Mesh tiles";
 
+  private:
+    QString uriFromIon( const QString &uri );
 
   private:
     QString mUri; // For clone()


### PR DESCRIPTION
Using the same logic as how it is done for 3D tiles, so that the quantized mesh terrain datasets can be added from Cesium Ion plugin.
