### PR TITLE
Layout fix invalid node item

### DIFF
--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
@@ -111,6 +111,14 @@ Deselects any selected nodes.
     virtual double estimatedFrameBleed() const;
 
 
+
+    virtual bool isValid() const;
+%Docstring
+Can be reimplemented in subclasses. Typically a polyline is valid if it has at least 2 distinct nodes, while
+a polygon is valid if it has at least 3 distinct nodes.
+
+.. versionadded:: 3.40
+%End
   protected:
 
     QgsLayoutNodesItem( QgsLayout *layout );

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
@@ -111,14 +111,15 @@ Deselects any selected nodes.
     virtual double estimatedFrameBleed() const;
 
 
-
-    virtual bool isValid() const;
+    virtual bool isValid() const = 0;
 %Docstring
-Can be reimplemented in subclasses. Typically a polyline is valid if it has at least 2 distinct nodes, while
-a polygon is valid if it has at least 3 distinct nodes.
+Must be reimplemented in subclasses.
+Typically a polyline is valid if it has at least 2 distinct nodes,
+while a polygon is valid if it has at least 3 distinct nodes.
 
 .. versionadded:: 3.40
 %End
+
   protected:
 
     QgsLayoutNodesItem( QgsLayout *layout );

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitempolygon.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitempolygon.sip.in
@@ -53,6 +53,8 @@ The caller takes responsibility for deleting the returned object.
 
     virtual QgsGeometry clipPath() const;
 
+    virtual bool isValid() const;
+
 
     QgsFillSymbol *symbol();
 %Docstring

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -55,6 +55,8 @@ The caller takes responsibility for deleting the returned object.
 
     virtual QPainterPath shape() const;
 
+    virtual bool isValid() const;
+
 
     QgsLineSymbol *symbol();
 %Docstring

--- a/python/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
@@ -111,6 +111,14 @@ Deselects any selected nodes.
     virtual double estimatedFrameBleed() const;
 
 
+
+    virtual bool isValid() const;
+%Docstring
+Can be reimplemented in subclasses. Typically a polyline is valid if it has at least 2 distinct nodes, while
+a polygon is valid if it has at least 3 distinct nodes.
+
+.. versionadded:: 3.40
+%End
   protected:
 
     QgsLayoutNodesItem( QgsLayout *layout );

--- a/python/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
@@ -111,14 +111,15 @@ Deselects any selected nodes.
     virtual double estimatedFrameBleed() const;
 
 
-
-    virtual bool isValid() const;
+    virtual bool isValid() const = 0;
 %Docstring
-Can be reimplemented in subclasses. Typically a polyline is valid if it has at least 2 distinct nodes, while
-a polygon is valid if it has at least 3 distinct nodes.
+Must be reimplemented in subclasses.
+Typically a polyline is valid if it has at least 2 distinct nodes,
+while a polygon is valid if it has at least 3 distinct nodes.
 
 .. versionadded:: 3.40
 %End
+
   protected:
 
     QgsLayoutNodesItem( QgsLayout *layout );

--- a/python/core/auto_generated/layout/qgslayoutitempolygon.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolygon.sip.in
@@ -53,6 +53,8 @@ The caller takes responsibility for deleting the returned object.
 
     virtual QgsGeometry clipPath() const;
 
+    virtual bool isValid() const;
+
 
     QgsFillSymbol *symbol();
 %Docstring

--- a/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -55,6 +55,8 @@ The caller takes responsibility for deleting the returned object.
 
     virtual QPainterPath shape() const;
 
+    virtual bool isValid() const;
+
 
     QgsLineSymbol *symbol();
 %Docstring

--- a/src/core/layout/qgslayoutitemnodeitem.h
+++ b/src/core/layout/qgslayoutitemnodeitem.h
@@ -113,14 +113,14 @@ class CORE_EXPORT QgsLayoutNodesItem: public QgsLayoutItem
     // rather than the item's pen
     double estimatedFrameBleed() const override;
 
-
     /**
-     * Can be reimplemented in subclasses. Typically a polyline is valid if it has at least 2 distinct nodes, while
-     * a polygon is valid if it has at least 3 distinct nodes.
+     * Must be reimplemented in subclasses.
+     * Typically a polyline is valid if it has at least 2 distinct nodes,
+     * while a polygon is valid if it has at least 3 distinct nodes.
      *
      * \since QGIS 3.40
      */
-    virtual bool isValid() const { return true; };
+    virtual bool isValid() const = 0;
 
   protected:
 

--- a/src/core/layout/qgslayoutitemnodeitem.h
+++ b/src/core/layout/qgslayoutitemnodeitem.h
@@ -113,6 +113,15 @@ class CORE_EXPORT QgsLayoutNodesItem: public QgsLayoutItem
     // rather than the item's pen
     double estimatedFrameBleed() const override;
 
+
+    /**
+     * Can be reimplemented in subclasses. Typically a polyline is valid if it has at least 2 distinct nodes, while
+     * a polygon is valid if it has at least 3 distinct nodes.
+     *
+     * \since QGIS 3.40
+     */
+    virtual bool isValid() const { return true; };
+
   protected:
 
     /**

--- a/src/core/layout/qgslayoutitempolygon.cpp
+++ b/src/core/layout/qgslayoutitempolygon.cpp
@@ -132,6 +132,7 @@ QgsGeometry QgsLayoutItemPolygon::clipPath() const
 
 bool QgsLayoutItemPolygon::isValid() const
 {
+  // A Polygon is valid if it has at least 3 unique points
   QList<QPointF> uniquePoints;
   int seen = 0;
   for ( QPointF point : mPolygon )

--- a/src/core/layout/qgslayoutitempolygon.cpp
+++ b/src/core/layout/qgslayoutitempolygon.cpp
@@ -194,20 +194,15 @@ void QgsLayoutItemPolygon::_writeXmlStyle( QDomDocument &doc, QDomElement &elmt,
 
 bool QgsLayoutItemPolygon::_removeNode( const int index )
 {
-  if ( index < 0 || index >= mPolygon.size() )
+  if ( index < 0 || index >= mPolygon.size() || mPolygon.size() <= 3 )
     return false;
 
   mPolygon.remove( index );
 
-  if ( mPolygon.size() < 3 )
-    mPolygon.clear();
-  else
-  {
-    int newSelectNode = index;
-    if ( index == mPolygon.size() )
-      newSelectNode = 0;
-    setSelectedNode( newSelectNode );
-  }
+  int newSelectNode = index;
+  if ( index == mPolygon.size() )
+    newSelectNode = 0;
+  setSelectedNode( newSelectNode );
 
   return true;
 }

--- a/src/core/layout/qgslayoutitempolygon.cpp
+++ b/src/core/layout/qgslayoutitempolygon.cpp
@@ -129,6 +129,23 @@ QgsGeometry QgsLayoutItemPolygon::clipPath() const
   return QgsGeometry::fromQPolygonF( path );
 }
 
+
+bool QgsLayoutItemPolygon::isValid() const
+{
+  QList<QPointF> uniquePoints;
+  int seen = 0;
+  for ( QPointF point : mPolygon )
+  {
+    if ( !uniquePoints.contains( point ) )
+    {
+      uniquePoints.append( point );
+      if ( ++seen > 2 )
+        return true;
+    }
+  }
+  return false;
+}
+
 QgsFillSymbol *QgsLayoutItemPolygon::symbol()
 {
   return mPolygonStyleSymbol.get();

--- a/src/core/layout/qgslayoutitempolygon.h
+++ b/src/core/layout/qgslayoutitempolygon.h
@@ -58,6 +58,7 @@ class CORE_EXPORT QgsLayoutItemPolygon: public QgsLayoutNodesItem
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
     QgsLayoutItem::Flags itemFlags() const override;
     QgsGeometry clipPath() const override;
+    bool isValid() const override;
 
     /**
      * Returns the fill symbol used to draw the shape.

--- a/src/core/layout/qgslayoutitempolyline.cpp
+++ b/src/core/layout/qgslayoutitempolyline.cpp
@@ -85,17 +85,17 @@ bool QgsLayoutItemPolyline::_removeNode( const int index )
 {
   if ( index < 0 || index >= mPolygon.size() )
     return false;
-
+  
   mPolygon.remove( index );
 
   if ( mPolygon.size() < 2 )
     mPolygon.clear();
   else
   {
-    int newSelectNode = index;
-    if ( index >= mPolygon.size() )
-      newSelectNode = mPolygon.size() - 1;
-    setSelectedNode( newSelectNode );
+  int newSelectNode = index;
+  if ( index >= mPolygon.size() )
+    newSelectNode = mPolygon.size() - 1;
+  setSelectedNode( newSelectNode );
   }
 
   return true;
@@ -342,6 +342,22 @@ QPainterPath QgsLayoutItemPolyline::shape() const
   const QPainterPath strokedOutline = ps.createStroke( path );
 
   return strokedOutline;
+}
+
+bool QgsLayoutItemPolyline::isValid() const
+{
+  QList<QPointF> uniquePoints;
+  int seen = 0;
+  for (QPointF point: mPolygon)
+  {
+    if( !uniquePoints.contains( point ) )
+    {
+      uniquePoints.append( point );
+      if (++seen > 1)
+        return true;
+    }
+  }
+  return false;
 }
 
 QgsLineSymbol *QgsLayoutItemPolyline::symbol()

--- a/src/core/layout/qgslayoutitempolyline.cpp
+++ b/src/core/layout/qgslayoutitempolyline.cpp
@@ -341,6 +341,7 @@ QPainterPath QgsLayoutItemPolyline::shape() const
 
 bool QgsLayoutItemPolyline::isValid() const
 {
+  // A Polyline is valid if it has at least 2 unique points
   QList<QPointF> uniquePoints;
   int seen = 0;
   for ( QPointF point : mPolygon )

--- a/src/core/layout/qgslayoutitempolyline.cpp
+++ b/src/core/layout/qgslayoutitempolyline.cpp
@@ -83,20 +83,15 @@ bool QgsLayoutItemPolyline::_addNode( const int indexPoint,
 
 bool QgsLayoutItemPolyline::_removeNode( const int index )
 {
-  if ( index < 0 || index >= mPolygon.size() )
+  if ( index < 0 || index >= mPolygon.size() || mPolygon.size() <= 2 )
     return false;
-  
+
   mPolygon.remove( index );
 
-  if ( mPolygon.size() < 2 )
-    mPolygon.clear();
-  else
-  {
   int newSelectNode = index;
   if ( index >= mPolygon.size() )
     newSelectNode = mPolygon.size() - 1;
   setSelectedNode( newSelectNode );
-  }
 
   return true;
 }
@@ -348,12 +343,12 @@ bool QgsLayoutItemPolyline::isValid() const
 {
   QList<QPointF> uniquePoints;
   int seen = 0;
-  for (QPointF point: mPolygon)
+  for ( QPointF point : mPolygon )
   {
-    if( !uniquePoints.contains( point ) )
+    if ( !uniquePoints.contains( point ) )
     {
       uniquePoints.append( point );
-      if (++seen > 1)
+      if ( ++seen > 1 )
         return true;
     }
   }

--- a/src/core/layout/qgslayoutitempolyline.h
+++ b/src/core/layout/qgslayoutitempolyline.h
@@ -66,6 +66,7 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
     QIcon icon() const override;
     QString displayName() const override;
     QPainterPath shape() const override;
+    bool isValid() const override;
 
     /**
      * Returns the line symbol used to draw the shape.

--- a/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
+++ b/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
@@ -69,23 +69,22 @@ void QgsLayoutViewToolAddNodeItem::layoutPressEvent( QgsLayoutViewMouseEvent *ev
     // last (temporary) point is removed
     mPolygon.remove( mPolygon.count() - 1 );
 
-    QgsLayoutItem *item = QgsGui::layoutItemGuiRegistry()->createItem( mItemMetadataId, layout() );
+    std::unique_ptr< QgsLayoutItem > item( QgsGui::layoutItemGuiRegistry()->createItem( mItemMetadataId, layout() ) );
     if ( !item )
       return;
 
-    if ( QgsLayoutNodesItem *nodesItem = qobject_cast< QgsLayoutNodesItem * >( item ) )
+    if ( QgsLayoutNodesItem *nodesItem = qobject_cast< QgsLayoutNodesItem * >( item.get() ) )
     {
       nodesItem->setNodes( mPolygon );
       if ( !nodesItem->isValid() )
       {
-        nodesItem->deleteLater();
         mRubberBand.reset();
         return;
       }
     }
-
-    layout()->addLayoutItem( item );
-    layout()->setSelectedItem( item );
+    QgsLayoutItem *newItem = item.get();
+    layout()->addLayoutItem( item.release() );
+    layout()->setSelectedItem( newItem );
     emit createdItem();
   }
   else

--- a/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
+++ b/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
@@ -74,7 +74,15 @@ void QgsLayoutViewToolAddNodeItem::layoutPressEvent( QgsLayoutViewMouseEvent *ev
       return;
 
     if ( QgsLayoutNodesItem *nodesItem = qobject_cast< QgsLayoutNodesItem * >( item ) )
+    {
       nodesItem->setNodes( mPolygon );
+      if ( !nodesItem->isValid() )
+      {
+        nodesItem->deleteLater();
+        mRubberBand.reset();
+        return;
+      }
+    }
 
     layout()->addLayoutItem( item );
     layout()->setSelectedItem( item );


### PR DESCRIPTION
## Description

Prevent the Polyline/Polygon and Arrow layout tools to create invalid node items.

A polyline must have at least 2 distinct nodes. Trying to create a polyline with only one node (left click, then right click anywhere) will just rest the rubberband. Similarly, trying to create a polygon with only 2 points (two left clicks then one right click) will also reset the rubberband.

Besides, the edit node tool can no longer remove nodes if it would make the node item invalid.

Previously, removing a node on a 2-nodes polyline or 3-nodes polygon would result in an empty, invisible node item that still appeared in the items list. 

### Current (buggy) behavior
![invalid_items](https://github.com/user-attachments/assets/1059ec30-ffc8-49fc-bae4-55b1d7ca4e4d)
