### PR TITLE
fix(QgsAdvancedDigitizingTools): Add precision (decimals) to Circle D…

### DIFF
--- a/src/gui/qgsadvanceddigitizingtools.cpp
+++ b/src/gui/qgsadvanceddigitizingtools.cpp
@@ -95,6 +95,7 @@ QWidget *QgsAdvancedDigitizingCirclesIntersectionTool::createWidget()
   mCircle1Distance->setToolTip( tr( "Distance" ) );
   mCircle1Distance->setMinimum( 0 );
   mCircle1Distance->setMaximum( std::numeric_limits<double>::max() );
+  mCircle1Distance->setDecimals( mCadDockWidget->constraintX()->precision() );
   connect( mCircle1Distance, &QgsDoubleSpinBox::returnPressed, this, [ = ]() { mCircle2Digitize->setChecked( true ); } );
   layout->addWidget( mCircle1Distance, 3, 1 );
 
@@ -143,6 +144,7 @@ QWidget *QgsAdvancedDigitizingCirclesIntersectionTool::createWidget()
   mCircle1Distance->setToolTip( tr( "Distance" ) );
   mCircle2Distance->setMinimum( 0 );
   mCircle2Distance->setMaximum( std::numeric_limits<double>::max() );
+  mCircle2Distance->setDecimals( mCadDockWidget->constraintX()->precision() );
   layout->addWidget( mCircle2Distance, 7, 1 );
 
   connect( mCircle1X, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, [ = ]( double ) { processParameters(); } );


### PR DESCRIPTION
## Description

Precision is everywhere, but not always the same, and sometimes there isn't any. 
Here, as it's in the same perimeter, I suggest adding the same number of decimals as for CadTool.

![Capture d'écran 2024-10-21 104915](https://github.com/user-attachments/assets/f78db459-b915-4917-882c-b64a072a2bae)


Fixes: https://github.com/qgis/QGIS/issues/59039