### PR TITLE
Adding missing parameters for Windows CMAKE

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -776,7 +776,9 @@ cmake -S . \
       -DSDK_PATH="path/to/vcpkg-export-[date]" \
       -DBUILD_WITH_QT6=ON \
       -DWITH_QTWEBKIT=OFF \
-      -DVCPKG_TARGET_TRIPLET=x64-windows-release
+      -DVCPKG_TARGET_TRIPLET=x64-windows-release \
+      -DFLEX_EXECUTABLE="path/to/flex-executable" \
+      -DBISON_EXECUTABLE="path/to/bison-executable"
 ```
 
 This will provide you with a configured project. You can either build it directly


### PR DESCRIPTION
Adding missing parameters on the Configure CMAKE for building out the Visual Studio solution.

When I ran this while working on building QGIS in Windows, it reported the  FLEX_EXECUTABLE and BISON_EXECUTABLE were required parameters. 


