### PR TITLE
fix(QgsCurve): properly handle area cache when reversing geometry

### DIFF
--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -1605,6 +1605,8 @@ QgsCircularString *QgsCircularString::reversed() const
   {
     std::reverse( copy->mM.begin(), copy->mM.end() );
   }
+
+  copy->mSummedUpArea = -mSummedUpArea;
   return copy;
 }
 

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1464,6 +1464,8 @@ QgsLineString *QgsLineString::reversed() const
   {
     std::reverse( copy->mM.begin(), copy->mM.end() );
   }
+
+  copy->mSummedUpArea = -mSummedUpArea;
   return copy;
 }
 

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -389,6 +389,22 @@ class TestQgsLineString(QgisTestCase):
         self.assertEqual(p.simplifyByDistance(0).asWkt(),
                          'LineString (2 0, 2 2, 0 2, 0 0, 2 0)')
 
+    def test_orientation(self):
+        """
+        test orientation. From https://github.com/qgis/QGIS/issues/58333
+        """
+        geom = QgsLineString()
+        geom.fromWkt('LineString (1 1, 2 1, 2 2, 1 2, 1 1)')
+        self.assertEqual(geom.sumUpArea(), 1.0)
+        self.assertEqual(geom.orientation(), Qgis.AngularDirection.CounterClockwise)
+        geom.fromWkt('LineString (1 1, 1 2, 2 2, 2 1, 1 1)')
+        self.assertEqual(geom.sumUpArea(), -1.0)
+        self.assertEqual(geom.orientation(), Qgis.AngularDirection.Clockwise)
+        geom = geom.reversed()
+        self.assertEqual(geom.asWkt(), 'LineString (1 1, 2 1, 2 2, 1 2, 1 1)')
+        self.assertEqual(geom.sumUpArea(), 1.0)
+        self.assertEqual(geom.orientation(), Qgis.AngularDirection.CounterClockwise)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

@agiudiceandrea I was wrong in my previous PR about the `sumUpArea` method. While unconventional in my opinion, this method works correctly, particularly with compound curves where the "classical" approach would fail.

The issue appears to be cache-related. 
When reversing a line or circular string geometry, ensure the cached area value is also reversed by negating it. This ensures correct area orientation calculations, particularly important for:

- Maintaining correct winding order information
- Ensuring consistent orientation() results
- Preserving area sign conventions (positive for CCW, negative for CW)

Added unit tests verifying the area and orientation behavior for both clockwise and counter-clockwise line strings, and their reversed versions.

Follow-up https://github.com/qgis/QGIS/pull/59156
Fixes https://github.com/qgis/QGIS/issues/58333
