### PR TITLE
Fix missing include dir for untwine

### DIFF
--- a/external/untwine/api/QgisUntwine_win.cpp
+++ b/external/untwine/api/QgisUntwine_win.cpp
@@ -28,7 +28,7 @@ bool QgisUntwine::start(Options& options)
         cmdline += "--" + op.first + " \"" + op.second + "\" ";
 
     PROCESS_INFORMATION processInfo;
-    STARTUPINFO startupInfo;
+    STARTUPINFOA startupInfo;
 
     ZeroMemory(&processInfo, sizeof(PROCESS_INFORMATION));
     ZeroMemory(&startupInfo, sizeof(STARTUPINFO));

--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -101,6 +101,7 @@ set(UNTWINE_INCLUDE_DIRS
   ${CMAKE_SOURCE_DIR}/external/untwine/untwine
   ${CMAKE_SOURCE_DIR}/external/untwine/epf
   ${CMAKE_SOURCE_DIR}/external/untwine/bu
+  ${CMAKE_SOURCE_DIR}/external/untwine
   ${CMAKE_SOURCE_DIR}/untwine/api
   ${CMAKE_BINARY_DIR}/untwine
 )


### PR DESCRIPTION
Fixes the broken windows build.
Followup https://github.com/qgis/QGIS/pull/59160

CC @uclaros