### PR TITLE
Revert "[processing] Fix clipping of long WKT strings for geometry parameters by using our geometry widget"

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -75,7 +75,6 @@ class QgsProcessingPointCloudExpressionLineEdit;
 class QgsProcessingRasterCalculatorExpressionLineEdit;
 class QgsRubberBand;
 class QgsHighlightableLineEdit;
-class QgsGeometryWidget;
 
 ///@cond PRIVATE
 
@@ -1239,7 +1238,7 @@ class GUI_EXPORT QgsProcessingGeometryParameterDefinitionWidget : public QgsProc
 
   private:
 
-    QgsGeometryWidget *mGeometryWidget = nullptr;
+    QLineEdit *mDefaultLineEdit = nullptr;
 
 };
 
@@ -1275,7 +1274,7 @@ class GUI_EXPORT QgsProcessingGeometryWidgetWrapper : public QgsAbstractProcessi
     QString modelerExpressionFormatString() const override;
   private:
 
-    QgsGeometryWidget *mGeometryWidget = nullptr;
+    QLineEdit *mLineEdit = nullptr;
 
     friend class TestProcessingGui;
 };


### PR DESCRIPTION
Reverts qgis/QGIS#59090

This pr had failing tests, and needs modifications prior to merging.

Ping @nirvn @lbartoletti 