### PR TITLE
do not restore connection if URL is empty

### DIFF
--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -259,6 +259,9 @@ void QgsSettingsRegistryCore::migrateOldSettings()
       continue;
     for ( const QString &connection : connections )
     {
+      if ( settings.value( QStringLiteral( "%1/url" ).arg( connection ) ).toString().isEmpty() )
+        continue;
+
       QgsOwsConnection::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/url" ), {service.toLower(), connection}, true );
       QgsOwsConnection::settingsVersion->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/version" ), {service.toLower(), connection}, true );
       QgsOwsConnection::settingsIgnoreGetMapURI->copyValueFromKey( QStringLiteral( "qgis/connections-%1/%2/ignoreGetMapURI" ), {service.toLower(), connection}, true );
@@ -296,6 +299,9 @@ void QgsSettingsRegistryCore::migrateOldSettings()
     const QStringList connections = settings.childGroups();
     for ( const QString &connection : connections )
     {
+      if ( settings.value( QStringLiteral( "%1/url" ).arg( connection ) ).toString().isEmpty() )
+        continue;
+
       QgsVectorTileProviderConnection::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/url" ), {connection}, true );
       QgsVectorTileProviderConnection::settingsZmin->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmin" ), {connection}, true );
       QgsVectorTileProviderConnection::settingsZmax->copyValueFromKey( QStringLiteral( "qgis/connections-vector-tile/%1/zmax" ), {connection}, true );
@@ -320,6 +326,9 @@ void QgsSettingsRegistryCore::migrateOldSettings()
     const QStringList connections = settings.childGroups();
     for ( const QString &connection : connections )
     {
+      if ( settings.value( QStringLiteral( "%1/url" ).arg( connection ) ).toString().isEmpty() )
+        continue;
+
       QgsXyzConnectionSettings::settingsUrl->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/url" ), {connection}, true );
       QgsXyzConnectionSettings::settingsZmin->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/zmin" ), {connection}, true );
       QgsXyzConnectionSettings::settingsZmax->copyValueFromKey( QStringLiteral( "qgis/connections-xyz/%1/zmax" ), {connection}, true );


### PR DESCRIPTION
We might have some dangling referer settings which are never deleted because they are now part of the http-headers.

As safety, we do not restore connections which have empty URLs.

fixes #53321

