### PR TITLE
Make QgsChunkNode use doubles instead of floats for bounding boxes

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -36,7 +36,7 @@ extent of a geometry or collection of geometries.
 
   public:
 
-    QgsBox3D( SIP_PYOBJECT x /TypeHint="Optional[Union[QgsPoint, QgsRectangle, float]]"/ = Py_None, SIP_PYOBJECT y /TypeHint="Optional[QgsPoint, float]"/ = Py_None, SIP_PYOBJECT z /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT x2 /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT y2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT z2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT n /TypeHint="Optional[bool]"/ = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double x2 = 0.0, double y2 = 0.0, double z2 = 0.0, bool n = true )];
+    QgsBox3D( SIP_PYOBJECT x /TypeHint="Optional[Union[QgsPoint, QgsVector3D, QgsRectangle, float]]"/ = Py_None, SIP_PYOBJECT y /TypeHint="Optional[QgsPoint, QgsVector3D, float]"/ = Py_None, SIP_PYOBJECT z /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT x2 /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT y2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT z2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT n /TypeHint="Optional[bool]"/ = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double x2 = 0.0, double y2 = 0.0, double z2 = 0.0, bool n = true )];
 %Docstring
 Constructor for QgsBox3D which accepts the ranges of x/y/z coordinates. If ``normalize`` is ``False`` then
 the normalization step will not be applied automatically.
@@ -85,6 +85,30 @@ the normalization step will not be applied automatically.
         }
       }
     }
+    else if ( sipCanConvertToType( a0, sipType_QgsVector3D, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QgsVector3D, SIP_NOT_NONE ) && a3 == Py_None && a4 == Py_None && a5 == Py_None && a6 == Py_None )
+    {
+      int state;
+      sipIsErr = 0;
+
+      QgsVector3D *corner1 = reinterpret_cast<QgsVector3D *>( sipConvertToType( a0, sipType_QgsVector3D, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        sipReleaseType( corner1, sipType_QgsVector3D, state );
+      }
+      else
+      {
+        QgsVector3D *corner2 = reinterpret_cast<QgsVector3D *>( sipConvertToType( a1, sipType_QgsVector3D, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( sipIsErr )
+        {
+          sipReleaseType( corner2, sipType_QgsVector3D, state );
+        }
+        else
+        {
+          bool n = a2 == Py_None ? true : PyObject_IsTrue( a2 );
+          sipCpp = new QgsBox3D( *corner1, *corner2, n );
+        }
+      }
+    }
     else if (
       ( a0 == Py_None || PyFloat_AsDouble( a0 ) != -1.0 || !PyErr_Occurred() ) &&
       ( a1 == Py_None || PyFloat_AsDouble( a1 ) != -1.0 || !PyErr_Occurred() ) &&
@@ -108,15 +132,6 @@ the normalization step will not be applied automatically.
       PyErr_SetString( PyExc_TypeError, QStringLiteral( "Invalid type in constructor arguments." ).toUtf8().constData() );
       sipIsErr = 1;
     }
-%End
-
-    QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize = true );
-%Docstring
-Constructs a QgsBox3D from two 3D vectors representing opposite corners of the box.
-The box is normalized after construction. If ``normalize`` is ``False`` then
-the normalization step will not be applied automatically.
-
-.. versionadded:: 3.42
 %End
 
     void set( double xMin, double yMin, double zMin, double xMax, double yMax, double zMax, bool normalize = true );

--- a/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -110,6 +110,15 @@ the normalization step will not be applied automatically.
     }
 %End
 
+    QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize = true );
+%Docstring
+Constructs a QgsBox3D from two 3D vectors representing opposite corners of the box.
+The box is normalized after construction. If ``normalize`` is ``False`` then
+the normalization step will not be applied automatically.
+
+.. versionadded:: 3.42
+%End
+
     void set( double xMin, double yMin, double zMin, double xMax, double yMax, double zMax, bool normalize = true );
 %Docstring
 Sets the box from a set of (x,y,z) minimum and maximum coordinates.
@@ -375,6 +384,13 @@ If no ``center`` point is specified then the current center of the box will be u
 Scale the rectangle around a center coordinates.
 
 .. versionadded:: 3.26
+%End
+
+    void grow( double delta );
+%Docstring
+Grows the box in place by the specified amount in all dimensions.
+
+.. versionadded:: 3.42
 %End
 
     bool isNull() const /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -36,7 +36,7 @@ extent of a geometry or collection of geometries.
 
   public:
 
-    QgsBox3D( SIP_PYOBJECT x /TypeHint="Optional[Union[QgsPoint, QgsRectangle, float]]"/ = Py_None, SIP_PYOBJECT y /TypeHint="Optional[QgsPoint, float]"/ = Py_None, SIP_PYOBJECT z /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT x2 /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT y2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT z2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT n /TypeHint="Optional[bool]"/ = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double x2 = 0.0, double y2 = 0.0, double z2 = 0.0, bool n = true )];
+    QgsBox3D( SIP_PYOBJECT x /TypeHint="Optional[Union[QgsPoint, QgsVector3D, QgsRectangle, float]]"/ = Py_None, SIP_PYOBJECT y /TypeHint="Optional[QgsPoint, QgsVector3D, float]"/ = Py_None, SIP_PYOBJECT z /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT x2 /TypeHint="Optional[Union[bool, float]]"/ = Py_None, SIP_PYOBJECT y2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT z2 /TypeHint="Optional[float]"/ = Py_None, SIP_PYOBJECT n /TypeHint="Optional[bool]"/ = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double x2 = 0.0, double y2 = 0.0, double z2 = 0.0, bool n = true )];
 %Docstring
 Constructor for QgsBox3D which accepts the ranges of x/y/z coordinates. If ``normalize`` is ``False`` then
 the normalization step will not be applied automatically.
@@ -85,6 +85,30 @@ the normalization step will not be applied automatically.
         }
       }
     }
+    else if ( sipCanConvertToType( a0, sipType_QgsVector3D, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QgsVector3D, SIP_NOT_NONE ) && a3 == Py_None && a4 == Py_None && a5 == Py_None && a6 == Py_None )
+    {
+      int state;
+      sipIsErr = 0;
+
+      QgsVector3D *corner1 = reinterpret_cast<QgsVector3D *>( sipConvertToType( a0, sipType_QgsVector3D, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        sipReleaseType( corner1, sipType_QgsVector3D, state );
+      }
+      else
+      {
+        QgsVector3D *corner2 = reinterpret_cast<QgsVector3D *>( sipConvertToType( a1, sipType_QgsVector3D, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( sipIsErr )
+        {
+          sipReleaseType( corner2, sipType_QgsVector3D, state );
+        }
+        else
+        {
+          bool n = a2 == Py_None ? true : PyObject_IsTrue( a2 );
+          sipCpp = new QgsBox3D( *corner1, *corner2, n );
+        }
+      }
+    }
     else if (
       ( a0 == Py_None || PyFloat_AsDouble( a0 ) != -1.0 || !PyErr_Occurred() ) &&
       ( a1 == Py_None || PyFloat_AsDouble( a1 ) != -1.0 || !PyErr_Occurred() ) &&
@@ -108,15 +132,6 @@ the normalization step will not be applied automatically.
       PyErr_SetString( PyExc_TypeError, QStringLiteral( "Invalid type in constructor arguments." ).toUtf8().constData() );
       sipIsErr = 1;
     }
-%End
-
-    QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize = true );
-%Docstring
-Constructs a QgsBox3D from two 3D vectors representing opposite corners of the box.
-The box is normalized after construction. If ``normalize`` is ``False`` then
-the normalization step will not be applied automatically.
-
-.. versionadded:: 3.42
 %End
 
     void set( double xMin, double yMin, double zMin, double xMax, double yMax, double zMax, bool normalize = true );

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -110,6 +110,15 @@ the normalization step will not be applied automatically.
     }
 %End
 
+    QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize = true );
+%Docstring
+Constructs a QgsBox3D from two 3D vectors representing opposite corners of the box.
+The box is normalized after construction. If ``normalize`` is ``False`` then
+the normalization step will not be applied automatically.
+
+.. versionadded:: 3.42
+%End
+
     void set( double xMin, double yMin, double zMin, double xMax, double yMax, double zMax, bool normalize = true );
 %Docstring
 Sets the box from a set of (x,y,z) minimum and maximum coordinates.
@@ -375,6 +384,13 @@ If no ``center`` point is specified then the current center of the box will be u
 Scale the rectangle around a center coordinates.
 
 .. versionadded:: 3.26
+%End
+
+    void grow( double delta );
+%Docstring
+Grows the box in place by the specified amount in all dimensions.
+
+.. versionadded:: 3.42
 %End
 
     bool isNull() const /HoldGIL/;

--- a/src/3d/chunks/qgschunkedentity.cpp
+++ b/src/3d/chunks/qgschunkedentity.cpp
@@ -31,16 +31,16 @@
 ///@cond PRIVATE
 
 
-static float screenSpaceError( QgsChunkNode *node, const QgsChunkedEntity::SceneContext &sceneContext )
+static float screenSpaceError( const QgsAABB &nodeBbox, float nodeError, const QgsChunkedEntity::SceneContext &sceneContext )
 {
-  if ( node->error() <= 0 ) //it happens for meshes
+  if ( nodeError <= 0 ) //it happens for meshes
     return 0;
 
-  float dist = node->bbox().distanceFromPoint( sceneContext.cameraPos );
+  float dist = nodeBbox.distanceFromPoint( sceneContext.cameraPos );
 
   // TODO: what to do when distance == 0 ?
 
-  float sse = Qgs3DUtils::screenSpaceError( node->error(), dist, sceneContext.screenSizePx, sceneContext.cameraFov );
+  float sse = Qgs3DUtils::screenSpaceError( nodeError, dist, sceneContext.screenSizePx, sceneContext.cameraFov );
   return sse;
 }
 
@@ -194,7 +194,7 @@ void QgsChunkedEntity::handleSceneUpdate( const SceneContext &sceneContext )
   {
     QList<QgsAABB> bboxes;
     for ( QgsChunkNode *n : std::as_const( mActiveNodes ) )
-      bboxes << n->bbox();
+      bboxes << Qgs3DUtils::mapToWorldExtent( n->box3D(), mMapSettings->origin() );
     mBboxesEntity->setBoxes( bboxes );
   }
 
@@ -282,7 +282,7 @@ QgsRange<float> QgsChunkedEntity::getNearFarPlaneRange( const QMatrix4x4 &viewMa
   {
     // project each corner of bbox to camera coordinates
     // and determine closest and farthest point.
-    QgsAABB bbox = node->bbox();
+    QgsAABB bbox = Qgs3DUtils::mapToWorldExtent( node->box3D(), mMapSettings->origin() );
     float bboxfnear;
     float bboxffar;
     Qgs3DUtils::computeBoundingBoxNearFarPlanes( bbox, viewMatrix, bboxfnear, bboxffar );
@@ -344,7 +344,8 @@ void QgsChunkedEntity::pruneLoaderQueue( const SceneContext &sceneContext )
   while ( e )
   {
     Q_ASSERT( e->chunk->state() == QgsChunkNode::QueuedForLoad || e->chunk->state() == QgsChunkNode::QueuedForUpdate );
-    if ( Qgs3DUtils::isCullable( e->chunk->bbox(), sceneContext.viewProjectionMatrix ) )
+    const QgsAABB bbox = Qgs3DUtils::mapToWorldExtent( e->chunk->box3D(), mMapSettings->origin() );
+    if ( Qgs3DUtils::isCullable( bbox, sceneContext.viewProjectionMatrix ) )
     {
       toRemoveFromLoaderQueue.append( e->chunk );
     }
@@ -417,14 +418,16 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneContext &sceneCont
   };
   int renderedCount = 0;
   std::priority_queue<slotItem, std::vector<slotItem>, decltype( cmp_funct )> pq( cmp_funct );
-  pq.push( std::make_pair( root, screenSpaceError( root, sceneContext ) ) );
+  const QgsAABB rootBbox = Qgs3DUtils::mapToWorldExtent( root->box3D(), mMapSettings->origin() );
+  pq.push( std::make_pair( root, screenSpaceError( rootBbox, root->error(), sceneContext ) ) );
   while ( !pq.empty() && renderedCount <= mPrimitivesBudget )
   {
     slotItem s = pq.top();
     pq.pop();
     QgsChunkNode *node = s.first;
 
-    if ( Qgs3DUtils::isCullable( node->bbox(), sceneContext.viewProjectionMatrix ) )
+    const QgsAABB bbox = Qgs3DUtils::mapToWorldExtent( node->box3D(), mMapSettings->origin() );
+    if ( Qgs3DUtils::isCullable( bbox, sceneContext.viewProjectionMatrix ) )
     {
       ++mFrustumCulled;
       continue;
@@ -453,7 +456,7 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneContext &sceneCont
 
     // make sure all nodes leading to children are always loaded
     // so that zooming out does not create issues
-    double dist = node->bbox().center().distanceToPoint( sceneContext.cameraPos );
+    double dist = bbox.center().distanceToPoint( sceneContext.cameraPos );
     residencyRequests.push_back( ResidencyRequest( node, dist, node->level() ) );
 
     if ( !node->entity() && node->hasData() )
@@ -470,7 +473,7 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneContext &sceneCont
       // or not, it's the best we'll ever get...
       becomesActive = true;
     }
-    else if ( mTau > 0 && screenSpaceError( node, sceneContext ) <= mTau && node->hasData() )
+    else if ( mTau > 0 && screenSpaceError( bbox, node->error(), sceneContext ) <= mTau && node->hasData() )
     {
       // acceptable error for the current chunk - let's render it
       becomesActive = true;
@@ -492,18 +495,19 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneContext &sceneCont
         QgsChunkNode *const *children = node->children();
         for ( int i = 0; i < node->childCount(); ++i )
         {
+          const QgsAABB childBbox = Qgs3DUtils::mapToWorldExtent( children[i]->box3D(), mMapSettings->origin() );
           if ( children[i]->entity() || !children[i]->hasData() )
           {
             // chunk is resident - let's visit it recursively
-            pq.push( std::make_pair( children[i], screenSpaceError( children[i], sceneContext ) ) );
+            pq.push( std::make_pair( children[i], screenSpaceError( childBbox, children[i]->error(), sceneContext ) ) );
           }
           else
           {
             // chunk is not yet resident - let's try to load it
-            if ( Qgs3DUtils::isCullable( children[i]->bbox(), sceneContext.viewProjectionMatrix ) )
+            if ( Qgs3DUtils::isCullable( childBbox, sceneContext.viewProjectionMatrix ) )
               continue;
 
-            double dist = children[i]->bbox().center().distanceToPoint( sceneContext.cameraPos );
+            double dist = childBbox.center().distanceToPoint( sceneContext.cameraPos );
             residencyRequests.push_back( ResidencyRequest( children[i], dist, children[i]->level() ) );
           }
         }
@@ -517,7 +521,10 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneContext &sceneCont
         {
           QgsChunkNode *const *children = node->children();
           for ( int i = 0; i < node->childCount(); ++i )
-            pq.push( std::make_pair( children[i], screenSpaceError( children[i], sceneContext ) ) );
+          {
+            const QgsAABB childBbox = Qgs3DUtils::mapToWorldExtent( children[i]->box3D(), mMapSettings->origin() );
+            pq.push( std::make_pair( children[i], screenSpaceError( childBbox, children[i]->error(), sceneContext ) ) );
+          }
         }
         else
         {
@@ -526,7 +533,8 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneContext &sceneCont
           QgsChunkNode *const *children = node->children();
           for ( int i = 0; i < node->childCount(); ++i )
           {
-            double dist = children[i]->bbox().center().distanceToPoint( sceneContext.cameraPos );
+            const QgsAABB childBbox = Qgs3DUtils::mapToWorldExtent( children[i]->box3D(), mMapSettings->origin() );
+            double dist = childBbox.center().distanceToPoint( sceneContext.cameraPos );
             residencyRequests.push_back( ResidencyRequest( children[i], dist, children[i]->level() ) );
           }
         }

--- a/src/3d/chunks/qgschunkloader.cpp
+++ b/src/3d/chunks/qgschunkloader.cpp
@@ -23,17 +23,17 @@ QgsQuadtreeChunkLoaderFactory::QgsQuadtreeChunkLoaderFactory() = default;
 
 QgsQuadtreeChunkLoaderFactory::~QgsQuadtreeChunkLoaderFactory() = default;
 
-void QgsQuadtreeChunkLoaderFactory::setupQuadtree( const QgsAABB &rootBbox, float rootError, int maxLevel, const QgsAABB &clippingBbox )
+void QgsQuadtreeChunkLoaderFactory::setupQuadtree( const QgsBox3D &rootBox3D, float rootError, int maxLevel, const QgsBox3D &clippingBox3D )
 {
-  mRootBbox = rootBbox;
+  mRootBox3D = rootBox3D;
   mRootError = rootError;
   mMaxLevel = maxLevel;
-  mClippingBbox = clippingBbox;
+  mClippingBox3D = clippingBox3D;
 }
 
 QgsChunkNode *QgsQuadtreeChunkLoaderFactory::createRootNode() const
 {
-  return new QgsChunkNode( QgsChunkNodeId( 0, 0, 0 ), mRootBbox, mRootError );
+  return new QgsChunkNode( QgsChunkNodeId( 0, 0, 0 ), mRootBox3D, mRootError );
 }
 
 QVector<QgsChunkNode *> QgsQuadtreeChunkLoaderFactory::createChildren( QgsChunkNode *node ) const
@@ -45,25 +45,24 @@ QVector<QgsChunkNode *> QgsQuadtreeChunkLoaderFactory::createChildren( QgsChunkN
 
   const QgsChunkNodeId nodeId = node->tileId();
   const float childError = node->error() / 2;
-  const QgsAABB bbox = node->bbox();
-  float xc = bbox.xCenter(), zc = bbox.zCenter();
+  const QgsBox3D box3D = node->box3D();
+  QgsVector3D center = box3D.center();
 
   for ( int i = 0; i < 4; ++i )
   {
     int dx = i & 1, dy = !!( i & 2 );
     const QgsChunkNodeId childId( nodeId.d + 1, nodeId.x * 2 + dx, nodeId.y * 2 + ( dy ? 0 : 1 ) );  // TODO: inverse dy?
-    // the Y and Z coordinates below are intentionally flipped, because
-    // in chunk node IDs the X,Y axes define horizontal plane,
-    // while in our 3D scene the X,Z axes define the horizontal plane
-    const float chXMin = dx ? xc : bbox.xMin;
-    const float chXMax = dx ? bbox.xMax : xc;
-    const float chZMin = dy ? zc : bbox.zMin;
-    const float chZMax = dy ? bbox.zMax : zc;
-    const float chYMin = bbox.yMin;
-    const float chYMax = bbox.yMax;
-    const QgsAABB childBbox = QgsAABB( chXMin, chYMin, chZMin, chXMax, chYMax, chZMax );
-    if ( mClippingBbox.isEmpty() || childBbox.intersects( mClippingBbox ) )
-      children << new QgsChunkNode( childId, childBbox, childError, node );
+
+    const double chXMin = dx ? center.x() : box3D.xMinimum();
+    const double chXMax = dx ? box3D.xMaximum() : center.x();
+    const double chYMin = dy ? center.y() : box3D.yMinimum();
+    const double chYMax = dy ? box3D.yMaximum() : center.y();
+    const double chZMin = box3D.zMinimum();
+    const double chZMax = box3D.zMaximum();
+    const QgsBox3D childBox3D( chXMin, chYMin, chZMin, chXMax, chYMax, chZMax );
+
+    if ( mClippingBox3D.isEmpty() || childBox3D.intersects( mClippingBox3D ) )
+      children << new QgsChunkNode( childId, childBox3D, childError, node );
   }
   return children;
 }

--- a/src/3d/chunks/qgschunkloader.cpp
+++ b/src/3d/chunks/qgschunkloader.cpp
@@ -51,7 +51,7 @@ QVector<QgsChunkNode *> QgsQuadtreeChunkLoaderFactory::createChildren( QgsChunkN
   for ( int i = 0; i < 4; ++i )
   {
     int dx = i & 1, dy = !!( i & 2 );
-    const QgsChunkNodeId childId( nodeId.d + 1, nodeId.x * 2 + dx, nodeId.y * 2 + ( dy ? 0 : 1 ) );  // TODO: inverse dy?
+    const QgsChunkNodeId childId( nodeId.d + 1, nodeId.x * 2 + dx, nodeId.y * 2 + dy );
 
     const double chXMin = dx ? center.x() : box3D.xMinimum();
     const double chXMax = dx ? box3D.xMaximum() : center.x();

--- a/src/3d/chunks/qgschunkloader.h
+++ b/src/3d/chunks/qgschunkloader.h
@@ -27,7 +27,9 @@
 // version without notice, or even be removed.
 //
 
+#include "qgis_3d.h"
 #include "qgschunkqueuejob.h"
+#include "qgsbox3d.h"
 
 #define SIP_NO_FILE
 
@@ -109,8 +111,6 @@ class QgsChunkLoaderFactory  : public QObject
 };
 
 
-#include "qgsaabb.h"
-
 /**
  * \ingroup 3d
  * \brief Base class for factories where the hierarchy is a quadtree where all leaves
@@ -126,14 +126,14 @@ class _3D_EXPORT QgsQuadtreeChunkLoaderFactory : public QgsChunkLoaderFactory
     virtual ~QgsQuadtreeChunkLoaderFactory();
 
     //! Initializes the root node setup (bounding box and error) and tree depth
-    void setupQuadtree( const QgsAABB &rootBbox, float rootError, int maxLevel, const QgsAABB &clippingBbox = QgsAABB() );
+    void setupQuadtree( const QgsBox3D &rootBox3D, float rootError, int maxLevel, const QgsBox3D &clippingBox3D = QgsBox3D() );
 
     virtual QgsChunkNode *createRootNode() const override;
     virtual QVector<QgsChunkNode *> createChildren( QgsChunkNode *node ) const override;
 
   protected:
-    QgsAABB mRootBbox;
-    QgsAABB mClippingBbox;
+    QgsBox3D mRootBox3D;
+    QgsBox3D mClippingBox3D;
     float mRootError = 0;
     //! maximum allowed depth of quad tree
     int mMaxLevel = 0;

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -471,10 +471,10 @@ void Qgs3DMapScene::createTerrainDeferred()
   {
     double tile0width = mMap.terrainGenerator()->rootChunkExtent().width();
     int maxZoomLevel = Qgs3DUtils::maxZoomLevel( tile0width, mMap.mapTileResolution(), mMap.maxTerrainGroundError() );
-    QgsAABB rootBbox = mMap.terrainGenerator()->rootChunkBbox( mMap );
+    const QgsBox3D rootBox3D = mMap.terrainGenerator()->rootChunkBox3D( mMap );
     float rootError = mMap.terrainGenerator()->rootChunkError( mMap );
-    const QgsAABB clippingBbox = Qgs3DUtils::mapToWorldExtent( mMap.extent(), rootBbox.zMin, rootBbox.zMax, mMap.origin() );
-    mMap.terrainGenerator()->setupQuadtree( rootBbox, rootError, maxZoomLevel, clippingBbox );
+    const QgsBox3D clippingBox3D( mMap.extent(), rootBox3D.zMinimum(), rootBox3D.zMaximum() );
+    mMap.terrainGenerator()->setupQuadtree( rootBox3D, rootError, maxZoomLevel, clippingBox3D );
 
     mTerrain = new QgsTerrainEntity( &mMap );
     mTerrain->setParent( this );
@@ -1069,9 +1069,9 @@ QgsDoubleRange Qgs3DMapScene::elevationRange() const
   double yMax = std::numeric_limits< double >::lowest();
   if ( mMap.terrainRenderingEnabled() && mTerrain )
   {
-    const QgsAABB bbox = mTerrain->rootNode()->bbox();
-    yMin = std::min( yMin, static_cast< double >( bbox.yMin ) );
-    yMax = std::max( yMax, static_cast< double >( bbox.yMax ) );
+    const QgsBox3D box3D = mTerrain->rootNode()->box3D();
+    yMin = std::min( yMin, box3D.zMinimum() );
+    yMax = std::max( yMax, box3D.zMaximum() );
   }
 
   for ( auto it = mLayerEntities.constBegin(); it != mLayerEntities.constEnd(); it++ )

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -633,6 +633,17 @@ QgsAABB Qgs3DUtils::mapToWorldExtent( const QgsRectangle &extent, double zMin, d
   return rootBbox;
 }
 
+QgsAABB Qgs3DUtils::mapToWorldExtent( const QgsBox3D &box3D, const QgsVector3D &mapOrigin )
+{
+  const QgsVector3D extentMin3D( box3D.xMinimum(), box3D.yMinimum(), box3D.zMinimum() );
+  const QgsVector3D extentMax3D( box3D.xMaximum(), box3D.yMaximum(), box3D.zMaximum() );
+  const QgsVector3D worldExtentMin3D = mapToWorldCoordinates( extentMin3D, mapOrigin );
+  const QgsVector3D worldExtentMax3D = mapToWorldCoordinates( extentMax3D, mapOrigin );
+  QgsAABB rootBbox( worldExtentMin3D.x(), worldExtentMin3D.y(), worldExtentMin3D.z(),
+                    worldExtentMax3D.x(), worldExtentMax3D.y(), worldExtentMax3D.z() );
+  return rootBbox;
+}
+
 QgsRectangle Qgs3DUtils::worldToMapExtent( const QgsAABB &bbox, const QgsVector3D &mapOrigin )
 {
   const QgsVector3D worldExtentMin3D = Qgs3DUtils::worldToMapCoordinates( QgsVector3D( bbox.xMin, bbox.yMin, bbox.zMin ), mapOrigin );

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -639,9 +639,13 @@ QgsAABB Qgs3DUtils::mapToWorldExtent( const QgsBox3D &box3D, const QgsVector3D &
   const QgsVector3D extentMax3D( box3D.xMaximum(), box3D.yMaximum(), box3D.zMaximum() );
   const QgsVector3D worldExtentMin3D = mapToWorldCoordinates( extentMin3D, mapOrigin );
   const QgsVector3D worldExtentMax3D = mapToWorldCoordinates( extentMax3D, mapOrigin );
-  QgsAABB rootBbox( worldExtentMin3D.x(), worldExtentMin3D.y(), worldExtentMin3D.z(),
-                    worldExtentMax3D.x(), worldExtentMax3D.y(), worldExtentMax3D.z() );
-  return rootBbox;
+  // casting to float should be ok, assuming that the map origin is not too far from the box
+  return QgsAABB( static_cast<float>( worldExtentMin3D.x() ),
+                  static_cast<float>( worldExtentMin3D.y() ),
+                  static_cast<float>( worldExtentMin3D.z() ),
+                  static_cast<float>( worldExtentMax3D.x() ),
+                  static_cast<float>( worldExtentMax3D.y() ),
+                  static_cast<float>( worldExtentMax3D.z() ) );
 }
 
 QgsRectangle Qgs3DUtils::worldToMapExtent( const QgsAABB &bbox, const QgsVector3D &mapOrigin )

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -175,6 +175,12 @@ class _3D_EXPORT Qgs3DUtils
     static QgsAABB mapToWorldExtent( const QgsRectangle &extent, double zMin, double zMax, const QgsVector3D &mapOrigin );
 
     /**
+     * Converts 3D box in map coordinates to AABB in world coordinates.
+     * \since QGIS 3.42
+     */
+    static QgsAABB mapToWorldExtent( const QgsBox3D &box3D, const QgsVector3D &mapOrigin );
+
+    /**
      * Converts axis aligned bounding box in 3D world coordinates to extent in map coordinates
      * \since QGIS 3.12
      */

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -81,8 +81,8 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
   mFutureWatcher = new QFutureWatcher<void>( this );
   connect( mFutureWatcher, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished );
 
-  const QgsAABB bbox = node->bbox();
-  const QFuture<void> future = QtConcurrent::run( [pc, pcNode, bbox, this]
+  const QgsBox3D box3D = node->box3D();
+  const QFuture<void> future = QtConcurrent::run( [pc, pcNode, box3D, this]
   {
     const QgsEventTracing::ScopedEvent e( QStringLiteral( "3D" ), QStringLiteral( "PC chunk load" ) );
 
@@ -101,7 +101,7 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
     }
 
     if ( mContext.symbol()->renderAsTriangles() )
-      mHandler->triangulate( pc, pcNode, mContext, bbox );
+      mHandler->triangulate( pc, pcNode, mContext, box3D );
   } );
 
   // emit finished() as soon as the handler is populated with features
@@ -177,13 +177,38 @@ int QgsPointCloudLayerChunkLoaderFactory::primitivesCount( QgsChunkNode *node ) 
   return mPointCloudIndex->nodePointCount( n );
 }
 
-QgsAABB nodeBoundsToAABB( QgsPointCloudDataBounds nodeBounds, QgsVector3D offset, QgsVector3D scale, const Qgs3DRenderContext &context, const QgsCoordinateTransform &coordinateTransform, double zValueOffset );
+
+QgsBox3D nodeBoundsToBox3D( QgsPointCloudDataBounds nodeBounds, QgsVector3D offset, QgsVector3D scale, const QgsCoordinateTransform &coordinateTransform, double zValueOffset, double zValueScale )
+{
+  QgsVector3D extentMin3D( nodeBounds.xMin() * scale.x() + offset.x(),
+                           nodeBounds.yMin() * scale.y() + offset.y(),
+                           ( nodeBounds.zMin() * scale.z() + offset.z() ) * zValueScale + zValueOffset );
+  QgsVector3D extentMax3D( nodeBounds.xMax() * scale.x() + offset.x(),
+                           nodeBounds.yMax() * scale.y() + offset.y(),
+                           ( nodeBounds.zMax() * scale.z() + offset.z() ) * zValueScale + zValueOffset );
+  QgsCoordinateTransform extentTransform = coordinateTransform;
+  extentTransform.setBallparkTransformsAreAppropriate( true );
+  try
+  {
+    extentMin3D = extentTransform.transform( extentMin3D );
+    extentMax3D = extentTransform.transform( extentMax3D );
+  }
+  catch ( QgsCsException & )
+  {
+    QgsDebugError( QStringLiteral( "Error transforming node bounds coordinate" ) );
+  }
+  return QgsBox3D( extentMin3D.x(), extentMin3D.y(), extentMin3D.z(),
+                   extentMax3D.x(), extentMax3D.y(), extentMax3D.z() );
+}
+
 
 QgsChunkNode *QgsPointCloudLayerChunkLoaderFactory::createRootNode() const
 {
-  const QgsAABB bbox = nodeBoundsToAABB( mPointCloudIndex->nodeBounds( IndexedPointCloudNode( 0, 0, 0, 0 ) ), mPointCloudIndex->offset(), mPointCloudIndex->scale(), mRenderContext, mCoordinateTransform, mZValueOffset );
+  const QgsPointCloudDataBounds rootNodeBounds = mPointCloudIndex->nodeBounds( IndexedPointCloudNode( 0, 0, 0, 0 ) );
+  QgsBox3D rootNodeBox3D = nodeBoundsToBox3D( rootNodeBounds, mPointCloudIndex->offset(), mPointCloudIndex->scale(), mCoordinateTransform, mZValueOffset, mZValueScale );
+
   const float error = mPointCloudIndex->nodeError( IndexedPointCloudNode( 0, 0, 0, 0 ) );
-  QgsChunkNode *node = new QgsChunkNode( QgsChunkNodeId( 0, 0, 0, 0 ), bbox, error );
+  QgsChunkNode *node = new QgsChunkNode( QgsChunkNodeId( 0, 0, 0, 0 ), rootNodeBox3D, error );
   node->setRefinementProcess( mSymbol->renderAsTriangles() ? Qgis::TileRefinementProcess::Replacement : Qgis::TileRefinementProcess::Additive );
   return node;
 }
@@ -192,9 +217,7 @@ QVector<QgsChunkNode *> QgsPointCloudLayerChunkLoaderFactory::createChildren( Qg
 {
   QVector<QgsChunkNode *> children;
   const QgsChunkNodeId nodeId = node->tileId();
-  const QgsAABB bbox = node->bbox();
   const float childError = node->error() / 2;
-  float xc = bbox.xCenter(), yc = bbox.yCenter(), zc = bbox.zCenter();
 
   for ( int i = 0; i < 8; ++i )
   {
@@ -207,17 +230,10 @@ QVector<QgsChunkNode *> QgsPointCloudLayerChunkLoaderFactory::createChildren( Qg
          !mPointCloudIndex->nodeMapExtent( IndexedPointCloudNode( childId.d, childId.x, childId.y, childId.z ) ).intersects( mExtent ) )
       continue;
 
-    // the Y and Z coordinates below are intentionally flipped, because
-    // in chunk node IDs the X,Y axes define horizontal plane,
-    // while in our 3D scene the X,Z axes define the horizontal plane
-    const float chXMin = dx ? xc : bbox.xMin;
-    const float chXMax = dx ? bbox.xMax : xc;
-    // Z axis: values are increasing to the south
-    const float chZMin = !dy ? zc : bbox.zMin;
-    const float chZMax = !dy ? bbox.zMax : zc;
-    const float chYMin = dz ? yc : bbox.yMin;
-    const float chYMax = dz ? bbox.yMax : yc;
-    QgsChunkNode *child = new QgsChunkNode( childId, QgsAABB( chXMin, chYMin, chZMin, chXMax, chYMax, chZMax ), childError, node );
+    const QgsPointCloudDataBounds childBounds = mPointCloudIndex->nodeBounds( IndexedPointCloudNode( childId.d, childId.x, childId.y, childId.z ) );
+    QgsBox3D childBox3D = nodeBoundsToBox3D( childBounds, mPointCloudIndex->offset(), mPointCloudIndex->scale(), mCoordinateTransform, mZValueOffset, mZValueScale );
+
+    QgsChunkNode *child = new QgsChunkNode( childId, childBox3D, childError, node );
     child->setRefinementProcess( mSymbol->renderAsTriangles() ? Qgis::TileRefinementProcess::Replacement : Qgis::TileRefinementProcess::Additive );
     children << child;
   }
@@ -225,29 +241,6 @@ QVector<QgsChunkNode *> QgsPointCloudLayerChunkLoaderFactory::createChildren( Qg
 }
 
 ///////////////
-
-
-QgsAABB nodeBoundsToAABB( QgsPointCloudDataBounds nodeBounds, QgsVector3D offset, QgsVector3D scale, const Qgs3DRenderContext &context, const QgsCoordinateTransform &coordinateTransform, double zValueOffset )
-{
-  QgsVector3D extentMin3D( nodeBounds.xMin() * scale.x() + offset.x(), nodeBounds.yMin() * scale.y() + offset.y(), nodeBounds.zMin() * scale.z() + offset.z() + zValueOffset );
-  QgsVector3D extentMax3D( nodeBounds.xMax() * scale.x() + offset.x(), nodeBounds.yMax() * scale.y() + offset.y(), nodeBounds.zMax() * scale.z() + offset.z() + zValueOffset );
-  QgsCoordinateTransform extentTransform = coordinateTransform;
-  extentTransform.setBallparkTransformsAreAppropriate( true );
-  try
-  {
-    extentMin3D = extentTransform.transform( extentMin3D );
-    extentMax3D = extentTransform.transform( extentMax3D );
-  }
-  catch ( QgsCsException & )
-  {
-    QgsDebugError( QStringLiteral( "Error transforming node bounds coordinate" ) );
-  }
-  const QgsVector3D worldExtentMin3D = Qgs3DUtils::mapToWorldCoordinates( extentMin3D, context.origin() );
-  const QgsVector3D worldExtentMax3D = Qgs3DUtils::mapToWorldCoordinates( extentMax3D, context.origin() );
-  QgsAABB rootBbox( worldExtentMin3D.x(), worldExtentMin3D.y(), worldExtentMin3D.z(),
-                    worldExtentMax3D.x(), worldExtentMax3D.y(), worldExtentMax3D.z() );
-  return rootBbox;
-}
 
 
 QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( Qgs3DMapSettings *map, QgsPointCloudIndex *pc,
@@ -313,7 +306,8 @@ QVector<QgsRayCastingUtils::RayHit> QgsPointCloudLayerChunkedEntity::rayIntersec
     if ( !index->hasNode( n ) )
       continue;
 
-    if ( !QgsRayCastingUtils::rayBoxIntersection( ray, node->bbox() ) )
+    const QgsAABB nodeBbox = Qgs3DUtils::mapToWorldExtent( node->box3D(), mMapSettings->origin() );
+    if ( !QgsRayCastingUtils::rayBoxIntersection( ray, nodeBbox ) )
       continue;
 
     std::unique_ptr<QgsPointCloudBlock> block( index->nodeData( n, request ) );

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -180,12 +180,12 @@ int QgsPointCloudLayerChunkLoaderFactory::primitivesCount( QgsChunkNode *node ) 
 
 QgsBox3D nodeBoundsToBox3D( QgsPointCloudDataBounds nodeBounds, QgsVector3D offset, QgsVector3D scale, const QgsCoordinateTransform &coordinateTransform, double zValueOffset, double zValueScale )
 {
-  QgsVector3D extentMin3D( nodeBounds.xMin() * scale.x() + offset.x(),
-                           nodeBounds.yMin() * scale.y() + offset.y(),
-                           ( nodeBounds.zMin() * scale.z() + offset.z() ) * zValueScale + zValueOffset );
-  QgsVector3D extentMax3D( nodeBounds.xMax() * scale.x() + offset.x(),
-                           nodeBounds.yMax() * scale.y() + offset.y(),
-                           ( nodeBounds.zMax() * scale.z() + offset.z() ) * zValueScale + zValueOffset );
+  QgsVector3D extentMin3D( static_cast<double>( nodeBounds.xMin() ) * scale.x() + offset.x(),
+                           static_cast<double>( nodeBounds.yMin() ) * scale.y() + offset.y(),
+                           ( static_cast<double>( nodeBounds.zMin() ) * scale.z() + offset.z() ) * zValueScale + zValueOffset );
+  QgsVector3D extentMax3D( static_cast<double>( nodeBounds.xMax() ) * scale.x() + offset.x(),
+                           static_cast<double>( nodeBounds.yMax() ) * scale.y() + offset.y(),
+                           ( static_cast<double>( nodeBounds.zMax() ) * scale.z() + offset.z() ) * zValueScale + zValueOffset );
   QgsCoordinateTransform extentTransform = coordinateTransform;
   extentTransform.setBallparkTransformsAreAppropriate( true );
   try

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -51,7 +51,7 @@ QgsRuleBasedChunkLoader::QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderF
   QgsVectorLayer *layer = mFactory->mLayer;
 
   // only a subset of data to be queried
-  const QgsRectangle rect = Qgs3DUtils::worldToMapExtent( node->bbox(), mContext.origin() );
+  const QgsRectangle rect = node->box3D().toRectangle();
   // origin for coordinates of the chunk - it is kind of arbitrary, but it should be
   // picked so that the coordinates are relatively small to avoid numerical precision issues
   QgsVector3D chunkOrigin( rect.center().x(), rect.center().y(), 0 );
@@ -153,10 +153,10 @@ Qt3DCore::QEntity *QgsRuleBasedChunkLoader::createEntity( Qt3DCore::QEntity *par
   // fix the vertical range of the node from the estimated vertical range to the true range
   if ( zMin != std::numeric_limits<float>::max() && zMax != std::numeric_limits<float>::lowest() )
   {
-    QgsAABB box = mNode->bbox();
-    box.yMin = zMin;
-    box.yMax = zMax;
-    mNode->setExactBbox( box );
+    QgsBox3D box = mNode->box3D();
+    box.setZMinimum( zMin );
+    box.setZMaximum( zMax );
+    mNode->setExactBox3D( box );
     mNode->updateParentBoundingBoxesRecursively();
   }
 
@@ -173,8 +173,8 @@ QgsRuleBasedChunkLoaderFactory::QgsRuleBasedChunkLoaderFactory( const Qgs3DRende
   , mRootRule( rootRule->clone() )
   , mLeafLevel( leafLevel )
 {
-  const QgsAABB rootBbox = Qgs3DUtils::mapToWorldExtent( context.extent(), zMin, zMax, context.origin() );
-  setupQuadtree( rootBbox, -1, leafLevel );  // negative root error means that the node does not contain anything
+  const QgsBox3D rootBox3D( context.extent(), zMin, zMax );
+  setupQuadtree( rootBox3D, -1, leafLevel );  // negative root error means that the node does not contain anything
 }
 
 QgsRuleBasedChunkLoaderFactory::~QgsRuleBasedChunkLoaderFactory() = default;
@@ -269,6 +269,6 @@ void QgsRuleBasedChunkedEntity::onTerrainElevationOffsetChanged( float newOffset
 
 QVector<QgsRayCastingUtils::RayHit> QgsRuleBasedChunkedEntity::rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const
 {
-  return QgsVectorLayerChunkedEntity::rayIntersection( activeNodes(), mTransform->matrix(), ray, context );
+  return QgsVectorLayerChunkedEntity::rayIntersection( activeNodes(), mTransform->matrix(), ray, context, mMapSettings->origin() );
 }
 /// @endcond

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -60,7 +60,7 @@ QgsVectorLayerChunkLoader::QgsVectorLayerChunkLoader( const QgsVectorLayerChunkL
   mHandler.reset( handler );
 
   // only a subset of data to be queried
-  const QgsRectangle rect = Qgs3DUtils::worldToMapExtent( node->bbox(), mRenderContext.origin() );
+  const QgsRectangle rect = node->box3D().toRectangle();
   // origin for coordinates of the chunk - it is kind of arbitrary, but it should be
   // picked so that the coordinates are relatively small to avoid numerical precision issues
   QgsVector3D chunkOrigin( rect.center().x(), rect.center().y(), 0 );
@@ -136,7 +136,7 @@ Qt3DCore::QEntity *QgsVectorLayerChunkLoader::createEntity( Qt3DCore::QEntity *p
   {
     // an empty node, so we return no entity. This tags the node as having no data and effectively removes it.
     // we just make sure first that its initial estimated vertical range does not affect its parents' bboxes calculation
-    mNode->setExactBbox( QgsAABB() );
+    mNode->setExactBox3D( QgsBox3D() );
     mNode->updateParentBoundingBoxesRecursively();
     return nullptr;
   }
@@ -148,10 +148,10 @@ Qt3DCore::QEntity *QgsVectorLayerChunkLoader::createEntity( Qt3DCore::QEntity *p
   // fix the vertical range of the node from the estimated vertical range to the true range
   if ( mHandler->zMinimum() != std::numeric_limits<float>::max() && mHandler->zMaximum() != std::numeric_limits<float>::lowest() )
   {
-    QgsAABB box = mNode->bbox();
-    box.yMin = mHandler->zMinimum();
-    box.yMax = mHandler->zMaximum();
-    mNode->setExactBbox( box );
+    QgsBox3D box = mNode->box3D();
+    box.setZMinimum( mHandler->zMinimum() );
+    box.setZMaximum( mHandler->zMaximum() );
+    mNode->setExactBox3D( box );
     mNode->updateParentBoundingBoxesRecursively();
   }
 
@@ -168,15 +168,10 @@ QgsVectorLayerChunkLoaderFactory::QgsVectorLayerChunkLoaderFactory( const Qgs3DR
   , mSymbol( symbol->clone() )
   , mLeafLevel( leafLevel )
 {
-  QgsAABB rootBbox = Qgs3DUtils::mapToWorldExtent( context.extent(), zMin, zMax, context.origin() );
+  QgsBox3D rootBox3D( context.extent(), zMin, zMax );
   // add small padding to avoid clipping of point features located at the edge of the bounding box
-  rootBbox.xMin -= 1.0;
-  rootBbox.xMax += 1.0;
-  rootBbox.yMin -= 1.0;
-  rootBbox.yMax += 1.0;
-  rootBbox.zMin -= 1.0;
-  rootBbox.zMax += 1.0;
-  setupQuadtree( rootBbox, -1, leafLevel );  // negative root error means that the node does not contain anything
+  rootBox3D.grow( 1.0 );
+  setupQuadtree( rootBox3D, -1, leafLevel );  // negative root error means that the node does not contain anything
 }
 
 QgsChunkLoader *QgsVectorLayerChunkLoaderFactory::createChunkLoader( QgsChunkNode *node ) const
@@ -263,10 +258,10 @@ void QgsVectorLayerChunkedEntity::onTerrainElevationOffsetChanged( float newOffs
 
 QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const
 {
-  return QgsVectorLayerChunkedEntity::rayIntersection( activeNodes(), mTransform->matrix(), ray, context );
+  return QgsVectorLayerChunkedEntity::rayIntersection( activeNodes(), mTransform->matrix(), ray, context, mMapSettings->origin() );
 }
 
-QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection( const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context )
+QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection( const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context, const QgsVector3D &origin )
 {
   Q_UNUSED( context )
   QgsDebugMsgLevel( QStringLiteral( "Ray cast on vector layer" ), 2 );
@@ -287,9 +282,12 @@ QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection
 #ifdef QGISDEBUG
     nodesAll++;
 #endif
+
+    QgsAABB nodeBbox = Qgs3DUtils::mapToWorldExtent( node->box3D(), origin );
+
     if ( node->entity() &&
-         ( minDist < 0 || node->bbox().distanceFromPoint( ray.origin() ) < minDist ) &&
-         QgsRayCastingUtils::rayBoxIntersection( ray, node->bbox() ) )
+         ( minDist < 0 || nodeBbox.distanceFromPoint( ray.origin() ) < minDist ) &&
+         QgsRayCastingUtils::rayBoxIntersection( ray, nodeBbox ) )
     {
 #ifdef QGISDEBUG
       nodeUsed++;

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -129,7 +129,7 @@ class QgsVectorLayerChunkedEntity : public QgsChunkedEntity
   private:
     friend class QgsRuleBasedChunkedEntity;
     //! This implementation is shared between QgsVectorLayerChunkedEntity and QgsRuleBasedChunkedEntity
-    static QVector<QgsRayCastingUtils::RayHit> rayIntersection( const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context );
+    static QVector<QgsRayCastingUtils::RayHit> rayIntersection( const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context, const QgsVector3D &origin );
 
     Qt3DCore::QTransform *mTransform = nullptr;
 

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -359,7 +359,7 @@ void QgsPointCloud3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const 
 }
 
 
-std::vector<double> QgsPointCloud3DSymbolHandler::getVertices( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox )
+std::vector<double> QgsPointCloud3DSymbolHandler::getVertices( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsBox3D &box3D )
 {
 
   bool hasColorData = !outNormal.colors.empty();
@@ -382,11 +382,10 @@ std::vector<double> QgsPointCloud3DSymbolHandler::getVertices( QgsPointCloudInde
   //factor to take account of the density of the point to calculate extension of the bounding box
   // with a usual value span = 128, bounding box is extended by 12.5 % on each side.
   double extraBoxFactor = 16 / span;
-  double extraX = extraBoxFactor * bbox.xExtent();
-  double extraY = extraBoxFactor * bbox.yExtent();
 
   // We keep all points in vertical direction to avoid odd triangulation if points are isolated on top
-  const QgsAABB extendedBBox( bbox.xMin - extraX, bbox.yMin - extraY, -std::numeric_limits<float>::max(), bbox.xMax + extraX, bbox.yMax + extraY, std::numeric_limits<float>::max() );
+  QgsRectangle rectRelativeToChunkOrigin = ( box3D - outNormal.positionsOrigin ).toRectangle();
+  rectRelativeToChunkOrigin.grow( extraBoxFactor * std::max( box3D.width(), box3D.height() ) );
 
   PointData filteredExtraPointData;
   while ( parentNode.d() >= 0 )
@@ -400,7 +399,7 @@ std::vector<double> QgsPointCloud3DSymbolHandler::getVertices( QgsPointCloudInde
     for ( int i = 0; i < outputParent.positions.count(); ++i )
     {
       const QVector3D pos = outputParent.positions.at( i ) + originDifference;
-      if ( extendedBBox.intersects( pos.x(), pos.y(), pos.z() ) )
+      if ( rectRelativeToChunkOrigin.contains( pos.x(), pos.y() ) )
       {
         filteredExtraPointData.positions.append( pos );
         vertices.push_back( pos.x() );
@@ -458,7 +457,7 @@ void QgsPointCloud3DSymbolHandler::calculateNormals( const std::vector<size_t> &
   }
 }
 
-void QgsPointCloud3DSymbolHandler::filterTriangles( const std::vector<size_t> &triangleIndexes, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox )
+void QgsPointCloud3DSymbolHandler::filterTriangles( const std::vector<size_t> &triangleIndexes, const QgsPointCloud3DRenderContext &context, const QgsBox3D &box3D )
 {
   outNormal.triangles.resize( triangleIndexes.size() * sizeof( quint32 ) );
   quint32 *indexPtr = reinterpret_cast<quint32 *>( outNormal.triangles.data() );
@@ -469,6 +468,8 @@ void QgsPointCloud3DSymbolHandler::filterTriangles( const std::vector<size_t> &t
   float horizontalThreshold =  context.symbol()->horizontalFilterThreshold();
   float verticalThreshold =  context.symbol()->verticalFilterThreshold();
 
+  QgsBox3D boxRelativeToChunkOrigin = box3D - outNormal.positionsOrigin;
+
   for ( size_t i = 0; i < triangleIndexes.size(); i += 3 )
   {
     bool atLeastOneInBox = false;
@@ -477,7 +478,7 @@ void QgsPointCloud3DSymbolHandler::filterTriangles( const std::vector<size_t> &t
     for ( size_t j = 0; j < 3; j++ )
     {
       QVector3D pos = outNormal.positions.at( triangleIndexes.at( i  + j ) );
-      atLeastOneInBox |= bbox.intersects( pos.x(), pos.y(), pos.z() );
+      atLeastOneInBox |= boxRelativeToChunkOrigin.contains( pos.x(), pos.y(), pos.z() );
 
       if ( verticalFilter || horizontalFilter )
       {
@@ -519,30 +520,16 @@ void QgsPointCloud3DSymbolHandler::filterTriangles( const std::vector<size_t> &t
   }
 }
 
-void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox )
+void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsBox3D &box3D )
 {
   if ( outNormal.positions.isEmpty() )
     return;
-
-  // The bbox we get is in world coordinates, we need to transform it to map coordinates
-  // (flip axes and add scene origin vector), but relative to the chunk's origin (subtract it)
-  // because that's the coordinate system used within the chunk
-  QgsBox3D boxRelativeToChunkOrigin(
-    bbox.xMin + context.origin().x() - outNormal.positionsOrigin.x(),
-    -bbox.zMax + context.origin().y() - outNormal.positionsOrigin.y(),
-    bbox.yMin + context.origin().z() - outNormal.positionsOrigin.z(),
-    bbox.xMax + context.origin().x() - outNormal.positionsOrigin.x(),
-    -bbox.zMin + context.origin().y() - outNormal.positionsOrigin.y(),
-    bbox.yMax + context.origin().z() - outNormal.positionsOrigin.z() );
-  QgsAABB aabbRelativeToChunkOrigin(
-    boxRelativeToChunkOrigin.xMinimum(), boxRelativeToChunkOrigin.yMinimum(), boxRelativeToChunkOrigin.zMinimum(),
-    boxRelativeToChunkOrigin.xMaximum(), boxRelativeToChunkOrigin.yMaximum(), boxRelativeToChunkOrigin.zMaximum() );
 
   // Triangulation happens here
   std::unique_ptr<delaunator::Delaunator> triangulation;
   try
   {
-    std::vector<double> vertices = getVertices( pc, n, context, aabbRelativeToChunkOrigin );
+    std::vector<double> vertices = getVertices( pc, n, context, box3D );
     triangulation.reset( new delaunator::Delaunator( vertices ) );
   }
   catch ( std::exception &e )
@@ -557,7 +544,7 @@ void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const In
   const std::vector<size_t> &triangleIndexes = triangulation->triangles;
 
   calculateNormals( triangleIndexes );
-  filterTriangles( triangleIndexes, context, aabbRelativeToChunkOrigin );
+  filterTriangles( triangleIndexes, context, box3D );
 }
 
 std::unique_ptr<QgsPointCloudBlock> QgsPointCloud3DSymbolHandler::pointCloudBlock( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloudRequest &request, const QgsPointCloud3DRenderContext &context )

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.h
@@ -48,7 +48,7 @@ class QgsPointCloud3DSymbolHandler
     virtual void processNode( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, PointData *output = nullptr ) = 0; // override;
     virtual void finalize( Qt3DCore::QEntity *parent, const QgsPointCloud3DRenderContext &context ) = 0;// override;
 
-    void triangulate( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox );
+    void triangulate( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsBox3D &box3D );
 
     float zMinimum() const { return mZMin; }
     float zMaximum() const { return mZMax; }
@@ -83,7 +83,7 @@ class QgsPointCloud3DSymbolHandler
 
   private:
     //! Returns all vertices of the node \a n, and of its parents contained in \a bbox and in an extension of this box depending of the density of the points
-    std::vector<double> getVertices( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox );
+    std::vector<double> getVertices( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsBox3D &box3D );
 
     //! Calculates the normals of triangles dedined by index contained in \a triangles. Must be used only in the method triangulate().
     void calculateNormals( const std::vector<size_t> &triangles );
@@ -91,12 +91,12 @@ class QgsPointCloud3DSymbolHandler
     /**
      * Applies a filter on triangles to improve the rendering:
      *
-     * - keeps only triangles that have a least one point in the bounding box \a bbox
+     * - keeps only triangles that have a least one point in the bounding box \a box3D
      * - if options are selected, skips triangles with horizontal or vertical size greater than a threshold
      *
      * Must be used only in the method triangulate().
      */
-    void filterTriangles( const std::vector<size_t> &triangleIndexes, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox );
+    void filterTriangles( const std::vector<size_t> &triangleIndexes, const QgsPointCloud3DRenderContext &context, const QgsBox3D &box3D );
 };
 
 class QgsSingleColorPointCloud3DSymbolHandler : public QgsPointCloud3DSymbolHandler

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -123,7 +123,8 @@ Qt3DCore::QEntity *QgsDemTerrainTileLoader::createEntity( Qt3DCore::QEntity *par
   transform->setScale( side );
   transform->setTranslation( QVector3D( x0 + half, 0, - ( y0 + half ) ) );
 
-  mNode->setExactBbox( QgsAABB( x0, zMin * map->terrainVerticalScale(), -y0, x0 + side, zMax * map->terrainVerticalScale(), -( y0 + side ) ) );
+  mNode->setExactBox3D( QgsBox3D( extent.xMinimum(), extent.yMinimum(), zMin * map->terrainVerticalScale(),
+                                  extent.xMinimum() + side, extent.yMinimum() + side, zMax * map->terrainVerticalScale() ) );
   mNode->updateParentBoundingBoxesRecursively();
 
   entity->setParent( parent );

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -77,7 +77,7 @@ Qt3DCore::QEntity *FlatTerrainChunkLoader::createEntity( Qt3DCore::QEntity *pare
   const double yMin = commonExtent.yMinimum() - map->origin().y();
 
   transform->setScale3D( QVector3D( xSide, 1, ySide ) );
-  transform->setTranslation( QVector3D( xMin + xSide / 2, 0, yMin + ySide / 2 ) );
+  transform->setTranslation( QVector3D( xMin + xSide / 2, 0, -( yMin + ySide / 2 ) ) );
 
   createTextureComponent( entity, map->isTerrainShadingEnabled(), map->terrainShadingMaterial(), !map->layers().empty() );
 

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -76,8 +76,8 @@ Qt3DCore::QEntity *FlatTerrainChunkLoader::createEntity( Qt3DCore::QEntity *pare
   const double xMin = commonExtent.xMinimum() - map->origin().x();
   const double yMin = commonExtent.yMinimum() - map->origin().y();
 
-  transform->setScale3D( QVector3D( xSide, 1, ySide ) );
-  transform->setTranslation( QVector3D( xMin + xSide / 2, 0, -( yMin + ySide / 2 ) ) );
+  transform->setScale3D( QVector3D( static_cast<float>( xSide ), 1, static_cast<float>( ySide ) ) );
+  transform->setTranslation( QVector3D( static_cast<float>( xMin + xSide / 2 ), 0, static_cast<float>( -( yMin + ySide / 2 ) ) ) );
 
   createTextureComponent( entity, map->isTerrainShadingEnabled(), map->terrainShadingMaterial(), !map->layers().empty() );
 

--- a/src/3d/terrain/qgsterrainentity.cpp
+++ b/src/3d/terrain/qgsterrainentity.cpp
@@ -120,9 +120,12 @@ QVector<QgsRayCastingUtils::RayHit> QgsTerrainEntity::rayIntersection( const Qgs
       const QList<QgsChunkNode *> activeNodes = this->activeNodes();
       for ( QgsChunkNode *node : activeNodes )
       {
+
+        QgsAABB nodeBbox = Qgs3DUtils::mapToWorldExtent( node->box3D(), mMapSettings->origin() );
+
         if ( node->entity() &&
-             ( minDist < 0 || node->bbox().distanceFromPoint( ray.origin() ) < minDist ) &&
-             QgsRayCastingUtils::rayBoxIntersection( ray, node->bbox() ) )
+             ( minDist < 0 || nodeBbox.distanceFromPoint( ray.origin() ) < minDist ) &&
+             QgsRayCastingUtils::rayBoxIntersection( ray, nodeBbox ) )
         {
           Qt3DRender::QGeometryRenderer *rend = node->entity()->findChild<Qt3DRender::QGeometryRenderer *>();
           auto *geom = rend->geometry();

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -15,18 +15,18 @@
 
 #include "qgsterraingenerator.h"
 
-#include "qgsaabb.h"
 #include "qgs3dmapsettings.h"
 #include "qgs3dutils.h"
 #include "qgscoordinatetransform.h"
 
-QgsAABB QgsTerrainGenerator::rootChunkBbox( const Qgs3DMapSettings &map ) const
+QgsBox3D QgsTerrainGenerator::rootChunkBox3D( const Qgs3DMapSettings &map ) const
 {
   QgsRectangle te = Qgs3DUtils::tryReprojectExtent2D( rootChunkExtent(), crs(), map.crs(), map.transformContext() );
 
   float hMin, hMax;
   rootChunkHeightRange( hMin, hMax );
-  return Qgs3DUtils::mapToWorldExtent( te, hMin * map.terrainVerticalScale(), hMax * map.terrainVerticalScale(), map.origin() );
+  return QgsBox3D( te.xMinimum(), te.yMinimum(), hMin * map.terrainVerticalScale(),
+                   te.xMaximum(), te.yMaximum(), hMax * map.terrainVerticalScale() );
 }
 
 float QgsTerrainGenerator::rootChunkError( const Qgs3DMapSettings &map ) const

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -79,8 +79,8 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsQuadtreeChunkLoaderFactory
     //! extent of the terrain's root chunk in terrain's CRS
     virtual QgsRectangle rootChunkExtent() const = 0;
 
-    //! Returns bounding box of the root chunk
-    virtual QgsAABB rootChunkBbox( const Qgs3DMapSettings &map ) const;
+    //! Returns 3D box (in map coordinates) of the root chunk
+    virtual QgsBox3D rootChunkBox3D( const Qgs3DMapSettings &map ) const;
 
     //! Returns error of the root chunk in world coordinates
     virtual float rootChunkError( const Qgs3DMapSettings &map ) const;

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -53,6 +53,17 @@ QgsBox3D::QgsBox3D( const QgsRectangle &rect, double zMin, double zMax, bool nor
   }
 }
 
+QgsBox3D::QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize )
+  : mBounds2d( corner1.x(), corner1.y(), corner2.x(), corner2.y() )
+  , mZmin( corner1.z() )
+  , mZmax( corner2.z() )
+{
+  if ( normalize )
+  {
+    QgsBox3D::normalize();
+  }
+}
+
 void QgsBox3D::setXMinimum( double x )
 {
   mBounds2d.setXMinimum( x );
@@ -284,6 +295,15 @@ void QgsBox3D::scale( double scaleFactor, double centerX, double centerY, double
 
   setZMinimum( centerZ + ( zMinimum() - centerZ ) * scaleFactor );
   setZMaximum( centerZ + ( zMaximum() - centerZ ) * scaleFactor );
+}
+
+void QgsBox3D::grow( double delta )
+{
+  if ( isNull() )
+    return;
+  mBounds2d.grow( delta );
+  mZmin -= delta;
+  mZmax += delta;
 }
 
 bool QgsBox3D::isNull() const

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -54,7 +54,7 @@ QgsBox3D::QgsBox3D( const QgsRectangle &rect, double zMin, double zMax, bool nor
 }
 
 QgsBox3D::QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize )
-  : mBounds2d( corner1.x(), corner1.y(), corner2.x(), corner2.y() )
+  : mBounds2d( corner1.x(), corner1.y(), corner2.x(), corner2.y(), false )
   , mZmin( corner1.z() )
   , mZmax( corner2.z() )
 {

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -68,6 +68,7 @@ class CORE_EXPORT QgsBox3D
     QgsBox3D( const QgsRectangle &rect,
               double zMin = std::numeric_limits<double>::quiet_NaN(), double zMax = std::numeric_limits<double>::quiet_NaN(),
               bool normalize = true );
+
 #else
     QgsBox3D( SIP_PYOBJECT x SIP_TYPEHINT( Optional[Union[QgsPoint, QgsRectangle, float]] ) = Py_None, SIP_PYOBJECT y SIP_TYPEHINT( Optional[QgsPoint, float] ) = Py_None, SIP_PYOBJECT z SIP_TYPEHINT( Optional[Union[bool, float]] ) = Py_None, SIP_PYOBJECT x2 SIP_TYPEHINT( Optional[Union[bool, float]] ) = Py_None, SIP_PYOBJECT y2 SIP_TYPEHINT( Optional[float] ) = Py_None, SIP_PYOBJECT z2 SIP_TYPEHINT( Optional[float] ) = Py_None, SIP_PYOBJECT n SIP_TYPEHINT( Optional[bool] ) = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double x2 = 0.0, double y2 = 0.0, double z2 = 0.0, bool n = true )];
     % MethodCode
@@ -139,6 +140,14 @@ class CORE_EXPORT QgsBox3D
     }
     % End
 #endif
+
+    /**
+     * Constructs a QgsBox3D from two 3D vectors representing opposite corners of the box.
+     * The box is normalized after construction. If \a normalize is FALSE then
+     * the normalization step will not be applied automatically.
+     * \since QGIS 3.42
+     */
+    QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize = true );
 
     /**
      * Sets the box from a set of (x,y,z) minimum and maximum coordinates.
@@ -385,6 +394,12 @@ class CORE_EXPORT QgsBox3D
      * \since QGIS 3.26
      */
     void scale( double scaleFactor, double centerX, double centerY, double centerZ ) SIP_HOLDGIL;
+
+    /**
+     * Grows the box in place by the specified amount in all dimensions.
+     * \since QGIS 3.42
+     */
+    void grow( double delta );
 
     /**
      * Test if the box is null (holding no spatial information).

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -62,6 +62,14 @@ class CORE_EXPORT QgsBox3D
     QgsBox3D( const QgsPoint &p1, const QgsPoint &p2, bool normalize = true );
 
     /**
+     * Constructs a QgsBox3D from two 3D vectors representing opposite corners of the box.
+     * The box is normalized after construction. If \a normalize is FALSE then
+     * the normalization step will not be applied automatically.
+     * \since QGIS 3.42
+     */
+    QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize = true );
+
+    /**
      * Constructs a QgsBox3D from a rectangle.
      * If \a normalize is FALSE then the normalization step will not be applied automatically.
      */
@@ -70,7 +78,7 @@ class CORE_EXPORT QgsBox3D
               bool normalize = true );
 
 #else
-    QgsBox3D( SIP_PYOBJECT x SIP_TYPEHINT( Optional[Union[QgsPoint, QgsRectangle, float]] ) = Py_None, SIP_PYOBJECT y SIP_TYPEHINT( Optional[QgsPoint, float] ) = Py_None, SIP_PYOBJECT z SIP_TYPEHINT( Optional[Union[bool, float]] ) = Py_None, SIP_PYOBJECT x2 SIP_TYPEHINT( Optional[Union[bool, float]] ) = Py_None, SIP_PYOBJECT y2 SIP_TYPEHINT( Optional[float] ) = Py_None, SIP_PYOBJECT z2 SIP_TYPEHINT( Optional[float] ) = Py_None, SIP_PYOBJECT n SIP_TYPEHINT( Optional[bool] ) = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double x2 = 0.0, double y2 = 0.0, double z2 = 0.0, bool n = true )];
+    QgsBox3D( SIP_PYOBJECT x SIP_TYPEHINT( Optional[Union[QgsPoint, QgsVector3D, QgsRectangle, float]] ) = Py_None, SIP_PYOBJECT y SIP_TYPEHINT( Optional[QgsPoint, QgsVector3D, float] ) = Py_None, SIP_PYOBJECT z SIP_TYPEHINT( Optional[Union[bool, float]] ) = Py_None, SIP_PYOBJECT x2 SIP_TYPEHINT( Optional[Union[bool, float]] ) = Py_None, SIP_PYOBJECT y2 SIP_TYPEHINT( Optional[float] ) = Py_None, SIP_PYOBJECT z2 SIP_TYPEHINT( Optional[float] ) = Py_None, SIP_PYOBJECT n SIP_TYPEHINT( Optional[bool] ) = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double x2 = 0.0, double y2 = 0.0, double z2 = 0.0, bool n = true )];
     % MethodCode
     if ( sipCanConvertToType( a0, sipType_QgsRectangle, SIP_NOT_NONE ) && a4 == Py_None && a5 == Py_None && a6 == Py_None )
     {
@@ -115,6 +123,30 @@ class CORE_EXPORT QgsBox3D
         }
       }
     }
+    else if ( sipCanConvertToType( a0, sipType_QgsVector3D, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QgsVector3D, SIP_NOT_NONE ) && a3 == Py_None && a4 == Py_None && a5 == Py_None && a6 == Py_None )
+    {
+      int state;
+      sipIsErr = 0;
+
+      QgsVector3D *corner1 = reinterpret_cast<QgsVector3D *>( sipConvertToType( a0, sipType_QgsVector3D, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+      if ( sipIsErr )
+      {
+        sipReleaseType( corner1, sipType_QgsVector3D, state );
+      }
+      else
+      {
+        QgsVector3D *corner2 = reinterpret_cast<QgsVector3D *>( sipConvertToType( a1, sipType_QgsVector3D, 0, SIP_NOT_NONE, &state, &sipIsErr ) );
+        if ( sipIsErr )
+        {
+          sipReleaseType( corner2, sipType_QgsVector3D, state );
+        }
+        else
+        {
+          bool n = a2 == Py_None ? true : PyObject_IsTrue( a2 );
+          sipCpp = new QgsBox3D( *corner1, *corner2, n );
+        }
+      }
+    }
     else if (
       ( a0 == Py_None || PyFloat_AsDouble( a0 ) != -1.0 || !PyErr_Occurred() ) &&
       ( a1 == Py_None || PyFloat_AsDouble( a1 ) != -1.0 || !PyErr_Occurred() ) &&
@@ -140,14 +172,6 @@ class CORE_EXPORT QgsBox3D
     }
     % End
 #endif
-
-    /**
-     * Constructs a QgsBox3D from two 3D vectors representing opposite corners of the box.
-     * The box is normalized after construction. If \a normalize is FALSE then
-     * the normalization step will not be applied automatically.
-     * \since QGIS 3.42
-     */
-    QgsBox3D( const QgsVector3D &corner1, const QgsVector3D &corner2, bool normalize = true );
 
     /**
      * Sets the box from a set of (x,y,z) minimum and maximum coordinates.

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -151,9 +151,9 @@ void TestQgs3DCameraController::testTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QVector3D diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 
@@ -667,9 +667,9 @@ void TestQgs3DCameraController::testTranslateRotationCenterTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QVector3D diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 
@@ -702,9 +702,9 @@ void TestQgs3DCameraController::testTranslateRotationCenterTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::RotationCenter );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 9.1, 8.2, -42.0 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 9.1, 8.2, -42.0 ), 4.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 3.8, 5.3, 68.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 3.8, 5.3, 68.3 ), 4.0 );
   float diffPitch = scene->cameraController()->pitch() - initialPitch;
   float diffYaw = scene->cameraController()->yaw() - initialYaw;
   QGSCOMPARENEAR( diffPitch, 2.5, 0.1 );
@@ -748,9 +748,9 @@ void TestQgs3DCameraController::testTranslateRotationCenterTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -20.2, 0.0, -22.4 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -20.2, 0.0, -22.4 ), 4.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -20.2, 0.0, -22.4 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -20.2, 0.0, -22.4 ), 4.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 
@@ -829,9 +829,9 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QVector3D diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 
@@ -857,7 +857,7 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( 4.8, 9.9, 4.4 ), 1.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -615.0, -108.0, -116.6 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -615.0, -108.0, -116.6 ), 4.0 );
   QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1743.4, 2.0 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
   QCOMPARE( scene->cameraController()->mClickPoint, QPoint() );
@@ -982,9 +982,9 @@ void TestQgs3DCameraController::testTranslateRotationCameraTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QVector3D diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -944.6, 0.0, -180.3 ), 4.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 
@@ -1015,9 +1015,9 @@ void TestQgs3DCameraController::testTranslateRotationCameraTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::RotationCamera );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 2.7, 1.5, -78.0 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 2.7, 1.5, -78.0 ), 2.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 0.0, 0.0, 0.0 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 0.0, 0.0, 0.0 ), 2.0 );
   float diffPitch = scene->cameraController()->pitch() - initialPitch;
   float diffYaw = scene->cameraController()->yaw() - initialYaw;
   QGSCOMPARENEAR( diffPitch, 1.8, 0.1 );
@@ -1061,9 +1061,9 @@ void TestQgs3DCameraController::testTranslateRotationCameraTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -20.2, 0.0, -22.4 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -20.2, 0.0, -22.4 ), 2.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -20.2, 0.0, -22.4 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -20.2, 0.0, -22.4 ), 2.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -95,6 +95,31 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(box.yMaximum(), 13.0)
         self.assertEqual(box.zMaximum(), 5.0)
 
+        # constructor using two corners
+        box = QgsBox3d(QgsVector3D(3, 4, 5), QgsVector3D(8, 9, 10))
+        self.assertEqual(box.xMinimum(), 3.0)
+        self.assertEqual(box.yMinimum(), 4.0)
+        self.assertEqual(box.zMinimum(), 5.0)
+        self.assertEqual(box.xMaximum(), 8.0)
+        self.assertEqual(box.yMaximum(), 9.0)
+        self.assertEqual(box.zMaximum(), 10.0)
+
+        box = QgsBox3d(QgsVector3D(3, 4, 5), QgsVector3D(1, 2, 6))
+        self.assertEqual(box.xMinimum(), 1.0)
+        self.assertEqual(box.yMinimum(), 2.0)
+        self.assertEqual(box.zMinimum(), 5.0)
+        self.assertEqual(box.xMaximum(), 3.0)
+        self.assertEqual(box.yMaximum(), 4.0)
+        self.assertEqual(box.zMaximum(), 6.0)
+
+        box = QgsBox3d(QgsVector3D(3, 4, 5), QgsVector3D(1, 2, 6), False)
+        self.assertEqual(box.xMinimum(), 3.0)
+        self.assertEqual(box.yMinimum(), 4.0)
+        self.assertEqual(box.zMinimum(), 5.0)
+        self.assertEqual(box.xMaximum(), 1.0)
+        self.assertEqual(box.yMaximum(), 2.0)
+        self.assertEqual(box.zMaximum(), 6.0)
+
     def test_repr(self):
         box = QgsBox3d(5.0, 6.0, 7.0, 10.0, 11.0, 12.0)
         self.assertEqual(str(box), '<QgsBox3D(5, 6, 7, 10, 11, 12)>')
@@ -390,6 +415,16 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(box3.xMinimum(), 1.0)
         self.assertEqual(box3.yMinimum(), -7.0)
         self.assertEqual(box3.zMinimum(), -3.0)
+
+    def testGrow(self):
+        box = QgsBox3d(5.0, 6.0, 7.0, 11.0, 13.0, 15.0)
+        box.grow(2.0)
+        self.assertEqual(box.xMinimum(), 3.0)
+        self.assertEqual(box.yMinimum(), 4.0)
+        self.assertEqual(box.zMinimum(), 5.0)
+        self.assertEqual(box.xMaximum(), 13.0)
+        self.assertEqual(box.yMaximum(), 15.0)
+        self.assertEqual(box.zMaximum(), 17.0)
 
     def testIsNull(self):
         box1 = QgsBox3d()


### PR DESCRIPTION
- move from QgsAABB to QgsBox3D
- also switch from "world" coordinates (relative to 3d map scene origin, and flipped axes) to map coordinates
