### PR TITLE
Layout better node item creation

### DIFF
--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -90,7 +90,7 @@ should be created. The default behavior is to create a rectangular rubber band.
 .. seealso:: :py:func:`createNodeRubberBand`
 %End
 
-    virtual QAbstractGraphicsShapeItem *createNodeRubberBand( QgsLayoutView *view ) /TransferBack/;
+    virtual QGraphicsItem *createNodeRubberBand( QgsLayoutView *view ) /TransferBack/;
 %Docstring
 Creates a rubber band for use when creating layout node based items of this type. Can return ``None`` if no rubber band
 should be created. The default behavior is to return ``None``.

--- a/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -90,7 +90,7 @@ should be created. The default behavior is to create a rectangular rubber band.
 .. seealso:: :py:func:`createNodeRubberBand`
 %End
 
-    virtual QAbstractGraphicsShapeItem *createNodeRubberBand( QgsLayoutView *view ) /TransferBack/;
+    virtual QGraphicsItem *createNodeRubberBand( QgsLayoutView *view ) /TransferBack/;
 %Docstring
 Creates a rubber band for use when creating layout node based items of this type. Can return ``None`` if no rubber band
 should be created. The default behavior is to return ``None``.

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -3930,6 +3930,11 @@ void QgsLayoutDesignerDialog::activateNewItemCreationTool( int id, bool nodeBase
     if ( mView )
       mView->setTool( mAddNodeItemTool );
   }
+
+  if ( mLayout )
+  {
+    mLayout->deselectAll();
+  }
 }
 
 void QgsLayoutDesignerDialog::createLayoutPropertiesWidget()

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -611,6 +611,11 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   backSpace->setContext( Qt::WidgetWithChildrenShortcut );
 #endif
 
+  // Delete selection should be disabled when creating node item
+  connect( mAddNodeItemTool, &QgsLayoutViewTool::activated, this, [ this, backSpace ] { backSpace->setEnabled( false ); mActionDeleteSelection->setEnabled( false ); } );
+  connect( mAddNodeItemTool, &QgsLayoutViewTool::deactivated, this, [ this, backSpace ] { backSpace->setEnabled( true ); mActionDeleteSelection->setEnabled( true ); } );
+
+
   mActionPreviewModeOff->setChecked( true );
   connect( mActionPreviewModeOff, &QAction::triggered, this, [=] {
     mView->setPreviewModeEnabled( false );

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -613,8 +613,8 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
 #endif
 
   // Delete selection should be disabled when creating node item
-  connect( mAddNodeItemTool, &QgsLayoutViewTool::activated, this, [ this, backSpace ] { backSpace->setEnabled( false ); mActionDeleteSelection->setEnabled( false ); } );
-  connect( mAddNodeItemTool, &QgsLayoutViewTool::deactivated, this, [ this, backSpace ] { backSpace->setEnabled( true ); mActionDeleteSelection->setEnabled( true ); } );
+  connect( mAddNodeItemTool, &QgsLayoutViewTool::activated, this, [this, backSpace] { backSpace->setEnabled( false ); mActionDeleteSelection->setEnabled( false ); } );
+  connect( mAddNodeItemTool, &QgsLayoutViewTool::deactivated, this, [this, backSpace] { backSpace->setEnabled( true ); mActionDeleteSelection->setEnabled( true ); } );
 
 
   mActionPreviewModeOff->setChecked( true );
@@ -3935,11 +3935,6 @@ void QgsLayoutDesignerDialog::activateNewItemCreationTool( int id, bool nodeBase
     mAddNodeItemTool->setItemMetadataId( id );
     if ( mView )
       mView->setTool( mAddNodeItemTool );
-  }
-
-  if ( mLayout )
-  {
-    mLayout->deselectAll();
   }
 }
 

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -431,6 +431,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   mViewFrame->setLayout( viewLayout );
   mViewFrame->setContentsMargins( 0, 0, 0, 1 ); // 1 is deliberate!
   mView->setFrameShape( QFrame::NoFrame );
+  mView->setRenderHints( QPainter::Antialiasing );
 
   connect( mActionClose, &QAction::triggered, this, &QWidget::close );
 

--- a/src/gui/layout/qgslayoutguiutils.cpp
+++ b/src/gui/layout/qgslayoutguiutils.cpp
@@ -387,9 +387,14 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
     arrow->setEndMarker( QgsLayoutItemPolyline::ArrowHead );
     return arrow.release();
   } );
-  arrowMetadata->setNodeRubberBandCreationFunction( []( QgsLayoutView * ) -> QGraphicsPathItem * {
-    std::unique_ptr<QGraphicsPathItem> band = std::make_unique<QGraphicsPathItem>();
-    band->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0 ) );
+  arrowMetadata->setNodeRubberBandCreationFunction( []( QgsLayoutView * ) -> QGraphicsItemGroup * {
+    std::unique_ptr<QGraphicsItemGroup> band = std::make_unique<QGraphicsItemGroup>();
+    QGraphicsPathItem *poly = new QGraphicsPathItem( band.get() );
+    poly->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0 ) );
+
+    QGraphicsPathItem *tempPoly = new QGraphicsPathItem( band.get() );
+    tempPoly->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0, Qt::DotLine ) );
+
     band->setZValue( QgsLayout::ZViewTool );
     return band.release();
   } );
@@ -404,10 +409,16 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
     },
     createRubberBand, QStringLiteral( "nodes" ), true
   );
-  polygonMetadata->setNodeRubberBandCreationFunction( []( QgsLayoutView * ) -> QGraphicsPolygonItem * {
-    std::unique_ptr<QGraphicsPolygonItem> band = std::make_unique<QGraphicsPolygonItem>();
-    band->setBrush( Qt::NoBrush );
-    band->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0 ) );
+  polygonMetadata->setNodeRubberBandCreationFunction( []( QgsLayoutView * ) -> QGraphicsItemGroup * {
+    std::unique_ptr<QGraphicsItemGroup> band = std::make_unique<QGraphicsItemGroup>();
+    QGraphicsPolygonItem *poly = new QGraphicsPolygonItem( band.get() );
+    poly->setBrush( QBrush( QColor( 227, 22, 22, 20 ) ) );
+    poly->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0 ) );
+
+    QGraphicsPolygonItem *tempPoly = new QGraphicsPolygonItem( band.get() );
+    tempPoly->setBrush( Qt::NoBrush );
+    tempPoly->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0, Qt::DotLine ) );
+
     band->setZValue( QgsLayout::ZViewTool );
     return band.release();
   } );
@@ -420,9 +431,14 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
     },
     createRubberBand, QStringLiteral( "nodes" ), true
   );
-  polylineMetadata->setNodeRubberBandCreationFunction( []( QgsLayoutView * ) -> QGraphicsPathItem * {
-    std::unique_ptr<QGraphicsPathItem> band = std::make_unique<QGraphicsPathItem>();
-    band->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0 ) );
+  polylineMetadata->setNodeRubberBandCreationFunction( []( QgsLayoutView * ) -> QGraphicsItemGroup * {
+    std::unique_ptr<QGraphicsItemGroup> band = std::make_unique<QGraphicsItemGroup>();
+    QGraphicsPathItem *poly = new QGraphicsPathItem( band.get() );
+    poly->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0 ) );
+
+    QGraphicsPathItem *tempPoly = new QGraphicsPathItem( band.get() );
+    tempPoly->setPen( QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0, Qt::DotLine ) );
+
     band->setZValue( QgsLayout::ZViewTool );
     return band.release();
   } );

--- a/src/gui/layout/qgslayoutitemguiregistry.cpp
+++ b/src/gui/layout/qgslayoutitemguiregistry.cpp
@@ -28,7 +28,7 @@ QgsLayoutViewRubberBand *QgsLayoutItemAbstractGuiMetadata::createRubberBand( Qgs
   return new QgsLayoutViewRectangularRubberBand( view );
 }
 
-QAbstractGraphicsShapeItem *QgsLayoutItemAbstractGuiMetadata::createNodeRubberBand( QgsLayoutView * )
+QGraphicsItem *QgsLayoutItemAbstractGuiMetadata::createNodeRubberBand( QgsLayoutView * )
 {
   return nullptr;
 }
@@ -160,7 +160,7 @@ QgsLayoutViewRubberBand *QgsLayoutItemGuiRegistry::createItemRubberBand( int met
   return mMetadata[metadataId]->createRubberBand( view );
 }
 
-QAbstractGraphicsShapeItem *QgsLayoutItemGuiRegistry::createNodeItemRubberBand( int metadataId, QgsLayoutView *view )
+QGraphicsItem *QgsLayoutItemGuiRegistry::createNodeItemRubberBand( int metadataId, QgsLayoutView *view )
 {
   if ( !mMetadata.contains( metadataId ) )
     return nullptr;

--- a/src/gui/layout/qgslayoutitemguiregistry.h
+++ b/src/gui/layout/qgslayoutitemguiregistry.h
@@ -137,7 +137,7 @@ class GUI_EXPORT QgsLayoutItemAbstractGuiMetadata
      * should be created. The default behavior is to return NULLPTR.
      * \see createRubberBand()
      */
-    virtual QAbstractGraphicsShapeItem *createNodeRubberBand( QgsLayoutView *view ) SIP_TRANSFERBACK;
+    virtual QGraphicsItem *createNodeRubberBand( QgsLayoutView *view ) SIP_TRANSFERBACK;
 
     /**
      * Creates an instance of the corresponding item type.
@@ -176,7 +176,7 @@ typedef std::function<QgsLayoutItemBaseWidget *( QgsLayoutItem * )> QgsLayoutIte
 typedef std::function<QgsLayoutViewRubberBand *( QgsLayoutView * )> QgsLayoutItemRubberBandFunc SIP_SKIP;
 
 //! Layout node based rubber band creation function
-typedef std::function<QAbstractGraphicsShapeItem *( QgsLayoutView * )> QgsLayoutNodeItemRubberBandFunc SIP_SKIP;
+typedef std::function<QGraphicsItem *( QgsLayoutView * )> QgsLayoutNodeItemRubberBandFunc SIP_SKIP;
 
 //! Layout item added to layout callback
 typedef std::function<void( QgsLayoutItem *, const QVariantMap & )> QgsLayoutItemAddedToLayoutFunc SIP_SKIP;
@@ -290,7 +290,7 @@ class GUI_EXPORT QgsLayoutItemGuiMetadata : public QgsLayoutItemAbstractGuiMetad
     QIcon creationIcon() const override { return mIcon.isNull() ? QgsLayoutItemAbstractGuiMetadata::creationIcon() : mIcon; }
     QgsLayoutItemBaseWidget *createItemWidget( QgsLayoutItem *item ) override { return mWidgetFunc ? mWidgetFunc( item ) : nullptr; }
     QgsLayoutViewRubberBand *createRubberBand( QgsLayoutView *view ) override { return mRubberBandFunc ? mRubberBandFunc( view ) : nullptr; }
-    QAbstractGraphicsShapeItem *createNodeRubberBand( QgsLayoutView *view ) override { return mNodeRubberBandFunc ? mNodeRubberBandFunc( view ) : nullptr; }
+    QGraphicsItem *createNodeRubberBand( QgsLayoutView *view ) override { return mNodeRubberBandFunc ? mNodeRubberBandFunc( view ) : nullptr; }
 
     QgsLayoutItem *createItem( QgsLayout *layout ) override;
     void newItemAddedToLayout( QgsLayoutItem *item ) override;
@@ -494,7 +494,7 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
      * \see createItemRubberBand()
      * \note not available from Python bindings
      */
-    QAbstractGraphicsShapeItem *createNodeItemRubberBand( int metadataId, QgsLayoutView *view ) SIP_SKIP;
+    QGraphicsItem *createNodeItemRubberBand( int metadataId, QgsLayoutView *view ) SIP_SKIP;
 
     /**
      * Returns a list of available item metadata ids handled by the registry.

--- a/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
+++ b/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
@@ -55,6 +55,9 @@ void QgsLayoutViewToolAddNodeItem::layoutPressEvent( QgsLayoutViewMouseEvent *ev
       mRubberBand.reset( QgsGui::layoutItemGuiRegistry()->createNodeItemRubberBand( mItemMetadataId, view() ) );
       if ( mRubberBand )
         layout()->addItem( mRubberBand.get() );
+
+      // On first press, deselect the currently selected item, if any
+      view()->deselectAll();
     }
 
     if ( mRubberBand )
@@ -192,8 +195,14 @@ void QgsLayoutViewToolAddNodeItem::moveTemporaryNode( QPointF scenePoint, Qt::Ke
 void QgsLayoutViewToolAddNodeItem::setRubberBandNodes()
 {
   QList<QGraphicsItem *> items = mRubberBand->childItems();
+
+  // Rubber band is not a QGraphicsItem with children, but may be
+  // a custom QGraphicsPolygonItem / QGraphicsPathItem returned by a Python plugin
+  // In this case, directly append it to the list.
   if ( items.isEmpty() )
-    return;
+  {
+    items << mRubberBand.get();
+  }
 
   if ( QGraphicsPolygonItem *polygonItem = dynamic_cast<QGraphicsPolygonItem *>( items[0] ) )
   {

--- a/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
+++ b/src/gui/layout/qgslayoutviewtooladdnodeitem.cpp
@@ -131,6 +131,7 @@ void QgsLayoutViewToolAddNodeItem::keyPressEvent( QKeyEvent *event )
       //remove last added vertex
       mPolygon.pop_back();
       setRubberBandNodes();
+      moveTemporaryNode( view()->mapToScene( view()->mapFromGlobal( QCursor::pos() ) ), event->modifiers() );
     }
     else
     {

--- a/src/gui/layout/qgslayoutviewtooladdnodeitem.h
+++ b/src/gui/layout/qgslayoutviewtooladdnodeitem.h
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsLayoutViewToolAddNodeItem : public QgsLayoutViewTool
     int mItemMetadataId = -1;
 
     //! Rubber band item
-    std::unique_ptr<QAbstractGraphicsShapeItem> mRubberBand;
+    std::unique_ptr<QGraphicsItem> mRubberBand;
 
     QPolygonF mPolygon;
 


### PR DESCRIPTION
## Description

Add a secondary rubberband in node item creation tools to better show the polyline / polygon being traced, which match the digitizing tools behavior.

Tracing a new node item now clears the current selection.

Also fix pressing Backspace/Del keypress removes the last node. It was "eaten" by the global QShortcut that deletes the current item.


### Before (Not possible to remove point, unclear what polygon will actually be drawn if one right-clicks)

![add_node_item_old](https://github.com/user-attachments/assets/2671cdea-372e-4f73-9fe3-5498cec468c0)


### After

![add_node_item](https://github.com/user-attachments/assets/0a5119bc-a8a9-46b1-8171-4085d3b19f14)
