### PR TITLE
Update the milestone during issue report creation for docs repo

### DIFF
--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -1,6 +1,7 @@
 name: 📅 Auto set milestone on PR
 
 on:
+  workflow_call:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - closed
 
 permissions:
   contents: read

--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -76,6 +76,12 @@ jobs:
           reactions: '+1'
 
 
+  update-milestone:
+    if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'Needs Documentation') ) || github.event.label.name == 'Needs Documentation' )
+    # Update the milestone (if necessary)
+    name: Update final milestone
+    uses: ./.github/workflows/pr-auto-milestone.yml
+
   create-doc-issue:
     if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'Needs Documentation') ) || github.event.label.name == 'Needs Documentation' )
     runs-on: ubuntu-latest


### PR DESCRIPTION
calling the existing action in the workflow

As you can see in https://github.com/qgis/QGIS-Documentation/issues/9319 and https://github.com/qgis/QGIS-Documentation/issues/9318, the reported version is 3.40 instead of 3.42, meaning that #57421 which is supposed to update the version number during merging didn't work as expected. This PR provides an alternative approach.