### PR TITLE
Fix passing missing context to expression of "select by expression"

### DIFF
--- a/python/plugins/processing/algs/qgis/SelectByExpression.py
+++ b/python/plugins/processing/algs/qgis/SelectByExpression.py
@@ -87,6 +87,8 @@ class SelectByExpression(QgisAlgorithm):
         if qExp.hasParserError():
             raise QgsProcessingException(qExp.parserErrorString())
 
-        layer.selectByExpression(expression, behavior)
+        expression_context = self.createExpressionContext(parameters, context)
+
+        layer.selectByExpression(expression, behavior, expression_context)
 
         return {self.OUTPUT: parameters[self.INPUT]}


### PR DESCRIPTION
Just creating the context and pass it to `selectByExpression`

It needs it to use context (like variables) when it's used in the modeller.