### PR TITLE
Fix slow retrieval of horizontal crs from compound crs

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -203,6 +203,11 @@ If no prefix is specified, WKT definition is assumed.
 
 :param definition: A String containing a coordinate reference system definition.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 .. seealso:: :py:func:`createFromString`
 %End
 
@@ -245,6 +250,11 @@ QgsCoordinateReferenceSystem object.
 %Docstring
 Creates a CRS from a given OGC WMS-format Coordinate Reference System string.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 :param ogcCrs: OGR compliant CRS definition, e.g., "EPSG:4326"
 
 :return: matching CRS, or an invalid CRS if string could not be matched
@@ -256,6 +266,11 @@ Creates a CRS from a given OGC WMS-format Coordinate Reference System string.
 %Docstring
 Creates a CRS from a given EPSG ID.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 :param epsg: epsg CRS ID
 
 :return: matching CRS, or an invalid CRS if string could not be matched
@@ -264,6 +279,11 @@ Creates a CRS from a given EPSG ID.
  static QgsCoordinateReferenceSystem fromProj4( const QString &proj4 ) /Deprecated/;
 %Docstring
 Creates a CRS from a proj style formatted string.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 :return: matching CRS, or an invalid CRS if string could not be matched
 
@@ -291,6 +311,11 @@ Creates a CRS from a proj style formatted string.
 %Docstring
 Creates a CRS from a WKT spatial ref sys definition string.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 :param wkt: WKT for the desired spatial reference system.
 
 :return: matching CRS, or an invalid CRS if string could not be matched
@@ -301,6 +326,11 @@ Creates a CRS from a WKT spatial ref sys definition string.
     static QgsCoordinateReferenceSystem fromSrsId( long srsId );
 %Docstring
 Creates a CRS from a specified QGIS SRS ID.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 :param srsId: internal QGIS SRS ID
 
@@ -354,7 +384,8 @@ and refer to QGIS internal CRS IDs.
 
 .. note::
 
-   this method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromOgcWmsCrs`
 %End
@@ -390,7 +421,8 @@ and :py:func:`~QgsCoordinateReferenceSystem.createFromOgcWmsCrs` is used to init
 
 .. note::
 
-   this method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromWkt`
 %End
@@ -408,7 +440,8 @@ user's local CRS database from home directory is used.
 
 .. note::
 
-   this method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromSrsId`
 
@@ -445,7 +478,8 @@ We try to match the Proj string to internal QGIS CRS ID using the following logi
 
 .. note::
 
-   This method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromProj`
 
@@ -484,7 +518,8 @@ We try to match the Proj string to internal QGIS CRS ID using the following logi
 
 .. note::
 
-   This method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromProj`
 
@@ -506,6 +541,11 @@ It supports the following formats:
 If no prefix is specified, WKT definition is assumed.
 
 :param definition: A String containing a coordinate reference system definition.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 :return: ``True`` on success else ``False``
 %End
@@ -531,6 +571,11 @@ For more details on supported formats see OGRSpatialReference.SetFromUserInput()
 
    this function generates a WKT string using OSRSetFromUserInput() and
    passes it to :py:func:`~QgsCoordinateReferenceSystem.createFromWkt` function.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 %End
 
  static void setupESRIWktFix() /Deprecated/;

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -203,6 +203,11 @@ If no prefix is specified, WKT definition is assumed.
 
 :param definition: A String containing a coordinate reference system definition.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 .. seealso:: :py:func:`createFromString`
 %End
 
@@ -245,6 +250,11 @@ QgsCoordinateReferenceSystem object.
 %Docstring
 Creates a CRS from a given OGC WMS-format Coordinate Reference System string.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 :param ogcCrs: OGR compliant CRS definition, e.g., "EPSG:4326"
 
 :return: matching CRS, or an invalid CRS if string could not be matched
@@ -256,6 +266,11 @@ Creates a CRS from a given OGC WMS-format Coordinate Reference System string.
 %Docstring
 Creates a CRS from a given EPSG ID.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 :param epsg: epsg CRS ID
 
 :return: matching CRS, or an invalid CRS if string could not be matched
@@ -264,6 +279,11 @@ Creates a CRS from a given EPSG ID.
  static QgsCoordinateReferenceSystem fromProj4( const QString &proj4 ) /Deprecated/;
 %Docstring
 Creates a CRS from a proj style formatted string.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 :return: matching CRS, or an invalid CRS if string could not be matched
 
@@ -291,6 +311,11 @@ Creates a CRS from a proj style formatted string.
 %Docstring
 Creates a CRS from a WKT spatial ref sys definition string.
 
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+
 :param wkt: WKT for the desired spatial reference system.
 
 :return: matching CRS, or an invalid CRS if string could not be matched
@@ -301,6 +326,11 @@ Creates a CRS from a WKT spatial ref sys definition string.
     static QgsCoordinateReferenceSystem fromSrsId( long srsId );
 %Docstring
 Creates a CRS from a specified QGIS SRS ID.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 :param srsId: internal QGIS SRS ID
 
@@ -354,7 +384,8 @@ and refer to QGIS internal CRS IDs.
 
 .. note::
 
-   this method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromOgcWmsCrs`
 %End
@@ -390,7 +421,8 @@ and :py:func:`~QgsCoordinateReferenceSystem.createFromOgcWmsCrs` is used to init
 
 .. note::
 
-   this method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromWkt`
 %End
@@ -408,7 +440,8 @@ user's local CRS database from home directory is used.
 
 .. note::
 
-   this method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromSrsId`
 
@@ -445,7 +478,8 @@ We try to match the Proj string to internal QGIS CRS ID using the following logi
 
 .. note::
 
-   This method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromProj`
 
@@ -484,7 +518,8 @@ We try to match the Proj string to internal QGIS CRS ID using the following logi
 
 .. note::
 
-   This method uses an internal cache. Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 .. seealso:: :py:func:`fromProj`
 
@@ -506,6 +541,11 @@ It supports the following formats:
 If no prefix is specified, WKT definition is assumed.
 
 :param definition: A String containing a coordinate reference system definition.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 
 :return: ``True`` on success else ``False``
 %End
@@ -531,6 +571,11 @@ For more details on supported formats see OGRSpatialReference.SetFromUserInput()
 
    this function generates a WKT string using OSRSetFromUserInput() and
    passes it to :py:func:`~QgsCoordinateReferenceSystem.createFromWkt` function.
+
+.. note::
+
+   This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+   Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 %End
 
  static void setupESRIWktFix() /Deprecated/;

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -3242,7 +3242,7 @@ bool QgsCoordinateReferenceSystem::createFromProjObject( PJ *object )
     // maybe we can directly grab the auth name and code from the crs
     const QString authName( proj_get_id_auth_name( d->threadLocalProjObject(), 0 ) );
     const QString authCode( proj_get_id_code( d->threadLocalProjObject(), 0 ) );
-    if ( !authName.isEmpty() && !authCode.isEmpty() && loadFromAuthCode( authName, authCode ) )
+    if ( !authName.isEmpty() && !authCode.isEmpty() && createFromOgcWmsCrs( QStringLiteral( "%1:%2" ).arg( authName, authCode ) ) )
     {
       return d->mIsValid;
     }

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -247,6 +247,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *
      * If no prefix is specified, WKT definition is assumed.
      * \param definition A String containing a coordinate reference system definition.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \see createFromString()
      */
     explicit QgsCoordinateReferenceSystem( const QString &definition );
@@ -287,6 +291,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Creates a CRS from a given OGC WMS-format Coordinate Reference System string.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \param ogcCrs OGR compliant CRS definition, e.g., "EPSG:4326"
      * \returns matching CRS, or an invalid CRS if string could not be matched
      * \see createFromOgcWmsCrs()
@@ -295,6 +303,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Creates a CRS from a given EPSG ID.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \param epsg epsg CRS ID
      * \returns matching CRS, or an invalid CRS if string could not be matched
     */
@@ -302,6 +314,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Creates a CRS from a proj style formatted string.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \returns matching CRS, or an invalid CRS if string could not be matched
      * \see createFromProj()
      * \deprecated QGIS 3.10. Use fromProj() instead.
@@ -319,6 +335,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Creates a CRS from a WKT spatial ref sys definition string.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \param wkt WKT for the desired spatial reference system.
      * \returns matching CRS, or an invalid CRS if string could not be matched
      * \see createFromWkt()
@@ -327,6 +347,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Creates a CRS from a specified QGIS SRS ID.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \param srsId internal QGIS SRS ID
      * \returns matching CRS, or an invalid CRS if ID could not be found
      * \see createFromSrsId()
@@ -371,7 +395,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * It also recognizes "QGIS", "USER", "CUSTOM" authorities, which all have the same meaning
      * and refer to QGIS internal CRS IDs.
      * \returns TRUE on success else FALSE
-     * \note this method uses an internal cache. Call invalidateCache() to clear the cache.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \see fromOgcWmsCrs()
      */
     bool createFromOgcWmsCrs( const QString &crs );
@@ -396,7 +423,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \param wkt The WKT for the desired spatial reference system.
      * \returns TRUE on success else FALSE
      * \note Some members may be left blank if no match can be found in CRS database.
-     * \note this method uses an internal cache. Call invalidateCache() to clear the cache.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \see fromWkt()
      */
     bool createFromWkt( const QString &wkt );
@@ -408,7 +438,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * user's local CRS database from home directory is used.
      * \param srsId The internal QGIS CRS ID for the desired spatial reference system.
      * \returns TRUE on success else FALSE
-     * \note this method uses an internal cache. Call invalidateCache() to clear the cache.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \see fromSrsId()
      * \warning This method is highly discouraged, and CRS objects should instead be constructed
      * using auth:id codes or WKT strings
@@ -434,7 +467,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \param projString A Proj format string
      * \returns TRUE on success else FALSE
      * \note Some members may be left blank if no match can be found in CRS database.
-     * \note This method uses an internal cache. Call invalidateCache() to clear the cache.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \see fromProj()
      * \deprecated QGIS 3.10. Use createFromProj() instead.
      */
@@ -463,7 +499,9 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *
      * \returns TRUE on success else FALSE
      * \note Some members may be left blank if no match can be found in CRS database.
-     * \note This method uses an internal cache. Call invalidateCache() to clear the cache.
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \see fromProj()
      * \since QGIS 3.10.3
      */
@@ -486,6 +524,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *
      * If no prefix is specified, WKT definition is assumed.
      * \param definition A String containing a coordinate reference system definition.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
+     *
      * \returns TRUE on success else FALSE
      */
     bool createFromString( const QString &definition );
@@ -506,6 +548,9 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \returns TRUE on success else FALSE
      * \note this function generates a WKT string using OSRSetFromUserInput() and
      * passes it to createFromWkt() function.
+     *
+     * \note This method uses an internal cache to speed up creation of multiple CRS with the same definition.
+     * Call invalidateCache() to clear the cache.
      */
     bool createFromUserInput( const QString &definition );
 
@@ -1043,14 +1088,14 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 #ifndef SIP_RUN
 
     /**
-     * Returns the underlying PROJ PJ object corresponding to the CRS, or NULLPTR
-     * if the CRS is invalid.
-     *
-     * This object is only valid for the lifetime of the QgsCoordinateReferenceSystem.
-     *
-     * \note Not available in Python bindings.
-     * \since QGIS 3.8
-     */
+    * Returns the underlying PROJ PJ object corresponding to the CRS, or NULLPTR
+    * if the CRS is invalid.
+    *
+    * This object is only valid for the lifetime of the QgsCoordinateReferenceSystem.
+    *
+    * \note Not available in Python bindings.
+    * \since QGIS 3.8
+    */
     PJ *projObject() const;
 
     /**
@@ -1188,6 +1233,11 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     //! Helper for getting number of user CRS already in db
     static long getRecordCount();
 
+    /**
+     * \warning This method does not utilize caching, and can be slow to call. Consider
+     * using one of the alternate createFrom methods or constructors which take
+     * advantage of caches.
+     */
     bool loadFromAuthCode( const QString &auth, const QString &code );
 
     /**


### PR DESCRIPTION
Build horizontal CRS object from proj object using a method which can take advantage of previously cached CRS objects

Fixes #59266
