### PR TITLE
Optimise QgsCoordinateTransform::transformBoundingBox

### DIFF
--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -634,9 +634,9 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
 
   // We're interfacing with C-style vectors in the
   // end, so let's do C-style vectors here too.
-  QVector<double> x( nXPoints * nYPoints );
-  QVector<double> y( nXPoints * nYPoints );
-  QVector<double> z( nXPoints * nYPoints );
+  std::vector<double> x( nXPoints * static_cast< std::size_t >( nYPoints ) );
+  std::vector<double> y( nXPoints * static_cast< std::size_t >( nYPoints ) );
+  std::vector<double> z( nXPoints * static_cast< std::size_t >( nYPoints ) );
 
   QgsDebugMsgLevel( QStringLiteral( "Entering transformBoundingBox..." ), 4 );
 

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -632,8 +632,6 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
   QgsRectangle bb_rect;
   bb_rect.setNull();
 
-  // We're interfacing with C-style vectors in the
-  // end, so let's do C-style vectors here too.
   std::vector<double> x( nXPoints * static_cast< std::size_t >( nYPoints ) );
   std::vector<double> y( nXPoints * static_cast< std::size_t >( nYPoints ) );
   std::vector<double> z( nXPoints * static_cast< std::size_t >( nYPoints ) );


### PR DESCRIPTION
Using std::vector is preferable here, as we don't need implicit sharing of the container or want the extra overhead associated with it
