### PR TITLE
Fix building qgis with Qt6 on MinGW-w64

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -525,9 +525,9 @@ else()
   endif()
   add_executable(${QGIS_APP_NAME} ${MACOSX_BUNDLE} WIN32 ${QGIS_APPMAIN_SRCS})
 
-  if(MSVC AND BUILD_WITH_QT6)
+  if(WIN32 AND BUILD_WITH_QT6)
     qt_disable_unicode_defines(${QGIS_APP_NAME})
-  endif(MSVC AND BUILD_WITH_QT6)
+  endif(WIN32 AND BUILD_WITH_QT6)
 
   # require c++17
   target_compile_features(${QGIS_APP_NAME} PRIVATE cxx_std_17)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1664,6 +1664,11 @@ if(MSVC)
     ${CMAKE_BINARY_DIR}/src/gui/qgis_gui_autogen/mocs_compilation.cpp
     PROPERTIES COMPILE_FLAGS "/bigobj"
   )
+elseif(MINGW)
+  set_source_files_properties(
+    ${CMAKE_BINARY_DIR}/src/gui/qgis_gui_autogen/mocs_compilation.cpp
+    PROPERTIES COMPILE_FLAGS "-Wa,-mbig-obj"
+  )
 endif()
 
 #############################################################


### PR DESCRIPTION
## Description

These changes fix building QGIS with Qt6 on MinGW-w64
