### PR TITLE
fix(featurepool): cache management - fixes #58113

### DIFF
--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
@@ -121,15 +121,20 @@ To be used by implementations of ``addFeature``.
    the original layer's thread.
 %End
 
-    void refreshCache( const QgsFeature &feature );
+    void refreshCache( QgsFeature feature, const QgsFeature &origFeature );
 %Docstring
 Changes a feature in the cache and the spatial index.
 To be used by implementations of ``updateFeature``.
+
+:param feature: the new feature to put in the cache and index
+:param origFeature: the original feature to remove from the index
 
 .. note::
 
    This method can safely be called from a different thread vs the object's creation thread or
    the original layer's thread.
+
+.. versionadded:: 3.42
 %End
 
     void removeFeature( const QgsFeatureId featureId );

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsfeaturepool.sip.in
@@ -121,15 +121,20 @@ To be used by implementations of ``addFeature``.
    the original layer's thread.
 %End
 
-    void refreshCache( const QgsFeature &feature );
+    void refreshCache( QgsFeature feature, const QgsFeature &origFeature );
 %Docstring
 Changes a feature in the cache and the spatial index.
 To be used by implementations of ``updateFeature``.
+
+:param feature: the new feature to put in the cache and index
+:param origFeature: the original feature to remove from the index
 
 .. note::
 
    This method can safely be called from a different thread vs the object's creation thread or
    the original layer's thread.
+
+.. versionadded:: 3.42
 %End
 
     void removeFeature( const QgsFeatureId featureId );

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -49,7 +49,18 @@ bool QgsFeaturePool::getFeature( QgsFeatureId id, QgsFeature &feature )
   //
   // https://bugreports.qt.io/browse/QTBUG-19794
 
-  QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Write );
+  // If the feature we want is amongst the features that have been updated,
+  // then get it from the dedicated hash.
+  // It would not be thread-safe to get it directly from the layer,
+  // and it could be outdated in the feature source (in case of a memory layer),
+  // and it could have been cleared from the cache due to a cache overflow.
+  if ( mUpdatedFeatures.contains( id ) )
+  {
+    feature = mUpdatedFeatures[id];
+    return true;
+  }
+
+  QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Read );
   QgsFeature *cachedFeature = mFeatureCache.object( id );
   if ( cachedFeature )
   {
@@ -78,6 +89,7 @@ QgsFeatureIds QgsFeaturePool::getFeatures( const QgsFeatureRequest &request, Qgs
   Q_ASSERT( mLayer );
   Q_ASSERT( QThread::currentThread() == mLayer->thread() );
 
+  mUpdatedFeatures.clear();
   mFeatureCache.clear();
   mIndex = QgsSpatialIndex();
 
@@ -131,19 +143,21 @@ void QgsFeaturePool::insertFeature( const QgsFeature &feature, bool skipLock )
   mIndex.addFeature( indexFeature );
 }
 
-void QgsFeaturePool::refreshCache( const QgsFeature &feature )
+void QgsFeaturePool::refreshCache( QgsFeature feature, const QgsFeature &origFeature )
 {
-  QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Write );
-  mFeatureCache.remove( feature.id() );
-  mIndex.deleteFeature( feature );
-  locker.unlock();
+  // insert/refresh the updated features as well
+  mUpdatedFeatures.insert( feature.id(), feature );
 
-  QgsFeature tempFeature;
-  getFeature( feature.id(), tempFeature );
+  QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Write );
+  mFeatureCache.insert( feature.id(), new QgsFeature( feature ) );
+  mIndex.deleteFeature( origFeature );
+  mIndex.addFeature( feature );
+  locker.unlock();
 }
 
 void QgsFeaturePool::removeFeature( const QgsFeatureId featureId )
 {
+  mUpdatedFeatures.remove( featureId );
   QgsFeature origFeature;
   QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Unlocked );
   if ( getFeature( featureId, origFeature ) )

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -171,10 +171,14 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink SIP_ABSTRACT
      * Changes a feature in the cache and the spatial index.
      * To be used by implementations of ``updateFeature``.
      *
+     * \param feature the new feature to put in the cache and index
+     * \param origFeature the original feature to remove from the index
+     *
      * \note This method can safely be called from a different thread vs the object's creation thread or
      * the original layer's thread.
+     * \since QGIS 3.42
      */
-    void refreshCache( const QgsFeature &feature );
+    void refreshCache( QgsFeature feature, const QgsFeature &origFeature );
 
     /**
      * Removes a feature from the cache and the spatial index.
@@ -219,6 +223,20 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink SIP_ABSTRACT
     QString mLayerId;
     QString mLayerName;
     QgsCoordinateReferenceSystem mCrs;
+
+    /**
+    * Hash containing features whose geometry has been updated
+    * but which are not accessible if we get them
+    * from the layer (not thread-safe).
+    *
+    * The philosophy is that as soon as a feature geometry has
+    * changed, it will be in this hash, and the cache will not
+    * be used any more.
+    * \since QGIS 3.42
+    */
+    QHash<QgsFeatureId, QgsFeature> mUpdatedFeatures;
+
+    friend class TestQgsVectorLayerFeaturePool;
 };
 
 #endif // QGS_FEATUREPOOL_H

--- a/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
@@ -153,7 +153,7 @@ void QgsVectorDataProviderFeaturePool::updateFeature( QgsFeature &feature )
     }
   } );
 
-  refreshCache( feature );
+  refreshCache( feature, origFeature );
 }
 
 void QgsVectorDataProviderFeaturePool::deleteFeature( QgsFeatureId fid )

--- a/src/analysis/vector/geometry_checker/qgsvectorlayerfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsvectorlayerfeaturepool.cpp
@@ -109,6 +109,9 @@ bool QgsVectorLayerFeaturePool::addFeatures( QgsFeatureList &features, QgsFeatur
 
 void QgsVectorLayerFeaturePool::updateFeature( QgsFeature &feature )
 {
+  QgsFeature origFeature;
+  getFeature( feature.id(), origFeature );
+
   QgsThreadingUtils::runOnMainThread( [this, &feature]()
   {
     QgsVectorLayer *lyr = layer();
@@ -118,7 +121,7 @@ void QgsVectorLayerFeaturePool::updateFeature( QgsFeature &feature )
     }
   } );
 
-  refreshCache( feature );
+  refreshCache( feature, origFeature );
 }
 
 void QgsVectorLayerFeaturePool::deleteFeature( QgsFeatureId fid )
@@ -136,14 +139,12 @@ void QgsVectorLayerFeaturePool::deleteFeature( QgsFeatureId fid )
 
 void QgsVectorLayerFeaturePool::onGeometryChanged( QgsFeatureId fid, const QgsGeometry &geometry )
 {
-  Q_UNUSED( geometry )
-
-  if ( isFeatureCached( fid ) )
-  {
-    QgsFeature feature;
-    getFeature( fid, feature );
-    refreshCache( feature );
-  }
+  QgsFeature feature;
+  QgsFeature origFeature;
+  getFeature( fid, origFeature );
+  feature = origFeature;
+  feature.setGeometry( geometry );
+  refreshCache( feature, origFeature );
 }
 
 void QgsVectorLayerFeaturePool::onFeatureDeleted( QgsFeatureId fid )

--- a/tests/src/geometry_checker/testqgsvectorlayerfeaturepool.cpp
+++ b/tests/src/geometry_checker/testqgsvectorlayerfeaturepool.cpp
@@ -142,29 +142,59 @@ void TestQgsVectorLayerFeaturePool::changeGeometry()
   feat.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon((100 100, 110 100, 110 110, 100 110, 100 100))" ) ) );
   vl->updateFeature( feat );
 
-  // Still working on the cached data
+  // Cached data updated with geometryChanged vector layer signal
   const QgsFeatureIds ids3 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
-  QCOMPARE( ids3.size(), 1 );
+  QCOMPARE( ids3.size(), 0 );
 
-  // Repopulate the cache
-  const QgsFeatureIds ids4 = pool.getFeatures( QgsFeatureRequest().setFilterRect( QgsRectangle( 0, 0, 10, 10 ) ) );
-  QCOMPARE( ids4.size(), 0 );
-
-  // Still working on the cached data
-  const QgsFeatureIds ids5 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
-  QCOMPARE( ids5.size(), 0 );
+  // Verify that the geometry is up to date
+  pool.getFeature( 1, feat );
+  QCOMPARE( feat.geometry().asWkt(), QStringLiteral( "Polygon ((100 100, 110 100, 110 110, 100 110, 100 100))" ) );
 
   // Update a feature to be inside the AOI
   feat.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon((0 0, 10 0, 10 10, 0 10, 0 0))" ) ) );
   vl->updateFeature( feat );
 
-  // Still cached
-  const QgsFeatureIds ids6 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
-  QCOMPARE( ids6.size(), 0 );
+  // Cached data updated with geometryChanged vector layer signal
+  const QgsFeatureIds ids4 = pool.getIntersects( QgsRectangle( 0, 0, 10, 10 ) );
+  QCOMPARE( ids4.size(), 1 );
 
-  // One in there again
-  const QgsFeatureIds ids7 = pool.getFeatures( QgsFeatureRequest().setFilterRect( QgsRectangle( 0, 0, 10, 10 ) ) );
-  QCOMPARE( ids7.size(), 1 );
+  // Verify that the geometry is up to date
+  pool.getFeature( 1, feat );
+  QCOMPARE( feat.geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0))" ) );
+
+  // Add enough features for the cache to be full
+  for ( int i = 0; i < 1100; i++ )  // max cache size is 1000
+  {
+    feat = QgsFeature();
+    feat.setGeometry( QgsGeometry::fromWkt( "Polygon (( 0 0, 20 0, 20 20, 0 20, 0 0))" ) );
+    vl->dataProvider()->addFeature( feat );
+  }
+
+  // Get all features: fill-in the cache
+  const QgsFeatureIds ids5 = pool.getFeatures( QgsFeatureRequest() );
+  QCOMPARE( ids5.size(), 1102 );
+
+  // Verify that the features 1 to 102 have been removed from the cache
+  for ( QgsFeatureId i : ids5 )
+  {
+    if ( i <= 102 )
+      QVERIFY( !pool.isFeatureCached( i ) );
+    else
+      QVERIFY( pool.isFeatureCached( i ) );
+  }
+
+  // Update enough features so that the first are removed from the cache
+  for ( int i = 100; i < 1103; i++ )
+  {
+    pool.getFeature( i, feat );
+    feat.setGeometry( QgsGeometry::fromWkt( "Polygon (( 0 0, 30 0, 30 30, 0 30, 0 0))" ) );
+    vl->updateFeature( feat );
+  }
+  QVERIFY( !pool.isFeatureCached( 102 ) );
+
+  // Verify that when we get a feature that is no more in the cache we have the updated geometry
+  pool.getFeature( 102, feat );
+  QCOMPARE( feat.geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 30 0, 30 30, 0 30, 0 0))" ) );
 }
 
 std::unique_ptr<QgsVectorLayer> TestQgsVectorLayerFeaturePool::createPopulatedLayer()


### PR DESCRIPTION
This is a PR following the review of https://github.com/qgis/QGIS/pull/58132 , to facilitate discussion as this is another approach suggested by @nyalldawson .

Geometry checker cache does not work properly with memory layers. refreshCache now handles a list of updated features to be thread-safe.

Also, fixes a locker mode, and correctly remove features from spatial index.

Fixes https://github.com/qgis/QGIS/issues/58113
