### PR TITLE
Don't allow non-polygon avoid intersection layers

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -1065,6 +1065,7 @@ A list of layers with which intersections should be avoided.
 %Docstring
 Sets the list of layers with which intersections should be avoided.
 Only used if the avoid intersection mode is set to advanced.
+Line and point layers will not be added.
 %End
 
     void setAvoidIntersectionsMode( const Qgis::AvoidIntersectionsMode mode );

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1065,6 +1065,7 @@ A list of layers with which intersections should be avoided.
 %Docstring
 Sets the list of layers with which intersections should be avoided.
 Only used if the avoid intersection mode is set to advanced.
+Line and point layers will not be added.
 %End
 
     void setAvoidIntersectionsMode( const Qgis::AvoidIntersectionsMode mode );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -2824,8 +2824,13 @@ void QgsProject::setAvoidIntersectionsLayers( const QList<QgsVectorLayer *> &lay
 
   QStringList list;
   list.reserve( layers.size() );
+
   for ( QgsVectorLayer *layer : layers )
-    list << layer->id();
+  {
+    if ( layer->geometryType() == Qgis::GeometryType::Polygon )
+      list << layer->id();
+  }
+
   writeEntry( QStringLiteral( "Digitizing" ), QStringLiteral( "/AvoidIntersectionsList" ), list );
   emit avoidIntersectionsLayersChanged();
 }

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1113,6 +1113,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Sets the list of layers with which intersections should be avoided.
      * Only used if the avoid intersection mode is set to advanced.
+     * Line and point layers will not be added.
      *
      */
     void setAvoidIntersectionsLayers( const QList<QgsVectorLayer *> &layers );


### PR DESCRIPTION
Disallow adding line and point layers to avoid intersections layers. This mainly concerns PyQGIS - setting avoid intersections layers through the GUI for non-polygon layers is already not possible.

Fixes #59067 