### PR TITLE
[processing] Add algorithm to extract min/max pixel from raster

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -143,6 +143,46 @@ Returns the minimum tile width returned during iteration.
 .. seealso:: :py:func:`maximumTileWidth`
 %End
 
+    int blockCountWidth() const;
+%Docstring
+Returns the total number of blocks which cover the width of the input raster.
+
+.. seealso:: :py:func:`blockCount`
+
+.. seealso:: :py:func:`blockCountHeight`
+
+.. versionadded:: 3.42
+%End
+
+    int blockCountHeight() const;
+%Docstring
+Returns the total number of blocks which cover the height of the input raster.
+
+.. seealso:: :py:func:`blockCount`
+
+.. seealso:: :py:func:`blockCountWidth`
+
+.. versionadded:: 3.42
+%End
+
+    qgssize blockCount() const;
+%Docstring
+Returns the total number of blocks required to iterate over the input raster.
+
+.. seealso:: :py:func:`blockCountWidth`
+
+.. seealso:: :py:func:`blockCountHeight`
+
+.. versionadded:: 3.42
+%End
+
+    double progress( int bandNumber ) const;
+%Docstring
+Returns the raster iteration progress as a fraction from 0 to 1.0, for the specified ``bandNumber``.
+
+.. versionadded:: 3.42
+%End
+
     static const int DEFAULT_MAXIMUM_TILE_WIDTH;
 
     static const int DEFAULT_MAXIMUM_TILE_HEIGHT;

--- a/python/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -143,6 +143,46 @@ Returns the minimum tile width returned during iteration.
 .. seealso:: :py:func:`maximumTileWidth`
 %End
 
+    int blockCountWidth() const;
+%Docstring
+Returns the total number of blocks which cover the width of the input raster.
+
+.. seealso:: :py:func:`blockCount`
+
+.. seealso:: :py:func:`blockCountHeight`
+
+.. versionadded:: 3.42
+%End
+
+    int blockCountHeight() const;
+%Docstring
+Returns the total number of blocks which cover the height of the input raster.
+
+.. seealso:: :py:func:`blockCount`
+
+.. seealso:: :py:func:`blockCountWidth`
+
+.. versionadded:: 3.42
+%End
+
+    qgssize blockCount() const;
+%Docstring
+Returns the total number of blocks required to iterate over the input raster.
+
+.. seealso:: :py:func:`blockCountWidth`
+
+.. seealso:: :py:func:`blockCountHeight`
+
+.. versionadded:: 3.42
+%End
+
+    double progress( int bandNumber ) const;
+%Docstring
+Returns the raster iteration progress as a fraction from 0 to 1.0, for the specified ``bandNumber``.
+
+.. versionadded:: 3.42
+%End
+
     static const int DEFAULT_MAXIMUM_TILE_WIDTH;
 
     static const int DEFAULT_MAXIMUM_TILE_HEIGHT;

--- a/python/plugins/processing/tests/testdata/expected/raster_max.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_max.gml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ raster_max.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.7964514376 18.6964479442</gml:lowerCorner><gml:upperCorner>45.7964514376 18.6964479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                              
+  <ogr:featureMember>
+    <ogr:raster_max gml:id="raster_max.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.7964514376 18.6964479442</gml:lowerCorner><gml:upperCorner>45.7964514376 18.6964479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_max.geom.0"><gml:pos>45.7964514376 18.6964479442</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:value>243.00000000</ogr:value>
+      <ogr:extremum>maximum</ogr:extremum>
+    </ogr:raster_max>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_max.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_max.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="raster_max" type="ogr:raster_max_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="raster_max_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="value" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="8"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/raster_min.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_min.gml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ raster_min.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.8027514376 18.6786479442</gml:lowerCorner><gml:upperCorner>45.8027514376 18.6786479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                              
+  <ogr:featureMember>
+    <ogr:raster_min gml:id="raster_min.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.8027514376 18.6786479442</gml:lowerCorner><gml:upperCorner>45.8027514376 18.6786479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_min.geom.0"><gml:pos>45.8027514376 18.6786479442</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:value>85.00000000</ogr:value>
+      <ogr:extremum>minimum</ogr:extremum>
+    </ogr:raster_min>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_min.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_min.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="raster_min" type="ogr:raster_min_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="raster_min_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="value" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="8"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/raster_min_max.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_min_max.gml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ raster_min_max.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.7964514376 18.6786479442</gml:lowerCorner><gml:upperCorner>45.8027514376 18.6964479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                              
+  <ogr:featureMember>
+    <ogr:raster_min_max gml:id="raster_min_max.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.8027514376 18.6786479442</gml:lowerCorner><gml:upperCorner>45.8027514376 18.6786479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_min_max.geom.0"><gml:pos>45.8027514376 18.6786479442</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:value>85.00000000</ogr:value>
+      <ogr:extremum>minimum</ogr:extremum>
+    </ogr:raster_min_max>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:raster_min_max gml:id="raster_min_max.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.7964514376 18.6964479442</gml:lowerCorner><gml:upperCorner>45.7964514376 18.6964479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_min_max.geom.1"><gml:pos>45.7964514376 18.6964479442</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:value>243.00000000</ogr:value>
+      <ogr:extremum>maximum</ogr:extremum>
+    </ogr:raster_min_max>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_min_max.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_min_max.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="raster_min_max" type="ogr:raster_min_max_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="raster_min_max_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="value" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="8"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
@@ -247,3 +247,41 @@ tests:
         name: expected/create_grid_negative_overlay.gml
         type: vector
 
+  - algorithm: native:rasterminmax
+    name: Raster min max
+    params:
+      BAND: 1
+      EXTRACT: 0
+      INPUT:
+        name: dem.tif
+        type: raster
+    results:
+      OUTPUT:
+        name: expected/raster_min_max.gml
+        type: vector
+
+  - algorithm: native:rasterminmax
+    name: Raster min
+    params:
+      BAND: 1
+      EXTRACT: 1
+      INPUT:
+        name: dem.tif
+        type: raster
+    results:
+      OUTPUT:
+        name: expected/raster_min.gml
+        type: vector
+
+  - algorithm: native:rasterminmax
+    name: Raster max
+    params:
+      BAND: 1
+      EXTRACT: 2
+      INPUT:
+        name: dem.tif
+        type: raster
+    results:
+      OUTPUT:
+        name: expected/raster_max.gml
+        type: vector

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -181,6 +181,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmrasterlayerproperties.cpp
   processing/qgsalgorithmrasterlayeruniquevalues.cpp
   processing/qgsalgorithmrasterlogicalop.cpp
+  processing/qgsalgorithmrasterminmax.cpp
   processing/qgsalgorithmrasterize.cpp
   processing/qgsalgorithmrastersampling.cpp
   processing/qgsalgorithmrasterstackposition.cpp

--- a/src/analysis/processing/qgsalgorithmrasterminmax.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterminmax.cpp
@@ -83,7 +83,6 @@ QgsRasterMinMaxAlgorithm *QgsRasterMinMaxAlgorithm::createInstance() const
 bool QgsRasterMinMaxAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   QgsRasterLayer *layer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT" ), context );
-  const int band = parameterAsInt( parameters, QStringLiteral( "BAND" ), context );
 
   if ( !layer )
     throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT" ) ) );
@@ -94,7 +93,7 @@ bool QgsRasterMinMaxAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
                                   .arg( layer->bandCount() ) );
 
   mInterface.reset( layer->dataProvider()->clone() );
-  mHasNoDataValue = layer->dataProvider()->sourceHasNoDataValue( band );
+  mHasNoDataValue = layer->dataProvider()->sourceHasNoDataValue( mBand );
   mLayerWidth = layer->width();
   mLayerHeight = layer->height();
   mExtent = layer->extent();

--- a/src/analysis/processing/qgsalgorithmrasterminmax.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterminmax.cpp
@@ -1,0 +1,237 @@
+/***************************************************************************
+                         qgsalgorithmrasterminmax.cpp
+                         ---------------------
+    begin                : October 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmrasterminmax.h"
+
+///@cond PRIVATE
+
+QString QgsRasterMinMaxAlgorithm::name() const
+{
+  return QStringLiteral( "rasterminmax" );
+}
+
+QString QgsRasterMinMaxAlgorithm::displayName() const
+{
+  return QObject::tr( "Raster minimum/maximum" );
+}
+
+QStringList QgsRasterMinMaxAlgorithm::tags() const
+{
+  return QObject::tr( "dem,statistics,value,extrema,extremes,largest,smallest" ).split( ',' );
+}
+
+QString QgsRasterMinMaxAlgorithm::group() const
+{
+  return QObject::tr( "Raster analysis" );
+}
+
+QString QgsRasterMinMaxAlgorithm::groupId() const
+{
+  return QStringLiteral( "rasteranalysis" );
+}
+
+void QgsRasterMinMaxAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT" ),
+                QObject::tr( "Input layer" ) ) );
+  addParameter( new QgsProcessingParameterBand( QStringLiteral( "BAND" ),
+                QObject::tr( "Band number" ), 1, QStringLiteral( "INPUT" ) ) );
+  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "EXTRACT" ),
+                QObject::tr( "Extract extrema" ), QStringList()
+                << QObject::tr( "Minimum and Maximum" )
+                << QObject::tr( "Minimum" )
+                << QObject::tr( "Maximum" ), false, 0 ) );
+
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ),
+                QObject::tr( "Output" ), Qgis::ProcessingSourceType::VectorPoint, QVariant(), true, true ) );
+
+  addOutput( new QgsProcessingOutputNumber( QStringLiteral( "MINIMUM" ), QObject::tr( "Minimum" ) ) );
+  addOutput( new QgsProcessingOutputNumber( QStringLiteral( "MAXIMUM" ), QObject::tr( "Maximum" ) ) );
+}
+
+QString QgsRasterMinMaxAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm extracts extrema (minimum and maximum) values from a given band of the raster layer.\n\n"
+                      "The output is a vector layer containing point features for the selected extrema, at the center of the associated pixel.\n\n"
+                      "If multiple pixels in the raster share the minimum or maximum value, then only one of these pixels will be included in the output." );
+}
+
+QString QgsRasterMinMaxAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Calculates the minimum and maximum pixel in a raster layer." );
+}
+
+QgsRasterMinMaxAlgorithm *QgsRasterMinMaxAlgorithm::createInstance() const
+{
+  return new QgsRasterMinMaxAlgorithm();
+}
+
+bool QgsRasterMinMaxAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsRasterLayer *layer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT" ), context );
+  const int band = parameterAsInt( parameters, QStringLiteral( "BAND" ), context );
+
+  if ( !layer )
+    throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT" ) ) );
+
+  mBand = parameterAsInt( parameters, QStringLiteral( "BAND" ), context );
+  if ( mBand < 1 || mBand > layer->bandCount() )
+    throw QgsProcessingException( QObject::tr( "Invalid band number for BAND (%1): Valid values for input raster are 1 to %2" ).arg( mBand )
+                                  .arg( layer->bandCount() ) );
+
+  mInterface.reset( layer->dataProvider()->clone() );
+  mHasNoDataValue = layer->dataProvider()->sourceHasNoDataValue( band );
+  mLayerWidth = layer->width();
+  mLayerHeight = layer->height();
+  mExtent = layer->extent();
+  mCrs = layer->crs();
+  mRasterUnitsPerPixelX = std::abs( layer->rasterUnitsPerPixelX() );
+  mRasterUnitsPerPixelY = std::abs( layer->rasterUnitsPerPixelY() );
+  return true;
+}
+
+QVariantMap QgsRasterMinMaxAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  QString dest;
+  std::unique_ptr< QgsFeatureSink > sink;
+  if ( parameters.value( QStringLiteral( "OUTPUT" ) ).isValid() )
+  {
+    QgsFields outFields;
+    outFields.append( QgsField( QStringLiteral( "value" ), QMetaType::Type::Double, QString(), 20, 8 ) );
+    outFields.append( QgsField( QStringLiteral( "extremum" ), QMetaType::Type::QString ) );
+    sink.reset( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, outFields, Qgis::WkbType::Point, mCrs ) );
+    if ( !sink )
+      throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
+  }
+
+  const int extractType = parameterAsInt( parameters, QStringLiteral( "EXTRACT" ), context );
+
+  const int maxWidth = QgsRasterIterator::DEFAULT_MAXIMUM_TILE_WIDTH;
+  const int maxHeight = QgsRasterIterator::DEFAULT_MAXIMUM_TILE_HEIGHT;
+  const int numberBlocksWidth = static_cast< int >( std::ceil( 1.0 * mLayerWidth / maxWidth ) );
+  const int numberBlocksHeight = static_cast< int >( std::ceil( 1.0 * mLayerHeight / maxHeight ) );
+  const qint64 numberBlocks = static_cast< qint64>( numberBlocksWidth ) * numberBlocksHeight;
+
+  QgsRasterIterator iter( mInterface.get() );
+  iter.startRasterRead( mBand, mLayerWidth, mLayerHeight, mExtent );
+
+  int iterLeft = 0;
+  int iterTop = 0;
+  int iterCols = 0;
+  int iterRows = 0;
+  std::unique_ptr< QgsRasterBlock > rasterBlock;
+
+  double rasterMinimum = std::numeric_limits< double >::quiet_NaN();
+  double rasterMaximum = std::numeric_limits< double >::quiet_NaN();
+  QgsPointXY rasterMinPoint;
+  QgsPointXY rasterMaxPoint;
+
+  auto blockRowColToXY = [this]( const QgsRectangle & blockExtent, int row, int col ) -> QgsPointXY
+  {
+    return QgsPointXY( blockExtent.xMinimum() + mRasterUnitsPerPixelX * ( col + 0.5 ),
+                       blockExtent.yMaximum() - mRasterUnitsPerPixelY * ( row + 0.5 ) );
+  };
+
+  QgsRectangle blockExtent;
+  while ( iter.readNextRasterPart( mBand, iterCols, iterRows, rasterBlock, iterLeft, iterTop, &blockExtent ) )
+  {
+    feedback->setProgress( 100 * ( ( iterTop / static_cast< double >( maxHeight * numberBlocksWidth ) ) + iterLeft / static_cast< double >( maxWidth ) ) / static_cast< double >( numberBlocks ) );
+    if ( feedback->isCanceled() )
+      break;
+
+    double blockMinimum = std::numeric_limits< double >::quiet_NaN();
+    double blockMaximum = std::numeric_limits< double >::quiet_NaN();
+    int blockMinRow = 0;
+    int blockMinCol = 0;
+    int blockMaxRow = 0;
+    int blockMaxCol = 0;
+    switch ( extractType )
+    {
+      case 0:
+      {
+        if ( !rasterBlock->minimumMaximum( blockMinimum, blockMinRow, blockMinCol, blockMaximum, blockMaxRow, blockMaxCol ) )
+          continue;
+
+        if ( std::isnan( rasterMinimum ) || blockMinimum < rasterMinimum )
+        {
+          rasterMinimum = blockMinimum;
+          rasterMinPoint = blockRowColToXY( blockExtent, blockMinRow, blockMinCol );
+        }
+        if ( std::isnan( rasterMaximum ) || blockMaximum > rasterMaximum )
+        {
+          rasterMaximum = blockMaximum;
+          rasterMaxPoint = blockRowColToXY( blockExtent, blockMaxRow, blockMaxCol );
+        }
+        break;
+      }
+
+      case 1:
+      {
+        if ( !rasterBlock->minimum( blockMinimum, blockMinRow, blockMinCol ) )
+          continue;
+        if ( std::isnan( rasterMinimum ) || blockMinimum < rasterMinimum )
+        {
+          rasterMinimum = blockMinimum;
+          rasterMinPoint = blockRowColToXY( blockExtent, blockMinRow, blockMinCol );
+        }
+        break;
+      }
+
+      case 2:
+      {
+        if ( !rasterBlock->maximum( blockMaximum, blockMaxRow, blockMaxCol ) )
+          continue;
+        if ( std::isnan( rasterMaximum ) || blockMaximum > rasterMaximum )
+        {
+          rasterMaximum = blockMaximum;
+          rasterMaxPoint = blockRowColToXY( blockExtent, blockMaxRow, blockMaxCol );
+        }
+        break;
+      }
+      default:
+        continue;
+    }
+  }
+
+  QVariantMap outputs;
+  if ( sink )
+  {
+    QgsFeature f;
+    if ( !std::isnan( rasterMinimum ) )
+    {
+
+      f.setAttributes( QgsAttributes() << rasterMinimum << QStringLiteral( "minimum" ) );
+      f.setGeometry( QgsGeometry::fromPointXY( rasterMinPoint ) );
+      if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
+        throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+    }
+    if ( !std::isnan( rasterMaximum ) )
+    {
+      f.setAttributes( QgsAttributes() << rasterMaximum << QStringLiteral( "maximum" ) );
+      f.setGeometry( QgsGeometry::fromPointXY( rasterMaxPoint ) );
+      if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
+        throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+    }
+    outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  }
+  outputs.insert( QStringLiteral( "MINIMUM" ), !std::isnan( rasterMinimum ) ? QVariant::fromValue( rasterMinimum ) : QVariant() );
+  outputs.insert( QStringLiteral( "MAXIMUM" ), !std::isnan( rasterMaximum ) ? QVariant::fromValue( rasterMaximum ) : QVariant() );
+  return outputs;
+}
+
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmrasterminmax.h
+++ b/src/analysis/processing/qgsalgorithmrasterminmax.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+                         qgsalgorithmrasterminmax.cpp
+                         ---------------------
+    begin                : October 2024
+    copyright            : (C) 2024 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMRASTERMINMAX_H
+#define QGSALGORITHMRASTERMINMAX_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native raster layer minimum and/or maximum value algorithm.
+ */
+class QgsRasterMinMaxAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsRasterMinMaxAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsRasterMinMaxAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+
+    std::unique_ptr< QgsRasterInterface > mInterface;
+    bool mHasNoDataValue = false;
+    int mBand = 1;
+    int mLayerWidth = 0;
+    int mLayerHeight = 0;
+    QgsRectangle mExtent;
+    QgsCoordinateReferenceSystem mCrs;
+    double mRasterUnitsPerPixelX = 0;
+    double mRasterUnitsPerPixelY = 0;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMRASTERMINMAX_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -164,6 +164,7 @@
 #include "qgsalgorithmrasterlayerproperties.h"
 #include "qgsalgorithmrasterlayeruniquevalues.h"
 #include "qgsalgorithmrasterlogicalop.h"
+#include "qgsalgorithmrasterminmax.h"
 #include "qgsalgorithmrasterize.h"
 #include "qgsalgorithmrastersampling.h"
 #include "qgsalgorithmrasterstackposition.h"
@@ -472,6 +473,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsRasterLayerZonalStatsAlgorithm() );
   addAlgorithm( new QgsRasterLogicalAndAlgorithm() );
   addAlgorithm( new QgsRasterLogicalOrAlgorithm() );
+  addAlgorithm( new QgsRasterMinMaxAlgorithm() );
   addAlgorithm( new QgsRasterizeAlgorithm() );
   addAlgorithm( new QgsRasterPixelsToPointsAlgorithm() );
   addAlgorithm( new QgsRasterPixelsToPolygonsAlgorithm() );

--- a/src/core/raster/qgsrasteriterator.cpp
+++ b/src/core/raster/qgsrasteriterator.cpp
@@ -232,7 +232,7 @@ double QgsRasterIterator::progress( int bandNumber ) const
     return 0;
   }
 
-  return ( ( partIt->currentRow / static_cast< double >( mMaximumTileHeight ) ) * mNumberBlocksWidth + partIt->currentCol / static_cast< double >( mMaximumTileWidth ) ) / ( static_cast< double >( mNumberBlocksWidth ) * static_cast< double >( mNumberBlocksHeight ) );
+  return ( ( static_cast< double >( partIt->currentRow ) / static_cast< double >( mMaximumTileHeight ) ) * mNumberBlocksWidth + static_cast< double >( partIt->currentCol ) / static_cast< double >( mMaximumTileWidth ) ) / ( static_cast< double >( mNumberBlocksWidth ) * static_cast< double >( mNumberBlocksHeight ) );
 }
 
 void QgsRasterIterator::removePartInfo( int bandNumber )

--- a/src/core/raster/qgsrasteriterator.cpp
+++ b/src/core/raster/qgsrasteriterator.cpp
@@ -93,6 +93,9 @@ void QgsRasterIterator::startRasterRead( int bandNumber, qgssize nCols, qgssize 
   pInfo.currentCol = 0;
   pInfo.currentRow = 0;
   mRasterPartInfos.insert( bandNumber, pInfo );
+
+  mNumberBlocksWidth = static_cast< int >( std::ceil( static_cast< double >( nCols ) / mMaximumTileWidth ) );
+  mNumberBlocksHeight = static_cast< int >( std::ceil( static_cast< double >( nRows ) / mMaximumTileHeight ) );
 }
 
 bool QgsRasterIterator::next( int bandNumber, int &columns, int &rows, int &topLeftColumn, int &topLeftRow, QgsRectangle &blockExtent )
@@ -219,6 +222,17 @@ bool QgsRasterIterator::readNextRasterPartInternal( int bandNumber, int &nCols, 
 void QgsRasterIterator::stopRasterRead( int bandNumber )
 {
   removePartInfo( bandNumber );
+}
+
+double QgsRasterIterator::progress( int bandNumber ) const
+{
+  const auto partIt = mRasterPartInfos.find( bandNumber );
+  if ( partIt == mRasterPartInfos.constEnd() )
+  {
+    return 0;
+  }
+
+  return ( ( partIt->currentRow / static_cast< double >( mMaximumTileHeight ) ) * mNumberBlocksWidth + partIt->currentCol / static_cast< double >( mMaximumTileWidth ) ) / ( static_cast< double >( mNumberBlocksWidth ) * static_cast< double >( mNumberBlocksHeight ) );
 }
 
 void QgsRasterIterator::removePartInfo( int bandNumber )

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -170,6 +170,40 @@ class CORE_EXPORT QgsRasterIterator
      */
     int maximumTileHeight() const { return mMaximumTileHeight; }
 
+    /**
+     * Returns the total number of blocks which cover the width of the input raster.
+     *
+     * \see blockCount()
+     * \see blockCountHeight()
+     * \since QGIS 3.42
+     */
+    int blockCountWidth() const { return mNumberBlocksWidth; }
+
+    /**
+     * Returns the total number of blocks which cover the height of the input raster.
+     *
+     * \see blockCount()
+     * \see blockCountWidth()
+     * \since QGIS 3.42
+     */
+    int blockCountHeight() const { return mNumberBlocksWidth; }
+
+    /**
+     * Returns the total number of blocks required to iterate over the input raster.
+     *
+     * \see blockCountWidth()
+     * \see blockCountHeight()
+     * \since QGIS 3.42
+     */
+    qgssize blockCount() const { return static_cast< qgssize >( mNumberBlocksHeight ) * mNumberBlocksWidth; }
+
+    /**
+     * Returns the raster iteration progress as a fraction from 0 to 1.0, for the specified \a bandNumber.
+     *
+     * \since QGIS 3.42
+     */
+    double progress( int bandNumber ) const;
+
     //! Default maximum tile width
     static const int DEFAULT_MAXIMUM_TILE_WIDTH = 2000;
 
@@ -194,6 +228,9 @@ class CORE_EXPORT QgsRasterIterator
     int mTileOverlapPixels = 0;
     int mMaximumTileWidth;
     int mMaximumTileHeight;
+
+    int mNumberBlocksWidth = 0;
+    int mNumberBlocksHeight = 0;
 
     //! Remove part into and release memory
     void removePartInfo( int bandNumber );

--- a/tests/src/core/testqgsrasteriterator.cpp
+++ b/tests/src/core/testqgsrasteriterator.cpp
@@ -89,6 +89,11 @@ void TestQgsRasterIterator::testBasic()
 
   it.startRasterRead( 1, mpRasterLayer->width(), mpRasterLayer->height(), mpRasterLayer->extent() );
 
+  QCOMPARE( it.blockCount(), 9 );
+  QCOMPARE( it.blockCountWidth(), 3 );
+  QCOMPARE( it.blockCountHeight(), 3 );
+  QCOMPARE( it.progress( 1 ), 0 );
+
   int nCols;
   int nRows;
   int topLeftCol;
@@ -97,6 +102,7 @@ void TestQgsRasterIterator::testBasic()
   std::unique_ptr< QgsRasterBlock > block;
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.111, 0.001 );
   QCOMPARE( nCols, 3000 );
   QCOMPARE( nRows, 2500 );
   QCOMPARE( topLeftCol, 0 );
@@ -116,6 +122,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.222, 0.001 );
   QCOMPARE( nCols, 3000 );
   QCOMPARE( nRows, 2500 );
   QCOMPARE( topLeftCol, 3000 );
@@ -131,6 +138,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.333, 0.001 );
   QCOMPARE( nCols, 1200 );
   QCOMPARE( nRows, 2500 );
   QCOMPARE( topLeftCol, 6000 );
@@ -146,6 +154,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.444, 0.001 );
   QCOMPARE( nCols, 3000 );
   QCOMPARE( nRows, 2500 );
   QCOMPARE( topLeftCol, 0 );
@@ -161,6 +170,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.555, 0.001 );
   QCOMPARE( nCols, 3000 );
   QCOMPARE( nRows, 2500 );
   QCOMPARE( topLeftCol, 3000 );
@@ -176,6 +186,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.666, 0.001 );
   QCOMPARE( nCols, 1200 );
   QCOMPARE( nRows, 2500 );
   QCOMPARE( topLeftCol, 6000 );
@@ -189,6 +200,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.777, 0.001 );
   QCOMPARE( nCols, 3000 );
   QCOMPARE( nRows, 450 );
   QCOMPARE( topLeftCol, 0 );
@@ -204,6 +216,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 0.888, 0.001 );
   QCOMPARE( nCols, 3000 );
   QCOMPARE( nRows, 450 );
   QCOMPARE( topLeftCol, 3000 );
@@ -217,6 +230,7 @@ void TestQgsRasterIterator::testBasic()
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QGSCOMPARENEAR( it.progress( 1 ), 1.0, 0.01 );
   QCOMPARE( nCols, 1200 );
   QCOMPARE( nRows, 450 );
   QCOMPARE( topLeftCol, 6000 );


### PR DESCRIPTION
This algorithm extracts extrema (minimum and maximum) values from a given band of the raster layer.

The output is a vector layer containing point features for the selected extrema, at the center of the associated pixel.

If multiple pixels in the raster share the minimum or maximum value, then only one of these pixels will be included in the output.

The algorithm uses raster iterator to remain efficient on huge rasters, and does not require reading the entire raster to memory
