### PR TITLE
[MultiEdits] fire valueChanged when syncing form same fields

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1044,9 +1044,8 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
     if ( formEditorWidget->editorWidget() == eww )
       continue;
 
-    // formEditorWidget and eww points to the same field, so block signals
-    // as there is no need to handle valueChanged again for each duplicate
-    whileBlocking( formEditorWidget->editorWidget() )->setValue( value );
+    // formEditorWidget and eww points to the same field, so update its value
+    formEditorWidget->editorWidget()->setValue( value );
   }
 
   switch ( mMode )

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -438,11 +438,31 @@ void TestQgsDualView::testDuplicateField()
 
   const QList<QgsAttributeFormEditorWidget *> formEditorWidgets = dualView.mAttributeForm->mFormEditorWidgets.values( 0 );
 
+  // reset mIsChanged state
+  formEditorWidgets[0]->changesCommitted();
+  formEditorWidgets[1]->changesCommitted();
+  QVERIFY( !formEditorWidgets[0]->hasChanged() );
+  QVERIFY( !formEditorWidgets[1]->hasChanged() );
+
   formEditorWidgets[0]->editorWidget()->setValues( 20, QVariantList() );
+  QCOMPARE( formEditorWidgets[0]->editorWidget()->value().toInt(), 20 );
+  QCOMPARE( formEditorWidgets[1]->editorWidget()->value().toInt(), 20 );
+  QVERIFY( formEditorWidgets[0]->hasChanged() );
+  QVERIFY( formEditorWidgets[1]->hasChanged() );
   ft = layer->getFeature( ft.id() );
   QCOMPARE( ft.attribute( QStringLiteral( "col0" ) ).toInt(), 20 );
 
+  // reset mIsChanged state
+  formEditorWidgets[0]->changesCommitted();
+  formEditorWidgets[1]->changesCommitted();
+  QVERIFY( !formEditorWidgets[0]->hasChanged() );
+  QVERIFY( !formEditorWidgets[1]->hasChanged() );
+
   formEditorWidgets[1]->editorWidget()->setValues( 21, QVariantList() );
+  QCOMPARE( formEditorWidgets[0]->editorWidget()->value().toInt(), 21 );
+  QCOMPARE( formEditorWidgets[1]->editorWidget()->value().toInt(), 21 );
+  QVERIFY( formEditorWidgets[0]->hasChanged() );
+  QVERIFY( formEditorWidgets[1]->hasChanged() );
   ft = layer->getFeature( ft.id() );
   QCOMPARE( ft.attribute( QStringLiteral( "col0" ) ).toInt(), 21 );
 


### PR DESCRIPTION
If not, mIsChanged state and multiedit button icon are not updated in QgsAttributeFormEditorWidget. The former leads to not saving modification issues when applying multi edit modifications because widget could appear not changed.

@nirvn Still the same piece of code, may I request your review here?

**Funded by coforet**