### PR TITLE
[feature] Add raster zonal min/max algorithm

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10430,7 +10430,7 @@ Qgis.ZonalStatistic.Majority.__doc__ = "Majority of pixel values"
 Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
 Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
-Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
+Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for maximum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.All.__doc__ = "All statistics"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
@@ -10453,7 +10453,7 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 
   .. versionadded:: 3.42
 
-* ``MaximumPoint``: Pixel centroid for minimum pixel value
+* ``MaximumPoint``: Pixel centroid for maximum pixel value
 
   .. versionadded:: 3.42
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10431,7 +10431,8 @@ Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
 Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for maximum pixel value \n.. versionadded:: 3.42"
-Qgis.ZonalStatistic.All.__doc__ = "All statistics, excluding MinimumPoint and MaximumPoint"
+Qgis.ZonalStatistic.All.__doc__ = "All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead."
+Qgis.ZonalStatistic.AllNumeric.__doc__ = "All numeric statistics \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
 
@@ -10457,7 +10458,11 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 
   .. versionadded:: 3.42
 
-* ``All``: All statistics, excluding MinimumPoint and MaximumPoint
+* ``All``: All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead.
+* ``AllNumeric``: All numeric statistics
+
+  .. versionadded:: 3.42
+
 * ``Default``: Default statistics
 
 """

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10429,6 +10429,8 @@ Qgis.ZonalStatistic.Minority.__doc__ = "Minority of pixel values"
 Qgis.ZonalStatistic.Majority.__doc__ = "Majority of pixel values"
 Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
+Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
+Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.All.__doc__ = "All statistics"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
@@ -10447,6 +10449,14 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 * ``Majority``: Majority of pixel values
 * ``Variety``: Variety (count of distinct) pixel values
 * ``Variance``: Variance of pixel values
+* ``MinimumPoint``: Pixel centroid for minimum pixel value
+
+  .. versionadded:: 3.42
+
+* ``MaximumPoint``: Pixel centroid for minimum pixel value
+
+  .. versionadded:: 3.42
+
 * ``All``: All statistics
 * ``Default``: Default statistics
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10431,7 +10431,7 @@ Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
 Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for maximum pixel value \n.. versionadded:: 3.42"
-Qgis.ZonalStatistic.All.__doc__ = "All statistics"
+Qgis.ZonalStatistic.All.__doc__ = "All statistics, excluding MinimumPoint and MaximumPoint"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
 
@@ -10457,7 +10457,7 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 
   .. versionadded:: 3.42
 
-* ``All``: All statistics
+* ``All``: All statistics, excluding MinimumPoint and MaximumPoint
 * ``Default``: Default statistics
 
 """

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3017,6 +3017,7 @@ The development version
       Other,
     };
 
+
     enum class ZonalStatistic /BaseType=IntFlag/
     {
       Count,
@@ -3034,6 +3035,7 @@ The development version
       MinimumPoint,
       MaximumPoint,
       All,
+      AllNumeric,
       Default,
     };
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3031,6 +3031,8 @@ The development version
       Majority,
       Variety,
       Variance,
+      MinimumPoint,
+      MaximumPoint,
       All,
       Default,
     };

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10347,7 +10347,7 @@ Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
 Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for maximum pixel value \n.. versionadded:: 3.42"
-Qgis.ZonalStatistic.All.__doc__ = "All statistics"
+Qgis.ZonalStatistic.All.__doc__ = "All statistics, excluding MinimumPoint and MaximumPoint"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
 
@@ -10373,7 +10373,7 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 
   .. versionadded:: 3.42
 
-* ``All``: All statistics
+* ``All``: All statistics, excluding MinimumPoint and MaximumPoint
 * ``Default``: Default statistics
 
 """

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10345,6 +10345,8 @@ Qgis.ZonalStatistic.Minority.__doc__ = "Minority of pixel values"
 Qgis.ZonalStatistic.Majority.__doc__ = "Majority of pixel values"
 Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
+Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
+Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.All.__doc__ = "All statistics"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
@@ -10363,6 +10365,14 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 * ``Majority``: Majority of pixel values
 * ``Variety``: Variety (count of distinct) pixel values
 * ``Variance``: Variance of pixel values
+* ``MinimumPoint``: Pixel centroid for minimum pixel value
+
+  .. versionadded:: 3.42
+
+* ``MaximumPoint``: Pixel centroid for minimum pixel value
+
+  .. versionadded:: 3.42
+
 * ``All``: All statistics
 * ``Default``: Default statistics
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10346,7 +10346,7 @@ Qgis.ZonalStatistic.Majority.__doc__ = "Majority of pixel values"
 Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
 Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
-Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
+Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for maximum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.All.__doc__ = "All statistics"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
@@ -10369,7 +10369,7 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 
   .. versionadded:: 3.42
 
-* ``MaximumPoint``: Pixel centroid for minimum pixel value
+* ``MaximumPoint``: Pixel centroid for maximum pixel value
 
   .. versionadded:: 3.42
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10347,7 +10347,8 @@ Qgis.ZonalStatistic.Variety.__doc__ = "Variety (count of distinct) pixel values"
 Qgis.ZonalStatistic.Variance.__doc__ = "Variance of pixel values"
 Qgis.ZonalStatistic.MinimumPoint.__doc__ = "Pixel centroid for minimum pixel value \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.MaximumPoint.__doc__ = "Pixel centroid for maximum pixel value \n.. versionadded:: 3.42"
-Qgis.ZonalStatistic.All.__doc__ = "All statistics, excluding MinimumPoint and MaximumPoint"
+Qgis.ZonalStatistic.All.__doc__ = "All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead."
+Qgis.ZonalStatistic.AllNumeric.__doc__ = "All numeric statistics \n.. versionadded:: 3.42"
 Qgis.ZonalStatistic.Default.__doc__ = "Default statistics"
 Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal statistics operation.
 
@@ -10373,7 +10374,11 @@ Qgis.ZonalStatistic.__doc__ = """Statistics to be calculated during a zonal stat
 
   .. versionadded:: 3.42
 
-* ``All``: All statistics, excluding MinimumPoint and MaximumPoint
+* ``All``: All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead.
+* ``AllNumeric``: All numeric statistics
+
+  .. versionadded:: 3.42
+
 * ``Default``: Default statistics
 
 """

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -3017,6 +3017,7 @@ The development version
       Other,
     };
 
+
     enum class ZonalStatistic
     {
       Count,
@@ -3034,6 +3035,7 @@ The development version
       MinimumPoint,
       MaximumPoint,
       All,
+      AllNumeric,
       Default,
     };
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -3031,6 +3031,8 @@ The development version
       Majority,
       Variety,
       Variance,
+      MinimumPoint,
+      MaximumPoint,
       All,
       Default,
     };

--- a/python/plugins/processing/tests/testdata/expected/raster_max.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_max.gml
@@ -12,7 +12,7 @@
       <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.7964514376 18.6964479442</gml:lowerCorner><gml:upperCorner>45.7964514376 18.6964479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_max.geom.0"><gml:pos>45.7964514376 18.6964479442</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:value>243.00000000</ogr:value>
-      <ogr:extremum>maximum</ogr:extremum>
+      <ogr:extremum_type>maximum</ogr:extremum_type>
     </ogr:raster_max>
   </ogr:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_max.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_max.xsd
@@ -48,7 +48,7 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
-        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+        <xs:element name="extremum_type" nillable="true" minOccurs="0" maxOccurs="1">
           <xs:simpleType>
             <xs:restriction base="xs:string">
             </xs:restriction>

--- a/python/plugins/processing/tests/testdata/expected/raster_min.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_min.gml
@@ -12,7 +12,7 @@
       <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.8027514376 18.6786479442</gml:lowerCorner><gml:upperCorner>45.8027514376 18.6786479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_min.geom.0"><gml:pos>45.8027514376 18.6786479442</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:value>85.00000000</ogr:value>
-      <ogr:extremum>minimum</ogr:extremum>
+      <ogr:extremum_type>minimum</ogr:extremum_type>
     </ogr:raster_min>
   </ogr:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_min.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_min.xsd
@@ -48,7 +48,7 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
-        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+        <xs:element name="extremum_type" nillable="true" minOccurs="0" maxOccurs="1">
           <xs:simpleType>
             <xs:restriction base="xs:string">
             </xs:restriction>

--- a/python/plugins/processing/tests/testdata/expected/raster_min_max.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_min_max.gml
@@ -12,7 +12,7 @@
       <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.8027514376 18.6786479442</gml:lowerCorner><gml:upperCorner>45.8027514376 18.6786479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_min_max.geom.0"><gml:pos>45.8027514376 18.6786479442</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:value>85.00000000</ogr:value>
-      <ogr:extremum>minimum</ogr:extremum>
+      <ogr:extremum_type>minimum</ogr:extremum_type>
     </ogr:raster_min_max>
   </ogr:featureMember>
   <ogr:featureMember>
@@ -20,7 +20,7 @@
       <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.7964514376 18.6964479442</gml:lowerCorner><gml:upperCorner>45.7964514376 18.6964479442</gml:upperCorner></gml:Envelope></gml:boundedBy>
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="raster_min_max.geom.1"><gml:pos>45.7964514376 18.6964479442</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:value>243.00000000</ogr:value>
-      <ogr:extremum>maximum</ogr:extremum>
+      <ogr:extremum_type>maximum</ogr:extremum_type>
     </ogr:raster_min_max>
   </ogr:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_min_max.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_min_max.xsd
@@ -48,7 +48,7 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
-        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+        <xs:element name="extremum_type" nillable="true" minOccurs="0" maxOccurs="1">
           <xs:simpleType>
             <xs:restriction base="xs:string">
             </xs:restriction>

--- a/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.gml
@@ -13,7 +13,7 @@
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.0"><gml:pos>2078985.88326099 5746736.89404743</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:zone>zone 1</ogr:zone>
       <ogr:value>97.50000000</ogr:value>
-      <ogr:extremum>minimum</ogr:extremum>
+      <ogr:extremum_type>minimum</ogr:extremum_type>
     </ogr:raster_zonal_extremum>
   </ogr:featureMember>
   <ogr:featureMember>
@@ -22,7 +22,7 @@
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.1"><gml:pos>2078752.11232507 5745092.4177069</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:zone>zone 1</ogr:zone>
       <ogr:value>219.19999695</ogr:value>
-      <ogr:extremum>maximum</ogr:extremum>
+      <ogr:extremum_type>maximum</ogr:extremum_type>
     </ogr:raster_zonal_extremum>
   </ogr:featureMember>
   <ogr:featureMember>
@@ -31,7 +31,7 @@
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.2"><gml:pos>2080499.82836984 5749099.83092514</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:zone>zone 2</ogr:zone>
       <ogr:value>108.06781769</ogr:value>
-      <ogr:extremum>minimum</ogr:extremum>
+      <ogr:extremum_type>minimum</ogr:extremum_type>
     </ogr:raster_zonal_extremum>
   </ogr:featureMember>
   <ogr:featureMember>
@@ -40,7 +40,7 @@
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.3"><gml:pos>2081279.06482292 5747790.6361686</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:zone>zone 2</ogr:zone>
       <ogr:value>243.00000000</ogr:value>
-      <ogr:extremum>maximum</ogr:extremum>
+      <ogr:extremum_type>maximum</ogr:extremum_type>
     </ogr:raster_zonal_extremum>
   </ogr:featureMember>
   <ogr:featureMember>
@@ -49,7 +49,7 @@
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.4"><gml:pos>2080421.90472453 5747072.17563143</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:zone>zone 3</ogr:zone>
       <ogr:value>163.57766724</ogr:value>
-      <ogr:extremum>minimum</ogr:extremum>
+      <ogr:extremum_type>minimum</ogr:extremum_type>
     </ogr:raster_zonal_extremum>
   </ogr:featureMember>
   <ogr:featureMember>
@@ -58,7 +58,7 @@
       <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.5"><gml:pos>2080433.03667386 5747056.20984171</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:zone>zone 3</ogr:zone>
       <ogr:value>170.00000000</ogr:value>
-      <ogr:extremum>maximum</ogr:extremum>
+      <ogr:extremum_type>maximum</ogr:extremum_type>
     </ogr:raster_zonal_extremum>
   </ogr:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.gml
+++ b/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.gml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ raster_zonal_extremum.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::3857"><gml:lowerCorner>2078752.11232507 5745092.4177069</gml:lowerCorner><gml:upperCorner>2081279.06482292 5749099.83092514</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                   
+  <ogr:featureMember>
+    <ogr:raster_zonal_extremum gml:id="raster_zonal_extremum.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::3857"><gml:lowerCorner>2078985.88326099 5746736.89404743</gml:lowerCorner><gml:upperCorner>2078985.88326099 5746736.89404743</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.0"><gml:pos>2078985.88326099 5746736.89404743</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:zone>zone 1</ogr:zone>
+      <ogr:value>97.50000000</ogr:value>
+      <ogr:extremum>minimum</ogr:extremum>
+    </ogr:raster_zonal_extremum>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:raster_zonal_extremum gml:id="raster_zonal_extremum.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::3857"><gml:lowerCorner>2078752.11232507 5745092.4177069</gml:lowerCorner><gml:upperCorner>2078752.11232507 5745092.4177069</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.1"><gml:pos>2078752.11232507 5745092.4177069</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:zone>zone 1</ogr:zone>
+      <ogr:value>219.19999695</ogr:value>
+      <ogr:extremum>maximum</ogr:extremum>
+    </ogr:raster_zonal_extremum>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:raster_zonal_extremum gml:id="raster_zonal_extremum.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::3857"><gml:lowerCorner>2080499.82836984 5749099.83092514</gml:lowerCorner><gml:upperCorner>2080499.82836984 5749099.83092514</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.2"><gml:pos>2080499.82836984 5749099.83092514</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:zone>zone 2</ogr:zone>
+      <ogr:value>108.06781769</ogr:value>
+      <ogr:extremum>minimum</ogr:extremum>
+    </ogr:raster_zonal_extremum>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:raster_zonal_extremum gml:id="raster_zonal_extremum.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::3857"><gml:lowerCorner>2081279.06482292 5747790.6361686</gml:lowerCorner><gml:upperCorner>2081279.06482292 5747790.6361686</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.3"><gml:pos>2081279.06482292 5747790.6361686</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:zone>zone 2</ogr:zone>
+      <ogr:value>243.00000000</ogr:value>
+      <ogr:extremum>maximum</ogr:extremum>
+    </ogr:raster_zonal_extremum>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:raster_zonal_extremum gml:id="raster_zonal_extremum.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::3857"><gml:lowerCorner>2080421.90472453 5747072.17563143</gml:lowerCorner><gml:upperCorner>2080421.90472453 5747072.17563143</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.4"><gml:pos>2080421.90472453 5747072.17563143</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:zone>zone 3</ogr:zone>
+      <ogr:value>163.57766724</ogr:value>
+      <ogr:extremum>minimum</ogr:extremum>
+    </ogr:raster_zonal_extremum>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:raster_zonal_extremum gml:id="raster_zonal_extremum.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::3857"><gml:lowerCorner>2080433.03667386 5747056.20984171</gml:lowerCorner><gml:upperCorner>2080433.03667386 5747056.20984171</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::3857" gml:id="raster_zonal_extremum.geom.5"><gml:pos>2080433.03667386 5747056.20984171</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:zone>zone 3</ogr:zone>
+      <ogr:value>170.00000000</ogr:value>
+      <ogr:extremum>maximum</ogr:extremum>
+    </ogr:raster_zonal_extremum>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.xsd
@@ -54,7 +54,7 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
-        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+        <xs:element name="extremum_type" nillable="true" minOccurs="0" maxOccurs="1">
           <xs:simpleType>
             <xs:restriction base="xs:string">
             </xs:restriction>

--- a/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.xsd
+++ b/python/plugins/processing/tests/testdata/expected/raster_zonal_extremum.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="raster_zonal_extremum" type="ogr:raster_zonal_extremum_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="raster_zonal_extremum_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::3857" -->
+        <xs:element name="zone" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="value" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="8"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="extremum" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
@@ -285,3 +285,18 @@ tests:
       OUTPUT:
         name: expected/raster_max.gml
         type: vector
+
+  - algorithm: native:zonalminmaxpoint
+    name: Raster zonal min max
+    params:
+      INPUT:
+        name: custom/dem_zones.geojson
+        type: vector
+      INPUT_RASTER:
+        name: custom/dem_crs.tif
+        type: raster
+      RASTER_BAND: 1
+    results:
+      OUTPUT:
+        name: expected/raster_zonal_extremum.gml
+        type: vector

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -254,6 +254,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmwritevectortiles.cpp
   processing/qgsalgorithmxyztiles.cpp
   processing/qgsalgorithmzonalhistogram.cpp
+  processing/qgsalgorithmzonalminmaxpoint.cpp
   processing/qgsalgorithmzonalstatistics.cpp
   processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
   processing/qgsbookmarkalgorithms.cpp

--- a/src/analysis/processing/qgsalgorithmrasterminmax.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterminmax.cpp
@@ -111,7 +111,7 @@ QVariantMap QgsRasterMinMaxAlgorithm::processAlgorithm( const QVariantMap &param
   {
     QgsFields outFields;
     outFields.append( QgsField( QStringLiteral( "value" ), QMetaType::Type::Double, QString(), 20, 8 ) );
-    outFields.append( QgsField( QStringLiteral( "extremum" ), QMetaType::Type::QString ) );
+    outFields.append( QgsField( QStringLiteral( "extremum_type" ), QMetaType::Type::QString ) );
     sink.reset( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, outFields, Qgis::WkbType::Point, mCrs ) );
     if ( !sink )
       throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );

--- a/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
@@ -142,14 +142,14 @@ QVariantMap QgsZonalHistogramAlgorithm::processAlgorithm( const QVariantMap &par
 
     QHash< double, qgssize > fUniqueValues;
     QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( mRasterInterface.get(), mRasterBand, featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
-    rasterBlockExtent, [ &fUniqueValues]( double value ) { fUniqueValues[value]++; }, false );
+    rasterBlockExtent, [ &fUniqueValues]( double value, const QgsPointXY & ) { fUniqueValues[value]++; }, false );
 
     if ( fUniqueValues.count() < 1 )
     {
       // The cell resolution is probably larger than the polygon area. We switch to slower precise pixel - polygon intersection in this case
       // TODO: eventually deal with weight if needed
       QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( mRasterInterface.get(), mRasterBand, featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
-      rasterBlockExtent, [ &fUniqueValues]( double value, double ) { fUniqueValues[value]++; }, false );
+      rasterBlockExtent, [ &fUniqueValues]( double value, double, const QgsPointXY & ) { fUniqueValues[value]++; }, false );
     }
 
     for ( auto it = fUniqueValues.constBegin(); it != fUniqueValues.constEnd(); ++it )

--- a/src/analysis/processing/qgsalgorithmzonalminmaxpoint.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalminmaxpoint.cpp
@@ -136,7 +136,7 @@ bool QgsZonalMinimumMaximumPointAlgorithm::prepareAlgorithm( const QVariantMap &
 
   QgsFields newFields;
   newFields.append( QgsField( QStringLiteral( "value" ), QMetaType::Type::Double, QString(), 20, 8 ) );
-  newFields.append( QgsField( QStringLiteral( "extremum" ), QMetaType::Type::QString ) );
+  newFields.append( QgsField( QStringLiteral( "extremum_type" ), QMetaType::Type::QString ) );
   mOutputFields = QgsProcessingUtils::combineFields( source->fields(), newFields );
 
   return true;

--- a/src/analysis/processing/qgsalgorithmzonalminmaxpoint.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalminmaxpoint.cpp
@@ -1,0 +1,191 @@
+/***************************************************************************
+                         qgsalgorithmzonalminmaxpoint.cpp
+                         ------------------------------
+    begin                : November 2024
+    copyright            : (C) 2024 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmzonalminmaxpoint.h"
+#include "qgszonalstatistics.h"
+
+///@cond PRIVATE
+
+QString QgsZonalMinimumMaximumPointAlgorithm::name() const
+{
+  return QStringLiteral( "zonalminmaxpoint" );
+}
+
+QString QgsZonalMinimumMaximumPointAlgorithm::displayName() const
+{
+  return QObject::tr( "Zonal minimum/maximum point" );
+}
+
+QStringList QgsZonalMinimumMaximumPointAlgorithm::tags() const
+{
+  return QObject::tr( "stats,statistics,zones,maximum,minimum,raster,extrema,extremum" ).split( ',' );
+}
+
+QString QgsZonalMinimumMaximumPointAlgorithm::group() const
+{
+  return QObject::tr( "Raster analysis" );
+}
+
+QString QgsZonalMinimumMaximumPointAlgorithm::groupId() const
+{
+  return QStringLiteral( "rasteranalysis" );
+}
+
+QString QgsZonalMinimumMaximumPointAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Extracts point locations for minimum and maximum raster values within polygon zones." );
+}
+
+QString QgsZonalMinimumMaximumPointAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm extracts point features corresponding to the minimum "
+                      "and maximum pixel values contained within polygon zones.\n\n"
+                      "The output will contain one point feature for the minimum and one "
+                      "for the maximum raster value for every individual zonal feature "
+                      "from a polygon layer.\n\n"
+                      "The created point layer will be in the same spatial reference system as the selected raster layer." );
+}
+
+QList<int> QgsZonalMinimumMaximumPointAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << static_cast< int >( Qgis::ProcessingSourceType::VectorPolygon );
+}
+
+QgsZonalMinimumMaximumPointAlgorithm *QgsZonalMinimumMaximumPointAlgorithm::createInstance() const
+{
+  return new QgsZonalMinimumMaximumPointAlgorithm();
+}
+
+void QgsZonalMinimumMaximumPointAlgorithm::initParameters( const QVariantMap &configuration )
+{
+  Q_UNUSED( configuration )
+  addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT_RASTER" ), QObject::tr( "Raster layer" ) ) );
+  addParameter( new QgsProcessingParameterBand( QStringLiteral( "RASTER_BAND" ),
+                QObject::tr( "Raster band" ), 1, QStringLiteral( "INPUT_RASTER" ) ) );
+}
+
+QString QgsZonalMinimumMaximumPointAlgorithm::outputName() const
+{
+  return QObject::tr( "Zonal Extrema" );
+}
+
+QgsFields QgsZonalMinimumMaximumPointAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  Q_UNUSED( inputFields )
+  return mOutputFields;
+}
+
+Qgis::ProcessingSourceType QgsZonalMinimumMaximumPointAlgorithm::outputLayerType() const
+{
+  return Qgis::ProcessingSourceType::VectorPoint;
+}
+
+Qgis::WkbType QgsZonalMinimumMaximumPointAlgorithm::outputWkbType( Qgis::WkbType ) const
+{
+  return Qgis::WkbType::Point;
+}
+
+QgsFeatureSink::SinkFlags QgsZonalMinimumMaximumPointAlgorithm::sinkFlags() const
+{
+  return QgsFeatureSink::SinkFlag::RegeneratePrimaryKey;
+}
+
+Qgis::ProcessingAlgorithmDocumentationFlags QgsZonalMinimumMaximumPointAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RegeneratesPrimaryKey;
+}
+
+QgsCoordinateReferenceSystem QgsZonalMinimumMaximumPointAlgorithm::outputCrs( const QgsCoordinateReferenceSystem & ) const
+{
+  return mCrs;
+}
+
+bool QgsZonalMinimumMaximumPointAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsRasterLayer *rasterLayer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT_RASTER" ), context );
+  if ( !rasterLayer )
+    throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT_RASTER" ) ) );
+
+  mBand = parameterAsInt( parameters, QStringLiteral( "RASTER_BAND" ), context );
+  if ( mBand < 1 || mBand > rasterLayer->bandCount() )
+    throw QgsProcessingException( QObject::tr( "Invalid band number for BAND (%1): Valid values for input raster are 1 to %2" ).arg( mBand )
+                                  .arg( rasterLayer->bandCount() ) );
+
+  if ( !rasterLayer->dataProvider() )
+    throw QgsProcessingException( QObject::tr( "Invalid raster layer. Layer %1 is invalid." ).arg( rasterLayer->id() ) );
+
+  mRaster.reset( rasterLayer->dataProvider()->clone() );
+  mCrs = rasterLayer->crs();
+  mPixelSizeX = rasterLayer->rasterUnitsPerPixelX();
+  mPixelSizeY = rasterLayer->rasterUnitsPerPixelY();
+  std::unique_ptr<QgsFeatureSource> source( parameterAsSource( parameters, inputParameterName(), context ) );
+
+  QgsFields newFields;
+  newFields.append( QgsField( QStringLiteral( "value" ), QMetaType::Type::Double, QString(), 20, 8 ) );
+  newFields.append( QgsField( QStringLiteral( "extremum" ), QMetaType::Type::QString ) );
+  mOutputFields = QgsProcessingUtils::combineFields( source->fields(), newFields );
+
+  return true;
+}
+
+QgsFeatureList QgsZonalMinimumMaximumPointAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  if ( !mCreatedTransform )
+  {
+    mCreatedTransform = true;
+    mFeatureToRasterTransform = QgsCoordinateTransform( sourceCrs(), mCrs, context.transformContext() );
+  }
+
+  Q_UNUSED( feedback )
+  QgsAttributes attributes = feature.attributes();
+
+  QgsGeometry geometry = feature.geometry();
+  try
+  {
+    geometry.transform( mFeatureToRasterTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    if ( feedback )
+      feedback->reportError( QObject::tr( "Encountered a transform error when reprojecting feature with id %1." ).arg( feature.id() ) );
+  }
+
+  const QMap<Qgis::ZonalStatistic, QVariant> results = QgsZonalStatistics::calculateStatistics( mRaster.get(), geometry, mPixelSizeX, mPixelSizeY, mBand,
+      Qgis::ZonalStatistic::Min | Qgis::ZonalStatistic::MinimumPoint | Qgis::ZonalStatistic::Max | Qgis::ZonalStatistic::MaximumPoint );
+
+  QgsFeature minPointFeature( mOutputFields );
+  QgsAttributes minAttributes = attributes;
+  minAttributes << results.value( Qgis::ZonalStatistic::Min ) << QStringLiteral( "minimum" );
+  minPointFeature.setAttributes( minAttributes );
+  minPointFeature.setGeometry( QgsGeometry::fromPointXY( results.value( Qgis::ZonalStatistic::MinimumPoint ).value< QgsPointXY >() ) );
+
+  QgsFeature maxPointFeature( mOutputFields );
+  QgsAttributes maxAttributes = attributes;
+  maxAttributes << results.value( Qgis::ZonalStatistic::Max ) << QStringLiteral( "maximum" );
+  maxPointFeature.setAttributes( maxAttributes );
+  maxPointFeature.setGeometry( QgsGeometry::fromPointXY( results.value( Qgis::ZonalStatistic::MaximumPoint ).value< QgsPointXY >() ) );
+
+  return QgsFeatureList { minPointFeature, maxPointFeature };
+}
+
+bool QgsZonalMinimumMaximumPointAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  Q_UNUSED( layer )
+  return false;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmzonalminmaxpoint.h
+++ b/src/analysis/processing/qgsalgorithmzonalminmaxpoint.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+                         qgsalgorithmzonalminmaxpoint.h
+                         ------------------------------
+    begin                : November 2024
+    copyright            : (C) 2024 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMZONALMINMAXPOINT_H
+#define QGSALGORITHMZONALMINMAXPOINT_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native zonal minimum and maximum point algorithm.
+ */
+class QgsZonalMinimumMaximumPointAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsZonalMinimumMaximumPointAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortDescription() const override;
+    QString shortHelpString() const override;
+    QList<int> inputLayerTypes() const override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+    QgsZonalMinimumMaximumPointAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    QString outputName() const override;
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+    Qgis::ProcessingSourceType outputLayerType() const override;
+    Qgis::WkbType outputWkbType( Qgis::WkbType inputWkbType ) const override;
+    QgsFeatureSink::SinkFlags sinkFlags() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
+    QgsCoordinateReferenceSystem outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const override;
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+    std::unique_ptr< QgsRasterInterface > mRaster;
+    int mBand = 1;
+    QgsCoordinateReferenceSystem mCrs;
+    bool mCreatedTransform = false;
+    QgsCoordinateTransform mFeatureToRasterTransform;
+    double mPixelSizeX = 0;
+    double mPixelSizeY = 0;
+    QgsFields mOutputFields;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMZONALMINMAXPOINT_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -237,6 +237,7 @@
 #include "qgsalgorithmwritevectortiles.h"
 #include "qgsalgorithmxyztiles.h"
 #include "qgsalgorithmzonalhistogram.h"
+#include "qgsalgorithmzonalminmaxpoint.h"
 #include "qgsalgorithmzonalstatistics.h"
 #include "qgsalgorithmzonalstatisticsfeaturebased.h"
 #include "qgsalgorithmpolygonstolines.h"
@@ -557,6 +558,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsXyzTilesDirectoryAlgorithm() );
   addAlgorithm( new QgsXyzTilesMbtilesAlgorithm() );
   addAlgorithm( new QgsZonalHistogramAlgorithm() );
+  addAlgorithm( new QgsZonalMinimumMaximumPointAlgorithm() );
   addAlgorithm( new QgsZonalStatisticsAlgorithm() );
   addAlgorithm( new QgsZonalStatisticsFeatureBasedAlgorithm() );
   addAlgorithm( new QgsPolygonsToLinesAlgorithm() );

--- a/src/analysis/processing/qgsrasteranalysisutils.cpp
+++ b/src/analysis/processing/qgsrasteranalysisutils.cpp
@@ -59,7 +59,7 @@ void QgsRasterAnalysisUtils::cellInfoForBBox( const QgsRectangle &rasterBBox, co
                                     rasterBBox.yMaximum() - ( nCellsY + offsetY ) * cellSizeY );
 }
 
-void QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox,  const std::function<void( double )> &addValue, bool skipNodata )
+void QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox,  const std::function<void( double, const QgsPointXY & )> &addValue, bool skipNodata )
 {
   std::unique_ptr< QgsGeos > polyEngine = std::make_unique< QgsGeos >( poly.constGet( ) );
   if ( !polyEngine )
@@ -92,7 +92,7 @@ void QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( QgsRasterInterface *
         {
           if ( polyEngine->contains( cellCenterX, cellCenterY ) )
           {
-            addValue( pixelValue );
+            addValue( pixelValue, QgsPointXY( cellCenterX, cellCenterY ) );
           }
         }
         cellCenterX += cellSizeX;
@@ -102,7 +102,7 @@ void QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( QgsRasterInterface *
   }
 }
 
-void QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox,  const std::function<void( double, double )> &addValue, bool skipNodata )
+void QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox,  const std::function<void( double, double, const QgsPointXY & )> &addValue, bool skipNodata )
 {
   QgsGeometry pixelRectGeometry;
 
@@ -152,7 +152,7 @@ void QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( QgsRasterInterfa
               if ( intersectionArea > 0.0 )
               {
                 weight = intersectionArea / pixelArea;
-                addValue( pixelValue, weight );
+                addValue( pixelValue, weight, QgsPointXY( currentX, currentY ) );
               }
             }
           }

--- a/src/analysis/processing/qgsrasteranalysisutils.h
+++ b/src/analysis/processing/qgsrasteranalysisutils.h
@@ -18,6 +18,7 @@
 
 #include "qgis_analysis.h"
 #include "qgis.h"
+#include "qgspointxy.h"
 
 #include <functional>
 #include <memory>
@@ -48,11 +49,11 @@ namespace QgsRasterAnalysisUtils
 
   //! Returns statistics by considering the pixels where the center point is within the polygon (fast)
   void statisticsFromMiddlePointTest( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY,
-                                      double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, const std::function<void( double )> &addValue, bool skipNodata = true );
+                                      double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, const std::function<void( double, const QgsPointXY & )> &addValue, bool skipNodata = true );
 
   //! Returns statistics with precise pixel - polygon intersection test (slow)
   void statisticsFromPreciseIntersection( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY,
-                                          double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, const std::function<void( double, double )> &addValue, bool skipNodata = true );
+                                          double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, const std::function<void( double, double, const QgsPointXY & )> &addValue, bool skipNodata = true );
 
   //! Tests whether a pixel's value should be included in the result
   bool validPixel( double value );

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -235,6 +235,10 @@ QString QgsZonalStatistics::displayName( Qgis::ZonalStatistic statistic )
       return QObject::tr( "Minimum" );
     case Qgis::ZonalStatistic::Max:
       return QObject::tr( "Maximum" );
+    case Qgis::ZonalStatistic::MinimumPoint:
+      return QObject::tr( "Minimum point" );
+    case Qgis::ZonalStatistic::MaximumPoint:
+      return QObject::tr( "Maximum point" );
     case Qgis::ZonalStatistic::Range:
       return QObject::tr( "Range" );
     case Qgis::ZonalStatistic::Minority:
@@ -270,6 +274,10 @@ QString QgsZonalStatistics::shortName( Qgis::ZonalStatistic statistic )
       return QStringLiteral( "min" );
     case Qgis::ZonalStatistic::Max:
       return QStringLiteral( "max" );
+    case Qgis::ZonalStatistic::MinimumPoint:
+      return QStringLiteral( "minpoint" );
+    case Qgis::ZonalStatistic::MaximumPoint:
+      return QStringLiteral( "maxpoint" );
     case Qgis::ZonalStatistic::Range:
       return QStringLiteral( "range" );
     case Qgis::ZonalStatistic::Minority:
@@ -330,13 +338,13 @@ QMap<Qgis::ZonalStatistic, QVariant> QgsZonalStatistics::calculateStatistics( Qg
   QgsRasterAnalysisUtils::cellInfoForBBox( rasterBBox, featureRect, cellSizeX, cellSizeY, nCellsX, nCellsY, nCellsXProvider, nCellsYProvider, rasterBlockExtent );
 
   featureStats.reset();
-  QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( rasterInterface, rasterBand, geometry, nCellsX, nCellsY, cellSizeX, cellSizeY, rasterBlockExtent, [ &featureStats ]( double value ) { featureStats.addValue( value ); } );
+  QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( rasterInterface, rasterBand, geometry, nCellsX, nCellsY, cellSizeX, cellSizeY, rasterBlockExtent, [ &featureStats ]( double value, const QgsPointXY & point ) { featureStats.addValue( value, point ); } );
 
   if ( featureStats.count <= 1 )
   {
     //the cell resolution is probably larger than the polygon area. We switch to precise pixel - polygon intersection in this case
     featureStats.reset();
-    QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( rasterInterface, rasterBand, geometry, nCellsX, nCellsY, cellSizeX, cellSizeY, rasterBlockExtent, [ &featureStats ]( double value, double weight ) { featureStats.addValue( value, weight ); } );
+    QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( rasterInterface, rasterBand, geometry, nCellsX, nCellsY, cellSizeX, cellSizeY, rasterBlockExtent, [ &featureStats ]( double value, double weight, const QgsPointXY & point ) { featureStats.addValue( value, point, weight ); } );
   }
 
   // calculate the statistics
@@ -387,6 +395,10 @@ QMap<Qgis::ZonalStatistic, QVariant> QgsZonalStatistics::calculateStatistics( Qg
       results.insert( Qgis::ZonalStatistic::Min, QVariant( featureStats.min ) );
     if ( statistics & Qgis::ZonalStatistic::Max )
       results.insert( Qgis::ZonalStatistic::Max, QVariant( featureStats.max ) );
+    if ( statistics & Qgis::ZonalStatistic::MinimumPoint )
+      results.insert( Qgis::ZonalStatistic::MinimumPoint, QVariant( featureStats.minPoint ) );
+    if ( statistics & Qgis::ZonalStatistic::MaximumPoint )
+      results.insert( Qgis::ZonalStatistic::MaximumPoint, QVariant( featureStats.maxPoint ) );
     if ( statistics & Qgis::ZonalStatistic::Range )
       results.insert( Qgis::ZonalStatistic::Range, QVariant( featureStats.max - featureStats.min ) );
     if ( statistics & Qgis::ZonalStatistic::Minority || statistics & Qgis::ZonalStatistic::Majority )

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -164,7 +164,7 @@ class ANALYSIS_EXPORT QgsZonalStatistics
           values.clear();
         }
 
-        void addValue( double value, double weight = 1.0 )
+        void addValue( double value, const QgsPointXY &point, double weight = 1.0 )
         {
           if ( weight < 1.0 )
           {
@@ -176,8 +176,16 @@ class ANALYSIS_EXPORT QgsZonalStatistics
             sum += value;
             ++count;
           }
-          min = std::min( min, value );
-          max = std::max( max, value );
+          if ( value < min )
+          {
+            min = value;
+            minPoint = point;
+          }
+          if ( value > max )
+          {
+            max = value;
+            maxPoint = point;
+          }
           if ( mStoreValueCounts )
             valueCount.insert( value, valueCount.value( value, 0 ) + 1 );
           if ( mStoreValues )
@@ -187,6 +195,8 @@ class ANALYSIS_EXPORT QgsZonalStatistics
         double count = 0.0;
         double max = std::numeric_limits<double>::lowest();
         double min = std::numeric_limits<double>::max();
+        QgsPointXY minPoint;
+        QgsPointXY maxPoint;
         QMap< double, int > valueCount;
         QList< double > values;
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5361,7 +5361,7 @@ class CORE_EXPORT Qgis
       Variety = 1 << 10, //!< Variety (count of distinct) pixel values
       Variance = 1 << 11, //!< Variance of pixel values
       MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
-      MaximumPoint = 1 << 13, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
+      MaximumPoint = 1 << 13, //!< Pixel centroid for maximum pixel value \since QGIS 3.42
       All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance | MinimumPoint | MaximumPoint, //!< All statistics
       Default = Count | Sum | Mean, //!< Default statistics
     };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5341,6 +5341,9 @@ class CORE_EXPORT Qgis
     };
     Q_ENUM( VsiHandlerType )
 
+    // TODO QGIS 4: make All include all values (we can't do this before 4.0, as we need to keep
+    // compatibility with code which expects all these statistics to give numeric results)
+
     /**
      * Statistics to be calculated during a zonal statistics operation.
      *
@@ -5362,7 +5365,8 @@ class CORE_EXPORT Qgis
       Variance = 1 << 11, //!< Variance of pixel values
       MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
       MaximumPoint = 1 << 13, //!< Pixel centroid for maximum pixel value \since QGIS 3.42
-      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics, excluding MinimumPoint and MaximumPoint
+      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead.
+      AllNumeric = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All numeric statistics \since QGIS 3.42
       Default = Count | Sum | Mean, //!< Default statistics
     };
     Q_ENUM( ZonalStatistic )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5348,19 +5348,21 @@ class CORE_EXPORT Qgis
      */
     enum class ZonalStatistic : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Count = 1,  //!< Pixel count
-      Sum = 2,  //!< Sum of pixel values
-      Mean = 4,  //!< Mean of pixel values
-      Median = 8, //!< Median of pixel values
-      StDev = 16, //!< Standard deviation of pixel values
-      Min = 32,  //!< Min of pixel values
-      Max = 64,  //!< Max of pixel values
-      Range = 128, //!< Range of pixel values (max - min)
-      Minority = 256, //!< Minority of pixel values
-      Majority = 512, //!< Majority of pixel values
-      Variety = 1024, //!< Variety (count of distinct) pixel values
-      Variance = 2048, //!< Variance of pixel values
-      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics
+      Count = 1 << 0,  //!< Pixel count
+      Sum = 1 << 1,  //!< Sum of pixel values
+      Mean = 1 << 2,  //!< Mean of pixel values
+      Median = 1 << 3, //!< Median of pixel values
+      StDev = 1 << 4, //!< Standard deviation of pixel values
+      Min = 1 << 5,  //!< Min of pixel values
+      Max = 1 << 6,  //!< Max of pixel values
+      Range = 1 << 7, //!< Range of pixel values (max - min)
+      Minority = 1 << 8, //!< Minority of pixel values
+      Majority = 1 << 9, //!< Majority of pixel values
+      Variety = 1 << 10, //!< Variety (count of distinct) pixel values
+      Variance = 1 << 11, //!< Variance of pixel values
+      MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
+      MaximumPoint = 1 << 13, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
+      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance | MinimumPoint | MaximumPoint, //!< All statistics
       Default = Count | Sum | Mean, //!< Default statistics
     };
     Q_ENUM( ZonalStatistic )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5362,7 +5362,7 @@ class CORE_EXPORT Qgis
       Variance = 1 << 11, //!< Variance of pixel values
       MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
       MaximumPoint = 1 << 13, //!< Pixel centroid for maximum pixel value \since QGIS 3.42
-      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance | MinimumPoint | MaximumPoint, //!< All statistics
+      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics, excluding MinimumPoint and MaximumPoint
       Default = Count | Sum | Mean, //!< Default statistics
     };
     Q_ENUM( ZonalStatistic )


### PR DESCRIPTION
This algorithm extracts point features corresponding to the minimum and maximum pixel values contained within polygon zones.

The output will contain one point feature for the minimum and one for the maximum raster value for every individual zonal feature from a polygon layer.
