### PR TITLE
Set appropriate permissions to called workflow

### DIFF
--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -80,6 +80,9 @@ jobs:
     if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'Needs Documentation') ) || github.event.label.name == 'Needs Documentation' )
     # Update the milestone (if necessary)
     name: Update final milestone
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/pr-auto-milestone.yml
 
   create-doc-issue:


### PR DESCRIPTION
Follow up #59295. The action was failing due to
> [Invalid workflow file: .github/workflows/pr-needs-documentation.yml#L79](https://github.com/qgis/QGIS/actions/runs/11713449162/workflow)
The workflow is not valid. .github/workflows/pr-needs-documentation.yml (Line: 79, Col: 3): Error calling workflow 'qgis/QGIS/.github/workflows/pr-auto-milestone.yml@1910a2b03aaa80ed69ac49c007d6e7c5a926a2bc'. The nested job 'pr-without-milestones' is requesting 'issues: write, pull-requests: write', but is only allowed 'issues: none, pull-requests: none'.