### PR TITLE
Add contents permissoon

### DIFF
--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -83,6 +83,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      contents: read
     uses: ./.github/workflows/pr-auto-milestone.yml
 
   create-doc-issue:


### PR DESCRIPTION
_Really sorry for the trial and catch_

The milestone action now complains about missing "contents" permission. Afaict, should be the last permission in this file. Hopefully...

> [Invalid workflow file: .github/workflows/pr-needs-documentation.yml#L79](https://github.com/qgis/QGIS/actions/runs/11718184875/workflow)
The workflow is not valid. .github/workflows/pr-needs-documentation.yml (Line: 79, Col: 3): Error calling workflow 'qgis/QGIS/.github/workflows/pr-auto-milestone.yml@21ed8fc6640d707db7e3ff00476c61879c577ffe'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.