### PR TITLE
Plots: Add title and axis titles; scatterplot option for logarithmic axes [FEATURE]

### DIFF
--- a/doc/CONTRIBUTORS
+++ b/doc/CONTRIBUTORS
@@ -39,6 +39,7 @@ Even Rouault
 Fernando Pacheco
 Florian El Ahdab
 Florian Hof
+Florian Neukirchen
 Frank Warmerdam
 Germán Carrillo
 Giovanni Manghi

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -106,9 +106,12 @@ class BarPlot(QgisAlgorithm):
         xaxis_title = self.parameterAsString(parameters, self.XAXIS_TITLE, context)
         yaxis_title = self.parameterAsString(parameters, self.YAXIS_TITLE, context)
 
-        if title.strip() == "": title = None
-        if xaxis_title.strip() == "": xaxis_title = None
-        if yaxis_title.strip() == "": yaxis_title = None
+        if title.strip() == "":
+            title = None
+        if xaxis_title.strip() == "":
+            xaxis_title = namefieldname
+        if yaxis_title.strip() == "":
+            yaxis_title = valuefieldname
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -108,7 +108,7 @@ class BarPlot(QgisAlgorithm):
 
         if title.strip() == "": title = None
         if xaxis_title.strip() == "": xaxis_title = None
-        if yaxis_title.strip() == "": xaxis_title = None
+        if yaxis_title.strip() == "": yaxis_title = None
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -70,12 +70,12 @@ class BarPlot(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('Xaxis Title'),
+            self.tr('X-axis Title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Yaxis Title'),
+            self.tr('Y-axis Title'),
             optional=True))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -108,10 +108,14 @@ class BarPlot(QgisAlgorithm):
 
         if title.strip() == "":
             title = None
-        if xaxis_title.strip() == "":
+        if xaxis_title == "":
             xaxis_title = namefieldname
-        if yaxis_title.strip() == "":
+        elif xaxis_title == " ":
+            xaxis_title = None
+        if yaxis_title == "":
             yaxis_title = valuefieldname
+        elif yaxis_title == " ":
+            yaxis_title = None
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -70,12 +70,12 @@ class BarPlot(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('X-axis Title'),
+            self.tr('X-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Y-axis Title'),
+            self.tr('Y-axis title'),
             optional=True))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -120,7 +120,7 @@ class BoxPlot(QgisAlgorithm):
 
         if title.strip() == "": title = None
         if xaxis_title.strip() == "": xaxis_title = None
-        if yaxis_title.strip() == "": xaxis_title = None
+        if yaxis_title.strip() == "": yaxis_title = None
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -118,9 +118,12 @@ class BoxPlot(QgisAlgorithm):
         xaxis_title = self.parameterAsString(parameters, self.XAXIS_TITLE, context)
         yaxis_title = self.parameterAsString(parameters, self.YAXIS_TITLE, context)
 
-        if title.strip() == "": title = None
-        if xaxis_title.strip() == "": xaxis_title = None
-        if yaxis_title.strip() == "": yaxis_title = None
+        if title.strip() == "":
+            title = None
+        if xaxis_title.strip() == "":
+            xaxis_title = namefieldname
+        if yaxis_title.strip() == "":
+            yaxis_title = valuefieldname
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -120,10 +120,14 @@ class BoxPlot(QgisAlgorithm):
 
         if title.strip() == "":
             title = None
-        if xaxis_title.strip() == "":
+        if xaxis_title == "":
             xaxis_title = namefieldname
+        elif xaxis_title == " ":
+            xaxis_title = None
         if yaxis_title.strip() == "":
             yaxis_title = valuefieldname
+        elif yaxis_title == " ":
+            yaxis_title = None
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -80,12 +80,12 @@ class BoxPlot(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('Xaxis Title'),
+            self.tr('X-axis Title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Yaxis Title'),
+            self.tr('Y-axis Title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Box plot'), self.tr('HTML files (*.html)')))

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -80,12 +80,12 @@ class BoxPlot(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('X-axis Title'),
+            self.tr('X-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Y-axis Title'),
+            self.tr('Y-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Box plot'), self.tr('HTML files (*.html)')))

--- a/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
+++ b/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
@@ -54,7 +54,9 @@ class MeanAndStdDevPlot(QgisAlgorithm):
                                                       self.tr('Category name field'), parentLayerParameterName=self.INPUT,
                                                       type=QgsProcessingParameterField.DataType.Any))
         self.addParameter(QgsProcessingParameterField(self.VALUE_FIELD,
-                                                      self.tr('Value field'), parentLayerParameterName=self.INPUT))
+                                                      self.tr('Value field'),
+                                                      parentLayerParameterName=self.INPUT,
+                                                      type=QgsProcessingParameterField.DataType.Numeric))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Plot'), self.tr('HTML files (*.html)')))
 

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -126,10 +126,14 @@ class VectorLayerScatterplot(QgisAlgorithm):
 
         if title.strip() == "":
             title = None
-        if xaxis_title.strip() == "":
+        if xaxis_title == "":
             xaxis_title = xfieldname
-        if yaxis_title.strip() == "":
+        elif xaxis_title == " ":
+            xaxis_title = None
+        if yaxis_title == "":
             yaxis_title = yfieldname
+        elif yaxis_title == " ":
+            yaxis_title = None
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -72,23 +72,23 @@ class VectorLayerScatterplot(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('Xaxis Title'),
+            self.tr('X-axis Title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Yaxis Title'),
+            self.tr('Y-axis Title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterBoolean(
             self.XAXIS_LOG,
-            self.tr('Xaxis logarithmic'),
+            self.tr('Use logarithmic scale for x-axis'),
             defaultValue=False,
             optional=True))
 
         self.addParameter(QgsProcessingParameterBoolean(
             self.YAXIS_LOG,
-            self.tr('Yaxis logarithmic'),
+            self.tr('Use logarithmic scale for y-axis'),
             defaultValue=False,
             optional=True))
 

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -72,12 +72,12 @@ class VectorLayerScatterplot(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('X-axis Title'),
+            self.tr('X-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Y-axis Title'),
+            self.tr('Y-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterBoolean(

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -124,9 +124,12 @@ class VectorLayerScatterplot(QgisAlgorithm):
         xaxis_log = self.parameterAsBool(parameters, self.XAXIS_LOG, context)
         yaxis_log = self.parameterAsBool(parameters, self.YAXIS_LOG, context)
 
-        if title.strip() == "": title = None
-        if xaxis_title.strip() == "": xaxis_title = None
-        if yaxis_title.strip() == "": yaxis_title = None
+        if title.strip() == "":
+            title = None
+        if xaxis_title.strip() == "":
+            xaxis_title = xfieldname
+        if yaxis_title.strip() == "":
+            yaxis_title = yfieldname
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -76,20 +76,20 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('Xaxis Title'),
+            self.tr('X-axis Title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Yaxis Title'),
+            self.tr('Y-axis Title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.ZAXIS_TITLE,
-            self.tr('Zaxis Title'),
+            self.tr('Z-axis Title'),
             optional=True))
 
-        self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Histogram'), self.tr('HTML files (*.html)')))
+        self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Scatterplot 3D'), self.tr('HTML files (*.html)')))
 
     def name(self):
         return 'scatter3dplot'

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -23,7 +23,9 @@ import warnings
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFileDestination,
-                       QgsProcessingException)
+                       QgsProcessingException,
+                       QgsProcessingParameterString)
+
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 from processing.tools import vector
@@ -37,6 +39,10 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
     XFIELD = 'XFIELD'
     YFIELD = 'YFIELD'
     ZFIELD = 'ZFIELD'
+    TITLE = 'TITLE'
+    XAXIS_TITLE = "XAXIS_TITLE"
+    YAXIS_TITLE = "YAXIS_TITLE"
+    ZAXIS_TITLE = "ZAXIS_TITLE"
 
     def group(self):
         return self.tr('Plots')
@@ -62,6 +68,26 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
                                                       self.tr('Z attribute'),
                                                       parentLayerParameterName=self.INPUT,
                                                       type=QgsProcessingParameterField.DataType.Numeric))
+
+        self.addParameter(QgsProcessingParameterString(
+            self.TITLE,
+            self.tr('Title'),
+            optional=True))
+
+        self.addParameter(QgsProcessingParameterString(
+            self.XAXIS_TITLE,
+            self.tr('Xaxis Title'),
+            optional=True))
+
+        self.addParameter(QgsProcessingParameterString(
+            self.YAXIS_TITLE,
+            self.tr('Yaxis Title'),
+            optional=True))
+
+        self.addParameter(QgsProcessingParameterString(
+            self.ZAXIS_TITLE,
+            self.tr('Zaxis Title'),
+            optional=True))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Histogram'), self.tr('HTML files (*.html)')))
 
@@ -90,6 +116,16 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
         yfieldname = self.parameterAsString(parameters, self.YFIELD, context)
         zfieldname = self.parameterAsString(parameters, self.ZFIELD, context)
 
+        title = self.parameterAsString(parameters, self.TITLE, context)
+        xaxis_title = self.parameterAsString(parameters, self.XAXIS_TITLE, context)
+        yaxis_title = self.parameterAsString(parameters, self.YAXIS_TITLE, context)
+        zaxis_title = self.parameterAsString(parameters, self.YAXIS_TITLE, context)
+
+        if title.strip() == "": title = None
+        if xaxis_title.strip() == "": xaxis_title = None
+        if yaxis_title.strip() == "": xaxis_title = None
+        if zaxis_title.strip() == "": xaxis_title = None
+
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 
         values = vector.values(source, xfieldname, yfieldname, zfieldname)
@@ -100,6 +136,14 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
                 z=values[zfieldname],
                 mode='markers')]
 
-        plt.offline.plot(data, filename=output, auto_open=False)
+
+        fig = go.Figure(
+            data=data,
+            layout_title_text=title,
+            layout_scene_xaxis_title=xaxis_title,
+            layout_scene_yaxis_title=yaxis_title,
+            layout_scene_zaxis_title=zaxis_title)
+
+        fig.write_html(output)
 
         return {self.OUTPUT: output}

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -123,6 +123,8 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
 
         if title.strip() == "":
             title = None
+        # Passing None for axis titles to Plotly does not work in this case: Unlike in 2D charts, Plotly would use x, y, z as axis titles.
+        # If our users enter space, we still get invisible axes titles, resulting in the same behavoir as for the other algs.
         if xaxis_title == "":
             xaxis_title = xfieldname
         if yaxis_title == "":

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -119,12 +119,12 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
         title = self.parameterAsString(parameters, self.TITLE, context)
         xaxis_title = self.parameterAsString(parameters, self.XAXIS_TITLE, context)
         yaxis_title = self.parameterAsString(parameters, self.YAXIS_TITLE, context)
-        zaxis_title = self.parameterAsString(parameters, self.YAXIS_TITLE, context)
+        zaxis_title = self.parameterAsString(parameters, self.ZAXIS_TITLE, context)
 
         if title.strip() == "": title = None
         if xaxis_title.strip() == "": xaxis_title = None
-        if yaxis_title.strip() == "": xaxis_title = None
-        if zaxis_title.strip() == "": xaxis_title = None
+        if yaxis_title.strip() == "": yaxis_title = None
+        if zaxis_title.strip() == "": zaxis_title = None
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -140,7 +140,6 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
                 z=values[zfieldname],
                 mode='markers')]
 
-
         fig = go.Figure(
             data=data,
             layout_title_text=title,

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -124,7 +124,7 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
         if title.strip() == "":
             title = None
         # Passing None for axis titles to Plotly does not work in this case: Unlike in 2D charts, Plotly would use x, y, z as axis titles.
-        # If our users enter space, we still get invisible axes titles, resulting in the same behavoir as for the other algs.
+        # If our users enter space, we still get invisible axes titles, resulting in the same behavior as for the other algs.
         if xaxis_title == "":
             xaxis_title = xfieldname
         if yaxis_title == "":

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -76,17 +76,17 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterString(
             self.XAXIS_TITLE,
-            self.tr('X-axis Title'),
+            self.tr('X-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.YAXIS_TITLE,
-            self.tr('Y-axis Title'),
+            self.tr('Y-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterString(
             self.ZAXIS_TITLE,
-            self.tr('Z-axis Title'),
+            self.tr('Z-axis title'),
             optional=True))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Scatterplot 3D'), self.tr('HTML files (*.html)')))

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -123,11 +123,11 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
 
         if title.strip() == "":
             title = None
-        if xaxis_title.strip() == "":
+        if xaxis_title == "":
             xaxis_title = xfieldname
-        if yaxis_title.strip() == "":
+        if yaxis_title == "":
             yaxis_title = yfieldname
-        if zaxis_title.strip() == "":
+        if zaxis_title == "":
             zaxis_title = zfieldname
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -121,10 +121,14 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
         yaxis_title = self.parameterAsString(parameters, self.YAXIS_TITLE, context)
         zaxis_title = self.parameterAsString(parameters, self.ZAXIS_TITLE, context)
 
-        if title.strip() == "": title = None
-        if xaxis_title.strip() == "": xaxis_title = None
-        if yaxis_title.strip() == "": yaxis_title = None
-        if zaxis_title.strip() == "": zaxis_title = None
+        if title.strip() == "":
+            title = None
+        if xaxis_title.strip() == "":
+            xaxis_title = xfieldname
+        if yaxis_title.strip() == "":
+            yaxis_title = yfieldname
+        if zaxis_title.strip() == "":
+            zaxis_title = zfieldname
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 


### PR DESCRIPTION
## Description
New features and bugfixes for the plotting algorithms (in "Plots") to get more meaningful plots.

### Title and axis titles
Add title and axis titles as optional parameters to the processing algorithms:
  - Vector layer Scatterplot
  - Vector layer Scatterplot3D
  - Barplot
  - Boxplot
If axis titles are empty, the name of the field is used as axis title. If a single space is entered, the axis title is not shown (and the plot looks like before the changes).

### Logarithmic axes in scatterplot
Optionally, in "Vector layer Scatterplot", allow x-axis and/or y-axis to be logarithmic.

### Bugfixes
  - Boxplot: "Value field" type must be numeric
  - Vectorlayer Scatterplot3D: Output name "Scatterplot 3D" instead of "Histogram" 

### Screenshots

Vector layer Scatterplot, new version (with logarithmic axes, title, y-axis title; while x-axis title was not given and the field name is used)

![screenshot-1](https://github.com/user-attachments/assets/99dfe9ce-7199-4130-a3ac-db9844544567)

Vector layer Scatterplot, old version for comparison
![screenshot-now](https://github.com/user-attachments/assets/c6fc8b2b-9037-4a7b-8882-c2f3c4ba73fa)

## Documentation

For https://docs.qgis.org/3.34/en/docs/user_manual/processing_algs/qgis/plots.html



### Section Bar Plot
New Parameters (Label | Name | Type | Description):
- Title | TITLE | [string] Default: "" | Title of the plot
-  X-axis Title | XAXIS_TITLE | [string] Default: "" | X axis title, if empty, the name of the category field is used. With a single space, the axis title is not shown.
- Y-axis Title | YAXIS_TITLE | [string] Default: "" | Y axis title, if empty, the name of the value field is used. With a single space, the axis title is not shown.

### Section Box Plot
New Parameters (Label | Name | Type | Description):
- Title | TITLE | [string] Default: "" | Title of the plot
-  X-axis Title | XAXIS_TITLE | [string] Default: "" | X axis title, if empty, the name of the category field is used. With a single space, the axis title is not shown.
- Y-axis Title | YAXIS_TITLE | [string] Default: "" | Y axis title, if empty, the name of the value field is used. With a single space, the axis title is not shown.

Change to Parameter "Value Field": Type is now: [tablefield: numeric]


### Section Vector layer scatterplot
New Parameters (Label | Name | Type | Description):
- Title | TITLE | [string] Default: "" | Title of the plot
-  X-axis Title | XAXIS_TITLE | [string] Default: "" | X axis title, if empty, the field name of the x attribute is used.  With a single space, the axis title is not shown.
- Y-axis Title | YAXIS_TITLE | [string] Default: "" | Y axis title, if empty, the field name of the y attribute is used. With a single space, the axis title is not shown.
-  Use logarithmic scale for x-axis | XAXIS_LOG | [boolean] Default: False | Optionally use logarithmic x axis
-  Use logarithmic scale for y-axis | YAXIS_LOG | [boolean] Default: False | Optionally use logarithmic y axis


### Section Vector layer scatterplot 3D
New Parameters (Label | Name | Type | Description):
- Title | TITLE | [string] Default: "" | Title of the plot
-  X-axis Title | XAXIS_TITLE | [string] Default: "" | X axis title, if empty, the field name of the x attribute is used.  
- Y-axis Title | YAXIS_TITLE | [string] Default: "" | Y axis title, if empty, the field name of the y attribute is used. 
- Z-axis Title | ZAXIS_TITLE | [string] Default: "" | Z axis title, if empty, the field name of the y attribute is used. 

Change to Outputs:
Label of "OUTPUT" is now "Scatterplot 3D", not "Histogram"
