### PR TITLE
Make plugin watchdog considering timestamp of last run. Fixes #59370

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -118,11 +118,11 @@ class QgsPluginInstaller(QObject):
                 self.uninstallPlugin(key, quiet=True)
                 updateAvailablePlugins()
                 if plugin_is_active:
-                    settings.setValue("/PythonPlugins/watchDog/" + key,
+                    settings.setValue("/PythonPlugins/watchDogTimestamp/" + key,
                                       QDateTime.currentDateTime().toSecsSinceEpoch())
                     loadPlugin(key)
                     startPlugin(key)
-                    settings.remove("/PythonPlugins/watchDog/" + key)
+                    settings.remove("/PythonPlugins/watchDogTimestamp/" + key)
 
     # ----------------------------------------- #
     def fetchAvailablePlugins(self, reloadMode):

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -29,7 +29,7 @@ import zipfile
 from functools import partial
 
 from qgis.PyQt import sip
-from qgis.PyQt.QtCore import Qt, QObject, QDir, QUrl, QFileInfo, QFile
+from qgis.PyQt.QtCore import Qt, QObject, QDateTime, QDir, QUrl, QFileInfo, QFile
 from qgis.PyQt.QtWidgets import (
     QApplication,
     QDialog,
@@ -118,7 +118,8 @@ class QgsPluginInstaller(QObject):
                 self.uninstallPlugin(key, quiet=True)
                 updateAvailablePlugins()
                 if plugin_is_active:
-                    settings.setValue("/PythonPlugins/watchDog/" + key, True)
+                    settings.setValue("/PythonPlugins/watchDog/" + key,
+                                      QDateTime.currentDateTime().toSecsSinceEpoch())
                     loadPlugin(key)
                     startPlugin(key)
                     settings.remove("/PythonPlugins/watchDog/" + key)

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -317,7 +317,7 @@ void QgsPluginRegistry::loadPythonPlugin( const QString &packageName )
     settings.setValue( "/PythonPlugins/" + packageName, true );
     QgsMessageLog::logMessage( QObject::tr( "Loaded %1 (package: %2)" ).arg( pluginName, packageName ), QObject::tr( "Plugins" ), Qgis::MessageLevel::Info );
 
-    settings.remove( "/PythonPlugins/watchDog/" + packageName );
+    settings.remove( "/PythonPlugins/watchDogTimestamp/" + packageName );
   }
 #else
   Q_UNUSED( packageName )
@@ -402,7 +402,7 @@ void QgsPluginRegistry::loadCppPlugin( const QString &fullPathName )
             }
           }
 
-          settings.remove( "/Plugins/watchDog/" + baseName );
+          settings.remove( "/Plugins/watchDogTimestamp/" + baseName );
         }
         else
         {
@@ -509,7 +509,7 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
 
       bool pluginCrashedPreviously = false;
       const QString baseName = QFileInfo( myFullPath ).baseName();
-      const QVariant lastRun = mySettings.value( QStringLiteral( "Plugins/watchDog/%1" ).arg( baseName ) );
+      const QVariant lastRun = mySettings.value( QStringLiteral( "Plugins/watchDogTimestamp/%1" ).arg( baseName ) );
       if ( lastRun.isValid() )
       {
         if ( QDateTime::currentDateTime().toSecsSinceEpoch() - lastRun.toLongLong() > 5 )
@@ -544,14 +544,14 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
           QgsSettings settings;
           settings.setValue( "/Plugins/" + baseName, true );
           loadCppPlugin( myFullPath );
-          settings.remove( QStringLiteral( "/Plugins/watchDog/%1" ).arg( baseName ) );
+          settings.remove( QStringLiteral( "/Plugins/watchDogTimestamp/%1" ).arg( baseName ) );
           mQgisInterface->messageBar()->popWidget( watchdogMsg );
         } );
         QObject::connect( btnIgnore, &QToolButton::clicked, mQgisInterface->messageBar(), [ = ]()
         {
           QgsSettings settings;
           settings.setValue( "/Plugins/" + baseName, false );
-          settings.remove( "/Plugins/watchDog/" + baseName );
+          settings.remove( "/Plugins/watchDogTimestamp/" + baseName );
           mQgisInterface->messageBar()->popWidget( watchdogMsg );
         } );
 
@@ -560,10 +560,10 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
       }
       if ( mySettings.value( "/Plugins/" + baseName ).toBool() )
       {
-        mySettings.setValue( QStringLiteral( "Plugins/watchDog/%1" ).arg( baseName ),
+        mySettings.setValue( QStringLiteral( "Plugins/watchDogTimestamp/%1" ).arg( baseName ),
                              QDateTime::currentDateTime().toSecsSinceEpoch() );
         loadCppPlugin( myFullPath );
-        mySettings.remove( QStringLiteral( "/Plugins/watchDog/%1" ).arg( baseName ) );
+        mySettings.remove( QStringLiteral( "/Plugins/watchDogTimestamp/%1" ).arg( baseName ) );
       }
     }
   }
@@ -611,7 +611,7 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
       // end - temporary fix for issue #5879, more below
 
       bool pluginCrashedPreviously = false;
-      const QVariant lastRun = mySettings.value( QStringLiteral( "/PythonPlugins/watchDog/%1" ).arg( packageName ) );
+      const QVariant lastRun = mySettings.value( QStringLiteral( "/PythonPlugins/watchDogTimestamp/%1" ).arg( packageName ) );
       if ( lastRun.isValid() )
       {
         if ( QDateTime::currentDateTime().toSecsSinceEpoch() - lastRun.toLongLong() > 5 )
@@ -649,7 +649,7 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
           {
             loadPythonPlugin( packageName );
           }
-          settings.remove( "/PythonPlugins/watchDog/" + packageName );
+          settings.remove( "/PythonPlugins/watchDogTimestamp/" + packageName );
 
           mQgisInterface->messageBar()->popWidget( watchdogMsg );
         } );
@@ -658,7 +658,7 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
         {
           QgsSettings settings;
           settings.setValue( "/PythonPlugins/" + packageName, false );
-          settings.remove( "/PythonPlugins/watchDog/" + packageName );
+          settings.remove( "/PythonPlugins/watchDogTimestamp/" + packageName );
           mQgisInterface->messageBar()->popWidget( watchdogMsg );
         } );
 
@@ -669,13 +669,13 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
       // check if the plugin was active on last session
       if ( mySettings.value( "/PythonPlugins/" + packageName ).toBool() )
       {
-        mySettings.setValue( "/PythonPlugins/watchDog/" + packageName,
+        mySettings.setValue( "/PythonPlugins/watchDogTimestamp/" + packageName,
                              QDateTime::currentDateTime().toSecsSinceEpoch() );
         if ( checkPythonPlugin( packageName ) )
         {
           loadPythonPlugin( packageName );
         }
-        mySettings.remove( "/PythonPlugins/watchDog/" + packageName );
+        mySettings.remove( "/PythonPlugins/watchDogTimestamp/" + packageName );
 
       }
     }

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -512,10 +512,9 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
       const QVariant lastRun = mySettings.value( QStringLiteral( "Plugins/watchDog/%1" ).arg( baseName ) );
       if ( lastRun.isValid() )
       {
-        const int delta = QDateTime::currentDateTime().toSecsSinceEpoch() - lastRun.toInt();
-        if ( delta > 5 )
+        if ( QDateTime::currentDateTime().toSecsSinceEpoch() - lastRun.toLongLong() > 5 )
         {
-          // The timestamp is left unremoved and is older than 5 seconds, so it doesn't come
+          // The timestamp is left unremoved and is older than 5 seconds, so it's not coming
           // from a parallelly running instance.
           pluginCrashedPreviously = true;
         }
@@ -615,10 +614,9 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
       const QVariant lastRun = mySettings.value( QStringLiteral( "/PythonPlugins/watchDog/%1" ).arg( packageName ) );
       if ( lastRun.isValid() )
       {
-        const int delta = QDateTime::currentDateTime().toSecsSinceEpoch() - lastRun.toInt();
-        if ( delta > 5 )
+        if ( QDateTime::currentDateTime().toSecsSinceEpoch() - lastRun.toLongLong() > 5 )
         {
-          // The timestamp is left unremoved and is older than 5 seconds, so it doesn't come
+          // The timestamp is left unremoved and is older than 5 seconds, so it's not coming
           // from a parallelly running instance.
           pluginCrashedPreviously = true;
         }


### PR DESCRIPTION
## Description

When you quickly run two QGIS instances one by one, it often wakes the plugin watchdog up: one instance sets the QgsSettings entry, and then the another sees it and thinks it's a crash leftover.

This PR contains a proposed solution: switching the settings entry from boolean value to timestamp. Entries older then 5 seconds are considered crash leftovers, while newer are considered to come from a parallel instance. 

Backward compatibility is ensured: 
1. Older QGIS versions only check if the entry exists, so the new datatype doesn't hurt them.
2. Settings written by older QGIS versions (`true`) are converted to integer `1`, thus are recognized as a very old timestamp.   
