### PR TITLE
Do not flip axes of the 4x4 transform used by 3D point symbol

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -952,3 +952,25 @@ QByteArray Qgs3DUtils::removeDefinesFromShaderCode( const QByteArray &shaderCode
 
   return newShaderCode;
 }
+
+void Qgs3DUtils::decomposeTransformMatrix( const QMatrix4x4 &matrix, QVector3D &translation, QQuaternion &rotation, QVector3D &scale )
+{
+  // decompose the transform matrix
+  // assuming the last row has values [0 0 0 1]
+  // see https://math.stackexchange.com/questions/237369/given-this-transformation-matrix-how-do-i-decompose-it-into-translation-rotati
+  const float *md = matrix.data();  // returns data in column-major order
+  const float sx = QVector3D( md[0], md[1], md[2] ).length();
+  const float sy = QVector3D( md[4], md[5], md[6] ).length();
+  const float sz = QVector3D( md[8], md[9], md[10] ).length();
+  float rd[9] =
+  {
+    md[0] / sx, md[4] / sy, md[8] / sz,
+    md[1] / sx, md[5] / sy, md[9] / sz,
+    md[2] / sx, md[6] / sy, md[10] / sz,
+  };
+  const QMatrix3x3 rot3x3( rd ); // takes data in row-major order
+
+  scale = QVector3D( sx, sy, sz );
+  rotation = QQuaternion::fromRotationMatrix( rot3x3 );
+  translation = QVector3D( md[12], md[13], md[14] );
+}

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -331,6 +331,15 @@ class _3D_EXPORT Qgs3DUtils
      * \since QGIS 3.40
      */
     static QByteArray removeDefinesFromShaderCode( const QByteArray &shaderCode, const QStringList &defines );
+
+    /**
+     * Tries to decompose a 4x4 transform matrix into translation, rotation and scale components.
+     * It is expected that the matrix has been created by only applying these transforms, otherwise
+     * the results are undefined.
+     *
+     * \since QGIS 3.42
+     */
+    static void decomposeTransformMatrix( const QMatrix4x4 &matrix, QVector3D &translation, QQuaternion &rotation, QVector3D &scale );
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/shaders/instanced.vert
+++ b/src/3d/shaders/instanced.vert
@@ -20,16 +20,12 @@ uniform mat4 instNormal;  // should be mat3 but Qt3D only supports mat4...
 
 void main()
 {
-    // vertexPosition uses XZ plane as the base plane, with Y going upwards
+    // vertexPosition uses XY plane as the base plane, with Z going upwards
     // and the coordinates are local to the object
 
     // first let's apply user defined transform for each object (translation, rotation, scaling)
     vec3 vertexPositionObject = vec3(inst * vec4(vertexPosition, 1.0));
     vec3 vertexNormalObject = mat3(instNormal) * vertexNormal;
-
-    // next let's flip axes, so we have XY plane as the base plane (like in map coordinates)
-    vertexPositionObject = vec3(vertexPositionObject.x, -vertexPositionObject.z, vertexPositionObject.y);
-    vertexNormalObject = vec3(vertexNormalObject.x, -vertexNormalObject.z, vertexNormalObject.y);
 
     // add offset of the object relative to the chunk's origin
     vec3 vertexPositionChunk = vertexPositionObject + pos;

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -41,6 +41,10 @@ QgsPoint3DSymbol::QgsPoint3DSymbol()
   : mMaterialSettings( std::make_unique< QgsPhongMaterialSettings >() )
 {
   setBillboardSymbol( static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
+
+  // our built-in 3D geometries (e.g. cylinder, plane, ...) assume Y axis going "up",
+  // let's rotate them by default so that their Z axis goes "up" (like the rest of the scene)
+  mTransform.rotate( QQuaternion::fromAxisAndAngle( QVector3D( 1, 0, 0 ), 90 ) );
 }
 
 QgsPoint3DSymbol::QgsPoint3DSymbol( const QgsPoint3DSymbol &other )
@@ -274,7 +278,7 @@ QVariant QgsPoint3DSymbol::shapeProperty( const QString &property ) const
 
 float QgsPoint3DSymbol::billboardHeight() const
 {
-  return mTransform.data()[13];
+  return mTransform.data()[14];
 }
 
 QgsAbstractMaterialSettings *QgsPoint3DSymbol::materialSettings() const

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -139,7 +139,7 @@ void QgsInstancedPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
   updateZRangeFromPositions( outSelected.positions );
 
   // the elevation offset is applied in the vertex shader so let's account for it as well
-  const float symbolOffset = mSymbol->transform().data()[13];
+  const float symbolOffset = mSymbol->transform().data()[14];
 
   // also account for the actual height of the objects themselves
   // NOTE -- these calculations are naive, and assume no rotation or scaling of the symbol!
@@ -474,7 +474,7 @@ void QgsModelPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qg
   updateZRangeFromPositions( outSelected.positions );
 
   // the elevation offset is applied separately in QTransform added to sub-entities
-  const float symbolHeight = mSymbol->transform().data()[13];
+  const float symbolHeight = mSymbol->transform().data()[14];
   mZMin += symbolHeight;
   mZMax += symbolHeight;
 }
@@ -564,17 +564,13 @@ void QgsModelPoint3DSymbolHandler::addMeshEntities( const Qgs3DRenderContext &co
 
 Qt3DCore::QTransform *QgsModelPoint3DSymbolHandler::transform( QVector3D position, const QgsPoint3DSymbol *symbol, const QgsVector3D &chunkOrigin, const QgsVector3D &contextOrigin )
 {
-  // symbol's transform is still using XZ as the base plane, so we need to flip axes
-  QMatrix4x4 flipAxes;
-  flipAxes.rotate( QQuaternion::fromAxisAndAngle( QVector3D( 1, 0, 0 ), 90 ) );  // flip (x,z,-y) to map (x,y,z)
-
   // position is relative to chunkOrigin
   QVector3D nodeTranslation = ( chunkOrigin - contextOrigin ).toVector3D();
   QMatrix4x4 translation;
   translation.translate( nodeTranslation + position );
 
   Qt3DCore::QTransform *tr = new Qt3DCore::QTransform;
-  tr->setMatrix( translation * flipAxes * symbol->transform() );
+  tr->setMatrix( translation * symbol->transform() );
   return tr;
 }
 
@@ -646,7 +642,7 @@ void QgsPoint3DBillboardSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
   updateZRangeFromPositions( outSelected.positions );
 
   // the elevation offset is applied externally through a QTransform of QEntity so let's account for it
-  const float billboardHeight = mSymbol->transform().data()[13];
+  const float billboardHeight = mSymbol->billboardHeight();
   mZMin += billboardHeight;
   mZMax += billboardHeight;
 }
@@ -678,7 +674,7 @@ void QgsPoint3DBillboardSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, co
 
   // Billboard Transform
   Qt3DCore::QTransform *billboardTransform = new Qt3DCore::QTransform();
-  QVector3D billboardHeightTranslation( 0, mSymbol->billboardHeight(), 0 );
+  QVector3D billboardHeightTranslation( 0, 0, mSymbol->billboardHeight() );
   // our geometry has coordinates relative to mChunkOrigin
   QVector3D nodeTranslation = ( mChunkOrigin - context.origin() ).toVector3D();
   billboardTransform->setTranslation( billboardHeightTranslation + nodeTranslation );

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -23,7 +23,7 @@
 #include "qgssymbolbutton.h"
 #include "qgsmarkersymbol.h"
 #include "qgsabstractmaterialsettings.h"
-#include "qgsvector3d.h"
+#include "qgs3dutils.h"
 
 QgsPoint3DSymbolWidget::QgsPoint3DSymbolWidget( QWidget *parent )
   : Qgs3DSymbolWidget( parent )
@@ -150,36 +150,22 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
     widgetMaterial->setType( QStringLiteral( "null" ) );
   }
 
-  // decompose the transform matrix
-  // assuming the last row has values [0 0 0 1]
-  // see https://math.stackexchange.com/questions/237369/given-this-transformation-matrix-how-do-i-decompose-it-into-translation-rotati
-  // A point on the 2D plane (x', y') is transformed to (x, -z) in the 3D world.
-  // The formula from stackexchange need to be changed to take into account the 3D representation.
-  QMatrix4x4 m = pointSymbol->transform();
-  float *md = m.data();  // returns data in column-major order
-  const float sx = QVector3D( md[0], md[1], md[2] ).length();
-  const float sz = QVector3D( md[4], md[5], md[6] ).length();
-  const float sy = QVector3D( md[8], md[9], md[10] ).length();
-  float rd[9] =
-  {
-    md[0] / sx, md[4] / sy, md[8] / sz,
-    md[1] / sx, md[5] / sy, md[9] / sz,
-    md[2] / sx, md[6] / sy, md[10] / sz,
-  };
-  const QMatrix3x3 rot3x3( rd ); // takes data in row-major order
-  const QVector3D rot = QQuaternion::fromRotationMatrix( rot3x3 ).toEulerAngles();
-  const QgsVector3D translationMapCoords( md[12], -md[14], md[13] );
+  QVector3D translation, scale;
+  QQuaternion rotation;
+  Qgs3DUtils::decomposeTransformMatrix( pointSymbol->transform(), translation, rotation, scale );
 
-  spinBillboardHeight->setValue( md[13] );
-  spinTX->setValue( translationMapCoords.x() );
-  spinTY->setValue( translationMapCoords.y() );
-  spinTZ->setValue( translationMapCoords.z() );
-  spinSX->setValue( sx );
-  spinSY->setValue( sy );
-  spinSZ->setValue( sz );
+  const QVector3D rot = rotation.toEulerAngles();
+
+  spinBillboardHeight->setValue( translation.z() );
+  spinTX->setValue( translation.x() );
+  spinTY->setValue( translation.y() );
+  spinTZ->setValue( translation.z() );
+  spinSX->setValue( scale.x() );
+  spinSY->setValue( scale.y() );
+  spinSZ->setValue( scale.z() );
   spinRX->setValue( QgsLayoutUtils::normalizedAngle( rot.x() ) );
-  spinRY->setValue( QgsLayoutUtils::normalizedAngle( 360.0 - rot.z() ) );
-  spinRZ->setValue( QgsLayoutUtils::normalizedAngle( rot.y() ) );
+  spinRY->setValue( QgsLayoutUtils::normalizedAngle( rot.y() ) );
+  spinRZ->setValue( QgsLayoutUtils::normalizedAngle( rot.z() ) );
 }
 
 QgsAbstract3DSymbol *QgsPoint3DSymbolWidget::symbol()
@@ -221,12 +207,9 @@ QgsAbstract3DSymbol *QgsPoint3DSymbolWidget::symbol()
       break;
   }
 
-  // A point on the 2D plane (x', y') is transformed to (x, -z) in the 3D world.
-  // The rotation, scale and translation values need to be converted in the 3D world.
-  const QgsVector3D translationWorldCoords( spinTX->value(), spinTZ->value(), -spinTY->value() );
-  const QQuaternion rot( QQuaternion::fromEulerAngles( static_cast<float>( spinRX->value() ), static_cast<float>( spinRZ->value() ), static_cast<float>( 360.0 - spinRY->value() ) ) );
-  const QVector3D sca( static_cast<float>( spinSX->value() ), static_cast<float>( spinSZ->value() ), static_cast<float>( spinSY->value() ) );
-  const QVector3D tra( static_cast<float>( translationWorldCoords.x() ), static_cast<float>( translationWorldCoords.y() ), static_cast<float>( translationWorldCoords.z() ) );
+  const QQuaternion rot( QQuaternion::fromEulerAngles( static_cast<float>( spinRX->value() ), static_cast<float>( spinRY->value() ), static_cast<float>( spinRZ->value() ) ) );
+  const QVector3D sca( static_cast<float>( spinSX->value() ), static_cast<float>( spinSY->value() ), static_cast<float>( spinSZ->value() ) );
+  const QVector3D tra( static_cast<float>( spinTX->value() ), static_cast<float>( spinTY->value() ), static_cast<float>( spinTZ->value() ) );
 
   QMatrix4x4 tr;
   tr.translate( tra );


### PR DESCRIPTION
This is a part of the continued quest to get rid of the [x,-z,y] flipped axes "Y-up" convention used in 3D scenes. Now that the world coordinates use "Z-up" convention, we also change the 4x4 transform used for 3D point symbols to be consistent with the rest of the code.

Follow up of https://github.com/qgis/QGIS/pull/59272