### PR TITLE
Add human readable conversion of gps time in point clouds

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -410,7 +410,7 @@ QByteArray QgsCopcPointCloudIndex::fetchCopcStatisticsEvlrData()
 
 bool QgsCopcPointCloudIndex::gpsTimeFlag() const
 {
-  return mLazInfo.get()->header().global_encoding % 2;
+  return mLazInfo.get()->header().global_encoding & 1;
 }
 
 ///@endcond

--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -408,4 +408,9 @@ QByteArray QgsCopcPointCloudIndex::fetchCopcStatisticsEvlrData()
   return statisticsEvlrData;
 }
 
+bool QgsCopcPointCloudIndex::gpsTimeFlag() const
+{
+  return mLazInfo.get()->header().global_encoding % 2;
+}
+
 ///@endcond

--- a/src/core/pointcloud/qgscopcpointcloudindex.h
+++ b/src/core/pointcloud/qgscopcpointcloudindex.h
@@ -89,8 +89,9 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsPointCloudIndex
     void copyCommonProperties( QgsCopcPointCloudIndex *destination ) const;
 
     /**
-     * Returns the gps time flag from LAS header
-     * \since QGIS 3.34.12
+     * Returns the gps time flag from global_encoding field in LAS header, 0 indicates GPS week time (seconds passed since the beginning of the week)
+     * 1 indicates GPS adjusted time, which is seconds passed since the GPS base time minus 1e9
+     * \since QGIS 3.42
      */
     bool gpsTimeFlag() const;
 

--- a/src/core/pointcloud/qgscopcpointcloudindex.h
+++ b/src/core/pointcloud/qgscopcpointcloudindex.h
@@ -88,6 +88,12 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsPointCloudIndex
      */
     void copyCommonProperties( QgsCopcPointCloudIndex *destination ) const;
 
+    /**
+     * Returns the gps time flag from LAS header
+     * \since QGIS 3.34.12
+     */
+    bool gpsTimeFlag() const;
+
   protected:
     bool loadSchema( QgsLazInfo &lazInfo );
     bool loadHierarchy();

--- a/src/core/pointcloud/qgspointclouddataprovider.cpp
+++ b/src/core/pointcloud/qgspointclouddataprovider.cpp
@@ -296,12 +296,12 @@ struct MapIndexedPointCloudNode
 
         if ( const QgsCopcPointCloudIndex *copcIndex = dynamic_cast<QgsCopcPointCloudIndex *>( mIndex ) )
         {
-          const QDateTime gpsBaseTime =
-            QDateTime::fromSecsSinceEpoch( 315964809, Qt::UTC );
+          const QDateTime gpsBaseTime = QDateTime::fromSecsSinceEpoch( 315964809, Qt::UTC );
           constexpr int numberOfSecsInWeek = 3600 * 24 * 7;
-          // here we check the flag set in header to determine if we need to parse the time as GPS week time or GPS adjusted standard time
+          // here we check the flag set in header to determine if we need to
+          // parse the time as GPS week time or GPS adjusted standard time
           // however often times the flag is set wrong, so we determine if the value is bigger than the maximum amount of seconds in week then it has to be adjusted standard time
-          if ( const bool gpsTimeFlag = copcIndex->gpsTimeFlag(); gpsTimeFlag || pointAttr[QStringLiteral( "GpsTime" )].toDouble() > numberOfSecsInWeek )
+          if ( copcIndex->gpsTimeFlag() || pointAttr[QStringLiteral( "GpsTime" )].toDouble() > numberOfSecsInWeek )
           {
             const QString utcTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toDouble() + 1e9 ).toString( Qt::ISODate );
             pointAttr[ QStringLiteral( "GpsTime (raw)" )] = pointAttr[QStringLiteral( "GpsTime" )];

--- a/src/core/pointcloud/qgspointclouddataprovider.cpp
+++ b/src/core/pointcloud/qgspointclouddataprovider.cpp
@@ -293,21 +293,23 @@ struct MapIndexedPointCloudNode
         pointAttr[ QStringLiteral( "Y" ) ] = y;
         pointAttr[ QStringLiteral( "Z" ) ] = z;
 
-        const QDateTime gpsBaseTime = QDateTime::fromSecsSinceEpoch( 315964809, Qt::UTC );
-        const int numberOfSecsInWeek = 3600 * 24 * 7;
-        const QgsCopcPointCloudIndex *recastedIndex = dynamic_cast<QgsCopcPointCloudIndex *>( mIndex );
-        if ( recastedIndex )
+
+        if ( const QgsCopcPointCloudIndex *copcIndex = dynamic_cast<QgsCopcPointCloudIndex *>( mIndex ) )
         {
-          const uint16_t gpsTimeFlag = recastedIndex->gpsTimeFlag();
-          if ( gpsTimeFlag || pointAttr[QStringLiteral( "GpsTime" )].toDouble() > numberOfSecsInWeek )
+          const QDateTime gpsBaseTime =
+            QDateTime::fromSecsSinceEpoch( 315964809, Qt::UTC );
+          constexpr int numberOfSecsInWeek = 3600 * 24 * 7;
+          // here we check the flag set in header to determine if we need to parse the time as GPS week time or GPS adjusted standard time
+          // however often times the flag is set wrong, so we determine if the value is bigger than the maximum amount of seconds in week then it has to be adjusted standard time
+          if ( const bool gpsTimeFlag = copcIndex->gpsTimeFlag(); gpsTimeFlag || pointAttr[QStringLiteral( "GpsTime" )].toDouble() > numberOfSecsInWeek )
           {
-            QString utcTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toDouble() + qPow( 10, 9 ) ).toString( Qt::ISODate );
+            const QString utcTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toDouble() + 1e9 ).toString( Qt::ISODate );
             pointAttr[ QStringLiteral( "GpsTime (raw)" )] = pointAttr[QStringLiteral( "GpsTime" )];
             pointAttr[ QStringLiteral( "GpsTime" )] = utcTime;
           }
           else
           {
-            QString weekTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toDouble() ).toString( "ddd hh:mm:ss" );
+            const QString weekTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toDouble() ).toString( "ddd hh:mm:ss" );
             pointAttr[ QStringLiteral( "GpsTime (raw)" )] = pointAttr[QStringLiteral( "GpsTime" )];
             pointAttr[ QStringLiteral( "GpsTime" )] = weekTime;
           }

--- a/src/core/pointcloud/qgspointclouddataprovider.cpp
+++ b/src/core/pointcloud/qgspointclouddataprovider.cpp
@@ -303,13 +303,13 @@ struct MapIndexedPointCloudNode
           // however often times the flag is set wrong, so we determine if the value is bigger than the maximum amount of seconds in week then it has to be adjusted standard time
           if ( copcIndex->gpsTimeFlag() || pointAttr[QStringLiteral( "GpsTime" )].toDouble() > numberOfSecsInWeek )
           {
-            const QString utcTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toDouble() + 1e9 ).toString( Qt::ISODate );
+            const QString utcTime = gpsBaseTime.addSecs( static_cast<qint64>( pointAttr[QStringLiteral( "GpsTime" )].toDouble() + 1e9 ) ).toString( Qt::ISODate );
             pointAttr[ QStringLiteral( "GpsTime (raw)" )] = pointAttr[QStringLiteral( "GpsTime" )];
             pointAttr[ QStringLiteral( "GpsTime" )] = utcTime;
           }
           else
           {
-            const QString weekTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toDouble() ).toString( "ddd hh:mm:ss" );
+            const QString weekTime = gpsBaseTime.addSecs( pointAttr[QStringLiteral( "GpsTime" )].toLongLong() ).toString( "ddd hh:mm:ss" );
             pointAttr[ QStringLiteral( "GpsTime (raw)" )] = pointAttr[QStringLiteral( "GpsTime" )];
             pointAttr[ QStringLiteral( "GpsTime" )] = weekTime;
           }

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -36,6 +36,7 @@
 #include "qgspointcloudattribute.h"
 #include "qgspointcloudexpression.h"
 #include "qgspointcloudrequest.h"
+#include "qgslazinfo.h"
 
 #define SIP_NO_FILE
 

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -36,7 +36,7 @@
 #include "qgspointcloudattribute.h"
 #include "qgspointcloudexpression.h"
 #include "qgspointcloudrequest.h"
-#include "qgslazinfo.h"
+
 
 #define SIP_NO_FILE
 

--- a/tests/src/providers/testqgscopcprovider.cpp
+++ b/tests/src/providers/testqgscopcprovider.cpp
@@ -397,7 +397,7 @@ void TestQgsCopcProvider::testIdentify()
     expected[ QStringLiteral( "Blue" ) ] = 0;
     expected[ QStringLiteral( "Classification" ) ] = 2;
     expected[ QStringLiteral( "EdgeOfFlightLine" ) ] = 0;
-    expected[ QStringLiteral( "GpsTime" ) ] = 268793.37257748609409;
+    expected[ QStringLiteral( "GpsTime (raw)" ) ] = 268793.37257748609409;
     expected[ QStringLiteral( "Green" ) ] = 0;
     expected[ QStringLiteral( "Intensity" ) ] = 1765;
     expected[ QStringLiteral( "NumberOfReturns" ) ] = 1;
@@ -436,7 +436,7 @@ void TestQgsCopcProvider::testIdentify()
       point[ QStringLiteral( "Blue" ) ] =  "0" ;
       point[ QStringLiteral( "Classification" ) ] =  "2" ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =  "0" ;
-      point[ QStringLiteral( "GpsTime" ) ] =  "268793.3373408913" ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =  "268793.3373408913" ;
       point[ QStringLiteral( "Green" ) ] =  "0" ;
       point[ QStringLiteral( "Intensity" ) ] =  "278" ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =  "1" ;
@@ -479,7 +479,7 @@ void TestQgsCopcProvider::testIdentify()
       point[ QStringLiteral( "Blue" ) ] =  "0" ;
       point[ QStringLiteral( "Classification" ) ] =  "2" ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =  "0" ;
-      point[ QStringLiteral( "GpsTime" ) ] =  "268793.3813974548" ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =  "268793.3813974548" ;
       point[ QStringLiteral( "Green" ) ] =  "0" ;
       point[ QStringLiteral( "Intensity" ) ] =  "1142" ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =  "1" ;
@@ -499,7 +499,7 @@ void TestQgsCopcProvider::testIdentify()
       point[ QStringLiteral( "Blue" ) ] =  "0" ;
       point[ QStringLiteral( "Classification" ) ] =  "3" ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =  "0" ;
-      point[ QStringLiteral( "GpsTime" ) ] =  "269160.5176644815" ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =  "269160.5176644815" ;
       point[ QStringLiteral( "Green" ) ] =  "0" ;
       point[ QStringLiteral( "Intensity" ) ] =  "1631" ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =  "1" ;
@@ -589,7 +589,7 @@ void TestQgsCopcProvider::testExtraBytesAttributesValues()
       point[ QStringLiteral( "Classification" ) ] =   "2"  ;
       point[ QStringLiteral( "Deviation" ) ] =   "0"  ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =   "0"  ;
-      point[ QStringLiteral( "GpsTime" ) ] =   "302522582.235839"  ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =   "302522582.235839"  ;
       point[ QStringLiteral( "Green" ) ] =   "0"  ;
       point[ QStringLiteral( "Intensity" ) ] =   "1417"  ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =   "3"  ;
@@ -612,7 +612,7 @@ void TestQgsCopcProvider::testExtraBytesAttributesValues()
       point[ QStringLiteral( "Classification" ) ] =   "5"  ;
       point[ QStringLiteral( "Deviation" ) ] =   "2"  ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =   "0"  ;
-      point[ QStringLiteral( "GpsTime" ) ] =   "302522582.235838"  ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =   "302522582.235838"  ;
       point[ QStringLiteral( "Green" ) ] =   "0"  ;
       point[ QStringLiteral( "Intensity" ) ] =   "441"  ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =   "3"  ;
@@ -673,7 +673,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Classification" ) ] =   "2"  ;
       point[ QStringLiteral( "Deviation" ) ] =   "0"  ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =   "0"  ;
-      point[ QStringLiteral( "GpsTime" ) ] =   "302522582.235839"  ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =   "302522582.235839"  ;
       point[ QStringLiteral( "Green" ) ] =   "0"  ;
       point[ QStringLiteral( "Intensity" ) ] =   "1417"  ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =   "3"  ;
@@ -700,7 +700,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Classification" ) ] =   "5"  ;
       point[ QStringLiteral( "Deviation" ) ] =   "2"  ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =   "0"  ;
-      point[ QStringLiteral( "GpsTime" ) ] =   "302522582.235838"  ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =   "302522582.235838"  ;
       point[ QStringLiteral( "Green" ) ] =   "0"  ;
       point[ QStringLiteral( "Intensity" ) ] =   "441"  ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =   "3"  ;
@@ -727,7 +727,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Classification" ) ] =   "5"  ;
       point[ QStringLiteral( "Deviation" ) ] =   "8"  ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =   "0"  ;
-      point[ QStringLiteral( "GpsTime" ) ] =   "302522582.235837"  ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =   "302522582.235837"  ;
       point[ QStringLiteral( "Green" ) ] =   "0"  ;
       point[ QStringLiteral( "Intensity" ) ] =   "754"  ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =   "3"  ;
@@ -754,7 +754,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Classification" ) ] =   "2"  ;
       point[ QStringLiteral( "Deviation" ) ] =   "6"  ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =   "0"  ;
-      point[ QStringLiteral( "GpsTime" ) ] =   "302522582.235838"  ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =   "302522582.235838"  ;
       point[ QStringLiteral( "Green" ) ] =   "0"  ;
       point[ QStringLiteral( "Intensity" ) ] =   "1539"  ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =   "3"  ;
@@ -781,7 +781,7 @@ void TestQgsCopcProvider::testClassFlagsValues()
       point[ QStringLiteral( "Classification" ) ] =   "5"  ;
       point[ QStringLiteral( "Deviation" ) ] =   "43"  ;
       point[ QStringLiteral( "EdgeOfFlightLine" ) ] =   "0"  ;
-      point[ QStringLiteral( "GpsTime" ) ] =   "302522582.23583597"  ;
+      point[ QStringLiteral( "GpsTime (raw)" ) ] =   "302522582.23583597"  ;
       point[ QStringLiteral( "Green" ) ] =   "0"  ;
       point[ QStringLiteral( "Intensity" ) ] =   "1171"  ;
       point[ QStringLiteral( "NumberOfReturns" ) ] =   "3"  ;


### PR DESCRIPTION
## Description

Point cloud files have GPS time stored for every point, however this value is not easily readable as it is essentially `Double`. This PR adds another attribute field (`GpsTime`) to the point with the original value translated either to the UTC timestamp or day and time in week. The original value of GPS time is moved to `GpsTime (raw)` attribute field.  This feature has been requested in Issue #58695 .

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
