### PR TITLE
Fix typo in the QgsSymbol::exportImage function leading to clipped renders for non-square sizes

### DIFF
--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -1250,7 +1250,7 @@ void QgsSymbol::exportImage( const QString &path, const QString &format, QSize s
     QSvgGenerator generator;
     generator.setFileName( path );
     generator.setSize( size );
-    generator.setViewBox( QRect( 0, 0, size.height(), size.height() ) );
+    generator.setViewBox( QRect( 0, 0, size.width(), size.height() ) );
 
     QPainter painter( &generator );
     drawPreviewIcon( &painter, size );


### PR DESCRIPTION
## Description

TLDR: width != height