### PR TITLE
Fix layout picture rotation

### DIFF
--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -575,9 +575,11 @@ void QgsLayoutItemPicture::loadPicture( const QVariant &data )
     loadPictureUsingCache( mEvaluatedPath );
   }
 
+  mLoaded = false;
   if ( mMode != Qgis::PictureFormat::Unknown ) //make sure we start with a new QImage
   {
     recalculateSize();
+    mLoaded = true;
   }
   else if ( mHasExpressionError || !mEvaluatedPath.isEmpty() )
   {
@@ -662,11 +664,15 @@ void QgsLayoutItemPicture::setPictureRotation( double rotation )
 {
   const double oldRotation = mPictureRotation;
   mPictureRotation = rotation;
+  const QSizeF currentPictureSize = pictureSize();
+
+  // If the picture is not loaded yet, do not compute its rotated size
+  if ( !mLoaded || currentPictureSize == QSizeF( 0, 0 ) )
+    return;
 
   if ( mResizeMode == Zoom )
   {
     //find largest scaling of picture with this rotation which fits in item
-    const QSizeF currentPictureSize = pictureSize();
     const QRectF rotatedImageRect = QgsLayoutUtils::largestRotatedRectWithinBounds( QRectF( 0, 0, currentPictureSize.width(), currentPictureSize.height() ), rect(), mPictureRotation );
     mPictureWidth = rotatedImageRect.width();
     mPictureHeight = rotatedImageRect.height();
@@ -674,7 +680,6 @@ void QgsLayoutItemPicture::setPictureRotation( double rotation )
   }
   else if ( mResizeMode == ZoomResizeFrame )
   {
-    const QSizeF currentPictureSize = pictureSize();
     const QRectF oldRect = QRectF( pos().x(), pos().y(), rect().width(), rect().height() );
 
     //calculate actual size of image inside frame

--- a/tests/src/core/testqgslayoutpicture.cpp
+++ b/tests/src/core/testqgslayoutpicture.cpp
@@ -170,6 +170,14 @@ void TestQgsLayoutPicture::pictureRotation()
 
   mLayout->removeItem( mPicture );
   mPicture->setPictureRotation( 0 );
+
+  // Set picture rotation on uninitialized picture should not create an invalid size (NaN)
+  std::unique_ptr<QgsLayoutItemPicture> uninitialized( new QgsLayoutItemPicture( mLayout ) );
+  uninitialized->setResizeMode( QgsLayoutItemPicture::ZoomResizeFrame );
+  QCOMPARE( uninitialized->sizeWithUnits().toQSizeF(), QSizeF( 0, 0 ) );
+  uninitialized->setPictureRotation( 10 );
+  QCOMPARE( uninitialized->sizeWithUnits().toQSizeF(), QSizeF( 0, 0 ) );
+
 }
 
 void TestQgsLayoutPicture::pictureItemRotation()


### PR DESCRIPTION
- Fix #37460
- Fix #57489
- Fix #59094

## Description

Rotated size was computed before the picture was loaded, hence the original size was QSize(0,0), and the rotated size was QSize(nan,nan)
