### PR TITLE
[GUI] Field Calculator: disable OK and Apply buttons when "Update existing field" is checked and a field is not selected (also fix some tool-tips)

### DIFF
--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -56,6 +56,7 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
   connect( mCreateVirtualFieldCheckbox, &QCheckBox::stateChanged, this, &QgsFieldCalculator::mCreateVirtualFieldCheckbox_stateChanged );
   connect( mOutputFieldNameLineEdit, &QLineEdit::textChanged, this, &QgsFieldCalculator::mOutputFieldNameLineEdit_textChanged );
   connect( mOutputFieldTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsFieldCalculator::mOutputFieldTypeComboBox_activated );
+  connect( mExistingFieldComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsFieldCalculator::mExistingFieldComboBox_currentIndexChanged );
 
   QgsGui::enableAutoGeometryRestore( this );
 
@@ -502,6 +503,12 @@ void QgsFieldCalculator::mOutputFieldTypeComboBox_activated( int index )
   setPrecisionMinMax();
 }
 
+void QgsFieldCalculator::mExistingFieldComboBox_currentIndexChanged( const int index )
+{
+  Q_UNUSED( index )
+  setDialogButtonState();
+}
+
 void QgsFieldCalculator::populateFields()
 {
   if ( !mVectorLayer )
@@ -574,9 +581,20 @@ void QgsFieldCalculator::setDialogButtonState()
     tooltip = tr( "Please enter a field name" );
     enableButtons = false;
   }
+  else if ( ( mUpdateExistingGroupBox->isChecked() || !mNewFieldGroupBox->isEnabled() )
+            && mExistingFieldComboBox->currentIndex() == -1 )
+  {
+    tooltip = tr( "Please select a field" );
+    enableButtons = false;
+  }
+  else if ( builder->expressionText().isEmpty() )
+  {
+    tooltip = tr( "Please insert an expression" );
+    enableButtons = false;
+  }
   else if ( !builder->isExpressionValid() )
   {
-    tooltip = tr( "The expression is invalid see \"(more info)\" for details" );
+    tooltip = tr( "The expression is invalid. See \"(more info)\" for details" );
     enableButtons = false;
   }
 

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -62,6 +62,7 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
     void mCreateVirtualFieldCheckbox_stateChanged( int state );
     void mOutputFieldNameLineEdit_textChanged( const QString &text );
     void mOutputFieldTypeComboBox_activated( int index );
+    void mExistingFieldComboBox_currentIndexChanged( const int index );
 
     //! Sets the dialog buttons (Ok and Apply) enabled / disabled
     void setDialogButtonState();


### PR DESCRIPTION
## Description

In the Field Calculator's dialog window, the "OK" and "Apply" buttons are currently incorrectly enabled when "Update existing field" checkbox is checked and no field is selected in the fields' list combobox. That behaviour may trick the user: see https://gis.stackexchange.com/questions/487749/updating-attribute-table-is-not-working-on-qgis.

This PR fixes the incorrect behaviour making sure that the OK and Apply buttons are disabled when "Update existing field" checkbox is checked and no field is selected in the combobox with the fields' list. In such case, the OK and Apply buttons will also display a tool-tip with the text: `Please select a field`.

It additionally replaces the tool-tip's text `The expression is invalid see ("more info") for details` with the text `The expression is invalid. See ("more info") for details`.

It also additionally makes sure that the above tool-tip is not displayed when no expression has been inserted and thus there is no `("more info")` to see. In such case, the OK and Apply buttons (which are disabled) will display a tool-tip with the text: `Please insert an expression`. (Or would it be better `Please provide an expression`?)

Note: the fixed issues also affects QGIS 3.34, but it is probably not worth to manually backport to 3.34.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
