### PR TITLE
Create highlight for all digitized features

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -48,8 +48,25 @@ std::unique_ptr<QgsHighlight> QgsMapToolAddFeature::createHighlight( QgsVectorLa
 {
   std::unique_ptr< QgsHighlight > highlight = std::make_unique< QgsHighlight >( mCanvas, f.geometry(), layer );
   highlight->applyDefaultStyle();
-  highlight->mPointSizeRadiusMM = 1.0;
-  highlight->mPointSymbol = QgsHighlight::PointSymbol::Circle;
+
+  switch ( f.geometry().type() )
+  {
+    case Qgis::GeometryType::Point:
+    {
+      highlight->mPointSizeRadiusMM = 1.0;
+      highlight->mPointSymbol = QgsHighlight::PointSymbol::Circle;
+
+      break;
+    }
+    case Qgis::GeometryType::Line:
+    {
+      highlight->setWidth( 2 );
+
+      break;
+    }
+    default:
+      break;
+  }
   return highlight;
 };
 
@@ -64,13 +81,14 @@ bool QgsMapToolAddFeature::addFeature( QgsVectorLayer *vlayer, const QgsFeature 
   {
     connect( action, &QgsFeatureAction::addFeatureFinished, rb, &QgsRubberBand::deleteLater );
   }
-  else
-  {
-    // if we didn't get a rubber band, then create manually a highlight for the geometry. This ensures
-    // that tools which don't create a rubber band (ie those which digitize single points) still have
-    // a visible way of representing the captured geometry
+
+  // create a highlight for all spatial layers to enable distinguishing features in case
+  // the user digitizes multiple features and has many pending attribute dialogs. This also
+  // ensures that tools which don't create a rubber band (ie those which digitize single points)
+  // still have a visible way of representing the captured geometry
+
+  if ( vlayer->isSpatial() )
     highlight = createHighlight( vlayer, f );
-  }
 
   const QgsFeatureAction::AddFeatureResult res = action->addFeature( QgsAttributeMap(), showModal, std::move( scope ), false, std::move( highlight ) );
   if ( showModal )


### PR DESCRIPTION
Fixes #50671.

The feature described in the issue essentially already exists for point features, so I thought it'd be okay to just extend the same behavior to line and polygon features to take care of this use case.

![pr](https://github.com/user-attachments/assets/e2f95050-a5e8-436e-a9c9-64ad750cf35d)

**Funded by** National Land Survey of Finland.

