### PR TITLE
[optimisation] Greatly speed up clone of QgsSvgMarkerSymbolLayer

### DIFF
--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -1062,6 +1062,7 @@ any data defined overrides and offsets which are set for the marker layer.
 
   protected:
 
+
     QgsMarkerSymbolLayer( bool locked = false );
 %Docstring
 Constructor for QgsMarkerSymbolLayer.

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -1062,6 +1062,7 @@ any data defined overrides and offsets which are set for the marker layer.
 
   protected:
 
+
     QgsMarkerSymbolLayer( bool locked = false );
 %Docstring
 Constructor for QgsMarkerSymbolLayer.

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -2100,6 +2100,20 @@ QgsSvgMarkerSymbolLayer::QgsSvgMarkerSymbolLayer( const QString &path, double si
   setPath( path );
 }
 
+QgsSvgMarkerSymbolLayer::QgsSvgMarkerSymbolLayer( const QgsSvgMarkerSymbolLayer &other )
+  : QgsMarkerSymbolLayer( other )
+  , mPath( other.mPath )
+  , mDefaultAspectRatio( other.mDefaultAspectRatio )
+  , mFixedAspectRatio( other.mFixedAspectRatio )
+  , mHasFillParam( other.mHasFillParam )
+  , mStrokeColor( other.mStrokeColor )
+  , mStrokeWidth( other.mStrokeWidth )
+  , mParameters( other.mParameters )
+  , mStrokeWidthUnit( other.mStrokeWidthUnit )
+  , mStrokeWidthMapUnitScale( other.mStrokeWidthMapUnitScale )
+{
+}
+
 QgsSvgMarkerSymbolLayer::~QgsSvgMarkerSymbolLayer() = default;
 
 QgsSymbolLayer *QgsSvgMarkerSymbolLayer::create( const QVariantMap &props )
@@ -2615,25 +2629,7 @@ bool QgsSvgMarkerSymbolLayer::usesMapUnits() const
 
 QgsSvgMarkerSymbolLayer *QgsSvgMarkerSymbolLayer::clone() const
 {
-  QgsSvgMarkerSymbolLayer *m = new QgsSvgMarkerSymbolLayer( mPath, mSize, mAngle );
-  m->setFixedAspectRatio( mFixedAspectRatio );
-  m->setColor( mColor );
-  m->setStrokeColor( mStrokeColor );
-  m->setStrokeWidth( mStrokeWidth );
-  m->setStrokeWidthUnit( mStrokeWidthUnit );
-  m->setStrokeWidthMapUnitScale( mStrokeWidthMapUnitScale );
-  m->setOffset( mOffset );
-  m->setOffsetUnit( mOffsetUnit );
-  m->setOffsetMapUnitScale( mOffsetMapUnitScale );
-  m->setSizeUnit( mSizeUnit );
-  m->setSizeMapUnitScale( mSizeMapUnitScale );
-  m->setHorizontalAnchorPoint( mHorizontalAnchorPoint );
-  m->setVerticalAnchorPoint( mVerticalAnchorPoint );
-  m->setParameters( mParameters );
-
-  copyDataDefinedProperties( m );
-  copyPaintEffect( m );
-  return m;
+  return new QgsSvgMarkerSymbolLayer( *this );
 }
 
 void QgsSvgMarkerSymbolLayer::setOutputUnit( Qgis::RenderUnit unit )

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -496,6 +496,7 @@ class CORE_EXPORT QgsSvgMarkerSymbolLayer : public QgsMarkerSymbolLayer
                              double size = DEFAULT_SVGMARKER_SIZE,
                              double angle = DEFAULT_SVGMARKER_ANGLE,
                              Qgis::ScaleMethod scaleMethod = DEFAULT_SCALE_METHOD );
+    QgsSvgMarkerSymbolLayer( const QgsSvgMarkerSymbolLayer &other ) SIP_SKIP;
 
     ~QgsSvgMarkerSymbolLayer() override;
 

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -231,6 +231,21 @@ void QgsSymbolLayer::setPaintEffect( QgsPaintEffect *effect )
   mPaintEffect.reset( effect );
 }
 
+QgsSymbolLayer::QgsSymbolLayer( const QgsSymbolLayer &other )
+  : mType( other.mType )
+  , mEnabled( other.mEnabled )
+  , mUserFlags( other.mUserFlags )
+  , mLocked( other.mLocked )
+  , mColor( other.mColor )
+  , mRenderingPass( other.mRenderingPass )
+  , mId( other.mId )
+  , mDataDefinedProperties( other.mDataDefinedProperties )
+  , mPaintEffect( other.mPaintEffect ? other.mPaintEffect->clone() : nullptr )
+  , mFields( other.mFields )
+  , mClipPath( other.mClipPath )
+{
+}
+
 QgsSymbolLayer::QgsSymbolLayer( Qgis::SymbolType type, bool locked )
   : mType( type )
   , mLocked( locked )
@@ -532,6 +547,23 @@ void QgsLineSymbolLayer::setRingFilter( const RenderRingFilter filter )
 QgsFillSymbolLayer::QgsFillSymbolLayer( bool locked )
   : QgsSymbolLayer( Qgis::SymbolType::Fill, locked )
 {
+}
+
+QgsMarkerSymbolLayer::QgsMarkerSymbolLayer( const QgsMarkerSymbolLayer &other )
+  : QgsSymbolLayer( other )
+  , mAngle( other.mAngle )
+  , mLineAngle( other.mLineAngle )
+  , mSize( other.mSize )
+  , mSizeUnit( other.mSizeUnit )
+  , mSizeMapUnitScale( other.mSizeMapUnitScale )
+  , mOffset( other.mOffset )
+  , mOffsetUnit( other.mOffsetUnit )
+  , mOffsetMapUnitScale( other.mOffsetMapUnitScale )
+  , mScaleMethod( other.mScaleMethod )
+  , mHorizontalAnchorPoint( other.mHorizontalAnchorPoint )
+  , mVerticalAnchorPoint( other.mVerticalAnchorPoint )
+{
+
 }
 
 void QgsMarkerSymbolLayer::startRender( QgsSymbolRenderContext &context )

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -228,7 +228,6 @@ class CORE_EXPORT QgsSymbolLayer
 
     virtual ~QgsSymbolLayer();
 
-    QgsSymbolLayer( const QgsSymbolLayer &other ) = delete;
     QgsSymbolLayer &operator=( const QgsSymbolLayer &other ) = delete;
 
     /**
@@ -674,6 +673,7 @@ class CORE_EXPORT QgsSymbolLayer
     bool installMasks( QgsRenderContext &context, bool recursive, const QRectF &rect = QRectF() );
 
   protected:
+    QgsSymbolLayer( const QgsSymbolLayer &other ) SIP_SKIP;
 
     /**
      * Constructor for QgsSymbolLayer.
@@ -783,7 +783,6 @@ class CORE_EXPORT QgsMarkerSymbolLayer : public QgsSymbolLayer
       Bottom, //!< Align to bottom of symbol
     };
 
-    QgsMarkerSymbolLayer( const QgsMarkerSymbolLayer &other ) = delete;
     QgsMarkerSymbolLayer &operator=( const QgsMarkerSymbolLayer &other ) = delete;
 
     void startRender( QgsSymbolRenderContext &context ) override;
@@ -1001,6 +1000,8 @@ class CORE_EXPORT QgsMarkerSymbolLayer : public QgsSymbolLayer
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) = 0;
 
   protected:
+
+    QgsMarkerSymbolLayer( const QgsMarkerSymbolLayer &other ) SIP_SKIP;
 
     /**
      * Constructor for QgsMarkerSymbolLayer.


### PR DESCRIPTION
The old method was very inefficient, as it required a re-load and re-parse of the associated SVG file content with every clone, only for many of the parsed properties to be immediately overwritten.

Optimise by just directly copying members, avoiding all unnecessary work.

This is frequently seen as a hotspot when profiling map renders, as that involves cloning all symbol layers upfront.

Speeds up a benchtest cloning 100k markers from 4.3 seconds to 150ms.
