### PR TITLE
Add feature map tool: Make highlight width always bigger than rubberband

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -20,6 +20,8 @@
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsvectorlayer.h"
 #include "qgslogger.h"
 #include "qgsfeatureaction.h"
@@ -58,9 +60,13 @@ std::unique_ptr<QgsHighlight> QgsMapToolAddFeature::createHighlight( QgsVectorLa
 
       break;
     }
+
+    case Qgis::GeometryType::Polygon:
     case Qgis::GeometryType::Line:
     {
-      highlight->setWidth( 2 );
+      const double rubberbandWidth = QgsSettingsRegistryCore::settingsDigitizingLineWidth->value();
+
+      highlight->setWidth( static_cast<int>( rubberbandWidth ) + 1 );
 
       break;
     }


### PR DESCRIPTION
There's no issue for this, since this addresses an oversight in #59424. I wasn't sure if one should be created in this case.

The highlight width was hardcoded to 2, which didn't take into account the user having potentially changed the rubberband width. Now the width will always be set as wider than the rubberband.

I also applied the width to polygons for consistency and in case the user has set an opaque rubberband.