### PR TITLE
[code editors] Fix python console editor's modified content lost when switching to another app

### DIFF
--- a/src/gui/codeeditors/qgscodeeditorwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditorwidget.cpp
@@ -418,10 +418,10 @@ bool QgsCodeEditorWidget::loadFile( const QString &path )
   {
     const QString content = file.readAll();
     mEditor->setText( content );
-    mEditor->setModified( false );
-    mEditor->recolor();
-    mLastModified = QFileInfo( path ).lastModified();
     setFilePath( path );
+    mEditor->recolor();
+    mEditor->setModified( false );
+    mLastModified = QFileInfo( path ).lastModified();
     return true;
   }
   return false;
@@ -449,9 +449,9 @@ bool QgsCodeEditorWidget::save( const QString &path )
       file.write( mEditor->text().toUtf8() );
       file.close();
 
+      setFilePath( filePath );
       mEditor->setModified( false );
       mLastModified = QFileInfo( filePath ).lastModified();
-      setFilePath( filePath );
 
       return true;
     }


### PR DESCRIPTION
## Description

The setFilePath() function resets the last modified, we should therefore call that _before_ we fetch the file's last modified value :)

