### PR TITLE
[backport] Highlight features when multiple attribute forms are open

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -20,6 +20,8 @@
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsvectorlayer.h"
 #include "qgslogger.h"
 #include "qgsfeatureaction.h"
@@ -48,8 +50,29 @@ std::unique_ptr<QgsHighlight> QgsMapToolAddFeature::createHighlight( QgsVectorLa
 {
   std::unique_ptr< QgsHighlight > highlight = std::make_unique< QgsHighlight >( mCanvas, f.geometry(), layer );
   highlight->applyDefaultStyle();
-  highlight->mPointSizeRadiusMM = 1.0;
-  highlight->mPointSymbol = QgsHighlight::PointSymbol::Circle;
+
+  switch ( f.geometry().type() )
+  {
+    case Qgis::GeometryType::Point:
+    {
+      highlight->mPointSizeRadiusMM = 1.0;
+      highlight->mPointSymbol = QgsHighlight::PointSymbol::Circle;
+
+      break;
+    }
+
+    case Qgis::GeometryType::Polygon:
+    case Qgis::GeometryType::Line:
+    {
+      const double rubberbandWidth = QgsSettingsRegistryCore::settingsDigitizingLineWidth->value();
+
+      highlight->setWidth( static_cast<int>( rubberbandWidth ) + 1 );
+
+      break;
+    }
+    default:
+      break;
+  }
   return highlight;
 };
 
@@ -64,13 +87,14 @@ bool QgsMapToolAddFeature::addFeature( QgsVectorLayer *vlayer, const QgsFeature 
   {
     connect( action, &QgsFeatureAction::addFeatureFinished, rb, &QgsRubberBand::deleteLater );
   }
-  else
-  {
-    // if we didn't get a rubber band, then create manually a highlight for the geometry. This ensures
-    // that tools which don't create a rubber band (ie those which digitize single points) still have
-    // a visible way of representing the captured geometry
+
+  // create a highlight for all spatial layers to enable distinguishing features in case
+  // the user digitizes multiple features and has many pending attribute dialogs. This also
+  // ensures that tools which don't create a rubber band (ie those which digitize single points)
+  // still have a visible way of representing the captured geometry
+
+  if ( vlayer->isSpatial() )
     highlight = createHighlight( vlayer, f );
-  }
 
   const QgsFeatureAction::AddFeatureResult res = action->addFeature( QgsAttributeMap(), showModal, std::move( scope ), false, std::move( highlight ) );
   if ( showModal )


### PR DESCRIPTION
Manual backport PR for 3.40.1, if possible. Includes #59424 and #59447

![pr_new](https://github.com/user-attachments/assets/3690afbc-1815-4276-92ad-5dec0f91c743)

Funded by National Land Survey of Finland.