### PR TITLE
overlay_intersects: flatten collections and filter by type

### DIFF
--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -41,7 +41,7 @@
     },
     {
       "arg": "return_details",
-      "description": "Set this to true to return a list of maps containing (key names in quotes) the feature 'id', the expression 'result' and the 'overlap' value. The 'radius' of the maximum inscribed circle is also returned when the target layer is a polygon. Only valid when used with the expression parameter",
+      "description": "Set this to true to return a list of maps containing (key names in quotes) the feature 'id', the expression 'result' and the 'overlap' value (of the largest element in case of multipart). The 'radius' of the maximum inscribed circle is also returned when the target layer is a polygon. Only valid when used with the expression parameter",
       "optional": true
     },
     {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -7975,7 +7975,8 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
     bool testResult { false };
     // For return measures:
     QVector<double> overlapValues;
-    for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
+    const QgsGeometry merged { intersection.mergeLines() };
+    for ( auto it = merged.const_parts_begin(); ! testResult && it != merged.const_parts_end(); ++it )
     {
       const QgsCurve *geom = qgsgeometry_cast< const QgsCurve * >( *it );
       // Check min overlap for intersection (if set)
@@ -8083,7 +8084,68 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
 
       if ( isIntersectsFunc && ( requireMeasures || overlapOrRadiusFilter ) )
       {
-        const QgsGeometry intersection { geometry.intersection( feat2.geometry() ) };
+
+        QgsGeometry intersection { geometry.intersection( feat2.geometry() ) };
+
+        // Pre-process collections: if the tested geometry is a polygon we take the polygons from the collection
+        if ( intersection.wkbType() == Qgis::WkbType::GeometryCollection )
+        {
+          const QVector<QgsGeometry> geometries { intersection.asGeometryCollection() };
+          intersection = QgsGeometry();
+          QgsMultiPolygonXY poly;
+          QgsMultiPolylineXY line;
+          QgsMultiPointXY point;
+          for ( const auto &geom : std::as_const( geometries ) )
+          {
+            switch ( geom.type() )
+            {
+              case Qgis::GeometryType::Polygon:
+              {
+                poly.append( geom.asPolygon() );
+                break;
+              }
+              case Qgis::GeometryType::Line:
+              {
+                line.append( geom.asPolyline() );
+                break;
+              }
+              case Qgis::GeometryType::Point:
+              {
+                point.append( geom.asPoint() );
+                break;
+              }
+              case Qgis::GeometryType::Unknown:
+              case Qgis::GeometryType::Null:
+              {
+                break;
+              }
+            }
+          }
+
+          switch ( geometry.type() )
+          {
+            case Qgis::GeometryType::Polygon:
+            {
+              intersection = QgsGeometry::fromMultiPolygonXY( poly );
+              break;
+            }
+            case Qgis::GeometryType::Line:
+            {
+              intersection = QgsGeometry::fromMultiPolylineXY( line );
+              break;
+            }
+            case Qgis::GeometryType::Point:
+            {
+              intersection = QgsGeometry::fromMultiPointXY( point );
+              break;
+            }
+            case Qgis::GeometryType::Unknown:
+            case Qgis::GeometryType::Null:
+            {
+              break;
+            }
+          }
+        }
 
         // Depending on the intersection geometry type and on the geometry type of
         // the tested geometry we can run different tests and collect different measures

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -65,7 +65,6 @@ class TestQgsOverlayExpression : public QObject
     void testOverlayMeasure_data();
 
     void testOverlayIntersectsDetails();
-
 };
 
 
@@ -451,7 +450,6 @@ void TestQgsOverlayExpression::testOverlayIntersectsDetails()
 
   QgsProject::instance()->removeMapLayer( poly1->id() );
   QgsProject::instance()->removeMapLayer( line->id() );
-
 }
 
 void TestQgsOverlayExpression::testOverlayExpression()


### PR DESCRIPTION
Partial fix for #59408

- try to merge multilinestrings to get the max length
- consider the tested geomery type when intersection is a collection

Funded by: Body & Soul ♬
