### PR TITLE
qgsdockablewidgethelper: Prevent crash when closing dock

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4786,7 +4786,7 @@ QgsMapCanvasDockWidget *QgisApp::createNewMapCanvasDock( const QString &name, bo
   connect( mapCanvasWidget->dockableWidgetHelper(), &QgsDockableWidgetHelper::closed, this, [ this, mapCanvasWidget]
   {
     mOpen2DMapViews.remove( mapCanvasWidget );
-    delete mapCanvasWidget;
+    mapCanvasWidget->deleteLater();
     markDirty();
   } );
   connect( mapCanvasWidget, &QgsMapCanvasDockWidget::renameTriggered, this, &QgisApp::renameView );


### PR DESCRIPTION
## Description

When closing the dock, QGIS sometimes crash. It seems like the `mDialog::finished` slot sends `visibilityChanged` signal. However, the `QgsDockableWidgetHelper` may have been destroyed in the meantime. Hence, the crash.

I tried to solve this issue by ensuring to emit this signal if the object still exists. I cannot reproduce the issue anymore but I'm not sure this is the proper fix.
