### PR TITLE
Fix QgsCsException messages

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1688,7 +1688,11 @@ void QgsCoordinateReferenceSystem::setProjString( const QString &proj4String )
   {
 #ifdef QGISDEBUG
     const int errNo = proj_context_errno( ctx );
+#if PROJ_VERSION_MAJOR>=8
+    QgsDebugError( QStringLiteral( "proj string rejected: %1" ).arg( proj_context_errno_string( ctx, errNo ) ) );
+#else
     QgsDebugError( QStringLiteral( "proj string rejected: %1" ).arg( proj_errno_string( errNo ) ) );
+#endif
 #endif
     d->mIsValid = false;
   }

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -829,10 +829,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     }
   }
 
-  // something which won't clash with Proj's real error codes!
-  constexpr int PROJ_RESULT_FALLBACK_OPERATION_FAILED = -481516;
-
   mFallbackOperationOccurred = false;
+  bool errorOccurredDuringFallbackOperation = false;
   if ( actualRes != 0
        && ( d->mAvailableOpCount > 1 || d->mAvailableOpCount == -1 ) // only use fallbacks if more than one operation is possible -- otherwise we've already tried it and it failed
        && ( d->mAllowFallbackTransforms || mBallparkTransformsAreAppropriate ) )
@@ -857,13 +855,14 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
       // So here just check proj_errno() for single point transform
       if ( numPoints == 1 )
       {
+        projResult = proj_errno( transform );
         // hmm - something very odd here. We can't trust proj_errno( transform ), as that's giving us incorrect error numbers
         // (such as "failed to load datum shift file", which is definitely incorrect for a default proj created operation!)
         // so we resort to testing values ourselves...
-        projResult = std::isinf( xprev[0] ) || std::isinf( yprev[0] ) || std::isinf( zprev[0] ) ? PROJ_RESULT_FALLBACK_OPERATION_FAILED : 0;
+        errorOccurredDuringFallbackOperation = std::isinf( xprev[0] ) || std::isinf( yprev[0] ) || std::isinf( zprev[0] );
       }
 
-      if ( projResult == 0 )
+      if ( !errorOccurredDuringFallbackOperation )
       {
         memcpy( x, xprev.data(), sizeof( double ) * numPoints );
         memcpy( y, yprev.data(), sizeof( double ) * numPoints );
@@ -888,7 +887,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     z[pos] = std::numeric_limits<double>::quiet_NaN();
   }
 
-  if ( projResult != 0 )
+  if ( projResult != 0 || errorOccurredDuringFallbackOperation )
   {
     //something bad happened....
     QString points;
@@ -903,9 +902,9 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
 #if PROJ_VERSION_MAJOR>=8
     PJ_CONTEXT *projContext = QgsProjContext::get();
-    const QString projError = projResult != PROJ_RESULT_FALLBACK_OPERATION_FAILED ? QString::fromUtf8( proj_context_errno_string( projContext, projResult ) ) : QObject::tr( "Fallback transform failed" );
+    const QString projError = !errorOccurredDuringFallbackOperation ? QString::fromUtf8( proj_context_errno_string( projContext, projResult ) ) : QObject::tr( "Fallback transform failed" );
 #else
-    const QString projError = projResult != PROJ_RESULT_FALLBACK_OPERATION_FAILED ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" );
+    const QString projError = !errorOccurredDuringFallbackOperation ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" );
 #endif
 
     const QString msg = QObject::tr( "%1 (%2 to %3) of%4%5Error: %6" )

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -892,7 +892,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
     for ( int i = 0; i < numPoints; ++i )
     {
-      points += QStringLiteral( "(%1, %2)\n" ).arg( x[i], 0, 'f' ).arg( y[i], 0, 'f' );
+      points += QStringLiteral( "(%1, %2)\n" ).arg( xprev[i], 0, 'f' ).arg( yprev[i], 0, 'f' );
     }
 
     const QString dir = ( direction == Qgis::TransformDirection::Forward ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -901,11 +901,18 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
     const QString dir = ( direction == Qgis::TransformDirection::Forward ) ? QObject::tr( "Forward transform" ) : QObject::tr( "Inverse transform" );
 
+#if PROJ_VERSION_MAJOR>=8
+    PJ_CONTEXT *projContext = QgsProjContext::get();
+    const QString projError = projResult != PROJ_RESULT_FALLBACK_OPERATION_FAILED ? QString::fromUtf8( proj_context_errno_string( projContext, projResult ) ) : QObject::tr( "Fallback transform failed" );
+#else
+    const QString projError = projResult != PROJ_RESULT_FALLBACK_OPERATION_FAILED ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" );
+#endif
+
     const QString msg = QObject::tr( "%1 of%2%3Error: %4" )
                         .arg( dir,
                               QString( delim ),
                               points,
-                              projResult != PROJ_RESULT_FALLBACK_OPERATION_FAILED ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" ) );
+                              projError );
 
     // don't flood console with thousands of duplicate transform error messages
     if ( msg != mLastError )

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -890,17 +890,17 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     //something bad happened....
     QString points;
 
+    const QChar delim = numPoints > 1 ? '\n' : ' ';
     for ( int i = 0; i < numPoints; ++i )
     {
-      points += QStringLiteral( "(%1, %2)\n" ).arg( xprev[i], 0, 'f' ).arg( yprev[i], 0, 'f' );
+      points += QStringLiteral( "(%1, %2)" ).arg( xprev[i], 0, 'f' ).arg( yprev[i], 0, 'f' ) + delim;
     }
 
-    const QString dir = ( direction == Qgis::TransformDirection::Forward ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
+    const QString dir = ( direction == Qgis::TransformDirection::Forward ) ? QObject::tr( "Forward transform" ) : QObject::tr( "Inverse transform" );
 
-    const QString msg = QObject::tr( "%1 of\n"
-                                     "%2"
-                                     "Error: %3" )
+    const QString msg = QObject::tr( "%1 of%2%3Error: %4" )
                         .arg( dir,
+                              QString( delim ),
                               points,
                               projResult < 0 ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" ) );
 

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -908,8 +908,10 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     const QString projError = projResult != PROJ_RESULT_FALLBACK_OPERATION_FAILED ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" );
 #endif
 
-    const QString msg = QObject::tr( "%1 of%2%3Error: %4" )
+    const QString msg = QObject::tr( "%1 (%2 to %3) of%4%5Error: %6" )
                         .arg( dir,
+                              ( direction == Qgis::TransformDirection::Forward ) ? d->mSourceCRS.authid() : d->mDestCRS.authid(),
+                              ( direction == Qgis::TransformDirection::Forward ) ? d->mDestCRS.authid() : d->mSourceCRS.authid(),
                               QString( delim ),
                               points,
                               projError );

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -829,6 +829,9 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     }
   }
 
+  // something which won't clash with Proj's real error codes!
+  constexpr int PROJ_RESULT_FALLBACK_OPERATION_FAILED = -481516;
+
   mFallbackOperationOccurred = false;
   if ( actualRes != 0
        && ( d->mAvailableOpCount > 1 || d->mAvailableOpCount == -1 ) // only use fallbacks if more than one operation is possible -- otherwise we've already tried it and it failed
@@ -857,7 +860,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
         // hmm - something very odd here. We can't trust proj_errno( transform ), as that's giving us incorrect error numbers
         // (such as "failed to load datum shift file", which is definitely incorrect for a default proj created operation!)
         // so we resort to testing values ourselves...
-        projResult = std::isinf( xprev[0] ) || std::isinf( yprev[0] ) || std::isinf( zprev[0] ) ? 1 : 0;
+        projResult = std::isinf( xprev[0] ) || std::isinf( yprev[0] ) || std::isinf( zprev[0] ) ? PROJ_RESULT_FALLBACK_OPERATION_FAILED : 0;
       }
 
       if ( projResult == 0 )
@@ -902,8 +905,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
                         .arg( dir,
                               QString( delim ),
                               points,
-                              projResult < 0 ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" ) );
-
+                              projResult != PROJ_RESULT_FALLBACK_OPERATION_FAILED ? QString::fromUtf8( proj_errno_string( projResult ) ) : QObject::tr( "Fallback transform failed" ) );
 
     // don't flood console with thousands of duplicate transform error messages
     if ( msg != mLastError )

--- a/src/core/proj/qgscoordinatetransform_p.cpp
+++ b/src/core/proj/qgscoordinatetransform_p.cpp
@@ -334,7 +334,11 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
         const int errNo = proj_context_errno( context );
         if ( errNo && errNo != -61 )
         {
+#if PROJ_VERSION_MAJOR>=8
+          nonAvailableError = QString( proj_context_errno_string( context, errNo ) );
+#else
           nonAvailableError = QString( proj_errno_string( errNo ) );
+#endif
         }
         else
         {
@@ -468,7 +472,11 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
     const QStringList projErrors = errorLogger.errors();
     if ( errNo && errNo != -61 )
     {
+#if PROJ_VERSION_MAJOR>=8
+      nonAvailableError = QString( proj_context_errno_string( context, errNo ) );
+#else
       nonAvailableError = QString( proj_errno_string( errNo ) );
+#endif
     }
     else if ( !projErrors.empty() )
     {

--- a/src/core/proj/qgscoordinatetransform_p.cpp
+++ b/src/core/proj/qgscoordinatetransform_p.cpp
@@ -332,7 +332,7 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
       {
         // huh?
         const int errNo = proj_context_errno( context );
-        if ( errNo && errNo != -61 )
+        if ( errNo )
         {
 #if PROJ_VERSION_MAJOR>=8
           nonAvailableError = QString( proj_context_errno_string( context, errNo ) );
@@ -342,6 +342,7 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
         }
         else
         {
+          // in theory should never be hit!
           nonAvailableError = QObject::tr( "No coordinate operations are available between these two reference systems" );
         }
       }
@@ -470,7 +471,7 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
   {
     const int errNo = proj_context_errno( context );
     const QStringList projErrors = errorLogger.errors();
-    if ( errNo && errNo != -61 )
+    if ( errNo )
     {
 #if PROJ_VERSION_MAJOR>=8
       nonAvailableError = QString( proj_context_errno_string( context, errNo ) );

--- a/tests/src/python/test_qgscoordinatetransform.py
+++ b/tests/src/python/test_qgscoordinatetransform.py
@@ -11,11 +11,14 @@ __copyright__ = 'Copyright 2012, The QGIS Project'
 
 
 from qgis.core import (
+    Qgis,
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
     QgsCoordinateTransformContext,
     QgsProject,
     QgsRectangle,
+    QgsPointXY,
+    QgsCsException
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -207,6 +210,22 @@ class TestQgsCoordinateTransform(QgisTestCase):
             QgsCoordinateTransformContext()
         )
         self.assertTrue(transform.hasVerticalComponent())
+
+    def test_cs_exception(self):
+        ct = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:4326'),
+                                    QgsCoordinateReferenceSystem('EPSG:3857'), QgsProject.instance())
+        point = QgsPointXY(-7603859, -7324441)
+        with self.assertRaises(QgsCsException) as e:
+            ct.transform(point)
+        self.assertEqual(str(e.exception), 'Forward transform (EPSG:4326 to EPSG:3857) of (-7603859.000000, -7324441.000000) Error: Invalid coordinate')
+
+        # reverse transform
+        ct = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:3857'),
+                                    QgsCoordinateReferenceSystem('EPSG:4326'), QgsProject.instance())
+        point = QgsPointXY(-7603859, -7324441)
+        with self.assertRaises(QgsCsException) as e:
+            ct.transform(point, Qgis.TransformDirection.Reverse)
+        self.assertEqual(str(e.exception), 'Inverse transform (EPSG:4326 to EPSG:3857) of (-7603859.000000, -7324441.000000) Error: Invalid coordinate')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Heh... for the longest time I thought the useless `forward transform of (inf, inf)` exceptions messages contained within QgsCsException were just proj not giving very useful error messages... but it turns out our QgsCsException message generation logic was completely wonky and generating nonsense messages.

Let's fix that!

Instead of:
```
QgsCsException: forward transform of
(inf, inf)
Error: Fallback transform failed
```

we now get much more useful exceptions, like:

`QgsCsException: Forward transform (EPSG:4326 to EPSG:3857) of (-7603859.000000, -7324441.000000) Error: Invalid coordinate`

    