### PR TITLE
[expression] Add a to_bool() function to convert various value types into a boolean

### DIFF
--- a/resources/function_help/json/to_bool
+++ b/resources/function_help/json/to_bool
@@ -1,0 +1,27 @@
+{
+  "name": "to_bool",
+  "type": "function",
+  "groups": ["Conversions"],
+  "description": "Converts a given value to a boolean. The function will return false if the value is NULL, an empty string, an empty list, or 0.",
+  "arguments": [{
+    "arg": "value",
+    "description": "value to convert to boolean"
+  }],
+  "examples": [{
+    "expression": "to_bool('')",
+    "returns": "false"
+  },{
+    "expression": "to_bool('123')",
+    "returns": "true"
+  },{
+    "expression": "to_bool(0)",
+    "returns": "false"
+  },{
+    "expression": "to_bool(1)",
+    "returns": "true"
+  },{
+    "expression": "to_bool(null)",
+    "returns": "false"
+  }],
+  "tags": ["converts", "boolean"]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1244,6 +1244,24 @@ static QVariant fcnCeil( const QVariantList &values, const QgsExpressionContext 
   return QVariant( std::ceil( x ) );
 }
 
+static QVariant fcnToBool( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
+{
+  const QVariant value = values.at( 0 );
+  if ( QgsExpressionUtils::isNull( value.isValid() ) )
+  {
+    return QVariant( false );
+  }
+  else if ( value.userType() == QMetaType::QString )
+  {
+    // Capture strings to avoid a '0' string value casted to 0 and wrongly returning false
+    return QVariant( !value.toString().isEmpty() );
+  }
+  else if ( QgsExpressionUtils::isList( value ) )
+  {
+    return !value.toList().isEmpty();
+  }
+  return QVariant( value.toBool() );
+}
 static QVariant fcnToInt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) );
@@ -8367,6 +8385,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "floor" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnFloor, QStringLiteral( "Math" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "ceil" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnCeil, QStringLiteral( "Math" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "pi" ), 0, fcnPi, QStringLiteral( "Math" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "$pi" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "to_bool" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnToBool, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "tobool" ), /* handlesNull = */ true )
         << new QgsStaticExpressionFunction( QStringLiteral( "to_int" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnToInt, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "toint" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "to_real" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnToReal, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "toreal" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "to_string" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnToString, QStringList() << QStringLiteral( "Conversions" ) << QStringLiteral( "String" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "tostring" ) )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1829,6 +1829,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "try invalid with alternative" ) << "try(to_int('a'),0)" << false << QVariant( 0 );
       QTest::newRow( "try invalid without alternative" ) << "try(to_int('a'))" << false << QVariant();
 
+      QTest::newRow( "to_bool with empty string" ) << "to_bool('')" << false << QVariant( false );
+      QTest::newRow( "to_bool with non-empty string" ) << "to_bool('0')" << false << QVariant( true );
+      QTest::newRow( "to_bool with zero" ) << "to_bool(0)" << false << QVariant( false );
+      QTest::newRow( "to_bool with number" ) << "to_bool(123)" << false << QVariant( true );
+      QTest::newRow( "to_bool with null" ) << "to_bool(null)" << false << QVariant( false );
+      QTest::newRow( "to_bool with empty list" ) << "to_bool(array())" << false << QVariant( false );
+      QTest::newRow( "to_bool with non-empty list" ) << "to_bool(array(1,2,3))" << false << QVariant( true );
+
       // Datetime functions
       QTest::newRow( "make date" ) << "make_date(2012,6,28)" << false << QVariant( QDate( 2012, 6, 28 ) );
       QTest::newRow( "make date invalid" ) << "make_date('a',6,28)" << true << QVariant();


### PR DESCRIPTION
## Description

Title says it all. The PR adds a useful function to convert various value types into a boolean. 

Required for a follow up PR to add support for mapbox gl's to-boolean expression when importing vector tile styles (https://docs.mapbox.com/style-spec/reference/expressions/#types-to-boolean)