### PR TITLE
[vector tiles] Handle 'to-boolean' mapboxgl expressions when importing styles

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -3428,6 +3428,10 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
   {
     return QStringLiteral( "to_string(%1)" ).arg( parseExpression( expression.value( 1 ).toList(), context ) );
   }
+  else if ( op == QLatin1String( "to-boolean" ) )
+  {
+    return QStringLiteral( "to_bool(%1)" ).arg( parseExpression( expression.value( 1 ).toList(), context ) );
+  }
   else if ( op == QLatin1String( "case" ) )
   {
     QString caseString = QStringLiteral( "CASE" );

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -529,6 +529,9 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                                                                    conversion_context),
                          '''"name"''')
 
+        self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["to-boolean", ["get", "name"]],
+                                                                   conversion_context),
+                         '''to_bool("name")''')
         self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["to-string", ["get", "name"]],
                                                                    conversion_context),
                          '''to_string("name")''')


### PR DESCRIPTION
## Description

As seen in the wild when testing the brand new OSM vector tiles, this PR adds support for the to-boolean expression function as defined in the mapbox gl spec.

Proof of life:
![Screenshot From 2024-11-19 11-09-29](https://github.com/user-attachments/assets/a796a3c7-edf5-40db-96f4-80a593d915bd)

(requires https://github.com/qgis/QGIS/pull/59488 to be merged)
