### PR TITLE
Add an example with a string to the to_bool expression

### DIFF
--- a/resources/function_help/json/to_bool
+++ b/resources/function_help/json/to_bool
@@ -14,6 +14,9 @@
     "expression": "to_bool('123')",
     "returns": "true"
   },{
+    "expression": "to_bool('false')",
+    "returns": "true"
+  },{
     "expression": "to_bool(0)",
     "returns": "false"
   },{


### PR DESCRIPTION
Thanks @nirvn for the explanation.

Just to avoid any feedbacks in the future from users, I would prefer to be explicit in the example ;-)