### PR TITLE
QgsPointsToPathsAlgorithm: fix copy&paste issue in parameter creation

### DIFF
--- a/src/analysis/processing/qgsalgorithmpointstopaths.cpp
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.cpp
@@ -87,11 +87,11 @@ void QgsPointsToPathsAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( orderField );
   QgsProcessingParameterField *groupField = new QgsProcessingParameterField( QStringLiteral( "GROUP_FIELD" ),
       QObject::tr( "Group field" ), QVariant(), QStringLiteral( "INPUT" ), Qgis::ProcessingFieldParameterDataType::Any, false, true );
-  groupField->setFlags( orderField->flags() | Qgis::ProcessingParameterFlag::Hidden );
+  groupField->setFlags( groupField->flags() | Qgis::ProcessingParameterFlag::Hidden );
   addParameter( groupField );
   QgsProcessingParameterString *dateFormat = new QgsProcessingParameterString( QStringLiteral( "DATE_FORMAT" ),
       QObject::tr( "Date format (if order field is DateTime)" ), QVariant(), false, true );
-  dateFormat->setFlags( orderField->flags() | Qgis::ProcessingParameterFlag::Hidden );
+  dateFormat->setFlags( dateFormat->flags() | Qgis::ProcessingParameterFlag::Hidden );
   addParameter( dateFormat );
 }
 


### PR DESCRIPTION
Fixes Coverity 450635
It warns about a use-after-free, which cannot happen in that situation, but it looks very much as we have a copy&paste error here.
