### PR TITLE
QgsProcessingAlgorithm: add variants of addParameter() and addOutput() that accept a std::unique_ptr

### DIFF
--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -519,6 +519,7 @@ occur.
 .. seealso:: :py:func:`addOutput`
 %End
 
+
     void removeParameter( const QString &name ) /HoldGIL/;
 %Docstring
 Removes the parameter with matching ``name`` from the algorithm, and deletes any existing

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -542,6 +542,7 @@ See the notes in :py:func:`~QgsProcessingAlgorithm.addParameter` for a descripti
 .. seealso:: :py:func:`initAlgorithm`
 %End
 
+
     virtual bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )  /VirtualErrorHandler=processing_exception_handler/;
 %Docstring
 Prepares the algorithm to run using the specified ``parameters``. Algorithms should implement

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -542,6 +542,7 @@ See the notes in :py:func:`~QgsProcessingAlgorithm.addParameter` for a descripti
 .. seealso:: :py:func:`initAlgorithm`
 %End
 
+
     virtual bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException ) /VirtualErrorHandler=processing_exception_handler/;
 %Docstring
 Prepares the algorithm to run using the specified ``parameters``. Algorithms should implement

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -519,6 +519,7 @@ occur.
 .. seealso:: :py:func:`addOutput`
 %End
 
+
     void removeParameter( const QString &name ) /HoldGIL/;
 %Docstring
 Removes the parameter with matching ``name`` from the algorithm, and deletes any existing

--- a/src/analysis/processing/qgsalgorithmpointstopaths.cpp
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.cpp
@@ -62,27 +62,29 @@ QString QgsPointsToPathsAlgorithm::groupId() const
 
 void QgsPointsToPathsAlgorithm::initAlgorithm( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint ) ) );
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "CLOSE_PATH" ), QObject::tr( "Create closed paths" ), false, true ) );
-  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "ORDER_EXPRESSION" ), QObject::tr( "Order expression" ), QVariant(), QStringLiteral( "INPUT" ), true ) );
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "NATURAL_SORT" ), QObject::tr( "Sort text containing numbers naturally" ), false, true ) );
-  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "GROUP_EXPRESSION" ), QObject::tr( "Path group expression" ), QVariant(), QStringLiteral( "INPUT" ), true ) );
-  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Paths" ), Qgis::ProcessingSourceType::VectorLine ) );
+  addParameter( std::make_unique<QgsProcessingParameterFeatureSource>( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint ) ) );
+  addParameter( std::make_unique<QgsProcessingParameterBoolean>( QStringLiteral( "CLOSE_PATH" ), QObject::tr( "Create closed paths" ), false, true ) );
+  addParameter( std::make_unique<QgsProcessingParameterExpression>( QStringLiteral( "ORDER_EXPRESSION" ), QObject::tr( "Order expression" ), QVariant(), QStringLiteral( "INPUT" ), true ) );
+  addParameter( std::make_unique<QgsProcessingParameterBoolean>( QStringLiteral( "NATURAL_SORT" ), QObject::tr( "Sort text containing numbers naturally" ), false, true ) );
+  addParameter( std::make_unique<QgsProcessingParameterExpression>( QStringLiteral( "GROUP_EXPRESSION" ), QObject::tr( "Path group expression" ), QVariant(), QStringLiteral( "INPUT" ), true ) );
+  addParameter( std::make_unique<QgsProcessingParameterFeatureSink>( QStringLiteral( "OUTPUT" ), QObject::tr( "Paths" ), Qgis::ProcessingSourceType::VectorLine ) );
   // TODO QGIS 4: remove parameter. move logic to separate algorithm if needed.
-  addParameter( new QgsProcessingParameterFolderDestination( QStringLiteral( "OUTPUT_TEXT_DIR" ), QObject::tr( "Directory for text output" ), QVariant(), true, false ) );
-  addOutput( new QgsProcessingOutputNumber( QStringLiteral( "NUM_PATHS" ), QObject::tr( "Number of paths" ) ) );
+  addParameter( std::make_unique<QgsProcessingParameterFolderDestination>( QStringLiteral( "OUTPUT_TEXT_DIR" ), QObject::tr( "Directory for text output" ), QVariant(), true, false ) );
+  addOutput( std::make_unique<QgsProcessingOutputNumber>( QStringLiteral( "NUM_PATHS" ), QObject::tr( "Number of paths" ) ) );
 
   // backwards compatibility parameters
   // TODO QGIS 4: remove compatibility parameters and their logic
-  QgsProcessingParameterField *orderField = new QgsProcessingParameterField( QStringLiteral( "ORDER_FIELD" ), QObject::tr( "Order field" ), QVariant(), QString(), Qgis::ProcessingFieldParameterDataType::Any, false, true );
+  auto orderField = std::make_unique<QgsProcessingParameterField>( QStringLiteral( "ORDER_FIELD" ), QObject::tr( "Order field" ), QVariant(), QString(), Qgis::ProcessingFieldParameterDataType::Any, false, true );
   orderField->setFlags( orderField->flags() | Qgis::ProcessingParameterFlag::Hidden );
-  addParameter( orderField );
-  QgsProcessingParameterField *groupField = new QgsProcessingParameterField( QStringLiteral( "GROUP_FIELD" ), QObject::tr( "Group field" ), QVariant(), QStringLiteral( "INPUT" ), Qgis::ProcessingFieldParameterDataType::Any, false, true );
+  addParameter( std::move( orderField ) );
+
+  auto groupField = std::make_unique<QgsProcessingParameterField>( QStringLiteral( "GROUP_FIELD" ), QObject::tr( "Group field" ), QVariant(), QStringLiteral( "INPUT" ), Qgis::ProcessingFieldParameterDataType::Any, false, true );
   groupField->setFlags( groupField->flags() | Qgis::ProcessingParameterFlag::Hidden );
-  addParameter( groupField );
-  QgsProcessingParameterString *dateFormat = new QgsProcessingParameterString( QStringLiteral( "DATE_FORMAT" ), QObject::tr( "Date format (if order field is DateTime)" ), QVariant(), false, true );
+  addParameter( std::move( groupField ) );
+
+  auto dateFormat = std::make_unique<QgsProcessingParameterString>( QStringLiteral( "DATE_FORMAT" ), QObject::tr( "Date format (if order field is DateTime)" ), QVariant(), false, true );
   dateFormat->setFlags( dateFormat->flags() | Qgis::ProcessingParameterFlag::Hidden );
-  addParameter( dateFormat );
+  addParameter( std::move( dateFormat ) );
 }
 
 QgsPointsToPathsAlgorithm *QgsPointsToPathsAlgorithm::createInstance() const

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -445,6 +445,11 @@ void QgsProcessingAlgorithm::removeParameter( const QString &name )
 
 bool QgsProcessingAlgorithm::addOutput( QgsProcessingOutputDefinition *definition )
 {
+  return addOutput( std::unique_ptr<QgsProcessingOutputDefinition>( definition ) );
+}
+
+bool QgsProcessingAlgorithm::addOutput( std::unique_ptr<QgsProcessingOutputDefinition> definition )
+{
   if ( !definition )
     return false;
 
@@ -452,11 +457,10 @@ bool QgsProcessingAlgorithm::addOutput( QgsProcessingOutputDefinition *definitio
   if ( QgsProcessingAlgorithm::outputDefinition( definition->name() ) )
   {
     QgsMessageLog::logMessage( QObject::tr( "Duplicate output %1 registered for alg %2" ).arg( definition->name(), id() ), QObject::tr( "Processing" ) );
-    delete definition;
     return false;
   }
 
-  mOutputs << definition;
+  mOutputs << definition.release();
   return true;
 }
 

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -555,6 +555,12 @@ class CORE_EXPORT QgsProcessingAlgorithm
     bool addOutput( QgsProcessingOutputDefinition *outputDefinition SIP_TRANSFER ) SIP_HOLDGIL;
 
     /**
+     * Same as above addOutput(QgsProcessingOutputDefinition*), but using
+     * a smart pointer for safer use.
+     */
+    bool addOutput( std::unique_ptr<QgsProcessingOutputDefinition> outputDefinition ) SIP_SKIP;
+
+    /**
      * Prepares the algorithm to run using the specified \a parameters. Algorithms should implement
      * their logic for evaluating parameter values here. The evaluated parameter results should
      * be stored in member variables ready for a call to processAlgorithm().

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -528,6 +528,12 @@ class CORE_EXPORT QgsProcessingAlgorithm
     bool addParameter( QgsProcessingParameterDefinition *parameterDefinition SIP_TRANSFER, bool createOutput = true ) SIP_HOLDGIL;
 
     /**
+     * Same as above addParameter(QgsProcessingParameterDefinition*, bool), but using
+     * a smart pointer for safer use.
+     */
+    bool addParameter( std::unique_ptr<QgsProcessingParameterDefinition> parameterDefinition, bool createOutput = true ) SIP_SKIP;
+
+    /**
      * Removes the parameter with matching \a name from the algorithm, and deletes any existing
      * definition.
      */
@@ -1110,7 +1116,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
     bool mHasPostProcessed = false;
     std::unique_ptr< QgsProcessingContext > mLocalContext;
 
-    bool createAutoOutputForParameter( QgsProcessingParameterDefinition *parameter );
+    bool createAutoOutputForParameter( const QgsProcessingParameterDefinition *parameter );
 
 
     friend class QgsProcessingProvider;


### PR DESCRIPTION
If we had those 2 new variants and used them, we would have immediately detected the issue fixed by https://github.com/qgis/QGIS/pull/59511, because the std::move() would have zeroed the smart pointer causing an immediate null-ptr derefrence when later used.

There is no good reason in 2024 to use explicit new and delete :-)