### PR TITLE
[ValueRelationWidget] Restore correctly value on widget value changed

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -19,16 +19,11 @@
 #include "qgis.h"
 #include "qgsfields.h"
 #include "qgsproject.h"
-#include "qgsvaluerelationwidgetfactory.h"
 #include "qgsvectorlayer.h"
 #include "qgsfilterlineedit.h"
-#include "qgsfeatureiterator.h"
 #include "qgsvaluerelationfieldformatter.h"
 #include "qgsattributeform.h"
-#include "qgsattributes.h"
-#include "qgsjsonutils.h"
 #include "qgspostgresstringutils.h"
-#include "qgsapplication.h"
 
 #include <QComboBox>
 #include <QLineEdit>
@@ -383,6 +378,11 @@ bool QgsValueRelationWidgetWrapper::valid() const
 
 void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
+  updateValue( value, true );
+}
+
+void QgsValueRelationWidgetWrapper::updateValue( const QVariant &value, bool forceComboInsertion )
+{
   if ( mTableWidget )
   {
     QStringList checkList;
@@ -417,7 +417,7 @@ void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const Q
     if ( idx == -1 )
     {
       // if value doesn't exist, we show it in '(...)' (just like value map widget)
-      if ( QgsVariantUtils::isNull( value ) )
+      if ( QgsVariantUtils::isNull( value ) || !forceComboInsertion )
       {
         mComboBox->setCurrentIndex( -1 );
       }
@@ -470,7 +470,7 @@ void QgsValueRelationWidgetWrapper::widgetValueChanged( const QString &attribute
     {
       populate();
       // Restore value
-      updateValues( value( ) );
+      updateValue( oldValue, false );
       // If the value has changed as a result of another widget's value change,
       // we need to emit the signal to make sure other dependent widgets are
       // updated.

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -198,6 +198,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
     /**
      * Set widget wrapper value, called by updateValues()
+     * \param value new value to update the widget with
      * \param forceComboInsertion if TRUE \a value would be inserted even if it doesn't exist in
      * combobox items and would appear as '(value)', else value would not be inserted. This has
      * no effects for widgets other than combobox because other widgets have different behavior:

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -196,6 +196,16 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
   private:
     void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
 
+    /**
+     * Set widget wrapper value, called by updateValues()
+     * \param forceComboInsertion if TRUE \a value would be inserted even if it doesn't exist in
+     * combobox items and would appear as '(value)', else value would not be inserted. This has
+     * no effects for widgets other than combobox because other widgets have different behavior:
+     *
+     * - line edit displays '(no selection)' if value doesn't exist
+     * - table widget would check only items existing in value
+     */
+    void updateValue( const QVariant &value, bool forceComboInsertion );
 
     /**
      * Returns the value configured in `NofColumns` or 1 if not

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -1937,7 +1937,9 @@ void TestQgsValueRelationWidgetWrapper::testMultiEditMode()
   cfg.insert( QStringLiteral( "AllowNull" ), false );
   cfg.insert( QStringLiteral( "OrderByValue" ), false );
   cfg.insert( QStringLiteral( "UseCompleter" ), false );
-  cfg.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "left(\"name\",4)  = current_value('firstname')" ) );
+
+  // we match only the 3 first character so Jhon and Jhon would work both. Useful for later tests
+  cfg.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "left(\"name\",3)  = left(current_value('firstname'),3)" ) );
 
   people->setEditorWidgetSetup( 1, QgsEditorWidgetSetup( QStringLiteral( "ValueRelation" ), cfg ) );
 
@@ -1973,6 +1975,14 @@ void TestQgsValueRelationWidgetWrapper::testMultiEditMode()
   QCOMPARE( valueRelationWrapper->mComboBox->model()->data( valueRelationWrapper->mComboBox->model()->index( 0, 0 ), Qt::DisplayRole ), QStringLiteral( "Jhon Carpenter" ) );
   QCOMPARE( valueRelationWrapper->mComboBox->model()->data( valueRelationWrapper->mComboBox->model()->index( 1, 0 ), Qt::DisplayRole ), QStringLiteral( "Jhon F. Kennedy" ) );
   QCOMPARE( valueRelationWrapper->mComboBox->model()->data( valueRelationWrapper->mComboBox->model()->index( 2, 0 ), Qt::DisplayRole ), QStringLiteral( "Jhon Lennon" ) );
+
+  valueRelationWrapper->setValues( QStringLiteral( "Jhon Lennon" ), QVariantList() );
+  QCOMPARE( valueRelationWrapper->mComboBox->currentIndex(), 2 );
+  QCOMPARE( valueRelationWrapper->mComboBox->currentText(), QStringLiteral( "Jhon Lennon" ) );
+
+  firstNameWrapper->setValues( QStringLiteral( "Jho" ), QVariantList() );
+  QCOMPARE( valueRelationWrapper->mComboBox->currentIndex(), 2 );
+  QCOMPARE( valueRelationWrapper->mComboBox->currentText(), QStringLiteral( "Jhon Lennon" ) );
 
   people->rollBack();
   QgsProject::instance()->removeMapLayer( people.get() );


### PR DESCRIPTION
When selecting several features on multiedit mode, widgets are intialized in no known order (see
QgsAttributeForm::setMultiEditFeatureIds() ), and so we could initialize a value relation widget before an other widget it is related to (through its expression). That would cause the current selected value to be lost.

So we need to restore properly this value on widget value changed.

**Funded by Coforet**