### PR TITLE
[Vcpkg] Don't install python3 if we build without bindings

### DIFF
--- a/cmake/VcpkgInstallDeps.cmake
+++ b/cmake/VcpkgInstallDeps.cmake
@@ -23,6 +23,8 @@ install(DIRECTORY "${PROJ_DATA_PATH}/" DESTINATION "${CMAKE_INSTALL_DATADIR}/pro
 install(DIRECTORY "${VCPKG_BASE_DIR}/share/gdal/" DESTINATION "${CMAKE_INSTALL_DATADIR}/gdal")
 install(DIRECTORY "${VCPKG_BASE_DIR}/bin/Qca/" DESTINATION "bin/Qca") # QCA plugins
 install(DIRECTORY "${VCPKG_BASE_DIR}/Qt6/" DESTINATION "bin/Qt6") # qt plugins (qml and others)
-install(DIRECTORY "${VCPKG_BASE_DIR}/tools/python3/"
-        DESTINATION "bin"
-        PATTERN "*.sip" EXCLUDE)
+if(WITH_BINDINGS)
+  install(DIRECTORY "${VCPKG_BASE_DIR}/tools/python3/"
+    DESTINATION "bin"
+    PATTERN "*.sip" EXCLUDE)
+endif()


### PR DESCRIPTION
I actually only add if(WITH_BINDINGS) to the last python install instruction. Others modifications are only because of removed ^M at end of lines

**Funded by Gispo**