### PR TITLE
Call build_artifact_comment.yml only for PRs

### DIFF
--- a/.github/workflows/build_artifact_comment.yml
+++ b/.github/workflows/build_artifact_comment.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   on-success:
+    if: github.event.workflow_run.event == 'pull_request'
 
     permissions:
       pull-requests: write


### PR DESCRIPTION
This will avoid false negative workflow failures