### PR TITLE
Fix deadlock in oath2 authentication

### DIFF
--- a/external/o2/src/o0baseauth.cpp
+++ b/external/o2/src/o0baseauth.cpp
@@ -92,7 +92,10 @@ bool O0BaseAuth::useExternalWebInterceptor() {
 }
 
 void O0BaseAuth::setUseExternalWebInterceptor(bool useExternalWebInterceptor) {
+    if ( useExternalWebInterceptor_ == useExternalWebInterceptor )
+        return;
     useExternalWebInterceptor_ = useExternalWebInterceptor;
+    Q_EMIT useExternalWebInterceptorChanged(useExternalWebInterceptor_);
 }
 
 QByteArray O0BaseAuth::replyContent() const {
@@ -100,9 +103,14 @@ QByteArray O0BaseAuth::replyContent() const {
 }
 
 void O0BaseAuth::setReplyContent(const QByteArray &value) {
+    bool changed = replyContent_ != value;
     replyContent_ = value;
     if (replyServer_) {
         replyServer_->setReplyContent(replyContent_);
+    }
+    if ( changed )
+    {
+        Q_EMIT replyContentChanged();
     }
 }
 

--- a/external/o2/src/o0baseauth.h
+++ b/external/o2/src/o0baseauth.h
@@ -58,13 +58,13 @@ public:
     void setClientSecret(const QString &value);
 
     /// Should we use a reply server (default) or an external web interceptor?
-    Q_PROPERTY(bool useExternalWebInterceptor READ useExternalWebInterceptor WRITE setUseExternalWebInterceptor)
+    Q_PROPERTY(bool useExternalWebInterceptor READ useExternalWebInterceptor WRITE setUseExternalWebInterceptor NOTIFY useExternalWebInterceptorChanged)
     bool useExternalWebInterceptor();
     void setUseExternalWebInterceptor(bool useExternalWebInterceptor);
 
     /// Page content on local host after successful oauth.
     /// Provide it in case you do not want to close the browser, but display something
-    Q_PROPERTY(QByteArray replyContent READ replyContent WRITE setReplyContent)
+    Q_PROPERTY(QByteArray replyContent READ replyContent WRITE setReplyContent NOTIFY replyContentChanged)
     QByteArray replyContent() const;
     void setReplyContent(const QByteArray &value);
 
@@ -121,6 +121,8 @@ Q_SIGNALS:
     void tokenChanged();
     void tokenSecretChanged();
     void extraTokensChanged();
+    void useExternalWebInterceptorChanged( bool enabled );
+    void replyContentChanged();
 
 protected:
     /// Set authentication token.

--- a/external/o2/src/o1.cpp
+++ b/external/o2/src/o1.cpp
@@ -39,7 +39,11 @@ QByteArray O1::userAgent() const {
 }
 
 void O1::setUserAgent(const QByteArray &value) {
+    if (userAgent_ == value)
+        return;
+
     userAgent_ = value;
+    Q_EMIT userAgentChanged(userAgent_);
 }
 
 QUrl O1::requestTokenUrl() {
@@ -57,6 +61,7 @@ QList<O0RequestParameter> O1::requestParameters() {
 
 void O1::setRequestParameters(const QList<O0RequestParameter> &value) {
     requestParameters_ = value;
+    Q_EMIT requestParametersChanged();
 }
 
 QString O1::callbackUrl() {
@@ -64,7 +69,11 @@ QString O1::callbackUrl() {
 }
 
 void O1::setCallbackUrl(const QString &value) {
+    if ( callbackUrl_ == value )
+        return;
+
     callbackUrl_ = value;
+    Q_EMIT callbackUrlChanged(callbackUrl_);
 }
 
 QUrl O1::authorizeUrl() {

--- a/external/o2/src/o1.h
+++ b/external/o2/src/o1.h
@@ -17,7 +17,7 @@ public:
     /// Set user agent to a value unique for your application (https://tools.ietf.org/html/rfc7231#section-5.5.3)
     /// if you see the following error in the application log:
     /// O1::onTokenRequestError: 201 "Error transferring requestTokenUrl() - server replied: Forbidden" "Bad bot"
-    Q_PROPERTY(QByteArray userAgent READ userAgent WRITE setUserAgent)
+    Q_PROPERTY(QByteArray userAgent READ userAgent WRITE setUserAgent NOTIFY userAgentChanged)
     QByteArray userAgent() const;
     void setUserAgent(const QByteArray &value);
 
@@ -32,14 +32,14 @@ public:
     void setRequestTokenUrl(const QUrl &value);
 
     /// Parameters to pass with request URL.
-    Q_PROPERTY(QList<O0RequestParameter> requestParameters READ requestParameters WRITE setRequestParameters)
+    Q_PROPERTY(QList<O0RequestParameter> requestParameters READ requestParameters WRITE setRequestParameters NOTIFY requestParametersChanged)
     QList<O0RequestParameter> requestParameters();
     void setRequestParameters(const QList<O0RequestParameter> &value);
 
     /// Callback URL.
     /// It should contain a `%1` place marker, to be replaced by `O0BaseAuth::localPort()`.
     /// Defaults to `O2_CALLBACK_URL`.
-    Q_PROPERTY(QString callbackUrl READ callbackUrl WRITE setCallbackUrl)
+    Q_PROPERTY(QString callbackUrl READ callbackUrl WRITE setCallbackUrl NOTIFY callbackUrlChanged)
     QString callbackUrl();
     void setCallbackUrl(const QString &value);
 
@@ -99,6 +99,9 @@ Q_SIGNALS:
     void authorizeUrlChanged();
     void accessTokenUrlChanged();
     void signatureMethodChanged();
+    void userAgentChanged(const QByteArray& agent);
+    void requestParametersChanged();
+    void callbackUrlChanged(const QString& url);
 
 public Q_SLOTS:
     /// Handle verification received from the reply server.

--- a/external/o2/src/o1smugmug.h
+++ b/external/o2/src/o1smugmug.h
@@ -42,7 +42,7 @@ public:
     };
     Q_ENUM(Permissions)
 
-    Q_INVOKABLE void initAuthorizationUrl(Access access, Permissions permissions);
+    Q_INVOKABLE void initAuthorizationUrl(O1SmugMug::Access access, O1SmugMug::Permissions permissions);
 
 #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     class AuthorizationUrlBuilder {

--- a/external/o2/src/o2.h
+++ b/external/o2/src/o2.h
@@ -51,18 +51,18 @@ public:
 
     /// Localhost policy. By default it's value is http://127.0.0.1:%1/, however some services may
     /// require the use of http://localhost:%1/ or any other value.
-    Q_PROPERTY(QString localhostPolicy READ localhostPolicy WRITE setLocalhostPolicy)
+    Q_PROPERTY(QString localhostPolicy READ localhostPolicy WRITE setLocalhostPolicy NOTIFY localHostPolicyChanged)
     QString localhostPolicy() const;
     void setLocalhostPolicy(const QString &value);
 
     /// API key.
-    Q_PROPERTY(QString apiKey READ apiKey WRITE setApiKey)
+    Q_PROPERTY(QString apiKey READ apiKey WRITE setApiKey NOTIFY apiKeyChanged)
     QString apiKey();
     void setApiKey(const QString &value);
 
     /// Allow ignoring SSL errors?
     /// E.g. SurveyMonkey fails on Mac due to SSL error. Ignoring the error circumvents the problem
-    Q_PROPERTY(bool ignoreSslErrors READ ignoreSslErrors WRITE setIgnoreSslErrors)
+    Q_PROPERTY(bool ignoreSslErrors READ ignoreSslErrors WRITE setIgnoreSslErrors NOTIFY ignoreSslErrorsChanged)
     bool ignoreSslErrors();
     void setIgnoreSslErrors(bool ignoreSslErrors);
 
@@ -87,7 +87,7 @@ public:
     void setRefreshTokenUrl(const QString &value);
 
     /// Grant type (if non-standard)
-    Q_PROPERTY(QString grantType READ grantType WRITE setGrantType)
+    Q_PROPERTY(QString grantType READ grantType WRITE setGrantType NOTIFY grantTypeChanged)
     QString grantType();
     void setGrantType(const QString &value);
 
@@ -103,7 +103,7 @@ public:
     QString refreshToken();
 
     /// Get token expiration time (seconds from Epoch).
-    int expires();
+    qint64 expires();
 
 public Q_SLOTS:
     /// Authenticate.
@@ -131,6 +131,10 @@ Q_SIGNALS:
     void extraRequestParamsChanged();
     void refreshTokenUrlChanged();
     void tokenUrlChanged();
+    void localHostPolicyChanged(const QString& policy);
+    void apiKeyChanged(const QString& key);
+    void ignoreSslErrorsChanged(bool ignore);
+    void grantTypeChanged(const QString& type);
 
 public Q_SLOTS:
     /// Handle verification response.
@@ -163,7 +167,7 @@ protected:
     void setRefreshToken(const QString &v);
 
     /// Set token expiration time.
-    void setExpires(int v);
+    void setExpires(qint64 v);
 
     /// Returns the QNetworkAccessManager instance to use for network access
     virtual QNetworkAccessManager *getManager();

--- a/external/o2/src/o2pollserver.cpp
+++ b/external/o2/src/o2pollserver.cpp
@@ -43,6 +43,7 @@ int O2PollServer::interval() const
 void O2PollServer::setInterval(int interval)
 {
     pollTimer.setInterval(interval * 1000);
+    Q_EMIT intervalChanged(interval);
 }
 
 void O2PollServer::startPolling()

--- a/external/o2/src/o2pollserver.h
+++ b/external/o2/src/o2pollserver.h
@@ -21,13 +21,14 @@ public:
     explicit O2PollServer(QNetworkAccessManager * manager, const QNetworkRequest &request, const QByteArray & payload, int expiresIn, QObject *parent = nullptr);
 
     /// Seconds to wait between polling requests
-    Q_PROPERTY(int interval READ interval WRITE setInterval)
+    Q_PROPERTY(int interval READ interval WRITE setInterval NOTIFY intervalChanged)
     int interval() const;
     void setInterval(int interval);
 
 Q_SIGNALS:
     void verificationReceived(QMap<QString, QString>);
     void serverClosed(bool); // whether it has found parameters
+    void intervalChanged(int interval);
 
 public Q_SLOTS:
     void startPolling();

--- a/external/o2/src/o2replyserver.cpp
+++ b/external/o2/src/o2replyserver.cpp
@@ -152,7 +152,10 @@ QByteArray O2ReplyServer::replyContent() {
 }
 
 void O2ReplyServer::setReplyContent(const QByteArray &value) {
-  replyContent_ = value;
+    if (replyContent_ == value)
+        return;
+    replyContent_ = value;
+    Q_EMIT replyContentChanged();
 }
 
 int O2ReplyServer::timeout()
@@ -162,7 +165,11 @@ int O2ReplyServer::timeout()
 
 void O2ReplyServer::setTimeout(int timeout)
 {
-  timeout_ = timeout;
+    if ( timeout_ == timeout )
+        return;
+
+    timeout_ = timeout;
+    Q_EMIT timeoutChanged(timeout_);
 }
 
 int O2ReplyServer::callbackTries()
@@ -172,7 +179,11 @@ int O2ReplyServer::callbackTries()
 
 void O2ReplyServer::setCallbackTries(int maxtries)
 {
-  maxtries_ = maxtries;
+    if (maxtries_ == maxtries)
+        return;
+
+    maxtries_ = maxtries;
+    Q_EMIT callbackTriesChanged(maxtries_);
 }
 
 QString O2ReplyServer::uniqueState()

--- a/external/o2/src/o2replyserver.h
+++ b/external/o2/src/o2replyserver.h
@@ -16,17 +16,17 @@ public:
     explicit O2ReplyServer(QObject *parent = nullptr);
 
     /// Page content on local host after successful oauth - in case you do not want to close the browser, but display something
-    Q_PROPERTY(QByteArray replyContent READ replyContent WRITE setReplyContent)
+    Q_PROPERTY(QByteArray replyContent READ replyContent WRITE setReplyContent NOTIFY replyContentChanged)
     QByteArray replyContent();
     void setReplyContent(const QByteArray &value);
 
     /// Seconds to keep listening *after* first response for a callback with token content
-    Q_PROPERTY(int timeout READ timeout WRITE setTimeout)
+    Q_PROPERTY(int timeout READ timeout WRITE setTimeout NOTIFY timeoutChanged)
     int timeout();
     void setTimeout(int timeout);
 
     /// Maximum number of callback tries to accept, in case some don't have token content (favicons, etc.)
-    Q_PROPERTY(int callbackTries READ callbackTries WRITE setCallbackTries)
+    Q_PROPERTY(int callbackTries READ callbackTries WRITE setCallbackTries NOTIFY callbackTriesChanged)
     int callbackTries();
     void setCallbackTries(int maxtries);
 
@@ -36,6 +36,9 @@ public:
 Q_SIGNALS:
     void verificationReceived(QMap<QString, QString>);
     void serverClosed(bool); // whether it has found parameters
+    void replyContentChanged();
+    void timeoutChanged(int timeout);
+    void callbackTriesChanged(int maxtries);
 
 public Q_SLOTS:
     void onIncomingConnection();

--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -105,7 +105,9 @@ QgsO2 *QgsOAuth2Factory::createO2Private( const QString &authcfg, QgsAuthOAuth2C
   else
   {
     oauth2config->moveToThread( nullptr );
+#ifndef __clang_analyzer__
     QMetaObject::invokeMethod( this, createO2InThread, Qt::BlockingQueuedConnection );
+#endif
   }
   Q_ASSERT( o2->thread() == this );
 

--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -81,10 +81,14 @@ QgsO2 *QgsOAuth2Factory::createO2( const QString &authcfg, QgsAuthOAuth2Config *
 
 void QgsOAuth2Factory::requestLink( QgsO2 *o2 )
 {
+#ifndef __clang_analyzer__
   if ( QThread::currentThread() == o2->thread() )
     o2->link();
   else
     QMetaObject::invokeMethod( o2, &QgsO2::link, Qt::BlockingQueuedConnection );
+#else
+  ( void )o2;
+#endif
 }
 
 QgsO2 *QgsOAuth2Factory::createO2Private( const QString &authcfg, QgsAuthOAuth2Config *oauth2config )

--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -47,10 +47,6 @@ const QString QgsAuthOAuth2Method::AUTH_METHOD_KEY = QStringLiteral( "OAuth2" );
 const QString QgsAuthOAuth2Method::AUTH_METHOD_DESCRIPTION = QStringLiteral( "OAuth2 authentication" );
 const QString QgsAuthOAuth2Method::AUTH_METHOD_DISPLAY_DESCRIPTION = tr( "OAuth2 authentication" );
 
-QMap<QString, QgsO2 * > QgsAuthOAuth2Method::sOAuth2ConfigCache =
-  QMap<QString, QgsO2 * >();
-
-
 QgsAuthOAuth2Method::QgsAuthOAuth2Method()
 {
   setVersion( 1 );
@@ -522,10 +518,10 @@ QgsO2 *QgsAuthOAuth2Method::getOAuth2Bundle( const QString &authcfg, bool fullco
   // TODO: update to QgsMessageLog output where appropriate
 
   // check if it is cached
-  if ( sOAuth2ConfigCache.contains( authcfg ) )
+  if ( QgsO2 *cachedBundle = mOAuth2ConfigCache.value( authcfg ) )
   {
     QgsDebugMsgLevel( QStringLiteral( "Retrieving OAuth bundle for authcfg: %1" ).arg( authcfg ), 2 );
-    return sOAuth2ConfigCache.value( authcfg );
+    return cachedBundle;
   }
 
   QgsAuthOAuth2Config *config = new QgsAuthOAuth2Config( );
@@ -645,15 +641,16 @@ QgsO2 *QgsAuthOAuth2Method::getOAuth2Bundle( const QString &authcfg, bool fullco
 void QgsAuthOAuth2Method::putOAuth2Bundle( const QString &authcfg, QgsO2 *bundle )
 {
   QgsDebugMsgLevel( QStringLiteral( "Putting oauth2 bundle for authcfg: %1" ).arg( authcfg ), 2 );
-  sOAuth2ConfigCache.insert( authcfg, bundle );
+  mOAuth2ConfigCache.insert( authcfg, bundle );
 }
 
 void QgsAuthOAuth2Method::removeOAuth2Bundle( const QString &authcfg )
 {
-  if ( sOAuth2ConfigCache.contains( authcfg ) )
+  auto it = mOAuth2ConfigCache.find( authcfg );
+  if ( it != mOAuth2ConfigCache.end() )
   {
-    sOAuth2ConfigCache.value( authcfg )->deleteLater();
-    sOAuth2ConfigCache.remove( authcfg );
+    it.value()->deleteLater();
+    mOAuth2ConfigCache.erase( it );
     QgsDebugMsgLevel( QStringLiteral( "Removed oauth2 bundle for authcfg: %1" ).arg( authcfg ), 2 );
   }
 }

--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -82,6 +82,14 @@ QgsO2 *QgsOAuth2Factory::createO2( const QString &authcfg, QgsAuthOAuth2Config *
   return instance()->createO2Private( authcfg, oauth2config );
 }
 
+void QgsOAuth2Factory::requestLink( QgsO2 *o2 )
+{
+  if ( QThread::currentThread() == o2->thread() )
+    o2->link();
+  else
+    QMetaObject::invokeMethod( o2, &QgsO2::link, Qt::BlockingQueuedConnection );
+}
+
 QgsO2 *QgsOAuth2Factory::createO2Private( const QString &authcfg, QgsAuthOAuth2Config *oauth2config )
 {
   QgsO2 *o2 = nullptr;
@@ -268,7 +276,7 @@ bool QgsAuthOAuth2Method::updateNetworkRequest( QNetworkRequest &request, const 
     timer.start();
 
     // asynchronously attempt the linking
-    o2->link();
+    QgsOAuth2Factory::requestLink( o2 );
 
     // block request update until asynchronous linking loop is quit
     loop.exec();

--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -65,14 +65,11 @@ QgsOAuth2Factory::QgsOAuth2Factory( QObject *parent )
 
 QgsOAuth2Factory *QgsOAuth2Factory::instance()
 {
+  static QMutex sMutex;
+  const QMutexLocker locker( &sMutex );
   if ( !sInstance )
   {
-    static QMutex sMutex;
-    const QMutexLocker locker( &sMutex );
-    if ( !sInstance )
-    {
-      sInstance = new QgsOAuth2Factory();
-    }
+    sInstance = new QgsOAuth2Factory();
   }
   return sInstance;
 }

--- a/src/auth/oauth2/core/qgsauthoauth2method.h
+++ b/src/auth/oauth2/core/qgsauthoauth2method.h
@@ -58,6 +58,12 @@ class QgsOAuth2Factory : public QThread
      */
     static QgsO2 *createO2( const QString &authcfg, QgsAuthOAuth2Config *oauth2config );
 
+    /**
+     * Request linking a \a o2 object. This ensures that the link is done
+     * in a thread-safe manner.
+     */
+    static void requestLink( QgsO2 *o2 );
+
   private:
     static QgsOAuth2Factory *instance();
 

--- a/src/auth/oauth2/core/qgsauthoauth2method.h
+++ b/src/auth/oauth2/core/qgsauthoauth2method.h
@@ -21,10 +21,10 @@
 #include <QEventLoop>
 #include <QTimer>
 #include <QMutex>
+#include <QReadWriteLock>
 
 #include "qgsauthmethod.h"
 #include "qgsauthmethodmetadata.h"
-
 
 class QgsO2;
 
@@ -113,10 +113,12 @@ class QgsAuthOAuth2Method : public QgsAuthMethod
 
     void removeOAuth2Bundle( const QString &authcfg );
 
+    QReadWriteLock mO2CacheLock;
     QMap<QString, QgsO2 *> mOAuth2ConfigCache;
 
     QgsO2 *authO2( const QString &authcfg );
 
+    // TODO: This mutex does not appear to be protecting anything which is thread-unsafe?
     QRecursiveMutex mNetworkRequestMutex;
 };
 

--- a/src/auth/oauth2/core/qgsauthoauth2method.h
+++ b/src/auth/oauth2/core/qgsauthoauth2method.h
@@ -105,7 +105,6 @@ class QgsAuthOAuth2Method : public QgsAuthMethod
     void setAuthCode( const QString code );
 
   private:
-    QString mTempStorePath;
 
     QgsO2 *getOAuth2Bundle( const QString &authcfg, bool fullconfig = true );
 

--- a/src/auth/oauth2/core/qgsauthoauth2method.h
+++ b/src/auth/oauth2/core/qgsauthoauth2method.h
@@ -113,7 +113,7 @@ class QgsAuthOAuth2Method : public QgsAuthMethod
 
     void removeOAuth2Bundle( const QString &authcfg );
 
-    static QMap<QString, QgsO2 *> sOAuth2ConfigCache;
+    QMap<QString, QgsO2 *> mOAuth2ConfigCache;
 
     QgsO2 *authO2( const QString &authcfg );
 

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -417,7 +417,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
         if ( ok )
         {
           QgsDebugMsgLevel( QStringLiteral( "O2::onVerificationReceived: Token expires in %1 seconds" ).arg( expiresIn ), 2 );
-          setExpires( static_cast< int >( QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn ) );
+          setExpires( QDateTime::currentMSecsSinceEpoch() / 1000 + static_cast< qint64 >( expiresIn ) );
         }
       }
       setLinked( true );
@@ -507,7 +507,7 @@ void QgsO2::refreshSynchronous()
     else
     {
       setToken( tokens.value( O2_OAUTH2_ACCESS_TOKEN ).toString() );
-      setExpires( static_cast< int >( QDateTime::currentMSecsSinceEpoch() / 1000 + tokens.value( O2_OAUTH2_EXPIRES_IN ).toInt() ) );
+      setExpires( QDateTime::currentMSecsSinceEpoch() / 1000 + static_cast< qint64 >( tokens.value( O2_OAUTH2_EXPIRES_IN ).toInt() ) );
       const QString refreshToken = tokens.value( O2_OAUTH2_REFRESH_TOKEN ).toString();
       if ( !refreshToken.isEmpty() )
         setRefreshToken( refreshToken );
@@ -527,6 +527,6 @@ void QgsO2::refreshSynchronous()
 
 void QgsO2::computeExpirationDelay()
 {
-  const int lExpires = expires();
-  mExpirationDelay = lExpires > 0 ? lExpires - static_cast<int>( QDateTime::currentMSecsSinceEpoch() / 1000 ) : 0;
+  const qint64 lExpires = expires();
+  mExpirationDelay = static_cast< int >( lExpires > 0 ? lExpires - static_cast<qint64>( QDateTime::currentMSecsSinceEpoch() / 1000 ) : 0 );
 }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -197,6 +197,8 @@ void QgsO2::onSetAuthCode( const QString &code )
 
 void QgsO2::link()
 {
+  Q_ASSERT( thread() == QThread::currentThread() );
+
   QgsDebugMsgLevel( QStringLiteral( "QgsO2::link" ), 4 );
 
   // Create the reply server if it doesn't exist

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -18,7 +18,6 @@
 #include "o0globals.h"
 #include "o0settingsstore.h"
 #include "o2replyserver.h"
-#include "qgsapplication.h"
 #include "qgsauthoauth2config.h"
 #include "qgslogger.h"
 #include "qgsnetworkaccessmanager.h"
@@ -309,12 +308,10 @@ void QgsO2::link()
     if ( !apiKey_.isEmpty() )
       parameters.append( O0RequestParameter( O2_OAUTH2_API_KEY, apiKey_.toUtf8() ) );
 
-
     for ( auto iter = extraReqParams_.constBegin(); iter != extraReqParams_.constEnd(); ++iter )
     {
       parameters.append( O0RequestParameter( iter.key().toUtf8(), iter.value().toString().toUtf8() ) );
     }
-
 
     const QByteArray payload = O0BaseAuth::createQueryParameters( parameters );
 
@@ -329,13 +326,11 @@ void QgsO2::link()
   }
 }
 
-
 void QgsO2::setState( const QString & )
 {
   state_ = QString::number( QRandomGenerator::system()->generate() );
   Q_EMIT stateChanged();
 }
-
 
 void QgsO2::onVerificationReceived( QMap<QString, QString> response )
 {
@@ -417,7 +412,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
         if ( ok )
         {
           QgsDebugMsgLevel( QStringLiteral( "O2::onVerificationReceived: Token expires in %1 seconds" ).arg( expiresIn ), 2 );
-          setExpires( QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn );
+          setExpires( static_cast< int >( QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn ) );
         }
       }
       setLinked( true );
@@ -507,7 +502,7 @@ void QgsO2::refreshSynchronous()
     else
     {
       setToken( tokens.value( O2_OAUTH2_ACCESS_TOKEN ).toString() );
-      setExpires( QDateTime::currentMSecsSinceEpoch() / 1000 + tokens.value( O2_OAUTH2_EXPIRES_IN ).toInt() );
+      setExpires( static_cast< int >( QDateTime::currentMSecsSinceEpoch() / 1000 + tokens.value( O2_OAUTH2_EXPIRES_IN ).toInt() ) );
       const QString refreshToken = tokens.value( O2_OAUTH2_REFRESH_TOKEN ).toString();
       if ( !refreshToken.isEmpty() )
         setRefreshToken( refreshToken );

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -240,11 +240,11 @@ void QgsO2::link()
           // Start listening to authentication replies
           if ( replyServer()->listen( QHostAddress::Any, localPort_ ) )
           {
-//qDebug() << "O2::link: Reply server listening on port" << localPort();
+            QgsDebugMsgLevel( QStringLiteral( "O2::link: Reply server listening on port %1" ).arg( localPort() ), 2 );
           }
           else
           {
-            qWarning() << "O2::link: Reply server failed to start listening on port" << localPort();
+            QgsDebugError( QStringLiteral( "O2::link: Reply server failed to start listening on port %1" ).arg( localPort() ) );
             emit linkingFailed();
             return;
           }
@@ -408,7 +408,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     // Check for mandatory tokens
     if ( response.contains( O2_OAUTH2_ACCESS_TOKEN ) )
     {
-      qDebug() << "O2::onVerificationReceived: Access token returned for implicit flow";
+      QgsDebugMsgLevel( QStringLiteral( "O2::onVerificationReceived: Access token returned for implicit flow" ), 2 );
       setToken( response.value( O2_OAUTH2_ACCESS_TOKEN ) );
       if ( response.contains( O2_OAUTH2_EXPIRES_IN ) )
       {
@@ -416,7 +416,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
         const int expiresIn = response.value( O2_OAUTH2_EXPIRES_IN ).toInt( &ok );
         if ( ok )
         {
-          qDebug() << "O2::onVerificationReceived: Token expires in" << expiresIn << "seconds";
+          QgsDebugMsgLevel( QStringLiteral( "O2::onVerificationReceived: Token expires in %1 seconds" ).arg( expiresIn ), 2 );
           setExpires( QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn );
         }
       }
@@ -425,7 +425,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     }
     else
     {
-      qWarning() << "O2::onVerificationReceived: Access token missing from response for implicit flow";
+      QgsDebugError( QStringLiteral( "O2::onVerificationReceived: Access token missing from response for implicit flow" ) );
       Q_EMIT linkingFailed();
     }
   }
@@ -448,13 +448,13 @@ static QVariantMap parseTokenResponse( const QByteArray &data )
   const QJsonDocument doc = QJsonDocument::fromJson( data, &err );
   if ( err.error != QJsonParseError::NoError )
   {
-    qWarning() << "parseTokenResponse: Failed to parse token response due to err:" << err.errorString();
+    QgsDebugError( QStringLiteral( "parseTokenResponse: Failed to parse token response due to err: %1" ).arg( err.errorString() ) );
     return QVariantMap();
   }
 
   if ( !doc.isObject() )
   {
-    qWarning() << "parseTokenResponse: Token response is not an object";
+    QgsDebugError( QStringLiteral( "parseTokenResponse: Token response is not an object" ) );
     return QVariantMap();
   }
 
@@ -464,17 +464,17 @@ static QVariantMap parseTokenResponse( const QByteArray &data )
 // Code adapted from O2::refresh(), but using QgsBlockingNetworkRequest
 void QgsO2::refreshSynchronous()
 {
-  qDebug() << "O2::refresh: Token: ..." << refreshToken().right( 7 );
+  QgsDebugMsgLevel( QStringLiteral( "O2::refresh: Token: ... %1" ).arg( refreshToken().right( 7 ) ), 2 );
 
   if ( refreshToken().isEmpty() )
   {
-    qWarning() << "O2::refresh: No refresh token";
+    QgsDebugError( QStringLiteral( "O2::refresh: No refresh token" ) );
     onRefreshError( QNetworkReply::AuthenticationRequiredError );
     return;
   }
   if ( refreshTokenUrl_.isEmpty() )
   {
-    qWarning() << "O2::refresh: Refresh token URL not set";
+    QgsDebugError( QStringLiteral( "O2::refresh: Refresh token URL not set" ) );
     onRefreshError( QNetworkReply::AuthenticationRequiredError );
     return;
   }
@@ -501,7 +501,7 @@ void QgsO2::refreshSynchronous()
     const QVariantMap tokens = parseTokenResponse( reply );
     if ( tokens.contains( QStringLiteral( "error" ) ) )
     {
-      qDebug() << " Error refreshing token" << tokens.value( QStringLiteral( "error" ) ).toMap().value( QStringLiteral( "message" ) ).toString().toLocal8Bit().constData();
+      QgsDebugError( QStringLiteral( "Error refreshing token %1" ).arg( tokens.value( QStringLiteral( "error" ) ).toMap().value( QStringLiteral( "message" ) ).toString().toLocal8Bit().constData() ) );
       unlink();
     }
     else
@@ -512,7 +512,7 @@ void QgsO2::refreshSynchronous()
       if ( !refreshToken.isEmpty() )
         setRefreshToken( refreshToken );
       setLinked( true );
-      qDebug() << " New token expires in" << expires() << "seconds";
+      QgsDebugMsgLevel( QStringLiteral( "New token expires in %1 seconds" ).arg( expires() ), 2 );
       emit linkingSucceeded();
     }
     emit refreshFinished( QNetworkReply::NoError );
@@ -520,7 +520,7 @@ void QgsO2::refreshSynchronous()
   else
   {
     unlink();
-    qDebug() << "O2::onRefreshFinished: Error" << blockingRequest.errorMessage();
+    QgsDebugError( QStringLiteral( "O2::onRefreshFinished: Error %1" ).arg( blockingRequest.errorMessage() ) );
     emit refreshFinished( blockingRequest.reply().error() );
   }
 }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -65,6 +65,9 @@ QgsO2::QgsO2( const QString &authcfg, QgsAuthOAuth2Config *oauth2config,
     } );
   } );
 
+  if ( mOAuth2Config )
+    mOAuth2Config->setParent( this );
+
   initOAuthConfig();
 }
 

--- a/src/auth/oauth2/core/qgso2.h
+++ b/src/auth/oauth2/core/qgso2.h
@@ -35,12 +35,14 @@ class QgsO2: public O2
     /**
      * Construct QgsO2
      * \param authcfg authentication configuration id
-     * \param oauth2config OAuth2 configuration
+     * \param oauth2config OAuth2 configuration. Will be reparented to this object.
      * \param parent
      * \param manager QGIS network access manager instance
      */
-    explicit QgsO2( const QString &authcfg, QgsAuthOAuth2Config *oauth2config = nullptr,
-                    QObject *parent = nullptr, QNetworkAccessManager *manager = nullptr );
+    explicit QgsO2( const QString &authcfg,
+                    QgsAuthOAuth2Config *oauth2config = nullptr,
+                    QObject *parent = nullptr,
+                    QNetworkAccessManager *manager = nullptr );
 
     ~QgsO2() override;
 

--- a/src/auth/oauth2/core/qgso2.h
+++ b/src/auth/oauth2/core/qgso2.h
@@ -83,9 +83,6 @@ class QgsO2: public O2
     //! Triggered when auth code was set
     void onSetAuthCode( const QString &code );
 
-    //! Authenticate.
-    void link() override;
-
   protected slots:
 
     //! Handle verification response.
@@ -104,6 +101,12 @@ class QgsO2: public O2
     void getAuthCode();
 
   private:
+
+    // block from calling externally -- this may be dangerous, we want to prevent
+    // anyone from calling this from a different thread
+    // Use instead QgsOAuth2Factory::requestLink
+    void link() override;
+
     void initOAuthConfig();
 
     void setSettingsStore( bool persist = false );
@@ -121,6 +124,7 @@ class QgsO2: public O2
     int mExpirationDelay = 0;
 
     static QString O2_OAUTH2_STATE;
+    friend class QgsOAuth2Factory;
 };
 
 #endif // QGSO2_H

--- a/src/core/network/qgssetrequestinitiator_p.h
+++ b/src/core/network/qgssetrequestinitiator_p.h
@@ -26,8 +26,8 @@ constexpr int sFilePrefixLength = CMAKE_SOURCE_DIR[sizeof( CMAKE_SOURCE_DIR ) - 
 #define QgsSetRequestInitiatorClass(request, _class) ( request ).setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorClass ), _class ); ( request ).setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorRequestId ), QString(QString( __FILE__ ).mid( sFilePrefixLength ) + ':' + QString::number( __LINE__ ) + " (" + ( __FUNCTION__ ) + ")") );
 #define QgsSetRequestInitiatorId(request, str) ( request ).setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorRequestId ), QString(QString( __FILE__ ).mid( sFilePrefixLength ) + ':' + QString::number( __LINE__ ) + " (" + ( __FUNCTION__ ) + "): " + ( str ) ) );
 #else
-#define QgsSetRequestInitiatorClass(request, _class) (void)request; (void)_class;
-#define QgsSetRequestInitiatorId(request, str) (void)request; (void)str;
+#define QgsSetRequestInitiatorClass(request, _class) (void)(request); (void)(_class);
+#define QgsSetRequestInitiatorId(request, str) (void)(request); (void)(str);
 #endif
 
 #define QgsSetCPLHTTPFetchOverriderInitiatorClass(overrider, _class) QgsSetRequestInitiatorClass((overrider), _class)

--- a/src/core/network/qgssetrequestinitiator_p.h
+++ b/src/core/network/qgssetrequestinitiator_p.h
@@ -22,8 +22,13 @@
 
 constexpr int sFilePrefixLength = CMAKE_SOURCE_DIR[sizeof( CMAKE_SOURCE_DIR ) - 1] == '/' ? sizeof( CMAKE_SOURCE_DIR ) + 1 : sizeof( CMAKE_SOURCE_DIR );
 
+#ifndef __clang_analyzer__
 #define QgsSetRequestInitiatorClass(request, _class) ( request ).setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorClass ), _class ); ( request ).setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorRequestId ), QString(QString( __FILE__ ).mid( sFilePrefixLength ) + ':' + QString::number( __LINE__ ) + " (" + ( __FUNCTION__ ) + ")") );
 #define QgsSetRequestInitiatorId(request, str) ( request ).setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorRequestId ), QString(QString( __FILE__ ).mid( sFilePrefixLength ) + ':' + QString::number( __LINE__ ) + " (" + ( __FUNCTION__ ) + "): " + ( str ) ) );
+#else
+#define QgsSetRequestInitiatorClass(request, _class) (void)request; (void)_class;
+#define QgsSetRequestInitiatorId(request, str) (void)request; (void)str;
+#endif
 
 #define QgsSetCPLHTTPFetchOverriderInitiatorClass(overrider, _class) QgsSetRequestInitiatorClass((overrider), _class)
 #endif // QGSSETREQUESTINITIATOR_P_H


### PR DESCRIPTION
We have to take care that we don't directly create QgsO2 objects on the thread where the authentication request is occurring,
as QgsO2 objects are long running but the thread requesting authentication may be short-lived. If we create QgsO2 objects
on a short-running thread, then when we later try to authenticate using the same oauth2 authentication method we
will get a deadlock, as the O2 reply server will no longer have an active thread or an event loop running.

This was especially evident in browser items which use oauth2 authentication. Since these are usually populated using very
short-life threads, we'd often hit this situation:

1. The connection would be expanded. Browser would create a thread to populate the connection. The oauth2 objects would then be created on this same thread, and everything would initially work OK. The user could complete the authentication since the browser population thread was blocked until this was done.
2. The browser item got populated, and then the thread populating it was destroyed
3. Later, something else would request authentication using the same oauth2 config. This may be eg the user expanding out a
different folder on the browser connection.
4. If the oauth2 token had expired, then we'd try to refresh it. But this relied on event-based logic, and the event loop for the
QgsO2 object was no longer around to handle this. The authentication request would dead-lock.

Fix this by ensuring that all QgsO2 objects are created and run on an instance of a new QgsOAuth2Factory QThread. This thread is created on demand, and will then exist for the life of the QGIS session.

This ensures that all QgsO2 objects will run on a thread with an application-long lifetime, so there's no issue if they later
require event-loop based logic (such as token refresh)

Funded by RGD Savoie Mont Blanc
