### PR TITLE
Action on double click layout item

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10916,6 +10916,37 @@ Qgis.DocumentationBrowser.__doc__ = """Documentation API browser
 """
 # --
 Qgis.DocumentationBrowser.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.MouseHandlesAction.MoveItem.__doc__ = "Move item"
+Qgis.MouseHandlesAction.ResizeUp.__doc__ = "Resize up (Top handle)"
+Qgis.MouseHandlesAction.ResizeDown.__doc__ = "Resize down (Bottom handle)"
+Qgis.MouseHandlesAction.ResizeLeft.__doc__ = "Resize left (Left handle)"
+Qgis.MouseHandlesAction.ResizeRight.__doc__ = "Resize right (Right handle)"
+Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)"
+Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
+Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
+Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
+Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
+Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
+Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
+
+.. versionadded:: 3.42
+
+* ``MoveItem``: Move item
+* ``ResizeUp``: Resize up (Top handle)
+* ``ResizeDown``: Resize down (Bottom handle)
+* ``ResizeLeft``: Resize left (Left handle)
+* ``ResizeRight``: Resize right (Right handle)
+* ``ResizeLeftUp``: Resize left up (Top left handle)
+* ``ResizeRightUp``: Resize right up (Top right handle)
+* ``ResizeLeftDown``: Resize left down (Bottom left handle)
+* ``ResizeRightDown``: Resize right down (Bottom right handle)
+* ``SelectItem``: Select item
+* ``NoAction``: No action
+
+"""
+# --
+Qgis.MouseHandlesAction.baseClass = Qgis
 try:
     Qgis.__attribute_docs__ = {'QGIS_DEV_VERSION': 'The development version', 'DEFAULT_SEARCH_RADIUS_MM': 'Identify search radius in mm', 'DEFAULT_MAPTOPIXEL_THRESHOLD': 'Default threshold between map coordinates and device coordinates for map2pixel simplification', 'DEFAULT_HIGHLIGHT_COLOR': 'Default highlight color.  The transparency is expected to only be applied to polygon\nfill. Lines and outlines are rendered opaque.', 'DEFAULT_HIGHLIGHT_BUFFER_MM': 'Default highlight buffer in mm.', 'DEFAULT_HIGHLIGHT_MIN_WIDTH_MM': 'Default highlight line/stroke minimum width in mm.', 'SCALE_PRECISION': 'Fudge factor used to compare two scales. The code is often going from scale to scale\ndenominator. So it looses precision and, when a limit is inclusive, can lead to errors.\nTo avoid that, use this factor instead of using <= or >=.\n\n.. deprecated:: 3.40\n\n   No longer used by QGIS and will be removed in QGIS 4.0.', 'DEFAULT_Z_COORDINATE': 'Default Z coordinate value.\nThis value have to be assigned to the Z coordinate for the vertex.', 'DEFAULT_M_COORDINATE': 'Default M coordinate value.\nThis value have to be assigned to the M coordinate for the vertex.\n\n.. versionadded:: 3.20', 'UI_SCALE_FACTOR': 'UI scaling factor. This should be applied to all widget sizes obtained from font metrics,\nto account for differences in the default font sizes across different platforms.', 'DEFAULT_SNAP_TOLERANCE': 'Default snapping distance tolerance.', 'DEFAULT_SNAP_UNITS': 'Default snapping distance units.'}
     Qgis.version = staticmethod(Qgis.version)

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3190,6 +3190,21 @@ The development version
       SystemWebBrowser,
     };
 
+    enum class MouseHandlesAction /BaseType=IntEnum/
+    {
+      MoveItem,
+      ResizeUp,
+      ResizeDown,
+      ResizeLeft,
+      ResizeRight,
+      ResizeLeftUp,
+      ResizeRightUp,
+      ResizeLeftDown,
+      ResizeRightDown,
+      SelectItem,
+      NoAction
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -112,7 +112,17 @@ This is only called for additions which result from GUI operations - i.e. it is 
 called for items added from templates.
 %End
 
+    virtual void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action );
+%Docstring
+Called when a layout item is double-clicked.
+The action parameter is used to specify which mouse handle, if any, was clicked
+If no mouse handle is selected, MouseAction.NoAction is used
+
+.. versionadded:: 3.42
+%End
+
 };
+
 
 
 

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -112,11 +112,11 @@ This is only called for additions which result from GUI operations - i.e. it is 
 called for items added from templates.
 %End
 
-    virtual void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action );
+    virtual void handleDoubleClick( QgsLayoutItem *item, Qgis::MouseHandlesAction action );
 %Docstring
 Called when a layout item is double-clicked.
 The action parameter is used to specify which mouse handle, if any, was clicked
-If no mouse handle is selected, MouseAction.NoAction is used
+If no mouse handle is selected, :py:class:`Qgis`.MouseHandlesAction.NoAction is used
 
 .. versionadded:: 3.42
 %End

--- a/python/PyQt6/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
@@ -140,6 +140,8 @@ Sets the ``layer`` to be used associated with the expression editor context.
 .. versionadded:: 3.40
 %End
 
+
+
   signals:
 
     void tableChanged();

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10826,6 +10826,37 @@ Qgis.DocumentationBrowser.__doc__ = """Documentation API browser
 """
 # --
 Qgis.DocumentationBrowser.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.MouseHandlesAction.MoveItem.__doc__ = "Move item"
+Qgis.MouseHandlesAction.ResizeUp.__doc__ = "Resize up (Top handle)"
+Qgis.MouseHandlesAction.ResizeDown.__doc__ = "Resize down (Bottom handle)"
+Qgis.MouseHandlesAction.ResizeLeft.__doc__ = "Resize left (Left handle)"
+Qgis.MouseHandlesAction.ResizeRight.__doc__ = "Resize right (Right handle)"
+Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)"
+Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
+Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
+Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
+Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
+Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
+Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
+
+.. versionadded:: 3.42
+
+* ``MoveItem``: Move item
+* ``ResizeUp``: Resize up (Top handle)
+* ``ResizeDown``: Resize down (Bottom handle)
+* ``ResizeLeft``: Resize left (Left handle)
+* ``ResizeRight``: Resize right (Right handle)
+* ``ResizeLeftUp``: Resize left up (Top left handle)
+* ``ResizeRightUp``: Resize right up (Top right handle)
+* ``ResizeLeftDown``: Resize left down (Bottom left handle)
+* ``ResizeRightDown``: Resize right down (Bottom right handle)
+* ``SelectItem``: Select item
+* ``NoAction``: No action
+
+"""
+# --
+Qgis.MouseHandlesAction.baseClass = Qgis
 from enum import Enum
 
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -3190,6 +3190,21 @@ The development version
       SystemWebBrowser,
     };
 
+    enum class MouseHandlesAction
+    {
+      MoveItem,
+      ResizeUp,
+      ResizeDown,
+      ResizeLeft,
+      ResizeRight,
+      ResizeLeftUp,
+      ResizeRightUp,
+      ResizeLeftDown,
+      ResizeRightDown,
+      SelectItem,
+      NoAction
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -112,7 +112,17 @@ This is only called for additions which result from GUI operations - i.e. it is 
 called for items added from templates.
 %End
 
+    virtual void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action );
+%Docstring
+Called when a layout item is double-clicked.
+The action parameter is used to specify which mouse handle, if any, was clicked
+If no mouse handle is selected, MouseAction.NoAction is used
+
+.. versionadded:: 3.42
+%End
+
 };
+
 
 
 

--- a/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -112,11 +112,11 @@ This is only called for additions which result from GUI operations - i.e. it is 
 called for items added from templates.
 %End
 
-    virtual void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action );
+    virtual void handleDoubleClick( QgsLayoutItem *item, Qgis::MouseHandlesAction action );
 %Docstring
 Called when a layout item is double-clicked.
 The action parameter is used to specify which mouse handle, if any, was clicked
-If no mouse handle is selected, MouseAction.NoAction is used
+If no mouse handle is selected, :py:class:`Qgis`.MouseHandlesAction.NoAction is used
 
 .. versionadded:: 3.42
 %End

--- a/python/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
+++ b/python/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
@@ -140,6 +140,8 @@ Sets the ``layer`` to be used associated with the expression editor context.
 .. versionadded:: 3.40
 %End
 
+
+
   signals:
 
     void tableChanged();

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5614,6 +5614,27 @@ class CORE_EXPORT Qgis
     Q_ENUM( DocumentationBrowser )
 
     /**
+     * Action to be performed by the mouse handles
+     *
+     * \since QGIS 3.42
+     */
+    enum class MouseHandlesAction : int
+    {
+      MoveItem, //!< Move item
+      ResizeUp, //!< Resize up (Top handle)
+      ResizeDown, //!< Resize down (Bottom handle)
+      ResizeLeft, //!< Resize left (Left handle)
+      ResizeRight, //!< Resize right (Right handle)
+      ResizeLeftUp, //!< Resize left up (Top left handle)
+      ResizeRightUp, //!< Resize right up (Top right handle)
+      ResizeLeftDown, //!< Resize left down (Bottom left handle)
+      ResizeRightDown, //!< Resize right down (Bottom right handle)
+      SelectItem, //!< Select item
+      NoAction //!< No action
+    };
+    Q_ENUM( MouseHandlesAction )
+
+    /**
      * Identify search radius in mm
      */
     static const double DEFAULT_SEARCH_RADIUS_MM;

--- a/src/gui/layout/qgslayoutguiutils.cpp
+++ b/src/gui/layout/qgslayoutguiutils.cpp
@@ -523,6 +523,10 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
     // cppcheck-suppress returnDanglingLifetime
     return f;
   } );
+  manualTableItemMetadata->setItemDoubleClickedFunction( [ = ]( QgsLayoutItem * item, QgsGraphicsViewMouseHandles::MouseAction )
+  {
+    QgsLayoutManualTableWidget::openTableDesigner( qobject_cast< QgsLayoutFrame * >( item ) );
+  } );
   registry->addLayoutItemGuiMetadata( manualTableItemMetadata.release() );
 
 

--- a/src/gui/layout/qgslayoutguiutils.cpp
+++ b/src/gui/layout/qgslayoutguiutils.cpp
@@ -523,7 +523,7 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
     // cppcheck-suppress returnDanglingLifetime
     return f;
   } );
-  manualTableItemMetadata->setItemDoubleClickedFunction( [ = ]( QgsLayoutItem * item, QgsGraphicsViewMouseHandles::MouseAction )
+  manualTableItemMetadata->setItemDoubleClickedFunction( [ = ]( QgsLayoutItem * item, Qgis::MouseHandlesAction )
   {
     QgsLayoutManualTableWidget::openTableDesigner( qobject_cast< QgsLayoutFrame * >( item ) );
   } );

--- a/src/gui/layout/qgslayoutitemguiregistry.cpp
+++ b/src/gui/layout/qgslayoutitemguiregistry.cpp
@@ -43,6 +43,17 @@ void QgsLayoutItemAbstractGuiMetadata::newItemAddedToLayout( QgsLayoutItem * )
 
 }
 
+void QgsLayoutItemAbstractGuiMetadata::handleDoubleClick( QgsLayoutItem *, QgsGraphicsViewMouseHandles::MouseAction )
+{
+}
+
+void QgsLayoutItemGuiMetadata::handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action )
+{
+  if ( mDoubleClickedFunc )
+    mDoubleClickedFunc( item, action );
+}
+
+
 QgsLayoutItemGuiRegistry::QgsLayoutItemGuiRegistry( QObject *parent )
   : QObject( parent )
 {

--- a/src/gui/layout/qgslayoutitemguiregistry.cpp
+++ b/src/gui/layout/qgslayoutitemguiregistry.cpp
@@ -43,11 +43,11 @@ void QgsLayoutItemAbstractGuiMetadata::newItemAddedToLayout( QgsLayoutItem * )
 
 }
 
-void QgsLayoutItemAbstractGuiMetadata::handleDoubleClick( QgsLayoutItem *, QgsGraphicsViewMouseHandles::MouseAction )
+void QgsLayoutItemAbstractGuiMetadata::handleDoubleClick( QgsLayoutItem *, Qgis::MouseHandlesAction )
 {
 }
 
-void QgsLayoutItemGuiMetadata::handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action )
+void QgsLayoutItemGuiMetadata::handleDoubleClick( QgsLayoutItem *item, Qgis::MouseHandlesAction action )
 {
   if ( mDoubleClickedFunc )
     mDoubleClickedFunc( item, action );

--- a/src/gui/layout/qgslayoutitemguiregistry.h
+++ b/src/gui/layout/qgslayoutitemguiregistry.h
@@ -21,7 +21,6 @@
 #include "qgsapplication.h"
 #include "qgspathresolver.h"
 #include "qgslayoutitemregistry.h"
-#include "qgsgraphicsviewmousehandles.h"
 #include <QGraphicsItem> //for QGraphicsItem::UserType
 #include <QIcon>
 #include <functional>
@@ -153,11 +152,11 @@ class GUI_EXPORT QgsLayoutItemAbstractGuiMetadata
     /**
      * Called when a layout item is double-clicked.
      * The action parameter is used to specify which mouse handle, if any, was clicked
-     * If no mouse handle is selected, MouseAction::NoAction is used
+     * If no mouse handle is selected, Qgis::MouseHandlesAction::NoAction is used
      *
      * \since QGIS 3.42
      */
-    virtual void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action );
+    virtual void handleDoubleClick( QgsLayoutItem *item, Qgis::MouseHandlesAction action );
 
   private:
 
@@ -182,7 +181,7 @@ typedef std::function<QAbstractGraphicsShapeItem *( QgsLayoutView * )> QgsLayout
 typedef std::function<void ( QgsLayoutItem *, const QVariantMap & )> QgsLayoutItemAddedToLayoutFunc SIP_SKIP;
 
 //! Layout item double clicked
-typedef std::function<void ( QgsLayoutItem *, QgsGraphicsViewMouseHandles::MouseAction action )> QgsLayoutItemDoubleClickedFunc SIP_SKIP;
+typedef std::function<void ( QgsLayoutItem *, Qgis::MouseHandlesAction action )> QgsLayoutItemDoubleClickedFunc SIP_SKIP;
 
 #ifndef SIP_RUN
 
@@ -291,7 +290,7 @@ class GUI_EXPORT QgsLayoutItemGuiMetadata : public QgsLayoutItemAbstractGuiMetad
      */
     void setItemDoubleClickedFunction( const QgsLayoutItemDoubleClickedFunc &function ) { mDoubleClickedFunc = function; }
 
-    void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action ) override;
+    void handleDoubleClick( QgsLayoutItem *item, Qgis::MouseHandlesAction action ) override;
 
     QIcon creationIcon() const override { return mIcon.isNull() ? QgsLayoutItemAbstractGuiMetadata::creationIcon() : mIcon; }
     QgsLayoutItemBaseWidget *createItemWidget( QgsLayoutItem *item ) override { return mWidgetFunc ? mWidgetFunc( item ) : nullptr; }

--- a/src/gui/layout/qgslayoutitemguiregistry.h
+++ b/src/gui/layout/qgslayoutitemguiregistry.h
@@ -21,6 +21,7 @@
 #include "qgsapplication.h"
 #include "qgspathresolver.h"
 #include "qgslayoutitemregistry.h"
+#include "qgsgraphicsviewmousehandles.h"
 #include <QGraphicsItem> //for QGraphicsItem::UserType
 #include <QIcon>
 #include <functional>
@@ -149,6 +150,15 @@ class GUI_EXPORT QgsLayoutItemAbstractGuiMetadata
      */
     virtual void newItemAddedToLayout( QgsLayoutItem *item );
 
+    /**
+     * Called when a layout item is double-clicked.
+     * The action parameter is used to specify which mouse handle, if any, was clicked
+     * If no mouse handle is selected, MouseAction::NoAction is used
+     *
+     * \since QGIS 3.42
+     */
+    virtual void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action );
+
   private:
 
     int mType = -1;
@@ -170,6 +180,9 @@ typedef std::function<QAbstractGraphicsShapeItem *( QgsLayoutView * )> QgsLayout
 
 //! Layout item added to layout callback
 typedef std::function<void ( QgsLayoutItem *, const QVariantMap & )> QgsLayoutItemAddedToLayoutFunc SIP_SKIP;
+
+//! Layout item double clicked
+typedef std::function<void ( QgsLayoutItem *, QgsGraphicsViewMouseHandles::MouseAction action )> QgsLayoutItemDoubleClickedFunc SIP_SKIP;
 
 #ifndef SIP_RUN
 
@@ -266,6 +279,20 @@ class GUI_EXPORT QgsLayoutItemGuiMetadata : public QgsLayoutItemAbstractGuiMetad
      */
     void setItemAddedToLayoutFunction( const QgsLayoutItemAddedToLayoutFunc &function ) { mAddedToLayoutFunc = function; }
 
+    /**
+     * Returns the classes' item double clicked function.
+     * \see setItemAddedToLayoutFunction()
+     */
+    QgsLayoutItemDoubleClickedFunc itemDoubleClickedFunction() const { return mDoubleClickedFunc; }
+
+    /**
+     * Sets the classes' item double clicked \a function.
+     * \see itemDoubleClickedFunction()
+     */
+    void setItemDoubleClickedFunction( const QgsLayoutItemDoubleClickedFunc &function ) { mDoubleClickedFunc = function; }
+
+    void handleDoubleClick( QgsLayoutItem *item, QgsGraphicsViewMouseHandles::MouseAction action ) override;
+
     QIcon creationIcon() const override { return mIcon.isNull() ? QgsLayoutItemAbstractGuiMetadata::creationIcon() : mIcon; }
     QgsLayoutItemBaseWidget *createItemWidget( QgsLayoutItem *item ) override { return mWidgetFunc ? mWidgetFunc( item ) : nullptr; }
     QgsLayoutViewRubberBand *createRubberBand( QgsLayoutView *view ) override { return mRubberBandFunc ? mRubberBandFunc( view ) : nullptr; }
@@ -294,6 +321,7 @@ class GUI_EXPORT QgsLayoutItemGuiMetadata : public QgsLayoutItemAbstractGuiMetad
     QgsLayoutNodeItemRubberBandFunc mNodeRubberBandFunc = nullptr;
     QgsLayoutItemCreateFunc mCreateFunc = nullptr;
     QgsLayoutItemAddedToLayoutFunc mAddedToLayoutFunc = nullptr;
+    QgsLayoutItemDoubleClickedFunc mDoubleClickedFunc = nullptr;
 
 };
 

--- a/src/gui/layout/qgslayoutmanualtablewidget.h
+++ b/src/gui/layout/qgslayoutmanualtablewidget.h
@@ -48,7 +48,7 @@ class GUI_EXPORT QgsLayoutManualTableWidget: public QgsLayoutItemBaseWidget, pub
     QgsExpressionContext createExpressionContext() const override;
 
     //! Creates and open the table editor dialog
-    static QgsTableEditorDialog *openTableDesigner( QgsLayoutFrame *frame, QWidget *parent = nullptr );
+    static void openTableDesigner( QgsLayoutFrame *frame, QWidget *parent = nullptr );
 
 
   protected:
@@ -60,10 +60,10 @@ class GUI_EXPORT QgsLayoutManualTableWidget: public QgsLayoutItemBaseWidget, pub
     QPointer< QgsLayoutFrame > mFrame;
     QgsLayoutItemPropertiesWidget *mItemPropertiesWidget = nullptr;
 
-    QPointer< QgsTableEditorDialog > mEditorDialog;
-
     //! Blocks / unblocks the signals of all GUI elements
     void blockAllSignals( bool b );
+
+    static QPointer< QgsTableEditorDialog > sEditorDialog;
 
   private slots:
 

--- a/src/gui/layout/qgslayoutmanualtablewidget.h
+++ b/src/gui/layout/qgslayoutmanualtablewidget.h
@@ -28,6 +28,7 @@
 
 class QgsLayoutItemManualTable;
 class QgsLayoutFrame;
+class QgsTableEditorDialog;
 
 /**
  * \ingroup gui
@@ -45,6 +46,10 @@ class GUI_EXPORT QgsLayoutManualTableWidget: public QgsLayoutItemBaseWidget, pub
 
     void setMasterLayout( QgsMasterLayoutInterface *masterLayout ) override;
     QgsExpressionContext createExpressionContext() const override;
+
+    //! Creates and open the table editor dialog
+    static QgsTableEditorDialog *openTableDesigner( QgsLayoutFrame *frame, QWidget *parent = nullptr );
+
 
   protected:
 

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -84,6 +84,10 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     void endItemCommand( QGraphicsItem *item ) override;
     void startMacroCommand( const QString &text ) override;
     void endMacroCommand() override;
+
+
+    void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
+
   public slots:
 
     //! Sets up listeners to sizeChanged signal for all selected items

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -57,11 +57,11 @@ void QgsLayoutViewToolSelect::layoutPressEvent( QgsLayoutViewMouseEvent *event )
   if ( mMouseHandles->isVisible() )
   {
     //selection handles are being shown, get mouse action for current cursor position
-    QgsLayoutMouseHandles::MouseAction mouseAction = mMouseHandles->mouseActionForScenePos( event->layoutPoint() );
+    Qgis::MouseHandlesAction mouseAction = mMouseHandles->mouseActionForScenePos( event->layoutPoint() );
 
-    if ( mouseAction != QgsLayoutMouseHandles::MoveItem
-         && mouseAction != QgsLayoutMouseHandles::NoAction
-         && mouseAction != QgsLayoutMouseHandles::SelectItem )
+    if ( mouseAction != Qgis::MouseHandlesAction::MoveItem
+         && mouseAction != Qgis::MouseHandlesAction::NoAction
+         && mouseAction != Qgis::MouseHandlesAction::SelectItem )
     {
       //mouse is over a resize handle, so propagate event onward
       event->ignore();

--- a/src/gui/processing/models/qgsmodelviewtoolselect.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.cpp
@@ -55,11 +55,11 @@ void QgsModelViewToolSelect::modelPressEvent( QgsModelViewMouseEvent *event )
   if ( mMouseHandles->isVisible() )
   {
     //selection handles are being shown, get mouse action for current cursor position
-    QgsGraphicsViewMouseHandles::MouseAction mouseAction = mMouseHandles->mouseActionForScenePos( event->modelPoint() );
+    Qgis::MouseHandlesAction mouseAction = mMouseHandles->mouseActionForScenePos( event->modelPoint() );
 
-    if ( mouseAction != QgsGraphicsViewMouseHandles::MoveItem
-         && mouseAction != QgsGraphicsViewMouseHandles::NoAction
-         && mouseAction != QgsGraphicsViewMouseHandles::SelectItem )
+    if ( mouseAction != Qgis::MouseHandlesAction::MoveItem
+         && mouseAction != Qgis::MouseHandlesAction::NoAction
+         && mouseAction != Qgis::MouseHandlesAction::SelectItem )
     {
       //mouse is over a resize handle, so propagate event onward
       event->ignore();

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -226,7 +226,7 @@ double QgsGraphicsViewMouseHandles::rectHandlerBorderTolerance()
 
 Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoordPos )
 {
-  QgsGraphicsViewMouseHandles::MouseAction mouseAction = mouseActionForPosition( itemCoordPos );
+  Qgis::MouseHandlesAction mouseAction = mouseActionForPosition( itemCoordPos );
   double normalizedRotation = std::fmod( rotation(), 360 );
   if ( normalizedRotation < 0 )
   {
@@ -234,12 +234,12 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
   }
   switch ( mouseAction )
   {
-    case NoAction:
+    case Qgis::MouseHandlesAction::NoAction:
       return Qt::ForbiddenCursor;
-    case MoveItem:
+    case Qgis::MouseHandlesAction::MoveItem:
       return Qt::SizeAllCursor;
-    case ResizeUp:
-    case ResizeDown:
+    case Qgis::MouseHandlesAction::ResizeUp:
+    case Qgis::MouseHandlesAction::ResizeDown:
       //account for rotation
       if ( ( normalizedRotation <= 22.5 || normalizedRotation >= 337.5 ) || ( normalizedRotation >= 157.5 && normalizedRotation <= 202.5 ) )
       {
@@ -257,8 +257,8 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
       {
         return Qt::SizeFDiagCursor;
       }
-    case ResizeLeft:
-    case ResizeRight:
+    case Qgis::MouseHandlesAction::ResizeLeft:
+    case Qgis::MouseHandlesAction::ResizeRight:
       //account for rotation
       if ( ( normalizedRotation <= 22.5 || normalizedRotation >= 337.5 ) || ( normalizedRotation >= 157.5 && normalizedRotation <= 202.5 ) )
       {
@@ -277,8 +277,8 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
         return Qt::SizeBDiagCursor;
       }
 
-    case ResizeLeftUp:
-    case ResizeRightDown:
+    case Qgis::MouseHandlesAction::ResizeLeftUp:
+    case Qgis::MouseHandlesAction::ResizeRightDown:
       //account for rotation
       if ( ( normalizedRotation <= 22.5 || normalizedRotation >= 337.5 ) || ( normalizedRotation >= 157.5 && normalizedRotation <= 202.5 ) )
       {
@@ -296,8 +296,8 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
       {
         return Qt::SizeHorCursor;
       }
-    case ResizeRightUp:
-    case ResizeLeftDown:
+    case Qgis::MouseHandlesAction::ResizeRightUp:
+    case Qgis::MouseHandlesAction::ResizeLeftDown:
       //account for rotation
       if ( ( normalizedRotation <= 22.5 || normalizedRotation >= 337.5 ) || ( normalizedRotation >= 157.5 && normalizedRotation <= 202.5 ) )
       {
@@ -315,14 +315,14 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
       {
         return Qt::SizeVerCursor;
       }
-    case SelectItem:
+    case Qgis::MouseHandlesAction::SelectItem:
       return Qt::ArrowCursor;
   }
 
   return Qt::ArrowCursor;
 }
 
-QgsGraphicsViewMouseHandles::MouseAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QPointF itemCoordPos )
+Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QPointF itemCoordPos )
 {
   bool nearLeftBorder = false;
   bool nearRightBorder = false;
@@ -361,35 +361,35 @@ QgsGraphicsViewMouseHandles::MouseAction QgsGraphicsViewMouseHandles::mouseActio
 
   if ( nearLeftBorder && nearUpperBorder )
   {
-    return QgsGraphicsViewMouseHandles::ResizeLeftUp;
+    return Qgis::MouseHandlesAction::ResizeLeftUp;
   }
   else if ( nearLeftBorder && nearLowerBorder )
   {
-    return QgsGraphicsViewMouseHandles::ResizeLeftDown;
+    return Qgis::MouseHandlesAction::ResizeLeftDown;
   }
   else if ( nearRightBorder && nearUpperBorder )
   {
-    return QgsGraphicsViewMouseHandles::ResizeRightUp;
+    return Qgis::MouseHandlesAction::ResizeRightUp;
   }
   else if ( nearRightBorder && nearLowerBorder )
   {
-    return QgsGraphicsViewMouseHandles::ResizeRightDown;
+    return Qgis::MouseHandlesAction::ResizeRightDown;
   }
   else if ( nearLeftBorder && withinHeight )
   {
-    return QgsGraphicsViewMouseHandles::ResizeLeft;
+    return Qgis::MouseHandlesAction::ResizeLeft;
   }
   else if ( nearRightBorder && withinHeight )
   {
-    return QgsGraphicsViewMouseHandles::ResizeRight;
+    return Qgis::MouseHandlesAction::ResizeRight;
   }
   else if ( nearUpperBorder && withinWidth )
   {
-    return QgsGraphicsViewMouseHandles::ResizeUp;
+    return Qgis::MouseHandlesAction::ResizeUp;
   }
   else if ( nearLowerBorder && withinWidth )
   {
-    return QgsGraphicsViewMouseHandles::ResizeDown;
+    return Qgis::MouseHandlesAction::ResizeDown;
   }
 
   //find out if cursor position is over a selected item
@@ -398,22 +398,22 @@ QgsGraphicsViewMouseHandles::MouseAction QgsGraphicsViewMouseHandles::mouseActio
   if ( itemsAtCursorPos.isEmpty() )
   {
     //no items at cursor position
-    return QgsGraphicsViewMouseHandles::SelectItem;
+    return Qgis::MouseHandlesAction::SelectItem;
   }
   for ( QGraphicsItem *graphicsItem : itemsAtCursorPos )
   {
     if ( graphicsItem && graphicsItem->isSelected() )
     {
       //cursor is over a selected layout item
-      return QgsGraphicsViewMouseHandles::MoveItem;
+      return Qgis::MouseHandlesAction::MoveItem;
     }
   }
 
   //default
-  return QgsGraphicsViewMouseHandles::SelectItem;
+  return Qgis::MouseHandlesAction::SelectItem;
 }
 
-QgsGraphicsViewMouseHandles::MouseAction QgsGraphicsViewMouseHandles::mouseActionForScenePos( QPointF sceneCoordPos )
+Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForScenePos( QPointF sceneCoordPos )
 {
   // convert sceneCoordPos to item coordinates
   QPointF itemPos = mapFromScene( sceneCoordPos );
@@ -434,7 +434,7 @@ void QgsGraphicsViewMouseHandles::startMove( QPointF sceneCoordPos )
   mBeginHandlePos = scenePos();
   mBeginHandleWidth = rect().width();
   mBeginHandleHeight = rect().height();
-  mCurrentMouseMoveAction = MoveItem;
+  mCurrentMouseMoveAction = Qgis::MouseHandlesAction::MoveItem;
   mIsDragging = true;
   hideAlignItems();
 
@@ -495,13 +495,13 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
 
   hideAlignItems();
 
-  if ( mCurrentMouseMoveAction == MoveItem )
+  if ( mCurrentMouseMoveAction == Qgis::MouseHandlesAction::MoveItem )
   {
     //moving items
     mIsDragging = true;
   }
-  else if ( mCurrentMouseMoveAction != SelectItem &&
-            mCurrentMouseMoveAction != NoAction )
+  else if ( mCurrentMouseMoveAction != Qgis::MouseHandlesAction::SelectItem &&
+            mCurrentMouseMoveAction != Qgis::MouseHandlesAction::NoAction )
   {
     //resizing items
     mIsResizing = true;
@@ -573,7 +573,7 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
     return;
   }
 
-  if ( mCurrentMouseMoveAction == MoveItem )
+  if ( mCurrentMouseMoveAction == Qgis::MouseHandlesAction::MoveItem )
   {
     //move selected items
     startMacroCommand( tr( "Move Items" ) );
@@ -599,7 +599,7 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
     }
     endMacroCommand();
   }
-  else if ( mCurrentMouseMoveAction != NoAction )
+  else if ( mCurrentMouseMoveAction != Qgis::MouseHandlesAction::NoAction )
   {
     //resize selected items
     startMacroCommand( tr( "Resize Items" ) );
@@ -649,7 +649,7 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
   }
 
   //reset default action
-  mCurrentMouseMoveAction = MoveItem;
+  mCurrentMouseMoveAction = Qgis::MouseHandlesAction::MoveItem;
   //redraw handles
   resetTransform();
   updateHandles();
@@ -798,19 +798,19 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
   {
     //snapping only occurs if handles are not rotated for now
 
-    bool snapVertical = mCurrentMouseMoveAction == ResizeLeft ||
-                        mCurrentMouseMoveAction == ResizeRight ||
-                        mCurrentMouseMoveAction == ResizeLeftUp ||
-                        mCurrentMouseMoveAction == ResizeRightUp ||
-                        mCurrentMouseMoveAction == ResizeLeftDown ||
-                        mCurrentMouseMoveAction == ResizeRightDown;
+    bool snapVertical = mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeLeft ||
+                        mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeRight ||
+                        mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeLeftUp ||
+                        mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeRightUp ||
+                        mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeLeftDown ||
+                        mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeRightDown;
 
-    bool snapHorizontal = mCurrentMouseMoveAction == ResizeUp ||
-                          mCurrentMouseMoveAction == ResizeDown ||
-                          mCurrentMouseMoveAction == ResizeLeftUp ||
-                          mCurrentMouseMoveAction == ResizeRightUp ||
-                          mCurrentMouseMoveAction == ResizeLeftDown ||
-                          mCurrentMouseMoveAction == ResizeRightDown;
+    bool snapHorizontal = mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeUp ||
+                          mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeDown ||
+                          mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeLeftUp ||
+                          mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeRightUp ||
+                          mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeLeftDown ||
+                          mCurrentMouseMoveAction == Qgis::MouseHandlesAction::ResizeRightDown;
 
     //subtract cursor edge offset from begin mouse event and current cursor position, so that snapping occurs to edge of mouse handles
     //rather then cursor position
@@ -837,7 +837,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
   switch ( mCurrentMouseMoveAction )
   {
     //vertical resize
-    case ResizeUp:
+    case Qgis::MouseHandlesAction::ResizeUp:
     {
       if ( ratio )
       {
@@ -857,7 +857,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
-    case ResizeDown:
+    case Qgis::MouseHandlesAction::ResizeDown:
     {
       if ( ratio )
       {
@@ -878,7 +878,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
     }
 
     //horizontal resize
-    case ResizeLeft:
+    case Qgis::MouseHandlesAction::ResizeLeft:
     {
       if ( ratio )
       {
@@ -897,7 +897,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
-    case ResizeRight:
+    case Qgis::MouseHandlesAction::ResizeRight:
     {
       if ( ratio )
       {
@@ -917,7 +917,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
     }
 
     //diagonal resize
-    case ResizeLeftUp:
+    case Qgis::MouseHandlesAction::ResizeLeftUp:
     {
       if ( ratio )
       {
@@ -937,7 +937,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
-    case ResizeRightDown:
+    case Qgis::MouseHandlesAction::ResizeRightDown:
     {
       if ( ratio )
       {
@@ -957,7 +957,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
-    case ResizeRightUp:
+    case Qgis::MouseHandlesAction::ResizeRightUp:
     {
       if ( ratio )
       {
@@ -976,7 +976,7 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
-    case ResizeLeftDown:
+    case Qgis::MouseHandlesAction::ResizeLeftDown:
     {
       if ( ratio )
       {
@@ -996,9 +996,9 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
-    case MoveItem:
-    case SelectItem:
-    case NoAction:
+    case Qgis::MouseHandlesAction::MoveItem:
+    case Qgis::MouseHandlesAction::SelectItem:
+    case Qgis::MouseHandlesAction::NoAction:
       break;
   }
 
@@ -1083,35 +1083,35 @@ QSizeF QgsGraphicsViewMouseHandles::calcCursorEdgeOffset( QPointF cursorPos )
   switch ( mCurrentMouseMoveAction )
   {
     //vertical resize
-    case QgsGraphicsViewMouseHandles::ResizeUp:
+    case Qgis::MouseHandlesAction::ResizeUp:
       return QSizeF( 0, sceneMousePos.y() );
 
-    case QgsGraphicsViewMouseHandles::ResizeDown:
+    case Qgis::MouseHandlesAction::ResizeDown:
       return QSizeF( 0, sceneMousePos.y() - rect().height() );
 
     //horizontal resize
-    case QgsGraphicsViewMouseHandles::ResizeLeft:
+    case Qgis::MouseHandlesAction::ResizeLeft:
       return QSizeF( sceneMousePos.x(), 0 );
 
-    case QgsGraphicsViewMouseHandles::ResizeRight:
+    case Qgis::MouseHandlesAction::ResizeRight:
       return QSizeF( sceneMousePos.x() - rect().width(), 0 );
 
     //diagonal resize
-    case QgsGraphicsViewMouseHandles::ResizeLeftUp:
+    case Qgis::MouseHandlesAction::ResizeLeftUp:
       return QSizeF( sceneMousePos.x(), sceneMousePos.y() );
 
-    case QgsGraphicsViewMouseHandles::ResizeRightDown:
+    case Qgis::MouseHandlesAction::ResizeRightDown:
       return QSizeF( sceneMousePos.x() - rect().width(), sceneMousePos.y() - rect().height() );
 
-    case QgsGraphicsViewMouseHandles::ResizeRightUp:
+    case Qgis::MouseHandlesAction::ResizeRightUp:
       return QSizeF( sceneMousePos.x() - rect().width(), sceneMousePos.y() );
 
-    case QgsGraphicsViewMouseHandles::ResizeLeftDown:
+    case Qgis::MouseHandlesAction::ResizeLeftDown:
       return QSizeF( sceneMousePos.x(), sceneMousePos.y() - rect().height() );
 
-    case MoveItem:
-    case SelectItem:
-    case NoAction:
+    case Qgis::MouseHandlesAction::MoveItem:
+    case Qgis::MouseHandlesAction::SelectItem:
+    case Qgis::MouseHandlesAction::NoAction:
       return QSizeF();
   }
 

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -25,6 +25,7 @@
 #include <QPointer>
 #include <memory>
 
+#include "qgis.h"
 #include "qgis_gui.h"
 
 class QGraphicsView;
@@ -46,22 +47,6 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
 {
     Q_OBJECT
   public:
-
-    //! Describes the action (move or resize in different direction) to be done during mouse move
-    enum MouseAction
-    {
-      MoveItem,
-      ResizeUp,
-      ResizeDown,
-      ResizeLeft,
-      ResizeRight,
-      ResizeLeftUp,
-      ResizeRightUp,
-      ResizeLeftDown,
-      ResizeRightDown,
-      SelectItem,
-      NoAction
-    };
 
     enum ItemPositionMode
     {
@@ -85,7 +70,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     QgsGraphicsViewMouseHandles( QGraphicsView *view );
 
     //! Finds out which mouse move action to choose depending on the scene cursor position
-    QgsGraphicsViewMouseHandles::MouseAction mouseActionForScenePos( QPointF sceneCoordPos );
+    Qgis::MouseHandlesAction mouseActionForScenePos( QPointF sceneCoordPos );
 
     //! Returns TRUE is user is currently dragging the handles
     bool isDragging() const { return mIsDragging; }
@@ -171,7 +156,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     void setHandleSize( double size );
 
     //! Finds out which mouse move action to choose depending on the cursor position inside the widget
-    MouseAction mouseActionForPosition( QPointF itemCoordPos );
+    Qgis::MouseHandlesAction mouseActionForPosition( QPointF itemCoordPos );
 
     //! Calculates the distance of the mouse cursor from thed edge of the mouse handles
     QSizeF calcCursorEdgeOffset( QPointF cursorPos );
@@ -219,7 +204,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     //! Start point of the last mouse move action (in scene coordinates)
     QPointF mMouseMoveStartPos;
 
-    MouseAction mCurrentMouseMoveAction = NoAction;
+    Qgis::MouseHandlesAction mCurrentMouseMoveAction = Qgis::MouseHandlesAction::NoAction;
 
     //! True if user is currently dragging items
     bool mIsDragging = false;

--- a/src/gui/tableeditor/qgstableeditordialog.cpp
+++ b/src/gui/tableeditor/qgstableeditordialog.cpp
@@ -22,7 +22,11 @@
 #include "qgspanelwidgetstack.h"
 #include "qgstableeditorformattingwidget.h"
 #include "qgssettings.h"
-#include "qgsmaplayer.h"
+#include "qgsvectorlayer.h"
+#include "qgslayout.h"
+#include "qgslayoutreportcontext.h"
+#include "qgslayoutitemmanualtable.h"
+#include "qgslayouttablecolumn.h"
 
 #include <QClipboard>
 #include <QMessageBox>
@@ -167,6 +171,48 @@ void QgsTableEditorDialog::setLayer( QgsMapLayer *layer )
     mFormattingWidget->setLayer( layer );
   }
 }
+
+QgsLayoutItemManualTable *QgsTableEditorDialog::table() const
+{
+  return mTable;
+}
+
+void QgsTableEditorDialog::setTable( QgsLayoutItemManualTable *table )
+{
+  if ( mTable == table )
+    return;
+
+  mTable = table;
+
+  if ( QgsLayout *layout = table->layout() )
+  {
+    setLayer( layout->reportContext().layer() );
+  }
+  registerExpressionContextGenerator( table );
+
+  setIncludeTableHeader( table->includeTableHeader() );
+  setTableContents( table->tableContents() );
+
+  int row = 0;
+  const QList< double > rowHeights = table->rowHeights();
+  for ( const double height : rowHeights )
+  {
+    setTableRowHeight( row, height );
+    row++;
+  }
+  int col = 0;
+  const QList< double > columnWidths = table->columnWidths();
+  QVariantList headers;
+  headers.reserve( columnWidths.size() );
+  for ( const double width : columnWidths )
+  {
+    setTableColumnWidth( col, width );
+    headers << ( col < table->headers().count() ? table->headers().value( col ).heading() : QVariant() );
+    col++;
+  }
+  setTableHeaders( headers );
+}
+
 
 
 bool QgsTableEditorDialog::setTableContentsFromClipboard()

--- a/src/gui/tableeditor/qgstableeditordialog.h
+++ b/src/gui/tableeditor/qgstableeditordialog.h
@@ -28,6 +28,7 @@ class QgsPanelWidgetStack;
 class QgsTableEditorFormattingWidget;
 class QgsExpressionContextGenerator;
 class QgsMapLayer;
+class QgsLayoutItemManualTable;
 
 /**
  * \ingroup gui
@@ -156,6 +157,18 @@ class GUI_EXPORT QgsTableEditorDialog : public QMainWindow, private Ui::QgsTable
      */
     void setLayer( QgsMapLayer *layer );
 
+    /**
+     * Returns the manual table associated with the editor.
+     * \since QGIS 3.42
+     */
+    QgsLayoutItemManualTable *table() const SIP_SKIP;
+
+    /**
+     * Sets the \a table associated with the editor.
+     * \since QGIS 3.42
+     */
+    void setTable( QgsLayoutItemManualTable *table ) SIP_SKIP;
+
   signals:
 
     /**
@@ -180,6 +193,7 @@ class GUI_EXPORT QgsTableEditorDialog : public QMainWindow, private Ui::QgsTable
     QgsTableEditorFormattingWidget *mFormattingWidget = nullptr;
     bool mBlockSignals = false;
     QPointer< QgsMapLayer > mLayer;
+    QgsLayoutItemManualTable *mTable = nullptr;
 
     void updateActionsFromSelection();
 };


### PR DESCRIPTION
- Fix #46462

## Description

Add `QgsLayoutItemAbstractGuiMetadata::handleDoubleClick` to define an action that will be called when a layout item is double clicked.

This new method takes two arguments : a `QgsLayoutItem`, and a `Qgis::MouseHandlesAction` (new enum that replaces `QgsGraphicsViewMouseHandles::MouseAction`), which allow to define custom behavior if a specific mouse handle is doublecliked (could be used to resize a QgsLayoutItemLabel to fit the current text for instance).

As an example, this PR fixes #46462.