### PR TITLE
[qml] Upgrade QgsRectangle to Q_GADGET & expose QgsLocatorContext's transformContext as property

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -26,6 +26,9 @@ Examples are storing a layer extent or the current view extent of a map
 #include "qgsrectangle.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     QgsRectangle(); // optimised constructor for null rectangle - no need to call normalize here
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
@@ -59,6 +59,9 @@ A :py:class:`QgsRectangle` with associated coordinate reference system.
 #include "qgsreferencedgeometry.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     QgsReferencedRectangle( const QgsRectangle &rectangle, const QgsCoordinateReferenceSystem &crs );
 %Docstring

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
@@ -49,6 +49,7 @@ Constructor for QgsCoordinateTransformContext.
     QgsCoordinateTransformContext( const QgsCoordinateTransformContext &rhs );
 
     bool operator==( const QgsCoordinateTransformContext &rhs ) const;
+    bool operator!=( const QgsCoordinateTransformContext &rhs ) const;
 
     void clear();
 %Docstring

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -26,6 +26,9 @@ Examples are storing a layer extent or the current view extent of a map
 #include "qgsrectangle.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     QgsRectangle(); // optimised constructor for null rectangle - no need to call normalize here
 

--- a/python/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
@@ -59,6 +59,9 @@ A :py:class:`QgsRectangle` with associated coordinate reference system.
 #include "qgsreferencedgeometry.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     QgsReferencedRectangle( const QgsRectangle &rectangle, const QgsCoordinateReferenceSystem &crs );
 %Docstring

--- a/python/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
@@ -49,6 +49,7 @@ Constructor for QgsCoordinateTransformContext.
     QgsCoordinateTransformContext( const QgsCoordinateTransformContext &rhs );
 
     bool operator==( const QgsCoordinateTransformContext &rhs ) const;
+    bool operator!=( const QgsCoordinateTransformContext &rhs ) const;
 
     void clear();
 %Docstring

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -22,6 +22,7 @@
 #include "qgsbox3d.h"
 #include "qgspolygon.h"
 #include "qgslinestring.h"
+#include "moc_qgsrectangle.cpp"
 
 #include <QString>
 #include <QTextStream>

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -40,6 +40,20 @@ class QgsBox3D;
  */
 class CORE_EXPORT QgsRectangle
 {
+    Q_GADGET
+
+    Q_PROPERTY( double xMinimum READ xMinimum WRITE setXMinimum )
+    Q_PROPERTY( double xMaximum READ xMaximum WRITE setXMaximum )
+    Q_PROPERTY( double yMinimum READ yMinimum WRITE setYMinimum )
+    Q_PROPERTY( double yMaximum READ yMaximum WRITE setYMaximum )
+    Q_PROPERTY( double width READ width )
+    Q_PROPERTY( double height READ height )
+    Q_PROPERTY( double area READ area )
+    Q_PROPERTY( double perimeter READ perimeter )
+    Q_PROPERTY( QgsPointXY center READ center )
+    Q_PROPERTY( bool isEmpty READ isEmpty )
+    Q_PROPERTY( bool isNull READ isNull )
+
   public:
 
     //! Constructor for a null rectangle
@@ -518,12 +532,12 @@ class CORE_EXPORT QgsRectangle
     /**
      * Returns a string representation of the rectangle in WKT format.
      */
-    QString asWktCoordinates() const;
+    Q_INVOKABLE QString asWktCoordinates() const;
 
     /**
      * Returns a string representation of the rectangle as a WKT Polygon.
      */
-    QString asWktPolygon() const;
+    Q_INVOKABLE QString asWktPolygon() const;
 
     /**
      * Returns a QRectF with same coordinates as the rectangle.
@@ -538,7 +552,7 @@ class CORE_EXPORT QgsRectangle
      * Coordinates will be truncated to the specified precision.
      * If the specified precision is less than 0, a suitable minimum precision is used.
      */
-    QString toString( int precision = 16 ) const;
+    Q_INVOKABLE QString toString( int precision = 16 ) const;
 
     /**
      * Returns the rectangle as a polygon.

--- a/src/core/geometry/qgsreferencedgeometry.cpp
+++ b/src/core/geometry/qgsreferencedgeometry.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsreferencedgeometry.h"
+#include "moc_qgsreferencedgeometry.cpp"
 
 QgsReferencedGeometryBase::QgsReferencedGeometryBase( const QgsCoordinateReferenceSystem &crs )
   : mCrs( crs )

--- a/src/core/geometry/qgsreferencedgeometry.h
+++ b/src/core/geometry/qgsreferencedgeometry.h
@@ -70,6 +70,8 @@ class CORE_EXPORT QgsReferencedGeometryBase
  */
 class CORE_EXPORT QgsReferencedRectangle : public QgsRectangle, public QgsReferencedGeometryBase
 {
+    Q_GADGET
+
   public:
 
     /**

--- a/src/core/locator/qgslocatorcontext.h
+++ b/src/core/locator/qgslocatorcontext.h
@@ -34,6 +34,7 @@ class CORE_EXPORT QgsLocatorContext
 
     Q_PROPERTY( QgsRectangle targetExtent MEMBER targetExtent )
     Q_PROPERTY( QgsCoordinateReferenceSystem targetExtentCrs MEMBER targetExtentCrs )
+    Q_PROPERTY( QgsCoordinateTransformContext transformContext MEMBER transformContext )
     Q_PROPERTY( bool usingPrefix MEMBER usingPrefix )
 
   public:

--- a/src/core/proj/qgscoordinatetransformcontext.cpp
+++ b/src/core/proj/qgscoordinatetransformcontext.cpp
@@ -65,6 +65,11 @@ bool QgsCoordinateTransformContext::operator==( const QgsCoordinateTransformCont
   return equal;
 }
 
+bool QgsCoordinateTransformContext::operator!=( const QgsCoordinateTransformContext &rhs ) const
+{
+  return !( *this == rhs );
+}
+
 void QgsCoordinateTransformContext::clear()
 {
   d.detach();

--- a/src/core/proj/qgscoordinatetransformcontext.h
+++ b/src/core/proj/qgscoordinatetransformcontext.h
@@ -67,7 +67,8 @@ class CORE_EXPORT QgsCoordinateTransformContext
     QgsCoordinateTransformContext( const QgsCoordinateTransformContext &rhs );
     QgsCoordinateTransformContext &operator=( const QgsCoordinateTransformContext &rhs ) SIP_SKIP;
 
-    bool operator==( const QgsCoordinateTransformContext &rhs ) const ;
+    bool operator==( const QgsCoordinateTransformContext &rhs ) const;
+    bool operator!=( const QgsCoordinateTransformContext &rhs ) const;
 
     /**
      * Clears all stored transform information from the context.

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -361,12 +361,17 @@ void TestQgsRectangle::asVariant()
   const QgsRectangle rect1 = QgsRectangle( 10.0, 20.0, 110.0, 220.0 );
 
   //convert to and from a QVariant
-  const QVariant var = QVariant::fromValue( rect1 );
+  QVariant var = QVariant::fromValue( rect1 );
   QVERIFY( var.isValid() );
   QCOMPARE( var.userType(), qMetaTypeId<QgsRectangle>() );
-  QVERIFY( !var.canConvert< QgsReferencedRectangle >() );
-
   const QgsRectangle rect2 = qvariant_cast<QgsRectangle>( var );
+
+#if (QT_VERSION > QT_VERSION_CHECK(6, 0, 0))
+  QVERIFY( !var.convert( QMetaType::fromType<QgsReferencedRectangle >() ) );
+#else
+  QVERIFY( !var.convert( qMetaTypeId<QgsReferencedRectangle >() ) );
+#endif
+
   QCOMPARE( rect2.xMinimum(), rect1.xMinimum() );
   QCOMPARE( rect2.yMinimum(), rect1.yMinimum() );
   QCOMPARE( rect2.height(), rect1.height() );


### PR DESCRIPTION
## Description

Title says it all, a few more bits exposed to QML environments.

@nyalldawson , failing test adapted to work on both Qt5 and Qt6. Quite interestingly, in Qt6, a QVariant( QgsRectangle ) will have the canConvert() return true instead of false. Doing a qvariant_cast<QgsReferencedRectangle> of that variant will also work. 

However, both Qt5 and Qt6 return false when calling convert(), so I've upgraded the check to that.