### PR TITLE
Make Vertex Editor selection render last

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2697,7 +2697,7 @@ void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, H
     QgsVertexMarker *marker = new QgsVertexMarker( canvas() );
     marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
     marker->setZValue( marker->zValue() + 1 );
-    marker->setIconSize( QgsGuiUtils::scaleIconSize( 12 ) );
+    marker->setIconSize( QgsGuiUtils::scaleIconSize( 10 ) );
     marker->setPenWidth( QgsGuiUtils::scaleIconSize( 2 ) );
     marker->setColor( Qt::blue );
     marker->setCenter( toMapCoordinates( vertex.layer, geom.vertexAt( vertex.vertexId ) ) );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2696,7 +2696,8 @@ void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, H
 
     QgsVertexMarker *marker = new QgsVertexMarker( canvas() );
     marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
-    marker->setIconSize( QgsGuiUtils::scaleIconSize( 10 ) );
+    marker->setZValue( marker->zValue() + 1 );
+    marker->setIconSize( QgsGuiUtils::scaleIconSize( 12 ) );
     marker->setPenWidth( QgsGuiUtils::scaleIconSize( 2 ) );
     marker->setColor( Qt::blue );
     marker->setCenter( toMapCoordinates( vertex.layer, geom.vertexAt( vertex.vertexId ) ) );


### PR DESCRIPTION
## Description

A proposed solution to #54034 that adds a z order to vertex selection so that a selected vertex is always visible. Also increases the selected vertex size so that overlapping vertices are more obvious when only one is selected. While this is much better than the previous behavior the size change revealed that when vertices are selected using a mouse on the canvas they still draw the unselected vertex style underneath the selected style (as can be seen in this image: 
![image](https://github.com/user-attachments/assets/d7e3a7bb-2df3-45e0-8277-9ff34bccb7d7) ) 
rather than only the selected vertex style like when a vertex is selected in the table
(as can be seen in this image: 
![image](https://github.com/user-attachments/assets/8c5a8eb5-40c5-4d58-a6b1-8b6ee7db6e11)
). I was not able to figure out how to fix that issue. Open to suggestions. 

Fixes https://github.com/qgis/QGIS/issues/54034
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
