### PR TITLE
added possibility to add custom actions for the group-nodes in the layer tree

### DIFF
--- a/src/app/layout/qgslayoutappmenuprovider.cpp
+++ b/src/app/layout/qgslayoutappmenuprovider.cpp
@@ -38,7 +38,7 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
   //undo/redo
   menu->addAction( layout->undoStack()->stack()->createUndoAction( menu ) );
   menu->addAction( layout->undoStack()->stack()->createRedoAction( menu ) );
-  menu->addSeparator();
+  menu->addSeparator()->setObjectName( QLatin1String( "UndoRedoSeparator" ) );
 
 
   const QList<QgsLayoutItem *> selectedItems = layout->selectedLayoutItems();
@@ -76,7 +76,7 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
     }
 
     if ( addedGroupAction )
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "AddedGroupSeparator" ) );
 
     QAction *copyAction = new QAction( tr( "Copy" ), menu );
     connect( copyAction, &QAction::triggered, this, [this]() {
@@ -88,7 +88,7 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
       mDesigner->view()->copySelectedItems( QgsLayoutView::ClipboardCut );
     } );
     menu->addAction( cutAction );
-    menu->addSeparator();
+    menu->addSeparator()->setObjectName( QLatin1String( "CopyCutSeparator" ) );
   }
   else if ( mDesigner->view()->hasItemsInClipboard() )
   {
@@ -98,7 +98,7 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
       mDesigner->view()->pasteItems( pt );
     } );
     menu->addAction( pasteAction );
-    menu->addSeparator();
+    menu->addSeparator()->setObjectName( QLatin1String( "PasteSeparator" ) );
   }
 
   // is a page under the mouse?
@@ -136,7 +136,7 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
       removePageAction->setEnabled( false );
     menu->addAction( removePageAction );
 
-    menu->addSeparator();
+    menu->addSeparator()->setObjectName( QLatin1String( "ManagePageSeparator" ) );
   }
 
   if ( !selectedItems.empty() )

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -79,7 +79,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
     menu->addAction( actions->actionAddGroup( menu ) );
     menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionExpandTree.svg" ) ), tr( "&Expand All" ), mView, &QgsLayerTreeView::expandAll );
     menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionCollapseTree.svg" ) ), tr( "&Collapse All" ), mView, &QgsLayerTreeView::collapseAll );
-    menu->addSeparator();
+    menu->addSeparator()->setObjectName( QLatin1String( "GlobalSeparator" ) );
     if ( QgisApp::instance()->clipboard()->hasFormat( QGSCLIPBOARD_MAPLAYER_MIME ) )
     {
       QAction *actionPasteLayerOrGroup = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionEditPaste.svg" ) ), tr( "Paste Layer/Group" ), menu );
@@ -106,16 +106,16 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addAction( actions->actionRenameGroupOrLayer( menu ) );
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "RenameGroupOrLayerSeparator" ) );
       menu->addAction( actions->actionAddGroup( menu ) );
       QAction *removeAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemoveLayer.svg" ) ), tr( "&Remove Group…" ), QgisApp::instance(), &QgisApp::removeLayer );
       removeAction->setEnabled( removeActionEnabled() );
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "RemoveSeparator" ) );
 
       menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionSetCRS.png" ) ), tr( "Set Group &CRS…" ), QgisApp::instance(), &QgisApp::legendGroupSetCrs );
       menu->addAction( tr( "Set Group &WMS Data…" ), QgisApp::instance(), &QgisApp::legendGroupSetWmsData );
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "WmsSeparator" ) );
 
       menu->addAction( actions->actionMutuallyExclusiveGroup( menu ) );
 
@@ -135,7 +135,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( actions->actionMoveToBottom( menu ) );
       }
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "ExclusionSeparator" ) );
 
       if ( !mView->selectedNodes( true ).empty() )
         menu->addAction( actions->actionGroupSelected( menu ) );
@@ -145,7 +145,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( tr( "Paste Style" ), QgisApp::instance(), &QgisApp::applyStyleToGroup );
       }
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "GroupSeparator" ) );
 
       QMenu *menuExportGroup = new QMenu( tr( "E&xport" ), menu );
       menuExportGroup->setObjectName( QStringLiteral( "exportMenu" ) );
@@ -396,14 +396,14 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVirtualLayer.svg" ) ), tr( "Edit Virtual Layer…" ), QgisApp::instance(), &QgisApp::addVirtualLayer );
       }
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "LayerSeparator" ) );
 
       // duplicate layer
       QAction *duplicateLayersAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateLayer.svg" ) ), tr( "&Duplicate Layer" ), QgisApp::instance(), [] { QgisApp::instance()->duplicateLayers(); } );
       QAction *removeAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemoveLayer.svg" ) ), tr( "&Remove Layer…" ), QgisApp::instance(), &QgisApp::removeLayer );
       removeAction->setEnabled( removeActionEnabled() );
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "LayerActionSeparator" ) );
 
       if ( node->parent() != mView->layerTreeModel()->rootGroup() )
         menu->addAction( actions->actionMoveOutOfGroup( menu ) );
@@ -425,7 +425,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       if ( mView->selectedNodes( true ).count() >= 2 )
         menu->addAction( actions->actionGroupSelected( menu ) );
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "ActionPositionSeparator" ) );
 
       if ( vlayer || meshLayer || pcLayer )
       {
@@ -531,7 +531,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         }
       }
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "ActionPositionSeparator" ) );
 
       if ( layer && layer->isSpatial() )
       {
@@ -586,7 +586,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         const QList<QgsCoordinateReferenceSystem> recentProjections = QgsApplication::coordinateReferenceSystemRegistry()->recentCrs();
         if ( !recentProjections.isEmpty() )
         {
-          menuSetCRS->addSeparator();
+          menuSetCRS->addSeparator()->setObjectName( QLatin1String( "CRSSeparator" ) );
           int i = 0;
           for ( const QgsCoordinateReferenceSystem &crs : recentProjections )
           {
@@ -605,7 +605,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         }
 
         // set layer crs
-        menuSetCRS->addSeparator();
+        menuSetCRS->addSeparator()->setObjectName( QLatin1String( "SetLayerCrsSeparator" ) );
         QAction *actionSetLayerCrs = new QAction( tr( "Set &Layer CRS…" ), menuSetCRS );
         connect( actionSetLayerCrs, &QAction::triggered, QgisApp::instance(), &QgisApp::setLayerCrs );
         menuSetCRS->addAction( actionSetLayerCrs );
@@ -613,7 +613,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addMenu( menuSetCRS );
       }
 
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "LayerCrsSeparator" ) );
 
       // export menu
       if ( layer )
@@ -688,13 +688,13 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
             }
             break;
         }
-        menu->addSeparator();
+        menu->addSeparator()->setObjectName( QLatin1String( "LayerSpecificSeparator" ) );
       }
 
       // style-related actions
       if ( layer && mView->selectedLayerNodes().count() == 1 )
       {
-        menu->addSeparator();
+        menu->addSeparator()->setObjectName( QLatin1String( "StyleSeparator" ) );
         QMenu *menuStyleManager = new QMenu( tr( "Styles" ), menu );
         QgsMapLayerStyleManager *mgr = layer->styleManager();
         if ( mgr->styles().count() > 1 )
@@ -721,7 +721,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
             connect( copyAction, &QAction::triggered, this, [=]() { app->copyStyle( layer, category ); } );
             copyStyleMenu->addAction( copyAction );
             if ( category == QgsMapLayer::AllStyleCategories )
-              copyStyleMenu->addSeparator();
+              copyStyleMenu->addSeparator()->setObjectName( QLatin1String( "CopyStyleSeparator" ) );
           }
         }
         else
@@ -760,7 +760,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
                   connect( pasteAction, &QAction::triggered, this, [=]() { app->pasteStyle( layer, category ); } );
                   pasteStyleMenu->addAction( pasteAction );
                   if ( category == QgsMapLayer::AllStyleCategories )
-                    pasteStyleMenu->addSeparator();
+                    pasteStyleMenu->addSeparator()->setObjectName( QLatin1String( "PasteStyleSeparator" ) );
                   else
                     pasteAction->setEnabled( sourceCategories.testFlag( category ) );
                 }
@@ -773,7 +773,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           }
         }
 
-        menuStyleManager->addSeparator();
+        menuStyleManager->addSeparator()->setObjectName( QLatin1String( "MenuStyleSeparator" ) );
         QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( menuStyleManager, layer );
 
         if ( vlayer )
@@ -786,7 +786,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           if ( singleRenderer && singleRenderer->symbol() )
           {
             //single symbol renderer, so add set color/edit symbol actions
-            menuStyleManager->addSeparator();
+            menuStyleManager->addSeparator()->setObjectName( QLatin1String( "SymbolSeparator" ) );
             QgsColorWheel *colorWheel = new QgsColorWheel( menuStyleManager );
             colorWheel->setColor( singleRenderer->symbol()->color() );
             QgsColorWidgetAction *colorAction = new QgsColorWidgetAction( colorWheel, menuStyleManager, menuStyleManager );
@@ -808,7 +808,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
               connect( recentColorAction, &QgsColorSwatchGridAction::colorChanged, this, &QgsAppLayerTreeViewMenuProvider::setVectorSymbolColor );
             }
 
-            menuStyleManager->addSeparator();
+            menuStyleManager->addSeparator()->setObjectName( QLatin1String( "SymbolColorSeparator" ) );
             const QString layerId = vlayer->id();
 
             QAction *editSymbolAction = new QAction( tr( "Edit Symbol…" ), menuStyleManager );
@@ -880,7 +880,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionToggleAllLayers.svg" ) ), tr( "&Toggle Items" ), node, &QgsLayerTreeModelLegendNode::toggleAllItems );
       menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionShowAllLayers.svg" ) ), tr( "&Show All Items" ), node, &QgsLayerTreeModelLegendNode::checkAllItems );
       menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionHideAllLayers.svg" ) ), tr( "&Hide All Items" ), node, &QgsLayerTreeModelLegendNode::uncheckAllItems );
-      menu->addSeparator();
+      menu->addSeparator()->setObjectName( QLatin1String( "UserCheckableSeparator" ) );
     }
 
     if ( QgsSymbolLegendNode *symbolNode = qobject_cast<QgsSymbolLegendNode *>( node ) )
@@ -938,7 +938,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           }
         } );
 
-        menu->addSeparator();
+        menu->addSeparator()->setObjectName( QLatin1String( "MatchingAttributeSeparator" ) );
       }
 
       if ( layer && layer->type() == Qgis::LayerType::Vector && symbolNode->symbol() )
@@ -967,7 +967,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           connect( recentColorAction, &QgsColorSwatchGridAction::colorChanged, this, &QgsAppLayerTreeViewMenuProvider::setSymbolLegendNodeColor );
         }
 
-        menu->addSeparator();
+        menu->addSeparator()->setObjectName( QLatin1String( "VectorLayerSymbolSeparator" ) );
       }
 
       if ( layer && layer->type() == Qgis::LayerType::Vector )
@@ -1091,7 +1091,7 @@ void QgsAppLayerTreeViewMenuProvider::addCustomLayerActions( QMenu *menu, QgsMap
 
   if ( !lyrActions.isEmpty() )
   {
-    menu->addSeparator();
+    menu->addSeparator()->setObjectName( QLatin1String( "CustomLayerSeparator" ) );
     QList<QMenu *> menus;
     for ( int i = 0; i < lyrActions.count(); i++ )
     {
@@ -1146,7 +1146,7 @@ void QgsAppLayerTreeViewMenuProvider::addCustomLayerActions( QMenu *menu, QgsMap
         }
       }
     }
-    menu->addSeparator();
+    menu->addSeparator()->setObjectName( QLatin1String( "CustomLayerEndSeparator" ) );
   }
 }
 


### PR DESCRIPTION
## Description

Currently, you can create a custom action in the context menu of layer-tree only for different types of layers. This PR provides public API to add an action for groups of layers.

Two functions are added to public API of QGisInterface:

* Add action to context menu for all group-nodes in the layer tree.
    
**virtual void addCustomActionForGroups( QAction** ***action, const QString &menu ) = 0;**

* Remove action from the context menu for all group-nodes in the layer tree previously added with addCustomActionForGroups().

**virtual bool removeCustomActionForGroups( QAction** ***action ) = 0;**


![add_action_to_group](https://github.com/user-attachments/assets/b72a069c-0b4a-4270-b8b2-2b5b46b03614)
![remove_action_from_group](https://github.com/user-attachments/assets/8f1ce4c8-7e54-4da4-a96b-2017de30b48a)


Fixes #53692

