### PR TITLE
Add "GCP" to the Georeferencer buttons label, for harmonization

### DIFF
--- a/src/ui/georeferencer/qgsgeorefpluginguibase.ui
+++ b/src/ui/georeferencer/qgsgeorefpluginguibase.ui
@@ -237,10 +237,10 @@
   </action>
   <action name="mActionAddPoint">
    <property name="text">
-    <string>Add Point</string>
+    <string>Add GCP Point</string>
    </property>
    <property name="statusTip">
-    <string>Add point</string>
+    <string>Add GCP point</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+A</string>
@@ -248,10 +248,10 @@
   </action>
   <action name="mActionDeletePoint">
    <property name="text">
-    <string>Delete Point</string>
+    <string>Delete GCP Point</string>
    </property>
    <property name="statusTip">
-    <string>Delete point</string>
+    <string>Delete GCP point</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>


### PR DESCRIPTION
Most of the other tools in the dialog have GCP in their name...
refs https://github.com/qgis/QGIS-Documentation/pull/9402