### PR TITLE
Fix unavailable style-categories listed in qml-file 

### DIFF
--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -67,7 +67,7 @@ void QgsMapLayerStyleCategoriesModel::setCategories( QgsMapLayer::StyleCategorie
 
   // determine the allowed categories to consider only these in the last categories.
   QgsMapLayer::StyleCategories allowedCategories;
-  for ( const QgsMapLayer::StyleCategory &category : mCategoryList )
+  for ( QgsMapLayer::StyleCategory category : std::as_const( mCategoryList ) )
   {
     if ( category == QgsMapLayer::AllStyleCategories )
       continue;

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -65,6 +65,16 @@ void QgsMapLayerStyleCategoriesModel::setCategories( QgsMapLayer::StyleCategorie
   if ( mCategories == categories )
     return;
 
+  // determine the allowed categories to consider only these in the last categories.
+  QgsMapLayer::StyleCategories allowedCategories;
+  for ( const QgsMapLayer::StyleCategory &category : mCategoryList )
+  {
+    if ( category == QgsMapLayer::AllStyleCategories )
+      continue;
+    allowedCategories |= category;
+  }
+  categories &= allowedCategories;
+
   beginResetModel();
   mCategories = categories;
   endResetModel();

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -65,7 +65,7 @@ void QgsMapLayerStyleCategoriesModel::setCategories( QgsMapLayer::StyleCategorie
   if ( mCategories == categories )
     return;
 
-  // determine the allowed categories to consider only these in the last categories.
+  // filter the categories and only preserve the categories supported by the current layer type
   QgsMapLayer::StyleCategories allowedCategories;
   for ( QgsMapLayer::StyleCategory category : std::as_const( mCategoryList ) )
   {


### PR DESCRIPTION
**_Short: On loading a stylecategorymodel the last used category selection is passed to it. Since categories from vector layers can divert to categories from raster layers, this leaded to weird info in the qml-files. This change only passes the categories that the target layer allows (crops them)._**

When changing a layer, the previously stored or loaded category-selection is taken over.

![image](https://github.com/user-attachments/assets/897c3035-3073-48af-b7ed-6cc4f43574e5)

This is nice and makes sense on layer with the same type. On other types it don't mind that much, but are neither useful.

Anyway, the problem was, that with this in the `styleCategories` in the qml-file style categories where listed, that did not even exist for that layer type.

```xml

<qgis version="3.40.0-Bratislava" styleCategories="Symbology|Symbology3D|Labeling|Fields|Forms|Actions|Diagrams|GeometryOptions|Relations|Legend">

```

Not that bad, because there was no more content of them (since the `writeSymbology` methods are all layer-type-specific overrides) but still it's confusing.

So I decide that on taking  over the `lastStyleCategories` in the model they are "cropped" to the possible style categories according to the Categories-List of the layer type.

This leads to the situation  that when storing styles of raster and then open the dialog for a vector, the categories that are available in the vector layers but not in the rasters are disabled. IMO a behavior that is acceptable.