### PR TITLE
Fix case-sensitivity of http header checks

### DIFF
--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -508,7 +508,7 @@ QStringList QgsBaseNetworkRequest::sendOPTIONS( const QUrl &url )
 
     for ( const auto &headerKeyValue : mResponseHeaders )
     {
-      if ( headerKeyValue.first == QByteArray( "Allow" ) )
+      if ( headerKeyValue.first.compare( QByteArray( "Allow" ), Qt::CaseInsensitive ) == 0 )
       {
         allowValue = headerKeyValue.second;
         break;

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -419,7 +419,15 @@ void TestQgsNetworkAccessManager::fetchEncodedContent()
   connect( QgsNetworkAccessManager::instance(), qOverload<QgsNetworkReplyContent>( &QgsNetworkAccessManager::finished ), &context, [&]( const QgsNetworkReplyContent &reply ) {
     QCOMPARE( reply.error(), QNetworkReply::NoError );
     QCOMPARE( reply.requestId(), requestId );
-    QVERIFY( reply.rawHeaderList().contains( "Content-Length" ) );
+
+    // newer qt versions force headers to lower case, older ones didn't
+    QStringList lowerCaseRawHeaders;
+    for ( const QByteArray &header : reply.rawHeaderList() )
+    {
+      lowerCaseRawHeaders.append( header.toLower() );
+    }
+
+    QVERIFY( lowerCaseRawHeaders.contains( "content-length" ) );
     QCOMPARE( reply.request().url(), u );
     loaded = true;
   } );
@@ -502,7 +510,15 @@ void TestQgsNetworkAccessManager::fetchPost()
   connect( QgsNetworkAccessManager::instance(), qOverload<QgsNetworkReplyContent>( &QgsNetworkAccessManager::finished ), &context, [&]( const QgsNetworkReplyContent &reply ) {
     QCOMPARE( reply.error(), QNetworkReply::NoError );
     QCOMPARE( reply.requestId(), requestId );
-    QVERIFY( reply.rawHeaderList().contains( "Content-Type" ) );
+
+    // newer qt versions force headers to lower case, older ones didn't
+    QStringList lowerCaseRawHeaders;
+    for ( const QByteArray &header : reply.rawHeaderList() )
+    {
+      lowerCaseRawHeaders.append( header.toLower() );
+    }
+
+    QVERIFY( lowerCaseRawHeaders.contains( "content-type" ) );
     QCOMPARE( reply.request().url(), u );
     loaded = true;
   } );
@@ -591,7 +607,15 @@ void TestQgsNetworkAccessManager::fetchPostMultiPart()
   el.exec();
 
   QCOMPARE( reply->error(), QNetworkReply::NoError );
-  QVERIFY( reply->rawHeaderList().contains( "Content-Type" ) );
+
+  // newer qt versions force headers to lower case, older ones didn't
+  QStringList lowerCaseRawHeaders;
+  for ( const QByteArray &header : reply->rawHeaderList() )
+  {
+    lowerCaseRawHeaders.append( header.toLower() );
+  }
+  QVERIFY( lowerCaseRawHeaders.contains( "content-type" ) );
+
   QCOMPARE( reply->request().url(), u );
 }
 

--- a/tests/src/python/test_qgsblockingnetworkrequest.py
+++ b/tests/src/python/test_qgsblockingnetworkrequest.py
@@ -110,9 +110,10 @@ class TestQgsBlockingNetworkRequest(QgisTestCase):
         reply = request.reply()
         self.assertEqual(reply.error(), QNetworkReply.NetworkError.NoError)
         self.assertEqual(reply.content(), "<html></html>\n")
+        # newer qt versions FORCE lowercase header keys, older ones didn't
         self.assertEqual(
-            reply.rawHeaderList(),
-            [b"Server", b"Date", b"Content-type", b"Content-Length"],
+            [h.data().decode().lower() for h in reply.rawHeaderList()],
+            ["server", "date", "content-type", "content-length"],
         )
         self.assertEqual(reply.rawHeader(b"Content-type"), "text/html")
         self.assertEqual(reply.rawHeader(b"xxxxxxxxx"), "")


### PR DESCRIPTION
Since qt 6.8 header keys are forced to lowercase, so we need to adapt all checks accordingly
