### PR TITLE
[ui] Improve rendering of color button widget for semi-opaque colors

### DIFF
--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -725,7 +725,7 @@ void QgsColorButton::setButtonBackground( const QColor &color )
 
       //draw fully opaque color on the left side
       const QRectF clipRect( 0, 0,
-                             currentIconSize.width() / 2,
+                             static_cast<qreal>( currentIconSize.width() ) / 2.0,
                              currentIconSize.height() );
       p.setClipRect( clipRect );
       backgroundColor.setAlpha( 255 );

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -718,11 +718,25 @@ void QgsColorButton::setButtonBackground( const QColor &color )
       const QBrush checkBrush = QBrush( transparentBackground() );
       p.setBrush( checkBrush );
       p.drawRoundedRect( rect, 3, 3 );
-    }
 
-    //draw semi-transparent color on top
-    p.setBrush( backgroundColor );
-    p.drawRoundedRect( rect, 3, 3 );
+      //draw semi-transparent color on top
+      p.setBrush( backgroundColor );
+      p.drawRoundedRect( rect, 3, 3 );
+
+      //draw fully opaque color on the left side
+      const QRectF clipRect( 0, 0,
+                             currentIconSize.width() / 2,
+                             currentIconSize.height() );
+      p.setClipRect( clipRect );
+      backgroundColor.setAlpha( 255 );
+      p.setBrush( backgroundColor );
+      p.drawRoundedRect( rect, 3, 3 );
+    }
+    else
+    {
+      p.setBrush( backgroundColor );
+      p.drawRoundedRect( rect, 3, 3 );
+    }
     p.end();
   }
 


### PR DESCRIPTION
## Description

This PR aims at improving the rendering of the color button widget for semi-opaque colors by adopting blender's way of doing it. Long story short, the left half of the button renders the color fully opaque while the right half is rendered to reflect the opacity value. It looks like this:

![Screenshot From 2024-11-28 11-21-15](https://github.com/user-attachments/assets/9e3576c6-2d4f-4194-9ce0-9c3986eaed56)

The huge benefit of this is allowing for users to know the color value being used, which can have significant impacts for e.g. gradients going from fully opaque to fully transparent:

![image](https://github.com/user-attachments/assets/faf29bf7-d2bc-4e7b-b2d6-d9ed1f843c8c)

Without the left half, users wouldn't know whether their 2nd color with 0% opacity matches the 1st color with 100% opacity.