### PR TITLE
Avoid freeze when opening feature form with many relation reference widgets

### DIFF
--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -291,9 +291,11 @@ void QgsFeatureListComboBox::setIdentifierValuesToNull()
 
 QgsFeatureRequest QgsFeatureListComboBox::currentFeatureRequest() const
 {
+  QgsFeatureRequest request;
+  request.setRequestMayBeNested( true );
   if ( mModel->extraIdentifierValues().isEmpty() )
   {
-    return QgsFeatureRequest().setFilterFids( QgsFeatureIds() ); // NULL: Return a request that's guaranteed to not return anything
+    request.setFilterFids( QgsFeatureIds() ); // NULL: Return a request that's guaranteed to not return anything
   }
   else
   {
@@ -312,8 +314,9 @@ QgsFeatureRequest QgsFeatureListComboBox::currentFeatureRequest() const
       }
     }
     const QString expression = filtersAttrs.join( QLatin1String( " AND " ) );
-    return QgsFeatureRequest().setFilterExpression( expression );
+    return request.setFilterExpression( expression );
   }
+  return request;
 }
 
 QString QgsFeatureListComboBox::filterExpression() const


### PR DESCRIPTION
When opening a feature form with many relation widgets, background threads to populate the boxes are spawned.
At the same time, we also get the current feature from the main thread, which may be blocked by the background threads if they use `get_feature` or similar expressions which require calls to be executed on the main thread.

The following video demonstrates the problem:
![get_feature](https://github.com/qgis/QGIS/assets/588407/5c6f804e-83cd-4297-9479-7388a9987fde)

By setting the `requestMayBeNested` flag, we make sure that the main thread will get a connection in any case.