### PR TITLE
Fix qgis server fcgi response destructor

### DIFF
--- a/.ci/ogc/build.sh
+++ b/.ci/ogc/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-mkdir /usr/src/qgis/build
+mkdir -p /usr/src/qgis/build
 cd /usr/src/qgis/build || exit 1
 
 export CCACHE_TEMPDIR=/tmp

--- a/src/server/qgsfcgiserverresponse.cpp
+++ b/src/server/qgsfcgiserverresponse.cpp
@@ -114,9 +114,7 @@ void QgsSocketMonitoringThread::run()
   }
 
 #if defined( Q_OS_UNIX ) && !defined( Q_OS_ANDROID )
-#ifdef QGISDEBUG
   const pid_t threadId = gettid();
-#endif
 
   mShouldStop.store( false );
   char c;
@@ -135,10 +133,10 @@ void QgsSocketMonitoringThread::run()
     if ( rv == -1 )
     {
       // socket closed, nothing can be read
-      QgsDebugMsgLevel( QStringLiteral( "FCGIServer %1: remote socket has been closed (select)! errno: %2" ) //
-                          .arg( threadId )
-                          .arg( errno ),
-                        1 );
+      QgsMessageLog::logMessage( QStringLiteral( "FCGIServer %1: remote socket has been closed (select)! errno: %2" ) //
+                                   .arg( threadId )
+                                   .arg( errno ),
+                                 QStringLiteral( "FCGIServer" ), Qgis::MessageLevel::Warning );
       mFeedback->cancel();
       break;
     }
@@ -157,11 +155,11 @@ void QgsSocketMonitoringThread::run()
       else
       {
         // socket closed, nothing can be read
-        QgsDebugMsgLevel( QStringLiteral( "FCGIServer %1: remote socket has been closed (recv)! errno: %2, x: %3" ) //
-                            .arg( threadId )
-                            .arg( errno )
-                            .arg( x ),
-                          1 );
+        QgsMessageLog::logMessage( QStringLiteral( "FCGIServer %1: remote socket has been closed (recv)! errno: %2, x: %3" ) //
+                                     .arg( threadId )
+                                     .arg( errno )
+                                     .arg( x ),
+                                   QStringLiteral( "FCGIServer" ), Qgis::MessageLevel::Warning );
         mFeedback->cancel();
         break;
       }
@@ -179,7 +177,9 @@ void QgsSocketMonitoringThread::run()
   }
   else
   {
-    QgsDebugMsgLevel( QStringLiteral( "FCGIServer::run %1: socket monitoring quits: no more socket." ).arg( threadId ), 1 );
+    QgsMessageLog::logMessage( QStringLiteral( "FCGIServer::run %1: socket monitoring quits: no more socket." ) //
+                                 .arg( threadId ),                                                              //
+                               QStringLiteral( "FCGIServer" ), Qgis::MessageLevel::Warning );
   }
 #endif
 }

--- a/src/server/qgsfcgiserverresponse.cpp
+++ b/src/server/qgsfcgiserverresponse.cpp
@@ -285,5 +285,5 @@ void QgsFcgiServerResponse::truncate()
 
 void QgsFcgiServerResponse::setDefaultHeaders()
 {
-  setHeader( QStringLiteral( "Server" ), QStringLiteral( " QGIS FCGI server - QGIS version %1" ).arg( Qgis::version() ) );
+  mHeaders.insert( QStringLiteral( "Server" ), QStringLiteral( " QGIS FCGI server - QGIS version %1" ).arg( Qgis::version() ) );
 }

--- a/src/server/services/wms/qgswmsgetmap.cpp
+++ b/src/server/services/wms/qgswmsgetmap.cpp
@@ -52,6 +52,11 @@ namespace QgsWms
     QgsRenderer renderer( context );
     std::unique_ptr<QImage> result( renderer.getMap() );
 
+    if ( response.feedback() && response.feedback()->isCanceled() )
+    {
+      throw QgsServerException( QStringLiteral( "Remote socket has been closed!" ) );
+    }
+
     if ( result )
     {
       const QString format = request.parameters().value( QStringLiteral( "FORMAT" ), QStringLiteral( "PNG" ) );

--- a/src/server/services/wms/qgswmsgetmap.cpp
+++ b/src/server/services/wms/qgswmsgetmap.cpp
@@ -54,7 +54,7 @@ namespace QgsWms
 
     if ( response.feedback() && response.feedback()->isCanceled() )
     {
-      throw QgsServerException( QStringLiteral( "Remote socket has been closed!" ) );
+      return;
     }
 
     if ( result )

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1052,6 +1052,11 @@ namespace QgsWms
       throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue, QStringLiteral( "The requested map size is too large" ) );
     }
 
+    if ( mContext.socketFeedback() && mContext.socketFeedback()->isCanceled() )
+    {
+      return nullptr;
+    }
+
     // init layer restorer before doing anything
     std::unique_ptr<QgsWmsRestorer> restorer;
     restorer.reset( new QgsWmsRestorer( mContext ) );
@@ -1094,6 +1099,10 @@ namespace QgsWms
       image.reset( scaledImage );
 
     // return
+    if ( mContext.socketFeedback() && mContext.socketFeedback()->isCanceled() )
+    {
+      return nullptr;
+    }
     return image;
   }
 


### PR DESCRIPTION
Suppress wait in fcgi response destructor
    
In the previous version, the response destructor waited for the monitoring thread to end that may induce a 333ms sleep each time. We fix that by using a classic ptr to separate the thread and the response lifecycles.