### PR TITLE
fix(elevationprofilecanvas): avoid crash on segfault

### DIFF
--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -982,6 +982,9 @@ void QgsElevationProfileCanvas::onLayerProfileRendererPropertyChanged()
 
 void QgsElevationProfileCanvas::regenerateResultsForLayer()
 {
+  if ( !mCurrentJob )
+    return;
+
   if ( QgsMapLayer *layer = qobject_cast< QgsMapLayer * >( sender() ) )
   {
     if ( QgsAbstractProfileSource *source = dynamic_cast< QgsAbstractProfileSource * >( layer ) )


### PR DESCRIPTION
## Description

When the profile tool panel is opened, if no profile curve is set and regenerateResultsForLayer is run (triggered by adding a feature in a layer for instance), then QGIS crashes.