### PR TITLE
When merging cells in layout tables, concatenate original cell text

### DIFF
--- a/src/gui/tableeditor/qgstableeditorwidget.cpp
+++ b/src/gui/tableeditor/qgstableeditorwidget.cpp
@@ -1377,8 +1377,33 @@ void QgsTableEditorWidget::mergeSelectedCells()
     if ( maxCol == -1 || index.column() > maxCol )
       maxCol = index.column();
   }
+  QStringList mergedCellText;
+  for ( int row = minRow; row <= maxRow; ++row )
+  {
+    for ( int col = minCol; col <= maxCol; ++col )
+    {
+      if ( QTableWidgetItem *i = item( row, col ) )
+      {
+        const QString content = i->data( CellContent ).toString();
+        if ( !content.isEmpty() )
+        {
+          mergedCellText.append( content );
+        }
+      }
+    }
+  }
 
   setSpan( minRow, minCol, maxRow - minRow + 1, maxCol - minCol + 1 );
+
+  // set merged cell text to concatenate original cell text
+  if ( !mergedCellText.isEmpty() )
+  {
+    if ( QTableWidgetItem *i = item( minRow, minCol ) )
+    {
+      i->setText( mergedCellText.join( ' ' ) );
+      i->setData( CellContent, i->text() );
+    }
+  }
 
   if ( !mBlockSignals )
     emit tableChanged();


### PR DESCRIPTION
Fixes #59611
