### PR TITLE
[ui] Apply same semi-opaque color rendering to various color lists (raster renderers, color scheme lists, etc)

### DIFF
--- a/src/gui/qgscolorschemelist.cpp
+++ b/src/gui/qgscolorschemelist.cpp
@@ -704,7 +704,7 @@ void QgsColorSwatchDelegate::paint( QPainter *painter, const QStyleOptionViewIte
     painter->drawRect( option.rect );
   }
 
-  const QColor color = index.model()->data( index, Qt::DisplayRole ).value<QColor>();
+  QColor color = index.model()->data( index, Qt::DisplayRole ).value<QColor>();
   if ( !color.isValid() )
   {
     return;
@@ -729,11 +729,23 @@ void QgsColorSwatchDelegate::paint( QPainter *painter, const QStyleOptionViewIte
     const QBrush checkBrush = QBrush( transparentBackground() );
     painter->setBrush( checkBrush );
     painter->drawRoundedRect( rect, cornerSize, cornerSize );
+    //draw semi-transparent color on top
+    painter->setBrush( color );
+    painter->drawRoundedRect( rect, cornerSize, cornerSize );
+    //draw fully opaque color on the left side
+    const QRectF clipRect( rect.left(), rect.top(),
+                           static_cast<qreal>( rect.width() ) / 2.0,
+                           rect.height() );
+    painter->setClipRect( clipRect );
+    color.setAlpha( 255 );
+    painter->setBrush( color );
+    painter->drawRoundedRect( rect, cornerSize, cornerSize );
   }
-
-  //draw semi-transparent color on top
-  painter->setBrush( color );
-  painter->drawRoundedRect( rect, cornerSize, cornerSize );
+  else
+  {
+    painter->setBrush( color );
+    painter->drawRoundedRect( rect, cornerSize, cornerSize );
+  }
 }
 
 QPixmap QgsColorSwatchDelegate::transparentBackground() const


### PR DESCRIPTION
## Description

This PR applies the same improvement done to color button widget by rendering the color area of various color lists using both semi-opaque and full opacity to provide users with a better understand of what RGB/CMYK color is being used.

Screenshot:

![Screenshot From 2024-11-29 08-19-31](https://github.com/user-attachments/assets/eb38d3b5-127b-4524-8cad-f6f418b9ee12)

![Screenshot From 2024-11-29 08-13-33](https://github.com/user-attachments/assets/93256687-2909-49de-bf63-1f500b20ff95)
