### PR TITLE
WMS Ignore layer extent settings for default value

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -21,6 +21,7 @@ information for an HTTP Server for WMS, etc.
 #include "qgsnewhttpconnection.h"
 %End
   public:
+
     enum ConnectionType /BaseType=IntEnum/
     {
       ConnectionWfs,

--- a/python/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -21,6 +21,7 @@ information for an HTTP Server for WMS, etc.
 #include "qgsnewhttpconnection.h"
 %End
   public:
+
     enum ConnectionType
     {
       ConnectionWfs,

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -32,6 +32,8 @@
 #include <QRegularExpressionValidator>
 #include <QUrlQuery>
 
+const QgsSettingsEntryBool *QgsNewHttpConnection::settingsIgnoreReportedLayerExtentsDefault = new QgsSettingsEntryBool( QStringLiteral( "ignore-reported-layer-extents-default" ), sTreeHttpConnectionDialog, false ) ;
+
 QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes types, const QString &serviceName, const QString &connectionName, QgsNewHttpConnection::Flags flags, Qt::WindowFlags fl )
   : QDialog( parent, fl )
   , mTypes( types )
@@ -153,6 +155,8 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
       mGroupBox->layout()->removeWidget( lblTilePixelRatio );
     }
   }
+
+  cbxWmsIgnoreReportedLayerExtents->setChecked( settingsIgnoreReportedLayerExtentsDefault->value() );
 
   if ( !( flags & FlagShowTestConnection ) )
   {

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -32,7 +32,7 @@
 #include <QRegularExpressionValidator>
 #include <QUrlQuery>
 
-const QgsSettingsEntryBool *QgsNewHttpConnection::settingsIgnoreReportedLayerExtentsDefault = new QgsSettingsEntryBool( QStringLiteral( "ignore-reported-layer-extents-default" ), sTreeHttpConnectionDialog, false ) ;
+const QgsSettingsEntryBool *QgsNewHttpConnection::settingsIgnoreReportedLayerExtentsDefault = new QgsSettingsEntryBool( QStringLiteral( "ignore-reported-layer-extents-default" ), sTreeHttpConnectionDialog, false );
 
 QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes types, const QString &serviceName, const QString &connectionName, QgsNewHttpConnection::Flags flags, Qt::WindowFlags fl )
   : QDialog( parent, fl )

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -22,8 +22,10 @@
 #include "ui_qgsnewhttpconnectionbase.h"
 #include "qgsguiutils.h"
 #include "qgis_gui.h"
+#include "qgssettingstree.h"
 
 class QgsAuthSettingsWidget;
+class QgsSettingsEntryBool;
 
 /**
  * \ingroup gui
@@ -35,6 +37,12 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     Q_OBJECT
 
   public:
+#ifndef SIP_RUN
+    static inline QgsSettingsTreeNode *sTreeHttpConnectionDialog = QgsSettingsTree::sTreeConnections->createChildNode( QStringLiteral( "http-connection-dialog" ) );
+
+    static const QgsSettingsEntryBool *settingsIgnoreReportedLayerExtentsDefault;
+#endif
+
     /**
      * Available connection types for configuring in the dialog.
      */


### PR DESCRIPTION
Allow to personalize the initial state of the "Ignore reported layer extents" checkbox

![image](https://github.com/user-attachments/assets/02b172d5-2722-4505-b08a-6b341561e93e)
