### PR TITLE
[attribute form] Avoid showing a blank item in the drag and drop form layout for invalid/missing relations

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1160,8 +1160,8 @@ QTreeWidgetItem *QgsAttributesDnDTree::addItem( QTreeWidgetItem *parent, const Q
 
   if ( data.type() == QgsAttributesFormProperties::DnDTreeItemData::Relation )
   {
-    const bool isValid = QgsProject::instance()->relationManager()->relation( data.name() ).isValid();
-    if ( !isValid )
+    const QgsRelation relation = QgsProject::instance()->relationManager()->relation( data.name() );
+    if ( !relation.isValid() || relation.referencedLayer() != mLayer )
     {
       newItem->setText( 0, tr( "Invalid relation" ) );
       newItem->setForeground( 0, QColor( 255, 0, 0 ) );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -793,6 +793,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
     case DnDTreeItemData::Relation:
     {
       const QgsRelation relation = QgsProject::instance()->relationManager()->relation( itemData.name() );
+
       QgsAttributeEditorRelation *relDef = new QgsAttributeEditorRelation( relation, parent );
       const QgsAttributesFormProperties::RelationEditorConfiguration relationEditorConfig = itemData.relationEditorConfiguration();
       relDef->setRelationWidgetTypeId( relationEditorConfig.mRelationWidgetType );
@@ -1156,6 +1157,16 @@ QTreeWidgetItem *QgsAttributesDnDTree::addItem( QTreeWidgetItem *parent, const Q
   newItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, QVariant::fromValue( data ) );
   newItem->setText( 0, data.displayName() );
   newItem->setIcon( 0, icon );
+
+  if ( data.type() == QgsAttributesFormProperties::DnDTreeItemData::Relation )
+  {
+    const bool isValid = QgsProject::instance()->relationManager()->relation( data.name() ).isValid();
+    if ( !isValid )
+    {
+      newItem->setText( 0, tr( "Invalid relation" ) );
+      newItem->setForeground( 0, QColor( 255, 0, 0 ) );
+    }
+  }
 
   if ( index < 0 )
     parent->addChild( newItem );


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/59001 , whereas currently a broken relation item (relation gone missing) in the drag n drop form layout will end up showing as a blank item in the tree.

Before:

![image](https://github.com/user-attachments/assets/6b9ab549-d5da-49c7-9274-f97e7b3b9f55)

Now:

![image](https://github.com/user-attachments/assets/f1fc7a11-ed12-46d3-a6df-2f4ec018e570)