### PR TITLE
Significantly (23 to 33%) faster builds of qgis_core/analysis/3d/gui/app/server

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -239,6 +239,8 @@ set (QGIS_3D_RCCS  shaders.qrc  ../../resources/3d/textures/textures.qrc)
 
 add_library(qgis_3d SHARED ${QGIS_3D_SRCS} ${QGIS_3D_HDRS} ${QGIS_3D_RCCS} ${QGIS_3D_PRIVATE_HDRS})
 
+target_precompile_headers(qgis_3d PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/src/core/qgis.h>)
+
 # require c++17
 target_compile_features(qgis_3d PRIVATE cxx_std_17)
 

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -520,6 +520,8 @@ endif()
 
 add_library(qgis_analysis ${LIBRARY_TYPE} ${QGIS_ANALYSIS_SRCS} ${QGIS_ANALYSIS_HDRS})
 
+target_precompile_headers(qgis_analysis PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/src/core/qgis.h>)
+
 # require c++17
 target_compile_features(qgis_analysis PRIVATE cxx_std_17)
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -611,6 +611,8 @@ target_link_libraries(qgis_app
 
 target_compile_definitions(qgis_app PRIVATE "-DQT_NO_FOREACH")
 
+target_precompile_headers(qgis_app PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/src/core/qgis.h>)
+
 if (WITH_BINDINGS)
   add_definitions(-DWITH_BINDINGS)
   target_link_libraries(qgis_app qgispython)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2337,6 +2337,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(qgis_core ${LIBRARY_TYPE} ${QGIS_CORE_SRCS} ${QGIS_CORE_HDRS} ${QGIS_CORE_PRIVATE_HDRS} ${IMAGE_RCCS})
 
+target_precompile_headers(qgis_core PRIVATE $<$<COMPILE_LANGUAGE:CXX>:qgis.h>)
+
 # Add meshoptimizer
 if(WITH_INTERNAL_MESHOPTIMIZER)
   target_sources(qgis_core PRIVATE

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1678,6 +1678,8 @@ add_library(qgis_gui ${LIBRARY_TYPE}
 # require c++17
 target_compile_features(qgis_gui PRIVATE cxx_std_17)
 
+target_precompile_headers(qgis_gui PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/src/core/qgis.h>)
+
 target_include_directories(qgis_gui SYSTEM PUBLIC
   ${QWT_INCLUDE_DIR}
   ${QSCINTILLA_INCLUDE_DIR}

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -86,6 +86,8 @@ endif()
 
 add_library(qgis_server SHARED ${QGIS_SERVER_SRCS} ${QGIS_SERVER_HDRS})
 
+target_precompile_headers(qgis_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/src/core/qgis.h>)
+
 # require c++17
 target_compile_features(qgis_server PRIVATE cxx_std_17)
 


### PR DESCRIPTION
by precompiling qgis.h

Needs to be precompiled for each target due to different includes, defines, etc. (~ 4 second for each target to build the precompiled header in below timings)

Executive summary:
- ~ 33% faster builds on ubuntu 22.04, QT5
- ~ 23% faster builds (only measured on qgis_core) on fedora:rawhide, QT6
- build artifact increase size: + ~7%
- shared library increase size: + 1% at most

Setup: laptop with Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz, host OS Ubuntu 20.04, QGIS built in Docker
ccache and ${build_dir}/src/{component} directories emptied before each build

Details:

* ubuntu 22.04, QT5, regular, CMAKE_BUILD_TYPE=Debug

```bash
$ time make -j12 qgis_core
real	9m8.566s
user	90m24.917s
sys	    9m51.179s

$ du -c src/core | tail -n 1
1994796	total

$ ll ./output/lib/libqgis_core.so.3.41.0
-rwxr-xr-x 1 root root 590223936 Nov 30 00:35 ./output/lib/libqgis_core.so.3.41.0*
```

```bash
$ time make -j12 qgis_gui
real	8m26.430s
user	80m28.457s
sys	    11m27.936s

$ du -c src/gui | tail -n 1
1538440	total

$ ll ./output/lib/libqgis_gui.so.3.41.0
-rwxr-xr-x 1 root root 454560448 Nov 30 00:47 ./output/lib/libqgis_gui.so.3.41.0*
```

```bash
$ time make -j12 qgis_app
real	4m55.189s
user	47m4.876s
sys	    6m54.868s

$ du -c src/app | tail -n 1
783256	total

$ ll ./output/lib/libqgis_app.so.3.41.0
-rwxr-xr-x 1 root root 232041152 Nov 30 01:25 ./output/lib/libqgis_app.so.3.41.0*
```

* ubuntu 22.04, QT5, qgis.h as precompiled header, CMAKE_BUILD_TYPE=Debug:

```bash
$ time make -j12 qgis_core
real	6m3.472s
user	59m3.835s
sys	    5m22.424s

$ du -c src/core | tail -n 1
2137448	total

$ ll ./output/lib/libqgis_core.so.3.41.0
-rwxr-xr-x 1 root root 598395456 Nov 30 00:56 ./output/lib/libqgis_core.so.3.41.0*
```

```bash
$ time make -j12 qgis_gui
real	5m45.719s
user	53m30.107s
sys	    6m11.246s

$ du -c src/gui | tail -n 1
1660444	total

$ ll ./output/lib/libqgis_gui.so.3.41.0
-rwxr-xr-x 1 root root 456432320 Nov 30 01:04 ./output/lib/libqgis_gui.so.3.41.0*
```

```bash
$ time make -j12 qgis_analysis
real	2m36.504s
user	26m25.310s
sys	    2m17.601s

$ du -c src/analysis/ | tail -n 1
920912	total

$ ll ./output/lib/libqgis_analysis.so.3.41.0
-rwxr-xr-x 1 root root 228178496 Nov 30 01:11 ./output/lib/libqgis_analysis.so.3.41.0*
```

```bash
$ time make -j12 qgis_3d
real	0m43.710s
user	6m9.148s
sys	    0m39.859s

$ du -c src/3d | tail -n 1
315212	total

$ ll ./output/lib/libqgis_3d.so.3.41.0
-rwxr-xr-x 1 root root 58472960 Nov 30 01:14 ./output/lib/libqgis_3d.so.3.41.0*
```

```bash
$ time make -j12 qgis_app
real	3m35.156s
user	34m17.371s
sys	    3m52.111s

$ du -c src/app | tail -n 1
905160	total

$ ll ./output/lib/libqgis_app.so.3.41.0
-rwxr-xr-x 1 root root 232577728 Nov 30 01:19 ./output/lib/libqgis_app.so.3.41.0*
```

* fedora:rawhide, QT6, regular, CMAKE_BUILD_TYPE=Debug:

```bash
$ time ninja qgis_core
real	13m47.521s
user	134m48.546s
sys	    10m2.176s

$ du -c src/core | tail -n 1
2862200	total

$ ll ./output/lib/libqgis_core.so.3.41.0
-rwxr-xr-x 1 root root 824605072 Nov 30 00:53 ./output/lib/libqgis_core.so.3.41.0

```

* fedora:rawhide, QT6, qgis.h as precompiled header, CMAKE_BUILD_TYPE=Debug:

```bash
$ time ninja qgis_core
real	10m35.657s
user	97m51.161s
sys	    7m59.564s

$ du -c src/core | tail -n 1
3028420	total

$ ll ./output/lib/libqgis_core.so.3.41.0
-rwxr-xr-x 1 root root 825732184 Nov 30 00:38 ./output/lib/libqgis_core.so.3.41.0
```
