### PR TITLE
[snapping] Invalidate the filtered layer tree model when a parent group switches from empty/non-empty state

### DIFF
--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -409,8 +409,33 @@ QgsLayerTreeModel *QgsSnappingLayerTreeModel::layerTreeModel() const
 
 void QgsSnappingLayerTreeModel::setLayerTreeModel( QgsLayerTreeModel *layerTreeModel )
 {
+  if ( mLayerTreeModel )
+  {
+    disconnect( mLayerTreeModel, &QAbstractItemModel::rowsInserted, this, &QgsSnappingLayerTreeModel::onNodesInserted );
+    disconnect( mLayerTreeModel, &QAbstractItemModel::rowsRemoved, this, &QgsSnappingLayerTreeModel::onNodesRemoved );
+  }
+
   mLayerTreeModel = layerTreeModel;
   QSortFilterProxyModel::setSourceModel( layerTreeModel );
+
+  connect( mLayerTreeModel, &QAbstractItemModel::rowsInserted, this, &QgsSnappingLayerTreeModel::onNodesInserted );
+  connect( mLayerTreeModel, &QAbstractItemModel::rowsRemoved, this, &QgsSnappingLayerTreeModel::onNodesRemoved );
+}
+
+void QgsSnappingLayerTreeModel::onNodesInserted( const QModelIndex &parent, int first, int last )
+{
+  if ( mLayerTreeModel->rowCount( parent ) - ( last - first + 1 ) <= 0 )
+  {
+    invalidateFilter();
+  }
+}
+
+void QgsSnappingLayerTreeModel::onNodesRemoved( const QModelIndex &parent, int, int )
+{
+  if ( mLayerTreeModel->rowCount( parent ) == 0 )
+  {
+    invalidateFilter();
+  }
 }
 
 bool QgsSnappingLayerTreeModel::filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const

--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -91,6 +91,8 @@ class APP_EXPORT QgsSnappingLayerTreeModel : public QSortFilterProxyModel
     void onSnappingSettingsChanged();
 
   private:
+    void onNodesInserted( const QModelIndex &parent, int first, int last );
+    void onNodesRemoved( const QModelIndex &parent, int first, int last );
     bool nodeShown( QgsLayerTreeNode *node ) const;
 
     QgsProject *mProject = nullptr;


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/59469 whereas creating a new group and moving layers into that group doesn't show in the advanced snapping layer tree widget. 

The layers are hidden as the snapping layer tree model filters out empty group. When children are added into the group, the filtered model didn't invalidate its filter, resulting in both the group and the added children gone missing from the tree widget.