### PR TITLE
[ui] Improve rendering of color tooltips

### DIFF
--- a/src/gui/qgscolortooltip_p.h
+++ b/src/gui/qgscolortooltip_p.h
@@ -54,9 +54,19 @@ class QgsColorTooltip
 
       //draw color over pattern
       p.setBrush( QBrush( color ) );
+      p.drawRect( margin, margin, width, height );
+
+      if ( color.alpha() < 255 )
+      {
+        //draw fully opaque color over half of the area
+        color.setAlpha( 255 );
+        p.setBrush( QBrush( color ) );
+        p.drawRect( margin, margin, width / 2, height );
+      }
 
       //draw border
       p.setPen( QColor( 197, 197, 197 ) );
+      p.setBrush( Qt::NoBrush );
       p.drawRect( margin, margin, width, height );
       p.end();
 


### PR DESCRIPTION
## Description

Following up on improvements done to the color button and color list widgets, this PR improves rendering of the color tooltip by adding a fully-opaque color preview for semi-opaque colors:

![image](https://github.com/user-attachments/assets/76060b7e-fa9e-43be-931a-be3daeb5b3bc)
