### PR TITLE
Allow the Trim/Extend Tool to keep the reference line for multiple trim/extend actions

### DIFF
--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -153,7 +153,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
         if ( mIsIntersection )
         {
           mRubberBandIntersection.reset( createRubberBand( Qgis::GeometryType::Point ) );
-          mRubberBandIntersection->addPoint( QgsPointXY( mIntersection ) );
+          mRubberBandIntersection->addPoint( toMapCoordinates( mVlayer, QgsPointXY( mIntersection ) ) );
           mRubberBandIntersection->show();
 
           mRubberBandExtend.reset( createRubberBand( match.layer()->geometryType() ) );
@@ -194,7 +194,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
           if ( mIsModified )
           {
             mGeom.removeDuplicateNodes();
-            mRubberBandExtend->setToGeometry( mGeom );
+            mRubberBandExtend->setToGeometry( mGeom, mVlayer );
             mRubberBandExtend->show();
           }
         }
@@ -264,7 +264,10 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
         {
           emit messageEmitted( tr( "Couldn't trim or extend the feature." ) );
         }
-        deactivate();
+
+        // If Ctrl or Shift is pressed, keep the tool active with its reference feature
+        if ( !( e->modifiers() & ( Qt::ControlModifier | Qt::ShiftModifier ) ) )
+          deactivate();
         break;
     }
   }

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1178,6 +1178,12 @@ Shift+O to turn segments into straight or curve lines.</string>
    <property name="text">
     <string>Trim/Extend Feature</string>
    </property>
+   <property name="toolTip">
+    <string>Trim/Extend Feature
+- Click to set the reference segment
+- Click on another segment to trim it or extend it to the reference segment (Use Shift or Ctrl to keep the reference segment active)
+Note : Segment snapping must be enabled in the snapping Toolbar</string>
+   </property>
   </action>
   <action name="mActionSnappingOptions">
    <property name="text">


### PR DESCRIPTION
- Fix #59634

## Description

Pressing Shift while trimming/extending a feature now keeps the reference feature.
Also fix the rubber band display when the layer crs != canvas crs.

![trimextend](https://github.com/user-attachments/assets/2e94c652-981e-4f79-a2e9-aca42a51e49e)
