### PR TITLE
Fix case-sensitivity of http header checks (LTR)

### DIFF
--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -511,7 +511,7 @@ QStringList QgsBaseNetworkRequest::sendOPTIONS( const QUrl &url )
 
     for ( const auto &headerKeyValue : mResponseHeaders )
     {
-      if ( headerKeyValue.first == QByteArray( "Allow" ) )
+      if ( headerKeyValue.first.compare( QByteArray( "Allow" ), Qt::CaseInsensitive ) == 0 )
       {
         allowValue = headerKeyValue.second;
         break;

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -439,7 +439,15 @@ void TestQgsNetworkAccessManager::fetchEncodedContent()
   {
     QCOMPARE( reply.error(), QNetworkReply::NoError );
     QCOMPARE( reply.requestId(), requestId );
-    QVERIFY( reply.rawHeaderList().contains( "Content-Length" ) );
+
+    // newer qt versions force headers to lower case, older ones didn't
+    QStringList lowerCaseRawHeaders;
+    for ( const QByteArray &header : reply.rawHeaderList() )
+    {
+      lowerCaseRawHeaders.append( header.toLower() );
+    }
+
+    QVERIFY( lowerCaseRawHeaders.contains( "content-length" ) );
     QCOMPARE( reply.request().url(), u );
     loaded = true;
   } );
@@ -524,7 +532,15 @@ void TestQgsNetworkAccessManager::fetchPost()
   {
     QCOMPARE( reply.error(), QNetworkReply::NoError );
     QCOMPARE( reply.requestId(), requestId );
-    QVERIFY( reply.rawHeaderList().contains( "Content-Type" ) );
+
+    // newer qt versions force headers to lower case, older ones didn't
+    QStringList lowerCaseRawHeaders;
+    for ( const QByteArray &header : reply.rawHeaderList() )
+    {
+      lowerCaseRawHeaders.append( header.toLower() );
+    }
+
+    QVERIFY( lowerCaseRawHeaders.contains( "content-type" ) );
     QCOMPARE( reply.request().url(), u );
     loaded = true;
   } );
@@ -614,7 +630,15 @@ void TestQgsNetworkAccessManager::fetchPostMultiPart()
   el.exec();
 
   QCOMPARE( reply->error(), QNetworkReply::NoError );
-  QVERIFY( reply->rawHeaderList().contains( "Content-Type" ) );
+
+  // newer qt versions force headers to lower case, older ones didn't
+  QStringList lowerCaseRawHeaders;
+  for ( const QByteArray &header : reply->rawHeaderList() )
+  {
+    lowerCaseRawHeaders.append( header.toLower() );
+  }
+  QVERIFY( lowerCaseRawHeaders.contains( "content-type" ) );
+
   QCOMPARE( reply->request().url(), u );
 }
 

--- a/tests/src/python/test_qgsblockingnetworkrequest.py
+++ b/tests/src/python/test_qgsblockingnetworkrequest.py
@@ -83,10 +83,11 @@ class TestQgsBlockingNetworkRequest(QgisTestCase):
         reply = request.reply()
         self.assertEqual(reply.error(), QNetworkReply.NoError)
         self.assertEqual(reply.content(), '<html></html>\n')
-        self.assertEqual(reply.rawHeaderList(), [b'Server',
-                                                 b'Date',
-                                                 b'Content-type',
-                                                 b'Content-Length'])
+        # newer qt versions FORCE lowercase header keys, older ones didn't
+        self.assertEqual(
+            [h.data().decode().lower() for h in reply.rawHeaderList()],
+            ["server", "date", "content-type", "content-length"],
+        )
         self.assertEqual(reply.rawHeader(b'Content-type'), 'text/html')
         self.assertEqual(reply.rawHeader(b'xxxxxxxxx'), '')
         self.assertEqual(reply.attribute(QNetworkRequest.HttpStatusCodeAttribute), 200)


### PR DESCRIPTION
Since qt 6.8 header keys are forced to lowercase, so we need to adapt all checks accordingly

Manual backport of https://github.com/qgis/QGIS/pull/59619