### PR TITLE
Link QGIS gui to Qt QML

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1826,6 +1826,7 @@ target_link_libraries(qgis_gui
   ${QT_VERSION_BASE}::UiTools
   ${QWT_LIBRARY}
   ${QSCINTILLA_LIBRARY}
+  ${QT_VERSION_BASE}::Qml
   ${QT_VERSION_BASE}::QuickWidgets
   ${QT_VERSION_BASE}::Multimedia
   ${QT_VERSION_BASE}::MultimediaWidgets


### PR DESCRIPTION
Otherwise it's only linked if you compile with QUICK enabled

