### PR TITLE
Fix common angles guide line flickering

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1300,6 +1300,11 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   context.mConstraint = _constraint( mMConstraint.get() );
   context.distanceConstraint = _constraint( mDistanceConstraint.get() );
   context.angleConstraint = _constraint( mAngleConstraint.get() );
+
+  // if mAngleConstraint is only soft locked, do not consider that the context angle constraint
+  // is locked, as this would prevent the common angles constraint from being applied
+  context.angleConstraint.locked = mAngleConstraint->lockMode() == CadConstraint::HardLock;
+
   context.snappingToFeaturesOverridesCommonAngle = mSnappingPrioritizeFeatures;
 
   context.lineExtensionConstraint = _constraint( mLineExtensionConstraint.get() );


### PR DESCRIPTION
## Description

Fix the annoying flickering of the common angles guide line in Advanced digitizing.

### Before

![bug_common_angles](https://github.com/user-attachments/assets/b1e0bc86-e3b9-41dc-9ee6-7feeee02e3cd)

### After

![fix_common_angles](https://github.com/user-attachments/assets/1f416500-253d-4331-953b-619f65ae4097)
