### PR TITLE
Add API to QgsRasterIterator to handle resampling factor

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -26,32 +26,37 @@ Constructor for QgsRasterIterator, iterating over the specified ``input`` raster
 Since QGIS 3.34 the tileOverlapPixels can be used to specify a margin in pixels for retrieving pixels overlapping into neighbor cells.
 %End
 
-    void setResamplingFactor( int factor );
+    void setSnapToPixelFactor( int factor );
 %Docstring
-Sets the resampling factor in pixels. When set to a value greater than 1,
-the raster blocks will be snapped to boundaries of the resampled pixels.
-Set to 1 to disable resampling (default).
+Sets the "snap to pixel" factor in pixels.
+
+When set to a value greater than 1, the raster blocks will be snapped to boundaries
+matching exact multiples of this factor.
+
+Set to 1 to disable this behavior (default).
 
 .. warning::
 
-   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
-   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
-   exactly to the resampling factor.
+   When the "snap to pixel" factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``snap to pixel factor - 1``, may be skipped if they cannot be snapped
+   exactly to the factor.
+
+.. seealso:: :py:func:`snapToPixelFactor`
 
 .. versionadded:: 3.42
 %End
 
-    int resamplingFactor() const;
+    int snapToPixelFactor() const;
 %Docstring
-Returns the current resampling factor in pixels.
+Returns the current "snap to pixel" factor in pixels.
 
 .. warning::
 
-   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
-   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
-   exactly to the resampling factor.
+   When the "snap to pixel" factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``snap to pixel factor - 1``, may be skipped if they cannot be snapped
+   exactly to the factor.
 
-.. seealso:: :py:func:`setResamplingFactor`
+.. seealso:: :py:func:`setSnapToPixelFactor`
 
 .. versionadded:: 3.42
 %End

--- a/python/PyQt6/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -26,7 +26,37 @@ Constructor for QgsRasterIterator, iterating over the specified ``input`` raster
 Since QGIS 3.34 the tileOverlapPixels can be used to specify a margin in pixels for retrieving pixels overlapping into neighbor cells.
 %End
 
-    static QgsRectangle subRegion( const QgsRectangle &rasterExtent, int rasterWidth, int rasterHeight, const QgsRectangle &subRegion, int &subRegionWidth /Out/, int &subRegionHeight /Out/, int &subRegionLeft /Out/, int &subRegionTop /Out/ );
+    void setResamplingFactor( int factor );
+%Docstring
+Sets the resampling factor in pixels. When set to a value greater than 1,
+the raster blocks will be snapped to boundaries of the resampled pixels.
+Set to 1 to disable resampling (default).
+
+.. warning::
+
+   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
+   exactly to the resampling factor.
+
+.. versionadded:: 3.42
+%End
+
+    int resamplingFactor() const;
+%Docstring
+Returns the current resampling factor in pixels.
+
+.. warning::
+
+   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
+   exactly to the resampling factor.
+
+.. seealso:: :py:func:`setResamplingFactor`
+
+.. versionadded:: 3.42
+%End
+
+    static QgsRectangle subRegion( const QgsRectangle &rasterExtent, int rasterWidth, int rasterHeight, const QgsRectangle &subRegion, int &subRegionWidth /Out/, int &subRegionHeight /Out/, int &subRegionLeft /Out/, int &subRegionTop /Out/, int resamplingFactor = 1 );
 %Docstring
 Given an overall raster extent and width and height in pixels, calculates the sub region
 of the raster covering the specified ``subRegion``.
@@ -35,6 +65,7 @@ of the raster covering the specified ``subRegion``.
 :param rasterWidth: overall raster width
 :param rasterHeight: overall raster height
 :param subRegion: desired sub region extent
+:param resamplingFactor: optional resampling factor to snap boundaries to. When specified the calculated subregion will always be shrunk to snap to the pixel boundaries. (since QGIS 3.42)
 
 :return: - sub region geographic extent, snapped to exact pixel boundaries
          - subRegionWidth: width in pixels of sub region

--- a/python/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -26,32 +26,37 @@ Constructor for QgsRasterIterator, iterating over the specified ``input`` raster
 Since QGIS 3.34 the tileOverlapPixels can be used to specify a margin in pixels for retrieving pixels overlapping into neighbor cells.
 %End
 
-    void setResamplingFactor( int factor );
+    void setSnapToPixelFactor( int factor );
 %Docstring
-Sets the resampling factor in pixels. When set to a value greater than 1,
-the raster blocks will be snapped to boundaries of the resampled pixels.
-Set to 1 to disable resampling (default).
+Sets the "snap to pixel" factor in pixels.
+
+When set to a value greater than 1, the raster blocks will be snapped to boundaries
+matching exact multiples of this factor.
+
+Set to 1 to disable this behavior (default).
 
 .. warning::
 
-   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
-   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
-   exactly to the resampling factor.
+   When the "snap to pixel" factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``snap to pixel factor - 1``, may be skipped if they cannot be snapped
+   exactly to the factor.
+
+.. seealso:: :py:func:`snapToPixelFactor`
 
 .. versionadded:: 3.42
 %End
 
-    int resamplingFactor() const;
+    int snapToPixelFactor() const;
 %Docstring
-Returns the current resampling factor in pixels.
+Returns the current "snap to pixel" factor in pixels.
 
 .. warning::
 
-   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
-   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
-   exactly to the resampling factor.
+   When the "snap to pixel" factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``snap to pixel factor - 1``, may be skipped if they cannot be snapped
+   exactly to the factor.
 
-.. seealso:: :py:func:`setResamplingFactor`
+.. seealso:: :py:func:`setSnapToPixelFactor`
 
 .. versionadded:: 3.42
 %End

--- a/python/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -26,7 +26,37 @@ Constructor for QgsRasterIterator, iterating over the specified ``input`` raster
 Since QGIS 3.34 the tileOverlapPixels can be used to specify a margin in pixels for retrieving pixels overlapping into neighbor cells.
 %End
 
-    static QgsRectangle subRegion( const QgsRectangle &rasterExtent, int rasterWidth, int rasterHeight, const QgsRectangle &subRegion, int &subRegionWidth /Out/, int &subRegionHeight /Out/, int &subRegionLeft /Out/, int &subRegionTop /Out/ );
+    void setResamplingFactor( int factor );
+%Docstring
+Sets the resampling factor in pixels. When set to a value greater than 1,
+the raster blocks will be snapped to boundaries of the resampled pixels.
+Set to 1 to disable resampling (default).
+
+.. warning::
+
+   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
+   exactly to the resampling factor.
+
+.. versionadded:: 3.42
+%End
+
+    int resamplingFactor() const;
+%Docstring
+Returns the current resampling factor in pixels.
+
+.. warning::
+
+   When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+   A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
+   exactly to the resampling factor.
+
+.. seealso:: :py:func:`setResamplingFactor`
+
+.. versionadded:: 3.42
+%End
+
+    static QgsRectangle subRegion( const QgsRectangle &rasterExtent, int rasterWidth, int rasterHeight, const QgsRectangle &subRegion, int &subRegionWidth /Out/, int &subRegionHeight /Out/, int &subRegionLeft /Out/, int &subRegionTop /Out/, int resamplingFactor = 1 );
 %Docstring
 Given an overall raster extent and width and height in pixels, calculates the sub region
 of the raster covering the specified ``subRegion``.
@@ -35,6 +65,7 @@ of the raster covering the specified ``subRegion``.
 :param rasterWidth: overall raster width
 :param rasterHeight: overall raster height
 :param subRegion: desired sub region extent
+:param resamplingFactor: optional resampling factor to snap boundaries to. When specified the calculated subregion will always be shrunk to snap to the pixel boundaries. (since QGIS 3.42)
 
 :return: - sub region geographic extent, snapped to exact pixel boundaries
          - subRegionWidth: width in pixels of sub region

--- a/src/core/raster/qgsrasteriterator.cpp
+++ b/src/core/raster/qgsrasteriterator.cpp
@@ -187,11 +187,11 @@ bool QgsRasterIterator::readNextRasterPartInternal( int bandNumber, int &nCols, 
   tileColumns = static_cast< int >( std::min( static_cast< qgssize >( mMaximumTileWidth ), pInfo.nCols - tileTopLeftColumn ) );
   tileRows = static_cast< int >( std::min( static_cast< qgssize >( mMaximumTileHeight ), pInfo.nRows - tileTopLeftRow ) );
 
-  if ( mResamplingFactor > 1 )
+  if ( mSnapToPixelFactor > 1 )
   {
-    // Round down tile dimensions to resampling factor
-    tileColumns = ( tileColumns / mResamplingFactor ) * mResamplingFactor;
-    tileRows = ( tileRows / mResamplingFactor ) * mResamplingFactor;
+    // Round down tile dimensions to snap factor
+    tileColumns = ( tileColumns / mSnapToPixelFactor ) * mSnapToPixelFactor;
+    tileRows = ( tileRows / mSnapToPixelFactor ) * mSnapToPixelFactor;
   }
 
   const qgssize tileRight = tileTopLeftColumn + tileColumns;
@@ -205,11 +205,11 @@ bool QgsRasterIterator::readNextRasterPartInternal( int bandNumber, int &nCols, 
   nCols = blockRight - blockLeft;
   nRows = blockBottom - blockTop;
 
-  if ( mResamplingFactor > 1 )
+  if ( mSnapToPixelFactor > 1 )
   {
-    // Ensure overlap dimensions are also multiples of resampling factor
-    nCols = ( nCols / mResamplingFactor ) * mResamplingFactor;
-    nRows = ( nRows / mResamplingFactor ) * mResamplingFactor;
+    // Ensure overlap dimensions are also multiples of snap factor
+    nCols = ( nCols / mSnapToPixelFactor ) * mSnapToPixelFactor;
+    nRows = ( nRows / mSnapToPixelFactor ) * mSnapToPixelFactor;
     if ( nCols == 0 || nRows == 0 )
       return false;
   }

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -216,7 +216,7 @@ class CORE_EXPORT QgsRasterIterator
      * \see blockCountWidth()
      * \since QGIS 3.42
      */
-    int blockCountHeight() const { return mNumberBlocksWidth; }
+    int blockCountHeight() const { return mNumberBlocksHeight; }
 
     /**
      * Returns the total number of blocks required to iterate over the input raster.

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -43,29 +43,33 @@ class CORE_EXPORT QgsRasterIterator
     QgsRasterIterator( QgsRasterInterface *input, int tileOverlapPixels = 0 );
 
     /**
-     * Sets the resampling factor in pixels. When set to a value greater than 1,
-     * the raster blocks will be snapped to boundaries of the resampled pixels.
-     * Set to 1 to disable resampling (default).
+     * Sets the "snap to pixel" factor in pixels.
      *
-     * \warning When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
-     * A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
-     * exactly to the resampling factor.
+     * When set to a value greater than 1, the raster blocks will be snapped to boundaries
+     * matching exact multiples of this factor.
      *
+     * Set to 1 to disable this behavior (default).
+     *
+     * \warning When the "snap to pixel" factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+     * A band of pixels on the right and bottom, with size at most of ``snap to pixel factor - 1``, may be skipped if they cannot be snapped
+     * exactly to the factor.
+     *
+     * \see snapToPixelFactor()
      * \since QGIS 3.42
      */
-    void setResamplingFactor( int factor ) { mResamplingFactor = factor > 0 ? factor : 1; }
+    void setSnapToPixelFactor( int factor ) { mSnapToPixelFactor = factor > 0 ? factor : 1; }
 
     /**
-     * Returns the current resampling factor in pixels.
+     * Returns the current "snap to pixel" factor in pixels.
      *
-     * \warning When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
-     * A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
-     * exactly to the resampling factor.
+     * \warning When the "snap to pixel" factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+     * A band of pixels on the right and bottom, with size at most of ``snap to pixel factor - 1``, may be skipped if they cannot be snapped
+     * exactly to the factor.
      *
-     * \see setResamplingFactor()
+     * \see setSnapToPixelFactor()
      * \since QGIS 3.42
      */
-    int resamplingFactor() const { return mResamplingFactor; }
+    int snapToPixelFactor() const { return mSnapToPixelFactor; }
 
     /**
      * Given an overall raster extent and width and height in pixels, calculates the sub region
@@ -254,7 +258,7 @@ class CORE_EXPORT QgsRasterIterator
     int mTileOverlapPixels = 0;
     int mMaximumTileWidth;
     int mMaximumTileHeight;
-    int mResamplingFactor = 1;
+    int mSnapToPixelFactor = 1;
 
     int mNumberBlocksWidth = 0;
     int mNumberBlocksHeight = 0;

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -43,6 +43,31 @@ class CORE_EXPORT QgsRasterIterator
     QgsRasterIterator( QgsRasterInterface *input, int tileOverlapPixels = 0 );
 
     /**
+     * Sets the resampling factor in pixels. When set to a value greater than 1,
+     * the raster blocks will be snapped to boundaries of the resampled pixels.
+     * Set to 1 to disable resampling (default).
+     *
+     * \warning When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+     * A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
+     * exactly to the resampling factor.
+     *
+     * \since QGIS 3.42
+     */
+    void setResamplingFactor( int factor ) { mResamplingFactor = factor > 0 ? factor : 1; }
+
+    /**
+     * Returns the current resampling factor in pixels.
+     *
+     * \warning When the resampling factor is set, the iterated portion of the raster may not cover the entire input raster extent.
+     * A band of pixels on the right and bottom, with size at most of ``resampling factor - 1``, may be skipped if they cannot be snapped
+     * exactly to the resampling factor.
+     *
+     * \see setResamplingFactor()
+     * \since QGIS 3.42
+     */
+    int resamplingFactor() const { return mResamplingFactor; }
+
+    /**
      * Given an overall raster extent and width and height in pixels, calculates the sub region
      * of the raster covering the specified \a subRegion.
      *
@@ -54,12 +79,13 @@ class CORE_EXPORT QgsRasterIterator
      * \param subRegionHeight height in pixels of sub region
      * \param subRegionLeft starting column of left side of sub region
      * \param subRegionTop starting row of top side of sub region
+     * \param resamplingFactor optional resampling factor to snap boundaries to. When specified the calculated subregion will always be shrunk to snap to the pixel boundaries. (since QGIS 3.42)
      *
      * \returns sub region geographic extent, snapped to exact pixel boundaries
      *
      * \since QGIS 3.26
      */
-    static QgsRectangle subRegion( const QgsRectangle &rasterExtent, int rasterWidth, int rasterHeight, const QgsRectangle &subRegion, int &subRegionWidth SIP_OUT, int &subRegionHeight SIP_OUT, int &subRegionLeft SIP_OUT, int &subRegionTop SIP_OUT );
+    static QgsRectangle subRegion( const QgsRectangle &rasterExtent, int rasterWidth, int rasterHeight, const QgsRectangle &subRegion, int &subRegionWidth SIP_OUT, int &subRegionHeight SIP_OUT, int &subRegionLeft SIP_OUT, int &subRegionTop SIP_OUT, int resamplingFactor = 1 );
 
     /**
      * Start reading of raster band. Raster data can then be retrieved by calling readNextRasterPart until it returns FALSE.
@@ -228,6 +254,7 @@ class CORE_EXPORT QgsRasterIterator
     int mTileOverlapPixels = 0;
     int mMaximumTileWidth;
     int mMaximumTileHeight;
+    int mResamplingFactor = 1;
 
     int mNumberBlocksWidth = 0;
     int mNumberBlocksHeight = 0;
@@ -235,6 +262,7 @@ class CORE_EXPORT QgsRasterIterator
     //! Remove part into and release memory
     void removePartInfo( int bandNumber );
     bool readNextRasterPartInternal( int bandNumber, int &nCols, int &nRows, std::unique_ptr<QgsRasterBlock> *block, int &topLeftCol, int &topLeftRow, QgsRectangle *blockExtent, int &tileColumns, int &tileRows, int &tileTopLeftColumn, int &tileTopLeftRow );
+
 };
 
 #endif // QGSRASTERITERATOR_H

--- a/tests/src/core/testqgsrasteriterator.cpp
+++ b/tests/src/core/testqgsrasteriterator.cpp
@@ -42,7 +42,7 @@ class TestQgsRasterIterator : public QObject
     void testNoBlock();
     void testSubRegion();
     void testPixelOverlap();
-    void testResampling();
+    void testSnapToPixelFactor();
 
   private:
     QString mTestDataDir;
@@ -633,22 +633,22 @@ void TestQgsRasterIterator::testPixelOverlap()
   QVERIFY( !block.get() );
 }
 
-void TestQgsRasterIterator::testResampling()
+void TestQgsRasterIterator::testSnapToPixelFactor()
 {
-  // Test setting/getting resampling factor
+  // Test setting/getting snap to pixel factor
   QgsRasterIterator it( mpRasterLayer->dataProvider() );
-  QCOMPARE( it.resamplingFactor(), 1 );
+  QCOMPARE( it.snapToPixelFactor(), 1 );
 
-  it.setResamplingFactor( 2 );
-  QCOMPARE( it.resamplingFactor(), 2 );
+  it.setSnapToPixelFactor( 2 );
+  QCOMPARE( it.snapToPixelFactor(), 2 );
 
   // Test invalid values are sanitized
-  it.setResamplingFactor( 0 );
-  QCOMPARE( it.resamplingFactor(), 1 );
-  it.setResamplingFactor( -1 );
-  QCOMPARE( it.resamplingFactor(), 1 );
+  it.setSnapToPixelFactor( 0 );
+  QCOMPARE( it.snapToPixelFactor(), 1 );
+  it.setSnapToPixelFactor( -1 );
+  QCOMPARE( it.snapToPixelFactor(), 1 );
 
-  // Test subregion calculation with resampling
+  // Test subregion calculation with snapping
   int subRectWidth = 0;
   int subRectHeight = 0;
   int subRectTop = 0;
@@ -662,7 +662,7 @@ void TestQgsRasterIterator::testResampling()
   const QgsRectangle originalRegion( 497970.01, 7050985.05, 498030.95, 7051030.75 );
   QgsRectangle subRect = QgsRasterIterator::subRegion( rasterExtent, rasterWidth, rasterHeight, originalRegion, subRectWidth, subRectHeight, subRectLeft, subRectTop, 2 );
 
-  // Dimensions should be multiples of resampling factor
+  // Dimensions should be multiples of snapping factor
   QCOMPARE( subRectWidth, 608 );
   QCOMPARE( subRectHeight, 456 );
   QCOMPARE( subRectLeft, 5000 );
@@ -678,7 +678,7 @@ void TestQgsRasterIterator::testResampling()
   QGSCOMPARENEAR( subRect.yMinimum(), 7050985.2, 0.000001 );
   QGSCOMPARENEAR( subRect.yMaximum(), 7051030.8, 0.000001 );
 
-  // Test block iteration with resampling
+  // Test block iteration with snapping
   it.setMaximumTileWidth( 3000 );
   it.setMaximumTileHeight( 3000 );
   it.startRasterRead( 1, rasterWidth, rasterHeight, rasterExtent );
@@ -687,10 +687,10 @@ void TestQgsRasterIterator::testResampling()
   QgsRectangle blockExtent;
   std::unique_ptr<QgsRasterBlock> block;
 
-  // Test with resampling factor of 2
+  // Test with snapping factor of 2
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
 
-  // Block dimensions should be multiples of resampling factor
+  // Block dimensions should be multiples of snapping factor
   QCOMPARE( nCols, 3000 );
   QCOMPARE( nRows, 3000 );
   QCOMPARE( topLeftCol, 0 );
@@ -758,7 +758,7 @@ void TestQgsRasterIterator::testResampling()
 
   QVERIFY( !it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
 
-  // Test with resampling factor of 4
+  // Test with snapping factor of 4
   subRectWidth = 0;
   subRectHeight = 0;
   subRectTop = 0;
@@ -766,8 +766,8 @@ void TestQgsRasterIterator::testResampling()
 
   QgsRectangle subRect4 = QgsRasterIterator::subRegion( rasterExtent, rasterWidth, rasterHeight, originalRegion, subRectWidth, subRectHeight, subRectLeft, subRectTop, 4 );
 
-  // Test resampling factor 4 results
-  // Dimensions should be multiples of resampling factor
+  // Test snapping factor 4 results
+  // Dimensions should be multiples of snapping factor
   QCOMPARE( subRectWidth, 608 );
   QCOMPARE( subRectHeight, 456 );
   QCOMPARE( subRectLeft, 5000 );
@@ -785,8 +785,8 @@ void TestQgsRasterIterator::testResampling()
 
   const QgsRectangle subRect128 = QgsRasterIterator::subRegion( rasterExtent, rasterWidth, rasterHeight, originalRegion, subRectWidth, subRectHeight, subRectLeft, subRectTop, 128 );
 
-  // Test resampling factor 128 results
-  // Dimensions should be multiples of resampling factor
+  // Test snapping factor 128 results
+  // Dimensions should be multiples of snapping factor
   QCOMPARE( subRectWidth, 384 );
   QCOMPARE( subRectHeight, 384 );
   QCOMPARE( subRectLeft, 5120 );
@@ -802,12 +802,12 @@ void TestQgsRasterIterator::testResampling()
   QGSCOMPARENEAR( subRect128.yMinimum(), 7050989.2, 0.000001 );
   QGSCOMPARENEAR( subRect128.yMaximum(), 7051027.6, 0.000001 );
 
-  it.setResamplingFactor( 128 );
+  it.setSnapToPixelFactor( 128 );
   it.startRasterRead( 1, rasterWidth, rasterHeight, rasterExtent );
-  // Test with resampling factor of 128
+  // Test with snapping factor of 128
   QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
 
-  // Block dimensions should be multiples of resampling factor
+  // Block dimensions should be multiples of snapping factor
   QCOMPARE( nCols, 2944 );
   QCOMPARE( nRows, 2944 );
   QCOMPARE( topLeftCol, 0 );


### PR DESCRIPTION
Allows raster iterator to calculate blocks which are exactly multiples of the resampling factor, to aid in cases where the iterator will be used to fetch resampled raster blocks
