### PR TITLE
Set default elevation behavior to absolute/vertex

### DIFF
--- a/src/3d/symbols/qgsline3dsymbol.h
+++ b/src/3d/symbols/qgsline3dsymbol.h
@@ -124,7 +124,7 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTORS
 
   private:
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
     //! how to handle clamping of vertices of individual features
     Qgis::AltitudeBinding mAltBinding = Qgis::AltitudeBinding::Centroid;
 

--- a/src/3d/symbols/qgslinevertexdata_p.h
+++ b/src/3d/symbols/qgslinevertexdata_p.h
@@ -77,7 +77,7 @@ struct QgsLineVertexData
   bool withAdjacency = false;  //!< Whether line strip with adjacency primitive will be used
 
   // extra info to calculate elevation
-  Qgis::AltitudeClamping altClamping = Qgis::AltitudeClamping::Relative;
+  Qgis::AltitudeClamping altClamping = Qgis::AltitudeClamping::Absolute;
   Qgis::AltitudeBinding altBinding = Qgis::AltitudeBinding::Vertex;
   float baseHeight = 0;
   Qgs3DRenderContext renderContext;  // used for altitude clamping

--- a/src/3d/symbols/qgsmesh3dsymbol.h
+++ b/src/3d/symbols/qgsmesh3dsymbol.h
@@ -355,7 +355,7 @@ class _3D_EXPORT QgsMesh3DSymbol : public QgsAbstract3DSymbol
 #endif
 
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
     float mHeight = 0.0f;           //!< Base height of triangles
     std::unique_ptr< QgsAbstractMaterialSettings > mMaterialSettings;  //!< Defines appearance of objects
     bool mAddBackFaces = false;

--- a/src/3d/symbols/qgspoint3dsymbol.h
+++ b/src/3d/symbols/qgspoint3dsymbol.h
@@ -174,7 +174,7 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
     bool exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::QEntity *entity, const QString &objectNamePrefix ) const override SIP_SKIP;
   private:
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
 
     std::unique_ptr< QgsAbstractMaterialSettings> mMaterialSettings;  //!< Defines appearance of objects
     Qgis::Point3DShape mShape = Qgis::Point3DShape::Cylinder;  //!< What kind of shape to use

--- a/src/3d/symbols/qgspolygon3dsymbol.h
+++ b/src/3d/symbols/qgspolygon3dsymbol.h
@@ -186,7 +186,7 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCT
 
   private:
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
     //! how to handle clamping of vertices of individual features
     Qgis::AltitudeBinding mAltBinding = Qgis::AltitudeBinding::Centroid;
 

--- a/src/core/vector/qgsvectorlayerelevationproperties.cpp
+++ b/src/core/vector/qgsvectorlayerelevationproperties.cpp
@@ -141,7 +141,7 @@ void QgsVectorLayerElevationProperties::setDefaultsFromLayer( QgsMapLayer *layer
 
   if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) )
   {
-    mClamping = Qgis::AltitudeClamping::Relative;
+    mClamping = Qgis::AltitudeClamping::Absolute;
   }
   else
   {


### PR DESCRIPTION
Treat vector geometries $z cooridantes as absolute elevation values

> I don't expect the SIG to change my geometries if not explicitly stated.

## Description

When providing a project DTM/DEM, the default behavior for vector feature with a z-component is to offset the $z coordinates from project the terrain elevation model (used in the elevation profile view).

This has an undesired effect on 3D-defined geometries that are shifted by the project's terrain. I acknowledge that the relative feature **CAN BE** usefull, **BUT** geometries coordinates are supposed to be absolute (in their own CRS) ... 
> so why treat the Z-coordinate differently ?

If no z-coordinate exists, it uses the project/global DTM --> **OK**  
but if there is a $z it should **NOT** be messed with as default behavior (if not explicitly said otherwise, relative elevation is NOT a $z-coordinate so we should not encourage/support such behavior).

[see issue](https://github.com/qgis/QGIS/issues/59757)