### PR TITLE
disable pre-commit workflow

### DIFF
--- a/.github/workflows/pr-run-pre-commit.yml.disabled
+++ b/.github/workflows/pr-run-pre-commit.yml.disabled
@@ -1,3 +1,6 @@
+# this doesn't seem to work on PRs from forks
+# so we use pre-commit.ci instead
+
 name: 🤸 Run pre-commit on PR
 on:
   pull_request:


### PR DESCRIPTION
this workflow doesn't seem to work on PRs from forks so we use pre-commit.ci instead

