### PR TITLE
fix(AttributeEditor): Restore splitter position

### DIFF
--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -65,6 +65,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeAnnotations = treeRoot()->createChildNode( QStringLiteral( "annotations" ) );
     static inline QgsSettingsTreeNode *sTreeNetworkCache = treeRoot()->createChildNode( QStringLiteral( "cache" ) );
     static inline QgsSettingsTreeNode *sTreeAttributeTable = treeRoot()->createChildNode( QStringLiteral( "attribute-table" ) );
+    static inline QgsSettingsTreeNode *sTreeWindowState = sTreeGui->createChildNode( QStringLiteral( "window-state" ) );
 
 #endif
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -48,7 +48,7 @@
 #include "qgsvectorlayereditbuffer.h"
 #include "qgsactionmenu.h"
 
-const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::conditionnalFormattingSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-table-splitter-state" ), QgsSettingsTree::sTreeGui, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of conditionnal formatting splitter's layout so it could be restored when opening attribute table view." ) );
+const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::conditionalFormattingSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-table-splitter-state" ), QgsSettingsTree::sTreeGui, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of conditionnal formatting splitter's layout so it could be restored when opening attribute table view." ) );
 const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::attributeEditorSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-editor-splitter-state" ), QgsSettingsTree::sTreeGui, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of attribute editor splitter's layout so it could be restored when opening attribute editor view." ) );
 
 QgsDualView::QgsDualView( QWidget *parent )
@@ -72,8 +72,8 @@ QgsDualView::QgsDualView( QWidget *parent )
 
   const QgsSettings settings;
   // copy old setting
-  conditionnalFormattingSplitterState->copyValueFromKey( QStringLiteral( "/qgis/attributeTable/splitterState" ), true );
-  mConditionalSplitter->restoreState( conditionnalFormattingSplitterState->value().toByteArray() );
+  conditionalFormattingSplitterState->copyValueFromKey( QStringLiteral( "/qgis/attributeTable/splitterState" ), true );
+  mConditionalSplitter->restoreState( conditionalFormattingSplitterState->value().toByteArray() );
   mAttributeEditorViewSplitter->restoreState( attributeEditorSplitterState->value().toByteArray() );
 
   mPreviewColumnsMenu = new QMenu( this );
@@ -844,7 +844,7 @@ void QgsDualView::hideEvent( QHideEvent *event )
   // a new QgsDualView is created at project loading and we restore the old settings before saving the
   // new one.
   // And also, we override close event to just hide in QgsDockableWidgetHelper::eventFilter, that's why hideEvent
-  conditionnalFormattingSplitterState->setValue( mConditionalSplitter->saveState() );
+  conditionalFormattingSplitterState->setValue( mConditionalSplitter->saveState() );
   attributeEditorSplitterState->setValue( mAttributeEditorViewSplitter->saveState() );
 }
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -48,6 +48,8 @@
 #include "qgsvectorlayereditbuffer.h"
 #include "qgsactionmenu.h"
 
+const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::conditionnalFormattingSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-table-splitter-state" ), QgsSettingsTree::sTreeGui, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of conditionnal formatting splitter's layout so it could be restored when opening attribute table view." ) );
+const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::attributeEditorSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-editor-splitter-state" ), QgsSettingsTree::sTreeGui, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of attribute editor splitter's layout so it could be restored when opening attribute editor view." ) );
 
 QgsDualView::QgsDualView( QWidget *parent )
   : QStackedWidget( parent )
@@ -69,8 +71,10 @@ QgsDualView::QgsDualView( QWidget *parent )
   mConditionalFormatWidget->setDockMode( true );
 
   const QgsSettings settings;
-  mConditionalSplitter->restoreState( settings.value( QStringLiteral( "/qgis/attributeTable/splitterState" ), QByteArray() ).toByteArray() );
-  mAttributeEditorViewSplitter->restoreState( settings.value( QStringLiteral( "/qgis/attributeEditor/splitterState" ), QByteArray() ).toByteArray() );
+  // copy old setting
+  conditionnalFormattingSplitterState->copyValueFromKey( QStringLiteral( "/qgis/attributeTable/splitterState" ), true );
+  mConditionalSplitter->restoreState( conditionnalFormattingSplitterState->value().toByteArray() );
+  mAttributeEditorViewSplitter->restoreState( attributeEditorSplitterState->value().toByteArray() );
 
   mPreviewColumnsMenu = new QMenu( this );
   mActionPreviewColumnsMenu->setMenu( mPreviewColumnsMenu );
@@ -835,14 +839,13 @@ void QgsDualView::hideEvent( QHideEvent *event )
   Q_UNUSED( event )
   saveRecentDisplayExpressions();
 
-  // Better to save settings here than in destructor. This this last can be called after a new
+  // Better to save settings here than in destructor. This last can be called after a new
   // project is loaded. So, when Qgis::ProjectFlag::RememberAttributeTableWindowsBetweenSessions is set,
   // a new QgsDualView is created at project loading and we restore the old settings before saving the
   // new one.
   // And also, we override close event to just hide in QgsDockableWidgetHelper::eventFilter, that's why hideEvent
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "/qgis/attributeTable/splitterState" ), mConditionalSplitter->saveState() );
-  settings.setValue( QStringLiteral( "/qgis/attributeEditor/splitterState" ), mAttributeEditorViewSplitter->saveState() );
+  conditionnalFormattingSplitterState->setValue( mConditionalSplitter->saveState() );
+  attributeEditorSplitterState->setValue( mAttributeEditorViewSplitter->saveState() );
 }
 
 void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &masterIndex )

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -48,8 +48,8 @@
 #include "qgsvectorlayereditbuffer.h"
 #include "qgsactionmenu.h"
 
-const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::conditionalFormattingSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-table-splitter-state" ), QgsSettingsTree::sTreeGui, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of conditionnal formatting splitter's layout so it could be restored when opening attribute table view." ) );
-const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::attributeEditorSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-editor-splitter-state" ), QgsSettingsTree::sTreeGui, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of attribute editor splitter's layout so it could be restored when opening attribute editor view." ) );
+const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::conditionalFormattingSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-table-splitter-state" ), QgsSettingsTree::sTreeWindowState, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of conditionnal formatting splitter's layout so it could be restored when opening attribute table view." ) );
+const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::attributeEditorSplitterState = std::make_unique<QgsSettingsEntryVariant>( QStringLiteral( "attribute-editor-splitter-state" ), QgsSettingsTree::sTreeWindowState, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), QStringLiteral( "State of attribute editor splitter's layout so it could be restored when opening attribute editor view." ) );
 
 QgsDualView::QgsDualView( QWidget *parent )
   : QStackedWidget( parent )

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -70,6 +70,7 @@ QgsDualView::QgsDualView( QWidget *parent )
 
   const QgsSettings settings;
   mConditionalSplitter->restoreState( settings.value( QStringLiteral( "/qgis/attributeTable/splitterState" ), QByteArray() ).toByteArray() );
+  mAttributeEditorViewSplitter->restoreState( settings.value( QStringLiteral( "/qgis/attributeEditor/splitterState" ), QByteArray() ).toByteArray() );
 
   mPreviewColumnsMenu = new QMenu( this );
   mActionPreviewColumnsMenu->setMenu( mPreviewColumnsMenu );
@@ -115,8 +116,6 @@ QgsDualView::QgsDualView( QWidget *parent )
 
 QgsDualView::~QgsDualView()
 {
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "/qgis/attributeTable/splitterState" ), mConditionalSplitter->saveState() );
 }
 
 void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request,
@@ -835,6 +834,15 @@ void QgsDualView::hideEvent( QHideEvent *event )
 {
   Q_UNUSED( event )
   saveRecentDisplayExpressions();
+
+  // Better to save settings here than in destructor. This this last can be called after a new
+  // project is loaded. So, when Qgis::ProjectFlag::RememberAttributeTableWindowsBetweenSessions is set,
+  // a new QgsDualView is created at project loading and we restore the old settings before saving the
+  // new one.
+  // And also, we override close event to just hide in QgsDockableWidgetHelper::eventFilter, that's why hideEvent
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "/qgis/attributeTable/splitterState" ), mConditionalSplitter->saveState() );
+  settings.setValue( QStringLiteral( "/qgis/attributeEditor/splitterState" ), mAttributeEditorViewSplitter->saveState() );
 }
 
 void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &masterIndex )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -428,7 +428,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     //! Returns TRUE if the expression dialog has been accepted
     bool modifySort();
 
-    static const std::unique_ptr<QgsSettingsEntryVariant> conditionnalFormattingSplitterState;
+    static const std::unique_ptr<QgsSettingsEntryVariant> conditionalFormattingSplitterState;
     static const std::unique_ptr<QgsSettingsEntryVariant> attributeEditorSplitterState;
 
     QgsFieldConditionalFormatWidget *mConditionalFormatWidget = nullptr;

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -32,6 +32,7 @@ class QgsFeatureRequest;
 class QgsMapLayerAction;
 class QgsScrollArea;
 class QgsFieldConditionalFormatWidget;
+class QgsSettingsEntryVariant;
 
 /**
  * \ingroup gui
@@ -426,6 +427,9 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     //! Returns TRUE if the expression dialog has been accepted
     bool modifySort();
+
+    static const std::unique_ptr<QgsSettingsEntryVariant> conditionnalFormattingSplitterState;
+    static const std::unique_ptr<QgsSettingsEntryVariant> attributeEditorSplitterState;
 
     QgsFieldConditionalFormatWidget *mConditionalFormatWidget = nullptr;
     QgsAttributeEditorContext mEditorContext;


### PR DESCRIPTION
only the conditional formatting was saved and restored.

![splitter](https://github.com/user-attachments/assets/3ac9b582-8a99-4258-9d7f-570fbded8f49)

**Funded by coforet**