### PR TITLE
Fix exception when loading processing plugin on Qt 6 builds on KDE

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
@@ -247,6 +247,20 @@ Adds an ``action`` to the QGIS "Export project" menu.
 .. versionadded:: 3.30
 %End
 
+    virtual QMenu *projectModelsMenu() = 0;
+%Docstring
+Returns a reference to the main window "Projects" - "Models" submenu.
+
+.. versionadded:: 3.42
+%End
+
+    virtual QMenu *createProjectModelSubMenu( const QString &title ) = 0;
+%Docstring
+Creates a new project model submenu in the "Projects" - "Models" submenu.
+
+.. versionadded:: 3.42
+%End
+
     virtual QMenu *editMenu() = 0;
 %Docstring
 Returns a reference to the main window "Edit" menu.

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -247,6 +247,20 @@ Adds an ``action`` to the QGIS "Export project" menu.
 .. versionadded:: 3.30
 %End
 
+    virtual QMenu *projectModelsMenu() = 0;
+%Docstring
+Returns a reference to the main window "Projects" - "Models" submenu.
+
+.. versionadded:: 3.42
+%End
+
+    virtual QMenu *createProjectModelSubMenu( const QString &title ) = 0;
+%Docstring
+Creates a new project model submenu in the "Projects" - "Models" submenu.
+
+.. versionadded:: 3.42
+%End
+
     virtual QMenu *editMenu() = 0;
 %Docstring
 Returns a reference to the main window "Edit" menu.

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -665,6 +665,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Menus
     QMenu *projectMenu() { return mProjectMenu; }
     QMenu *projectImportExportMenu() { return menuImport_Export; }
+    QMenu *projectModelsMenu() { return mMenuProjectModels; }
     QMenu *editMenu() { return mEditMenu; }
     QMenu *viewMenu() { return mViewMenu; }
     QMenu *layerMenu() { return mLayerMenu; }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -733,6 +733,18 @@ void QgisAppInterface::removeProjectExportAction( QAction *action )
   }
 }
 
+QMenu *QgisAppInterface::projectModelsMenu()
+{
+  return qgis->projectModelsMenu();
+}
+
+QMenu *QgisAppInterface::createProjectModelSubMenu( const QString &title )
+{
+  QMenu *modelSubMenu = new QMenu( title, qgis->projectModelsMenu() );
+  qgis->projectModelsMenu()->addMenu( modelSubMenu );
+  return modelSubMenu;
+}
+
 QMenu *QgisAppInterface::editMenu() { return qgis->editMenu(); }
 QMenu *QgisAppInterface::viewMenu() { return qgis->viewMenu(); }
 QMenu *QgisAppInterface::layerMenu() { return qgis->layerMenu(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -172,6 +172,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void removeProjectImportAction( QAction *action ) override;
     void addProjectExportAction( QAction *action ) override;
     void removeProjectExportAction( QAction *action ) override;
+    QMenu *projectModelsMenu() override;
+    QMenu *createProjectModelSubMenu( const QString &title ) override;
     QMenu *editMenu() override;
     QMenu *viewMenu() override;
     QMenu *layerMenu() override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -282,6 +282,20 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void removeProjectExportAction( QAction *action ) = 0;
 
     /**
+     * Returns a reference to the main window "Projects" - "Models" submenu.
+     *
+     * \since QGIS 3.42
+     */
+    virtual QMenu *projectModelsMenu() = 0;
+
+    /**
+     * Creates a new project model submenu in the "Projects" - "Models" submenu.
+     *
+     * \since QGIS 3.42
+     */
+    virtual QMenu *createProjectModelSubMenu( const QString &title ) = 0;
+
+    /**
      * Returns a reference to the main window "Edit" menu.
      */
     virtual QMenu *editMenu() = 0;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -62,6 +62,11 @@
      <addaction name="separator"/>
      <addaction name="mActionDwgImport"/>
     </widget>
+    <widget class="QMenu" name="mMenuProjectModels">
+     <property name="title">
+      <string>Models</string>
+     </property>
+    </widget>
     <addaction name="mActionNewProject"/>
     <addaction name="mProjectFromTemplateMenu"/>
     <addaction name="separator"/>
@@ -84,6 +89,8 @@
     <addaction name="mActionNewReport"/>
     <addaction name="mActionShowLayoutManager"/>
     <addaction name="mLayoutsMenu"/>
+    <addaction name="separator"/>
+    <addaction name="mMenuProjectModels"/>
     <addaction name="separator"/>
     <addaction name="mActionExit"/>
    </widget>


### PR DESCRIPTION
Something internal in KDE itself adds child QObjects to menus, so the code which tries to find the last action in the menu fails and returns a QObject instead of a QAction, leading to an exception in the insertAction call.

This is all too fragile anyway, so avoid it by:

- Just creating the models menu directly in the ui
- Exposing this via interface for use in the processing plugin

Now there's no risk of this code breaking in future if the Project menu is re-arranged.
