### PR TITLE
Scatterplot: Optional hover text from a expression [Feature]

### DIFF
--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -186,13 +186,7 @@ class VectorLayerScatterplot(QgisAlgorithm):
             parameters, self.HOVERTEXT, context
         )
         if hoverexpression.strip():
-            exp_context = QgsExpressionContext()
-            vlayer = QgsProcessingUtils.mapLayerFromString(
-                parameters[self.INPUT], context
-            )
-            exp_context.appendScopes(
-                QgsExpressionContextUtils.globalProjectLayerScopes(vlayer)
-            )
+            exp_context = self.createExpressionContext(parameters, context, source)
             hoverexpression = QgsExpression(hoverexpression)
             if hoverexpression.hasParserError():
                 feedback.reportError(

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -185,7 +185,7 @@ class VectorLayerScatterplot(QgisAlgorithm):
         hoverexpression = self.parameterAsExpression(
             parameters, self.HOVERTEXT, context
         )
-        if hoverexpression.strip() != "":
+        if hoverexpression.strip():
             exp_context = QgsExpressionContext()
             vlayer = QgsProcessingUtils.mapLayerFromString(
                 parameters[self.INPUT], context

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -46,7 +46,7 @@ class VectorLayerScatterplot(QgisAlgorithm):
     OUTPUT = "OUTPUT"
     XFIELD = "XFIELD"
     YFIELD = "YFIELD"
-    HOVERTEXT = 'HOVERTEXT'
+    HOVERTEXT = "HOVERTEXT"
     TITLE = "TITLE"
     XAXIS_TITLE = "XAXIS_TITLE"
     YAXIS_TITLE = "YAXIS_TITLE"
@@ -86,7 +86,7 @@ class VectorLayerScatterplot(QgisAlgorithm):
         self.addParameter(
             QgsProcessingParameterExpression(
                 self.HOVERTEXT,
-                self.tr('Hover text'),
+                self.tr("Hover text"),
                 parentLayerParameterName=self.INPUT,
                 optional=True,
             )
@@ -182,14 +182,22 @@ class VectorLayerScatterplot(QgisAlgorithm):
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
 
-        hoverexpression = self.parameterAsExpression(parameters, self.HOVERTEXT, context)
+        hoverexpression = self.parameterAsExpression(
+            parameters, self.HOVERTEXT, context
+        )
         if hoverexpression.strip() != "":
             exp_context = QgsExpressionContext()
-            vlayer = QgsProcessingUtils.mapLayerFromString(parameters[self.INPUT], context)
-            exp_context.appendScopes(QgsExpressionContextUtils.globalProjectLayerScopes(vlayer))
+            vlayer = QgsProcessingUtils.mapLayerFromString(
+                parameters[self.INPUT], context
+            )
+            exp_context.appendScopes(
+                QgsExpressionContextUtils.globalProjectLayerScopes(vlayer)
+            )
             hoverexpression = QgsExpression(hoverexpression)
             if hoverexpression.hasParserError():
-                feedback.reportError(f"Expression evaluation error: {hoverexpression.evalErrorString()}")
+                feedback.reportError(
+                    f"Expression evaluation error: {hoverexpression.evalErrorString()}"
+                )
                 hoverexpression = None
         else:
             hoverexpression = None
@@ -217,8 +225,10 @@ class VectorLayerScatterplot(QgisAlgorithm):
                 exp_context.setFeature(feature)
                 txt = str(hoverexpression.evaluate(exp_context))
                 if hoverexpression.hasEvalError():
-                    txt = ''
-                    feedback.reportError(f"Expression evaluation error: {hoverexpression.evalErrorString()}")
+                    txt = ""
+                    feedback.reportError(
+                        f"Expression evaluation error: {hoverexpression.evalErrorString()}"
+                    )
                 hovertext.append(str(txt))
 
         data = [go.Scatter(x=values[xfieldname], y=values[yfieldname], mode="markers")]


### PR DESCRIPTION
## Description

In the processing algorithm "vector layer scatterplot", optionally add text that is shown on hover, such as the name of the feature. For more flexibility (i.e. to use several fields), a QGIS expression is used to define the text. This makes the algorithm much more useful for data exploration.

![hover](https://github.com/user-attachments/assets/d239f5fd-8f9b-4c28-95f8-5aa97750dfaa)

For comparison: hover label in QGIS 3.40:
![screenshot-hover-now](https://github.com/user-attachments/assets/cfc11995-7f5a-47ee-a1b0-4e5ccda67e16)

## Documentation

Related to merged PR #59366 

New parameter in "Vector layer scatterplot", https://docs.qgis.org/3.34/en/docs/user_manual/processing_algs/qgis/plots.html

Hover text | HOVERTEXT | [string] Default: "" | Text to be shown when hovering with the mouse

