### PR TITLE
[digitizing] Split features: always give largest geometry to original feature

### DIFF
--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -447,6 +447,22 @@ Qgis::GeometryOperationResult QgsVectorLayerEditUtils::splitFeatures( const QgsC
     topologyTestPoints.append( featureTopologyTestPoints );
     if ( splitFunctionReturn == Qgis::GeometryOperationResult::Success )
     {
+      //find largest geometry and give that to the original feature
+      std::function<double( const QgsGeometry & )> size = mLayer->geometryType() == Qgis::GeometryType::Polygon ? &QgsGeometry::area : &QgsGeometry::length;
+      double featureGeomSize = size( featureGeom );
+
+      QVector<QgsGeometry>::iterator largestNewFeature = std::max_element( newGeometries.begin(), newGeometries.end(), [ &size ]( const QgsGeometry & a, const QgsGeometry & b ) -> bool
+      {
+        return size( a ) < size( b );
+      } );
+
+      if ( size( *largestNewFeature ) > featureGeomSize )
+      {
+        QgsGeometry copy = *largestNewFeature;
+        *largestNewFeature = featureGeom;
+        featureGeom = copy;
+      }
+
       //change this geometry
       mLayer->changeGeometry( feat.id(), featureGeom );
 

--- a/tests/src/app/testqgsmaptoolsplitfeatures.cpp
+++ b/tests/src/app/testqgsmaptoolsplitfeatures.cpp
@@ -44,6 +44,8 @@ class TestQgsMapToolSplitFeatures : public QObject
     void testSplitSomeOfSelectedLines();
     // see https://github.com/qgis/QGIS/issues/29270
     void testSplitPolygonSnapToSegment();
+    void testLargestGeometryToOriginalFeaturePolygon();
+    void testLargestGeometryToOriginalFeatureLine();
 
   private:
     QPoint mapToPoint( double x, double y );
@@ -146,13 +148,17 @@ void TestQgsMapToolSplitFeatures::testSplitPolygon()
 {
   mCanvas->setCurrentLayer( mPolygonLayer );
 
+  QSet<QgsFeatureId> oldFids = mUtils->existingFeatureIds();
+
   mUtils->mouseClick( 4, 11, Qt::LeftButton );
   mUtils->mouseClick( 4, 3, Qt::LeftButton );
   mUtils->mouseClick( 4, 3, Qt::RightButton );
 
+  QgsFeatureId newFid = mUtils->newFeatureId( oldFids );
+
   QCOMPARE( mPolygonLayer->undoStack()->index(), 1 );
   QCOMPARE( mPolygonLayer->featureCount(), 3 );
-  QCOMPARE( mPolygonLayer->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon Z ((4 10 24, 4 5 14, 0 5 10, 0 10 20, 4 10 24))" ) );
+  QCOMPARE( mPolygonLayer->getFeature( newFid ).geometry().asWkt(), QStringLiteral( "Polygon Z ((4 10 24, 4 5 14, 0 5 10, 0 10 20, 4 10 24))" ) );
   QCOMPARE( mPolygonLayer->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon Z ((0 0 10, 0 5 20, 10 5 30, 0 0 10))" ) );
 
   // no change to other layers
@@ -165,13 +171,17 @@ void TestQgsMapToolSplitFeatures::testSplitPolygonTopologicalEditing()
   QgsProject::instance()->setTopologicalEditing( true );
   mCanvas->setCurrentLayer( mPolygonLayer );
 
+  QSet<QgsFeatureId> oldFids = mUtils->existingFeatureIds();
+
   mUtils->mouseClick( 4, 11, Qt::LeftButton );
   mUtils->mouseClick( 4, 3, Qt::LeftButton );
   mUtils->mouseClick( 4, 3, Qt::RightButton );
 
+  QgsFeatureId newFid = mUtils->newFeatureId( oldFids );
+
   QCOMPARE( mPolygonLayer->undoStack()->index(), 1 );
   QCOMPARE( mPolygonLayer->featureCount(), 3 );
-  QCOMPARE( mPolygonLayer->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon Z ((4 10 24, 4 5 14, 0 5 10, 0 10 20, 4 10 24))" ) );
+  QCOMPARE( mPolygonLayer->getFeature( newFid ).geometry().asWkt(), QStringLiteral( "Polygon Z ((4 10 24, 4 5 14, 0 5 10, 0 10 20, 4 10 24))" ) );
   QCOMPARE( mPolygonLayer->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon Z ((0 0 10, 0 5 20, 4 5 14, 10 5 30, 0 0 10))" ) );
 
   QCOMPARE( mMultiLineStringLayer->undoStack()->index(), 1 );
@@ -250,6 +260,52 @@ void TestQgsMapToolSplitFeatures::testSplitPolygonSnapToSegment()
   QCOMPARE( mMultiPolygonLayer->undoStack()->index(), 0 );
 
   mCanvas->snappingUtils()->setConfig( oldCfg );
+}
+
+void TestQgsMapToolSplitFeatures::testLargestGeometryToOriginalFeaturePolygon()
+{
+  mCanvas->setCurrentLayer( mPolygonLayer );
+
+  QSet<QgsFeatureId> oldFids = mUtils->existingFeatureIds();
+
+  mUtils->mouseClick( 1, 11, Qt::LeftButton );
+  mUtils->mouseClick( 1, 5, Qt::LeftButton );
+  mUtils->mouseClick( 1, 5, Qt::RightButton );
+
+  QgsFeatureId newFid = mUtils->newFeatureId( oldFids );
+
+  QCOMPARE( mPolygonLayer->featureCount(), 3 );
+
+  QgsFeature oldFeat = mPolygonLayer->getFeature( 1 );
+  QgsFeature newFeat = mPolygonLayer->getFeature( newFid );
+
+  //larger
+  QCOMPARE( oldFeat.geometry().asWkt(), QStringLiteral( "Polygon Z ((1 5 10, 1 10 21, 10 10 30, 10 5 20, 1 5 10))" ) );
+
+  //smaller
+  QCOMPARE( newFeat.geometry().asWkt(), QStringLiteral( "Polygon Z ((1 10 21, 1 5 10, 0 5 10, 0 10 20, 1 10 21))" ) );
+}
+
+void TestQgsMapToolSplitFeatures::testLargestGeometryToOriginalFeatureLine()
+{
+  mCanvas->setCurrentLayer( mMultiLineStringLayer );
+
+  QSet<QgsFeatureId> oldFids = mUtils->existingFeatureIds();
+
+  mUtils->mouseClick( 4, 1, Qt::LeftButton );
+  mUtils->mouseClick( 4, -1, Qt::LeftButton );
+  mUtils->mouseClick( 4, -1, Qt::RightButton );
+
+  QgsFeatureId newFid = mUtils->newFeatureId( oldFids );
+
+  QgsFeature oldFeat = mMultiLineStringLayer->getFeature( 1 );
+  QgsFeature newFeat = mMultiLineStringLayer->getFeature( newFid );
+
+  //larger
+  QCOMPARE( oldFeat.geometry().asWkt(), QStringLiteral( "MultiLineString ((4 0, 10 0))" ) );
+
+  //smaller
+  QCOMPARE( newFeat.geometry().asWkt(), QStringLiteral( "MultiLineString ((0 0, 4 0))" ) );
 }
 
 QGSTEST_MAIN( TestQgsMapToolSplitFeatures )

--- a/tests/src/python/test_qgsvectorlayereditutils.py
+++ b/tests/src/python/test_qgsvectorlayereditutils.py
@@ -752,9 +752,9 @@ class TestQgsVectorLayerEditUtils(QgisTestCase):
         self.assertCountEqual(
             attributes,
             [
-                [None, 3301.0, 302.0, 303.0, 8.664000000000001, 305.0],
+                [None, 3301.0, 302.0, 303.0, 277.53878260869567, 305.0],
+                [None, 301, 302.0, QgsUnsetAttributeValue(), 8.664000000000001, 305.0],
                 [None, 301, 302.0, QgsUnsetAttributeValue(), 17.797217391304347, 305.0],
-                [None, 301, 302.0, QgsUnsetAttributeValue(), 277.53878260869567, 305.0],
             ],
         )
 


### PR DESCRIPTION
Fixes #53696. **Backport to 3.40 requested.**

![split](https://github.com/user-attachments/assets/31aa3c51-e694-4902-b483-3ca0d593e65f)

Funded by the National Land Survey of Finland.