### PR TITLE
[elevation Profile] Correcly add a raster layer to an existing elevation profile widget

### DIFF
--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -410,7 +410,7 @@ Updates model when node's name has changed
 
     void layerFlagsChanged();
 %Docstring
-Emitted when layer flags have changed.
+Triggered when layer flags have changed.
 
 .. versionadded:: 3.18
 %End

--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -410,7 +410,7 @@ Updates model when node's name has changed
 
     void layerFlagsChanged();
 %Docstring
-Emitted when layer flags have changed.
+Triggered when layer flags have changed.
 
 .. versionadded:: 3.18
 %End

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -22,6 +22,7 @@
 #include "qgsapplication.h"
 #include "qgslayertree.h"
 #include "qgslayertreemodellegendnode.h"
+#include "qgsmaplayerelevationproperties.h"
 #include "qgsproject.h"
 #include "qgsmaphittest.h"
 #include "qgsmaplayer.h"
@@ -992,6 +993,11 @@ void QgsLayerTreeModel::connectToLayer( QgsLayerTreeLayer *nodeLayer )
   connect( layer, &QgsMapLayer::legendChanged, this, &QgsLayerTreeModel::layerLegendChanged, Qt::UniqueConnection );
   connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeModel::layerFlagsChanged, Qt::UniqueConnection );
 
+  if ( QgsMapLayerElevationProperties *elevationProperties = layer->elevationProperties() )
+  {
+    connect( elevationProperties, &QgsMapLayerElevationProperties::profileGenerationPropertyChanged, this, &QgsLayerTreeModel::layerProfileGenerationPropertyChanged, Qt::UniqueConnection );
+  }
+
   // using unique connection because there may be temporarily more nodes for a layer than just one
   // which would create multiple connections, however disconnect() would disconnect all multiple connections
   // even if we wanted to disconnect just one connection in each call.
@@ -1779,6 +1785,26 @@ void QgsLayerTreeModel::invalidateLegendMapBasedData()
   }
 
   mInvalidatedNodes.clear();
+}
+
+void QgsLayerTreeModel::layerProfileGenerationPropertyChanged()
+{
+  if ( !mRootNode )
+    return;
+
+  QgsMapLayerElevationProperties *elevationProperties = qobject_cast<QgsMapLayerElevationProperties *>( sender() );
+  if ( !elevationProperties )
+    return;
+
+  if ( QgsMapLayer *layer = qobject_cast< QgsMapLayer * >( elevationProperties->parent() ) )
+  {
+    QgsLayerTreeLayer *nodeLayer = mRootNode->findLayer( layer->id() );
+    if ( !nodeLayer )
+      return;
+
+    QModelIndex index = node2index( nodeLayer );
+    emit dataChanged( index, index );
+  }
 }
 
 // Legend nodes routines - end

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -394,6 +394,14 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
 
     void invalidateLegendMapBasedData();
 
+  private slots:
+
+    /**
+     * Triggered when layer elevation properties have changed.
+     * \since QGIS 3.42
+     */
+    void layerProfileGenerationPropertyChanged();
+
   protected:
     void removeLegendFromLayer( QgsLayerTreeLayer *nodeLayer );
     void addLegendToLayer( QgsLayerTreeLayer *nodeL );

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -383,7 +383,7 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
     void layerLegendChanged();
 
     /**
-     * Emitted when layer flags have changed.
+     * Triggered when layer flags have changed.
      * \since QGIS 3.18
      */
     void layerFlagsChanged();


### PR DESCRIPTION
## Issue
1. Create a new project
2. Open a new elevation profile
3. Open a Raster Layer
4. The Raster Layer is not added to the elevation profile widget

## Solution

If an elevation profile widget is already open, when a new raster layer is added, it is not added to the elevation widget treeview. Indeed, when a new raster is added,
`QgsRasterLayer::elevationProperties::hasElevation()` returns `False` by default and the proxy model of the elevation filters out the layers which do not have an elevation.

Later on, `QgsAppLayerHandling::postProcessAddedLayer` is called on this raster and it sets the elevation to `True` if it looks like a DEM (See
`QgsRasterLayerElevationProperties::layerLooksLikeDem()`). However, the layer tree of the elevation widget has already been populated and it is not updated.

This issue is fixed by emitting the the `dataChanged` signal every time the elevation properties of a layer changes. Indeed, this forces a full refresh of the model and displays the raster in that case.
