### PR TITLE
Script template - Add Python annotations

### DIFF
--- a/python/plugins/processing/script/ScriptTemplate.py
+++ b/python/plugins/processing/script/ScriptTemplate.py
@@ -9,14 +9,17 @@
 ***************************************************************************
 """
 
-from qgis.PyQt.QtCore import QCoreApplication
+from typing import Any, Optional
+
 from qgis.core import (
-    QgsProcessing,
     QgsFeatureSink,
-    QgsProcessingException,
+    QgsProcessing,
     QgsProcessingAlgorithm,
-    QgsProcessingParameterFeatureSource,
+    QgsProcessingContext,
+    QgsProcessingException,
+    QgsProcessingFeedback,
     QgsProcessingParameterFeatureSink,
+    QgsProcessingParameterFeatureSource,
 )
 from qgis import processing
 
@@ -42,16 +45,7 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
     INPUT = "INPUT"
     OUTPUT = "OUTPUT"
 
-    def tr(self, string):
-        """
-        Returns a translatable string with the self.tr() function.
-        """
-        return QCoreApplication.translate("Processing", string)
-
-    def createInstance(self):
-        return ExampleProcessingAlgorithm()
-
-    def name(self):
+    def name(self) -> str:
         """
         Returns the algorithm name, used for identifying the algorithm. This
         string should be fixed for the algorithm, and must not be localised.
@@ -61,21 +55,21 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
         """
         return "myscript"
 
-    def displayName(self):
+    def displayName(self) -> str:
         """
         Returns the translated algorithm name, which should be used for any
         user-visible display of the algorithm name.
         """
-        return self.tr("My Script")
+        return "My Script"
 
-    def group(self):
+    def group(self) -> str:
         """
         Returns the name of the group this algorithm belongs to. This string
         should be localised.
         """
-        return self.tr("Example scripts")
+        return "Example scripts"
 
-    def groupId(self):
+    def groupId(self) -> str:
         """
         Returns the unique ID of the group this algorithm belongs to. This
         string should be fixed for the algorithm, and must not be localised.
@@ -85,15 +79,15 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
         """
         return "examplescripts"
 
-    def shortHelpString(self):
+    def shortHelpString(self) -> str:
         """
         Returns a localised short helper string for the algorithm. This string
         should provide a basic description about what the algorithm does and the
-        parameters and outputs associated with it..
+        parameters and outputs associated with it.
         """
-        return self.tr("Example algorithm short description")
+        return "Example algorithm short description"
 
-    def initAlgorithm(self, config=None):
+    def initAlgorithm(self, config: Optional[dict[str, Any]] = None):
         """
         Here we define the inputs and output of the algorithm, along
         with some other properties.
@@ -104,7 +98,7 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
         self.addParameter(
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
-                self.tr("Input layer"),
+                "Input layer",
                 [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
@@ -113,10 +107,15 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
         # usually takes the form of a newly created vector layer when the
         # algorithm is run in QGIS).
         self.addParameter(
-            QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr("Output layer"))
+            QgsProcessingParameterFeatureSink(self.OUTPUT, "Output layer")
         )
 
-    def processAlgorithm(self, parameters, context, feedback):
+    def processAlgorithm(
+        self,
+        parameters: dict[str, Any],
+        context: QgsProcessingContext,
+        feedback: QgsProcessingFeedback,
+    ) -> dict[str, Any]:
         """
         Here is where the processing itself takes place.
         """
@@ -199,3 +198,6 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
         # dictionary, with keys matching the feature corresponding parameter
         # or output names.
         return {self.OUTPUT: dest_id}
+
+    def createInstance(self):
+        return self.__class__()


### PR DESCRIPTION
I think it would be nice to have some Python annotations.
It gives an hint for new comers about what are these objects.

If accepted, it would be nice to have in the 3.40.


Side question, what do you think of dropping `self.tr()` method from this template ?
A Processing script cannot be translated I think, the probability that someone will need a translated version of the script is low as well (he would need to go with a normal QGIS plugin).
It would decrease a little bit the comprehension of the "tutorial script" without the `self.tr`.