### PR TITLE
[relations] Show polymorphic relation name in config dialog

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -146,7 +146,17 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
 
   for ( const QgsRelation &relation : relations )
   {
-    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relation.id(), relation.name() );
+    QString name;
+    const QgsPolymorphicRelation polymorphicRelation = relation.polymorphicRelation();
+    if( polymorphicRelation.isValid() )
+    {
+      name = QStringLiteral( "%1 (%2)" ).arg( relation.name(), polymorphicRelation.name() );
+    }
+    else
+    {
+      name = relation.name();
+    }
+    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relation.id(), name );
     itemData.setShowLabel( true );
     QTreeWidgetItem *item = mAvailableWidgetsTree->addItem( catitem, itemData );
     item->setData( 0, FieldNameRole, relation.id() );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -148,7 +148,7 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
   {
     QString name;
     const QgsPolymorphicRelation polymorphicRelation = relation.polymorphicRelation();
-    if( polymorphicRelation.isValid() )
+    if ( polymorphicRelation.isValid() )
     {
       name = QStringLiteral( "%1 (%2)" ).arg( relation.name(), polymorphicRelation.name() );
     }


### PR DESCRIPTION
## Description

Add the name of the polymorphic relation in the attribute form dialog, so generated relations can be distinguished.

![image](https://github.com/user-attachments/assets/fd1d0353-5d9d-41c9-a983-5f9004585ba8)

The name can be edited in the relation configuration dialog (project properties)

Fixes https://github.com/qgis/QGIS/issues/59803