### PR TITLE
[PyQGIS] Add message to /Deprecated/ annotations

### DIFF
--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -63,6 +63,14 @@ MACRO(GENERATE_SIP_PYTHON_MODULE_CODE MODULE_NAME MODULE_SIP SIP_FILES CPP_FILES
     FILE(RELATIVE_PATH _sip_file_relpath ${BINDING_FILES_ROOT_DIR} "${_sip_file_path}/${_sip_file_name_we}")
     SET(_out_sip_file "${CMAKE_CURRENT_BINARY_DIR}/${_sip_file_relpath}.sip")
     CONFIGURE_FILE(${_sip_file} ${_out_sip_file})
+
+    # Deprecated annotation supports message only since version 6.9.0
+    if(${SIP_VERSION_STR} VERSION_LESS 6.9.0)
+      file(READ ${_out_sip_file} _content)
+      string(REGEX REPLACE "([/,])Deprecated=\"[^\"]*\"([/,])" "\\1Deprecated\\2" _content "${_content}")
+      file(GENERATE OUTPUT ${_out_sip_file} CONTENT "${_content}")
+    endif()
+
   ENDFOREACH (_sip_file)
 
   SET(_message "-DMESSAGE=Generating CPP code for module ${MODULE_NAME}")

--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -132,7 +132,7 @@ it may be useful to temporarily disable scene updates.
 .. versionadded:: 3.40
 %End
 
- static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated/;
+ static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated="Since 3.36. Use QgisAppInterface.mapCanvases3D() instead."/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.
 

--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -230,7 +230,7 @@ Sets the terrain settings.
 .. versionadded:: 3.42
 %End
 
- void setTerrainVerticalScale( double zScale ) /Deprecated/;
+ void setTerrainVerticalScale( double zScale ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets vertical scale (exaggeration) of terrain
 (1 = true scale, > 1 = hills get more pronounced)
@@ -240,7 +240,7 @@ Sets vertical scale (exaggeration) of terrain
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double terrainVerticalScale() const /Deprecated/;
+ double terrainVerticalScale() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns vertical scale (exaggeration) of terrain
 
@@ -249,7 +249,7 @@ Returns vertical scale (exaggeration) of terrain
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setMapTileResolution( int res ) /Deprecated/;
+ void setMapTileResolution( int res ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets resolution (in pixels) of the texture of a terrain tile
 
@@ -260,7 +260,7 @@ Sets resolution (in pixels) of the texture of a terrain tile
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- int mapTileResolution() const /Deprecated/;
+ int mapTileResolution() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns resolution (in pixels) of the texture of a terrain tile. This parameter influences
 how many zoom levels for terrain tiles there will be (together with :py:func:`~Qgs3DMapSettings.maxTerrainGroundError`)
@@ -270,7 +270,7 @@ how many zoom levels for terrain tiles there will be (together with :py:func:`~Q
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setMaxTerrainScreenError( double error ) /Deprecated/;
+ void setMaxTerrainScreenError( double error ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets maximum allowed screen error of terrain tiles in pixels.
 
@@ -281,7 +281,7 @@ Sets maximum allowed screen error of terrain tiles in pixels.
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double maxTerrainScreenError() const /Deprecated/;
+ double maxTerrainScreenError() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns maximum allowed screen error of terrain tiles in pixels. This parameter decides
 how aggressively less detailed terrain tiles are swapped to more detailed ones as camera gets closer.
@@ -294,7 +294,7 @@ be swapped by more detailed tiles with lower error.
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setMaxTerrainGroundError( double error ) /Deprecated/;
+ void setMaxTerrainGroundError( double error ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets the maximum ground error of terrain tiles in world units.
 
@@ -305,7 +305,7 @@ Sets the maximum ground error of terrain tiles in world units.
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double maxTerrainGroundError() const /Deprecated/;
+ double maxTerrainGroundError() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns maximum ground error of terrain tiles in world units. This parameter influences
 how many zoom levels there will be (together with :py:func:`~Qgs3DMapSettings.mapTileResolution`).
@@ -317,7 +317,7 @@ to further split terrain tiles into finer ones because they will not add extra d
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setTerrainElevationOffset( double offset ) /Deprecated/;
+ void setTerrainElevationOffset( double offset ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets the terrain elevation offset (used to move the terrain up or down)
 
@@ -328,7 +328,7 @@ Sets the terrain elevation offset (used to move the terrain up or down)
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double terrainElevationOffset() const /Deprecated/;
+ double terrainElevationOffset() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns the elevation offset of the terrain (used to move the terrain up or down)
 
@@ -837,7 +837,7 @@ Emitted when the terrain settings are changed.
 .. versionadded:: 3.42
 %End
 
- void terrainVerticalScaleChanged() /Deprecated/;
+ void terrainVerticalScaleChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the vertical scale of the terrain has changed
 
@@ -846,7 +846,7 @@ Emitted when the vertical scale of the terrain has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void mapTileResolutionChanged() /Deprecated/;
+ void mapTileResolutionChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the map tile resoulution has changed
 
@@ -855,7 +855,7 @@ Emitted when the map tile resoulution has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void maxTerrainScreenErrorChanged() /Deprecated/;
+ void maxTerrainScreenErrorChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the maximum terrain screen error has changed
 
@@ -864,7 +864,7 @@ Emitted when the maximum terrain screen error has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void maxTerrainGroundErrorChanged() /Deprecated/;
+ void maxTerrainGroundErrorChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the maximum terrain ground error has changed
 
@@ -873,7 +873,7 @@ Emitted when the maximum terrain ground error has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void terrainElevationOffsetChanged( double newElevation ) /Deprecated/;
+ void terrainElevationOffsetChanged( double newElevation ) /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the terrain elevation offset is changed
 

--- a/python/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
@@ -75,7 +75,7 @@ Returns width of the line symbol (in map units)
 Sets width of the line symbol (in map units)
 %End
 
- float height() const /Deprecated/;
+ float height() const /Deprecated="Since 3.36. Use offset() instead."/;
 %Docstring
 Returns height (altitude) of the symbol (in map units)
 
@@ -84,7 +84,7 @@ Returns height (altitude) of the symbol (in map units)
    Use :py:func:`~QgsLine3DSymbol.offset` instead.
 %End
 
- void setHeight( float height ) /Deprecated/;
+ void setHeight( float height ) /Deprecated="Since 3.36. Use setOffset() instead."/;
 %Docstring
 Sets height (altitude) of the symbol (in map units)
 

--- a/python/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
@@ -67,7 +67,7 @@ Returns method that determines how altitude is bound to individual vertices
 Sets method that determines how altitude is bound to individual vertices
 %End
 
- float height() const /Deprecated/;
+ float height() const /Deprecated="Since 3.36. Use offset() instead."/;
 %Docstring
 Returns height (altitude) of the symbol (in map units)
 
@@ -76,7 +76,7 @@ Returns height (altitude) of the symbol (in map units)
    Use :py:func:`~QgsPolygon3DSymbol.offset` instead.
 %End
 
- void setHeight( float height ) /Deprecated/;
+ void setHeight( float height ) /Deprecated="Since 3.36. Use setOffset() instead."/;
 %Docstring
 Sets height (altitude) of the symbol (in map units)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -371,18 +371,21 @@ if(WITH_QSCIAPI)
      set(_python ${Python_EXECUTABLE})
   endif()
 
-  configure_file("${APIS_SRC_DIR}/generate_console_pap.py.in" ${CMAKE_BINARY_DIR}/generate_console_pap.py)
+  if (QSCI_SIP_DIR)
+    configure_file("${APIS_SRC_DIR}/generate_console_pap.py.in" ${CMAKE_BINARY_DIR}/generate_console_pap.py)
 
-  add_custom_command(
-    OUTPUT "${QGIS_PYTHON_PAP_FILE}"
-    DEPENDS "${QGIS_PYTHON_API_FILE}"
-    COMMAND ${_python} "${CMAKE_BINARY_DIR}/generate_console_pap.py" -platform offscreen "${QGIS_PYTHON_PAP_FILE}" "${APIS_SRC_DIR}" "${APIS_OUT_DIR}"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-    COMMENT "Generating pap file for console auto-completion" VERBATIM)
+    add_custom_command(
+      OUTPUT "${QGIS_PYTHON_PAP_FILE}"
+      DEPENDS "${QGIS_PYTHON_API_FILE}"
+      COMMAND ${_python} "${CMAKE_BINARY_DIR}/generate_console_pap.py" -platform offscreen "${QGIS_PYTHON_PAP_FILE}" "${APIS_SRC_DIR}" "${APIS_OUT_DIR}"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+      COMMENT "Generating pap file for console auto-completion" VERBATIM)
 
-  ADD_QGIS_RESOURCES("${APIS_OUT_DIR}" "python/qsci_apis" DEST_DATA_FILES "PyQGIS.api;PyQGIS.pap")
+    ADD_QGIS_RESOURCES("${APIS_OUT_DIR}" "python/qsci_apis" DEST_DATA_FILES "PyQGIS.api;PyQGIS.pap")
 
-  add_custom_target(pyqgis-pap ALL DEPENDS ${QGIS_PYTHON_API_FILE} ${QGIS_PYTHON_PAP_FILE} ${DEST_DATA_FILES})
+    add_custom_target(pyqgis-pap ALL DEPENDS ${QGIS_PYTHON_API_FILE} ${QGIS_PYTHON_PAP_FILE} ${DEST_DATA_FILES})
+  endif()
+
 endif()
 
 if(WITH_CUSTOM_WIDGETS)
@@ -463,4 +466,3 @@ foreach(module ${PY_MODULES})
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${module}/auto_generated DESTINATION ${SIP_DEFAULT_SIP_DIR}/qgis/${module})
   endif()
 endforeach(module)
-

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -132,7 +132,7 @@ it may be useful to temporarily disable scene updates.
 .. versionadded:: 3.40
 %End
 
- static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated/;
+ static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated="Since 3.36. Use QgisAppInterface.mapCanvases3D() instead."/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.
 

--- a/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -230,7 +230,7 @@ Sets the terrain settings.
 .. versionadded:: 3.42
 %End
 
- void setTerrainVerticalScale( double zScale ) /Deprecated/;
+ void setTerrainVerticalScale( double zScale ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets vertical scale (exaggeration) of terrain
 (1 = true scale, > 1 = hills get more pronounced)
@@ -240,7 +240,7 @@ Sets vertical scale (exaggeration) of terrain
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double terrainVerticalScale() const /Deprecated/;
+ double terrainVerticalScale() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns vertical scale (exaggeration) of terrain
 
@@ -249,7 +249,7 @@ Returns vertical scale (exaggeration) of terrain
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setMapTileResolution( int res ) /Deprecated/;
+ void setMapTileResolution( int res ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets resolution (in pixels) of the texture of a terrain tile
 
@@ -260,7 +260,7 @@ Sets resolution (in pixels) of the texture of a terrain tile
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- int mapTileResolution() const /Deprecated/;
+ int mapTileResolution() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns resolution (in pixels) of the texture of a terrain tile. This parameter influences
 how many zoom levels for terrain tiles there will be (together with :py:func:`~Qgs3DMapSettings.maxTerrainGroundError`)
@@ -270,7 +270,7 @@ how many zoom levels for terrain tiles there will be (together with :py:func:`~Q
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setMaxTerrainScreenError( double error ) /Deprecated/;
+ void setMaxTerrainScreenError( double error ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets maximum allowed screen error of terrain tiles in pixels.
 
@@ -281,7 +281,7 @@ Sets maximum allowed screen error of terrain tiles in pixels.
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double maxTerrainScreenError() const /Deprecated/;
+ double maxTerrainScreenError() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns maximum allowed screen error of terrain tiles in pixels. This parameter decides
 how aggressively less detailed terrain tiles are swapped to more detailed ones as camera gets closer.
@@ -294,7 +294,7 @@ be swapped by more detailed tiles with lower error.
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setMaxTerrainGroundError( double error ) /Deprecated/;
+ void setMaxTerrainGroundError( double error ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets the maximum ground error of terrain tiles in world units.
 
@@ -305,7 +305,7 @@ Sets the maximum ground error of terrain tiles in world units.
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double maxTerrainGroundError() const /Deprecated/;
+ double maxTerrainGroundError() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns maximum ground error of terrain tiles in world units. This parameter influences
 how many zoom levels there will be (together with :py:func:`~Qgs3DMapSettings.mapTileResolution`).
@@ -317,7 +317,7 @@ to further split terrain tiles into finer ones because they will not add extra d
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- void setTerrainElevationOffset( double offset ) /Deprecated/;
+ void setTerrainElevationOffset( double offset ) /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Sets the terrain elevation offset (used to move the terrain up or down)
 
@@ -328,7 +328,7 @@ Sets the terrain elevation offset (used to move the terrain up or down)
    Use :py:func:`~Qgs3DMapSettings.terrainSettings` instead.
 %End
 
- double terrainElevationOffset() const /Deprecated/;
+ double terrainElevationOffset() const /Deprecated="Since 3.42. Use terrainSettings() instead."/;
 %Docstring
 Returns the elevation offset of the terrain (used to move the terrain up or down)
 
@@ -837,7 +837,7 @@ Emitted when the terrain settings are changed.
 .. versionadded:: 3.42
 %End
 
- void terrainVerticalScaleChanged() /Deprecated/;
+ void terrainVerticalScaleChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the vertical scale of the terrain has changed
 
@@ -846,7 +846,7 @@ Emitted when the vertical scale of the terrain has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void mapTileResolutionChanged() /Deprecated/;
+ void mapTileResolutionChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the map tile resoulution has changed
 
@@ -855,7 +855,7 @@ Emitted when the map tile resoulution has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void maxTerrainScreenErrorChanged() /Deprecated/;
+ void maxTerrainScreenErrorChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the maximum terrain screen error has changed
 
@@ -864,7 +864,7 @@ Emitted when the maximum terrain screen error has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void maxTerrainGroundErrorChanged() /Deprecated/;
+ void maxTerrainGroundErrorChanged() /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the maximum terrain ground error has changed
 
@@ -873,7 +873,7 @@ Emitted when the maximum terrain ground error has changed
    Use :py:func:`~Qgs3DMapSettings.terrainSettingsChanged` instead.
 %End
 
- void terrainElevationOffsetChanged( double newElevation ) /Deprecated/;
+ void terrainElevationOffsetChanged( double newElevation ) /Deprecated="Since 3.42. Use terrainSettingsChanged() instead."/;
 %Docstring
 Emitted when the terrain elevation offset is changed
 

--- a/python/PyQt6/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
+++ b/python/PyQt6/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
@@ -75,7 +75,7 @@ Returns width of the line symbol (in map units)
 Sets width of the line symbol (in map units)
 %End
 
- float height() const /Deprecated/;
+ float height() const /Deprecated="Since 3.36. Use offset() instead."/;
 %Docstring
 Returns height (altitude) of the symbol (in map units)
 
@@ -84,7 +84,7 @@ Returns height (altitude) of the symbol (in map units)
    Use :py:func:`~QgsLine3DSymbol.offset` instead.
 %End
 
- void setHeight( float height ) /Deprecated/;
+ void setHeight( float height ) /Deprecated="Since 3.36. Use setOffset() instead."/;
 %Docstring
 Sets height (altitude) of the symbol (in map units)
 

--- a/python/PyQt6/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
+++ b/python/PyQt6/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
@@ -67,7 +67,7 @@ Returns method that determines how altitude is bound to individual vertices
 Sets method that determines how altitude is bound to individual vertices
 %End
 
- float height() const /Deprecated/;
+ float height() const /Deprecated="Since 3.36. Use offset() instead."/;
 %Docstring
 Returns height (altitude) of the symbol (in map units)
 
@@ -76,7 +76,7 @@ Returns height (altitude) of the symbol (in map units)
    Use :py:func:`~QgsPolygon3DSymbol.offset` instead.
 %End
 
- void setHeight( float height ) /Deprecated/;
+ void setHeight( float height ) /Deprecated="Since 3.36. Use setOffset() instead."/;
 %Docstring
 Sets height (altitude) of the symbol (in map units)
 

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -97,7 +97,7 @@ QgsRasterCalculator constructor.
 %End
 
 
- QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated/;
+ QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated="Since 3.8. Use the version with transformContext instead."/;
 %Docstring
 QgsRasterCalculator constructor.
 
@@ -114,7 +114,7 @@ QgsRasterCalculator constructor.
    Use the version with transformContext instead.
 %End
 
- QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated/;
+ QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated="Since 3.8. Use the version with transformContext instead."/;
 %Docstring
 QgsRasterCalculator constructor.
 

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -191,7 +191,7 @@ Returns a list of available resolution methods.
 .. versionadded:: 3.12
 %End
 
- virtual QStringList resolutionMethods() const /Deprecated/;
+ virtual QStringList resolutionMethods() const /Deprecated="Since 3.12. Use availableResolutionMethods() instead."/;
 %Docstring
 Returns a list of descriptions for available resolutions for errors.
 The index will be passed as ``method`` to :py:func:`fixError`.

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotation.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotation.sip.in
@@ -144,7 +144,7 @@ the relative percentage for the position compared to the map width and height.
 .. seealso:: :py:func:`relativePosition`
 %End
 
- void setFrameOffsetFromReferencePoint( QPointF offset ) /Deprecated/;
+ void setFrameOffsetFromReferencePoint( QPointF offset ) /Deprecated="Since 3.40. Use setFrameOffsetFromReferencePointMm() instead."/;
 %Docstring
 Sets the annotation's frame's offset (in pixels) from the :py:func:`~QgsAnnotation.mapPosition` reference point.
 
@@ -155,7 +155,7 @@ Sets the annotation's frame's offset (in pixels) from the :py:func:`~QgsAnnotati
    Use :py:func:`~QgsAnnotation.setFrameOffsetFromReferencePointMm` instead.
 %End
 
- QPointF frameOffsetFromReferencePoint() const /Deprecated/;
+ QPointF frameOffsetFromReferencePoint() const /Deprecated="Since 3.40. Use frameOffsetFromReferencePointMm() instead."/;
 %Docstring
 Returns the annotation's frame's offset (in pixels) from the :py:func:`~QgsAnnotation.mapPosition` reference point.
 
@@ -184,7 +184,7 @@ Returns the annotation's frame's offset (in millimeters) from the :py:func:`~Qgs
 .. versionadded:: 3.4.8
 %End
 
- void setFrameSize( QSizeF size ) /Deprecated/;
+ void setFrameSize( QSizeF size ) /Deprecated="Since 3.40. Use setFrameSizeMm() instead."/;
 %Docstring
 Sets the size (in pixels) of the annotation's frame (the main area in which
 the annotation's content is drawn).
@@ -196,7 +196,7 @@ the annotation's content is drawn).
    Use :py:func:`~QgsAnnotation.setFrameSizeMm` instead.
 %End
 
- QSizeF frameSize() const /Deprecated/;
+ QSizeF frameSize() const /Deprecated="Since 3.40. Use frameSizeMm() instead."/;
 %Docstring
 Returns the size (in pixels) of the annotation's frame (the main area in which
 the annotation's content is drawn).

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationitem.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationitem.sip.in
@@ -123,7 +123,7 @@ Implementations should include a call to :py:func:`~QgsAnnotationItem.readCommon
 .. seealso:: :py:func:`readCommonProperties`
 %End
 
- virtual Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated/;
+ virtual Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated="Since 3.40. Use applyEditV2() instead."/;
 %Docstring
 Applies an edit ``operation`` to the item.
 
@@ -189,7 +189,7 @@ Sets if the item will be rendered or not in the layer.
 .. versionadded:: 3.36
 %End
 
- virtual QList< QgsAnnotationItemNode > nodes() const /Deprecated/;
+ virtual QList< QgsAnnotationItemNode > nodes() const /Deprecated="Since 3.40. Use nodesV2() instead."/;
 %Docstring
 Returns the nodes for the item, used for editing the item.
 

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -120,7 +120,7 @@ The optional ``feedback`` argument can be used to cancel the search early.
 .. versionadded:: 3.22
 %End
 
- Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated/;
+ Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated="Since 3.40. Use applyEditV2() instead."/;
 %Docstring
 Applies an edit ``operation`` to the layer.
 

--- a/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -34,7 +34,7 @@ and to utilize configurations through various authentication method plugins
       CRITICAL
     };
 
- bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) /Deprecated/;
+ bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) /Deprecated="Since 3.36. Use setup() or ensureInitialized() instead."/;
 %Docstring
 init initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
 
@@ -84,7 +84,7 @@ Returns the authentication configuration storage registry.
 .. versionadded:: 3.40
 %End
 
- QSqlDatabase authDatabaseConnection() const /Deprecated/;
+ QSqlDatabase authDatabaseConnection() const /Deprecated="Since 3.40. Direct access to the DB is not allowed, use QgsAuthConfigurationStorage API instead."/;
 %Docstring
 Sets up the application instance of the authentication database connection
 
@@ -93,7 +93,7 @@ Sets up the application instance of the authentication database connection
    Direct access to the DB is not allowed, use :py:class:`QgsAuthConfigurationStorage` API instead.
 %End
 
- const QString authDatabaseConfigTable() const /Deprecated/;
+ const QString authDatabaseConfigTable() const /Deprecated="Since 3.40. Direct access to the DB is not allowed, use methodConfigTableName() instead."/;
 %Docstring
 Name of the authentication database table that stores configs
 
@@ -110,7 +110,7 @@ or an empty string if none available. The table is prefixed with schema and esca
 .. versionadded:: 3.40
 %End
 
- const QString authDatabaseServersTable() const /Deprecated/;
+ const QString authDatabaseServersTable() const /Deprecated="Since 3.40. Direct access to the DB is not allowed, use QgsAuthConfigurationStorage API instead."/;
 %Docstring
 Name of the authentication database table that stores server exceptions/configs
 
@@ -829,7 +829,7 @@ Signals emitted on password helper success,
 mainly used in the tests to exit main application loop
 %End
 
- void messageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) const /Deprecated/;
+ void messageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) const /Deprecated="Since 3.40. Use messageLog() instead."/;
 %Docstring
 Custom logging signal to relay to console output and :py:class:`QgsMessageLog`
 
@@ -857,7 +857,7 @@ Custom logging signal to relay to console output and :py:class:`QgsMessageLog`
 .. versionadded:: 3.40
 %End
 
- void passwordHelperMessageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) /Deprecated/;
+ void passwordHelperMessageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) /Deprecated="Since 3.40. Use passwordHelperMessageLog() instead."/;
 %Docstring
 Custom logging signal to inform the user about master password <-> password manager interactions
 

--- a/python/PyQt6/core/auto_generated/browser/qgsbrowsermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsbrowsermodel.sip.in
@@ -142,7 +142,7 @@ items, i.e. it does not fetch children.
 .. versionadded:: 3.6
 %End
 
- void connectItem( QgsDataItem *item ) /Deprecated/;
+ void connectItem( QgsDataItem *item ) /Deprecated="Since 3.4. This method has no effect, and is dangerous to call in earlier QGIS versions. Any usage should be removed (and will have no harmful side-effects!)."/;
 %Docstring
 
 .. deprecated:: 3.4

--- a/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
@@ -154,7 +154,7 @@ Removes a child item and returns it without deleting it. Emits relevant signals 
 Returns ``True`` if this item is equal to another item (by testing item type and path).
 %End
 
- virtual QWidget *paramWidget() /Factory,Deprecated/;
+ virtual QWidget *paramWidget() /Factory,Deprecated="Since 3.10. "/;
 %Docstring
 Returns source widget from data item for :py:class:`QgsBrowserPropertiesWidget`
 
@@ -183,7 +183,7 @@ created menus is correctly handled by parenting them to the specified parent wid
 :return: list of menus
 %End
 
- virtual bool acceptDrop() /Deprecated/;
+ virtual bool acceptDrop() /Deprecated="Since 3.10. "/;
 %Docstring
 Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.
 Subclasses should override this and :py:func:`~QgsDataItem.handleDrop` to accept dropped layers.
@@ -196,7 +196,7 @@ Subclasses should override this and :py:func:`~QgsDataItem.handleDrop` to accept
 %End
 
 
- virtual bool handleDrop( const QMimeData * /*data*/, Qt::DropAction /*action*/ ) /Deprecated/;
+ virtual bool handleDrop( const QMimeData * /*data*/, Qt::DropAction /*action*/ ) /Deprecated="Since 3.10. "/;
 %Docstring
 Attempts to process the mime data dropped on this item. Subclasses must override this and :py:func:`~QgsDataItem.acceptDrop` if they
 accept dropped layers.
@@ -224,7 +224,7 @@ A draggable item has to implement :py:func:`~QgsDataItem.mimeUris` that will be 
 .. seealso:: :py:func:`mimeUris`
 %End
 
- virtual QgsMimeDataUtils::Uri mimeUri() const /Deprecated/;
+ virtual QgsMimeDataUtils::Uri mimeUri() const /Deprecated="Since 3.18. Use mimeUris() instead."/;
 %Docstring
 Returns mime URI for the data item.
 Items that return valid URI will be returned in mime data when dragging a selection from browser model.
@@ -247,7 +247,7 @@ Items that return valid URI will be returned in mime data when dragging a select
 .. versionadded:: 3.18
 %End
 
- virtual bool setCrs( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ virtual bool setCrs( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.6. This method is no longer used by QGIS and will be removed in QGIS 4.0."/;
 %Docstring
 Writes the selected crs into data source. The original data source will be modified when calling this
 method.
@@ -257,7 +257,7 @@ method.
    This method is no longer used by QGIS and will be removed in QGIS 4.0.
 %End
 
- virtual bool rename( const QString &name ) /Deprecated/;
+ virtual bool rename( const QString &name ) /Deprecated="Since 3.10. "/;
 %Docstring
 Sets a new ``name`` for the item, and returns ``True`` if the item was successfully renamed.
 
@@ -287,7 +287,7 @@ Sets the capabilities for the data item.
 .. seealso:: :py:func:`capabilities2`
 %End
 
- void setCapabilities( int capabilities ) /Deprecated/;
+ void setCapabilities( int capabilities ) /Deprecated="Since 3.40. Use setCapabilitiesV2() instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/PyQt6/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -109,6 +109,10 @@ If ``color`` is an invalid color then the default icon color will be used.
 
  virtual QWidget *paramWidget() /Factory,Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.20
+%End
     virtual bool hasDragEnabled() const;
     virtual QgsMimeDataUtils::UriList mimeUris() const;
 
@@ -214,8 +218,6 @@ Browser parameter widget implementation for directory items.
   public slots:
     void showHideColumn();
 };
-
-
 
 
 

--- a/python/PyQt6/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -107,7 +107,7 @@ If ``color`` is an invalid color then the default icon color will be used.
 .. versionadded:: 3.20
 %End
 
- virtual QWidget *paramWidget() /Factory,Deprecated/;
+ virtual QWidget *paramWidget() /Factory,Deprecated="Since 3.20. "/;
 
 %Docstring
 

--- a/python/PyQt6/core/auto_generated/browser/qgslayeritem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgslayeritem.sip.in
@@ -86,7 +86,7 @@ Returns the icon name of the given ``layerType``
 .. versionadded:: 3
 %End
 
- virtual bool deleteLayer() /Deprecated/;
+ virtual bool deleteLayer() /Deprecated="Since 3.10. "/;
 %Docstring
 Delete this layer item
 Use :py:class:`QgsDataItemGuiProvider`.deleteLayer instead

--- a/python/PyQt6/core/auto_generated/browser/qgszipitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgszipitem.sip.in
@@ -47,7 +47,7 @@ Constructor
 
     static QStringList sProviderNames;
 
- static QString vsiPrefix( const QString &uri ) /Deprecated/;
+ static QString vsiPrefix( const QString &uri ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
@@ -442,7 +442,7 @@ The ``calloutContext`` argument is used to specify additional contextual informa
 how a callout is being rendered.
 %End
 
- QgsGeometry labelAnchorGeometry( const QRectF &bodyBoundingBox, const double angle, LabelAnchorPoint anchor ) const /Deprecated/;
+ QgsGeometry labelAnchorGeometry( const QRectF &bodyBoundingBox, const double angle, LabelAnchorPoint anchor ) const /Deprecated="Since 3.20. Use calloutLabelPoint() instead."/;
 %Docstring
 Returns the anchor point geometry for a label with the given bounding box and ``anchor`` point mode.
 

--- a/python/PyQt6/core/auto_generated/classification/qgsclassificationmethod.sip.in
+++ b/python/PyQt6/core/auto_generated/classification/qgsclassificationmethod.sip.in
@@ -240,7 +240,7 @@ Defines if the trailing 0 are trimmed in the label
 Transforms a list of classes to a list of breaks
 %End
 
- QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses ) /Deprecated/;
+ QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses ) /Deprecated="Since 3.38. Use classesV2() instead."/;
 %Docstring
 This will calculate the classes for a given layer to define the classes.
 

--- a/python/PyQt6/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
+++ b/python/PyQt6/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
@@ -55,7 +55,7 @@ Returns the container type.
 .. versionadded:: 3.32
 %End
 
- virtual void setIsGroupBox( bool isGroupBox ) /Deprecated/;
+ virtual void setIsGroupBox( bool isGroupBox ) /Deprecated="Since 3.40. Use setType() instead."/;
 %Docstring
 Determines if this container is rendered as collapsible group box or tab in a tabwidget
 
@@ -66,7 +66,7 @@ Determines if this container is rendered as collapsible group box or tab in a ta
    Use :py:func:`~QgsAttributeEditorContainer.setType` instead.
 %End
 
- virtual bool isGroupBox() const /Deprecated/;
+ virtual bool isGroupBox() const /Deprecated="Since 3.40. Use type() instead."/;
 %Docstring
 Returns if this container is going to be a group box
 

--- a/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -266,7 +266,7 @@ Write XML information
 Serialize on project save
 %End
 
- QgsAttributeEditorElement *attributeEditorElementFromDomElement( QDomElement &elem, QgsAttributeEditorElement *parent, const QString &layerId = QString(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Deprecated/;
+ QgsAttributeEditorElement *attributeEditorElementFromDomElement( QDomElement &elem, QgsAttributeEditorElement *parent, const QString &layerId = QString(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Deprecated="Since 3.18. Use QgsAttributeEditorElement.create instead."/;
 %Docstring
 Deserialize drag and drop designer elements.
 

--- a/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
@@ -302,7 +302,7 @@ effects.
 .. seealso:: :py:func:`sourceAsImage`
 %End
 
- void fixQPictureDpi( QPainter *painter ) const /Deprecated/;
+ void fixQPictureDpi( QPainter *painter ) const /Deprecated="Since 3.40. Use QgsPainting.drawPicture() or QgsPainting.applyScaleFixForQPictureDpi() instead."/;
 %Docstring
 Applies a workaround to a QPainter to avoid an issue with incorrect scaling
 when drawing QPictures. This may need to be called by derived classes prior

--- a/python/PyQt6/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpression.sip.in
@@ -562,7 +562,7 @@ quotations where required.
 .. seealso:: :py:func:`quotedColumnRef`
 %End
 
- static QString quotedValue( const QVariant &value, QVariant::Type type ) /Deprecated/;
+ static QString quotedValue( const QVariant &value, QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Returns a string representation of a literal value, including appropriate
 quotations where required.
@@ -673,7 +673,7 @@ value. The value may be null.
 :return: the expression to evaluate field equality
 %End
 
- static QString createFieldEqualityExpression( const QString &fieldName, const QVariant &value, QVariant::Type fieldType ) /Deprecated/;
+ static QString createFieldEqualityExpression( const QString &fieldName, const QVariant &value, QVariant::Type fieldType ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Create an expression allowing to evaluate if a field is equal to a
 value. The value may be null.

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -46,7 +46,7 @@ The type is expected to be one of
 - QVariant.Time
 %End
 
- static QString defaultFormat( QVariant::Type type ) /Deprecated/;
+ static QString defaultFormat( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Gets the default format in function of the type.
 The type is expected to be one of
@@ -72,7 +72,7 @@ The type is expected to be one of
 .. versionadded:: 3.30
 %End
 
- static QString defaultDisplayFormat( QVariant::Type type ) /Deprecated/;
+ static QString defaultDisplayFormat( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Gets the default display format in function of the type.
 The type is expected to be one of

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -148,7 +148,7 @@ and a deep copy. Where possible, use :py:func:`~QgsGeometry.constGet` instead.
 .. seealso:: :py:func:`set`
 %End
 
- void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated="Since 3.0. "/;
+    void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated/;
 %Docstring
 Sets the underlying geometry store. Ownership of geometry is transferred.
 
@@ -165,8 +165,6 @@ Sets the underlying geometry store. Ownership of geometry is transferred.
 .. seealso:: :py:func:`get`
 
 .. seealso:: :py:func:`constGet`
-
-.. deprecated:: 3.0
 %End
 
     bool isNull() const /HoldGIL/;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -148,7 +148,7 @@ and a deep copy. Where possible, use :py:func:`~QgsGeometry.constGet` instead.
 .. seealso:: :py:func:`set`
 %End
 
-    void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated/;
+ void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated="Since 3.0. "/;
 %Docstring
 Sets the underlying geometry store. Ownership of geometry is transferred.
 
@@ -856,7 +856,7 @@ Adds a new ring to this geometry. This makes only sense for polygon and multipol
 :return: OperationResult a result code: success or reason of failure
 %End
 
- Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPointsXY,Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPointsXY,Deprecated="Since 3.38. Will be removed in QGIS 4.0. Use addPartV2 which accepts Qgis.WkbType geometry type instead of Qgis.GeometryType."/;
 %Docstring
 Adds a new part to a the geometry.
 
@@ -882,7 +882,7 @@ Adds a new part to a the geometry.
 .. versionadded:: 3.38
 %End
 
- Qgis::GeometryOperationResult addPart( const QgsPointSequence &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPoints,Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QgsPointSequence &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPoints,Deprecated="Since 3.38. Will be removed in QGIS 4.0. Use addPartV2 which accepts Qgis.WkbType geometry type instead of Qgis.GeometryType."/;
 %Docstring
 Adds a new part to a the geometry.
 
@@ -908,7 +908,7 @@ Adds a new part to a the geometry.
 .. versionadded:: 3.38
 %End
 
- Qgis::GeometryOperationResult addPart( QgsAbstractGeometry *part /Transfer/, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /Deprecated/;
+ Qgis::GeometryOperationResult addPart( QgsAbstractGeometry *part /Transfer/, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /Deprecated="Since 3.38. Will be removed in QGIS 4.0. Use addPartV2 which accepts Qgis.WkbType geometry type instead of Qgis.GeometryType."/;
 %Docstring
 Adds a new part to this geometry.
 
@@ -2471,7 +2471,7 @@ empty if none of the child geometries match the desired type.
 .. versionadded:: 3.2
 %End
 
- int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers ) /Deprecated/;
+ int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers ) /Deprecated="Since 3.34. "/;
 %Docstring
 Modifies geometry to avoid intersections with the layers specified in project properties
 
@@ -2793,7 +2793,7 @@ geometry will be a polyline.
 :param polygon: source QPolygonF
 %End
 
- static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) /Deprecated/;
+ static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) /Deprecated="Since 3.40. Use QgsGeometry.fromQPolygonF() or QgsLineString.fromQPolygonF() instead."/;
 %Docstring
 Creates a :py:class:`QgsPolylineXY` from a QPolygonF.
 
@@ -2808,7 +2808,7 @@ Creates a :py:class:`QgsPolylineXY` from a QPolygonF.
    Use :py:func:`QgsGeometry.fromQPolygonF()` or :py:func:`QgsLineString.fromQPolygonF()` instead.
 %End
 
- static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon ) /Deprecated/;
+ static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon ) /Deprecated="Since 3.40. Use QgsGeometry.fromQPolygonF() or QgsLineString.fromQPolygonF() instead."/;
 %Docstring
 Creates a :py:class:`QgsPolygonXYfrom` a QPolygonF.
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -165,6 +165,8 @@ Sets the underlying geometry store. Ownership of geometry is transferred.
 .. seealso:: :py:func:`get`
 
 .. seealso:: :py:func:`constGet`
+
+.. deprecated:: 3.0
 %End
 
     bool isNull() const /HoldGIL/;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -385,7 +385,7 @@ Create a perpendicular line segment from p to segment [s1, s2]
 :return: A line (segment) from p to perpendicular point on segment [s1, s2]
 %End
 
- static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point ) /Deprecated/;
+ static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point ) /Deprecated="Since 3.20. Use transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point ) instead."/;
 %Docstring
 A Z dimension is added to ``point`` if one of the point in the list
 ``points`` is in 3D. Moreover, the Z value of ``point`` is updated
@@ -493,7 +493,7 @@ looping twice over the set of points.
 
 
 
- static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 
@@ -518,7 +518,7 @@ Returns the squared 3D distance between two points.
 .. versionadded:: 3.36
 %End
 
- static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 
@@ -544,7 +544,7 @@ Returns the 3D distance between two points.
 %End
 
 
- static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /Deprecated,HoldGIL/;
+ static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the squared distance between a point and a line.
 
@@ -553,7 +553,7 @@ Returns the squared distance between a point and a line.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static int leftOfLine( const double x, const double y, const double x1, const double y1, const double x2, const double y2 ) /Deprecated,HoldGIL/;
+ static int leftOfLine( const double x, const double y, const double x1, const double y1, const double x2, const double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns a value < 0 if the point (``x``, ``y``) is left of the line from (``x1``, ``y1``) -> (``x2``, ``y2``).
 A positive return value indicates the point is to the right of the line.
@@ -605,7 +605,7 @@ Example
 
 
 
- static double ccwAngle( double dy, double dx ) /Deprecated,HoldGIL/;
+ static double ccwAngle( double dy, double dx ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the counter clockwise angle between a line with components dx, dy and the line with dx > 0 and dy = 0
 
@@ -615,7 +615,7 @@ Returns the counter clockwise angle between a line with components dx, dy and th
 %End
 
 
- static bool circleClockwise( double angle1, double angle2, double angle3 ) /Deprecated,HoldGIL/;
+ static bool circleClockwise( double angle1, double angle2, double angle3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns ``True`` if the circle defined by three angles is ordered clockwise.
 
@@ -627,7 +627,7 @@ Euclidean angles as opposed to geographic "North up" angles.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static bool circleAngleBetween( double angle, double angle1, double angle2, bool clockwise ) /Deprecated,HoldGIL/;
+ static bool circleAngleBetween( double angle, double angle1, double angle2, bool clockwise ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns ``True`` if, in a circle, angle is between angle1 and angle2
 
@@ -636,7 +636,7 @@ Returns ``True`` if, in a circle, angle is between angle1 and angle2
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static bool angleOnCircle( double angle, double angle1, double angle2, double angle3 ) /Deprecated,HoldGIL/;
+ static bool angleOnCircle( double angle, double angle1, double angle2, double angle3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns ``True`` if an angle is between angle1 and angle3 on a circle described by
 angle1, angle2 and angle3.
@@ -646,7 +646,7 @@ angle1, angle2 and angle3.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double circleLength( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double circleLength( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Length of a circular string segment defined by pt1, pt2, pt3
 
@@ -655,7 +655,7 @@ Length of a circular string segment defined by pt1, pt2, pt3
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double sweepAngle( double centerX, double centerY, double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double sweepAngle( double centerX, double centerY, double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates angle of a circular string part defined by pt1, pt2, pt3
 
@@ -664,7 +664,7 @@ Calculates angle of a circular string part defined by pt1, pt2, pt3
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 ) /Deprecated,HoldGIL/;
+ static double interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Interpolate a value at given angle on circular arc given values (zm1, zm2, zm3) at three different angles (a1, a2, a3).
 
@@ -673,7 +673,7 @@ Interpolate a value at given angle on circular arc given values (zm1, zm2, zm3) 
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double normalizedAngle( double angle ) /Deprecated,HoldGIL/;
+ static double normalizedAngle( double angle ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Ensures that an angle is in the range 0 <= angle < 2 pi.
 
@@ -686,7 +686,7 @@ Ensures that an angle is in the range 0 <= angle < 2 pi.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double lineAngle( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double lineAngle( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the direction of line joining two points in radians, clockwise from the north direction.
 
@@ -702,7 +702,7 @@ Calculates the direction of line joining two points in radians, clockwise from t
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double angleBetweenThreePoints( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double angleBetweenThreePoints( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the angle between the lines AB and BC, where AB and BC described
 by points a, b and b, c.
@@ -721,7 +721,7 @@ by points a, b and b, c.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double linePerpendicularAngle( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double linePerpendicularAngle( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the perpendicular angle to a line joining two points. Returned angle is in radians,
 clockwise from the north direction.
@@ -738,7 +738,7 @@ clockwise from the north direction.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double averageAngle( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double averageAngle( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the average angle (in radians) between the two linear segments from
 (``x1``, ``y1``) to (``x2``, ``y2``) and (``x2``, ``y2``) to (``x3``, ``y3``).
@@ -748,7 +748,7 @@ Calculates the average angle (in radians) between the two linear segments from
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double averageAngle( double a1, double a2 ) /Deprecated,HoldGIL/;
+ static double averageAngle( double a1, double a2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Averages two angles, correctly handling negative angles and ensuring the result is between 0 and 2 pi.
 
@@ -826,7 +826,7 @@ The result is a line (segment) centered in point p and perpendicular to segment 
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double skewLinesDistance( const QgsVector3D &P1, const QgsVector3D &P12, const QgsVector3D &P2, const QgsVector3D &P22 ) /Deprecated,HoldGIL/;
+ static double skewLinesDistance( const QgsVector3D &P1, const QgsVector3D &P12, const QgsVector3D &P2, const QgsVector3D &P22 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 An algorithm to calculate the shortest distance between two skew lines.
 
@@ -911,7 +911,7 @@ Example
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double triangleArea( double aX, double aY, double bX, double bY, double cX, double cY ) /Deprecated,HoldGIL/;
+ static double triangleArea( double aX, double aY, double bX, double bY, double cX, double cY ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the area of the triangle denoted by the points (``aX``, ``aY``), (``bX``, ``bY``) and
 (``cX``, ``cY``).

--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -854,7 +854,7 @@ corresponds to the last point in the line.
 %End
 
 
- QgsBox3D calculateBoundingBox3d() const /Deprecated/;
+ QgsBox3D calculateBoundingBox3d() const /Deprecated="Since 3.34. use calculateBoundingBox3D() instead"/;
 %Docstring
 Calculates the minimal 3D bounding box for the geometry.
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -120,7 +120,7 @@ A null rectangle is also empty by definition.
 .. versionadded:: 3.34
 %End
 
- void setMinimal() /Deprecated/;
+ void setMinimal() /Deprecated="Since 3.34. Will be removed in QGIS 4.0. Use setNull()."/;
 %Docstring
 Set a rectangle so that min corner is at max
 and max corner is at min. It is NOT normalized.

--- a/python/PyQt6/core/auto_generated/gps/qgsgpsdetector.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgsgpsdetector.sip.in
@@ -76,7 +76,7 @@ Call :py:func:`~QgsGpsDetector.takeConnection` to take ownership of the detected
 .. versionadded:: 3.38
 %End
 
- void detected( QgsGpsConnection *connection ) /Deprecated/;
+ void detected( QgsGpsConnection *connection ) /Deprecated="Since 3.40. This signal is dangerous and extremely unsafe! It is recommended to instead set the ``useUnsafeSignals`` parameter to ``False`` in the QgsGpsDetector constructor and use the safe connectionDetected() signal instead."/;
 %Docstring
 Emitted when the GPS connection has been detected. A single connection must listen for this signal and
 immediately take ownership of the ``connection`` object.

--- a/python/PyQt6/core/auto_generated/gps/qgsgpsinformation.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgsgpsinformation.sip.in
@@ -113,7 +113,7 @@ Returns whether the connection information is valid
 .. versionadded:: 3.10
 %End
 
- Qgis::GpsFixStatus fixStatus() const /Deprecated/;
+ Qgis::GpsFixStatus fixStatus() const /Deprecated="Since 3.40. Use constellationFixStatus() or bestFixStatus() instead."/;
 %Docstring
 Returns the fix status
 

--- a/python/PyQt6/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
@@ -92,7 +92,7 @@ Sets the maximum number of polygon label ``candidates`` per centimeter squared.
 .. versionadded:: 3.12
 %End
 
- void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon ) const /Deprecated/;
+ void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon ) const /Deprecated="Since 3.12. Use maximumPolygonCandidatesPerCmSquared() and maximumLineCandidatesPerCm() instead."/;
 %Docstring
 Gets number of candidate positions that will be generated for each label feature.
 
@@ -101,7 +101,7 @@ Gets number of candidate positions that will be generated for each label feature
    Use :py:func:`~QgsLabelingEngineSettings.maximumPolygonCandidatesPerCmSquared` and :py:func:`~QgsLabelingEngineSettings.maximumLineCandidatesPerCm` instead.
 %End
 
- void setNumCandidatePositions( int candPoint, int candLine, int candPolygon ) /Deprecated/;
+ void setNumCandidatePositions( int candPoint, int candLine, int candPolygon ) /Deprecated="Since 3.12. Use setMaximumPolygonCandidatesPerCmSquared() and setMaximumLineCandidatesPerCm() instead."/;
 %Docstring
 Sets the number of candidate positions that will be generated for each label feature.
 
@@ -110,7 +110,7 @@ Sets the number of candidate positions that will be generated for each label fea
    Use :py:func:`~QgsLabelingEngineSettings.setMaximumPolygonCandidatesPerCmSquared` and :py:func:`~QgsLabelingEngineSettings.setMaximumLineCandidatesPerCm` instead.
 %End
 
- void setSearchMethod( Search s ) /Deprecated/;
+ void setSearchMethod( Search s ) /Deprecated="Since 3.10. Chain is always used."/;
 %Docstring
 Used to set which search method to use for removal collisions between labels
 
@@ -119,7 +119,7 @@ Used to set which search method to use for removal collisions between labels
    Chain is always used.
 %End
 
- Search searchMethod() const /Deprecated/;
+ Search searchMethod() const /Deprecated="Since 3.10. Chain is always used."/;
 %Docstring
 Which search method to use for removal collisions between labels
 

--- a/python/PyQt6/core/auto_generated/labeling/qgslabelsearchtree.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgslabelsearchtree.sip.in
@@ -27,7 +27,7 @@ A class to query the labeling structure at a given point (small wrapper around p
     ~QgsLabelSearchTree();
 
 
- void clear() /Deprecated/;
+ void clear() /Deprecated="Since 3.40. Has no effect since QGIS 3.12."/;
 %Docstring
 Removes and deletes all the entries.
 

--- a/python/PyQt6/core/auto_generated/labeling/qgspallabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgspallabeling.sip.in
@@ -371,7 +371,7 @@ legendString
 :return: the string to show in the legend and in the preview icon
 %End
 
- void calculateLabelSize( const QFontMetricsF *fm, const QString &text, double &labelX, double &labelY, const QgsFeature *f = 0, QgsRenderContext *context = 0, double *rotatedLabelX /Out/ = 0, double *rotatedLabelY /Out/ = 0 ) /Deprecated/;
+ void calculateLabelSize( const QFontMetricsF *fm, const QString &text, double &labelX, double &labelY, const QgsFeature *f = 0, QgsRenderContext *context = 0, double *rotatedLabelX /Out/ = 0, double *rotatedLabelY /Out/ = 0 ) /Deprecated="Since 3.40. Will be removed from public API in QGIS 4.0."/;
 %Docstring
 Calculates the space required to render the provided ``text`` in map units.
 Results will be written to ``labelX`` and ``labelY``.

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -234,7 +234,7 @@ A scale <= 0 indicates that no scale filtering is being performed.
 .. seealso:: :py:func:`setLegendFilterByScale`
 %End
 
- void setLegendFilterByMap( const QgsMapSettings *settings ) /Deprecated/;
+ void setLegendFilterByMap( const QgsMapSettings *settings ) /Deprecated="Since 3.32. Use setFilterSettings() instead."/;
 %Docstring
 Force only display of legend nodes which are valid for given map settings.
 Setting ``None`` or invalid map settings will disable the functionality.
@@ -245,7 +245,7 @@ Ownership of map settings pointer does not change, a copy is made.
    Use :py:func:`~QgsLayerTreeModel.setFilterSettings` instead.
 %End
 
- void setLegendFilter( const QgsMapSettings *settings, bool useExtent = true, const QgsGeometry &polygon = QgsGeometry(), bool useExpressions = true ) /Deprecated/;
+ void setLegendFilter( const QgsMapSettings *settings, bool useExtent = true, const QgsGeometry &polygon = QgsGeometry(), bool useExpressions = true ) /Deprecated="Since 3.32. Use setFilterSettings() instead."/;
 %Docstring
 Filter display of legend nodes for given map settings
 

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
@@ -50,7 +50,7 @@ Create the instance that synchronizes given project with a layer tree root
     void setNewLayersVisible( bool enabled );
     bool newLayersVisible() const;
 
- void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index ) /Deprecated/;
+ void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index ) /Deprecated="Since 3.10. Use setLayerInsertionPoint( const InsertionPoint &insertionPoint ) instead."/;
 %Docstring
 Set where the new layers should be inserted - can be used to follow current selection.
 By default it is root group with zero index.

--- a/python/PyQt6/core/auto_generated/layout/qgslayouteffect.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayouteffect.sip.in
@@ -29,7 +29,7 @@ onto a scene with custom composition modes.
 
     QgsLayoutEffect();
 
- void setCompositionMode( QPainter::CompositionMode mode ) /Deprecated/;
+ void setCompositionMode( QPainter::CompositionMode mode ) /Deprecated="Since 3.34. This class should not be used, it is non-stable and results in crashes. See https//bugreports.qt.io/browse/QTBUG-58501."/;
 %Docstring
 Sets the composition (blending) ``mode`` used for rendering
 the item.
@@ -41,7 +41,7 @@ the item.
    This class should not be used, it is non-stable and results in crashes. See https://bugreports.qt.io/browse/QTBUG-58501.
 %End
 
- QPainter::CompositionMode compositionMode() const /Deprecated/;
+ QPainter::CompositionMode compositionMode() const /Deprecated="Since 3.34. This class should not be used, it is non-stable and results in crashes. See https//bugreports.qt.io/browse/QTBUG-58501."/;
 %Docstring
 Returns the composition (blending) mode used for rendering
 the item.

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -441,7 +441,7 @@ Returns the behavior of this item during exporting to layered exports (e.g. SVG 
 .. versionadded:: 3.10
 %End
 
- virtual int numberExportLayers() const /Deprecated/;
+ virtual int numberExportLayers() const /Deprecated="Since 3.40. Use nextExportPart() and exportLayerBehavior() instead."/;
 %Docstring
 Returns the number of layers that this item requires for exporting during layered exports (e.g. SVG).
 Returns 0 if this item is to be placed on the same layer as the previous item,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemlabel.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemlabel.sip.in
@@ -109,7 +109,7 @@ to switch between font based and HTML based rendering.
 .. seealso:: :py:func:`mode`
 %End
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Returns the label's current font.
 
@@ -120,7 +120,7 @@ Returns the label's current font.
    Use :py:func:`~QgsLayoutItemLabel.textFormat` instead (since QGIS 3.24).
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Sets the label's current ``font``.
 
@@ -221,7 +221,7 @@ contents, in layout units.
 .. seealso:: :py:func:`setMarginX`
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setTextFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Sets the label font ``color``.
 
@@ -232,7 +232,7 @@ Sets the label font ``color``.
    Use :py:func:`~QgsLayoutItemLabel.setTextFormat` instead (since QGIS 3.24).
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use textFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Returns the label font color.
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemlegend.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemlegend.sip.in
@@ -211,7 +211,7 @@ Returns legend style.
 Sets the style of ``component`` to ``style`` for the legend.
 %End
 
- QFont styleFont( QgsLegendStyle::Style component ) const /Deprecated/;
+ QFont styleFont( QgsLegendStyle::Style component ) const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() from style() instead."/;
 %Docstring
 Returns the font settings for a legend ``component``.
 
@@ -222,7 +222,7 @@ Returns the font settings for a legend ``component``.
    Use :py:func:`QgsLegendStyle.textFormat()` from :py:func:`~QgsLayoutItemLegend.style` instead.
 %End
 
- void setStyleFont( QgsLegendStyle::Style component, const QFont &font ) /Deprecated/;
+ void setStyleFont( QgsLegendStyle::Style component, const QFont &font ) /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Sets the style ``font`` for a legend ``component``.
 
@@ -243,7 +243,7 @@ Set the ``margin`` for a legend ``component``.
 Set the ``margin`` for a particular ``side`` of a legend ``component``.
 %End
 
- double lineSpacing() const /Deprecated/;
+ double lineSpacing() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() from style() instead."/;
 %Docstring
 Returns the spacing in-between lines in layout units.
 
@@ -254,7 +254,7 @@ Returns the spacing in-between lines in layout units.
    Use :py:func:`QgsLegendStyle.textFormat()` from :py:func:`~QgsLayoutItemLegend.style` instead.
 %End
 
- void setLineSpacing( double spacing ) /Deprecated/;
+ void setLineSpacing( double spacing ) /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Sets the ``spacing`` in-between multiple lines.
 
@@ -293,7 +293,7 @@ Sets the legend column ``spacing``.
 .. seealso:: :py:func:`columnSpace`
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Returns the legend font color.
 
@@ -304,7 +304,7 @@ Returns the legend font color.
    Use :py:func:`QgsLegendStyle.setTextFormat()` from :py:func:`~QgsLayoutItemLegend.style` instead.
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Sets the legend font ``color``.
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -362,7 +362,7 @@ The caller takes responsibility for deleting the returned object.
     virtual void paint( QPainter *painter, const QStyleOptionGraphicsItem *itemStyle, QWidget *pWidget );
 
 
- virtual int numberExportLayers() const /Deprecated/;
+ virtual int numberExportLayers() const /Deprecated="Since 3.10. "/;
 
 %Docstring
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -361,7 +361,13 @@ The caller takes responsibility for deleting the returned object.
 
     virtual void paint( QPainter *painter, const QStyleOptionGraphicsItem *itemStyle, QWidget *pWidget );
 
+
  virtual int numberExportLayers() const /Deprecated/;
+
+%Docstring
+
+.. deprecated:: 3.10
+%End
 
     virtual void startLayeredExport();
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -589,7 +589,7 @@ Returns the text format used when rendering grid annotations.
 .. versionadded:: 3.16
 %End
 
- void setAnnotationFont( const QFont &font ) /Deprecated/;
+ void setAnnotationFont( const QFont &font ) /Deprecated="Since 3.40. Use setAnnotationTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setFont().
@@ -601,7 +601,7 @@ Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setFont().
    Use :py:func:`~QgsLayoutItemMapGrid.setAnnotationTextFormat` instead.
 %End
 
- QFont annotationFont() const /Deprecated/;
+ QFont annotationFont() const /Deprecated="Since 3.40. Use annotationTextFormat() instead."/;
 %Docstring
 Returns the font used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.font().
@@ -613,7 +613,7 @@ Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.font().
    Use :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat` instead.
 %End
 
- void setAnnotationFontColor( const QColor &color ) /Deprecated/;
+ void setAnnotationFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setAnnotationTextFormat() instead."/;
 %Docstring
 Sets the font ``color`` used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setColor() and :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setOpacity().
@@ -625,7 +625,7 @@ Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setColor() an
    Use :py:func:`~QgsLayoutItemMapGrid.setAnnotationTextFormat` instead.
 %End
 
- QColor annotationFontColor() const /Deprecated/;
+ QColor annotationFontColor() const /Deprecated="Since 3.40. Use annotationTextFormat() instead."/;
 %Docstring
 Returns the font color used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.color() and :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.opacity().

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
@@ -392,7 +392,7 @@ transferred to the scalebar.
 .. versionadded:: 3.14
 %End
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the font used for drawing text in the scalebar.
 
@@ -403,7 +403,7 @@ Returns the font used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.textFormat` instead.
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for drawing text in the scalebar.
 
@@ -414,7 +414,7 @@ Sets the ``font`` used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setTextFormat` instead.
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the color used for drawing text in the scalebar.
 
@@ -427,7 +427,7 @@ Returns the color used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.textFormat` instead.
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``color`` used for drawing text in the scalebar.
 
@@ -440,7 +440,7 @@ Sets the ``color`` used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setTextFormat` instead.
 %End
 
- QColor fillColor() const /Deprecated/;
+ QColor fillColor() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the color used for fills in the scalebar.
 
@@ -453,7 +453,7 @@ Returns the color used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.fillSymbol` instead.
 %End
 
- void setFillColor( const QColor &color ) /Deprecated/;
+ void setFillColor( const QColor &color ) /Deprecated="Since 3.40. Use setFillSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for fills in the scalebar.
 
@@ -466,7 +466,7 @@ Sets the ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setFillSymbol` instead.
 %End
 
- QColor fillColor2() const /Deprecated/;
+ QColor fillColor2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary color used for fills in the scalebar.
 
@@ -479,7 +479,7 @@ Returns the secondary color used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.alternateFillSymbol` instead.
 %End
 
- void setFillColor2( const QColor &color ) /Deprecated/;
+ void setFillColor2( const QColor &color ) /Deprecated="Since 3.40. Use setAlternateFillSymbol() instead."/;
 %Docstring
 Sets the secondary ``color`` used for fills in the scalebar.
 
@@ -492,7 +492,7 @@ Sets the secondary ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setAlternateFillSymbol` instead.
 %End
 
- QColor lineColor() const /Deprecated/;
+ QColor lineColor() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the color used for lines in the scalebar.
 
@@ -503,7 +503,7 @@ Returns the color used for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineColor( const QColor &color ) /Deprecated/;
+ void setLineColor( const QColor &color ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for lines in the scalebar.
 
@@ -514,7 +514,7 @@ Sets the ``color`` used for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setLineSymbol` instead.
 %End
 
- double lineWidth() const /Deprecated/;
+ double lineWidth() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the line width in millimeters for lines in the scalebar.
 
@@ -525,7 +525,7 @@ Returns the line width in millimeters for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineWidth( double width ) /Deprecated/;
+ void setLineWidth( double width ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the line ``width`` in millimeters for lines in the scalebar.
 
@@ -536,7 +536,7 @@ Sets the line ``width`` in millimeters for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setLineSymbol` instead.
 %End
 
- QPen pen() const /Deprecated/;
+ QPen pen() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the pen used for drawing outlines in the scalebar.
 
@@ -547,7 +547,7 @@ Returns the pen used for drawing outlines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- QBrush brush() const /Deprecated/;
+ QBrush brush() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the primary brush for the scalebar.
 
@@ -562,7 +562,7 @@ Returns the primary brush for the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.fillSymbol` instead.
 %End
 
- QBrush brush2() const /Deprecated/;
+ QBrush brush2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary brush for the scalebar. This is used for alternating color style scalebars, such
 as single and double box styles.
@@ -696,7 +696,7 @@ Sets the distance ``units`` used by the scalebar.
 .. seealso:: :py:func:`units`
 %End
 
- Qt::PenJoinStyle lineJoinStyle() const /Deprecated/;
+ Qt::PenJoinStyle lineJoinStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the join style used for drawing lines in the scalebar.
 
@@ -707,7 +707,7 @@ Returns the join style used for drawing lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated/;
+ void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the join ``style`` used when drawing the lines in the scalebar
 
@@ -718,7 +718,7 @@ Sets the join ``style`` used when drawing the lines in the scalebar
    Use :py:func:`~QgsLayoutItemScaleBar.setLineSymbol` instead.
 %End
 
- Qt::PenCapStyle lineCapStyle() const /Deprecated/;
+ Qt::PenCapStyle lineCapStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the cap style used for drawing lines in the scalebar.
 
@@ -729,7 +729,7 @@ Returns the cap style used for drawing lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated/;
+ void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the cap ``style`` used when drawing the lines in the scalebar.
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutpagecollection.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutpagecollection.sip.in
@@ -193,7 +193,7 @@ Ownership is not transferred, and a copy of the symbol is created internally.
 .. seealso:: :py:func:`pageStyleSymbol`
 %End
 
- const QgsFillSymbol *pageStyleSymbol() const /Deprecated/;
+ const QgsFillSymbol *pageStyleSymbol() const /Deprecated="Since 3.40. Use QgsLayoutItemPage.pageStyleSymbol() instead."/;
 %Docstring
 Returns the symbol to use for drawing pages in the collection.
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -185,7 +185,7 @@ whether they will be rendered in layout exports.
 .. seealso:: :py:func:`setPagesVisible`
 %End
 
- void setCurrentExportLayer( int layer = -1 ) /Deprecated/;
+ void setCurrentExportLayer( int layer = -1 ) /Deprecated="Since 3.40. Items should now handle this themselves, via QgsLayoutItem.exportLayerBehavior() and returning QgsLayoutItem.nextExportPart()."/;
 %Docstring
 Sets the current item ``layer`` to draw while exporting. :py:class:`QgsLayoutItem` subclasses
 which support multi-layer SVG exports must check the :py:func:`~QgsLayoutRenderContext.currentExportLayer`
@@ -200,7 +200,7 @@ If ``layer`` is -1, all item layers will be rendered.
    Items should now handle this themselves, via :py:func:`QgsLayoutItem.exportLayerBehavior()` and returning :py:func:`QgsLayoutItem.nextExportPart()`.
 %End
 
- int currentExportLayer() const /Deprecated/;
+ int currentExportLayer() const /Deprecated="Since 3.40. Items should now handle this themselves, via QgsLayoutItem.exportLayerBehavior() and returning QgsLayoutItem.nextExportPart()."/;
 %Docstring
 Returns the current item layer to draw while exporting. :py:class:`QgsLayoutItem` subclasses
 which support multi-layer SVG exports must check this

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutreportcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutreportcontext.sip.in
@@ -74,7 +74,7 @@ Emits the :py:func:`~QgsLayoutReportContext.changed` signal.
 .. seealso:: :py:func:`layer`
 %End
 
- void setPredefinedScales( const QVector<qreal> &scales ) /Deprecated/;
+ void setPredefinedScales( const QVector<qreal> &scales ) /Deprecated="Since 3.40. Use QgsLayoutRenderContext.setPredefinedScales()."/;
 %Docstring
 Sets the list of predefined ``scales`` to use with the layout. This is used
 for maps which are set to the predefined atlas scaling mode.
@@ -86,7 +86,7 @@ for maps which are set to the predefined atlas scaling mode.
    Use :py:func:`QgsLayoutRenderContext.setPredefinedScales()`.
 %End
 
- QVector<qreal> predefinedScales() const /Deprecated/;
+ QVector<qreal> predefinedScales() const /Deprecated="Since 3.40. Use QgsLayoutRenderContext.predefinedScales()."/;
 %Docstring
 Returns the current list of predefined scales for use with the layout.
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayouttable.sip.in
@@ -187,7 +187,7 @@ Returns whether empty rows are drawn in the table.
 .. seealso:: :py:func:`setShowEmptyRows`
 %End
 
- void setHeaderFont( const QFont &font ) /Deprecated/;
+ void setHeaderFont( const QFont &font ) /Deprecated="Since 3.40. Use setHeaderTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used to draw header text in the table.
 
@@ -200,7 +200,7 @@ Sets the ``font`` used to draw header text in the table.
    Use :py:func:`~QgsLayoutTable.setHeaderTextFormat` instead.
 %End
 
- QFont headerFont() const /Deprecated/;
+ QFont headerFont() const /Deprecated="Since 3.40. Use headerTextFormat() instead."/;
 %Docstring
 Returns the font used to draw header text in the table.
 
@@ -213,7 +213,7 @@ Returns the font used to draw header text in the table.
    Use :py:func:`~QgsLayoutTable.headerTextFormat` instead.
 %End
 
- void setHeaderFontColor( const QColor &color ) /Deprecated/;
+ void setHeaderFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setHeaderTextFormat() instead."/;
 %Docstring
 Sets the ``color`` used to draw header text in the table.
 
@@ -228,7 +228,7 @@ Sets the ``color`` used to draw header text in the table.
    Use :py:func:`~QgsLayoutTable.setHeaderTextFormat` instead.
 %End
 
- QColor headerFontColor() const /Deprecated/;
+ QColor headerFontColor() const /Deprecated="Since 3.40. Use headerTextFormat() instead."/;
 %Docstring
 Returns the color used to draw header text in the table.
 
@@ -295,7 +295,7 @@ if and where headers are shown in the table.
 .. seealso:: :py:func:`setHeaderMode`
 %End
 
- void setContentFont( const QFont &font ) /Deprecated/;
+ void setContentFont( const QFont &font ) /Deprecated="Since 3.40. Use setContentTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used to draw text in table body cells.
 
@@ -308,7 +308,7 @@ Sets the ``font`` used to draw text in table body cells.
    Use :py:func:`~QgsLayoutTable.setContentTextFormat` instead.
 %End
 
- QFont contentFont() const /Deprecated/;
+ QFont contentFont() const /Deprecated="Since 3.40. Use contextTextFormat() instead."/;
 %Docstring
 Returns the font used to draw text in table body cells.
 
@@ -321,7 +321,7 @@ Returns the font used to draw text in table body cells.
    Use :py:func:`~QgsLayoutTable.contextTextFormat` instead.
 %End
 
- void setContentFontColor( const QColor &color ) /Deprecated/;
+ void setContentFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setContentTextFormat() instead."/;
 %Docstring
 Sets the ``color`` used to draw text in table body cells.
 
@@ -336,7 +336,7 @@ Sets the ``color`` used to draw text in table body cells.
    Use :py:func:`~QgsLayoutTable.setContentTextFormat` instead.
 %End
 
- QColor contentFontColor() const /Deprecated/;
+ QColor contentFontColor() const /Deprecated="Since 3.40. Use contextTextFormat() instead."/;
 %Docstring
 Returns the color used to draw text in table body cells.
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayouttablecolumn.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayouttablecolumn.sip.in
@@ -174,7 +174,7 @@ is part of a :py:class:`QgsLayoutItemAttributeTable` and when :py:func:`~QgsLayo
 .. seealso:: :py:func:`setSortByRank`
 %End
 
- int sortByRank() const /Deprecated/;
+ int sortByRank() const /Deprecated="Since 3.14. The order is now hold in a dedicated model."/;
 %Docstring
 Returns the sort rank for the column. If the sort rank is > 0 then the column
 will be sorted in the table. The sort rank specifies the priority given to the
@@ -197,7 +197,7 @@ If sort rank is <= 0 then the column is not being sorted.
    The order is now hold in a dedicated model.
 %End
 
- void setSortByRank( int rank ) /Deprecated/;
+ void setSortByRank( int rank ) /Deprecated="Since 3.14. The order is now hold in a dedicated model."/;
 %Docstring
 Sets the sort ``rank`` for the column. If the sort rank is > 0 then the column
 will be sorted in the table. The sort rank specifies the priority given to the
@@ -219,7 +219,7 @@ If the sort ``rank`` is <= 0 then the column is not being sorted.
    The order is now hold in a dedicated model.
 %End
 
- QgsLayoutTableColumn *clone() /Deprecated,Factory/;
+ QgsLayoutTableColumn *clone() /Deprecated="Since 3.14. Use a copy instead.",Factory/;
 %Docstring
 Creates a duplicate column which is a deep copy of this column.
 

--- a/python/PyQt6/core/auto_generated/layout/qgslayoututils.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoututils.sip.in
@@ -218,7 +218,7 @@ decoded orientation.
 If the string was correctly decoded, ``ok`` will be set to ``True``.
 %End
 
- static double scaleFactorFromItemStyle( const QStyleOptionGraphicsItem *style ) /Deprecated/;
+ static double scaleFactorFromItemStyle( const QStyleOptionGraphicsItem *style ) /Deprecated="Since 3.40. Use the variant with a QPainter argument instead."/;
 %Docstring
 Extracts the scale factor from an item ``style``.
 

--- a/python/PyQt6/core/auto_generated/maprenderer/qgsmaprenderercache.sip.in
+++ b/python/PyQt6/core/auto_generated/maprenderer/qgsmaprenderercache.sip.in
@@ -42,7 +42,7 @@ Invalidates the cache contents, clearing all cached images.
 .. seealso:: :py:func:`clearCacheImage`
 %End
 
- bool init( const QgsRectangle &extent, double scale ) /Deprecated/;
+ bool init( const QgsRectangle &extent, double scale ) /Deprecated="Since 3.18. Will be removed in QGIS 4.0. Use the updateParameters() and clear()."/;
 %Docstring
 Initialize cache: sets extent and scale parameters and clears the cache if any
 parameters have changed since last initialization.

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -49,7 +49,7 @@ Resulting dataset is always scalar
                                          const QgsRectangle &outputExtent,
                                          double startTime,
                                          double endTime,
-                                         QgsMeshLayer *layer ) /Deprecated/;
+                                         QgsMeshLayer *layer ) /Deprecated="Since 3.12. "/;
 %Docstring
 Creates calculator with bounding box (rectangular) mask
 
@@ -68,7 +68,7 @@ Creates calculator with bounding box (rectangular) mask
                                          const QgsGeometry &outputMask,
                                          double startTime,
                                          double endTime,
-                                         QgsMeshLayer *layer ) /Deprecated/;
+                                         QgsMeshLayer *layer ) /Deprecated="Since 3.12. "/;
 %Docstring
 Creates calculator with geometry mask
 
@@ -182,7 +182,7 @@ Starts the calculation, creates new dataset group and adds it to the mesh layer
 %End
 
  static Result expression_valid( const QString &formulaString,
-        QgsMeshLayer *layer ) /Deprecated/;
+        QgsMeshLayer *layer ) /Deprecated="Since 3.12. Use expressionIsValid."/;
 %Docstring
 Returns whether formula is valid for particular mesh layer
 

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -304,7 +304,7 @@ Returns whether the faces are active for particular dataset
         const QVector<QgsMeshDataBlock> &datasetValues,
         const QVector<QgsMeshDataBlock> &datasetActive,
         const QVector<double> &times
-                                                      ) /Deprecated/;
+                                                      ) /Deprecated="Since 3.12.3. "/;
 %Docstring
 Creates a new dataset group from a data and
 persists it into a destination path

--- a/python/PyQt6/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
@@ -216,7 +216,7 @@ Aborts the network request immediately.
 Emitted when when data arrives during a request.
 %End
 
- void downloadFinished() /Deprecated/;
+ void downloadFinished() /Deprecated="Since 3.40. Use the finished() signal instead."/;
 %Docstring
 Emitted once a request has finished downloading.
 

--- a/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
@@ -35,7 +35,7 @@ Constructor from map
 
     QgsHttpHeaders();
 
- QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() ) /Deprecated/;
+ QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() ) /Deprecated="Since 3.30. Use a variant map settings and the default constructor instead."/;
 %Docstring
 Constructor from :py:class:`QgsSettings` ``settings`` object and root ``key``
 
@@ -70,7 +70,7 @@ Returns the headers as a variant map
 .. versionadded:: 3.30
 %End
 
- bool updateSettings( QgsSettings &settings, const QString &key = QString() ) const /Deprecated/;
+ bool updateSettings( QgsSettings &settings, const QString &key = QString() ) const /Deprecated="Since 3.30. Directly use a variant setting instead."/;
 %Docstring
 Updates the ``settings`` by adding all the http headers in the path "key/PATH_PREFIX/"
 

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -471,7 +471,7 @@ Preprocesses request
 
   signals:
 
- void requestAboutToBeCreated( QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *device ) /Deprecated/;
+ void requestAboutToBeCreated( QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *device ) /Deprecated="Since 3.40. Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -617,7 +617,7 @@ See :py:class:`QgsSslErrorHandler` for details on how to handle SSL errors and p
 
 
 
- void requestCreated( QNetworkReply *reply ) /Deprecated/;
+ void requestCreated( QNetworkReply *reply ) /Deprecated="Since 3.40. Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/PyQt6/core/auto_generated/painting/qgsmaskpaintdevice.sip.in
+++ b/python/PyQt6/core/auto_generated/painting/qgsmaskpaintdevice.sip.in
@@ -27,7 +27,7 @@ used later as clip path
 %End
   public:
 
- QgsMaskPaintDevice( bool usePathStroker = false ) /Deprecated/;
+ QgsMaskPaintDevice( bool usePathStroker = false ) /Deprecated="Since 3.38. Use QgsGeometryPaintDevice instead."/;
 %Docstring
 !
 Constructor
@@ -45,7 +45,7 @@ pen configuration
     virtual int metric( PaintDeviceMetric metric ) const;
 
 
- QPainterPath maskPainterPath() const /Deprecated/;
+ QPainterPath maskPainterPath() const /Deprecated="Since 3.40. Use QgsGeometryPaintDevice instead."/;
 %Docstring
 Returns the mask painter path painted on this paint device
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -126,7 +126,7 @@ about what the algorithm does and the parameters and outputs associated with it.
 .. seealso:: :py:func:`helpUrl`
 %End
 
- virtual QString helpString() const /HoldGIL,Deprecated/;
+ virtual QString helpString() const /HoldGIL,Deprecated="Since 3.40. Unused, will be removed in QGIS 4.0."/;
 %Docstring
 Returns a localised help string for the algorithm. Algorithm subclasses should implement either
 :py:func:`~QgsProcessingAlgorithm.helpString` or :py:func:`~QgsProcessingAlgorithm.helpUrl`.
@@ -935,7 +935,7 @@ Evaluates the parameter with matching ``name`` to a list of files (for :py:class
 Evaluates the parameter with matching ``name`` to a range of values.
 %End
 
- QStringList parameterAsFields( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const /Deprecated/;
+ QStringList parameterAsFields( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const /Deprecated="Since 3.40. Use parameterAsStrings() instead."/;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of fields.
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -1462,7 +1462,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a range of
 .. versionadded:: 3.4
 %End
 
- static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context ) /Deprecated/;
+ static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context ) /Deprecated="Since 3.40. Use parameterAsStrings() instead."/;
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of fields.
 
@@ -1471,7 +1471,7 @@ Evaluates the parameter with matching ``definition`` to a list of fields.
    Use :py:func:`~QgsProcessingParameters.parameterAsStrings` instead.
 %End
 
- static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context ) /Deprecated/;
+ static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context ) /Deprecated="Since 3.40. Use parameterAsStrings() instead."/;
 %Docstring
 Evaluates the parameter with matching ``definition`` and ``value`` to a list of fields.
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -397,7 +397,7 @@ using the specified ``context``.
 .. versionadded:: 3.8
 %End
 
- static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) /Deprecated/;
+ static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) /Deprecated="Since 3.40. Use version with QgsProcessingContext argument instead."/;
 %Docstring
 Combines the extent of several map ``layers``. If specified, the target ``crs``
 will be used to transform the layer's extent to the desired output reference system.

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -212,7 +212,7 @@ If no prefix is specified, WKT definition is assumed.
 %End
 
 
- explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId ) /Deprecated/;
+ explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId ) /Deprecated="Since 3.10. We encourage you to use EPSG codes or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format."/;
 %Docstring
 Constructor
 
@@ -276,7 +276,7 @@ Creates a CRS from a given EPSG ID.
 :return: matching CRS, or an invalid CRS if string could not be matched
 %End
 
- static QgsCoordinateReferenceSystem fromProj4( const QString &proj4 ) /Deprecated/;
+ static QgsCoordinateReferenceSystem fromProj4( const QString &proj4 ) /Deprecated="Since 3.10. Use fromProj() instead."/;
 %Docstring
 Creates a CRS from a proj style formatted string.
 
@@ -360,7 +360,7 @@ or the compound CRS could not be created for the combination.
 
 
 
- bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated/;
+ bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated="Since 3.10. We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format."/;
 %Docstring
 Sets this CRS by lookup of the given ID in the CRS database.
 
@@ -391,7 +391,7 @@ and refer to QGIS internal CRS IDs.
 %End
 
 
- bool createFromSrid( long srid ) /Deprecated/;
+ bool createFromSrid( long srid ) /Deprecated="Since 3.10. Use alternative methods for SRS construction instead -- this method was specifically created for use by the postgres provider alone, and using it elsewhere will lead to subtle bugs."/;
 %Docstring
 Sets this CRS by lookup of the given PostGIS SRID in the CRS database.
 
@@ -451,7 +451,7 @@ user's local CRS database from home directory is used.
    using auth:id codes or WKT strings
 %End
 
- bool createFromProj4( const QString &projString ) /Deprecated/;
+ bool createFromProj4( const QString &projString ) /Deprecated="Since 3.10. Use createFromProj() instead."/;
 %Docstring
 Sets this CRS by passing it a PROJ style formatted string.
 
@@ -578,7 +578,7 @@ For more details on supported formats see OGRSpatialReference.SetFromUserInput()
    Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 %End
 
- static void setupESRIWktFix() /Deprecated/;
+ static void setupESRIWktFix() /Deprecated="Since 3.10. Not used on builds based on Proj version 6 or later."/;
 %Docstring
 Make sure that ESRI WKT import is done properly.
 This is required for proper shapefile CRS import when using gdal>= 1.9.
@@ -623,7 +623,7 @@ if that involves resorting to a hard coded default of geocs:wgs84.
 %End
 
 
- long findMatchingProj() /Deprecated/;
+ long findMatchingProj() /Deprecated="Since 3.10. Not used in Proj >= 6 based builds."/;
 %Docstring
 Walks the CRS databases (both system and user database) trying to match
 stored PROJ string to a database entry in order to fill in further
@@ -766,7 +766,7 @@ This is only used on builds based on Proj >= 6.
 .. seealso:: :py:func:`toProj`
 %End
 
- QString toProj4() const /Deprecated/;
+ QString toProj4() const /Deprecated="Since 3.10. Use toProj() instead."/;
 %Docstring
 Returns a Proj string representation of this CRS.
 
@@ -1185,7 +1185,7 @@ Returns auth id of related geographic CRS
 %End
 
 
- static QStringList recentProjections() /Deprecated/;
+ static QStringList recentProjections() /Deprecated="Since 3.10. Use QgsApplication.coordinateReferenceSystemRegistry()->recentCrs() instead."/;
 %Docstring
 Returns a list of recently used projections
 
@@ -1196,7 +1196,7 @@ Returns a list of recently used projections
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.recentCrs` instead.
 %End
 
- static QList< QgsCoordinateReferenceSystem > recentCoordinateReferenceSystems() /Deprecated/;
+ static QList< QgsCoordinateReferenceSystem > recentCoordinateReferenceSystems() /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->recentCrs() instead."/;
 %Docstring
 Returns a list of recently used CRS.
 
@@ -1205,7 +1205,7 @@ Returns a list of recently used CRS.
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.recentCrs` instead.
 %End
 
- static void pushRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ static void pushRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->pushRecent() instead."/;
 %Docstring
 Pushes a recently used CRS to the top of the recent CRS list.
 
@@ -1214,7 +1214,7 @@ Pushes a recently used CRS to the top of the recent CRS list.
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.pushRecent` instead.
 %End
 
- static void removeRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ static void removeRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->removeRecent() instead."/;
 %Docstring
 Removes a CRS from the list of recently used CRS.
 
@@ -1223,7 +1223,7 @@ Removes a CRS from the list of recently used CRS.
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.removeRecent` instead.
 %End
 
- static void clearRecentCoordinateReferenceSystems() /Deprecated/;
+ static void clearRecentCoordinateReferenceSystems() /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->clearRecent() instead."/;
 %Docstring
 Cleans the list of recently used CRS.
 

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -119,7 +119,7 @@ which dictate the behavior of the transformation.
  explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
         const QgsCoordinateReferenceSystem &destination,
         int sourceDatumTransformId,
-        int destinationDatumTransformId ) /Deprecated/;
+        int destinationDatumTransformId ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0. Use the constructor with a QgsCoordinateTransformContext argument instead."/;
 %Docstring
 Constructs a QgsCoordinateTransform to transform from the ``source``
 to ``destination`` coordinate reference system, with the specified
@@ -527,7 +527,7 @@ Returns ``True`` if a fallback operation occurred for the most recent transform.
 .. versionadded:: 3.12
 %End
 
- int sourceDatumTransformId() const /Deprecated/;
+ int sourceDatumTransformId() const /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Returns the ID of the datum transform to use when projecting from the source
 CRS.
@@ -546,7 +546,7 @@ but can be manually overwritten by a call to :py:func:`~QgsCoordinateTransform.s
    Unused on builds based on Proj 6.0 or later.
 %End
 
- void setSourceDatumTransformId( int datumId ) /Deprecated/;
+ void setSourceDatumTransformId( int datumId ) /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Sets the ``datumId`` ID of the datum transform to use when projecting from the source
 CRS.
@@ -565,7 +565,7 @@ Calling this method will overwrite any automatically calculated datum transform.
    Unused on builds based on Proj 6.0 or later.
 %End
 
- int destinationDatumTransformId() const /Deprecated/;
+ int destinationDatumTransformId() const /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Returns the ID of the datum transform to use when projecting to the destination
 CRS.
@@ -584,7 +584,7 @@ but can be manually overwritten by a call to :py:func:`~QgsCoordinateTransform.s
    Unused on builds based on Proj 6.0 or later.
 %End
 
- void setDestinationDatumTransformId( int datumId ) /Deprecated/;
+ void setDestinationDatumTransformId( int datumId ) /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Sets the ``datumId`` ID of the datum transform to use when projecting to the destination
 CRS.

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
@@ -56,7 +56,7 @@ Constructor for QgsCoordinateTransformContext.
 Clears all stored transform information from the context.
 %End
 
- QMap< QPair< QString, QString>, QgsDatumTransform::TransformPair > sourceDestinationDatumTransforms() const /Deprecated/;
+ QMap< QPair< QString, QString>, QgsDatumTransform::TransformPair > sourceDestinationDatumTransforms() const /Deprecated="Since 3.40. Has no effect on builds based on Proj 6.0 or later, use coordinateOperations() instead."/;
 %Docstring
 Returns the stored mapping for source to destination CRS pairs to associated datum transforms to use.
 The map keys will be :py:class:`QgsCoordinateReferenceSystems`.authid()s.
@@ -98,7 +98,7 @@ Returns the stored mapping for source to destination CRS pairs to associated coo
 .. versionadded:: 3.8
 %End
 
- bool addSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, int sourceTransformId, int destinationTransformId ) /Deprecated/;
+ bool addSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, int sourceTransformId, int destinationTransformId ) /Deprecated="Since 3.40. Has no effect on builds based on Proj 6.0 or later, use addCoordinateOperation() instead."/;
 %Docstring
 Adds a new ``sourceTransform`` and ``destinationTransform`` to use when projecting coordinates
 from the specified ``sourceCrs`` to the specified ``destinationCrs``.
@@ -155,7 +155,7 @@ Returns ``True`` if the new coordinate operation was added successfully.
 .. versionadded:: 3.8
 %End
 
- void removeSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs ) /Deprecated/;
+ void removeSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs ) /Deprecated="Since 3.40. Use removeCoordinateOperation() instead."/;
 %Docstring
 Removes the source to destination datum transform pair for the specified ``sourceCrs`` and
 ``destinationCrs``.
@@ -185,7 +185,7 @@ when transforming from the specified ``source`` CRS to ``destination`` CRS.
    source and destination are reversible.
 %End
 
- QgsDatumTransform::TransformPair calculateDatumTransforms( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const /Deprecated/;
+ QgsDatumTransform::TransformPair calculateDatumTransforms( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const /Deprecated="Since 3.40. Has no effect on builds based on Proj 6.0 or later. Use calculateCoordinateOperation() instead."/;
 %Docstring
 Returns the pair of source and destination datum transforms to use
 for a transform from the specified ``source`` CRS to ``destination`` CRS.

--- a/python/PyQt6/core/auto_generated/proj/qgsdatumtransform.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgsdatumtransform.sip.in
@@ -141,7 +141,7 @@ in the results. This requires Proj >= 6.2.
 .. versionadded:: 3.8
 %End
 
- static QList< QgsDatumTransform::TransformPair > datumTransformations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) /Deprecated/;
+ static QList< QgsDatumTransform::TransformPair > datumTransformations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns a list of datum transformations which are available for the given ``source`` and ``destination`` CRS.
 
@@ -154,7 +154,7 @@ Returns a list of datum transformations which are available for the given ``sour
    Not used for builds based on Proj >= 6.0.
 %End
 
- static QString datumTransformToProj( int datumTransformId ) /Deprecated/;
+ static QString datumTransformToProj( int datumTransformId ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns a proj string representing the specified ``datumTransformId`` datum transform ID.
 
@@ -169,7 +169,7 @@ Returns a proj string representing the specified ``datumTransformId`` datum tran
    Not used for builds based on Proj >= 6.0.
 %End
 
- static int projStringToDatumTransformId( const QString &string ) /Deprecated/;
+ static int projStringToDatumTransformId( const QString &string ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns the datum transform ID corresponding to a specified proj ``string``.
 Returns -1 if matching datum ID was not found.
@@ -181,7 +181,7 @@ Returns -1 if matching datum ID was not found.
    Not used for builds based on Proj >= 6.0.
 %End
 
- static QgsDatumTransform::TransformInfo datumTransformInfo( int datumTransformId ) /Deprecated/;
+ static QgsDatumTransform::TransformInfo datumTransformInfo( int datumTransformId ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns detailed information about the specified ``datumTransformId``.
 If ``datumTransformId`` was not a valid transform ID, a TransformInfo with TransformInfo.datumTransformId of

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -228,7 +228,7 @@ QGIS) project file to be overwritten when the project is next saved.
 .. versionadded:: 3.14
 %End
 
- QFileInfo fileInfo() const /Deprecated/;
+ QFileInfo fileInfo() const /Deprecated="Since 3.2. Use absoluteFilePath(), baseName() or lastModifiedTime() instead."/;
 %Docstring
 Returns QFileInfo object for the project's associated file.
 
@@ -961,7 +961,7 @@ Gets the list of layers which currently should not be taken into account on map 
    Use :py:func:`QgsMapLayer.setFlags()` instead.
 %End
 
- bool autoTransaction() const /Deprecated/;
+ bool autoTransaction() const /Deprecated="Since 3.26. Use transactionMode() instead."/;
 %Docstring
 Transactional editing means that on supported datasources (postgres databases) the edit state of
 all tables that originate from the same database are synchronized and executed in a server side
@@ -972,7 +972,7 @@ transaction.
    Use :py:func:`~QgsProject.transactionMode` instead.
 %End
 
- void setAutoTransaction( bool autoTransaction ) /Deprecated/;
+ void setAutoTransaction( bool autoTransaction ) /Deprecated="Since 3.26. Use setTransactionMode() instead."/;
 %Docstring
 Transactional editing means that on supported datasources (postgres databases) the edit state of
 all tables that originate from the same database are synchronized and executed in a server side
@@ -1028,7 +1028,7 @@ Returns the edit buffer group
 .. versionadded:: 3.26
 %End
 
- bool evaluateDefaultValues() const /Deprecated/;
+ bool evaluateDefaultValues() const /Deprecated="Since 3.40. Test whether the flags() method returns the Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide flag instead."/;
 %Docstring
 Should default values be evaluated on provider side when requested and not when committed.
 
@@ -1037,7 +1037,7 @@ Should default values be evaluated on provider side when requested and not when 
    Test whether the :py:func:`~QgsProject.flags` method returns the :py:class:`Qgis`.ProjectFlag.EvaluateDefaultValuesOnProviderSide flag instead.
 %End
 
- void setEvaluateDefaultValues( bool evaluateDefaultValues ) /Deprecated/;
+ void setEvaluateDefaultValues( bool evaluateDefaultValues ) /Deprecated="Since 3.40. Use setFlag( Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide ) instead."/;
 %Docstring
 Defines if default values should be evaluated on provider side when requested and not when committed.
 
@@ -1375,7 +1375,7 @@ Returns the default CRS for new layers based on the settings and
 the current project CRS
 %End
 
- void setTrustLayerMetadata( bool trust ) /Deprecated/;
+ void setTrustLayerMetadata( bool trust ) /Deprecated="Since 3.40. Use setFlag( Qgis.ProjectFlag.TrustStoredLayerStatistics ) instead."/;
 %Docstring
 Sets the trust option allowing to indicate if the extent has to be
 read from the XML document when data source has no metadata or if the
@@ -1390,7 +1390,7 @@ materialized views with Postgres provider.
    Use setFlag( :py:class:`Qgis`.ProjectFlag.TrustStoredLayerStatistics ) instead.
 %End
 
- bool trustLayerMetadata() const /Deprecated/;
+ bool trustLayerMetadata() const /Deprecated="Since 3.40. Test whether the flags() method returns the Qgis.ProjectFlag.TrustStoredLayerStatistics flag instead."/;
 %Docstring
 Returns ``True`` if the trust option is activated, ``False`` otherwise. This
 option allows indicateing if the extent has to be read from the XML
@@ -1565,7 +1565,7 @@ Returns the color used to highlight selected features
 .. versionadded:: 3.10
 %End
 
- void setMapScales( const QVector<double> &scales ) /Deprecated/;
+ void setMapScales( const QVector<double> &scales ) /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Sets the list of custom project map ``scales``.
 
@@ -1581,7 +1581,7 @@ The ``scales`` list consists of a list of scale denominator values, e.g.
    Use :py:func:`~QgsProject.viewSettings` instead.
 %End
 
- QVector<double> mapScales() const /Deprecated/;
+ QVector<double> mapScales() const /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Returns the list of custom project map scales.
 
@@ -1597,7 +1597,7 @@ The scales list consists of a list of scale denominator values, e.g.
    Use :py:func:`~QgsProject.viewSettings` instead.
 %End
 
- void setUseProjectScales( bool enabled ) /Deprecated/;
+ void setUseProjectScales( bool enabled ) /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Sets whether project :py:func:`~QgsProject.mapScales` are ``enabled``.
 
@@ -1610,7 +1610,7 @@ Sets whether project :py:func:`~QgsProject.mapScales` are ``enabled``.
    Use :py:func:`~QgsProject.viewSettings` instead.
 %End
 
- bool useProjectScales() const /Deprecated/;
+ bool useProjectScales() const /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Returns ``True`` if project :py:func:`~QgsProject.mapScales` are enabled.
 
@@ -1729,7 +1729,7 @@ additional information to the layer.
 Emitted when the project file has been written and closed.
 %End
 
- void oldProjectVersionWarning( const QString &warning ) /Deprecated/;
+ void oldProjectVersionWarning( const QString &warning ) /Deprecated="Since 3.40. Use readVersionMismatchOccurred() instead."/;
 %Docstring
 Emitted when an old project file is read.
 
@@ -2120,7 +2120,7 @@ Emitted when setDirty(true) is called.
 .. versionadded:: 3.20
 %End
 
- void mapScalesChanged() /Deprecated/;
+ void mapScalesChanged() /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Emitted when the list of custom project map scales changes.
 

--- a/python/PyQt6/core/auto_generated/project/qgsprojectstorage.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectstorage.sip.in
@@ -110,7 +110,7 @@ The default implementation returns an empty string.
 .. versionadded:: 3.8.1
 %End
 
- virtual QString visibleName() /Deprecated/;
+ virtual QString visibleName() /Deprecated="Since 3.10. Use QgsProjectStorageGuiProvider for GUI-related project storage functionality."/;
 %Docstring
 Returns human-readable name of the storage. Used as the menu item text in QGIS. Empty name
 indicates that the storage does not implement GUI support (:py:func:`~QgsProjectStorage.showLoadGui` and :py:func:`~QgsProjectStorage.showSaveGui`).
@@ -121,7 +121,7 @@ The name may be translatable and ideally unique as well.
    Use :py:class:`QgsProjectStorageGuiProvider` for GUI-related project storage functionality.
 %End
 
- virtual QString showLoadGui() /Deprecated/;
+ virtual QString showLoadGui() /Deprecated="Since 3.10. Use QgsProjectStorageGuiProvider for GUI-related project storage functionality."/;
 %Docstring
 Opens GUI to allow user to select a project to be loaded (GUI specific to this storage type).
 Returns project URI if user has picked a project or empty string if the GUI was canceled.
@@ -131,7 +131,7 @@ Returns project URI if user has picked a project or empty string if the GUI was 
    Use :py:class:`QgsProjectStorageGuiProvider` for GUI-related project storage functionality.
 %End
 
- virtual QString showSaveGui() /Deprecated/;
+ virtual QString showSaveGui() /Deprecated="Since 3.10. Use QgsProjectStorageGuiProvider for GUI-related project storage functionality."/;
 %Docstring
 Opens GUI to allow user to select where a project should be saved (GUI specific to this storage type).
 Returns project URI if user has picked a destination or empty string if the GUI was canceled.

--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
@@ -45,7 +45,7 @@ If ``user`` is blank then the user associated with the current logon details wil
 .. versionadded:: 3.24
 %End
 
- static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated/;
+ static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON user info for the specified user name. Only to avoid API break.
 
@@ -87,7 +87,7 @@ If ``user`` is blank then the user associated with the current logon details wil
 .. versionadded:: 3.24
 %End
 
- static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated/;
+ static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON definitions for all groups which the specified user name is a member of. Only to avoid API break.
 
@@ -128,7 +128,7 @@ Retrieves JSON definitions for all items which belong the the specified ``groupI
 .. versionadded:: 3.24
 %End
 
- static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated/;
+ static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified ``groupId``. Only to avoid API break.
 
@@ -173,7 +173,7 @@ Retrieves JSON definitions for all items which belong the the specified ``groupI
 
  static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
-        QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated/;
+        QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified ``groupId``. Only to avoid API break.
 

--- a/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -49,7 +49,7 @@ Constructs default metadata without any capabilities
  QgsMeshDriverMetadata( const QString &name,
         const QString &description,
         const MeshDriverCapabilities &capabilities,
-        const QString &writeDatasetOnFileSuffix ) /Deprecated/;
+        const QString &writeDatasetOnFileSuffix ) /Deprecated="Since 3.22. "/;
 %Docstring
 Constructs driver metadata with selected capabilities
 
@@ -250,7 +250,7 @@ Returns a list of the map layer types supported by the provider.
     }
 %End
 
- QString library() const /Deprecated/;
+ QString library() const /Deprecated="Since 3.10. Providers may not need to be loaded from a library (empty string returned)."/;
 %Docstring
 This returns the library file name
 

--- a/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -51,7 +51,7 @@ Means of accessing canonical single instance
 
     ~QgsProviderRegistry();
 
- QString library( const QString &providerKey ) const /Deprecated/;
+ QString library( const QString &providerKey ) const /Deprecated="Since 3.10. Providers may not need to be loaded from a library (empty string returned)."/;
 %Docstring
 Returns path for the library of the provider.
 
@@ -96,7 +96,7 @@ Creates a new instance of a provider.
 .. seealso:: :py:func:`createRasterDataProvider`
 %End
 
- Qgis::DataItemProviderCapabilities providerCapabilities( const QString &providerKey ) const /Deprecated/;
+ Qgis::DataItemProviderCapabilities providerCapabilities( const QString &providerKey ) const /Deprecated="Since 3.10. Use instead capabilities() method of individual data item provider."/;
 %Docstring
 Returns the provider capabilities
 
@@ -205,7 +205,7 @@ If a provider does not work with paths, unmodified URI will be returned.
 .. versionadded:: 3.30
 %End
 
- QWidget *createSelectionWidget( const QString &providerKey, QWidget *parent = 0, Qt::WindowFlags fl = Qt::WindowFlags(), QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Standalone ) /Deprecated/;
+ QWidget *createSelectionWidget( const QString &providerKey, QWidget *parent = 0, Qt::WindowFlags fl = Qt::WindowFlags(), QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Standalone ) /Deprecated="Since 3.10. Use QgsGui.sourceSelectProviderRegistry()->createDataSourceWidget() instead."/;
 %Docstring
 Returns a new widget for selecting layers from a provider.
 Either the ``parent`` widget must be set or the caller becomes
@@ -336,7 +336,7 @@ Returns new instance of transaction. Ownership is transferred to the caller
 .. versionadded:: 3.10
 %End
 
- QFunctionPointer function( const QString &providerKey, const QString &functionName ) const /Deprecated/;
+ QFunctionPointer function( const QString &providerKey, const QString &functionName ) const /Deprecated="Since 3.10. Any provider functionality should be accessed through QgsProviderMetadata."/;
 %Docstring
 Gets pointer to provider function
 
@@ -351,7 +351,7 @@ Gets pointer to provider function
    Any provider functionality should be accessed through :py:class:`QgsProviderMetadata`.
 %End
 
- QLibrary *createProviderLibrary( const QString &providerKey ) const /Factory,Deprecated/;
+ QLibrary *createProviderLibrary( const QString &providerKey ) const /Factory,Deprecated="Since 3.10. Providers may not need to be loaded from a library."/;
 %Docstring
 Returns a new QLibrary for the specified ``providerKey``. Ownership of the returned
 object is transferred to the caller and the caller is responsible for deleting it.
@@ -749,7 +749,7 @@ Returns a string containing the available directory drivers
 Returns a string containing the available protocol drivers
 %End
 
- void registerGuis( QWidget *widget ) /Deprecated/;
+ void registerGuis( QWidget *widget ) /Deprecated="Since 3.10. Does nothing - use QgsGui.providerGuiRegistry()."/;
 %Docstring
 
 .. deprecated:: 3.10

--- a/python/PyQt6/core/auto_generated/qgsapplication.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsapplication.sip.in
@@ -265,7 +265,7 @@ Returns the path to the settings directory in user's home dir
 Returns the path to the user qgis.db file.
 %End
 
- static QString qgisAuthDatabaseFilePath() /Deprecated/;
+ static QString qgisAuthDatabaseFilePath() /Deprecated="Since 3.30. Use qgisAuthDatabaseUri() instead."/;
 %Docstring
 Returns the path to the user authentication database file: qgis-auth.db.
 
@@ -698,7 +698,7 @@ Returns the application's task manager, used for managing application
 wide background task handling.
 %End
 
- static QgsSettingsRegistryCore *settingsRegistryCore() /KeepReference,Deprecated/;
+ static QgsSettingsRegistryCore *settingsRegistryCore() /KeepReference,Deprecated="Since 3.30. Use QgsSettings.treeRoot() instead."/;
 %Docstring
 Returns the application's settings registry, used for managing application settings.
 

--- a/python/PyQt6/core/auto_generated/qgsdbfilterproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdbfilterproxymodel.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsDatabaseFilterProxyModel : QSortFilterProxyModel /Deprecated/
+class QgsDatabaseFilterProxyModel : QSortFilterProxyModel /Deprecated="Since 3.24. "/
 {
 %Docstring(signature="appended")
 A class that implements a custom filter and can be used

--- a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
@@ -864,7 +864,7 @@ Check if a feature is accepted by this requests filter
 :return: ``True``, if the filter accepts the feature
 %End
 
- int connectionTimeout() const /Deprecated/;
+ int connectionTimeout() const /Deprecated="Since 3.40. Use timeout() instead."/;
 %Docstring
 Returns the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.
@@ -878,7 +878,7 @@ at this moment. A negative value (which is set by default) will wait forever.
    Use :py:func:`~QgsFeatureRequest.timeout` instead.
 %End
 
- QgsFeatureRequest &setConnectionTimeout( int connectionTimeout ) /Deprecated/;
+ QgsFeatureRequest &setConnectionTimeout( int connectionTimeout ) /Deprecated="Since 3.40. Use setTimeout() instead."/;
 %Docstring
 Sets the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.

--- a/python/PyQt6/core/auto_generated/qgsfield.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfield.sip.in
@@ -65,7 +65,7 @@ Constructor. Constructs a new QgsField object.
                                 int len = 0,
                                 int prec = 0,
                                 const QString &comment = QString(),
-                                QVariant::Type subType = QVariant::Invalid ) /HoldGIL,Deprecated/;
+                                QVariant::Type subType = QVariant::Invalid ) /HoldGIL,Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor. Constructs a new QgsField object.
 
@@ -262,7 +262,7 @@ Set the field name.
 Set variant ``type``.
 %End
 
- void setType( QVariant::Type type ) /HoldGIL,Deprecated/;
+ void setType( QVariant::Type type ) /HoldGIL,Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Set variant ``type``.
 
@@ -278,7 +278,7 @@ When all the elements don't need to have the same type, set this to
 QVariant.Invalid.
 %End
 
- void setSubType( QVariant::Type subType ) /HoldGIL,Deprecated/;
+ void setSubType( QVariant::Type subType ) /HoldGIL,Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 If the field is a collection, set its element's type.
 When all the elements don't need to have the same type, set this to

--- a/python/PyQt6/core/auto_generated/qgsfields.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfields.sip.in
@@ -377,7 +377,7 @@ Since QGIS 3.30, the optional ``typeString`` argument can be used to specify fie
 .. versionadded:: 3.16
 %End
 
- static QIcon iconForFieldType( QVariant::Type type, QVariant::Type subType, const QString &typeString = QString() ) /Deprecated/;
+ static QIcon iconForFieldType( QVariant::Type type, QVariant::Type subType, const QString &typeString = QString() ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Returns an icon corresponding to a field ``type``
 

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -366,7 +366,7 @@ Parse a simple array (depth=1)
              the conversion is not possible.
 %End
 
- static QVariantList parseArray( const QString &json, QVariant::Type type ) /Deprecated/;
+ static QVariantList parseArray( const QString &json, QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Parse a simple array (depth=1)
 

--- a/python/PyQt6/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslegendrenderer.sip.in
@@ -76,7 +76,7 @@ If the returned size is null, the legend will be drawn with the minimum possible
 .. seealso:: :py:func:`setLegendSize`
 %End
 
- void drawLegend( QPainter *painter ) /Deprecated/;
+ void drawLegend( QPainter *painter ) /Deprecated="Since 3.40. Use the variant which accepts a QgsRenderContext instead."/;
 %Docstring
 Draws the legend with given ``painter``. The legend will occupy the area reported in :py:func:`~QgsLegendRenderer.legendSize`.
 The ``painter`` should be scaled beforehand so that units correspond to millimeters.

--- a/python/PyQt6/core/auto_generated/qgslegendsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslegendsettings.sip.in
@@ -171,7 +171,7 @@ If ``False``, then then columns will be individually resized to their minimum po
 .. seealso:: :py:func:`equalColumnWidth`
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Returns the font color used for legend items.
 
@@ -182,7 +182,7 @@ Returns the font color used for legend items.
    Use :py:func:`QgsLegendStyle.textFormat()` instead.
 %End
 
- void setFontColor( const QColor &c ) /Deprecated/;
+ void setFontColor( const QColor &c ) /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Sets the font color used for legend items.
 
@@ -193,7 +193,7 @@ Sets the font color used for legend items.
    Use :py:func:`QgsLegendStyle.textFormat()` instead.
 %End
 
- QColor layerFontColor() const /Deprecated/;
+ QColor layerFontColor() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Returns layer font color, defaults to :py:func:`~QgsLegendSettings.fontColor`
 
@@ -206,7 +206,7 @@ Returns layer font color, defaults to :py:func:`~QgsLegendSettings.fontColor`
    Use :py:func:`QgsLegendStyle.textFormat()` instead.
 %End
 
- void setLayerFontColor( const QColor &fontColor ) /Deprecated/;
+ void setLayerFontColor( const QColor &fontColor ) /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Sets layer font color to ``fontColor``
 Overrides :py:func:`~QgsLegendSettings.fontColor`
@@ -404,7 +404,7 @@ Returns whether to request legend graphics synchronously.
 .. versionadded:: 3.34
 %End
 
- double lineSpacing() const /Deprecated/;
+ double lineSpacing() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() from style() instead."/;
 %Docstring
 Returns the line spacing to use between lines of legend text.
 
@@ -426,7 +426,7 @@ Sets the line spacing to use between lines of legend text.
    Use :py:func:`QgsLegendStyle.setTextFormat()` from :py:func:`~QgsLegendSettings.style` instead.
 %End
 
- double mmPerMapUnit() const /Deprecated/;
+ double mmPerMapUnit() const /Deprecated="Since 3.40. Use scale factor from render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -434,7 +434,7 @@ Sets the line spacing to use between lines of legend text.
    Use scale factor from render contexts instead.
 %End
 
- void setMmPerMapUnit( double mmPerMapUnit ) /Deprecated/;
+ void setMmPerMapUnit( double mmPerMapUnit ) /Deprecated="Since 3.40. Set scale factor on render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -442,7 +442,7 @@ Sets the line spacing to use between lines of legend text.
    Set scale factor on render contexts instead.
 %End
 
- bool useAdvancedEffects() const /Deprecated/;
+ bool useAdvancedEffects() const /Deprecated="Since 3.40. Use flags from render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -450,7 +450,7 @@ Sets the line spacing to use between lines of legend text.
    Use flags from render contexts instead.
 %End
 
- void setUseAdvancedEffects( bool use ) /Deprecated/;
+ void setUseAdvancedEffects( bool use ) /Deprecated="Since 3.40. Set flag on render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -458,7 +458,7 @@ Sets the line spacing to use between lines of legend text.
    Set flag on render contexts instead.
 %End
 
- double mapScale() const /Deprecated/;
+ double mapScale() const /Deprecated="Since 3.40. Take this property from the render context instead."/;
 %Docstring
 Returns the legend map scale.
 The scale value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
@@ -470,7 +470,7 @@ The scale value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
    Take this property from the render context instead.
 %End
 
- void setMapScale( double scale ) /Deprecated/;
+ void setMapScale( double scale ) /Deprecated="Since 3.40. Set this property on the render context instead."/;
 %Docstring
 Sets the legend map ``scale``.
 The ``scale`` value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
@@ -482,7 +482,7 @@ The ``scale`` value indicates the scale denominator, e.g. 1000.0 for a 1:1000 ma
    Set this property on the render context instead.
 %End
 
- double mapUnitsPerPixel() const /Deprecated/;
+ double mapUnitsPerPixel() const /Deprecated="Since 3.40. Take these properties on render contexts instead."/;
 %Docstring
 Returns the factor of map units per pixel for symbols with size given in map units calculated by dpi and mmPerMapUnit
 
@@ -493,7 +493,7 @@ Returns the factor of map units per pixel for symbols with size given in map uni
    Take these properties on render contexts instead.
 %End
 
- void setMapUnitsPerPixel( double mapUnitsPerPixel ) /Deprecated/;
+ void setMapUnitsPerPixel( double mapUnitsPerPixel ) /Deprecated="Since 3.40. Set these properties on render contexts instead."/;
 %Docstring
 Sets the mmPerMapUnit calculated by ``mapUnitsPerPixel`` mostly taken from the map settings.
 
@@ -504,7 +504,7 @@ Sets the mmPerMapUnit calculated by ``mapUnitsPerPixel`` mostly taken from the m
    Set these properties on render contexts instead.
 %End
 
- int dpi() const /Deprecated/;
+ int dpi() const /Deprecated="Since 3.40. Take dpi from render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -512,7 +512,7 @@ Sets the mmPerMapUnit calculated by ``mapUnitsPerPixel`` mostly taken from the m
    Take dpi from render contexts instead.
 %End
 
- void setDpi( int dpi ) /Deprecated/;
+ void setDpi( int dpi ) /Deprecated="Since 3.40. Set dpi on render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/PyQt6/core/auto_generated/qgslegendstyle.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslegendstyle.sip.in
@@ -43,7 +43,7 @@ Contains detailed styling information relating to how a layout legend should be 
 
     QgsLegendStyle();
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the font used for rendering this legend component.
 
@@ -54,7 +54,7 @@ Returns the font used for rendering this legend component.
    Use :py:func:`~QgsLegendStyle.textFormat` instead.
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for rendering this legend component.
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -243,7 +243,7 @@ Returns the layer data provider's metadata, it may be ``None``.
 .. versionadded:: 3.40
 %End
 
- void setShortName( const QString &shortName ) /Deprecated/;
+ void setShortName( const QString &shortName ) /Deprecated="Since 3.38. Use serverProperties()->setShortName() instead."/;
 %Docstring
 Sets the short name of the layer used by QGIS Server to identify the layer.
 
@@ -252,7 +252,7 @@ Sets the short name of the layer used by QGIS Server to identify the layer.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setShortName` instead.
 %End
 
- QString shortName() const /Deprecated/;
+ QString shortName() const /Deprecated="Since 3.38. Use serverProperties()->shortName() instead."/;
 %Docstring
 Returns the short name of the layer used by QGIS Server to identify the layer.
 
@@ -261,7 +261,7 @@ Returns the short name of the layer used by QGIS Server to identify the layer.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.shortName` instead.
 %End
 
- void setTitle( const QString &title ) /Deprecated/;
+ void setTitle( const QString &title ) /Deprecated="Since 3.38. Use serverProperties()->setTitle() instead."/;
 %Docstring
 Sets the title of the layer used by QGIS Server in GetCapabilities request.
 
@@ -270,7 +270,7 @@ Sets the title of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setTitle` instead.
 %End
 
- QString title() const /Deprecated/;
+ QString title() const /Deprecated="Since 3.38. Use serverProperties()->title() instead."/;
 %Docstring
 Returns the title of the layer used by QGIS Server in GetCapabilities request.
 
@@ -279,7 +279,7 @@ Returns the title of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.title` instead.
 %End
 
- void setAbstract( const QString &abstract ) /Deprecated/;
+ void setAbstract( const QString &abstract ) /Deprecated="Since 3.38. Use serverProperties()->setAbstract() instead."/;
 %Docstring
 Sets the abstract of the layer used by QGIS Server in GetCapabilities request.
 
@@ -288,7 +288,7 @@ Sets the abstract of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAbstract` instead.
 %End
 
- QString abstract() const /Deprecated/;
+ QString abstract() const /Deprecated="Since 3.38. Use serverProperties()->abstract() instead."/;
 %Docstring
 Returns the abstract of the layer used by QGIS Server in GetCapabilities request.
 
@@ -297,7 +297,7 @@ Returns the abstract of the layer used by QGIS Server in GetCapabilities request
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.abstract` instead.
 %End
 
- void setKeywordList( const QString &keywords ) /Deprecated/;
+ void setKeywordList( const QString &keywords ) /Deprecated="Since 3.38. Use serverProperties()->setKeywordList() instead."/;
 %Docstring
 Sets the keyword list of the layerused by QGIS Server in GetCapabilities request.
 
@@ -306,7 +306,7 @@ Sets the keyword list of the layerused by QGIS Server in GetCapabilities request
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setKeywordList` instead.
 %End
 
- QString keywordList() const /Deprecated/;
+ QString keywordList() const /Deprecated="Since 3.38. Use serverProperties()->keywordList() instead."/;
 %Docstring
 Returns the keyword list of the layer used by QGIS Server in GetCapabilities request.
 
@@ -315,7 +315,7 @@ Returns the keyword list of the layer used by QGIS Server in GetCapabilities req
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.keywordList` instead.
 %End
 
- void setDataUrl( const QString &dataUrl ) /Deprecated/;
+ void setDataUrl( const QString &dataUrl ) /Deprecated="Since 3.38. Use serverProperties()->setDataUrl() instead."/;
 %Docstring
 Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
@@ -324,7 +324,7 @@ Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrl` instead.
 %End
 
- QString dataUrl() const /Deprecated/;
+ QString dataUrl() const /Deprecated="Since 3.38. Use serverProperties()->dataUrl() instead."/;
 %Docstring
 Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
@@ -333,7 +333,7 @@ Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrl` instead.
 %End
 
- void setDataUrlFormat( const QString &dataUrlFormat ) /Deprecated/;
+ void setDataUrlFormat( const QString &dataUrlFormat ) /Deprecated="Since 3.38. Use serverProperties()->setDataUrlFormat() instead."/;
 %Docstring
 Sets the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
@@ -342,7 +342,7 @@ Sets the DataUrl format of the layer used by QGIS Server in GetCapabilities requ
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrlFormat` instead.
 %End
 
- QString dataUrlFormat() const /Deprecated/;
+ QString dataUrlFormat() const /Deprecated="Since 3.38. Use serverProperties()->dataUrlFormat() instead."/;
 %Docstring
 Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
@@ -351,7 +351,7 @@ Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities r
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrlFormat` instead.
 %End
 
- void setAttribution( const QString &attrib ) /Deprecated/;
+ void setAttribution( const QString &attrib ) /Deprecated="Since 3.38. Use serverProperties()->setAttribution() instead."/;
 %Docstring
 Sets the attribution of the layerused by QGIS Server in GetCapabilities request.
 
@@ -360,7 +360,7 @@ Sets the attribution of the layerused by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttribution` instead.
 %End
 
- QString attribution() const /Deprecated/;
+ QString attribution() const /Deprecated="Since 3.38. Use serverProperties()->attribution() instead."/;
 %Docstring
 Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
 
@@ -369,7 +369,7 @@ Returns the attribution of the layer used by QGIS Server in GetCapabilities requ
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.attribution` instead.
 %End
 
- void setAttributionUrl( const QString &attribUrl ) /Deprecated/;
+ void setAttributionUrl( const QString &attribUrl ) /Deprecated="Since 3.38. Use serverProperties()->setAttributionUrl() instead."/;
 %Docstring
 Sets the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
@@ -378,7 +378,7 @@ Sets the attribution URL of the layer used by QGIS Server in GetCapabilities req
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttributionUrl` instead.
 %End
 
- QString attributionUrl() const /Deprecated/;
+ QString attributionUrl() const /Deprecated="Since 3.38. Use serverProperties()->attributionUrl() instead."/;
 %Docstring
 Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
@@ -394,7 +394,7 @@ Returns QGIS Server Properties for the map layer
 
 .. versionadded:: 3.22
 %End
- void setMetadataUrl( const QString &metaUrl ) /Deprecated/;
+ void setMetadataUrl( const QString &metaUrl ) /Deprecated="Since 3.22. "/;
 %Docstring
 Sets the metadata URL of the layer
 used by QGIS Server in GetCapabilities request.
@@ -406,7 +406,7 @@ Since QGIS 3.22, it edits the first metadata URL link.
 .. deprecated:: 3.22
 %End
 
- QString metadataUrl() const /Deprecated/;
+ QString metadataUrl() const /Deprecated="Since 3.22. "/;
 %Docstring
 Returns the metadata URL of the layer
 used by QGIS Server in GetCapabilities request.
@@ -420,7 +420,7 @@ Since QGIS 3.22, it returns the first metadata URL link.
 .. deprecated:: 3.22
 %End
 
- void setMetadataUrlType( const QString &metaUrlType ) /Deprecated/;
+ void setMetadataUrlType( const QString &metaUrlType ) /Deprecated="Since 3.22. "/;
 %Docstring
 Set the metadata type of the layer
 used by QGIS Server in GetCapabilities request
@@ -432,7 +432,7 @@ Since QGIS 3.22, it edits the first metadata URL type.
 .. deprecated:: 3.22
 %End
 
- QString metadataUrlType() const /Deprecated/;
+ QString metadataUrlType() const /Deprecated="Since 3.22. "/;
 %Docstring
 Returns the metadata type of the layer
 used by QGIS Server in GetCapabilities request.
@@ -446,7 +446,7 @@ Since QGIS 3.22, it returns the first metadata URL type.
 .. deprecated:: 3.22
 %End
 
- void setMetadataUrlFormat( const QString &metaUrlFormat ) /Deprecated/;
+ void setMetadataUrlFormat( const QString &metaUrlFormat ) /Deprecated="Since 3.22. "/;
 %Docstring
 Sets the metadata format of the layer
 used by QGIS Server in GetCapabilities request.
@@ -458,7 +458,7 @@ Since QGIS 3.22, it edits the first metadata URL format.
 .. deprecated:: 3.22
 %End
 
- QString metadataUrlFormat() const /Deprecated/;
+ QString metadataUrlFormat() const /Deprecated="Since 3.22. "/;
 %Docstring
 Returns the metadata format of the layer
 used by QGIS Server in GetCapabilities request.
@@ -1174,7 +1174,7 @@ record in the users style table in their personal qgis.db)
 .. seealso:: :py:func:`saveNamedStyle`
 %End
 
- virtual QString saveDefaultStyle( bool &resultFlag /Out/ ) /Deprecated/;
+ virtual QString saveDefaultStyle( bool &resultFlag /Out/ ) /Deprecated="Since 3.26. "/;
 %Docstring
 Save the properties of this layer as the default style
 (either as a .qml file on disk or as a
@@ -1559,7 +1559,7 @@ Returns whether scale based visibility is enabled for the layer.
 .. seealso:: :py:func:`isInScaleRange`
 %End
 
- bool hasAutoRefreshEnabled() const /Deprecated/;
+ bool hasAutoRefreshEnabled() const /Deprecated="Since 3.40. Use autoRefreshMode() instead."/;
 %Docstring
 Returns ``True`` if auto refresh is enabled for the layer.
 
@@ -1607,7 +1607,7 @@ canvas must be refreshed separately in order to view the refreshed layer.
 .. seealso:: :py:func:`setAutoRefreshEnabled`
 %End
 
- void setAutoRefreshEnabled( bool enabled ) /Deprecated/;
+ void setAutoRefreshEnabled( bool enabled ) /Deprecated="Since 3.40. Use setAutoRefreshMode() instead."/;
 %Docstring
 Sets whether auto refresh is enabled for the layer.
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -39,7 +39,7 @@ Sets ``filter`` flags which affect how layers are filtered within the model.
 .. seealso:: :py:func:`filters`
 %End
 
- void setFilters( int filters ) /Deprecated/;
+ void setFilters( int filters ) /Deprecated="Since 3.34. Use the flag signature instead."/;
 %Docstring
 Filters according to layer type and/or geometry type.
 
@@ -77,7 +77,7 @@ Returns if the ``layer`` matches the given ``filters``
 .. versionadded:: 3.14
 %End
 
- void setLayerWhitelist( const QList<QgsMapLayer *> &layers ) /Deprecated/;
+ void setLayerWhitelist( const QList<QgsMapLayer *> &layers ) /Deprecated="Since 3.40. Use setLayerAllowList()."/;
 %Docstring
 Sets an allowlist of ``layers`` to include within the model. Only layers
 from this list will be shown.
@@ -107,7 +107,7 @@ An empty list indicates that no filter by allowlist should be performed.
 .. versionadded:: 3.14
 %End
 
- QList<QgsMapLayer *> layerWhitelist() /Deprecated/;
+ QList<QgsMapLayer *> layerWhitelist() /Deprecated="Since 3.40. Use layerAllowlist() instead."/;
 %Docstring
 Returns the list of layers which are excluded from the model.
 

--- a/python/PyQt6/core/auto_generated/qgsmaptopixel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaptopixel.sip.in
@@ -131,7 +131,7 @@ Transforms device coordinates to map (world) coordinates.
 :return: :py:class:`QgsPointXY` in map coorndiates
 %End
 
- QgsPointXY toMapPoint( double x, double y ) const /Deprecated/;
+ QgsPointXY toMapPoint( double x, double y ) const /Deprecated="Since 3.4. Use toMapCoordinates() instead."/;
 %Docstring
 Transforms device coordinates to map (world) coordinates.
 

--- a/python/PyQt6/core/auto_generated/qgsowsconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsowsconnection.sip.in
@@ -57,7 +57,7 @@ Returns a string representing the service type, e.g. "WMS".
 Returns the connection uri.
 %End
 
- static QgsDataSourceUri &addWmsWcsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated/;
+ static QgsDataSourceUri &addWmsWcsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated="Since 3.26. Use addWmsWcsConnectionSettings with service and connection name parameters."/;
 %Docstring
 Adds uri parameters relating to the settings for a WMS or WCS connection to a :py:class:`QgsDataSourceUri` ``uri``.
 Connection settings are taken from the specified QSettings ``settingsKey``.
@@ -75,7 +75,7 @@ Connection settings are taken from the specified ``servcie`` and ``connName``
 .. versionadded:: 3.26
 %End
 
- static QgsDataSourceUri &addWfsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated/;
+ static QgsDataSourceUri &addWfsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated="Since 3.26. Use addWfsConnectionSettings with service and connection name parameters."/;
 %Docstring
 Adds uri parameters relating to the settings for a WFS connection to a :py:class:`QgsDataSourceUri` ``uri``.
 Connection settings are taken from the specified QSettings ``settingsKey``.

--- a/python/PyQt6/core/auto_generated/qgsrenderchecker.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrenderchecker.sip.in
@@ -231,7 +231,7 @@ Test using two arbitrary images at the specified paths for equality.
 .. versionadded:: 3.18
 %End
 
- bool isKnownAnomaly( const QString &diffImageFile ) /Deprecated/;
+ bool isKnownAnomaly( const QString &diffImageFile ) /Deprecated="Since 3.40. Use the test mask system instead."/;
 %Docstring
 Gets a list of all the anomalies. An anomaly is a rendered difference
 file where there is some red pixel content (indicating a render check

--- a/python/PyQt6/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrendercontext.sip.in
@@ -110,7 +110,7 @@ This is currently used to implement selective masking.
 %End
 
 
- void setDisabledSymbolLayers( const QSet<const QgsSymbolLayer *> &symbolLayers ) /Deprecated/;
+ void setDisabledSymbolLayers( const QSet<const QgsSymbolLayer *> &symbolLayers ) /Deprecated="Since 3.30. And replaced with setDisabledSymbolLayersV2."/;
 %Docstring
 When rendering a map layer in a second pass (for selective masking),
 some symbol layers may be disabled.
@@ -142,7 +142,7 @@ Sets the list of disabled symbol layer ids.
 .. versionadded:: 3.30
 %End
 
- QSet<const QgsSymbolLayer *> disabledSymbolLayers() const /Deprecated/;
+ QSet<const QgsSymbolLayer *> disabledSymbolLayers() const /Deprecated="Since 3.30. And replaced with disabledSymbolLayersV2."/;
 %Docstring
 When rendering a map layer in a second pass (for selective masking),
 some symbol layers may be disabled.
@@ -873,7 +873,7 @@ in a mask painter, which is not meant to be visible, by definition.
 .. versionadded:: 3.12
 %End
 
- QVariantMap customRenderingFlags() const /Deprecated/;
+ QVariantMap customRenderingFlags() const /Deprecated="Since 3.40. Use customProperties() instead."/;
 %Docstring
 Gets custom rendering flags. Layers might honour these to alter their rendering.
 
@@ -897,7 +897,7 @@ Objects might honour these to alter their rendering.
 .. versionadded:: 3.40
 %End
 
- void setCustomRenderingFlag( const QString &flag, const QVariant &value ) /Deprecated/;
+ void setCustomRenderingFlag( const QString &flag, const QVariant &value ) /Deprecated="Since 3.40. Use setCustomProperty() instead."/;
 %Docstring
 Sets a custom rendering flag. Layers might honour these to alter their rendering.
 
@@ -922,7 +922,7 @@ Objects might honour these to alter their rendering.
 .. versionadded:: 3.40
 %End
 
- void clearCustomRenderingFlag( const QString &flag ) /Deprecated/;
+ void clearCustomRenderingFlag( const QString &flag ) /Deprecated="Since 3.40. Use clearCustomProperty() instead."/;
 %Docstring
 Clears the specified custom rendering flag.
 
@@ -1026,7 +1026,7 @@ are drawn and behave during render operations.
 .. versionadded:: 3.38
 %End
 
- void addSymbolLayerClipPath( const QString &symbolLayerId, QPainterPath path ) /Deprecated/;
+ void addSymbolLayerClipPath( const QString &symbolLayerId, QPainterPath path ) /Deprecated="Since 3.38. Use addSymbolLayerClipGeometry() instead."/;
 %Docstring
 Add a clip ``path`` to be applied to the ``symbolLayer`` before rendering
 
@@ -1037,7 +1037,7 @@ Add a clip ``path`` to be applied to the ``symbolLayer`` before rendering
    Use :py:func:`~QgsRenderContext.addSymbolLayerClipGeometry` instead.
 %End
 
- QList<QPainterPath> symbolLayerClipPaths( const QString &symbolLayerId ) const /Deprecated/;
+ QList<QPainterPath> symbolLayerClipPaths( const QString &symbolLayerId ) const /Deprecated="Since 3.38. Use symbolLayerClipGeometries() instead."/;
 %Docstring
 Returns clip paths to be applied to the ``symbolLayer`` before rendering
 

--- a/python/PyQt6/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -38,7 +38,7 @@ Constructor to create a new runtime profiler.
 %End
     ~QgsRuntimeProfiler();
 
- void beginGroup( const QString &name ) /Deprecated/;
+ void beginGroup( const QString &name ) /Deprecated="Since 3.40. Use start() instead."/;
 %Docstring
 Begin the group for the profiler. Groups will append {GroupName}/ to the
 front of the profile tag set using start.
@@ -50,7 +50,7 @@ front of the profile tag set using start.
    Use :py:func:`~QgsRuntimeProfiler.start` instead.
 %End
 
- void endGroup() /Deprecated/;
+ void endGroup() /Deprecated="Since 3.40. Use end() instead."/;
 %Docstring
 End the current active group.
 

--- a/python/PyQt6/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssnappingconfig.sip.in
@@ -47,7 +47,7 @@ Convenient method to returns the translated name of the enum type
 .. versionadded:: 3.26
 %End
 
- static QString snappingTypeFlagToString( Qgis::SnappingType type ) /Deprecated/;
+ static QString snappingTypeFlagToString( Qgis::SnappingType type ) /Deprecated="Since 3.26. Use snappingTypeToString() instead."/;
 %Docstring
 Convenient method to return the translated name of the enum type
 :py:class:`Qgis`.SnappingTypes.
@@ -68,7 +68,7 @@ Convenient method to return an icon corresponding to the enum type
 .. versionadded:: 3.20
 %End
 
- static QIcon snappingTypeFlagToIcon( Qgis::SnappingType type ) /Deprecated/;
+ static QIcon snappingTypeFlagToIcon( Qgis::SnappingType type ) /Deprecated="Since 3.26. Use snappingTypeToIcon() instead."/;
 %Docstring
 Convenient method to return an icon corresponding to the enum type
 :py:class:`Qgis`.SnappingTypes.
@@ -90,7 +90,7 @@ This is a container of advanced configuration (per layer) of the snapping of the
 %End
       public:
 
- IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, Qgis::MapToolUnit units ) /Deprecated/;
+ IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, Qgis::MapToolUnit units ) /Deprecated="Since 3.12. Use the method with Qgis.SnappingTypes instead."/;
 %Docstring
 IndividualLayerSettings
 
@@ -145,7 +145,7 @@ Returns the flags type (vertices | segments | area | centroid | middle)
 .. versionadded:: 3.12
 %End
 
- QgsSnappingConfig::SnappingType type() const /Deprecated/;
+ QgsSnappingConfig::SnappingType type() const /Deprecated="Since 3.12. Use typeFlag() instead."/;
 %Docstring
 Returns the flags type (vertices | segments | area | centroid | middle)
 
@@ -154,7 +154,7 @@ Returns the flags type (vertices | segments | area | centroid | middle)
    Use :py:func:`~IndividualLayerSettings.typeFlag` instead.
 %End
 
- void setType( SnappingType type ) /Deprecated/;
+ void setType( SnappingType type ) /Deprecated="Since 3.12. Use setTypeFlag() instead."/;
 %Docstring
 define the type of snapping
 
@@ -263,7 +263,7 @@ Returns the flags type (vertices | segments | area | centroid | middle)
 .. versionadded:: 3.12
 %End
 
- QgsSnappingConfig::SnappingType type() const /Deprecated/;
+ QgsSnappingConfig::SnappingType type() const /Deprecated="Since 3.12. Use typeFlag() instead."/;
 %Docstring
 Returns the flags type (vertices | segments | area | centroid | middle)
 

--- a/python/PyQt6/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsspatialindex.sip.in
@@ -78,7 +78,7 @@ that of the spatial index construction.
 
 
 
- bool insertFeature( const QgsFeature &feature ) /Deprecated/;
+ bool insertFeature( const QgsFeature &feature ) /Deprecated="Since 3.40. Use addFeature() instead."/;
 %Docstring
 Adds a ``feature`` to the index.
 
@@ -107,7 +107,7 @@ The ``flags`` argument is ignored.
 .. seealso:: :py:func:`addFeature`
 %End
 
- bool insertFeature( QgsFeatureId id, const QgsRectangle &bounds ) /Deprecated/;
+ bool insertFeature( QgsFeatureId id, const QgsRectangle &bounds ) /Deprecated="Since 3.40. Use addFeature() instead."/;
 %Docstring
 Add a feature ``id`` to the index with a specified bounding box.
 

--- a/python/PyQt6/core/auto_generated/qgsvariantutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvariantutils.sip.in
@@ -29,7 +29,7 @@ Returns a user-friendly translated string representing a QVariant ``type``.
 The optional ``subType`` can be used to specify the type of variant list or map values.
 %End
 
- static QString typeToDisplayString( QVariant::Type type, QVariant::Type subType = QVariant::Type::Invalid ) /Deprecated/;
+ static QString typeToDisplayString( QVariant::Type type, QVariant::Type subType = QVariant::Type::Invalid ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Returns a user-friendly translated string representing a QVariant ``type``.
 

--- a/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -245,7 +245,7 @@ Creates a clone of the FieldValueConverter.
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
-                                                                                 ) /Deprecated/;
+                                                                                 ) /Deprecated="Since 3.40. Use writeAsVectorFormatV2() instead."/;
 %Docstring
 Write contents of vector layer to an (OGR supported) vector format
 
@@ -296,7 +296,7 @@ Write contents of vector layer to an (OGR supported) vector format
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
-                                                                                 ) /Deprecated/;
+                                                                                 ) /Deprecated="Since 3.40. Use writeAsVectorFormatV2() instead."/;
 %Docstring
 Writes a layer out to a vector file.
 
@@ -400,7 +400,7 @@ Options to pass to :py:func:`~QgsVectorFileWriter.writeAsVectorFormat`
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = 0,
         QString *errorMessage /Out/ = 0
-                                                                                 ) /Deprecated/;
+                                                                                 ) /Deprecated="Since 3.40. Use writeAsVectorFormatV2() instead."/;
 %Docstring
 Writes a layer out to a vector file.
 
@@ -427,7 +427,7 @@ Writes a layer out to a vector file.
                                            QString *newFilename = 0,
                                            Qgis::FeatureSymbologyExport symbologyExport = Qgis::FeatureSymbologyExport::NoSymbology,
                                            QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags()
-                                         ) /Deprecated/;
+                                         ) /Deprecated="Since 3.40. Use create() instead."/;
 %Docstring
 Create a new vector file writer
 
@@ -469,7 +469,7 @@ Create a new vector file writer.
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = 0,
         QString *newLayer = 0,
-        QString *errorMessage /Out/ = 0 ) /Deprecated/;
+        QString *errorMessage /Out/ = 0 ) /Deprecated="Since 3.20. Use writeAsVectorFormatV3() instead."/;
 %Docstring
 Writes a layer out to a vector file.
 

--- a/python/PyQt6/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -24,7 +24,7 @@ Bilinear Raster Resampler
 
     QgsBilinearRasterResampler();
 
- virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated="Since 3.12. Use resampleV2() instead."/;
 
 %Docstring
 

--- a/python/PyQt6/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -23,8 +23,15 @@ Bilinear Raster Resampler
   public:
 
     QgsBilinearRasterResampler();
+
  virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.12
+
+   Use :py:func:`~QgsBilinearRasterResampler.resampleV2` instead.
+%End
 
     virtual QImage resampleV2( const QImage &source, const QSize &size );
 

--- a/python/PyQt6/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -27,8 +27,15 @@ Cubic Raster Resampler.
 
     virtual QImage resampleV2( const QImage &source, const QSize &size );
 
+
  virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.12
+
+   Use :py:func:`~QgsCubicRasterResampler.resampleV2` instead.
+%End
     virtual QString type() const;
 
     virtual int tileBufferPixels() const;

--- a/python/PyQt6/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -28,7 +28,7 @@ Cubic Raster Resampler.
     virtual QImage resampleV2( const QImage &source, const QSize &size );
 
 
- virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated="Since 3.12. Use resampleV2() instead."/;
 
 %Docstring
 

--- a/python/PyQt6/core/auto_generated/raster/qgshillshaderenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgshillshaderenderer.sip.in
@@ -62,7 +62,7 @@ Factory method to create a new renderer
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
 
- int band() const /Deprecated/;
+ int band() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 Returns the band used by the renderer
 
@@ -71,7 +71,7 @@ Returns the band used by the renderer
    Use :py:func:`~QgsHillshadeRenderer.inputBand` instead.
 %End
 
- void setBand( int bandNo ) /Deprecated/;
+ void setBand( int bandNo ) /Deprecated="Since 3.38. Use setInputBand() instead."/;
 %Docstring
 Sets the band used by the renderer.
 

--- a/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -122,7 +122,7 @@ Returns optional category label
 Set category label
 %End
 
- int band() const /Deprecated/;
+ int band() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 Returns the raster band used for rendering the raster.
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -73,7 +73,7 @@ The Field class represents a Raster Attribute Table field, including its name, u
 Creates a new Field with ``name``, ``type`` and ``usage``.
 %End
 
- Field( const QString &name, const Qgis::RasterAttributeTableFieldUsage &usage, const QVariant::Type type ) /Deprecated/;
+ Field( const QString &name, const Qgis::RasterAttributeTableFieldUsage &usage, const QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Creates a new Field with ``name``, ``type`` and ``usage``.
 
@@ -264,7 +264,7 @@ Inserts a new ``field`` at ``position``, optionally reporting any error in ``err
 Creates a new field from ``name``, ``usage`` and ``type`` and inserts it at ``position``, optionally reporting any error in ``errorMessage``, returns ``True`` on success.
 %End
 
- bool insertField( int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated/;
+ bool insertField( int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Creates a new field from ``name``, ``usage`` and ``type`` and inserts it at ``position``, optionally reporting any error in ``errorMessage``, returns ``True`` on success.
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterdrawer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterdrawer.sip.in
@@ -21,7 +21,7 @@ The drawing pipe for raster layers.
 %End
   public:
 
- QgsRasterDrawer( QgsRasterIterator *iterator, double dpiTarget ) /Deprecated/;
+ QgsRasterDrawer( QgsRasterIterator *iterator, double dpiTarget ) /Deprecated="Since 3.28. Use the constructor without the ``dpiTarget`` argument instead, as DPI is now handled by the draw() method which accepts a QgsRenderContext."/;
 %Docstring
 The QgsRasterDrawer constructor.
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
@@ -69,7 +69,7 @@ Ownership of the returned provider is passed to the caller.
 
 
  Qgis::RasterFileWriterResult writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
-        const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated/;
+        const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated="Since 3.8. Use version with transformContext instead."/;
 %Docstring
 Write raster file
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
@@ -30,7 +30,7 @@ QGIS interface.
  QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe /Transfer/,
         int columns, int rows,
         const QgsRectangle &outputExtent,
-        const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+        const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.8. Use version with transformContext instead."/;
 %Docstring
 Constructor for QgsRasterFileWriterTask. Takes a source ``writer``,
 ``columns``, ``rows``, ``outputExtent`` and destination ``crs``.

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterinterface.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterinterface.sip.in
@@ -184,7 +184,7 @@ Clone itself, create deep copy
 Returns the capabilities supported by the interface.
 %End
 
- QString capabilitiesString() const /Deprecated/;
+ QString capabilitiesString() const /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Returns the raster interface capabilities in friendly format.
 
@@ -295,7 +295,7 @@ It may be used to get info about original data, e.g. resolution to decide
 resampling etc.
 %End
 
- QgsRasterBandStats bandStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated/;
+ QgsRasterBandStats bandStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated="Since 3.40. Use Qgis.RasterBandStatistic instead of int for ``stats`` argument."/;
 %Docstring
 Returns the band statistics.
 
@@ -324,7 +324,7 @@ Returns the band statistics.
 :param feedback: optional feedback object
 %End
 
- bool hasStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0 ) /Deprecated/;
+ bool hasStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0 ) /Deprecated="Since 3.40. Use Qgis.RasterBandStatistic instead of int for ``stats`` argument."/;
 %Docstring
 Returns ``True`` if histogram is available (cached, already calculated).
 The parameters are the same as in :py:func:`~QgsRasterInterface.bandStatistics`
@@ -538,7 +538,7 @@ Fill in histogram defaults if not specified
 #endif
 %End
 
- void initStatistics( QgsRasterBandStats &statistics, int bandNo, int stats, const QgsRectangle &boundingBox = QgsRectangle(), int binCount = 0 ) const /Deprecated/;
+ void initStatistics( QgsRasterBandStats &statistics, int bandNo, int stats, const QgsRectangle &boundingBox = QgsRectangle(), int binCount = 0 ) const /Deprecated="Since 3.40. Use Qgis.RasterBandStatistic instead of int for ``stats`` argument."/;
 %Docstring
 Fill in statistics defaults if not specified
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -124,7 +124,7 @@ returned in ``retError``.
 Returns time stamp for given file name
 %End
 
- void setDataProvider( const QString &provider ) /Deprecated/;
+ void setDataProvider( const QString &provider ) /Deprecated="Since 3.40. Use the version with ProviderOptions instead."/;
 %Docstring
 Set the data provider.
 
@@ -286,7 +286,7 @@ This will be ``None`` if the layer is invalid.
 This is an overloaded version of the :py:func:`~QgsRasterLayer.draw` function that is called by both :py:func:`~QgsRasterLayer.draw` and thumbnailAsPixmap
 %End
 
- QgsLegendColorList legendSymbologyItems() const /Deprecated/;
+ QgsLegendColorList legendSymbologyItems() const /Deprecated="Since 3.40. Use QgsRasterRenderer.createLegendNodes() instead."/;
 %Docstring
 Returns a list with classification items (Text and color).
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterprojector.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterprojector.sip.in
@@ -49,7 +49,7 @@ PROJ transformations for optimised bulk reprojection of points.
 
 
  void setCrs( const QgsCoordinateReferenceSystem &srcCRS, const QgsCoordinateReferenceSystem &destCRS,
-                                   int srcDatumTransform = -1, int destDatumTransform = -1 ) /Deprecated/;
+                                   int srcDatumTransform = -1, int destDatumTransform = -1 ) /Deprecated="Since 3.8. Use transformContext version instead."/;
 %Docstring
 Sets the source and destination CRS
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterresampler.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterresampler.sip.in
@@ -32,7 +32,7 @@ Interface for resampling rasters (e.g. to have a smoother appearance)
   public:
     virtual ~QgsRasterResampler();
 
- virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0 /Deprecated/;
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0 /Deprecated="Since 3.10.1. Use the more efficient QgsRasterResamplerV2 interface instead."/;
 %Docstring
 Resamples a source image to a destination image.
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrastertransparency.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrastertransparency.sip.in
@@ -142,7 +142,7 @@ Sets the transparent three value pixel list, replacing the whole existing list.
 .. seealso:: :py:func:`transparentThreeValuePixelList`
 %End
 
- int alphaValue( double value, int globalTransparency = 255 ) const /Deprecated/;
+ int alphaValue( double value, int globalTransparency = 255 ) const /Deprecated="Since 3.40. Use opacityForValue() instead."/;
 %Docstring
 Returns the transparency value for a single ``value`` pixel.
 
@@ -167,7 +167,7 @@ the opacity corresponding to the value. Returns 1 if no matches are found.
 .. versionadded:: 3.38
 %End
 
- int alphaValue( double redValue, double greenValue, double blueValue, int globalTransparency = 255 ) const /Deprecated/;
+ int alphaValue( double redValue, double greenValue, double blueValue, int globalTransparency = 255 ) const /Deprecated="Since 3.40. Use opacityForRgbValues() instead."/;
 %Docstring
 Returns the transparency value for a RGB pixel.
 

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
@@ -43,7 +43,7 @@ QgsSingleBandGrayRenderer cannot be copied. Use :py:func:`~QgsSingleBandGrayRend
     virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = 0 ) /Factory/;
 
 
- int grayBand() const /Deprecated/;
+ int grayBand() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 
 .. deprecated:: 3.38
@@ -51,7 +51,7 @@ QgsSingleBandGrayRenderer cannot be copied. Use :py:func:`~QgsSingleBandGrayRend
    Use :py:func:`~QgsSingleBandGrayRenderer.inputBand` instead.
 %End
 
- void setGrayBand( int band ) /Deprecated/;
+ void setGrayBand( int band ) /Deprecated="Since 3.38. Use setInputBand() instead."/;
 %Docstring
 
 .. deprecated:: 3.38

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
@@ -90,7 +90,7 @@ Creates a color ramp shader
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
- int band() const /Deprecated/;
+ int band() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 Returns the band used by the renderer
 
@@ -99,7 +99,7 @@ Returns the band used by the renderer
    Use :py:func:`~QgsSingleBandPseudoColorRenderer.inputBand` instead.
 %End
 
- void setBand( int bandNo ) /Deprecated/;
+ void setBand( int bandNo ) /Deprecated="Since 3.38. Use setInputBand() instead."/;
 %Docstring
 Sets the band used by the renderer.
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
@@ -42,6 +42,12 @@ A scale bar style that draws text in the form of '1:XXXXX'.
 
  virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings, const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.14
+
+   Use the one with render context instead.
+%End
 
 };
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
@@ -40,7 +40,7 @@ A scale bar style that draws text in the form of '1:XXXXX'.
                              const QgsScaleBarSettings &settings,
                              const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
 
- virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings, const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated/;
+ virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings, const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated="Since 3.14. Use the one with render context instead."/;
 
 %Docstring
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
@@ -67,7 +67,7 @@ Returns ``True`` if the context has valid settings.
     QgsScaleBarRenderer();
     virtual ~QgsScaleBarRenderer();
 
- QString name() const /Deprecated/;
+ QString name() const /Deprecated="Since 3.40. Use id() instead."/;
 %Docstring
 Returns the unique name for this style.
 
@@ -117,7 +117,7 @@ Draws the scalebar using the specified ``settings`` and ``scaleContext`` to a de
 %End
 
  virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings,
-        const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated/;
+        const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated="Since 3.40. Use the version with a QgsRenderContext instead."/;
 %Docstring
 Calculates the required box size (in millimeters) for a scalebar using the specified ``settings`` and ``scaleContext``.
 
@@ -158,7 +158,7 @@ Draws default scalebar labels using the specified ``settings`` and ``scaleContex
 Returns the text used for the first label in the scalebar.
 %End
 
- double firstLabelXOffset( const QgsScaleBarSettings &settings ) const /Deprecated/;
+ double firstLabelXOffset( const QgsScaleBarSettings &settings ) const /Deprecated="Since 3.40. Use the version with QgsRenderContext instead."/;
 %Docstring
 Returns the x-offset (in millimeters) used for the first label in the scalebar.
 
@@ -174,7 +174,7 @@ Returns the x-offset (in render context painter units) used for the first label 
 .. versionadded:: 3.2
 %End
 
- QList<double> segmentPositions( const QgsScaleBarRenderer::ScaleBarContext &scaleContext, const QgsScaleBarSettings &settings ) const /Deprecated/;
+ QList<double> segmentPositions( const QgsScaleBarRenderer::ScaleBarContext &scaleContext, const QgsScaleBarSettings &settings ) const /Deprecated="Since 3.40. Use the version with a QgsRenderContext instead."/;
 %Docstring
 Returns a list of positions for each segment within the scalebar.
 

--- a/python/PyQt6/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
@@ -259,7 +259,7 @@ Sets the text ``format`` used for drawing text in the scalebar.
 .. versionadded:: 3.2
 %End
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the font used for drawing text in the scalebar.
 
@@ -270,7 +270,7 @@ Returns the font used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.textFormat` instead.
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for drawing text in the scalebar.
 
@@ -281,7 +281,7 @@ Sets the ``font`` used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setTextFormat` instead.
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the color used for drawing text in the scalebar.
 
@@ -294,7 +294,7 @@ Returns the color used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.textFormat` instead.
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Sets the ``color`` used for drawing text in the scalebar.
 
@@ -307,7 +307,7 @@ Sets the ``color`` used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.textFormat` instead.
 %End
 
- QColor fillColor() const /Deprecated/;
+ QColor fillColor() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the color used for fills in the scalebar.
 
@@ -320,7 +320,7 @@ Returns the color used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.fillSymbol` instead.
 %End
 
- void setFillColor( const QColor &color ) /Deprecated/;
+ void setFillColor( const QColor &color ) /Deprecated="Since 3.40. Use setFillSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for fills in the scalebar.
 
@@ -333,7 +333,7 @@ Sets the ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setFillSymbol` instead.
 %End
 
- QColor fillColor2() const /Deprecated/;
+ QColor fillColor2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary color used for fills in the scalebar.
 
@@ -346,7 +346,7 @@ Returns the secondary color used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.alternateFillSymbol` instead.
 %End
 
- void setFillColor2( const QColor &color ) /Deprecated/;
+ void setFillColor2( const QColor &color ) /Deprecated="Since 3.40. Use setAlternateFillSymbol() instead."/;
 %Docstring
 Sets the secondary ``color`` used for fills in the scalebar.
 
@@ -359,7 +359,7 @@ Sets the secondary ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setAlternateFillSymbol` instead.
 %End
 
- QColor lineColor() const /Deprecated/;
+ QColor lineColor() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the color used for lines in the scalebar.
 
@@ -370,7 +370,7 @@ Returns the color used for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineColor( const QColor &color ) /Deprecated/;
+ void setLineColor( const QColor &color ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for lines in the scalebar.
 
@@ -381,7 +381,7 @@ Sets the ``color`` used for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setLineSymbol` instead.
 %End
 
- double lineWidth() const /Deprecated/;
+ double lineWidth() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the line width in millimeters for lines in the scalebar.
 
@@ -392,7 +392,7 @@ Returns the line width in millimeters for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineWidth( double width ) /Deprecated/;
+ void setLineWidth( double width ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the line ``width`` in millimeters for lines in the scalebar.
 
@@ -403,7 +403,7 @@ Sets the line ``width`` in millimeters for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setLineSymbol` instead.
 %End
 
- QPen pen() const /Deprecated/;
+ QPen pen() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the pen used for drawing outlines in the scalebar.
 
@@ -416,7 +416,7 @@ Returns the pen used for drawing outlines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setPen( const QPen &pen ) /Deprecated/;
+ void setPen( const QPen &pen ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the pen used for drawing outlines in the scalebar.
 
@@ -565,7 +565,7 @@ transferred to the scalebar.
 .. versionadded:: 3.14
 %End
 
- QBrush brush() const /Deprecated/;
+ QBrush brush() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the primary brush used for filling the scalebar.
 
@@ -580,7 +580,7 @@ Returns the primary brush used for filling the scalebar.
    Use :py:func:`~QgsScaleBarSettings.fillSymbol` instead.
 %End
 
- void setBrush( const QBrush &brush ) /Deprecated/;
+ void setBrush( const QBrush &brush ) /Deprecated="Since 3.40. Use setFillSymbol() instead."/;
 %Docstring
 Sets the primary brush used for filling the scalebar.
 
@@ -591,7 +591,7 @@ Sets the primary brush used for filling the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setFillSymbol` instead.
 %End
 
- QBrush brush2() const /Deprecated/;
+ QBrush brush2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary brush for the scalebar. This is used for alternating color style scalebars, such
 as single and double box styles.
@@ -605,7 +605,7 @@ as single and double box styles.
    Use :py:func:`~QgsScaleBarSettings.alternateFillSymbol` instead.
 %End
 
- void setBrush2( const QBrush &brush ) /Deprecated/;
+ void setBrush2( const QBrush &brush ) /Deprecated="Since 3.40. Use setAlternateFillSymbol() instead."/;
 %Docstring
 Sets the secondary brush used for filling the scalebar.
 
@@ -708,7 +708,7 @@ Sets the scalebar ``alignment``.
 .. seealso:: :py:func:`alignment`
 %End
 
- Qt::PenJoinStyle lineJoinStyle() const /Deprecated/;
+ Qt::PenJoinStyle lineJoinStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the join style used for drawing lines in the scalebar.
 
@@ -719,7 +719,7 @@ Returns the join style used for drawing lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated/;
+ void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the join ``style`` used when drawing the lines in the scalebar
 
@@ -730,7 +730,7 @@ Sets the join ``style`` used when drawing the lines in the scalebar
    Use :py:func:`~QgsScaleBarSettings.setLineSymbol` instead.
 %End
 
- Qt::PenCapStyle lineCapStyle() const /Deprecated/;
+ Qt::PenCapStyle lineCapStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the cap style used for drawing lines in the scalebar.
 
@@ -741,7 +741,7 @@ Returns the cap style used for drawing lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated/;
+ void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the cap ``style`` used when drawing the lines in the scalebar.
 

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -246,7 +246,7 @@ Returns settings value.
 .. versionadded:: 3.26
 %End
 
- QVariant valueAsVariant( const QString &dynamicKeyPart, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated/;
+ QVariant valueAsVariant( const QString &dynamicKeyPart, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated="Since 3.26. Use valueAsVariantWithDefaultOverride() instead."/;
 %Docstring
 Returns settings value with an optional default value override
 
@@ -255,7 +255,7 @@ Returns settings value with an optional default value override
    Use :py:func:`~QgsSettingsEntryBase.valueAsVariantWithDefaultOverride` instead.
 %End
 
- QVariant valueAsVariant( const QStringList &dynamicKeyPartList, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated/;
+ QVariant valueAsVariant( const QStringList &dynamicKeyPartList, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated="Since 3.26. Use valueAsVariantWithDefaultOverride() instead."/;
 %Docstring
 Returns settings value with an optional default value override
 

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentrygroup.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentrygroup.sip.in
@@ -11,7 +11,7 @@
 
 
 
-class QgsSettingsEntryGroup /Deprecated/
+class QgsSettingsEntryGroup /Deprecated="Since 3.30. Use QgsSettingsTreeNode instead."/
 {
 %Docstring(signature="appended")
 Creates a group of setting which have a common definition of base key

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsregistry.sip.in
@@ -66,7 +66,7 @@ Returns the list of registered child QgsSettingsRegistry.
 Adds ``settingsEntry`` to the registry.
 %End
 
- void addSettingsEntryGroup( const QgsSettingsEntryGroup *settingsGroup ) /Deprecated/;
+ void addSettingsEntryGroup( const QgsSettingsEntryGroup *settingsGroup ) /Deprecated="Since 3.30. "/;
 %Docstring
 Adds a group of setting to the registry
 

--- a/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -479,7 +479,7 @@ output.
 hashtable for faster access to symbols
 %End
 
- QgsSymbol *skipRender() /Deprecated/;
+ QgsSymbol *skipRender() /Deprecated="Since 3.40. No longer used, will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -487,7 +487,7 @@ hashtable for faster access to symbols
    No longer used, will be removed in QGIS 4.0.
 %End
 
- QgsSymbol *symbolForValue( const QVariant &value ) const /Deprecated/;
+ QgsSymbol *symbolForValue( const QVariant &value ) const /Deprecated="Since 3.40. Use variant which takes a second bool argument instead."/;
 %Docstring
 Returns the matching symbol corresponding to an attribute ``value``.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgscptcityarchive.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscptcityarchive.sip.in
@@ -129,7 +129,7 @@ Removes a ``child`` item but doesn't delete it, signals to browser are emitted.
 Returns ``True`` if this item is equal to an ``other`` item.
 %End
 
- virtual QWidget *paramWidget() /Deprecated/;
+ virtual QWidget *paramWidget() /Deprecated="Since 3.40. Is unused and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -137,7 +137,7 @@ Returns ``True`` if this item is equal to an ``other`` item.
    Is unused and will be removed in QGIS 4.0.
 %End
 
- virtual bool acceptDrop() /Deprecated/;
+ virtual bool acceptDrop() /Deprecated="Since 3.40. Is unused and will be removed in QGIS 4.0."/;
 %Docstring
 Returns ``True`` if the item accepts drag & dropped layers - e.g. for import.
 
@@ -146,7 +146,7 @@ Returns ``True`` if the item accepts drag & dropped layers - e.g. for import.
    Is unused and will be removed in QGIS 4.0.
 %End
 
- virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) /Deprecated/;
+ virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) /Deprecated="Since 3.40. Is unused and will be removed in QGIS 4.0."/;
 %Docstring
 Tries to process the ``data`` dropped on this item.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -86,7 +86,7 @@ Creates the symbol layer
     virtual bool writeDxf( QgsDxfExport &e, double mmMapUnitScaleFactor, const QString &layerName, QgsSymbolRenderContext &context, QPointF shift = QPointF( 0.0, 0.0 ) ) const;
 
 
- void setSymbolName( const QString &name ) /Deprecated/;
+ void setSymbolName( const QString &name ) /Deprecated="Since 3.20. "/;
 %Docstring
 Sets the rendered ellipse marker shape using a symbol ``name``.
 
@@ -97,7 +97,7 @@ Sets the rendered ellipse marker shape using a symbol ``name``.
 .. deprecated:: 3.20
 %End
 
- QString symbolName() const /Deprecated/;
+ QString symbolName() const /Deprecated="Since 3.20. "/;
 %Docstring
 Returns the shape name for the rendered ellipse marker symbol.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -1138,7 +1138,7 @@ If the height is 0 then the height will be calculated automatically based on the
 .. versionadded:: 3.36
 %End
 
- void setWidthUnit( Qgis::RenderUnit unit ) /Deprecated/;
+ void setWidthUnit( Qgis::RenderUnit unit ) /Deprecated="Since 3.40. Use setSizeUnit() instead."/;
 %Docstring
 Sets the ``unit`` for the image's width.
 
@@ -1166,7 +1166,7 @@ Sets the ``unit`` for the image's width and height.
 .. versionadded:: 3.36
 %End
 
- Qgis::RenderUnit widthUnit() const /Deprecated/;
+ Qgis::RenderUnit widthUnit() const /Deprecated="Since 3.40. Use sizeUnit() instead."/;
 %Docstring
 Returns the units for the image's width.
 
@@ -1196,7 +1196,7 @@ Returns the units for the image's width and height.
 .. versionadded:: 3.36
 %End
 
- void setWidthMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated/;
+ void setWidthMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated="Since 3.40. Use setSizeMapUnitScale() instead."/;
 %Docstring
 Sets the map unit ``scale`` for the image's width.
 
@@ -1226,7 +1226,7 @@ Sets the map unit ``scale`` for the image's width and height.
 .. versionadded:: 3.36
 %End
 
- const QgsMapUnitScale &widthMapUnitScale() const /Deprecated/;
+ const QgsMapUnitScale &widthMapUnitScale() const /Deprecated="Since 3.40. Use sizeMapUnitScale() instead."/;
 %Docstring
 Returns the map unit scale for the image's width.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -151,14 +151,14 @@ This will take ownership of the method
     };
 
 
- Mode mode() const /Deprecated/;
+ Mode mode() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 
 .. deprecated:: 3.10
 
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
- void setMode( Mode mode ) /Deprecated/;
+ void setMode( Mode mode ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 
 .. deprecated:: 3.10
@@ -166,7 +166,7 @@ This will take ownership of the method
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- bool useSymmetricMode() const /Deprecated/;
+ bool useSymmetricMode() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Returns if we want to classify symmetric around a given value
 
@@ -177,7 +177,7 @@ Returns if we want to classify symmetric around a given value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
-  void setUseSymmetricMode( bool useSymmetricMode ) /Deprecated/;
+  void setUseSymmetricMode( bool useSymmetricMode ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Set if we want to classify symmetric around a given value
 
@@ -188,7 +188,7 @@ Set if we want to classify symmetric around a given value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- double symmetryPoint() const /Deprecated/;
+ double symmetryPoint() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Returns the pivot value for symmetric classification
 
@@ -199,7 +199,7 @@ Returns the pivot value for symmetric classification
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- void setSymmetryPoint( double symmetryPoint ) /Deprecated/;
+ void setSymmetryPoint( double symmetryPoint ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Set the pivot point
 
@@ -211,7 +211,7 @@ Set the pivot point
 %End
 
 
- bool astride() const /Deprecated/;
+ bool astride() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Returns if we want to have a central class astride the pivot value
 
@@ -222,7 +222,7 @@ Returns if we want to have a central class astride the pivot value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- void setAstride( bool astride ) /Deprecated/;
+ void setAstride( bool astride ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Set if we want a central class astride the pivot value
 
@@ -233,7 +233,7 @@ Set if we want a central class astride the pivot value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- static void makeBreaksSymmetric( QList<double> &breaks /In,Out/, double symmetryPoint, bool astride ) /Deprecated/;
+ static void makeBreaksSymmetric( QList<double> &breaks /In,Out/, double symmetryPoint, bool astride ) /Deprecated="Since 3.10. Use QgsClassificationMethod.makeBreaksSymmetric instead."/;
 %Docstring
 Remove the breaks that are above the existing opposite sign classes to keep colors symmetrically balanced around symmetryPoint
 Does not put a break on the symmetryPoint. This is done before.
@@ -249,7 +249,7 @@ Does not put a break on the symmetryPoint. This is done before.
    Use :py:class:`QgsClassificationMethod`.makeBreaksSymmetric instead.
 %End
 
- static QList<double> calcEqualIntervalBreaks( double minimum, double maximum, int classes, bool useSymmetricMode, double symmetryPoint, bool astride ) /Deprecated/;
+ static QList<double> calcEqualIntervalBreaks( double minimum, double maximum, int classes, bool useSymmetricMode, double symmetryPoint, bool astride ) /Deprecated="Since 3.10. Use QgsClassificationEqualInterval class instead."/;
 %Docstring
 Compute the equal interval classification
 
@@ -265,7 +265,7 @@ Compute the equal interval classification
    Use :py:class:`QgsClassificationEqualInterval` class instead.
 %End
 
- void updateClasses( QgsVectorLayer *vlayer, Mode mode, int nclasses, bool useSymmetricMode = false, double symmetryPoint = 0.0, bool astride = false ) /Deprecated/;
+ void updateClasses( QgsVectorLayer *vlayer, Mode mode, int nclasses, bool useSymmetricMode = false, double symmetryPoint = 0.0, bool astride = false ) /Deprecated="Since 3.10. "/;
 %Docstring
 Recalculate classes for a layer
 
@@ -290,7 +290,7 @@ Recalculate classes for a layer
 %End
 
 
- QgsRendererRangeLabelFormat labelFormat() const /Deprecated/;
+ QgsRendererRangeLabelFormat labelFormat() const /Deprecated="Since 3.10. Use classificationMethod() and QgsClassificationMethod.setLabelFormat instead."/;
 %Docstring
 Returns the label format used to generate default classification labels
 
@@ -299,7 +299,7 @@ Returns the label format used to generate default classification labels
    Use :py:func:`~QgsGraduatedSymbolRenderer.classificationMethod` and :py:class:`QgsClassificationMethod`.setLabelFormat instead.
 %End
 
- void setLabelFormat( const QgsRendererRangeLabelFormat &labelFormat, bool updateRanges = false ) /Deprecated/;
+ void setLabelFormat( const QgsRendererRangeLabelFormat &labelFormat, bool updateRanges = false ) /Deprecated="Since 3.10. Use classificationMethod() and QgsClassificationMethod.setLabelFormat instead."/;
 %Docstring
 Set the label format used to generate default classification labels
 
@@ -330,7 +330,7 @@ Reset the label decimal places to a numberbased on the minimum class interval
         bool useSymmetricMode = false,
         double symmetryPoint = 0.0,
         const QStringList &listForCboPrettyBreaks = QStringList(),
-        bool astride = false ) /Deprecated/;
+        bool astride = false ) /Deprecated="Since 3.10. "/;
 %Docstring
 Creates a new graduated renderer.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -340,7 +340,7 @@ Creates the symbol layer
     virtual bool canCauseArtifactsBetweenAdjacentTiles() const;
 
 
- void setExpressionsStringForWidth( const QString &start, const QString &end ) /Deprecated/;
+ void setExpressionsStringForWidth( const QString &start, const QString &end ) /Deprecated="Since 3.40. Use setDataDefinedProperty( QgsSymbolLayer.PropertyLineStartWidthValue ) and setDataDefinedProperty( QgsSymbolLayer.PropertyLineEndWidthValue ) instead."/;
 %Docstring
 Sets the expressions (as string) that define the extremety values af the line feature for width.
 
@@ -349,7 +349,7 @@ Sets the expressions (as string) that define the extremety values af the line fe
    Use setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartWidthValue ) and setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineEndWidthValue ) instead.
 %End
 
- QString startValueExpressionForWidth() const /Deprecated/;
+ QString startValueExpressionForWidth() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineStartWidthValue ) instead."/;
 %Docstring
 Returns the epression related to the start extremity value for width.
 
@@ -358,7 +358,7 @@ Returns the epression related to the start extremity value for width.
    Use dataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartWidthValue ) instead.
 %End
 
- QString endValueExpressionForWidth() const /Deprecated/;
+ QString endValueExpressionForWidth() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineEndWidthValue ) instead."/;
 %Docstring
 Returns the expression related to the end extremity value for width.
 
@@ -396,7 +396,7 @@ Returns the interpolated width used to render the width of lines, see ``:py:clas
 .. seealso:: :py:func:`setInterpolatedWidth`
 %End
 
- void setExpressionsStringForColor( const QString &start, const QString &end ) /Deprecated/;
+ void setExpressionsStringForColor( const QString &start, const QString &end ) /Deprecated="Since 3.40. Use setDataDefinedProperty( QgsSymbolLayer.PropertyLineStartColorValue ) and setDataDefinedProperty( QgsSymbolLayer.PropertyLineEndColorValue ) instead."/;
 %Docstring
 Sets the expressions (as string) that define the extremety values af the line feature for color.
 
@@ -405,7 +405,7 @@ Sets the expressions (as string) that define the extremety values af the line fe
    Use setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartColorValue ) and setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineEndColorValue ) instead.
 %End
 
- QString startValueExpressionForColor() const /Deprecated/;
+ QString startValueExpressionForColor() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineStartColorValue ) instead."/;
 %Docstring
 Returns the epression related to the start extremity value for width for color
 
@@ -414,7 +414,7 @@ Returns the epression related to the start extremity value for width for color
    Use dataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartColorValue ) instead.
 %End
 
- QString endValueExpressionForColor() const /Deprecated/;
+ QString endValueExpressionForColor() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineEndColorValue ) instead."/;
 %Docstring
 Returns the expression related to the end extremity value for width for color
 

--- a/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -678,7 +678,7 @@ Returns the map unit scale for the interval between symbols.
 .. seealso:: :py:func:`interval`
 %End
 
- Qgis::MarkerLinePlacement placement() const /Deprecated/;
+ Qgis::MarkerLinePlacement placement() const /Deprecated="Since 3.40. Use placements() instead."/;
 %Docstring
 Returns the placement of the symbols.
 
@@ -689,7 +689,7 @@ Returns the placement of the symbols.
    Use :py:func:`~QgsTemplatedLineSymbolLayerBase.placements` instead.
 %End
 
- void setPlacement( Qgis::MarkerLinePlacement placement ) /Deprecated/;
+ void setPlacement( Qgis::MarkerLinePlacement placement ) /Deprecated="Since 3.40. Use setPlacements() instead."/;
 %Docstring
 Sets the ``placement`` of the symbols.
 
@@ -1041,7 +1041,7 @@ Creates a new QgsMarkerLineSymbolLayer from an SLD XML DOM ``element``.
     virtual void setDataDefinedProperty( QgsSymbolLayer::Property key, const QgsProperty &property );
 
 
- bool rotateMarker() const /Deprecated/;
+ bool rotateMarker() const /Deprecated="Since 3.40. Use rotateSymbols() instead."/;
 %Docstring
 Shall the marker be rotated.
 
@@ -1052,7 +1052,7 @@ Shall the marker be rotated.
    Use :py:func:`~QgsMarkerLineSymbolLayer.rotateSymbols` instead.
 %End
 
- void setRotateMarker( bool rotate ) /Deprecated/;
+ void setRotateMarker( bool rotate ) /Deprecated="Since 3.40. Use setRotateSymbols() instead."/;
 %Docstring
 Shall the marker be rotated.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -183,7 +183,7 @@ Creates a DOM element representing the range in SLD format.
 typedef QList<QgsRendererRange> QgsRangeList;
 
 
-class QgsRendererRangeLabelFormat /Deprecated/
+class QgsRendererRangeLabelFormat /Deprecated="Since 3.10. Use QgsClassificationMethod instead."/
 {
 %Docstring(signature="appended")
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
@@ -857,7 +857,7 @@ This function will load an on-disk database and populate styles.
 .. seealso:: :py:func:`errorString`
 %End
 
- bool save( const QString &filename = QString() ) /Deprecated/;
+ bool save( const QString &filename = QString() ) /Deprecated="Since 3.40. This function has no effect."/;
 %Docstring
 Saves style into a file.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssvgcache.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssvgcache.sip.in
@@ -212,7 +212,7 @@ in the same thread to ensure provided the image.
 
   signals:
 
- void statusChanged( const QString  &statusQString ) /Deprecated/;
+ void statusChanged( const QString  &statusQString ) /Deprecated="Since 3.6. No longer emitted."/;
 %Docstring
 Emit a signal to be caught by qgisapp and display a msg on status bar.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
@@ -530,7 +530,7 @@ Returns a large (roughly 100x100 pixel) preview image for the symbol.
 .. seealso:: :py:func:`drawPreviewIcon`
 %End
 
- QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, int flags = static_cast< int >( Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) ) /Deprecated/;
+ QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, int flags = static_cast< int >( Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) ) /Deprecated="Since 3.40. Use bigSymbolPreviewImageV2() instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -807,7 +807,7 @@ and returns ``True`` if any of the layers returned ``True``.
 .. versionadded:: 3.18
 %End
 
- void setLayer( const QgsVectorLayer *layer ) /Deprecated/;
+ void setLayer( const QgsVectorLayer *layer ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. note::
@@ -819,7 +819,7 @@ and returns ``True`` if any of the layers returned ``True``.
    Will be removed in QGIS 4.0.
 %End
 
- const QgsVectorLayer *layer() const /Deprecated/;
+ const QgsVectorLayer *layer() const /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
@@ -105,7 +105,7 @@ Type used to refer to a specific symbol layer in a symbol of a layer.
 
     QgsSymbolLayerReference();
 
- QgsSymbolLayerReference( const QString &layerId, const QgsSymbolLayerId &symbolLayer ) /Deprecated/;
+ QgsSymbolLayerReference( const QString &layerId, const QgsSymbolLayerId &symbolLayer ) /Deprecated="Since 3.30. "/;
 %Docstring
 Constructor
 
@@ -130,7 +130,7 @@ Constructor
 The referenced vector layer / feature renderer
 %End
 
- QgsSymbolLayerId symbolLayerId() const /Deprecated/;
+ QgsSymbolLayerId symbolLayerId() const /Deprecated="Since 3.30. Use symbolLayerIdV2() instead."/;
 %Docstring
 The symbol layer's id
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbolrendercontext.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbolrendercontext.sip.in
@@ -49,7 +49,7 @@ Sets the original value variable value for data defined symbology
               before any data defined overrides have been applied.
 %End
 
- Qgis::RenderUnit outputUnit() const /Deprecated/;
+ Qgis::RenderUnit outputUnit() const /Deprecated="Since 3.40. No longer used and will be removed in QGIS 4.0."/;
 %Docstring
 Returns the output unit for the context.
 
@@ -58,7 +58,7 @@ Returns the output unit for the context.
    No longer used and will be removed in QGIS 4.0.
 %End
 
- void setOutputUnit( Qgis::RenderUnit u ) /Deprecated/;
+ void setOutputUnit( Qgis::RenderUnit u ) /Deprecated="Since 3.40. No longer used and will be removed in QGIS 4.0."/;
 %Docstring
 Sets the output unit for the context.
 
@@ -67,7 +67,7 @@ Sets the output unit for the context.
    No longer used and will be removed in QGIS 4.0.
 %End
 
- QgsMapUnitScale mapUnitScale() const /Deprecated/;
+ QgsMapUnitScale mapUnitScale() const /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -75,7 +75,7 @@ Sets the output unit for the context.
    Will be removed in QGIS 4.0.
 %End
 
- void setMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated/;
+ void setMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -197,7 +197,7 @@ Part number of current geometry
 Sets the part number of current geometry
 %End
 
- double outputLineWidth( double width ) const /Deprecated/;
+ double outputLineWidth( double width ) const /Deprecated="Since 3.40. Use the size conversion methods in QgsRenderContext instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -205,7 +205,7 @@ Sets the part number of current geometry
    Use the size conversion methods in :py:class:`QgsRenderContext` instead.
 %End
 
- double outputPixelSize( double size ) const /Deprecated/;
+ double outputPixelSize( double size ) const /Deprecated="Since 3.40. Use the size conversion methods in QgsRenderContext instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/PyQt6/core/auto_generated/textrenderer/qgsfontmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgsfontmanager.sip.in
@@ -209,7 +209,7 @@ Enables font downloads the the current QGIS session.
    Ensure that the :py:class:`QgsApplication` is fully initialized before calling this method.
 %End
 
- QString urlForFontDownload( const QString &family, QString &matchedFamily /Out/ ) const /Deprecated/;
+ QString urlForFontDownload( const QString &family, QString &matchedFamily /Out/ ) const /Deprecated="Since 3.38. Use detailsForFontDownload() instead."/;
 %Docstring
 Returns the URL at which the font ``family`` can be downloaded.
 
@@ -244,7 +244,7 @@ return an invalid :py:class:`QgsFontDownloadDetails` for any font families not p
 .. versionadded:: 3.38
 %End
 
- void downloadAndInstallFont( const QUrl &url, const QString &identifier = QString() ) /Deprecated/;
+ void downloadAndInstallFont( const QUrl &url, const QString &identifier = QString() ) /Deprecated="Since 3.38. Use the version which takes a QgsFontDownloadDetails argument instead."/;
 %Docstring
 Downloads a font and installs in the user's profile/fonts directory as an application font,
 where the font family can be downloaded via a single ``url``.

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextrenderer.sip.in
@@ -200,7 +200,7 @@ Draws a text document along a line using the specified settings.
 
  static void drawPart( const QRectF &rect, double rotation, Qgis::TextHorizontalAlignment alignment, const QStringList &textLines,
                                             QgsRenderContext &context, const QgsTextFormat &format,
-                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated/;
+                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated="Since 3.40. Private API only, will be removed in 4.0."/;
 %Docstring
 Draws a single component of rendered text using the specified settings.
 
@@ -225,7 +225,7 @@ Draws a single component of rendered text using the specified settings.
 
  static void drawPart( QPointF origin, double rotation, Qgis::TextHorizontalAlignment alignment, const QStringList &textLines,
                                             QgsRenderContext &context, const QgsTextFormat &format,
-                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated/;
+                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated="Since 3.40. Private API only, will be removed in 4.0."/;
 %Docstring
 Draws a single component of rendered text using the specified settings.
 

--- a/python/PyQt6/core/auto_generated/vector/qgsfielddomain.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsfielddomain.sip.in
@@ -51,7 +51,7 @@ Constructor for QgsFieldDomain, with the specified ``name``, ``description`` and
 
  QgsFieldDomain( const QString &name,
                                       const QString &description,
-                                      QVariant::Type fieldType ) /Deprecated/;
+                                      QVariant::Type fieldType ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsFieldDomain, with the specified ``name``, ``description`` and ``fieldType``.
 
@@ -119,7 +119,7 @@ Sets the associated field ``type``.
 .. seealso:: :py:func:`fieldType`
 %End
 
- void setFieldType( QVariant::Type type ) /Deprecated/;
+ void setFieldType( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Sets the associated field ``type``.
 
@@ -240,7 +240,7 @@ appear only once, but it is the responsibility of the user to check this.
  QgsCodedFieldDomain( const QString &name,
                                            const QString &description,
                                            QVariant::Type fieldType,
-                                           const QList<QgsCodedValue> &values ) /Deprecated/;
+                                           const QList<QgsCodedValue> &values ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsCodedFieldDomain, with the associated ``name``, ``description`` and ``fieldType``.
 
@@ -317,7 +317,7 @@ Set an invalid QVariant for ``minimum`` or ``maximum`` respectively if no minimu
                                            const QVariant &minimum,
                                            bool minimumIsInclusive,
                                            const QVariant &maximum,
-                                           bool maximumIsInclusive ) /Deprecated/;
+                                           bool maximumIsInclusive ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsRangeFieldDomain, with the specified ``name``, ``description`` and ``fieldType``.
 
@@ -460,7 +460,7 @@ The ``glob`` argument specifies the content validation glob, e.g. ``*[a-z][0-1]?
  QgsGlobFieldDomain( const QString &name,
                                           const QString &description,
                                           QVariant::Type fieldType,
-                                          const QString &glob ) /Deprecated/;
+                                          const QString &glob ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsGlobFieldDomain, with the specified ``name``, ``description`` and ``fieldType``.
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -449,7 +449,7 @@ Returns the name of the column storing geometry, if applicable.
 .. versionadded:: 3.42
 %End
 
- QgsAttrPalIndexNameHash palAttributeIndexNames() const /Deprecated/;
+ QgsAttrPalIndexNameHash palAttributeIndexNames() const /Deprecated="Since 3.32. This method is unused and will always return an empty hash."/;
 %Docstring
 Returns list of indexes to names for :py:class:`QgsPalLabeling` fix
 
@@ -550,7 +550,7 @@ providers will return ``None``.
 Convert ``value`` to ``type``
 %End
 
- static QVariant convertValue( QVariant::Type type, const QString &value ) /Deprecated/;
+ static QVariant convertValue( QVariant::Type type, const QString &value ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Convert ``value`` to ``type``
 
@@ -564,7 +564,7 @@ Convert ``value`` to ``type``
 Returns the transaction this data provider is included in, if any.
 %End
 
- virtual void forceReload() /Deprecated/;
+ virtual void forceReload() /Deprecated="Since 3.12. Will be removed in QGIS 4.0 - use reloadData() instead."/;
 %Docstring
 
 .. deprecated:: 3.12

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1185,7 +1185,7 @@ Deletes the selected features
 :return: ``True`` in case of success and ``False`` otherwise
 %End
 
- Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, QgsFeatureId *featureId = 0 ) /Deprecated/;
+ Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, QgsFeatureId *featureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a ring to polygon/multipolygon features
 
@@ -1269,7 +1269,7 @@ Adds a ring to polygon/multipolygon features (takes ownership)
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- Qgis::GeometryOperationResult addPart( const QList<QgsPointXY> &ring ) /Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QList<QgsPointXY> &ring ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a new part polygon to a multipart feature
 
@@ -1297,7 +1297,7 @@ Adds a new part polygon to a multipart feature
 %End
 
 
- Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring ) /PyName=addPartV2,Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring ) /PyName=addPartV2,Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a new part polygon to a multipart feature
 
@@ -1388,7 +1388,7 @@ Translates feature by dx, dy
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+ Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits parts cut by the given line
 
@@ -1442,7 +1442,7 @@ Splits parts cut by the given line
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+ Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits features cut by the given line
 
@@ -1552,7 +1552,7 @@ Adds topological points for every vertex of the geometry.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- int addTopologicalPoints( const QgsPointXY &p )  /Deprecated/;
+ int addTopologicalPoints( const QgsPointXY &p )  /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a vertex to segments which intersect point ``p`` but don't
 already have a vertex there. If a feature already has a vertex at position ``p``,
@@ -1953,7 +1953,7 @@ Sets a duplicate ``policy`` for the field with the specified index.
     }
 %End
 
- QSet<QString> excludeAttributesWms() const /Deprecated/;
+ QSet<QString> excludeAttributesWms() const /Deprecated="Since 3.16. Use fields().configurationFlags() instead."/;
 %Docstring
 A set of attributes that are not advertised in WMS requests with QGIS server.
 
@@ -1962,7 +1962,7 @@ A set of attributes that are not advertised in WMS requests with QGIS server.
    Use :py:func:`~QgsVectorLayer.fields`.configurationFlags() instead.
 %End
 
- void setExcludeAttributesWms( const QSet<QString> &att ) /Deprecated/;
+ void setExcludeAttributesWms( const QSet<QString> &att ) /Deprecated="Since 3.16. Use setFieldConfigurationFlag() instead."/;
 %Docstring
 A set of attributes that are not advertised in WMS requests with QGIS server.
 
@@ -1971,7 +1971,7 @@ A set of attributes that are not advertised in WMS requests with QGIS server.
    Use :py:func:`~QgsVectorLayer.setFieldConfigurationFlag` instead.
 %End
 
- QSet<QString> excludeAttributesWfs() const /Deprecated/;
+ QSet<QString> excludeAttributesWfs() const /Deprecated="Since 3.16. Use fields().configurationFlags() instead."/;
 %Docstring
 A set of attributes that are not advertised in WFS requests with QGIS server.
 
@@ -1980,7 +1980,7 @@ A set of attributes that are not advertised in WFS requests with QGIS server.
    Use :py:func:`~QgsVectorLayer.fields`.configurationFlags() instead.
 %End
 
- void setExcludeAttributesWfs( const QSet<QString> &att ) /Deprecated/;
+ void setExcludeAttributesWfs( const QSet<QString> &att ) /Deprecated="Since 3.16. Use setFieldConfigurationFlag() instead."/;
 %Docstring
 A set of attributes that are not advertised in WFS requests with QGIS server.
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -61,7 +61,7 @@ Deletes a vertex from a feature.
 :param vertex: index of vertex to delete
 %End
 
- Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated/;
+ Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a ring to polygon/multipolygon features
 
@@ -119,7 +119,7 @@ Adds a ring to polygon/multipolygon features
    available in python bindings as addCurvedRing
 %End
 
-  Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring, QgsFeatureId featureId ) /Deprecated/;
+  Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring, QgsFeatureId featureId ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a new part polygon to a multipart feature
 
@@ -178,7 +178,7 @@ Translates feature by dx, dy
 :return: 0 in case of success
 %End
 
-  Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+  Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits parts cut by the given line
 
@@ -216,7 +216,7 @@ Splits parts cut by the given line
          - :py:class:`QgsGeometry`.SplitCannotSplitPoint
 %End
 
-  Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+  Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits features cut by the given line
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
@@ -146,7 +146,7 @@ join layer information.
 :return: the corresponding joined feature
 %End
 
- void setJoinFieldNamesBlackList( const QStringList &blackList ) /Deprecated/;
+ void setJoinFieldNamesBlackList( const QStringList &blackList ) /Deprecated="Since 3.40. Use setJoinFieldNamesBlockList() instead."/;
 %Docstring
 Sets a list of fields to ignore whatever happens.
 
@@ -155,7 +155,7 @@ Sets a list of fields to ignore whatever happens.
    Use :py:func:`~QgsVectorLayerJoinInfo.setJoinFieldNamesBlockList` instead.
 %End
 
- QStringList joinFieldNamesBlackList() const /Deprecated/;
+ QStringList joinFieldNamesBlackList() const /Deprecated="Since 3.40. Use joinFieldNamesBlockList() instead."/;
 %Docstring
 Returns the list of fields to ignore.
 

--- a/python/PyQt6/gui/auto_generated/actions/qgsmaplayeraction.sip.in
+++ b/python/PyQt6/gui/auto_generated/actions/qgsmaplayeraction.sip.in
@@ -50,7 +50,7 @@ Creates a map layer action which can run on a specific type of layer
 Layer behavior flags.
 %End
 
- virtual bool canRunUsingLayer( QgsMapLayer *layer ) const /Deprecated/;
+ virtual bool canRunUsingLayer( QgsMapLayer *layer ) const /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Returns ``True`` if the action can run using the specified layer.
 
@@ -70,7 +70,7 @@ Returns ``True`` if the action can run using the specified layer.
 .. versionadded:: 3.30
 %End
 
- virtual void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated/;
+ virtual void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggers the action with the specified layer and list of feature.
 
@@ -79,7 +79,7 @@ Triggers the action with the specified layer and list of feature.
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- virtual void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated/;
+ virtual void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggers the action with the specified layer and feature.
 
@@ -88,7 +88,7 @@ Triggers the action with the specified layer and feature.
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- virtual void triggerForLayer( QgsMapLayer *layer ) /Deprecated/;
+ virtual void triggerForLayer( QgsMapLayer *layer ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggers the action with the specified layer.
 
@@ -134,7 +134,7 @@ Returns ``True`` if the action is only enabled for layers in editable mode.
 
   signals:
 
- void triggeredForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated/;
+ void triggeredForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggered when action has been run for a specific list of features
 
@@ -143,7 +143,7 @@ Triggered when action has been run for a specific list of features
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- void triggeredForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated/;
+ void triggeredForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggered when action has been run for a specific feature
 
@@ -152,7 +152,7 @@ Triggered when action has been run for a specific feature
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- void triggeredForLayer( QgsMapLayer *layer ) /Deprecated/;
+ void triggeredForLayer( QgsMapLayer *layer ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggered when action has been run for a specific layer
 

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -155,7 +155,7 @@ Emitted when a column in the view has been resized.
 :param width: new width in pixel
 %End
 
- void finished() /Deprecated/;
+ void finished() /Deprecated="Since 3.40. No longer used."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsfieldconditionalformatwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsfieldconditionalformatwidget.sip.in
@@ -23,7 +23,7 @@ A widget for customizing conditional formatting options.
 Constructor for QgsFieldConditionalFormatWidget.
 %End
 
- void viewRules() /Deprecated/;
+ void viewRules() /Deprecated="Since 3.40. No longer used, will be removed in QGIS 4.0."/;
 %Docstring
 Switches the widget to the rules page.
 
@@ -45,7 +45,7 @@ where ``index`` is the index of the conditional style to edit
 and ``style`` is the initial definition of the style.
 %End
 
- void loadStyle( const QgsConditionalStyle &style ) /Deprecated/;
+ void loadStyle( const QgsConditionalStyle &style ) /Deprecated="Since 3.40. No longer used, use QgsEditConditionalFormatRuleWidget.loadStyle instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -53,7 +53,7 @@ and ``style`` is the initial definition of the style.
    No longer used, use :py:class:`QgsEditConditionalFormatRuleWidget`.loadStyle instead.
 %End
 
- void reset() /Deprecated/;
+ void reset() /Deprecated="Since 3.40. No longer used, will be removed in QGIS 4.0."/;
 %Docstring
 Resets the formatting options to their default state.
 

--- a/python/PyQt6/gui/auto_generated/callouts/qgscalloutwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/callouts/qgscalloutwidget.sip.in
@@ -58,7 +58,7 @@ Returns the context in which the symbol widget is shown, e.g., the associated ma
 .. seealso:: :py:func:`setContext`
 %End
 
- const QgsVectorLayer *vectorLayer() const /Deprecated/;
+ const QgsVectorLayer *vectorLayer() const /Deprecated="Since 3.40. Use layer() instead."/;
 %Docstring
 Returns the vector layer associated with the widget.
 

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -140,7 +140,7 @@ Returns a user-friendly, translated name of the specified script ``language``.
 .. versionadded:: 3.30
 %End
 
- void setMarginVisible( bool margin ) /Deprecated/;
+ void setMarginVisible( bool margin ) /Deprecated="Since 3.40. Use base class methods for individual margins instead, or setLineNumbersVisible()."/;
 %Docstring
 Set margin visible state
 
@@ -151,7 +151,7 @@ Set margin visible state
    Use base class methods for individual margins instead, or :py:func:`~QgsCodeEditor.setLineNumbersVisible`.
 %End
 
- bool marginVisible() /Deprecated/;
+ bool marginVisible() /Deprecated="Since 3.40. Use base class methods for individual margins instead, or lineNumbersVisible()."/;
 %Docstring
 Returns whether margins are in a visible state
 

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -279,7 +279,7 @@ Is forwarded to the slot :py:func:`~QgsEditorWidgetWrapper.setValues`
 %End
 
 
-    virtual void setValue( const QVariant &value ) /Deprecated/;
+    virtual void setValue( const QVariant &value ) /Deprecated="Since 3.10. "/;
 %Docstring
 Is called when the value of the widget needs to be changed. Updates the widget representation
 to reflect the new value.

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsJsonEditWidget : QWidget
 {
 %Docstring(signature="appended")

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
@@ -69,7 +69,7 @@ Returns the default flags (equalTo)
 
   public slots:
 
- void onValueChanged( const QVariant &value ) /Deprecated/;
+ void onValueChanged( const QVariant &value ) /Deprecated="Since 3.10. Made private."/;
 %Docstring
 Called when current value of search widget changes
 

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -45,7 +45,7 @@ class QgsRelationReferenceWidget : QWidget
 
     void setRelationEditable( bool editable );
 
- void setForeignKey( const QVariant &value ) /Deprecated/;
+ void setForeignKey( const QVariant &value ) /Deprecated="Since 3.10. Use setForeignKeys."/;
 %Docstring
 this sets the related feature using from the foreign key
 
@@ -61,7 +61,7 @@ Sets the related feature using the foreign keys
 .. versionadded:: 3.10
 %End
 
- QVariant foreignKey() const /Deprecated/;
+ QVariant foreignKey() const /Deprecated="Since 3.10. "/;
 %Docstring
 returns the related feature foreign key
 
@@ -270,7 +270,7 @@ unset the currently related feature
 
   signals:
 
- void foreignKeyChanged( const QVariant &key ) /Deprecated/;
+ void foreignKeyChanged( const QVariant &key ) /Deprecated="Since 3.10. "/;
 %Docstring
 Emitted when the foreign key changed
 

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -39,7 +39,7 @@ Constructor for QgsRelationWidgetWrapper
 Constructor for QgsRelationWidgetWrapper
 %End
 
- bool showLabel() const /Deprecated/;
+ bool showLabel() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been called at least once.
@@ -49,7 +49,7 @@ Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been ca
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- void setShowLabel( bool showLabel ) /Deprecated/;
+ void setShowLabel( bool showLabel ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been called at least once.
@@ -59,7 +59,7 @@ Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been ca
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- bool showLinkButton() const /Deprecated/;
+ bool showLinkButton() const /Deprecated="Since 3.16. Use visibleButtons() instead."/;
 %Docstring
 Determines if the "link feature" button should be shown
 
@@ -68,7 +68,7 @@ Determines if the "link feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.visibleButtons` instead.
 %End
 
- void setShowLinkButton( bool showLinkButton ) /Deprecated/;
+ void setShowLinkButton( bool showLinkButton ) /Deprecated="Since 3.16. Use setVisibleButtons() instead."/;
 %Docstring
 Determines if the "link feature" button should be shown
 
@@ -77,7 +77,7 @@ Determines if the "link feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.setVisibleButtons` instead.
 %End
 
- bool showUnlinkButton() const /Deprecated/;
+ bool showUnlinkButton() const /Deprecated="Since 3.16. Use visibleButtons() instead."/;
 %Docstring
 Determines if the "unlink feature" button should be shown
 
@@ -86,7 +86,7 @@ Determines if the "unlink feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.visibleButtons` instead.
 %End
 
- void setShowUnlinkButton( bool showUnlinkButton ) /Deprecated/;
+ void setShowUnlinkButton( bool showUnlinkButton ) /Deprecated="Since 3.16. Use setVisibleButtons() instead."/;
 %Docstring
 Determines if the "unlink feature" button should be shown
 
@@ -95,7 +95,7 @@ Determines if the "unlink feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.setVisibleButtons` instead.
 %End
 
- void setShowSaveChildEditsButton( bool showChildEdits ) /Deprecated/;
+ void setShowSaveChildEditsButton( bool showChildEdits ) /Deprecated="Since 3.16. Use setVisibleButtons() instead."/;
 %Docstring
 Determines if the "Save child layer edits" button should be shown
 
@@ -106,7 +106,7 @@ Determines if the "Save child layer edits" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.setVisibleButtons` instead.
 %End
 
- bool showSaveChildEditsButton() const /Deprecated/;
+ bool showSaveChildEditsButton() const /Deprecated="Since 3.16. Use visibleButtons() instead."/;
 %Docstring
 Determines if the "Save child layer edits" button should be shown
 
@@ -117,7 +117,7 @@ Determines if the "Save child layer edits" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.visibleButtons` instead.
 %End
 
- void setVisibleButtons( const QgsAttributeEditorRelation::Buttons &buttons ) /Deprecated/;
+ void setVisibleButtons( const QgsAttributeEditorRelation::Buttons &buttons ) /Deprecated="Since 3.18. Use setWidgetConfig() instead."/;
 %Docstring
 Defines the buttons which are shown
 
@@ -128,7 +128,7 @@ Defines the buttons which are shown
    Use :py:func:`~QgsRelationWidgetWrapper.setWidgetConfig` instead.
 %End
 
- QgsAttributeEditorRelation::Buttons visibleButtons() const /Deprecated/;
+ QgsAttributeEditorRelation::Buttons visibleButtons() const /Deprecated="Since 3.18. Use widgetConfig() instead."/;
 %Docstring
 Returns the buttons which are shown
 
@@ -188,7 +188,7 @@ If it's empty, then it's considered as a 1:M relationship.
 .. versionadded:: 3.16
 %End
 
- QString label() const /Deprecated/;
+ QString label() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Determines the label of this element
 
@@ -199,7 +199,7 @@ Determines the label of this element
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- void setLabel( const QString &label = QString() ) /Deprecated/;
+ void setLabel( const QString &label = QString() ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Sets ``label`` for this element
 If it's empty it takes the relation id as label

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreemapcanvasbridge.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreemapcanvasbridge.sip.in
@@ -46,7 +46,7 @@ Associates overview canvas with the bridge, so the overview will be updated when
 %End
 
 
-    void setOvervewCanvas( QgsMapOverviewCanvas *overviewCanvas ) /Deprecated/; // TODO QGIS 4.0 remove
+    void setOvervewCanvas( QgsMapOverviewCanvas *overviewCanvas ) /Deprecated="Since 3.40. Use setOverviewCanvas() instead."/; // TODO QGIS 4.0 remove
 %MethodCode
     sipCpp->setOverviewCanvas( a0 );
 %End

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -47,7 +47,7 @@ Action to uncheck a group and all its children
 Action to check a group and all its parents
 %End
 
- QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory,Deprecated/;
+ QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory,Deprecated="Since 3.18. Use actionZoomToLayers()."/;
 %Docstring
 Action to zoom to the active layer from the layer tree.
 
@@ -109,7 +109,7 @@ Action to zoom to selected features of a vector layer
 Action to enable/disable mutually exclusive flag of a group (only one child node may be checked)
 %End
 
- void zoomToLayer( QgsMapCanvas *canvas ) /Deprecated/;
+ void zoomToLayer( QgsMapCanvas *canvas ) /Deprecated="Since 3.18. Use zoomToLayers()."/;
 %Docstring
 Zooms a map ``canvas`` to the extent of the active layer in the layer tree.
 
@@ -145,7 +145,7 @@ Zooms a map ``canvas`` to all the selected layer(s) in the layer tree
     void renameGroupOrLayer();
     void showFeatureCount();
 
- void zoomToLayer() /Deprecated/;
+ void zoomToLayer() /Deprecated="Since 3.18. Use zoomToLayers()."/;
 %Docstring
 Zooms to the extent of the active layer in the layer tree.
 
@@ -169,7 +169,7 @@ Zooms to the bounding box of all selected features of a vector layer.
 %End
     void zoomToGroup();
 
- void makeTopLevel() /Deprecated/;
+ void makeTopLevel() /Deprecated="Since 3.2. Use moveOutOfGroup()."/;
 %Docstring
 
 .. deprecated:: 3.2

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutcustomdrophandler.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutcustomdrophandler.sip.in
@@ -24,7 +24,7 @@ Abstract base class that may be implemented to handle new types of data to be dr
 Constructor for QgsLayoutCustomDropHandler.
 %End
 
- virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file ) /Deprecated/;
+ virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file ) /Deprecated="Since 3.40. Use the version which specifies a drop location instead."/;
 %Docstring
 Called when the specified ``file`` has been dropped onto a QGIS layout. If ``True``
 is returned, then the handler has accepted this file and it should not

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
@@ -169,7 +169,7 @@ WkbType of the current layer).
 
   public slots:
 
- void setCircularDigitizingEnabled( bool enable ) /Deprecated/;
+ void setCircularDigitizingEnabled( bool enable ) /Deprecated="Since 3.26. Use setCurrentCaptureTechnique() instead."/;
 %Docstring
 Enable the digitizing with curve
 
@@ -178,7 +178,7 @@ Enable the digitizing with curve
    Use :py:func:`~QgsMapToolCapture.setCurrentCaptureTechnique` instead.
 %End
 
- void setStreamDigitizingEnabled( bool enable ) /Deprecated/;
+ void setStreamDigitizingEnabled( bool enable ) /Deprecated="Since 3.26. Use setCurrentCaptureTechnique() instead."/;
 %Docstring
 Toggles the stream digitizing mode.
 
@@ -275,7 +275,7 @@ Number of points digitized
 :return: Number of points
 %End
 
- QVector<QgsPointXY> points() const /Deprecated/;
+ QVector<QgsPointXY> points() const /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant returns QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 List of digitized points
 
@@ -296,7 +296,7 @@ List of digitized points
 .. versionadded:: 3.12
 %End
 
- void setPoints( const QVector<QgsPointXY> &pointList ) /Deprecated/;
+ void setPoints( const QVector<QgsPointXY> &pointList ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Set the points on which to work
 

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptooledit.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptooledit.sip.in
@@ -83,7 +83,7 @@ Returns the current vector layer of the map canvas or 0
       InvalidLayer,
     };
 
- TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &vertices ) /Deprecated/;
+ TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &vertices ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a list of ``vertices`` to other features to keep topology up to date, e.g. to neighbouring polygons.
 The ``vertices`` list specifies a set of topological points to add, in the layer's coordinate reference system.

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolidentifyfeature.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolidentifyfeature.sip.in
@@ -43,7 +43,7 @@ change the layer used by the map tool to identify
 Emitted when a ``feature`` has been identified
 %End
 
- void featureIdentified( QgsFeatureId id ) /Deprecated/;
+ void featureIdentified( QgsFeatureId id ) /Deprecated="Since 3.40. Use the signal with a QgsFeature argument instead."/;
 %Docstring
 Emitted when a feature has been identified by its ``id``.
 

--- a/python/PyQt6/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/PyQt6/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -33,7 +33,7 @@ Constructor
 :param fl: Window flags
 %End
 
- void saveDefaultStyle() /Deprecated/;
+ void saveDefaultStyle() /Deprecated="Since 3.40. Use saveStyleAsDefault() instead."/;
 %Docstring
 Saves the default style when appropriate button is pressed
 
@@ -42,7 +42,7 @@ Saves the default style when appropriate button is pressed
    Use :py:func:`~QgsMeshLayerProperties.saveStyleAsDefault` instead.
 %End
 
- void loadStyle() /Deprecated/;
+ void loadStyle() /Deprecated="Since 3.40. Use loadStyleFromFile() instead."/;
 %Docstring
 Loads a saved style when appropriate button is pressed
 
@@ -51,7 +51,7 @@ Loads a saved style when appropriate button is pressed
    Use :py:func:`~QgsMeshLayerProperties.loadStyleFromFile` instead.
 %End
 
- void saveStyleAs() /Deprecated/;
+ void saveStyleAs() /Deprecated="Since 3.40. Use saveStyleToFile() instead."/;
 %Docstring
 Saves a style when appriate button is pressed
 

--- a/python/PyQt6/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
@@ -150,7 +150,7 @@ by the given Coordinate Reference Systems.
                   in the widget.
 %End
 
- void pushProjectionToFront() /Deprecated/;
+ void pushProjectionToFront() /Deprecated="Since 3.40. Has no effect since QGIS 3.20."/;
 %Docstring
 Marks the current selected projection for push to front of recent projections list.
 
@@ -173,7 +173,7 @@ Clear the list of recent projections.
 Emitted when a projection is selected in the widget.
 %End
 
- void initialized() /Deprecated/;
+ void initialized() /Deprecated="Since 3.40. No longer emitted."/;
 %Docstring
 Notifies others that the widget is now fully initialized, including deferred selection of projection.
 

--- a/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
@@ -615,7 +615,7 @@ Returns the native measure area action. Call :py:func:`~QgisInterface.trigger` o
 Returns the native zoom full extent action. Call :py:func:`~QgisInterface.trigger` on it to zoom to the full extent.
 %End
 
- virtual QAction *actionZoomToLayer() = 0 /Deprecated/;
+ virtual QAction *actionZoomToLayer() = 0 /Deprecated="Since 3.40. Use actionZoomToLayers() instead."/;
 %Docstring
 Returns the native zoom to layer action. Call :py:func:`~QgisInterface.trigger` on it to zoom to the active layer.
 
@@ -764,7 +764,7 @@ Returns the Hide Deselected Layers action.
     virtual QAction *actionAbout() = 0;
 
 
- virtual QAction *actionCircle2Points() /Deprecated/;
+ virtual QAction *actionCircle2Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 2 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -773,7 +773,7 @@ Returns the native add circle from 2 points action. Call :py:func:`~QgisInterfac
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircle3Points() /Deprecated/;
+ virtual QAction *actionCircle3Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 3 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -782,7 +782,7 @@ Returns the native add circle from 3 points action. Call :py:func:`~QgisInterfac
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircle3Tangents() /Deprecated/;
+ virtual QAction *actionCircle3Tangents() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 3 tangents action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -791,7 +791,7 @@ Returns the native add circle from 3 tangents action. Call :py:func:`~QgisInterf
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircle2TangentsPoint() /Deprecated/;
+ virtual QAction *actionCircle2TangentsPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 2 tangents and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -800,7 +800,7 @@ Returns the native add circle from 2 tangents and a point action. Call :py:func:
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircleCenterPoint() /Deprecated/;
+ virtual QAction *actionCircleCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from center action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -809,7 +809,7 @@ Returns the native add circle from center action. Call :py:func:`~QgisInterface.
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseCenter2Points() /Deprecated/;
+ virtual QAction *actionEllipseCenter2Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from center and 2 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -818,7 +818,7 @@ Returns the native add ellipse from center and 2 points action. Call :py:func:`~
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseCenterPoint() /Deprecated/;
+ virtual QAction *actionEllipseCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from center and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -827,7 +827,7 @@ Returns the native add ellipse from center and a point action. Call :py:func:`~Q
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseExtent() /Deprecated/;
+ virtual QAction *actionEllipseExtent() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from an extent action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -836,7 +836,7 @@ Returns the native add ellipse from an extent action. Call :py:func:`~QgisInterf
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseFoci() /Deprecated/;
+ virtual QAction *actionEllipseFoci() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from foci action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -845,7 +845,7 @@ Returns the native add ellipse from foci action. Call :py:func:`~QgisInterface.t
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangleCenterPoint() /Deprecated/;
+ virtual QAction *actionRectangleCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from center and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -854,7 +854,7 @@ Returns the native add rectangle from center and a point action. Call :py:func:`
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangleExtent() /Deprecated/;
+ virtual QAction *actionRectangleExtent() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from extent action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -863,7 +863,7 @@ Returns the native add rectangle from extent action. Call :py:func:`~QgisInterfa
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangle3PointsDistance() /Deprecated/;
+ virtual QAction *actionRectangle3PointsDistance() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from 3 points (distance from 2nd and 3rd points) action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -872,7 +872,7 @@ Returns the native add rectangle from 3 points (distance from 2nd and 3rd points
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangle3PointsProjected() /Deprecated/;
+ virtual QAction *actionRectangle3PointsProjected() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from 3 points (distance from projected 3rd point on segment p1 and p2) action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -881,7 +881,7 @@ Returns the native add rectangle from 3 points (distance from projected 3rd poin
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRegularPolygon2Points() /Deprecated/;
+ virtual QAction *actionRegularPolygon2Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add regular polygon from 2 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -890,7 +890,7 @@ Returns the native add regular polygon from 2 points action. Call :py:func:`~Qgi
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRegularPolygonCenterPoint() /Deprecated/;
+ virtual QAction *actionRegularPolygonCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add regular polygon from center and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -899,7 +899,7 @@ Returns the native add regular polygon from center and a point action. Call :py:
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRegularPolygonCenterCorner() /Deprecated/;
+ virtual QAction *actionRegularPolygonCenterCorner() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add regular polygon from center and a corner action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -1642,7 +1642,7 @@ Unregister a previously registered custom drop ``handler`` for layout windows.
 
 
 
-    virtual void openURL( const QString &url, bool useQgisDocDirectory = true ) = 0 /Deprecated/;
+    virtual void openURL( const QString &url, bool useQgisDocDirectory = true ) = 0 /Deprecated="Since 3.40. Use QDesktopServices instead."/;
 %Docstring
 Open a url in the users browser. By default the QGIS doc directory is used
 as the base for the URL. To open a URL that is not relative to the installed

--- a/python/PyQt6/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -105,7 +105,7 @@ This signal is normally forwarded the app and used to refresh browser items
 Emitted when a DB layer has been selected for addition
 %End
 
- void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey ) /Deprecated/;
+ void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a raster layer has been selected for addition
 
@@ -123,7 +123,7 @@ Emitted when one or more GDAL supported layers are selected for addition
 .. versionadded:: 3.20
 %End
 
- void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() ) /Deprecated/;
+ void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a vector layer has been selected for addition.
 
@@ -135,7 +135,7 @@ will be used.
    Use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
- void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated/;
+ void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a mesh layer has been selected for addition.
 
@@ -144,7 +144,7 @@ Emitted when a mesh layer has been selected for addition.
    Use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
- void addVectorTileLayer( const QString &url, const QString &baseName ) /Deprecated/;
+ void addVectorTileLayer( const QString &url, const QString &baseName ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a vector tile layer has been selected for addition.
 
@@ -153,7 +153,7 @@ Emitted when a vector tile layer has been selected for addition.
    Use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
- void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated/;
+ void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a point cloud layer has been selected for addition.
 
@@ -195,7 +195,7 @@ Emitted when a layer needs to be replaced
 :param provider: key
 %End
 
- void progress( int, int ) /Deprecated/;
+ void progress( int, int ) /Deprecated="Since 3.4. This signal is no longer used. Use QgsProxyProgressTask instead to show progress reports."/;
 %Docstring
 Emitted when a progress dialog is shown by the provider dialog.
 

--- a/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -98,7 +98,7 @@ Sets the editor ``context``
 Returns the attribute editor context.
 %End
 
- bool showLabel() const /Deprecated/;
+ bool showLabel() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 
@@ -107,7 +107,7 @@ Defines if a title label should be shown for this widget.
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- void setShowLabel( bool showLabel ) /Deprecated/;
+ void setShowLabel( bool showLabel ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 
@@ -127,7 +127,7 @@ Sets ``nmRelationId`` for the relation id of the second relation involved in an 
 If it's empty, then it's considered as a 1:M relationship.
 %End
 
- QString label() const /Deprecated/;
+ QString label() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Determines the label of this element
 
@@ -263,7 +263,7 @@ Duplicates features
 Refresh the UI when the widget becomes visible
 %End
 
- void updateTitle() /Deprecated/;
+ void updateTitle() /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Updates the title contents to reflect the current state of the widget
 
@@ -291,7 +291,7 @@ Should be used to refresh the UI regarding the new data.
 Check :py:class:`QgsRealationEditorWidget` as an example.
 %End
 
- virtual void setTitle( const QString &title ) /Deprecated/;
+ virtual void setTitle( const QString &title ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Sets the title of the widget, if it is wrapped within a :py:class:`QgsCollapsibleGroupBox`
 

--- a/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -483,7 +483,7 @@ Returns the last CAD point, in a map ``layer``'s coordinates.
 .. versionadded:: 3.22
 %End
 
- QgsPointXY currentPoint( bool *exists = 0 ) const /Deprecated/;
+ QgsPointXY currentPoint( bool *exists = 0 ) const /Deprecated="Since 3.22. Use currentPointV2() instead."/;
 %Docstring
 The last point.
 Helper for the CAD point list. The CAD point list is the list of points
@@ -500,7 +500,7 @@ Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
- QgsPointXY previousPoint( bool *exists = 0 ) const /Deprecated/;
+ QgsPointXY previousPoint( bool *exists = 0 ) const /Deprecated="Since 3.22. Use previousPointV2() instead."/;
 %Docstring
 The previous point.
 Helper for the CAD point list. The CAD point list is the list of points
@@ -517,7 +517,7 @@ Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
- QgsPointXY penultimatePoint( bool *exists = 0 ) const /Deprecated/;
+ QgsPointXY penultimatePoint( bool *exists = 0 ) const /Deprecated="Since 3.22. Use penultimatePointV2() instead."/;
 %Docstring
 The penultimate point.
 Helper for the CAD point list. The CAD point list is the list of points
@@ -706,7 +706,7 @@ when a constraint is toggled.
 .. versionadded:: 3.22
 %End
 
- void pointChanged( const QgsPointXY &point ) /Deprecated/;
+ void pointChanged( const QgsPointXY &point ) /Deprecated="Since 3.22. No longer used, will be removed in QGIS 4.0. Use pointChangedV2() instead."/;
 %Docstring
 Sometimes a constraint may change the current point out of a mouse event. This happens normally
 when a constraint is toggled.

--- a/python/PyQt6/gui/auto_generated/qgsaggregatetoolbutton.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsaggregatetoolbutton.sip.in
@@ -31,7 +31,7 @@ Constructor
 Based on the ``type`` of underlying data, some aggregates will be available or not.
 %End
 
- void setType( QVariant::Type type ) /Deprecated/;
+ void setType( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Based on the ``type`` of underlying data, some aggregates will be available or not.
 

--- a/python/PyQt6/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributeform.sip.in
@@ -181,7 +181,7 @@ Returns ``True`` if any of the form widgets need feature geometry
 
   signals:
 
- void attributeChanged( const QString &attribute, const QVariant &value ) /Deprecated/;
+ void attributeChanged( const QString &attribute, const QVariant &value ) /Deprecated="Since 3.0. "/;
 %Docstring
 Notifies about changes of attributes, this signal is not emitted when the value is set
 back to the original one.

--- a/python/PyQt6/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -35,7 +35,7 @@ Returns a pointer to the :py:class:`QgsBrowserWidget` used by the dock widget.
 .. versionadded:: 3.22
 %End
 
- void addFavoriteDirectory( const QString &favDir, const QString &name = QString() ) /Deprecated/;
+ void addFavoriteDirectory( const QString &favDir, const QString &name = QString() ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Add directory to favorites.
 
@@ -80,7 +80,7 @@ Used in the proxy browser model to hide items
 
   public slots:
 
- bool addLayerAtIndex( const QModelIndex &index ) /Deprecated/;
+ bool addLayerAtIndex( const QModelIndex &index ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - retrieve the QgsLayerItem itself and manually add to project."/;
 %Docstring
 Adds the layer corresponding to the specified model ``index``.
 
@@ -92,7 +92,7 @@ Returns ``True`` if the index was successfully intrepreted as a map layer and lo
    Will be removed in QGIS 4.0 - retrieve the :py:class:`QgsLayerItem` itself and manually add to project.
 %End
 
- void showContextMenu( QPoint ) /Deprecated/;
+ void showContextMenu( QPoint ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Show context menu.
 
@@ -101,7 +101,7 @@ Show context menu.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void addFavorite() /Deprecated/;
+ void addFavorite() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Add current item to favorite.
 
@@ -110,7 +110,7 @@ Add current item to favorite.
    Will be removed in QGIS 4.0 - use the methods in :py:class:`QgsBrowserModel` instead.
 %End
 
- void addFavoriteDirectory() /Deprecated/;
+ void addFavoriteDirectory() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Add directory from file dialog to favorite.
 
@@ -119,7 +119,7 @@ Add directory from file dialog to favorite.
    Will be removed in QGIS 4.0 - use the methods in :py:class:`QgsBrowserModel` instead.
 %End
 
- void removeFavorite() /Deprecated/;
+ void removeFavorite() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Remove from favorite.
 
@@ -133,7 +133,7 @@ Remove from favorite.
 Refresh the browser model and view.
 %End
 
- void showFilterWidget( bool visible ) /Deprecated/;
+ void showFilterWidget( bool visible ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Show/hide filter widget.
 
@@ -142,7 +142,7 @@ Show/hide filter widget.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void enablePropertiesWidget( bool enable ) /Deprecated/;
+ void enablePropertiesWidget( bool enable ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Enable/disable properties widget.
 
@@ -151,7 +151,7 @@ Enable/disable properties widget.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setFilterSyntax( QAction * ) /Deprecated/;
+ void setFilterSyntax( QAction * ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Sets filter syntax.
 
@@ -160,7 +160,7 @@ Sets filter syntax.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setCaseSensitive( bool caseSensitive ) /Deprecated/;
+ void setCaseSensitive( bool caseSensitive ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Sets filter case sensitivity.
 
@@ -169,7 +169,7 @@ Sets filter case sensitivity.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setFilter() /Deprecated/;
+ void setFilter() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Apply filter to the model.
 
@@ -178,7 +178,7 @@ Apply filter to the model.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setActiveIndex( const QModelIndex &index ) /Deprecated/;
+ void setActiveIndex( const QModelIndex &index ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Sets the selection to ``index`` and expand it.
 
@@ -187,7 +187,7 @@ Sets the selection to ``index`` and expand it.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void updateProjectHome() /Deprecated/;
+ void updateProjectHome() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Update project home directory.
 
@@ -196,7 +196,7 @@ Update project home directory.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void addSelectedLayers() /Deprecated/;
+ void addSelectedLayers() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Add selected layers to the project
 
@@ -205,7 +205,7 @@ Add selected layers to the project
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void showProperties() /Deprecated/;
+ void showProperties() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Show the layer properties.
 
@@ -214,7 +214,7 @@ Show the layer properties.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void hideItem() /Deprecated/;
+ void hideItem() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Hide current item.
 
@@ -223,7 +223,7 @@ Hide current item.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void toggleFastScan() /Deprecated/;
+ void toggleFastScan() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Toggle fast scan
 
@@ -232,7 +232,7 @@ Toggle fast scan
    Will be removed in QGIS 4.0.
 %End
 
- void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected ) /Deprecated/;
+ void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Selection has changed.
 
@@ -241,7 +241,7 @@ Selection has changed.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void splitterMoved() /Deprecated/;
+ void splitterMoved() /Deprecated="Since 3.40. No longer used."/;
 %Docstring
 Splitter has been moved.
 

--- a/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
@@ -72,7 +72,7 @@ Returns the color component which the widget controls
 .. seealso:: :py:func:`setComponent`
 %End
 
- int componentValue() const /Deprecated/;
+ int componentValue() const /Deprecated="Since 3.40. Use componentValueF() instead."/;
 %Docstring
 Returns the current value of the widget's color component
 
@@ -136,7 +136,7 @@ Sets the color component which the widget controls
 .. seealso:: :py:func:`component`
 %End
 
- virtual void setComponentValue( int value ) /Deprecated/;
+ virtual void setComponentValue( int value ) /Deprecated="Since 3.40. Use setComponentValueF() instead."/;
 %Docstring
 Alters the widget's color by setting the value for the widget's color component
 
@@ -208,7 +208,7 @@ Returns the range of valid values a color component
 :return: maximum value allowed for color component
 %End
 
- int componentValue( ColorComponent component ) const /Deprecated/;
+ int componentValue( ColorComponent component ) const /Deprecated="Since 3.40. Use componentValueF() instead."/;
 %Docstring
 Returns the value of a component of the widget's current color. This method correctly
 handles hue values when the color has an ambiguous hue (e.g., black or white shades)
@@ -239,7 +239,7 @@ handles hue values when the color has an ambiguous hue (e.g., black or white sha
 .. versionadded:: 3.40
 %End
 
- int hue() const /Deprecated/;
+ int hue() const /Deprecated="Since 3.40. Use hueF() instead."/;
 %Docstring
 Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
 as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
@@ -261,7 +261,7 @@ as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the satu
 .. versionadded:: 3.40
 %End
 
- static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) /Deprecated/;
+ static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) /Deprecated="Since 3.40. Use alterColorF() instead."/;
 %Docstring
 Alters a color by modifying the value of a specific color component
 
@@ -568,7 +568,7 @@ Sets the size for drawing the triangular markers on the ramp
 
   signals:
 
- void valueChanged( int value ) /Deprecated/;
+ void valueChanged( int value ) /Deprecated="Since 3.40. Use valueChangedF() instead."/;
 %Docstring
 Emitted when the widget's color component value changes
 

--- a/python/PyQt6/gui/auto_generated/qgscustomdrophandler.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscustomdrophandler.sip.in
@@ -69,7 +69,7 @@ determine whether the drag action should be accepted.
 %End
 
 
- virtual void handleMimeData( const QMimeData *data ) /Deprecated/;
+ virtual void handleMimeData( const QMimeData *data ) /Deprecated="Since 3.10. Use handleMimeDataV2() instead."/;
 %Docstring
 Called when the specified mime ``data`` has been dropped onto QGIS.
 

--- a/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -76,7 +76,7 @@ Sets layer in order to get the fields and values
 Returns the current layer or a None.
 %End
 
- void loadFieldNames() /Deprecated/;
+ void loadFieldNames() /Deprecated="Since 3.14. This is now done automatically."/;
 %Docstring
 
 .. deprecated:: 3.14
@@ -84,7 +84,7 @@ Returns the current layer or a None.
    This is now done automatically.
 %End
 
- void loadFieldNames( const QgsFields &fields ) /Deprecated/;
+ void loadFieldNames( const QgsFields &fields ) /Deprecated="Since 3.14. Use expressionTree()->loadFieldNames() instead."/;
 %Docstring
 
 .. deprecated:: 3.14
@@ -92,7 +92,7 @@ Returns the current layer or a None.
    Use :py:func:`~QgsExpressionBuilderWidget.expressionTree`->:py:func:`~QgsExpressionBuilderWidget.loadFieldNames` instead.
 %End
 
- void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues ) /Deprecated/;
+ void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues ) /Deprecated="Since 3.14. This will not do anything, use setLayer() instead."/;
 %Docstring
 Loads field names and values from the specified map.
 
@@ -199,7 +199,7 @@ objects (i.e. for objects which aren't vector layer features).
 %End
 
 
- void saveToRecent( const QString &collection = "generic" ) /Deprecated/;
+ void saveToRecent( const QString &collection = "generic" ) /Deprecated="Since 3.14. Use expressionTree()->saveRecent() instead."/;
 %Docstring
 Adds the current expression to the given ``collection``.
 By default it is saved to the collection "generic".
@@ -209,7 +209,7 @@ By default it is saved to the collection "generic".
    Use :py:func:`~QgsExpressionBuilderWidget.expressionTree`->:py:func:`~QgsExpressionBuilderWidget.saveRecent` instead.
 %End
 
- void loadRecent( const QString &collection = QStringLiteral( "generic" ) ) /Deprecated/;
+ void loadRecent( const QString &collection = QStringLiteral( "generic" ) ) /Deprecated="Since 3.14. Use expressionTree()->loadRecent() instead."/;
 %Docstring
 Loads the recent expressions from the given ``collection``.
 By default it is loaded from the collection "generic".
@@ -226,7 +226,7 @@ Returns the expression tree
 .. versionadded:: 3.14
 %End
 
- void loadUserExpressions() /Deprecated/;
+ void loadUserExpressions() /Deprecated="Since 3.14. Use expressionTree()->loadUserExpressions() instead."/;
 %Docstring
 Loads the user expressions.
 
@@ -236,7 +236,7 @@ Loads the user expressions.
 .. versionadded:: 3.12
 %End
 
- void saveToUserExpressions( const QString &label, const QString &expression, const QString &helpText ) /Deprecated/;
+ void saveToUserExpressions( const QString &label, const QString &expression, const QString &helpText ) /Deprecated="Since 3.14. Use expressionTree()->saveToUserExpressions() instead."/;
 %Docstring
 Stores the user ``expression`` with given ``label`` and ``helpText``.
 
@@ -246,7 +246,7 @@ Stores the user ``expression`` with given ``label`` and ``helpText``.
 .. versionadded:: 3.12
 %End
 
- void removeFromUserExpressions( const QString &label ) /Deprecated/;
+ void removeFromUserExpressions( const QString &label ) /Deprecated="Since 3.14. Use expressionTree()->removeFromUserExpressions() instead."/;
 %Docstring
 Removes the expression ``label`` from the user stored expressions.
 
@@ -295,7 +295,7 @@ Saves the current function editor text to a project entry.
 .. versionadded:: 3.40
 %End
 
- QStandardItemModel *model() /Deprecated/;
+ QStandardItemModel *model() /Deprecated="Since 3.14. "/;
 %Docstring
 Returns a pointer to the dialog's function item model.
 This method is exposed for testing purposes only - it should not be used to modify the model.

--- a/python/PyQt6/gui/auto_generated/qgsexternalresourcewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexternalresourcewidget.sip.in
@@ -62,7 +62,7 @@ documentPath returns the path of the current document in the widget
 :param type: determines the type of the returned null variant if the document is not defined yet
 %End
 
- QVariant documentPath( QVariant::Type type ) const /Deprecated/;
+ QVariant documentPath( QVariant::Type type ) const /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 documentPath returns the path of the current document in the widget
 

--- a/python/PyQt6/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -76,7 +76,7 @@ An additional expression to further restrict the available features.
 This can be used to integrate additional spatial or other constraints.
 %End
 
- QVariant identifierValue() const /Deprecated/;
+ QVariant identifierValue() const /Deprecated="Since 3.10. "/;
 %Docstring
 The identifier value of the currently selected feature. A value from the
 identifierField.
@@ -93,7 +93,7 @@ identifierField.
 %End
 
 
- void setIdentifierValue( const QVariant &identifierValue ) /Deprecated/;
+ void setIdentifierValue( const QVariant &identifierValue ) /Deprecated="Since 3.10. Use setIdentifierValues."/;
 %Docstring
 The identifier value of the currently selected feature. A value from the
 identifierField.
@@ -149,7 +149,7 @@ If set to 0, no limit is applied when fetching
 .. versionadded:: 3.32
 %End
 
- QString identifierField() const /Deprecated/;
+ QString identifierField() const /Deprecated="Since 3.10. "/;
 %Docstring
 Field name that will be used to uniquely identify the current feature.
 Normally the primary key of the layer.
@@ -165,7 +165,7 @@ Normally the primary key of the layer.
 .. versionadded:: 3.10
 %End
 
- void setIdentifierField( const QString &identifierField ) /Deprecated/;
+ void setIdentifierField( const QString &identifierField ) /Deprecated="Since 3.10. "/;
 %Docstring
 Field name that will be used to uniquely identify the current feature.
 Normally the primary key of the layer.

--- a/python/PyQt6/gui/auto_generated/qgshttpheaderwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgshttpheaderwidget.sip.in
@@ -43,7 +43,7 @@ Sets the widget from the headers
 .. versionadded:: 3.30
 %End
 
- void setFromSettings( const QgsSettings &settings, const QString &key ) /Deprecated/;
+ void setFromSettings( const QgsSettings &settings, const QString &key ) /Deprecated="Since 3.30. Use setFromHeaders() instead."/;
 %Docstring
 fill the inner header map from the settings defined at ``key``
 
@@ -57,7 +57,7 @@ fill the inner header map from the settings defined at ``key``
    Use :py:func:`~QgsHttpHeaderWidget.setFromHeaders` instead.
 %End
 
- void updateSettings( QgsSettings &settings, const QString &key ) const /Deprecated/;
+ void updateSettings( QgsSettings &settings, const QString &key ) const /Deprecated="Since 3.30. Use a variant map for settinds directly."/;
 %Docstring
 update the ``settings`` with the http headers present in the inner map.
 

--- a/python/PyQt6/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsidentifymenu.sip.in
@@ -154,7 +154,7 @@ exec
 :param pos: the position where the menu will be executed
 %End
 
- static void styleHighlight( QgsHighlight *highlight ) /Deprecated/;
+ static void styleHighlight( QgsHighlight *highlight ) /Deprecated="Since 3.40. Use QgsHighlight.applyDefaultStyle() instead."/;
 %Docstring
 Applies style from the settings to the highlight
 

--- a/python/PyQt6/gui/auto_generated/qgsmaplayercombobox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaplayercombobox.sip.in
@@ -36,7 +36,7 @@ This method allows filtering layers according to layer type and/or geometry type
 .. seealso:: :py:func:`filters`
 %End
 
- void setFilters( int filters ) /Deprecated/;
+ void setFilters( int filters ) /Deprecated="Since 3.34. Use the flag signature instead."/;
 %Docstring
 Filters according to layer type and/or geometry type.
 

--- a/python/PyQt6/gui/auto_generated/qgsnewvectorlayerdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsnewvectorlayerdialog.sip.in
@@ -16,7 +16,7 @@ class QgsNewVectorLayerDialog : QDialog
 #include "qgsnewvectorlayerdialog.h"
 %End
   public:
- static QString runAndCreateLayer( QWidget *parent = 0, QString *enc = 0, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), const QString &initialPath = QString() ) /Deprecated/;
+ static QString runAndCreateLayer( QWidget *parent = 0, QString *enc = 0, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), const QString &initialPath = QString() ) /Deprecated="Since 3.4.5. Use execAndCreateLayer() instead."/;
 %Docstring
 Runs the dialog and creates a layer matching the dialog parameters.
 

--- a/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -93,7 +93,7 @@ Defines the buttons which are shown
 Returns the buttons which are shown
 %End
 
- void duplicateFeature() /Deprecated/;
+ void duplicateFeature() /Deprecated="Since 3.18. Use duplicateSelectedFeatures() instead."/;
 %Docstring
 Duplicates a feature
 

--- a/python/PyQt6/gui/auto_generated/qgsscalevisibilitydialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsscalevisibilitydialog.sip.in
@@ -53,7 +53,7 @@ The scale value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
 
   public slots:
 
- void setScaleVisiblity( bool hasScaleVisibility ) /Deprecated/;
+ void setScaleVisiblity( bool hasScaleVisibility ) /Deprecated="Since 3.40. Use setScaleVisibility()."/;
 %Docstring
 Set whether scale based visibility is enabled.
 

--- a/python/PyQt6/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgssublayersdialog.sip.in
@@ -57,7 +57,7 @@ class QgsSublayersDialog : QDialog
     typedef QList<QgsSublayersDialog::LayerDefinition> LayerDefinitionList;
 
 
- QgsSublayersDialog( ProviderType providerType, const QString &name, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = Qt::WindowFlags(), const QString &dataSourceUri = QString() ) /Deprecated/;
+ QgsSublayersDialog( ProviderType providerType, const QString &name, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = Qt::WindowFlags(), const QString &dataSourceUri = QString() ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Construct a new QgsSublayersDialog object - a dialog to select which sub layers to be imported from a data source (e.g. from geopackage or zipfile)
 

--- a/python/PyQt6/gui/auto_generated/qgstextformatwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgstextformatwidget.sip.in
@@ -138,7 +138,7 @@ Sets the background color for the text preview widget.
 :param color: background color
 %End
 
- void enableDataDefinedAlignment( bool enable ) /Deprecated/;
+ void enableDataDefinedAlignment( bool enable ) /Deprecated="Since 3.24. "/;
 %Docstring
 Update the enabled state of the data defined alignment buttons.
 

--- a/python/PyQt6/gui/auto_generated/raster/qgsrasterattributetablemodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/raster/qgsrasterattributetablemodel.sip.in
@@ -79,7 +79,7 @@ Inserts a field at the given position.
          - errorMessage: error message
 %End
 
- bool insertField( const int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated/;
+ bool insertField( const int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Inserts a field at the given position.
 

--- a/python/PyQt6/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/PyQt6/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -43,7 +43,7 @@ Constructor
     virtual bool eventFilter( QObject *obj, QEvent *ev );
 
 
- void saveDefaultStyle() /Deprecated/;
+ void saveDefaultStyle() /Deprecated="Since 3.40. Use saveStyleAsDefault() instead."/;
 %Docstring
 Saves the default style when appropriate button is pressed
 

--- a/python/PyQt6/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -79,7 +79,7 @@ vector layers have been changed. Will request the parent dialog
 to re-synchronize with the variables.
 %End
 
- void symbolLevelsChanged() /Deprecated/;
+ void symbolLevelsChanged() /Deprecated="Since 3.20. No longer emitted."/;
 %Docstring
 Emitted when the symbol levels settings have been changed.
 

--- a/python/PyQt6/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -161,7 +161,7 @@ Closes the dialog
 Opens the associated help
 %End
 
- void itemChanged( QStandardItem *item ) /Deprecated/;
+ void itemChanged( QStandardItem *item ) /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -204,7 +204,7 @@ Toggles the interactive item tagging mode.
 Triggers the dialog for editing the selected smart group.
 %End
 
- void regrouped( QStandardItem * ) /Deprecated/;
+ void regrouped( QStandardItem * ) /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -266,7 +266,7 @@ Remove all tags from selected symbols
 %End
 
   protected:
- void populateTypes() /Deprecated/;
+ void populateTypes() /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 Populate combo box with known style items (symbols, color ramps).
 
@@ -280,7 +280,7 @@ Populate combo box with known style items (symbols, color ramps).
 populate the groups
 %End
 
- void setSymbolsChecked( const QStringList & ) /Deprecated/;
+ void setSymbolsChecked( const QStringList & ) /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -288,7 +288,7 @@ populate the groups
    Has no effect and will be removed in QGIS 4.0.
 %End
 
- void populateSymbols( const QStringList &symbolNames, bool checkable = false ) /Deprecated/;
+ void populateSymbols( const QStringList &symbolNames, bool checkable = false ) /Deprecated="Since 3.40. No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 Populates the list view with symbols of the current type with the given names.
 
@@ -297,7 +297,7 @@ Populates the list view with symbols of the current type with the given names.
    No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0.
 %End
 
- void populateColorRamps( const QStringList &colorRamps, bool checkable = false ) /Deprecated/;
+ void populateColorRamps( const QStringList &colorRamps, bool checkable = false ) /Deprecated="Since 3.40. No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 Populates the list view with color ramps of the current type with the given names.
 
@@ -317,7 +317,7 @@ add a new symbol to style
     bool editSymbol();
     bool editColorRamp();
 
- bool removeSymbol() /Deprecated/;
+ bool removeSymbol() /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -325,7 +325,7 @@ add a new symbol to style
    Has no effect and will be removed in QGIS 4.0.
 %End
 
- bool removeColorRamp() /Deprecated/;
+ bool removeColorRamp() /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6

--- a/python/PyQt6/gui/auto_generated/symbology/qgssvgselectorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgssvgselectorwidget.sip.in
@@ -134,7 +134,7 @@ Defines if the group box to fill parameters is visible
 .. versionadded:: 3.18
 %End
 
- bool allowParamerters() const /Deprecated/;
+ bool allowParamerters() const /Deprecated="Since 3.40. Use allowParameters()."/;
 %Docstring
 Returns if the group box to fill parameters is visible
 

--- a/python/PyQt6/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -452,7 +452,7 @@ Sets the dynamic SVG parameters
 
   protected:
 
- void populateList() /Deprecated/;
+ void populateList() /Deprecated="Since 3.16. "/;
 %Docstring
 This method does nothing anymore, the loading is automatic
 

--- a/python/PyQt6/gui/auto_generated/symbology/qgssymbollevelsdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgssymbollevelsdialog.sip.in
@@ -54,7 +54,7 @@ Sets whether the level ordering is always forced on and hide the checkbox (used 
 
   public slots:
 
- void apply() /Deprecated/;
+ void apply() /Deprecated="Since 3.20. Use symbolLevels() and manually apply the changes to the renderer as appropriate."/;
 %Docstring
 Apply button.
 

--- a/python/PyQt6/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
@@ -75,7 +75,7 @@ Returns ``True`` if the current selection has a mix of numeric formats.
 .. seealso:: :py:func:`selectionNumericFormat`
 %End
 
- QColor selectionForegroundColor() /Deprecated/;
+ QColor selectionForegroundColor() /Deprecated="Since 3.40. Use selectionTextFormat() instead."/;
 %Docstring
 Returns the foreground color for the currently selected cells.
 
@@ -295,7 +295,7 @@ current selected cells.
 Clears the contents of the currently selected cells.
 %End
 
- void setSelectionForegroundColor( const QColor &color ) /Deprecated/;
+ void setSelectionForegroundColor( const QColor &color ) /Deprecated="Since 3.40. Use setSelectionTextFormat() instead."/;
 %Docstring
 Sets the foreground color for the currently selected cells.
 

--- a/python/PyQt6/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
+++ b/python/PyQt6/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
@@ -27,7 +27,7 @@ Vectortile layer properties dialog
 Constructor
 %End
 
- void saveDefaultStyle() /Deprecated/;
+ void saveDefaultStyle() /Deprecated="Since 3.40. Use saveStyleAsDefault() instead."/;
 %Docstring
 Saves the default style when appropriate button is pressed
 
@@ -43,7 +43,7 @@ Loads a saved style when appropriate button is pressed
 .. versionadded:: 3.30
 %End
 
- void saveStyleAs() /Deprecated/;
+ void saveStyleAs() /Deprecated="Since 3.40. Use saveStyleToFile() instead."/;
 %Docstring
 Saves a style when appriate button is pressed
 

--- a/python/PyQt6/gui/gui.sip.in
+++ b/python/PyQt6/gui/gui.sip.in
@@ -12,6 +12,9 @@ ${DEFAULTDOCSTRINGSIGNATURE}
 %Import QtGui/QtGuimod.sip
 %Import QtXml/QtXmlmod.sip
 %Import QtMultimedia/QtMultimediamod.sip
-%Import ${QSCI_SIP_MOD_NAME}
+
+%If (HAVE_QSCI_SIP)
+    %Import ${QSCI_SIP_MOD_NAME}
+%End
 
 %Include gui_auto.sip

--- a/python/PyQt6/gui/gui_auto.sip
+++ b/python/PyQt6/gui/gui_auto.sip
@@ -323,7 +323,9 @@
 %Include auto_generated/editorwidgets/qgsdefaultsearchwidgetwrapper.sip
 %Include auto_generated/editorwidgets/qgsdoublespinbox.sip
 %Include auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip
+%If ( HAVE_QSCI_SIP )
 %Include auto_generated/editorwidgets/qgsjsoneditwidget.sip
+%End
 %Include auto_generated/editorwidgets/qgsmultiedittoolbutton.sip
 %Include auto_generated/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
 %Include auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip

--- a/python/PyQt6/server/auto_generated/qgsserverapiutils.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverapiutils.sip.in
@@ -136,7 +136,7 @@ Returns the list of CRSs (format: http://www.opengis.net/def/crs/OGC/1.3/CRS84) 
 Information is read from project WMS configuration.
 %End
 
- static QString crsToOgcUri( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ static QString crsToOgcUri( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.30. Use QgsCoordinateReferenceSystem.toOgcUri() instead."/;
 %Docstring
 Returns a ``crs`` as OGC URI (format: http://www.opengis.net/def/crs/OGC/1.3/CRS84)
 Returns an empty string on failure.

--- a/python/PyQt6/server/auto_generated/qgsserverfilter.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverfilter.sip.in
@@ -43,7 +43,7 @@ and must be passed to QgsServerFilter instances.
 Returns the :py:class:`QgsServerInterface` instance
 %End
 
- virtual void requestReady() /Deprecated/;
+ virtual void requestReady() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` is ready and populated with
 parameters, just before entering the main switch for core services.
@@ -56,7 +56,7 @@ be used instead.
    Will be removed in QGIS 4.0.
 %End
 
- virtual void responseComplete() /Deprecated/;
+ virtual void responseComplete() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` processing has done and
 the response is ready, just after the main switch for core services
@@ -70,7 +70,7 @@ be used instead.
    Will be removed in QGIS 4.0.
 %End
 
- virtual void sendResponse() /Deprecated/;
+ virtual void sendResponse() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` sends its data to FCGI stdout.
 This normally occurs at the end of core services processing just after

--- a/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
@@ -124,7 +124,7 @@ Returns the string representation of a ``ct`` (Content-Type) attribute.
 Returns the file extension for a ``ct`` (Content-Type).
 %End
 
- static QgsServerOgcApi::ContentType contenTypeFromExtension( const std::string &extension ) /Deprecated/;
+ static QgsServerOgcApi::ContentType contenTypeFromExtension( const std::string &extension ) /Deprecated="Since 3.40. Use contentTypeFromExtension()."/;
 %Docstring
 Returns the Content-Type value corresponding to ``extension``.
 

--- a/python/PyQt6/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverparameters.sip.in
@@ -30,7 +30,7 @@ Constructor for QgsServerParameterDefinition.
 %End
 
 
- QgsServerParameterDefinition( const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated/;
+ QgsServerParameterDefinition( const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsServerParameterDefinition.
 
@@ -241,7 +241,7 @@ Constructor for QgsServerParameter.
 :param defaultValue: The default value to use if not defined
 %End
 
- QgsServerParameter( const QgsServerParameter::Name name, const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated/;
+ QgsServerParameter( const QgsServerParameter::Name name, const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsServerParameter.
 

--- a/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -97,7 +97,7 @@ QgsRasterCalculator constructor.
 %End
 
 
- QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated/;
+ QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated="Since 3.8. Use the version with transformContext instead."/;
 %Docstring
 QgsRasterCalculator constructor.
 
@@ -114,7 +114,7 @@ QgsRasterCalculator constructor.
    Use the version with transformContext instead.
 %End
 
- QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated/;
+ QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated="Since 3.8. Use the version with transformContext instead."/;
 %Docstring
 QgsRasterCalculator constructor.
 

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -191,7 +191,7 @@ Returns a list of available resolution methods.
 .. versionadded:: 3.12
 %End
 
- virtual QStringList resolutionMethods() const /Deprecated/;
+ virtual QStringList resolutionMethods() const /Deprecated="Since 3.12. Use availableResolutionMethods() instead."/;
 %Docstring
 Returns a list of descriptions for available resolutions for errors.
 The index will be passed as ``method`` to :py:func:`fixError`.

--- a/python/core/auto_generated/annotations/qgsannotation.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotation.sip.in
@@ -144,7 +144,7 @@ the relative percentage for the position compared to the map width and height.
 .. seealso:: :py:func:`relativePosition`
 %End
 
- void setFrameOffsetFromReferencePoint( QPointF offset ) /Deprecated/;
+ void setFrameOffsetFromReferencePoint( QPointF offset ) /Deprecated="Since 3.40. Use setFrameOffsetFromReferencePointMm() instead."/;
 %Docstring
 Sets the annotation's frame's offset (in pixels) from the :py:func:`~QgsAnnotation.mapPosition` reference point.
 
@@ -155,7 +155,7 @@ Sets the annotation's frame's offset (in pixels) from the :py:func:`~QgsAnnotati
    Use :py:func:`~QgsAnnotation.setFrameOffsetFromReferencePointMm` instead.
 %End
 
- QPointF frameOffsetFromReferencePoint() const /Deprecated/;
+ QPointF frameOffsetFromReferencePoint() const /Deprecated="Since 3.40. Use frameOffsetFromReferencePointMm() instead."/;
 %Docstring
 Returns the annotation's frame's offset (in pixels) from the :py:func:`~QgsAnnotation.mapPosition` reference point.
 
@@ -184,7 +184,7 @@ Returns the annotation's frame's offset (in millimeters) from the :py:func:`~Qgs
 .. versionadded:: 3.4.8
 %End
 
- void setFrameSize( QSizeF size ) /Deprecated/;
+ void setFrameSize( QSizeF size ) /Deprecated="Since 3.40. Use setFrameSizeMm() instead."/;
 %Docstring
 Sets the size (in pixels) of the annotation's frame (the main area in which
 the annotation's content is drawn).
@@ -196,7 +196,7 @@ the annotation's content is drawn).
    Use :py:func:`~QgsAnnotation.setFrameSizeMm` instead.
 %End
 
- QSizeF frameSize() const /Deprecated/;
+ QSizeF frameSize() const /Deprecated="Since 3.40. Use frameSizeMm() instead."/;
 %Docstring
 Returns the size (in pixels) of the annotation's frame (the main area in which
 the annotation's content is drawn).

--- a/python/core/auto_generated/annotations/qgsannotationitem.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitem.sip.in
@@ -123,7 +123,7 @@ Implementations should include a call to :py:func:`~QgsAnnotationItem.readCommon
 .. seealso:: :py:func:`readCommonProperties`
 %End
 
- virtual Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated/;
+ virtual Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated="Since 3.40. Use applyEditV2() instead."/;
 %Docstring
 Applies an edit ``operation`` to the item.
 
@@ -189,7 +189,7 @@ Sets if the item will be rendered or not in the layer.
 .. versionadded:: 3.36
 %End
 
- virtual QList< QgsAnnotationItemNode > nodes() const /Deprecated/;
+ virtual QList< QgsAnnotationItemNode > nodes() const /Deprecated="Since 3.40. Use nodesV2() instead."/;
 %Docstring
 Returns the nodes for the item, used for editing the item.
 

--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -120,7 +120,7 @@ The optional ``feedback`` argument can be used to cancel the search early.
 .. versionadded:: 3.22
 %End
 
- Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated/;
+ Qgis::AnnotationItemEditOperationResult applyEdit( QgsAbstractAnnotationItemEditOperation *operation ) /Deprecated="Since 3.40. Use applyEditV2() instead."/;
 %Docstring
 Applies an edit ``operation`` to the layer.
 

--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -34,7 +34,7 @@ and to utilize configurations through various authentication method plugins
       CRITICAL
     };
 
- bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) /Deprecated/;
+ bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) /Deprecated="Since 3.36. Use setup() or ensureInitialized() instead."/;
 %Docstring
 init initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
 
@@ -84,7 +84,7 @@ Returns the authentication configuration storage registry.
 .. versionadded:: 3.40
 %End
 
- QSqlDatabase authDatabaseConnection() const /Deprecated/;
+ QSqlDatabase authDatabaseConnection() const /Deprecated="Since 3.40. Direct access to the DB is not allowed, use QgsAuthConfigurationStorage API instead."/;
 %Docstring
 Sets up the application instance of the authentication database connection
 
@@ -93,7 +93,7 @@ Sets up the application instance of the authentication database connection
    Direct access to the DB is not allowed, use :py:class:`QgsAuthConfigurationStorage` API instead.
 %End
 
- const QString authDatabaseConfigTable() const /Deprecated/;
+ const QString authDatabaseConfigTable() const /Deprecated="Since 3.40. Direct access to the DB is not allowed, use methodConfigTableName() instead."/;
 %Docstring
 Name of the authentication database table that stores configs
 
@@ -110,7 +110,7 @@ or an empty string if none available. The table is prefixed with schema and esca
 .. versionadded:: 3.40
 %End
 
- const QString authDatabaseServersTable() const /Deprecated/;
+ const QString authDatabaseServersTable() const /Deprecated="Since 3.40. Direct access to the DB is not allowed, use QgsAuthConfigurationStorage API instead."/;
 %Docstring
 Name of the authentication database table that stores server exceptions/configs
 
@@ -829,7 +829,7 @@ Signals emitted on password helper success,
 mainly used in the tests to exit main application loop
 %End
 
- void messageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) const /Deprecated/;
+ void messageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) const /Deprecated="Since 3.40. Use messageLog() instead."/;
 %Docstring
 Custom logging signal to relay to console output and :py:class:`QgsMessageLog`
 
@@ -857,7 +857,7 @@ Custom logging signal to relay to console output and :py:class:`QgsMessageLog`
 .. versionadded:: 3.40
 %End
 
- void passwordHelperMessageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) /Deprecated/;
+ void passwordHelperMessageOut( const QString &message, const QString &tag = QgsAuthManager::AUTH_MAN_TAG, QgsAuthManager::MessageLevel level = QgsAuthManager::INFO ) /Deprecated="Since 3.40. Use passwordHelperMessageLog() instead."/;
 %Docstring
 Custom logging signal to inform the user about master password <-> password manager interactions
 

--- a/python/core/auto_generated/browser/qgsbrowsermodel.sip.in
+++ b/python/core/auto_generated/browser/qgsbrowsermodel.sip.in
@@ -142,7 +142,7 @@ items, i.e. it does not fetch children.
 .. versionadded:: 3.6
 %End
 
- void connectItem( QgsDataItem *item ) /Deprecated/;
+ void connectItem( QgsDataItem *item ) /Deprecated="Since 3.4. This method has no effect, and is dangerous to call in earlier QGIS versions. Any usage should be removed (and will have no harmful side-effects!)."/;
 %Docstring
 
 .. deprecated:: 3.4

--- a/python/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdataitem.sip.in
@@ -154,7 +154,7 @@ Removes a child item and returns it without deleting it. Emits relevant signals 
 Returns ``True`` if this item is equal to another item (by testing item type and path).
 %End
 
- virtual QWidget *paramWidget() /Factory,Deprecated/;
+ virtual QWidget *paramWidget() /Factory,Deprecated="Since 3.10. "/;
 %Docstring
 Returns source widget from data item for :py:class:`QgsBrowserPropertiesWidget`
 
@@ -183,7 +183,7 @@ created menus is correctly handled by parenting them to the specified parent wid
 :return: list of menus
 %End
 
- virtual bool acceptDrop() /Deprecated/;
+ virtual bool acceptDrop() /Deprecated="Since 3.10. "/;
 %Docstring
 Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.
 Subclasses should override this and :py:func:`~QgsDataItem.handleDrop` to accept dropped layers.
@@ -196,7 +196,7 @@ Subclasses should override this and :py:func:`~QgsDataItem.handleDrop` to accept
 %End
 
 
- virtual bool handleDrop( const QMimeData * /*data*/, Qt::DropAction /*action*/ ) /Deprecated/;
+ virtual bool handleDrop( const QMimeData * /*data*/, Qt::DropAction /*action*/ ) /Deprecated="Since 3.10. "/;
 %Docstring
 Attempts to process the mime data dropped on this item. Subclasses must override this and :py:func:`~QgsDataItem.acceptDrop` if they
 accept dropped layers.
@@ -224,7 +224,7 @@ A draggable item has to implement :py:func:`~QgsDataItem.mimeUris` that will be 
 .. seealso:: :py:func:`mimeUris`
 %End
 
- virtual QgsMimeDataUtils::Uri mimeUri() const /Deprecated/;
+ virtual QgsMimeDataUtils::Uri mimeUri() const /Deprecated="Since 3.18. Use mimeUris() instead."/;
 %Docstring
 Returns mime URI for the data item.
 Items that return valid URI will be returned in mime data when dragging a selection from browser model.
@@ -247,7 +247,7 @@ Items that return valid URI will be returned in mime data when dragging a select
 .. versionadded:: 3.18
 %End
 
- virtual bool setCrs( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ virtual bool setCrs( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.6. This method is no longer used by QGIS and will be removed in QGIS 4.0."/;
 %Docstring
 Writes the selected crs into data source. The original data source will be modified when calling this
 method.
@@ -257,7 +257,7 @@ method.
    This method is no longer used by QGIS and will be removed in QGIS 4.0.
 %End
 
- virtual bool rename( const QString &name ) /Deprecated/;
+ virtual bool rename( const QString &name ) /Deprecated="Since 3.10. "/;
 %Docstring
 Sets a new ``name`` for the item, and returns ``True`` if the item was successfully renamed.
 
@@ -287,7 +287,7 @@ Sets the capabilities for the data item.
 .. seealso:: :py:func:`capabilities2`
 %End
 
- void setCapabilities( int capabilities ) /Deprecated/;
+ void setCapabilities( int capabilities ) /Deprecated="Since 3.40. Use setCapabilitiesV2() instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -109,6 +109,10 @@ If ``color`` is an invalid color then the default icon color will be used.
 
  virtual QWidget *paramWidget() /Factory,Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.20
+%End
     virtual bool hasDragEnabled() const;
     virtual QgsMimeDataUtils::UriList mimeUris() const;
 
@@ -214,8 +218,6 @@ Browser parameter widget implementation for directory items.
   public slots:
     void showHideColumn();
 };
-
-
 
 
 

--- a/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -107,7 +107,7 @@ If ``color`` is an invalid color then the default icon color will be used.
 .. versionadded:: 3.20
 %End
 
- virtual QWidget *paramWidget() /Factory,Deprecated/;
+ virtual QWidget *paramWidget() /Factory,Deprecated="Since 3.20. "/;
 
 %Docstring
 

--- a/python/core/auto_generated/browser/qgslayeritem.sip.in
+++ b/python/core/auto_generated/browser/qgslayeritem.sip.in
@@ -86,7 +86,7 @@ Returns the icon name of the given ``layerType``
 .. versionadded:: 3
 %End
 
- virtual bool deleteLayer() /Deprecated/;
+ virtual bool deleteLayer() /Deprecated="Since 3.10. "/;
 %Docstring
 Delete this layer item
 Use :py:class:`QgsDataItemGuiProvider`.deleteLayer instead

--- a/python/core/auto_generated/browser/qgszipitem.sip.in
+++ b/python/core/auto_generated/browser/qgszipitem.sip.in
@@ -47,7 +47,7 @@ Constructor
 
     static QStringList sProviderNames;
 
- static QString vsiPrefix( const QString &uri ) /Deprecated/;
+ static QString vsiPrefix( const QString &uri ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/core/auto_generated/callouts/qgscallout.sip.in
@@ -442,7 +442,7 @@ The ``calloutContext`` argument is used to specify additional contextual informa
 how a callout is being rendered.
 %End
 
- QgsGeometry labelAnchorGeometry( const QRectF &bodyBoundingBox, const double angle, LabelAnchorPoint anchor ) const /Deprecated/;
+ QgsGeometry labelAnchorGeometry( const QRectF &bodyBoundingBox, const double angle, LabelAnchorPoint anchor ) const /Deprecated="Since 3.20. Use calloutLabelPoint() instead."/;
 %Docstring
 Returns the anchor point geometry for a label with the given bounding box and ``anchor`` point mode.
 

--- a/python/core/auto_generated/classification/qgsclassificationmethod.sip.in
+++ b/python/core/auto_generated/classification/qgsclassificationmethod.sip.in
@@ -240,7 +240,7 @@ Defines if the trailing 0 are trimmed in the label
 Transforms a list of classes to a list of breaks
 %End
 
- QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses ) /Deprecated/;
+ QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses ) /Deprecated="Since 3.38. Use classesV2() instead."/;
 %Docstring
 This will calculate the classes for a given layer to define the classes.
 

--- a/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
@@ -55,7 +55,7 @@ Returns the container type.
 .. versionadded:: 3.32
 %End
 
- virtual void setIsGroupBox( bool isGroupBox ) /Deprecated/;
+ virtual void setIsGroupBox( bool isGroupBox ) /Deprecated="Since 3.40. Use setType() instead."/;
 %Docstring
 Determines if this container is rendered as collapsible group box or tab in a tabwidget
 
@@ -66,7 +66,7 @@ Determines if this container is rendered as collapsible group box or tab in a ta
    Use :py:func:`~QgsAttributeEditorContainer.setType` instead.
 %End
 
- virtual bool isGroupBox() const /Deprecated/;
+ virtual bool isGroupBox() const /Deprecated="Since 3.40. Use type() instead."/;
 %Docstring
 Returns if this container is going to be a group box
 

--- a/python/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -266,7 +266,7 @@ Write XML information
 Serialize on project save
 %End
 
- QgsAttributeEditorElement *attributeEditorElementFromDomElement( QDomElement &elem, QgsAttributeEditorElement *parent, const QString &layerId = QString(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Deprecated/;
+ QgsAttributeEditorElement *attributeEditorElementFromDomElement( QDomElement &elem, QgsAttributeEditorElement *parent, const QString &layerId = QString(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Deprecated="Since 3.18. Use QgsAttributeEditorElement.create instead."/;
 %Docstring
 Deserialize drag and drop designer elements.
 

--- a/python/core/auto_generated/effects/qgspainteffect.sip.in
+++ b/python/core/auto_generated/effects/qgspainteffect.sip.in
@@ -302,7 +302,7 @@ effects.
 .. seealso:: :py:func:`sourceAsImage`
 %End
 
- void fixQPictureDpi( QPainter *painter ) const /Deprecated/;
+ void fixQPictureDpi( QPainter *painter ) const /Deprecated="Since 3.40. Use QgsPainting.drawPicture() or QgsPainting.applyScaleFixForQPictureDpi() instead."/;
 %Docstring
 Applies a workaround to a QPainter to avoid an issue with incorrect scaling
 when drawing QPictures. This may need to be called by derived classes prior

--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -562,7 +562,7 @@ quotations where required.
 .. seealso:: :py:func:`quotedColumnRef`
 %End
 
- static QString quotedValue( const QVariant &value, QVariant::Type type ) /Deprecated/;
+ static QString quotedValue( const QVariant &value, QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Returns a string representation of a literal value, including appropriate
 quotations where required.
@@ -673,7 +673,7 @@ value. The value may be null.
 :return: the expression to evaluate field equality
 %End
 
- static QString createFieldEqualityExpression( const QString &fieldName, const QVariant &value, QVariant::Type fieldType ) /Deprecated/;
+ static QString createFieldEqualityExpression( const QString &fieldName, const QVariant &value, QVariant::Type fieldType ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Create an expression allowing to evaluate if a field is equal to a
 value. The value may be null.

--- a/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -46,7 +46,7 @@ The type is expected to be one of
 - QVariant.Time
 %End
 
- static QString defaultFormat( QVariant::Type type ) /Deprecated/;
+ static QString defaultFormat( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Gets the default format in function of the type.
 The type is expected to be one of
@@ -72,7 +72,7 @@ The type is expected to be one of
 .. versionadded:: 3.30
 %End
 
- static QString defaultDisplayFormat( QVariant::Type type ) /Deprecated/;
+ static QString defaultDisplayFormat( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Gets the default display format in function of the type.
 The type is expected to be one of

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -148,7 +148,7 @@ and a deep copy. Where possible, use :py:func:`~QgsGeometry.constGet` instead.
 .. seealso:: :py:func:`set`
 %End
 
- void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated="Since 3.0. "/;
+    void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated/;
 %Docstring
 Sets the underlying geometry store. Ownership of geometry is transferred.
 
@@ -165,8 +165,6 @@ Sets the underlying geometry store. Ownership of geometry is transferred.
 .. seealso:: :py:func:`get`
 
 .. seealso:: :py:func:`constGet`
-
-.. deprecated:: 3.0
 %End
 
     bool isNull() const /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -148,7 +148,7 @@ and a deep copy. Where possible, use :py:func:`~QgsGeometry.constGet` instead.
 .. seealso:: :py:func:`set`
 %End
 
-    void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated/;
+ void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated="Since 3.0. "/;
 %Docstring
 Sets the underlying geometry store. Ownership of geometry is transferred.
 
@@ -856,7 +856,7 @@ Adds a new ring to this geometry. This makes only sense for polygon and multipol
 :return: OperationResult a result code: success or reason of failure
 %End
 
- Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPointsXY,Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPointsXY,Deprecated="Since 3.38. Will be removed in QGIS 4.0. Use addPartV2 which accepts Qgis.WkbType geometry type instead of Qgis.GeometryType."/;
 %Docstring
 Adds a new part to a the geometry.
 
@@ -882,7 +882,7 @@ Adds a new part to a the geometry.
 .. versionadded:: 3.38
 %End
 
- Qgis::GeometryOperationResult addPart( const QgsPointSequence &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPoints,Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QgsPointSequence &points, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /PyName=addPoints,Deprecated="Since 3.38. Will be removed in QGIS 4.0. Use addPartV2 which accepts Qgis.WkbType geometry type instead of Qgis.GeometryType."/;
 %Docstring
 Adds a new part to a the geometry.
 
@@ -908,7 +908,7 @@ Adds a new part to a the geometry.
 .. versionadded:: 3.38
 %End
 
- Qgis::GeometryOperationResult addPart( QgsAbstractGeometry *part /Transfer/, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /Deprecated/;
+ Qgis::GeometryOperationResult addPart( QgsAbstractGeometry *part /Transfer/, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown ) /Deprecated="Since 3.38. Will be removed in QGIS 4.0. Use addPartV2 which accepts Qgis.WkbType geometry type instead of Qgis.GeometryType."/;
 %Docstring
 Adds a new part to this geometry.
 
@@ -2471,7 +2471,7 @@ empty if none of the child geometries match the desired type.
 .. versionadded:: 3.2
 %End
 
- int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers ) /Deprecated/;
+ int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers ) /Deprecated="Since 3.34. "/;
 %Docstring
 Modifies geometry to avoid intersections with the layers specified in project properties
 
@@ -2793,7 +2793,7 @@ geometry will be a polyline.
 :param polygon: source QPolygonF
 %End
 
- static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) /Deprecated/;
+ static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) /Deprecated="Since 3.40. Use QgsGeometry.fromQPolygonF() or QgsLineString.fromQPolygonF() instead."/;
 %Docstring
 Creates a :py:class:`QgsPolylineXY` from a QPolygonF.
 
@@ -2808,7 +2808,7 @@ Creates a :py:class:`QgsPolylineXY` from a QPolygonF.
    Use :py:func:`QgsGeometry.fromQPolygonF()` or :py:func:`QgsLineString.fromQPolygonF()` instead.
 %End
 
- static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon ) /Deprecated/;
+ static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon ) /Deprecated="Since 3.40. Use QgsGeometry.fromQPolygonF() or QgsLineString.fromQPolygonF() instead."/;
 %Docstring
 Creates a :py:class:`QgsPolygonXYfrom` a QPolygonF.
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -165,6 +165,8 @@ Sets the underlying geometry store. Ownership of geometry is transferred.
 .. seealso:: :py:func:`get`
 
 .. seealso:: :py:func:`constGet`
+
+.. deprecated:: 3.0
 %End
 
     bool isNull() const /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -385,7 +385,7 @@ Create a perpendicular line segment from p to segment [s1, s2]
 :return: A line (segment) from p to perpendicular point on segment [s1, s2]
 %End
 
- static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point ) /Deprecated/;
+ static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point ) /Deprecated="Since 3.20. Use transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point ) instead."/;
 %Docstring
 A Z dimension is added to ``point`` if one of the point in the list
 ``points`` is in 3D. Moreover, the Z value of ``point`` is updated
@@ -493,7 +493,7 @@ looping twice over the set of points.
 
 
 
- static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 
@@ -518,7 +518,7 @@ Returns the squared 3D distance between two points.
 .. versionadded:: 3.36
 %End
 
- static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 
@@ -544,7 +544,7 @@ Returns the 3D distance between two points.
 %End
 
 
- static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /Deprecated,HoldGIL/;
+ static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the squared distance between a point and a line.
 
@@ -553,7 +553,7 @@ Returns the squared distance between a point and a line.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static int leftOfLine( const double x, const double y, const double x1, const double y1, const double x2, const double y2 ) /Deprecated,HoldGIL/;
+ static int leftOfLine( const double x, const double y, const double x1, const double y1, const double x2, const double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns a value < 0 if the point (``x``, ``y``) is left of the line from (``x1``, ``y1``) -> (``x2``, ``y2``).
 A positive return value indicates the point is to the right of the line.
@@ -605,7 +605,7 @@ Example
 
 
 
- static double ccwAngle( double dy, double dx ) /Deprecated,HoldGIL/;
+ static double ccwAngle( double dy, double dx ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the counter clockwise angle between a line with components dx, dy and the line with dx > 0 and dy = 0
 
@@ -615,7 +615,7 @@ Returns the counter clockwise angle between a line with components dx, dy and th
 %End
 
 
- static bool circleClockwise( double angle1, double angle2, double angle3 ) /Deprecated,HoldGIL/;
+ static bool circleClockwise( double angle1, double angle2, double angle3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns ``True`` if the circle defined by three angles is ordered clockwise.
 
@@ -627,7 +627,7 @@ Euclidean angles as opposed to geographic "North up" angles.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static bool circleAngleBetween( double angle, double angle1, double angle2, bool clockwise ) /Deprecated,HoldGIL/;
+ static bool circleAngleBetween( double angle, double angle1, double angle2, bool clockwise ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns ``True`` if, in a circle, angle is between angle1 and angle2
 
@@ -636,7 +636,7 @@ Returns ``True`` if, in a circle, angle is between angle1 and angle2
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static bool angleOnCircle( double angle, double angle1, double angle2, double angle3 ) /Deprecated,HoldGIL/;
+ static bool angleOnCircle( double angle, double angle1, double angle2, double angle3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns ``True`` if an angle is between angle1 and angle3 on a circle described by
 angle1, angle2 and angle3.
@@ -646,7 +646,7 @@ angle1, angle2 and angle3.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double circleLength( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double circleLength( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Length of a circular string segment defined by pt1, pt2, pt3
 
@@ -655,7 +655,7 @@ Length of a circular string segment defined by pt1, pt2, pt3
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double sweepAngle( double centerX, double centerY, double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double sweepAngle( double centerX, double centerY, double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates angle of a circular string part defined by pt1, pt2, pt3
 
@@ -664,7 +664,7 @@ Calculates angle of a circular string part defined by pt1, pt2, pt3
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 ) /Deprecated,HoldGIL/;
+ static double interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Interpolate a value at given angle on circular arc given values (zm1, zm2, zm3) at three different angles (a1, a2, a3).
 
@@ -673,7 +673,7 @@ Interpolate a value at given angle on circular arc given values (zm1, zm2, zm3) 
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double normalizedAngle( double angle ) /Deprecated,HoldGIL/;
+ static double normalizedAngle( double angle ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Ensures that an angle is in the range 0 <= angle < 2 pi.
 
@@ -686,7 +686,7 @@ Ensures that an angle is in the range 0 <= angle < 2 pi.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double lineAngle( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double lineAngle( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the direction of line joining two points in radians, clockwise from the north direction.
 
@@ -702,7 +702,7 @@ Calculates the direction of line joining two points in radians, clockwise from t
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double angleBetweenThreePoints( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double angleBetweenThreePoints( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the angle between the lines AB and BC, where AB and BC described
 by points a, b and b, c.
@@ -721,7 +721,7 @@ by points a, b and b, c.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double linePerpendicularAngle( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
+ static double linePerpendicularAngle( double x1, double y1, double x2, double y2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the perpendicular angle to a line joining two points. Returned angle is in radians,
 clockwise from the north direction.
@@ -738,7 +738,7 @@ clockwise from the north direction.
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double averageAngle( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated,HoldGIL/;
+ static double averageAngle( double x1, double y1, double x2, double y2, double x3, double y3 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Calculates the average angle (in radians) between the two linear segments from
 (``x1``, ``y1``) to (``x2``, ``y2``) and (``x2``, ``y2``) to (``x3``, ``y3``).
@@ -748,7 +748,7 @@ Calculates the average angle (in radians) between the two linear segments from
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double averageAngle( double a1, double a2 ) /Deprecated,HoldGIL/;
+ static double averageAngle( double a1, double a2 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Averages two angles, correctly handling negative angles and ensuring the result is between 0 and 2 pi.
 
@@ -826,7 +826,7 @@ The result is a line (segment) centered in point p and perpendicular to segment 
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double skewLinesDistance( const QgsVector3D &P1, const QgsVector3D &P12, const QgsVector3D &P2, const QgsVector3D &P22 ) /Deprecated,HoldGIL/;
+ static double skewLinesDistance( const QgsVector3D &P1, const QgsVector3D &P12, const QgsVector3D &P2, const QgsVector3D &P22 ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 An algorithm to calculate the shortest distance between two skew lines.
 
@@ -911,7 +911,7 @@ Example
    Use :py:class:`QgsGeometryUtilsBase` methods instead.
 %End
 
- static double triangleArea( double aX, double aY, double bX, double bY, double cX, double cY ) /Deprecated,HoldGIL/;
+ static double triangleArea( double aX, double aY, double bX, double bY, double cX, double cY ) /Deprecated="Since 3.40. Use QgsGeometryUtilsBase methods instead.",HoldGIL/;
 %Docstring
 Returns the area of the triangle denoted by the points (``aX``, ``aY``), (``bX``, ``bY``) and
 (``cX``, ``cY``).

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -854,7 +854,7 @@ corresponds to the last point in the line.
 %End
 
 
- QgsBox3D calculateBoundingBox3d() const /Deprecated/;
+ QgsBox3D calculateBoundingBox3d() const /Deprecated="Since 3.34. use calculateBoundingBox3D() instead"/;
 %Docstring
 Calculates the minimal 3D bounding box for the geometry.
 

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -120,7 +120,7 @@ A null rectangle is also empty by definition.
 .. versionadded:: 3.34
 %End
 
- void setMinimal() /Deprecated/;
+ void setMinimal() /Deprecated="Since 3.34. Will be removed in QGIS 4.0. Use setNull()."/;
 %Docstring
 Set a rectangle so that min corner is at max
 and max corner is at min. It is NOT normalized.

--- a/python/core/auto_generated/gps/qgsgpsdetector.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsdetector.sip.in
@@ -76,7 +76,7 @@ Call :py:func:`~QgsGpsDetector.takeConnection` to take ownership of the detected
 .. versionadded:: 3.38
 %End
 
- void detected( QgsGpsConnection *connection ) /Deprecated/;
+ void detected( QgsGpsConnection *connection ) /Deprecated="Since 3.40. This signal is dangerous and extremely unsafe! It is recommended to instead set the ``useUnsafeSignals`` parameter to ``False`` in the QgsGpsDetector constructor and use the safe connectionDetected() signal instead."/;
 %Docstring
 Emitted when the GPS connection has been detected. A single connection must listen for this signal and
 immediately take ownership of the ``connection`` object.

--- a/python/core/auto_generated/gps/qgsgpsinformation.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsinformation.sip.in
@@ -113,7 +113,7 @@ Returns whether the connection information is valid
 .. versionadded:: 3.10
 %End
 
- Qgis::GpsFixStatus fixStatus() const /Deprecated/;
+ Qgis::GpsFixStatus fixStatus() const /Deprecated="Since 3.40. Use constellationFixStatus() or bestFixStatus() instead."/;
 %Docstring
 Returns the fix status
 

--- a/python/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
+++ b/python/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
@@ -92,7 +92,7 @@ Sets the maximum number of polygon label ``candidates`` per centimeter squared.
 .. versionadded:: 3.12
 %End
 
- void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon ) const /Deprecated/;
+ void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon ) const /Deprecated="Since 3.12. Use maximumPolygonCandidatesPerCmSquared() and maximumLineCandidatesPerCm() instead."/;
 %Docstring
 Gets number of candidate positions that will be generated for each label feature.
 
@@ -101,7 +101,7 @@ Gets number of candidate positions that will be generated for each label feature
    Use :py:func:`~QgsLabelingEngineSettings.maximumPolygonCandidatesPerCmSquared` and :py:func:`~QgsLabelingEngineSettings.maximumLineCandidatesPerCm` instead.
 %End
 
- void setNumCandidatePositions( int candPoint, int candLine, int candPolygon ) /Deprecated/;
+ void setNumCandidatePositions( int candPoint, int candLine, int candPolygon ) /Deprecated="Since 3.12. Use setMaximumPolygonCandidatesPerCmSquared() and setMaximumLineCandidatesPerCm() instead."/;
 %Docstring
 Sets the number of candidate positions that will be generated for each label feature.
 
@@ -110,7 +110,7 @@ Sets the number of candidate positions that will be generated for each label fea
    Use :py:func:`~QgsLabelingEngineSettings.setMaximumPolygonCandidatesPerCmSquared` and :py:func:`~QgsLabelingEngineSettings.setMaximumLineCandidatesPerCm` instead.
 %End
 
- void setSearchMethod( Search s ) /Deprecated/;
+ void setSearchMethod( Search s ) /Deprecated="Since 3.10. Chain is always used."/;
 %Docstring
 Used to set which search method to use for removal collisions between labels
 
@@ -119,7 +119,7 @@ Used to set which search method to use for removal collisions between labels
    Chain is always used.
 %End
 
- Search searchMethod() const /Deprecated/;
+ Search searchMethod() const /Deprecated="Since 3.10. Chain is always used."/;
 %Docstring
 Which search method to use for removal collisions between labels
 

--- a/python/core/auto_generated/labeling/qgslabelsearchtree.sip.in
+++ b/python/core/auto_generated/labeling/qgslabelsearchtree.sip.in
@@ -27,7 +27,7 @@ A class to query the labeling structure at a given point (small wrapper around p
     ~QgsLabelSearchTree();
 
 
- void clear() /Deprecated/;
+ void clear() /Deprecated="Since 3.40. Has no effect since QGIS 3.12."/;
 %Docstring
 Removes and deletes all the entries.
 

--- a/python/core/auto_generated/labeling/qgspallabeling.sip.in
+++ b/python/core/auto_generated/labeling/qgspallabeling.sip.in
@@ -371,7 +371,7 @@ legendString
 :return: the string to show in the legend and in the preview icon
 %End
 
- void calculateLabelSize( const QFontMetricsF *fm, const QString &text, double &labelX, double &labelY, const QgsFeature *f = 0, QgsRenderContext *context = 0, double *rotatedLabelX /Out/ = 0, double *rotatedLabelY /Out/ = 0 ) /Deprecated/;
+ void calculateLabelSize( const QFontMetricsF *fm, const QString &text, double &labelX, double &labelY, const QgsFeature *f = 0, QgsRenderContext *context = 0, double *rotatedLabelX /Out/ = 0, double *rotatedLabelY /Out/ = 0 ) /Deprecated="Since 3.40. Will be removed from public API in QGIS 4.0."/;
 %Docstring
 Calculates the space required to render the provided ``text`` in map units.
 Results will be written to ``labelX`` and ``labelY``.

--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -234,7 +234,7 @@ A scale <= 0 indicates that no scale filtering is being performed.
 .. seealso:: :py:func:`setLegendFilterByScale`
 %End
 
- void setLegendFilterByMap( const QgsMapSettings *settings ) /Deprecated/;
+ void setLegendFilterByMap( const QgsMapSettings *settings ) /Deprecated="Since 3.32. Use setFilterSettings() instead."/;
 %Docstring
 Force only display of legend nodes which are valid for given map settings.
 Setting ``None`` or invalid map settings will disable the functionality.
@@ -245,7 +245,7 @@ Ownership of map settings pointer does not change, a copy is made.
    Use :py:func:`~QgsLayerTreeModel.setFilterSettings` instead.
 %End
 
- void setLegendFilter( const QgsMapSettings *settings, bool useExtent = true, const QgsGeometry &polygon = QgsGeometry(), bool useExpressions = true ) /Deprecated/;
+ void setLegendFilter( const QgsMapSettings *settings, bool useExtent = true, const QgsGeometry &polygon = QgsGeometry(), bool useExpressions = true ) /Deprecated="Since 3.32. Use setFilterSettings() instead."/;
 %Docstring
 Filter display of legend nodes for given map settings
 

--- a/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
@@ -50,7 +50,7 @@ Create the instance that synchronizes given project with a layer tree root
     void setNewLayersVisible( bool enabled );
     bool newLayersVisible() const;
 
- void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index ) /Deprecated/;
+ void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index ) /Deprecated="Since 3.10. Use setLayerInsertionPoint( const InsertionPoint &insertionPoint ) instead."/;
 %Docstring
 Set where the new layers should be inserted - can be used to follow current selection.
 By default it is root group with zero index.

--- a/python/core/auto_generated/layout/qgslayouteffect.sip.in
+++ b/python/core/auto_generated/layout/qgslayouteffect.sip.in
@@ -29,7 +29,7 @@ onto a scene with custom composition modes.
 
     QgsLayoutEffect();
 
- void setCompositionMode( QPainter::CompositionMode mode ) /Deprecated/;
+ void setCompositionMode( QPainter::CompositionMode mode ) /Deprecated="Since 3.34. This class should not be used, it is non-stable and results in crashes. See https//bugreports.qt.io/browse/QTBUG-58501."/;
 %Docstring
 Sets the composition (blending) ``mode`` used for rendering
 the item.
@@ -41,7 +41,7 @@ the item.
    This class should not be used, it is non-stable and results in crashes. See https://bugreports.qt.io/browse/QTBUG-58501.
 %End
 
- QPainter::CompositionMode compositionMode() const /Deprecated/;
+ QPainter::CompositionMode compositionMode() const /Deprecated="Since 3.34. This class should not be used, it is non-stable and results in crashes. See https//bugreports.qt.io/browse/QTBUG-58501."/;
 %Docstring
 Returns the composition (blending) mode used for rendering
 the item.

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -441,7 +441,7 @@ Returns the behavior of this item during exporting to layered exports (e.g. SVG 
 .. versionadded:: 3.10
 %End
 
- virtual int numberExportLayers() const /Deprecated/;
+ virtual int numberExportLayers() const /Deprecated="Since 3.40. Use nextExportPart() and exportLayerBehavior() instead."/;
 %Docstring
 Returns the number of layers that this item requires for exporting during layered exports (e.g. SVG).
 Returns 0 if this item is to be placed on the same layer as the previous item,

--- a/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
@@ -109,7 +109,7 @@ to switch between font based and HTML based rendering.
 .. seealso:: :py:func:`mode`
 %End
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Returns the label's current font.
 
@@ -120,7 +120,7 @@ Returns the label's current font.
    Use :py:func:`~QgsLayoutItemLabel.textFormat` instead (since QGIS 3.24).
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Sets the label's current ``font``.
 
@@ -221,7 +221,7 @@ contents, in layout units.
 .. seealso:: :py:func:`setMarginX`
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setTextFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Sets the label font ``color``.
 
@@ -232,7 +232,7 @@ Sets the label font ``color``.
    Use :py:func:`~QgsLayoutItemLabel.setTextFormat` instead (since QGIS 3.24).
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use textFormat() instead (since QGIS 3.24)."/;
 %Docstring
 Returns the label font color.
 

--- a/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
@@ -211,7 +211,7 @@ Returns legend style.
 Sets the style of ``component`` to ``style`` for the legend.
 %End
 
- QFont styleFont( QgsLegendStyle::Style component ) const /Deprecated/;
+ QFont styleFont( QgsLegendStyle::Style component ) const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() from style() instead."/;
 %Docstring
 Returns the font settings for a legend ``component``.
 
@@ -222,7 +222,7 @@ Returns the font settings for a legend ``component``.
    Use :py:func:`QgsLegendStyle.textFormat()` from :py:func:`~QgsLayoutItemLegend.style` instead.
 %End
 
- void setStyleFont( QgsLegendStyle::Style component, const QFont &font ) /Deprecated/;
+ void setStyleFont( QgsLegendStyle::Style component, const QFont &font ) /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Sets the style ``font`` for a legend ``component``.
 
@@ -243,7 +243,7 @@ Set the ``margin`` for a legend ``component``.
 Set the ``margin`` for a particular ``side`` of a legend ``component``.
 %End
 
- double lineSpacing() const /Deprecated/;
+ double lineSpacing() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() from style() instead."/;
 %Docstring
 Returns the spacing in-between lines in layout units.
 
@@ -254,7 +254,7 @@ Returns the spacing in-between lines in layout units.
    Use :py:func:`QgsLegendStyle.textFormat()` from :py:func:`~QgsLayoutItemLegend.style` instead.
 %End
 
- void setLineSpacing( double spacing ) /Deprecated/;
+ void setLineSpacing( double spacing ) /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Sets the ``spacing`` in-between multiple lines.
 
@@ -293,7 +293,7 @@ Sets the legend column ``spacing``.
 .. seealso:: :py:func:`columnSpace`
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Returns the legend font color.
 
@@ -304,7 +304,7 @@ Returns the legend font color.
    Use :py:func:`QgsLegendStyle.setTextFormat()` from :py:func:`~QgsLayoutItemLegend.style` instead.
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use QgsLegendStyle.setTextFormat() from style() instead."/;
 %Docstring
 Sets the legend font ``color``.
 

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -362,7 +362,7 @@ The caller takes responsibility for deleting the returned object.
     virtual void paint( QPainter *painter, const QStyleOptionGraphicsItem *itemStyle, QWidget *pWidget );
 
 
- virtual int numberExportLayers() const /Deprecated/;
+ virtual int numberExportLayers() const /Deprecated="Since 3.10. "/;
 
 %Docstring
 

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -361,7 +361,13 @@ The caller takes responsibility for deleting the returned object.
 
     virtual void paint( QPainter *painter, const QStyleOptionGraphicsItem *itemStyle, QWidget *pWidget );
 
+
  virtual int numberExportLayers() const /Deprecated/;
+
+%Docstring
+
+.. deprecated:: 3.10
+%End
 
     virtual void startLayeredExport();
 

--- a/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -589,7 +589,7 @@ Returns the text format used when rendering grid annotations.
 .. versionadded:: 3.16
 %End
 
- void setAnnotationFont( const QFont &font ) /Deprecated/;
+ void setAnnotationFont( const QFont &font ) /Deprecated="Since 3.40. Use setAnnotationTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setFont().
@@ -601,7 +601,7 @@ Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setFont().
    Use :py:func:`~QgsLayoutItemMapGrid.setAnnotationTextFormat` instead.
 %End
 
- QFont annotationFont() const /Deprecated/;
+ QFont annotationFont() const /Deprecated="Since 3.40. Use annotationTextFormat() instead."/;
 %Docstring
 Returns the font used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.font().
@@ -613,7 +613,7 @@ Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.font().
    Use :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat` instead.
 %End
 
- void setAnnotationFontColor( const QColor &color ) /Deprecated/;
+ void setAnnotationFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setAnnotationTextFormat() instead."/;
 %Docstring
 Sets the font ``color`` used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setColor() and :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setOpacity().
@@ -625,7 +625,7 @@ Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.setColor() an
    Use :py:func:`~QgsLayoutItemMapGrid.setAnnotationTextFormat` instead.
 %End
 
- QColor annotationFontColor() const /Deprecated/;
+ QColor annotationFontColor() const /Deprecated="Since 3.40. Use annotationTextFormat() instead."/;
 %Docstring
 Returns the font color used for drawing grid annotations.
 Shortcut for :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.color() and :py:func:`~QgsLayoutItemMapGrid.annotationTextFormat`.opacity().

--- a/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
@@ -392,7 +392,7 @@ transferred to the scalebar.
 .. versionadded:: 3.14
 %End
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the font used for drawing text in the scalebar.
 
@@ -403,7 +403,7 @@ Returns the font used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.textFormat` instead.
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for drawing text in the scalebar.
 
@@ -414,7 +414,7 @@ Sets the ``font`` used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setTextFormat` instead.
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the color used for drawing text in the scalebar.
 
@@ -427,7 +427,7 @@ Returns the color used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.textFormat` instead.
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``color`` used for drawing text in the scalebar.
 
@@ -440,7 +440,7 @@ Sets the ``color`` used for drawing text in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setTextFormat` instead.
 %End
 
- QColor fillColor() const /Deprecated/;
+ QColor fillColor() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the color used for fills in the scalebar.
 
@@ -453,7 +453,7 @@ Returns the color used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.fillSymbol` instead.
 %End
 
- void setFillColor( const QColor &color ) /Deprecated/;
+ void setFillColor( const QColor &color ) /Deprecated="Since 3.40. Use setFillSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for fills in the scalebar.
 
@@ -466,7 +466,7 @@ Sets the ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setFillSymbol` instead.
 %End
 
- QColor fillColor2() const /Deprecated/;
+ QColor fillColor2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary color used for fills in the scalebar.
 
@@ -479,7 +479,7 @@ Returns the secondary color used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.alternateFillSymbol` instead.
 %End
 
- void setFillColor2( const QColor &color ) /Deprecated/;
+ void setFillColor2( const QColor &color ) /Deprecated="Since 3.40. Use setAlternateFillSymbol() instead."/;
 %Docstring
 Sets the secondary ``color`` used for fills in the scalebar.
 
@@ -492,7 +492,7 @@ Sets the secondary ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setAlternateFillSymbol` instead.
 %End
 
- QColor lineColor() const /Deprecated/;
+ QColor lineColor() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the color used for lines in the scalebar.
 
@@ -503,7 +503,7 @@ Returns the color used for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineColor( const QColor &color ) /Deprecated/;
+ void setLineColor( const QColor &color ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for lines in the scalebar.
 
@@ -514,7 +514,7 @@ Sets the ``color`` used for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setLineSymbol` instead.
 %End
 
- double lineWidth() const /Deprecated/;
+ double lineWidth() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the line width in millimeters for lines in the scalebar.
 
@@ -525,7 +525,7 @@ Returns the line width in millimeters for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineWidth( double width ) /Deprecated/;
+ void setLineWidth( double width ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the line ``width`` in millimeters for lines in the scalebar.
 
@@ -536,7 +536,7 @@ Sets the line ``width`` in millimeters for lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.setLineSymbol` instead.
 %End
 
- QPen pen() const /Deprecated/;
+ QPen pen() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the pen used for drawing outlines in the scalebar.
 
@@ -547,7 +547,7 @@ Returns the pen used for drawing outlines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- QBrush brush() const /Deprecated/;
+ QBrush brush() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the primary brush for the scalebar.
 
@@ -562,7 +562,7 @@ Returns the primary brush for the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.fillSymbol` instead.
 %End
 
- QBrush brush2() const /Deprecated/;
+ QBrush brush2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary brush for the scalebar. This is used for alternating color style scalebars, such
 as single and double box styles.
@@ -696,7 +696,7 @@ Sets the distance ``units`` used by the scalebar.
 .. seealso:: :py:func:`units`
 %End
 
- Qt::PenJoinStyle lineJoinStyle() const /Deprecated/;
+ Qt::PenJoinStyle lineJoinStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the join style used for drawing lines in the scalebar.
 
@@ -707,7 +707,7 @@ Returns the join style used for drawing lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated/;
+ void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the join ``style`` used when drawing the lines in the scalebar
 
@@ -718,7 +718,7 @@ Sets the join ``style`` used when drawing the lines in the scalebar
    Use :py:func:`~QgsLayoutItemScaleBar.setLineSymbol` instead.
 %End
 
- Qt::PenCapStyle lineCapStyle() const /Deprecated/;
+ Qt::PenCapStyle lineCapStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the cap style used for drawing lines in the scalebar.
 
@@ -729,7 +729,7 @@ Returns the cap style used for drawing lines in the scalebar.
    Use :py:func:`~QgsLayoutItemScaleBar.lineSymbol` instead.
 %End
 
- void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated/;
+ void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the cap ``style`` used when drawing the lines in the scalebar.
 

--- a/python/core/auto_generated/layout/qgslayoutpagecollection.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutpagecollection.sip.in
@@ -193,7 +193,7 @@ Ownership is not transferred, and a copy of the symbol is created internally.
 .. seealso:: :py:func:`pageStyleSymbol`
 %End
 
- const QgsFillSymbol *pageStyleSymbol() const /Deprecated/;
+ const QgsFillSymbol *pageStyleSymbol() const /Deprecated="Since 3.40. Use QgsLayoutItemPage.pageStyleSymbol() instead."/;
 %Docstring
 Returns the symbol to use for drawing pages in the collection.
 

--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -185,7 +185,7 @@ whether they will be rendered in layout exports.
 .. seealso:: :py:func:`setPagesVisible`
 %End
 
- void setCurrentExportLayer( int layer = -1 ) /Deprecated/;
+ void setCurrentExportLayer( int layer = -1 ) /Deprecated="Since 3.40. Items should now handle this themselves, via QgsLayoutItem.exportLayerBehavior() and returning QgsLayoutItem.nextExportPart()."/;
 %Docstring
 Sets the current item ``layer`` to draw while exporting. :py:class:`QgsLayoutItem` subclasses
 which support multi-layer SVG exports must check the :py:func:`~QgsLayoutRenderContext.currentExportLayer`
@@ -200,7 +200,7 @@ If ``layer`` is -1, all item layers will be rendered.
    Items should now handle this themselves, via :py:func:`QgsLayoutItem.exportLayerBehavior()` and returning :py:func:`QgsLayoutItem.nextExportPart()`.
 %End
 
- int currentExportLayer() const /Deprecated/;
+ int currentExportLayer() const /Deprecated="Since 3.40. Items should now handle this themselves, via QgsLayoutItem.exportLayerBehavior() and returning QgsLayoutItem.nextExportPart()."/;
 %Docstring
 Returns the current item layer to draw while exporting. :py:class:`QgsLayoutItem` subclasses
 which support multi-layer SVG exports must check this

--- a/python/core/auto_generated/layout/qgslayoutreportcontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutreportcontext.sip.in
@@ -74,7 +74,7 @@ Emits the :py:func:`~QgsLayoutReportContext.changed` signal.
 .. seealso:: :py:func:`layer`
 %End
 
- void setPredefinedScales( const QVector<qreal> &scales ) /Deprecated/;
+ void setPredefinedScales( const QVector<qreal> &scales ) /Deprecated="Since 3.40. Use QgsLayoutRenderContext.setPredefinedScales()."/;
 %Docstring
 Sets the list of predefined ``scales`` to use with the layout. This is used
 for maps which are set to the predefined atlas scaling mode.
@@ -86,7 +86,7 @@ for maps which are set to the predefined atlas scaling mode.
    Use :py:func:`QgsLayoutRenderContext.setPredefinedScales()`.
 %End
 
- QVector<qreal> predefinedScales() const /Deprecated/;
+ QVector<qreal> predefinedScales() const /Deprecated="Since 3.40. Use QgsLayoutRenderContext.predefinedScales()."/;
 %Docstring
 Returns the current list of predefined scales for use with the layout.
 

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -187,7 +187,7 @@ Returns whether empty rows are drawn in the table.
 .. seealso:: :py:func:`setShowEmptyRows`
 %End
 
- void setHeaderFont( const QFont &font ) /Deprecated/;
+ void setHeaderFont( const QFont &font ) /Deprecated="Since 3.40. Use setHeaderTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used to draw header text in the table.
 
@@ -200,7 +200,7 @@ Sets the ``font`` used to draw header text in the table.
    Use :py:func:`~QgsLayoutTable.setHeaderTextFormat` instead.
 %End
 
- QFont headerFont() const /Deprecated/;
+ QFont headerFont() const /Deprecated="Since 3.40. Use headerTextFormat() instead."/;
 %Docstring
 Returns the font used to draw header text in the table.
 
@@ -213,7 +213,7 @@ Returns the font used to draw header text in the table.
    Use :py:func:`~QgsLayoutTable.headerTextFormat` instead.
 %End
 
- void setHeaderFontColor( const QColor &color ) /Deprecated/;
+ void setHeaderFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setHeaderTextFormat() instead."/;
 %Docstring
 Sets the ``color`` used to draw header text in the table.
 
@@ -228,7 +228,7 @@ Sets the ``color`` used to draw header text in the table.
    Use :py:func:`~QgsLayoutTable.setHeaderTextFormat` instead.
 %End
 
- QColor headerFontColor() const /Deprecated/;
+ QColor headerFontColor() const /Deprecated="Since 3.40. Use headerTextFormat() instead."/;
 %Docstring
 Returns the color used to draw header text in the table.
 
@@ -295,7 +295,7 @@ if and where headers are shown in the table.
 .. seealso:: :py:func:`setHeaderMode`
 %End
 
- void setContentFont( const QFont &font ) /Deprecated/;
+ void setContentFont( const QFont &font ) /Deprecated="Since 3.40. Use setContentTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used to draw text in table body cells.
 
@@ -308,7 +308,7 @@ Sets the ``font`` used to draw text in table body cells.
    Use :py:func:`~QgsLayoutTable.setContentTextFormat` instead.
 %End
 
- QFont contentFont() const /Deprecated/;
+ QFont contentFont() const /Deprecated="Since 3.40. Use contextTextFormat() instead."/;
 %Docstring
 Returns the font used to draw text in table body cells.
 
@@ -321,7 +321,7 @@ Returns the font used to draw text in table body cells.
    Use :py:func:`~QgsLayoutTable.contextTextFormat` instead.
 %End
 
- void setContentFontColor( const QColor &color ) /Deprecated/;
+ void setContentFontColor( const QColor &color ) /Deprecated="Since 3.40. Use setContentTextFormat() instead."/;
 %Docstring
 Sets the ``color`` used to draw text in table body cells.
 
@@ -336,7 +336,7 @@ Sets the ``color`` used to draw text in table body cells.
    Use :py:func:`~QgsLayoutTable.setContentTextFormat` instead.
 %End
 
- QColor contentFontColor() const /Deprecated/;
+ QColor contentFontColor() const /Deprecated="Since 3.40. Use contextTextFormat() instead."/;
 %Docstring
 Returns the color used to draw text in table body cells.
 

--- a/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
@@ -174,7 +174,7 @@ is part of a :py:class:`QgsLayoutItemAttributeTable` and when :py:func:`~QgsLayo
 .. seealso:: :py:func:`setSortByRank`
 %End
 
- int sortByRank() const /Deprecated/;
+ int sortByRank() const /Deprecated="Since 3.14. The order is now hold in a dedicated model."/;
 %Docstring
 Returns the sort rank for the column. If the sort rank is > 0 then the column
 will be sorted in the table. The sort rank specifies the priority given to the
@@ -197,7 +197,7 @@ If sort rank is <= 0 then the column is not being sorted.
    The order is now hold in a dedicated model.
 %End
 
- void setSortByRank( int rank ) /Deprecated/;
+ void setSortByRank( int rank ) /Deprecated="Since 3.14. The order is now hold in a dedicated model."/;
 %Docstring
 Sets the sort ``rank`` for the column. If the sort rank is > 0 then the column
 will be sorted in the table. The sort rank specifies the priority given to the
@@ -219,7 +219,7 @@ If the sort ``rank`` is <= 0 then the column is not being sorted.
    The order is now hold in a dedicated model.
 %End
 
- QgsLayoutTableColumn *clone() /Deprecated,Factory/;
+ QgsLayoutTableColumn *clone() /Deprecated="Since 3.14. Use a copy instead.",Factory/;
 %Docstring
 Creates a duplicate column which is a deep copy of this column.
 

--- a/python/core/auto_generated/layout/qgslayoututils.sip.in
+++ b/python/core/auto_generated/layout/qgslayoututils.sip.in
@@ -218,7 +218,7 @@ decoded orientation.
 If the string was correctly decoded, ``ok`` will be set to ``True``.
 %End
 
- static double scaleFactorFromItemStyle( const QStyleOptionGraphicsItem *style ) /Deprecated/;
+ static double scaleFactorFromItemStyle( const QStyleOptionGraphicsItem *style ) /Deprecated="Since 3.40. Use the variant with a QPainter argument instead."/;
 %Docstring
 Extracts the scale factor from an item ``style``.
 

--- a/python/core/auto_generated/maprenderer/qgsmaprenderercache.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprenderercache.sip.in
@@ -42,7 +42,7 @@ Invalidates the cache contents, clearing all cached images.
 .. seealso:: :py:func:`clearCacheImage`
 %End
 
- bool init( const QgsRectangle &extent, double scale ) /Deprecated/;
+ bool init( const QgsRectangle &extent, double scale ) /Deprecated="Since 3.18. Will be removed in QGIS 4.0. Use the updateParameters() and clear()."/;
 %Docstring
 Initialize cache: sets extent and scale parameters and clears the cache if any
 parameters have changed since last initialization.

--- a/python/core/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -49,7 +49,7 @@ Resulting dataset is always scalar
                                          const QgsRectangle &outputExtent,
                                          double startTime,
                                          double endTime,
-                                         QgsMeshLayer *layer ) /Deprecated/;
+                                         QgsMeshLayer *layer ) /Deprecated="Since 3.12. "/;
 %Docstring
 Creates calculator with bounding box (rectangular) mask
 
@@ -68,7 +68,7 @@ Creates calculator with bounding box (rectangular) mask
                                          const QgsGeometry &outputMask,
                                          double startTime,
                                          double endTime,
-                                         QgsMeshLayer *layer ) /Deprecated/;
+                                         QgsMeshLayer *layer ) /Deprecated="Since 3.12. "/;
 %Docstring
 Creates calculator with geometry mask
 
@@ -182,7 +182,7 @@ Starts the calculation, creates new dataset group and adds it to the mesh layer
 %End
 
  static Result expression_valid( const QString &formulaString,
-        QgsMeshLayer *layer ) /Deprecated/;
+        QgsMeshLayer *layer ) /Deprecated="Since 3.12. Use expressionIsValid."/;
 %Docstring
 Returns whether formula is valid for particular mesh layer
 

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -304,7 +304,7 @@ Returns whether the faces are active for particular dataset
         const QVector<QgsMeshDataBlock> &datasetValues,
         const QVector<QgsMeshDataBlock> &datasetActive,
         const QVector<double> &times
-                                                      ) /Deprecated/;
+                                                      ) /Deprecated="Since 3.12.3. "/;
 %Docstring
 Creates a new dataset group from a data and
 persists it into a destination path

--- a/python/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
+++ b/python/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
@@ -216,7 +216,7 @@ Aborts the network request immediately.
 Emitted when when data arrives during a request.
 %End
 
- void downloadFinished() /Deprecated/;
+ void downloadFinished() /Deprecated="Since 3.40. Use the finished() signal instead."/;
 %Docstring
 Emitted once a request has finished downloading.
 

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -35,7 +35,7 @@ Constructor from map
 
     QgsHttpHeaders();
 
- QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() ) /Deprecated/;
+ QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() ) /Deprecated="Since 3.30. Use a variant map settings and the default constructor instead."/;
 %Docstring
 Constructor from :py:class:`QgsSettings` ``settings`` object and root ``key``
 
@@ -70,7 +70,7 @@ Returns the headers as a variant map
 .. versionadded:: 3.30
 %End
 
- bool updateSettings( QgsSettings &settings, const QString &key = QString() ) const /Deprecated/;
+ bool updateSettings( QgsSettings &settings, const QString &key = QString() ) const /Deprecated="Since 3.30. Directly use a variant setting instead."/;
 %Docstring
 Updates the ``settings`` by adding all the http headers in the path "key/PATH_PREFIX/"
 

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -471,7 +471,7 @@ Preprocesses request
 
   signals:
 
- void requestAboutToBeCreated( QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *device ) /Deprecated/;
+ void requestAboutToBeCreated( QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *device ) /Deprecated="Since 3.40. Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -617,7 +617,7 @@ See :py:class:`QgsSslErrorHandler` for details on how to handle SSL errors and p
 
 
 
- void requestCreated( QNetworkReply *reply ) /Deprecated/;
+ void requestCreated( QNetworkReply *reply ) /Deprecated="Since 3.40. Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/core/auto_generated/painting/qgsmaskpaintdevice.sip.in
+++ b/python/core/auto_generated/painting/qgsmaskpaintdevice.sip.in
@@ -27,7 +27,7 @@ used later as clip path
 %End
   public:
 
- QgsMaskPaintDevice( bool usePathStroker = false ) /Deprecated/;
+ QgsMaskPaintDevice( bool usePathStroker = false ) /Deprecated="Since 3.38. Use QgsGeometryPaintDevice instead."/;
 %Docstring
 !
 Constructor
@@ -45,7 +45,7 @@ pen configuration
     virtual int metric( PaintDeviceMetric metric ) const;
 
 
- QPainterPath maskPainterPath() const /Deprecated/;
+ QPainterPath maskPainterPath() const /Deprecated="Since 3.40. Use QgsGeometryPaintDevice instead."/;
 %Docstring
 Returns the mask painter path painted on this paint device
 

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -126,7 +126,7 @@ about what the algorithm does and the parameters and outputs associated with it.
 .. seealso:: :py:func:`helpUrl`
 %End
 
- virtual QString helpString() const /HoldGIL,Deprecated/;
+ virtual QString helpString() const /HoldGIL,Deprecated="Since 3.40. Unused, will be removed in QGIS 4.0."/;
 %Docstring
 Returns a localised help string for the algorithm. Algorithm subclasses should implement either
 :py:func:`~QgsProcessingAlgorithm.helpString` or :py:func:`~QgsProcessingAlgorithm.helpUrl`.
@@ -935,7 +935,7 @@ Evaluates the parameter with matching ``name`` to a list of files (for :py:class
 Evaluates the parameter with matching ``name`` to a range of values.
 %End
 
- QStringList parameterAsFields( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const /Deprecated/;
+ QStringList parameterAsFields( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const /Deprecated="Since 3.40. Use parameterAsStrings() instead."/;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of fields.
 

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -1462,7 +1462,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a range of
 .. versionadded:: 3.4
 %End
 
- static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context ) /Deprecated/;
+ static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context ) /Deprecated="Since 3.40. Use parameterAsStrings() instead."/;
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of fields.
 
@@ -1471,7 +1471,7 @@ Evaluates the parameter with matching ``definition`` to a list of fields.
    Use :py:func:`~QgsProcessingParameters.parameterAsStrings` instead.
 %End
 
- static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context ) /Deprecated/;
+ static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context ) /Deprecated="Since 3.40. Use parameterAsStrings() instead."/;
 %Docstring
 Evaluates the parameter with matching ``definition`` and ``value`` to a list of fields.
 

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -397,7 +397,7 @@ using the specified ``context``.
 .. versionadded:: 3.8
 %End
 
- static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) /Deprecated/;
+ static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) /Deprecated="Since 3.40. Use version with QgsProcessingContext argument instead."/;
 %Docstring
 Combines the extent of several map ``layers``. If specified, the target ``crs``
 will be used to transform the layer's extent to the desired output reference system.

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -212,7 +212,7 @@ If no prefix is specified, WKT definition is assumed.
 %End
 
 
- explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId ) /Deprecated/;
+ explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId ) /Deprecated="Since 3.10. We encourage you to use EPSG codes or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format."/;
 %Docstring
 Constructor
 
@@ -276,7 +276,7 @@ Creates a CRS from a given EPSG ID.
 :return: matching CRS, or an invalid CRS if string could not be matched
 %End
 
- static QgsCoordinateReferenceSystem fromProj4( const QString &proj4 ) /Deprecated/;
+ static QgsCoordinateReferenceSystem fromProj4( const QString &proj4 ) /Deprecated="Since 3.10. Use fromProj() instead."/;
 %Docstring
 Creates a CRS from a proj style formatted string.
 
@@ -360,7 +360,7 @@ or the compound CRS could not be created for the combination.
 
 
 
- bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated/;
+ bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated="Since 3.10. We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format."/;
 %Docstring
 Sets this CRS by lookup of the given ID in the CRS database.
 
@@ -391,7 +391,7 @@ and refer to QGIS internal CRS IDs.
 %End
 
 
- bool createFromSrid( long srid ) /Deprecated/;
+ bool createFromSrid( long srid ) /Deprecated="Since 3.10. Use alternative methods for SRS construction instead -- this method was specifically created for use by the postgres provider alone, and using it elsewhere will lead to subtle bugs."/;
 %Docstring
 Sets this CRS by lookup of the given PostGIS SRID in the CRS database.
 
@@ -451,7 +451,7 @@ user's local CRS database from home directory is used.
    using auth:id codes or WKT strings
 %End
 
- bool createFromProj4( const QString &projString ) /Deprecated/;
+ bool createFromProj4( const QString &projString ) /Deprecated="Since 3.10. Use createFromProj() instead."/;
 %Docstring
 Sets this CRS by passing it a PROJ style formatted string.
 
@@ -578,7 +578,7 @@ For more details on supported formats see OGRSpatialReference.SetFromUserInput()
    Call :py:func:`~QgsCoordinateReferenceSystem.invalidateCache` to clear the cache.
 %End
 
- static void setupESRIWktFix() /Deprecated/;
+ static void setupESRIWktFix() /Deprecated="Since 3.10. Not used on builds based on Proj version 6 or later."/;
 %Docstring
 Make sure that ESRI WKT import is done properly.
 This is required for proper shapefile CRS import when using gdal>= 1.9.
@@ -623,7 +623,7 @@ if that involves resorting to a hard coded default of geocs:wgs84.
 %End
 
 
- long findMatchingProj() /Deprecated/;
+ long findMatchingProj() /Deprecated="Since 3.10. Not used in Proj >= 6 based builds."/;
 %Docstring
 Walks the CRS databases (both system and user database) trying to match
 stored PROJ string to a database entry in order to fill in further
@@ -766,7 +766,7 @@ This is only used on builds based on Proj >= 6.
 .. seealso:: :py:func:`toProj`
 %End
 
- QString toProj4() const /Deprecated/;
+ QString toProj4() const /Deprecated="Since 3.10. Use toProj() instead."/;
 %Docstring
 Returns a Proj string representation of this CRS.
 
@@ -1185,7 +1185,7 @@ Returns auth id of related geographic CRS
 %End
 
 
- static QStringList recentProjections() /Deprecated/;
+ static QStringList recentProjections() /Deprecated="Since 3.10. Use QgsApplication.coordinateReferenceSystemRegistry()->recentCrs() instead."/;
 %Docstring
 Returns a list of recently used projections
 
@@ -1196,7 +1196,7 @@ Returns a list of recently used projections
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.recentCrs` instead.
 %End
 
- static QList< QgsCoordinateReferenceSystem > recentCoordinateReferenceSystems() /Deprecated/;
+ static QList< QgsCoordinateReferenceSystem > recentCoordinateReferenceSystems() /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->recentCrs() instead."/;
 %Docstring
 Returns a list of recently used CRS.
 
@@ -1205,7 +1205,7 @@ Returns a list of recently used CRS.
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.recentCrs` instead.
 %End
 
- static void pushRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ static void pushRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->pushRecent() instead."/;
 %Docstring
 Pushes a recently used CRS to the top of the recent CRS list.
 
@@ -1214,7 +1214,7 @@ Pushes a recently used CRS to the top of the recent CRS list.
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.pushRecent` instead.
 %End
 
- static void removeRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ static void removeRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->removeRecent() instead."/;
 %Docstring
 Removes a CRS from the list of recently used CRS.
 
@@ -1223,7 +1223,7 @@ Removes a CRS from the list of recently used CRS.
    Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.removeRecent` instead.
 %End
 
- static void clearRecentCoordinateReferenceSystems() /Deprecated/;
+ static void clearRecentCoordinateReferenceSystems() /Deprecated="Since 3.36. Use QgsApplication.coordinateReferenceSystemRegistry()->clearRecent() instead."/;
 %Docstring
 Cleans the list of recently used CRS.
 

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -119,7 +119,7 @@ which dictate the behavior of the transformation.
  explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
         const QgsCoordinateReferenceSystem &destination,
         int sourceDatumTransformId,
-        int destinationDatumTransformId ) /Deprecated/;
+        int destinationDatumTransformId ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0. Use the constructor with a QgsCoordinateTransformContext argument instead."/;
 %Docstring
 Constructs a QgsCoordinateTransform to transform from the ``source``
 to ``destination`` coordinate reference system, with the specified
@@ -527,7 +527,7 @@ Returns ``True`` if a fallback operation occurred for the most recent transform.
 .. versionadded:: 3.12
 %End
 
- int sourceDatumTransformId() const /Deprecated/;
+ int sourceDatumTransformId() const /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Returns the ID of the datum transform to use when projecting from the source
 CRS.
@@ -546,7 +546,7 @@ but can be manually overwritten by a call to :py:func:`~QgsCoordinateTransform.s
    Unused on builds based on Proj 6.0 or later.
 %End
 
- void setSourceDatumTransformId( int datumId ) /Deprecated/;
+ void setSourceDatumTransformId( int datumId ) /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Sets the ``datumId`` ID of the datum transform to use when projecting from the source
 CRS.
@@ -565,7 +565,7 @@ Calling this method will overwrite any automatically calculated datum transform.
    Unused on builds based on Proj 6.0 or later.
 %End
 
- int destinationDatumTransformId() const /Deprecated/;
+ int destinationDatumTransformId() const /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Returns the ID of the datum transform to use when projecting to the destination
 CRS.
@@ -584,7 +584,7 @@ but can be manually overwritten by a call to :py:func:`~QgsCoordinateTransform.s
    Unused on builds based on Proj 6.0 or later.
 %End
 
- void setDestinationDatumTransformId( int datumId ) /Deprecated/;
+ void setDestinationDatumTransformId( int datumId ) /Deprecated="Since 3.40. Unused on builds based on Proj 6.0 or later."/;
 %Docstring
 Sets the ``datumId`` ID of the datum transform to use when projecting to the destination
 CRS.

--- a/python/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransformcontext.sip.in
@@ -56,7 +56,7 @@ Constructor for QgsCoordinateTransformContext.
 Clears all stored transform information from the context.
 %End
 
- QMap< QPair< QString, QString>, QgsDatumTransform::TransformPair > sourceDestinationDatumTransforms() const /Deprecated/;
+ QMap< QPair< QString, QString>, QgsDatumTransform::TransformPair > sourceDestinationDatumTransforms() const /Deprecated="Since 3.40. Has no effect on builds based on Proj 6.0 or later, use coordinateOperations() instead."/;
 %Docstring
 Returns the stored mapping for source to destination CRS pairs to associated datum transforms to use.
 The map keys will be :py:class:`QgsCoordinateReferenceSystems`.authid()s.
@@ -98,7 +98,7 @@ Returns the stored mapping for source to destination CRS pairs to associated coo
 .. versionadded:: 3.8
 %End
 
- bool addSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, int sourceTransformId, int destinationTransformId ) /Deprecated/;
+ bool addSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, int sourceTransformId, int destinationTransformId ) /Deprecated="Since 3.40. Has no effect on builds based on Proj 6.0 or later, use addCoordinateOperation() instead."/;
 %Docstring
 Adds a new ``sourceTransform`` and ``destinationTransform`` to use when projecting coordinates
 from the specified ``sourceCrs`` to the specified ``destinationCrs``.
@@ -155,7 +155,7 @@ Returns ``True`` if the new coordinate operation was added successfully.
 .. versionadded:: 3.8
 %End
 
- void removeSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs ) /Deprecated/;
+ void removeSourceDestinationDatumTransform( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs ) /Deprecated="Since 3.40. Use removeCoordinateOperation() instead."/;
 %Docstring
 Removes the source to destination datum transform pair for the specified ``sourceCrs`` and
 ``destinationCrs``.
@@ -185,7 +185,7 @@ when transforming from the specified ``source`` CRS to ``destination`` CRS.
    source and destination are reversible.
 %End
 
- QgsDatumTransform::TransformPair calculateDatumTransforms( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const /Deprecated/;
+ QgsDatumTransform::TransformPair calculateDatumTransforms( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const /Deprecated="Since 3.40. Has no effect on builds based on Proj 6.0 or later. Use calculateCoordinateOperation() instead."/;
 %Docstring
 Returns the pair of source and destination datum transforms to use
 for a transform from the specified ``source`` CRS to ``destination`` CRS.

--- a/python/core/auto_generated/proj/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/proj/qgsdatumtransform.sip.in
@@ -141,7 +141,7 @@ in the results. This requires Proj >= 6.2.
 .. versionadded:: 3.8
 %End
 
- static QList< QgsDatumTransform::TransformPair > datumTransformations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) /Deprecated/;
+ static QList< QgsDatumTransform::TransformPair > datumTransformations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns a list of datum transformations which are available for the given ``source`` and ``destination`` CRS.
 
@@ -154,7 +154,7 @@ Returns a list of datum transformations which are available for the given ``sour
    Not used for builds based on Proj >= 6.0.
 %End
 
- static QString datumTransformToProj( int datumTransformId ) /Deprecated/;
+ static QString datumTransformToProj( int datumTransformId ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns a proj string representing the specified ``datumTransformId`` datum transform ID.
 
@@ -169,7 +169,7 @@ Returns a proj string representing the specified ``datumTransformId`` datum tran
    Not used for builds based on Proj >= 6.0.
 %End
 
- static int projStringToDatumTransformId( const QString &string ) /Deprecated/;
+ static int projStringToDatumTransformId( const QString &string ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns the datum transform ID corresponding to a specified proj ``string``.
 Returns -1 if matching datum ID was not found.
@@ -181,7 +181,7 @@ Returns -1 if matching datum ID was not found.
    Not used for builds based on Proj >= 6.0.
 %End
 
- static QgsDatumTransform::TransformInfo datumTransformInfo( int datumTransformId ) /Deprecated/;
+ static QgsDatumTransform::TransformInfo datumTransformInfo( int datumTransformId ) /Deprecated="Since 3.40. Not used for builds based on Proj >= 6.0."/;
 %Docstring
 Returns detailed information about the specified ``datumTransformId``.
 If ``datumTransformId`` was not a valid transform ID, a TransformInfo with TransformInfo.datumTransformId of

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -228,7 +228,7 @@ QGIS) project file to be overwritten when the project is next saved.
 .. versionadded:: 3.14
 %End
 
- QFileInfo fileInfo() const /Deprecated/;
+ QFileInfo fileInfo() const /Deprecated="Since 3.2. Use absoluteFilePath(), baseName() or lastModifiedTime() instead."/;
 %Docstring
 Returns QFileInfo object for the project's associated file.
 
@@ -961,7 +961,7 @@ Gets the list of layers which currently should not be taken into account on map 
    Use :py:func:`QgsMapLayer.setFlags()` instead.
 %End
 
- bool autoTransaction() const /Deprecated/;
+ bool autoTransaction() const /Deprecated="Since 3.26. Use transactionMode() instead."/;
 %Docstring
 Transactional editing means that on supported datasources (postgres databases) the edit state of
 all tables that originate from the same database are synchronized and executed in a server side
@@ -972,7 +972,7 @@ transaction.
    Use :py:func:`~QgsProject.transactionMode` instead.
 %End
 
- void setAutoTransaction( bool autoTransaction ) /Deprecated/;
+ void setAutoTransaction( bool autoTransaction ) /Deprecated="Since 3.26. Use setTransactionMode() instead."/;
 %Docstring
 Transactional editing means that on supported datasources (postgres databases) the edit state of
 all tables that originate from the same database are synchronized and executed in a server side
@@ -1028,7 +1028,7 @@ Returns the edit buffer group
 .. versionadded:: 3.26
 %End
 
- bool evaluateDefaultValues() const /Deprecated/;
+ bool evaluateDefaultValues() const /Deprecated="Since 3.40. Test whether the flags() method returns the Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide flag instead."/;
 %Docstring
 Should default values be evaluated on provider side when requested and not when committed.
 
@@ -1037,7 +1037,7 @@ Should default values be evaluated on provider side when requested and not when 
    Test whether the :py:func:`~QgsProject.flags` method returns the :py:class:`Qgis`.ProjectFlag.EvaluateDefaultValuesOnProviderSide flag instead.
 %End
 
- void setEvaluateDefaultValues( bool evaluateDefaultValues ) /Deprecated/;
+ void setEvaluateDefaultValues( bool evaluateDefaultValues ) /Deprecated="Since 3.40. Use setFlag( Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide ) instead."/;
 %Docstring
 Defines if default values should be evaluated on provider side when requested and not when committed.
 
@@ -1375,7 +1375,7 @@ Returns the default CRS for new layers based on the settings and
 the current project CRS
 %End
 
- void setTrustLayerMetadata( bool trust ) /Deprecated/;
+ void setTrustLayerMetadata( bool trust ) /Deprecated="Since 3.40. Use setFlag( Qgis.ProjectFlag.TrustStoredLayerStatistics ) instead."/;
 %Docstring
 Sets the trust option allowing to indicate if the extent has to be
 read from the XML document when data source has no metadata or if the
@@ -1390,7 +1390,7 @@ materialized views with Postgres provider.
    Use setFlag( :py:class:`Qgis`.ProjectFlag.TrustStoredLayerStatistics ) instead.
 %End
 
- bool trustLayerMetadata() const /Deprecated/;
+ bool trustLayerMetadata() const /Deprecated="Since 3.40. Test whether the flags() method returns the Qgis.ProjectFlag.TrustStoredLayerStatistics flag instead."/;
 %Docstring
 Returns ``True`` if the trust option is activated, ``False`` otherwise. This
 option allows indicateing if the extent has to be read from the XML
@@ -1565,7 +1565,7 @@ Returns the color used to highlight selected features
 .. versionadded:: 3.10
 %End
 
- void setMapScales( const QVector<double> &scales ) /Deprecated/;
+ void setMapScales( const QVector<double> &scales ) /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Sets the list of custom project map ``scales``.
 
@@ -1581,7 +1581,7 @@ The ``scales`` list consists of a list of scale denominator values, e.g.
    Use :py:func:`~QgsProject.viewSettings` instead.
 %End
 
- QVector<double> mapScales() const /Deprecated/;
+ QVector<double> mapScales() const /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Returns the list of custom project map scales.
 
@@ -1597,7 +1597,7 @@ The scales list consists of a list of scale denominator values, e.g.
    Use :py:func:`~QgsProject.viewSettings` instead.
 %End
 
- void setUseProjectScales( bool enabled ) /Deprecated/;
+ void setUseProjectScales( bool enabled ) /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Sets whether project :py:func:`~QgsProject.mapScales` are ``enabled``.
 
@@ -1610,7 +1610,7 @@ Sets whether project :py:func:`~QgsProject.mapScales` are ``enabled``.
    Use :py:func:`~QgsProject.viewSettings` instead.
 %End
 
- bool useProjectScales() const /Deprecated/;
+ bool useProjectScales() const /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Returns ``True`` if project :py:func:`~QgsProject.mapScales` are enabled.
 
@@ -1729,7 +1729,7 @@ additional information to the layer.
 Emitted when the project file has been written and closed.
 %End
 
- void oldProjectVersionWarning( const QString &warning ) /Deprecated/;
+ void oldProjectVersionWarning( const QString &warning ) /Deprecated="Since 3.40. Use readVersionMismatchOccurred() instead."/;
 %Docstring
 Emitted when an old project file is read.
 
@@ -2120,7 +2120,7 @@ Emitted when setDirty(true) is called.
 .. versionadded:: 3.20
 %End
 
- void mapScalesChanged() /Deprecated/;
+ void mapScalesChanged() /Deprecated="Since 3.40. Use viewSettings() instead."/;
 %Docstring
 Emitted when the list of custom project map scales changes.
 

--- a/python/core/auto_generated/project/qgsprojectstorage.sip.in
+++ b/python/core/auto_generated/project/qgsprojectstorage.sip.in
@@ -110,7 +110,7 @@ The default implementation returns an empty string.
 .. versionadded:: 3.8.1
 %End
 
- virtual QString visibleName() /Deprecated/;
+ virtual QString visibleName() /Deprecated="Since 3.10. Use QgsProjectStorageGuiProvider for GUI-related project storage functionality."/;
 %Docstring
 Returns human-readable name of the storage. Used as the menu item text in QGIS. Empty name
 indicates that the storage does not implement GUI support (:py:func:`~QgsProjectStorage.showLoadGui` and :py:func:`~QgsProjectStorage.showSaveGui`).
@@ -121,7 +121,7 @@ The name may be translatable and ideally unique as well.
    Use :py:class:`QgsProjectStorageGuiProvider` for GUI-related project storage functionality.
 %End
 
- virtual QString showLoadGui() /Deprecated/;
+ virtual QString showLoadGui() /Deprecated="Since 3.10. Use QgsProjectStorageGuiProvider for GUI-related project storage functionality."/;
 %Docstring
 Opens GUI to allow user to select a project to be loaded (GUI specific to this storage type).
 Returns project URI if user has picked a project or empty string if the GUI was canceled.
@@ -131,7 +131,7 @@ Returns project URI if user has picked a project or empty string if the GUI was 
    Use :py:class:`QgsProjectStorageGuiProvider` for GUI-related project storage functionality.
 %End
 
- virtual QString showSaveGui() /Deprecated/;
+ virtual QString showSaveGui() /Deprecated="Since 3.10. Use QgsProjectStorageGuiProvider for GUI-related project storage functionality."/;
 %Docstring
 Opens GUI to allow user to select where a project should be saved (GUI specific to this storage type).
 Returns project URI if user has picked a destination or empty string if the GUI was canceled.

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
@@ -45,7 +45,7 @@ If ``user`` is blank then the user associated with the current logon details wil
 .. versionadded:: 3.24
 %End
 
- static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated/;
+ static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON user info for the specified user name. Only to avoid API break.
 
@@ -87,7 +87,7 @@ If ``user`` is blank then the user associated with the current logon details wil
 .. versionadded:: 3.24
 %End
 
- static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated/;
+ static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON definitions for all groups which the specified user name is a member of. Only to avoid API break.
 
@@ -128,7 +128,7 @@ Retrieves JSON definitions for all items which belong the the specified ``groupI
 .. versionadded:: 3.24
 %End
 
- static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated/;
+ static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified ``groupId``. Only to avoid API break.
 
@@ -173,7 +173,7 @@ Retrieves JSON definitions for all items which belong the the specified ``groupI
 
  static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
-        QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated/;
+        QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() ) /Deprecated="Since 3.24. Use the version with QgsHttpHeaders instead."/;
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified ``groupId``. Only to avoid API break.
 

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -49,7 +49,7 @@ Constructs default metadata without any capabilities
  QgsMeshDriverMetadata( const QString &name,
         const QString &description,
         const MeshDriverCapabilities &capabilities,
-        const QString &writeDatasetOnFileSuffix ) /Deprecated/;
+        const QString &writeDatasetOnFileSuffix ) /Deprecated="Since 3.22. "/;
 %Docstring
 Constructs driver metadata with selected capabilities
 
@@ -250,7 +250,7 @@ Returns a list of the map layer types supported by the provider.
     }
 %End
 
- QString library() const /Deprecated/;
+ QString library() const /Deprecated="Since 3.10. Providers may not need to be loaded from a library (empty string returned)."/;
 %Docstring
 This returns the library file name
 

--- a/python/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -51,7 +51,7 @@ Means of accessing canonical single instance
 
     ~QgsProviderRegistry();
 
- QString library( const QString &providerKey ) const /Deprecated/;
+ QString library( const QString &providerKey ) const /Deprecated="Since 3.10. Providers may not need to be loaded from a library (empty string returned)."/;
 %Docstring
 Returns path for the library of the provider.
 
@@ -96,7 +96,7 @@ Creates a new instance of a provider.
 .. seealso:: :py:func:`createRasterDataProvider`
 %End
 
- Qgis::DataItemProviderCapabilities providerCapabilities( const QString &providerKey ) const /Deprecated/;
+ Qgis::DataItemProviderCapabilities providerCapabilities( const QString &providerKey ) const /Deprecated="Since 3.10. Use instead capabilities() method of individual data item provider."/;
 %Docstring
 Returns the provider capabilities
 
@@ -205,7 +205,7 @@ If a provider does not work with paths, unmodified URI will be returned.
 .. versionadded:: 3.30
 %End
 
- QWidget *createSelectionWidget( const QString &providerKey, QWidget *parent = 0, Qt::WindowFlags fl = Qt::WindowFlags(), QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Standalone ) /Deprecated/;
+ QWidget *createSelectionWidget( const QString &providerKey, QWidget *parent = 0, Qt::WindowFlags fl = Qt::WindowFlags(), QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Standalone ) /Deprecated="Since 3.10. Use QgsGui.sourceSelectProviderRegistry()->createDataSourceWidget() instead."/;
 %Docstring
 Returns a new widget for selecting layers from a provider.
 Either the ``parent`` widget must be set or the caller becomes
@@ -336,7 +336,7 @@ Returns new instance of transaction. Ownership is transferred to the caller
 .. versionadded:: 3.10
 %End
 
- QFunctionPointer function( const QString &providerKey, const QString &functionName ) const /Deprecated/;
+ QFunctionPointer function( const QString &providerKey, const QString &functionName ) const /Deprecated="Since 3.10. Any provider functionality should be accessed through QgsProviderMetadata."/;
 %Docstring
 Gets pointer to provider function
 
@@ -351,7 +351,7 @@ Gets pointer to provider function
    Any provider functionality should be accessed through :py:class:`QgsProviderMetadata`.
 %End
 
- QLibrary *createProviderLibrary( const QString &providerKey ) const /Factory,Deprecated/;
+ QLibrary *createProviderLibrary( const QString &providerKey ) const /Factory,Deprecated="Since 3.10. Providers may not need to be loaded from a library."/;
 %Docstring
 Returns a new QLibrary for the specified ``providerKey``. Ownership of the returned
 object is transferred to the caller and the caller is responsible for deleting it.
@@ -749,7 +749,7 @@ Returns a string containing the available directory drivers
 Returns a string containing the available protocol drivers
 %End
 
- void registerGuis( QWidget *widget ) /Deprecated/;
+ void registerGuis( QWidget *widget ) /Deprecated="Since 3.10. Does nothing - use QgsGui.providerGuiRegistry()."/;
 %Docstring
 
 .. deprecated:: 3.10

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -265,7 +265,7 @@ Returns the path to the settings directory in user's home dir
 Returns the path to the user qgis.db file.
 %End
 
- static QString qgisAuthDatabaseFilePath() /Deprecated/;
+ static QString qgisAuthDatabaseFilePath() /Deprecated="Since 3.30. Use qgisAuthDatabaseUri() instead."/;
 %Docstring
 Returns the path to the user authentication database file: qgis-auth.db.
 
@@ -698,7 +698,7 @@ Returns the application's task manager, used for managing application
 wide background task handling.
 %End
 
- static QgsSettingsRegistryCore *settingsRegistryCore() /KeepReference,Deprecated/;
+ static QgsSettingsRegistryCore *settingsRegistryCore() /KeepReference,Deprecated="Since 3.30. Use QgsSettings.treeRoot() instead."/;
 %Docstring
 Returns the application's settings registry, used for managing application settings.
 

--- a/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
+++ b/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsDatabaseFilterProxyModel : QSortFilterProxyModel /Deprecated/
+class QgsDatabaseFilterProxyModel : QSortFilterProxyModel /Deprecated="Since 3.24. "/
 {
 %Docstring(signature="appended")
 A class that implements a custom filter and can be used

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -864,7 +864,7 @@ Check if a feature is accepted by this requests filter
 :return: ``True``, if the filter accepts the feature
 %End
 
- int connectionTimeout() const /Deprecated/;
+ int connectionTimeout() const /Deprecated="Since 3.40. Use timeout() instead."/;
 %Docstring
 Returns the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.
@@ -878,7 +878,7 @@ at this moment. A negative value (which is set by default) will wait forever.
    Use :py:func:`~QgsFeatureRequest.timeout` instead.
 %End
 
- QgsFeatureRequest &setConnectionTimeout( int connectionTimeout ) /Deprecated/;
+ QgsFeatureRequest &setConnectionTimeout( int connectionTimeout ) /Deprecated="Since 3.40. Use setTimeout() instead."/;
 %Docstring
 Sets the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -65,7 +65,7 @@ Constructor. Constructs a new QgsField object.
                                 int len = 0,
                                 int prec = 0,
                                 const QString &comment = QString(),
-                                QVariant::Type subType = QVariant::Invalid ) /HoldGIL,Deprecated/;
+                                QVariant::Type subType = QVariant::Invalid ) /HoldGIL,Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor. Constructs a new QgsField object.
 
@@ -262,7 +262,7 @@ Set the field name.
 Set variant ``type``.
 %End
 
- void setType( QVariant::Type type ) /HoldGIL,Deprecated/;
+ void setType( QVariant::Type type ) /HoldGIL,Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Set variant ``type``.
 
@@ -278,7 +278,7 @@ When all the elements don't need to have the same type, set this to
 QVariant.Invalid.
 %End
 
- void setSubType( QVariant::Type subType ) /HoldGIL,Deprecated/;
+ void setSubType( QVariant::Type subType ) /HoldGIL,Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 If the field is a collection, set its element's type.
 When all the elements don't need to have the same type, set this to

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -377,7 +377,7 @@ Since QGIS 3.30, the optional ``typeString`` argument can be used to specify fie
 .. versionadded:: 3.16
 %End
 
- static QIcon iconForFieldType( QVariant::Type type, QVariant::Type subType, const QString &typeString = QString() ) /Deprecated/;
+ static QIcon iconForFieldType( QVariant::Type type, QVariant::Type subType, const QString &typeString = QString() ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Returns an icon corresponding to a field ``type``
 

--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -366,7 +366,7 @@ Parse a simple array (depth=1)
              the conversion is not possible.
 %End
 
- static QVariantList parseArray( const QString &json, QVariant::Type type ) /Deprecated/;
+ static QVariantList parseArray( const QString &json, QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Parse a simple array (depth=1)
 

--- a/python/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/core/auto_generated/qgslegendrenderer.sip.in
@@ -76,7 +76,7 @@ If the returned size is null, the legend will be drawn with the minimum possible
 .. seealso:: :py:func:`setLegendSize`
 %End
 
- void drawLegend( QPainter *painter ) /Deprecated/;
+ void drawLegend( QPainter *painter ) /Deprecated="Since 3.40. Use the variant which accepts a QgsRenderContext instead."/;
 %Docstring
 Draws the legend with given ``painter``. The legend will occupy the area reported in :py:func:`~QgsLegendRenderer.legendSize`.
 The ``painter`` should be scaled beforehand so that units correspond to millimeters.

--- a/python/core/auto_generated/qgslegendsettings.sip.in
+++ b/python/core/auto_generated/qgslegendsettings.sip.in
@@ -171,7 +171,7 @@ If ``False``, then then columns will be individually resized to their minimum po
 .. seealso:: :py:func:`equalColumnWidth`
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Returns the font color used for legend items.
 
@@ -182,7 +182,7 @@ Returns the font color used for legend items.
    Use :py:func:`QgsLegendStyle.textFormat()` instead.
 %End
 
- void setFontColor( const QColor &c ) /Deprecated/;
+ void setFontColor( const QColor &c ) /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Sets the font color used for legend items.
 
@@ -193,7 +193,7 @@ Sets the font color used for legend items.
    Use :py:func:`QgsLegendStyle.textFormat()` instead.
 %End
 
- QColor layerFontColor() const /Deprecated/;
+ QColor layerFontColor() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Returns layer font color, defaults to :py:func:`~QgsLegendSettings.fontColor`
 
@@ -206,7 +206,7 @@ Returns layer font color, defaults to :py:func:`~QgsLegendSettings.fontColor`
    Use :py:func:`QgsLegendStyle.textFormat()` instead.
 %End
 
- void setLayerFontColor( const QColor &fontColor ) /Deprecated/;
+ void setLayerFontColor( const QColor &fontColor ) /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() instead."/;
 %Docstring
 Sets layer font color to ``fontColor``
 Overrides :py:func:`~QgsLegendSettings.fontColor`
@@ -404,7 +404,7 @@ Returns whether to request legend graphics synchronously.
 .. versionadded:: 3.34
 %End
 
- double lineSpacing() const /Deprecated/;
+ double lineSpacing() const /Deprecated="Since 3.40. Use QgsLegendStyle.textFormat() from style() instead."/;
 %Docstring
 Returns the line spacing to use between lines of legend text.
 
@@ -426,7 +426,7 @@ Sets the line spacing to use between lines of legend text.
    Use :py:func:`QgsLegendStyle.setTextFormat()` from :py:func:`~QgsLegendSettings.style` instead.
 %End
 
- double mmPerMapUnit() const /Deprecated/;
+ double mmPerMapUnit() const /Deprecated="Since 3.40. Use scale factor from render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -434,7 +434,7 @@ Sets the line spacing to use between lines of legend text.
    Use scale factor from render contexts instead.
 %End
 
- void setMmPerMapUnit( double mmPerMapUnit ) /Deprecated/;
+ void setMmPerMapUnit( double mmPerMapUnit ) /Deprecated="Since 3.40. Set scale factor on render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -442,7 +442,7 @@ Sets the line spacing to use between lines of legend text.
    Set scale factor on render contexts instead.
 %End
 
- bool useAdvancedEffects() const /Deprecated/;
+ bool useAdvancedEffects() const /Deprecated="Since 3.40. Use flags from render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -450,7 +450,7 @@ Sets the line spacing to use between lines of legend text.
    Use flags from render contexts instead.
 %End
 
- void setUseAdvancedEffects( bool use ) /Deprecated/;
+ void setUseAdvancedEffects( bool use ) /Deprecated="Since 3.40. Set flag on render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -458,7 +458,7 @@ Sets the line spacing to use between lines of legend text.
    Set flag on render contexts instead.
 %End
 
- double mapScale() const /Deprecated/;
+ double mapScale() const /Deprecated="Since 3.40. Take this property from the render context instead."/;
 %Docstring
 Returns the legend map scale.
 The scale value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
@@ -470,7 +470,7 @@ The scale value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
    Take this property from the render context instead.
 %End
 
- void setMapScale( double scale ) /Deprecated/;
+ void setMapScale( double scale ) /Deprecated="Since 3.40. Set this property on the render context instead."/;
 %Docstring
 Sets the legend map ``scale``.
 The ``scale`` value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
@@ -482,7 +482,7 @@ The ``scale`` value indicates the scale denominator, e.g. 1000.0 for a 1:1000 ma
    Set this property on the render context instead.
 %End
 
- double mapUnitsPerPixel() const /Deprecated/;
+ double mapUnitsPerPixel() const /Deprecated="Since 3.40. Take these properties on render contexts instead."/;
 %Docstring
 Returns the factor of map units per pixel for symbols with size given in map units calculated by dpi and mmPerMapUnit
 
@@ -493,7 +493,7 @@ Returns the factor of map units per pixel for symbols with size given in map uni
    Take these properties on render contexts instead.
 %End
 
- void setMapUnitsPerPixel( double mapUnitsPerPixel ) /Deprecated/;
+ void setMapUnitsPerPixel( double mapUnitsPerPixel ) /Deprecated="Since 3.40. Set these properties on render contexts instead."/;
 %Docstring
 Sets the mmPerMapUnit calculated by ``mapUnitsPerPixel`` mostly taken from the map settings.
 
@@ -504,7 +504,7 @@ Sets the mmPerMapUnit calculated by ``mapUnitsPerPixel`` mostly taken from the m
    Set these properties on render contexts instead.
 %End
 
- int dpi() const /Deprecated/;
+ int dpi() const /Deprecated="Since 3.40. Take dpi from render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -512,7 +512,7 @@ Sets the mmPerMapUnit calculated by ``mapUnitsPerPixel`` mostly taken from the m
    Take dpi from render contexts instead.
 %End
 
- void setDpi( int dpi ) /Deprecated/;
+ void setDpi( int dpi ) /Deprecated="Since 3.40. Set dpi on render contexts instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/core/auto_generated/qgslegendstyle.sip.in
+++ b/python/core/auto_generated/qgslegendstyle.sip.in
@@ -43,7 +43,7 @@ Contains detailed styling information relating to how a layout legend should be 
 
     QgsLegendStyle();
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the font used for rendering this legend component.
 
@@ -54,7 +54,7 @@ Returns the font used for rendering this legend component.
    Use :py:func:`~QgsLegendStyle.textFormat` instead.
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for rendering this legend component.
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -243,7 +243,7 @@ Returns the layer data provider's metadata, it may be ``None``.
 .. versionadded:: 3.40
 %End
 
- void setShortName( const QString &shortName ) /Deprecated/;
+ void setShortName( const QString &shortName ) /Deprecated="Since 3.38. Use serverProperties()->setShortName() instead."/;
 %Docstring
 Sets the short name of the layer used by QGIS Server to identify the layer.
 
@@ -252,7 +252,7 @@ Sets the short name of the layer used by QGIS Server to identify the layer.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setShortName` instead.
 %End
 
- QString shortName() const /Deprecated/;
+ QString shortName() const /Deprecated="Since 3.38. Use serverProperties()->shortName() instead."/;
 %Docstring
 Returns the short name of the layer used by QGIS Server to identify the layer.
 
@@ -261,7 +261,7 @@ Returns the short name of the layer used by QGIS Server to identify the layer.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.shortName` instead.
 %End
 
- void setTitle( const QString &title ) /Deprecated/;
+ void setTitle( const QString &title ) /Deprecated="Since 3.38. Use serverProperties()->setTitle() instead."/;
 %Docstring
 Sets the title of the layer used by QGIS Server in GetCapabilities request.
 
@@ -270,7 +270,7 @@ Sets the title of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setTitle` instead.
 %End
 
- QString title() const /Deprecated/;
+ QString title() const /Deprecated="Since 3.38. Use serverProperties()->title() instead."/;
 %Docstring
 Returns the title of the layer used by QGIS Server in GetCapabilities request.
 
@@ -279,7 +279,7 @@ Returns the title of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.title` instead.
 %End
 
- void setAbstract( const QString &abstract ) /Deprecated/;
+ void setAbstract( const QString &abstract ) /Deprecated="Since 3.38. Use serverProperties()->setAbstract() instead."/;
 %Docstring
 Sets the abstract of the layer used by QGIS Server in GetCapabilities request.
 
@@ -288,7 +288,7 @@ Sets the abstract of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAbstract` instead.
 %End
 
- QString abstract() const /Deprecated/;
+ QString abstract() const /Deprecated="Since 3.38. Use serverProperties()->abstract() instead."/;
 %Docstring
 Returns the abstract of the layer used by QGIS Server in GetCapabilities request.
 
@@ -297,7 +297,7 @@ Returns the abstract of the layer used by QGIS Server in GetCapabilities request
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.abstract` instead.
 %End
 
- void setKeywordList( const QString &keywords ) /Deprecated/;
+ void setKeywordList( const QString &keywords ) /Deprecated="Since 3.38. Use serverProperties()->setKeywordList() instead."/;
 %Docstring
 Sets the keyword list of the layerused by QGIS Server in GetCapabilities request.
 
@@ -306,7 +306,7 @@ Sets the keyword list of the layerused by QGIS Server in GetCapabilities request
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setKeywordList` instead.
 %End
 
- QString keywordList() const /Deprecated/;
+ QString keywordList() const /Deprecated="Since 3.38. Use serverProperties()->keywordList() instead."/;
 %Docstring
 Returns the keyword list of the layer used by QGIS Server in GetCapabilities request.
 
@@ -315,7 +315,7 @@ Returns the keyword list of the layer used by QGIS Server in GetCapabilities req
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.keywordList` instead.
 %End
 
- void setDataUrl( const QString &dataUrl ) /Deprecated/;
+ void setDataUrl( const QString &dataUrl ) /Deprecated="Since 3.38. Use serverProperties()->setDataUrl() instead."/;
 %Docstring
 Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
@@ -324,7 +324,7 @@ Sets the DataUrl of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrl` instead.
 %End
 
- QString dataUrl() const /Deprecated/;
+ QString dataUrl() const /Deprecated="Since 3.38. Use serverProperties()->dataUrl() instead."/;
 %Docstring
 Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
 
@@ -333,7 +333,7 @@ Returns the DataUrl of the layer used by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrl` instead.
 %End
 
- void setDataUrlFormat( const QString &dataUrlFormat ) /Deprecated/;
+ void setDataUrlFormat( const QString &dataUrlFormat ) /Deprecated="Since 3.38. Use serverProperties()->setDataUrlFormat() instead."/;
 %Docstring
 Sets the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
@@ -342,7 +342,7 @@ Sets the DataUrl format of the layer used by QGIS Server in GetCapabilities requ
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setDataUrlFormat` instead.
 %End
 
- QString dataUrlFormat() const /Deprecated/;
+ QString dataUrlFormat() const /Deprecated="Since 3.38. Use serverProperties()->dataUrlFormat() instead."/;
 %Docstring
 Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities request.
 
@@ -351,7 +351,7 @@ Returns the DataUrl format of the layer used by QGIS Server in GetCapabilities r
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.dataUrlFormat` instead.
 %End
 
- void setAttribution( const QString &attrib ) /Deprecated/;
+ void setAttribution( const QString &attrib ) /Deprecated="Since 3.38. Use serverProperties()->setAttribution() instead."/;
 %Docstring
 Sets the attribution of the layerused by QGIS Server in GetCapabilities request.
 
@@ -360,7 +360,7 @@ Sets the attribution of the layerused by QGIS Server in GetCapabilities request.
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttribution` instead.
 %End
 
- QString attribution() const /Deprecated/;
+ QString attribution() const /Deprecated="Since 3.38. Use serverProperties()->attribution() instead."/;
 %Docstring
 Returns the attribution of the layer used by QGIS Server in GetCapabilities request.
 
@@ -369,7 +369,7 @@ Returns the attribution of the layer used by QGIS Server in GetCapabilities requ
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.attribution` instead.
 %End
 
- void setAttributionUrl( const QString &attribUrl ) /Deprecated/;
+ void setAttributionUrl( const QString &attribUrl ) /Deprecated="Since 3.38. Use serverProperties()->setAttributionUrl() instead."/;
 %Docstring
 Sets the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
@@ -378,7 +378,7 @@ Sets the attribution URL of the layer used by QGIS Server in GetCapabilities req
    Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setAttributionUrl` instead.
 %End
 
- QString attributionUrl() const /Deprecated/;
+ QString attributionUrl() const /Deprecated="Since 3.38. Use serverProperties()->attributionUrl() instead."/;
 %Docstring
 Returns the attribution URL of the layer used by QGIS Server in GetCapabilities request.
 
@@ -394,7 +394,7 @@ Returns QGIS Server Properties for the map layer
 
 .. versionadded:: 3.22
 %End
- void setMetadataUrl( const QString &metaUrl ) /Deprecated/;
+ void setMetadataUrl( const QString &metaUrl ) /Deprecated="Since 3.22. "/;
 %Docstring
 Sets the metadata URL of the layer
 used by QGIS Server in GetCapabilities request.
@@ -406,7 +406,7 @@ Since QGIS 3.22, it edits the first metadata URL link.
 .. deprecated:: 3.22
 %End
 
- QString metadataUrl() const /Deprecated/;
+ QString metadataUrl() const /Deprecated="Since 3.22. "/;
 %Docstring
 Returns the metadata URL of the layer
 used by QGIS Server in GetCapabilities request.
@@ -420,7 +420,7 @@ Since QGIS 3.22, it returns the first metadata URL link.
 .. deprecated:: 3.22
 %End
 
- void setMetadataUrlType( const QString &metaUrlType ) /Deprecated/;
+ void setMetadataUrlType( const QString &metaUrlType ) /Deprecated="Since 3.22. "/;
 %Docstring
 Set the metadata type of the layer
 used by QGIS Server in GetCapabilities request
@@ -432,7 +432,7 @@ Since QGIS 3.22, it edits the first metadata URL type.
 .. deprecated:: 3.22
 %End
 
- QString metadataUrlType() const /Deprecated/;
+ QString metadataUrlType() const /Deprecated="Since 3.22. "/;
 %Docstring
 Returns the metadata type of the layer
 used by QGIS Server in GetCapabilities request.
@@ -446,7 +446,7 @@ Since QGIS 3.22, it returns the first metadata URL type.
 .. deprecated:: 3.22
 %End
 
- void setMetadataUrlFormat( const QString &metaUrlFormat ) /Deprecated/;
+ void setMetadataUrlFormat( const QString &metaUrlFormat ) /Deprecated="Since 3.22. "/;
 %Docstring
 Sets the metadata format of the layer
 used by QGIS Server in GetCapabilities request.
@@ -458,7 +458,7 @@ Since QGIS 3.22, it edits the first metadata URL format.
 .. deprecated:: 3.22
 %End
 
- QString metadataUrlFormat() const /Deprecated/;
+ QString metadataUrlFormat() const /Deprecated="Since 3.22. "/;
 %Docstring
 Returns the metadata format of the layer
 used by QGIS Server in GetCapabilities request.
@@ -1174,7 +1174,7 @@ record in the users style table in their personal qgis.db)
 .. seealso:: :py:func:`saveNamedStyle`
 %End
 
- virtual QString saveDefaultStyle( bool &resultFlag /Out/ ) /Deprecated/;
+ virtual QString saveDefaultStyle( bool &resultFlag /Out/ ) /Deprecated="Since 3.26. "/;
 %Docstring
 Save the properties of this layer as the default style
 (either as a .qml file on disk or as a
@@ -1559,7 +1559,7 @@ Returns whether scale based visibility is enabled for the layer.
 .. seealso:: :py:func:`isInScaleRange`
 %End
 
- bool hasAutoRefreshEnabled() const /Deprecated/;
+ bool hasAutoRefreshEnabled() const /Deprecated="Since 3.40. Use autoRefreshMode() instead."/;
 %Docstring
 Returns ``True`` if auto refresh is enabled for the layer.
 
@@ -1607,7 +1607,7 @@ canvas must be refreshed separately in order to view the refreshed layer.
 .. seealso:: :py:func:`setAutoRefreshEnabled`
 %End
 
- void setAutoRefreshEnabled( bool enabled ) /Deprecated/;
+ void setAutoRefreshEnabled( bool enabled ) /Deprecated="Since 3.40. Use setAutoRefreshMode() instead."/;
 %Docstring
 Sets whether auto refresh is enabled for the layer.
 

--- a/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -39,7 +39,7 @@ Sets ``filter`` flags which affect how layers are filtered within the model.
 .. seealso:: :py:func:`filters`
 %End
 
- void setFilters( int filters ) /Deprecated/;
+ void setFilters( int filters ) /Deprecated="Since 3.34. Use the flag signature instead."/;
 %Docstring
 Filters according to layer type and/or geometry type.
 
@@ -77,7 +77,7 @@ Returns if the ``layer`` matches the given ``filters``
 .. versionadded:: 3.14
 %End
 
- void setLayerWhitelist( const QList<QgsMapLayer *> &layers ) /Deprecated/;
+ void setLayerWhitelist( const QList<QgsMapLayer *> &layers ) /Deprecated="Since 3.40. Use setLayerAllowList()."/;
 %Docstring
 Sets an allowlist of ``layers`` to include within the model. Only layers
 from this list will be shown.
@@ -107,7 +107,7 @@ An empty list indicates that no filter by allowlist should be performed.
 .. versionadded:: 3.14
 %End
 
- QList<QgsMapLayer *> layerWhitelist() /Deprecated/;
+ QList<QgsMapLayer *> layerWhitelist() /Deprecated="Since 3.40. Use layerAllowlist() instead."/;
 %Docstring
 Returns the list of layers which are excluded from the model.
 

--- a/python/core/auto_generated/qgsmaptopixel.sip.in
+++ b/python/core/auto_generated/qgsmaptopixel.sip.in
@@ -131,7 +131,7 @@ Transforms device coordinates to map (world) coordinates.
 :return: :py:class:`QgsPointXY` in map coorndiates
 %End
 
- QgsPointXY toMapPoint( double x, double y ) const /Deprecated/;
+ QgsPointXY toMapPoint( double x, double y ) const /Deprecated="Since 3.4. Use toMapCoordinates() instead."/;
 %Docstring
 Transforms device coordinates to map (world) coordinates.
 

--- a/python/core/auto_generated/qgsowsconnection.sip.in
+++ b/python/core/auto_generated/qgsowsconnection.sip.in
@@ -57,7 +57,7 @@ Returns a string representing the service type, e.g. "WMS".
 Returns the connection uri.
 %End
 
- static QgsDataSourceUri &addWmsWcsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated/;
+ static QgsDataSourceUri &addWmsWcsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated="Since 3.26. Use addWmsWcsConnectionSettings with service and connection name parameters."/;
 %Docstring
 Adds uri parameters relating to the settings for a WMS or WCS connection to a :py:class:`QgsDataSourceUri` ``uri``.
 Connection settings are taken from the specified QSettings ``settingsKey``.
@@ -75,7 +75,7 @@ Connection settings are taken from the specified ``servcie`` and ``connName``
 .. versionadded:: 3.26
 %End
 
- static QgsDataSourceUri &addWfsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated/;
+ static QgsDataSourceUri &addWfsConnectionSettings( QgsDataSourceUri &uri, const QString &settingsKey ) /Deprecated="Since 3.26. Use addWfsConnectionSettings with service and connection name parameters."/;
 %Docstring
 Adds uri parameters relating to the settings for a WFS connection to a :py:class:`QgsDataSourceUri` ``uri``.
 Connection settings are taken from the specified QSettings ``settingsKey``.

--- a/python/core/auto_generated/qgsrenderchecker.sip.in
+++ b/python/core/auto_generated/qgsrenderchecker.sip.in
@@ -231,7 +231,7 @@ Test using two arbitrary images at the specified paths for equality.
 .. versionadded:: 3.18
 %End
 
- bool isKnownAnomaly( const QString &diffImageFile ) /Deprecated/;
+ bool isKnownAnomaly( const QString &diffImageFile ) /Deprecated="Since 3.40. Use the test mask system instead."/;
 %Docstring
 Gets a list of all the anomalies. An anomaly is a rendered difference
 file where there is some red pixel content (indicating a render check

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -110,7 +110,7 @@ This is currently used to implement selective masking.
 %End
 
 
- void setDisabledSymbolLayers( const QSet<const QgsSymbolLayer *> &symbolLayers ) /Deprecated/;
+ void setDisabledSymbolLayers( const QSet<const QgsSymbolLayer *> &symbolLayers ) /Deprecated="Since 3.30. And replaced with setDisabledSymbolLayersV2."/;
 %Docstring
 When rendering a map layer in a second pass (for selective masking),
 some symbol layers may be disabled.
@@ -142,7 +142,7 @@ Sets the list of disabled symbol layer ids.
 .. versionadded:: 3.30
 %End
 
- QSet<const QgsSymbolLayer *> disabledSymbolLayers() const /Deprecated/;
+ QSet<const QgsSymbolLayer *> disabledSymbolLayers() const /Deprecated="Since 3.30. And replaced with disabledSymbolLayersV2."/;
 %Docstring
 When rendering a map layer in a second pass (for selective masking),
 some symbol layers may be disabled.
@@ -873,7 +873,7 @@ in a mask painter, which is not meant to be visible, by definition.
 .. versionadded:: 3.12
 %End
 
- QVariantMap customRenderingFlags() const /Deprecated/;
+ QVariantMap customRenderingFlags() const /Deprecated="Since 3.40. Use customProperties() instead."/;
 %Docstring
 Gets custom rendering flags. Layers might honour these to alter their rendering.
 
@@ -897,7 +897,7 @@ Objects might honour these to alter their rendering.
 .. versionadded:: 3.40
 %End
 
- void setCustomRenderingFlag( const QString &flag, const QVariant &value ) /Deprecated/;
+ void setCustomRenderingFlag( const QString &flag, const QVariant &value ) /Deprecated="Since 3.40. Use setCustomProperty() instead."/;
 %Docstring
 Sets a custom rendering flag. Layers might honour these to alter their rendering.
 
@@ -922,7 +922,7 @@ Objects might honour these to alter their rendering.
 .. versionadded:: 3.40
 %End
 
- void clearCustomRenderingFlag( const QString &flag ) /Deprecated/;
+ void clearCustomRenderingFlag( const QString &flag ) /Deprecated="Since 3.40. Use clearCustomProperty() instead."/;
 %Docstring
 Clears the specified custom rendering flag.
 
@@ -1026,7 +1026,7 @@ are drawn and behave during render operations.
 .. versionadded:: 3.38
 %End
 
- void addSymbolLayerClipPath( const QString &symbolLayerId, QPainterPath path ) /Deprecated/;
+ void addSymbolLayerClipPath( const QString &symbolLayerId, QPainterPath path ) /Deprecated="Since 3.38. Use addSymbolLayerClipGeometry() instead."/;
 %Docstring
 Add a clip ``path`` to be applied to the ``symbolLayer`` before rendering
 
@@ -1037,7 +1037,7 @@ Add a clip ``path`` to be applied to the ``symbolLayer`` before rendering
    Use :py:func:`~QgsRenderContext.addSymbolLayerClipGeometry` instead.
 %End
 
- QList<QPainterPath> symbolLayerClipPaths( const QString &symbolLayerId ) const /Deprecated/;
+ QList<QPainterPath> symbolLayerClipPaths( const QString &symbolLayerId ) const /Deprecated="Since 3.38. Use symbolLayerClipGeometries() instead."/;
 %Docstring
 Returns clip paths to be applied to the ``symbolLayer`` before rendering
 

--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -38,7 +38,7 @@ Constructor to create a new runtime profiler.
 %End
     ~QgsRuntimeProfiler();
 
- void beginGroup( const QString &name ) /Deprecated/;
+ void beginGroup( const QString &name ) /Deprecated="Since 3.40. Use start() instead."/;
 %Docstring
 Begin the group for the profiler. Groups will append {GroupName}/ to the
 front of the profile tag set using start.
@@ -50,7 +50,7 @@ front of the profile tag set using start.
    Use :py:func:`~QgsRuntimeProfiler.start` instead.
 %End
 
- void endGroup() /Deprecated/;
+ void endGroup() /Deprecated="Since 3.40. Use end() instead."/;
 %Docstring
 End the current active group.
 

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -47,7 +47,7 @@ Convenient method to returns the translated name of the enum type
 .. versionadded:: 3.26
 %End
 
- static QString snappingTypeFlagToString( Qgis::SnappingType type ) /Deprecated/;
+ static QString snappingTypeFlagToString( Qgis::SnappingType type ) /Deprecated="Since 3.26. Use snappingTypeToString() instead."/;
 %Docstring
 Convenient method to return the translated name of the enum type
 :py:class:`Qgis`.SnappingTypes.
@@ -68,7 +68,7 @@ Convenient method to return an icon corresponding to the enum type
 .. versionadded:: 3.20
 %End
 
- static QIcon snappingTypeFlagToIcon( Qgis::SnappingType type ) /Deprecated/;
+ static QIcon snappingTypeFlagToIcon( Qgis::SnappingType type ) /Deprecated="Since 3.26. Use snappingTypeToIcon() instead."/;
 %Docstring
 Convenient method to return an icon corresponding to the enum type
 :py:class:`Qgis`.SnappingTypes.
@@ -90,7 +90,7 @@ This is a container of advanced configuration (per layer) of the snapping of the
 %End
       public:
 
- IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, Qgis::MapToolUnit units ) /Deprecated/;
+ IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, Qgis::MapToolUnit units ) /Deprecated="Since 3.12. Use the method with Qgis.SnappingTypes instead."/;
 %Docstring
 IndividualLayerSettings
 
@@ -145,7 +145,7 @@ Returns the flags type (vertices | segments | area | centroid | middle)
 .. versionadded:: 3.12
 %End
 
- QgsSnappingConfig::SnappingType type() const /Deprecated/;
+ QgsSnappingConfig::SnappingType type() const /Deprecated="Since 3.12. Use typeFlag() instead."/;
 %Docstring
 Returns the flags type (vertices | segments | area | centroid | middle)
 
@@ -154,7 +154,7 @@ Returns the flags type (vertices | segments | area | centroid | middle)
    Use :py:func:`~IndividualLayerSettings.typeFlag` instead.
 %End
 
- void setType( SnappingType type ) /Deprecated/;
+ void setType( SnappingType type ) /Deprecated="Since 3.12. Use setTypeFlag() instead."/;
 %Docstring
 define the type of snapping
 
@@ -263,7 +263,7 @@ Returns the flags type (vertices | segments | area | centroid | middle)
 .. versionadded:: 3.12
 %End
 
- QgsSnappingConfig::SnappingType type() const /Deprecated/;
+ QgsSnappingConfig::SnappingType type() const /Deprecated="Since 3.12. Use typeFlag() instead."/;
 %Docstring
 Returns the flags type (vertices | segments | area | centroid | middle)
 

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -78,7 +78,7 @@ that of the spatial index construction.
 
 
 
- bool insertFeature( const QgsFeature &feature ) /Deprecated/;
+ bool insertFeature( const QgsFeature &feature ) /Deprecated="Since 3.40. Use addFeature() instead."/;
 %Docstring
 Adds a ``feature`` to the index.
 
@@ -107,7 +107,7 @@ The ``flags`` argument is ignored.
 .. seealso:: :py:func:`addFeature`
 %End
 
- bool insertFeature( QgsFeatureId id, const QgsRectangle &bounds ) /Deprecated/;
+ bool insertFeature( QgsFeatureId id, const QgsRectangle &bounds ) /Deprecated="Since 3.40. Use addFeature() instead."/;
 %Docstring
 Add a feature ``id`` to the index with a specified bounding box.
 

--- a/python/core/auto_generated/qgsvariantutils.sip.in
+++ b/python/core/auto_generated/qgsvariantutils.sip.in
@@ -29,7 +29,7 @@ Returns a user-friendly translated string representing a QVariant ``type``.
 The optional ``subType`` can be used to specify the type of variant list or map values.
 %End
 
- static QString typeToDisplayString( QVariant::Type type, QVariant::Type subType = QVariant::Type::Invalid ) /Deprecated/;
+ static QString typeToDisplayString( QVariant::Type type, QVariant::Type subType = QVariant::Type::Invalid ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Returns a user-friendly translated string representing a QVariant ``type``.
 

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -245,7 +245,7 @@ Creates a clone of the FieldValueConverter.
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
-                                                                                 ) /Deprecated/;
+                                                                                 ) /Deprecated="Since 3.40. Use writeAsVectorFormatV2() instead."/;
 %Docstring
 Write contents of vector layer to an (OGR supported) vector format
 
@@ -296,7 +296,7 @@ Write contents of vector layer to an (OGR supported) vector format
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
-                                                                                 ) /Deprecated/;
+                                                                                 ) /Deprecated="Since 3.40. Use writeAsVectorFormatV2() instead."/;
 %Docstring
 Writes a layer out to a vector file.
 
@@ -400,7 +400,7 @@ Options to pass to :py:func:`~QgsVectorFileWriter.writeAsVectorFormat`
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = 0,
         QString *errorMessage /Out/ = 0
-                                                                                 ) /Deprecated/;
+                                                                                 ) /Deprecated="Since 3.40. Use writeAsVectorFormatV2() instead."/;
 %Docstring
 Writes a layer out to a vector file.
 
@@ -427,7 +427,7 @@ Writes a layer out to a vector file.
                                            QString *newFilename = 0,
                                            Qgis::FeatureSymbologyExport symbologyExport = Qgis::FeatureSymbologyExport::NoSymbology,
                                            QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags()
-                                         ) /Deprecated/;
+                                         ) /Deprecated="Since 3.40. Use create() instead."/;
 %Docstring
 Create a new vector file writer
 
@@ -469,7 +469,7 @@ Create a new vector file writer.
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = 0,
         QString *newLayer = 0,
-        QString *errorMessage /Out/ = 0 ) /Deprecated/;
+        QString *errorMessage /Out/ = 0 ) /Deprecated="Since 3.20. Use writeAsVectorFormatV3() instead."/;
 %Docstring
 Writes a layer out to a vector file.
 

--- a/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -24,7 +24,7 @@ Bilinear Raster Resampler
 
     QgsBilinearRasterResampler();
 
- virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated="Since 3.12. Use resampleV2() instead."/;
 
 %Docstring
 

--- a/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -23,8 +23,15 @@ Bilinear Raster Resampler
   public:
 
     QgsBilinearRasterResampler();
+
  virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.12
+
+   Use :py:func:`~QgsBilinearRasterResampler.resampleV2` instead.
+%End
 
     virtual QImage resampleV2( const QImage &source, const QSize &size );
 

--- a/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -27,8 +27,15 @@ Cubic Raster Resampler.
 
     virtual QImage resampleV2( const QImage &source, const QSize &size );
 
+
  virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.12
+
+   Use :py:func:`~QgsCubicRasterResampler.resampleV2` instead.
+%End
     virtual QString type() const;
 
     virtual int tileBufferPixels() const;

--- a/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -28,7 +28,7 @@ Cubic Raster Resampler.
     virtual QImage resampleV2( const QImage &source, const QSize &size );
 
 
- virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated="Since 3.12. Use resampleV2() instead."/;
 
 %Docstring
 

--- a/python/core/auto_generated/raster/qgshillshaderenderer.sip.in
+++ b/python/core/auto_generated/raster/qgshillshaderenderer.sip.in
@@ -62,7 +62,7 @@ Factory method to create a new renderer
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
 
- int band() const /Deprecated/;
+ int band() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 Returns the band used by the renderer
 
@@ -71,7 +71,7 @@ Returns the band used by the renderer
    Use :py:func:`~QgsHillshadeRenderer.inputBand` instead.
 %End
 
- void setBand( int bandNo ) /Deprecated/;
+ void setBand( int bandNo ) /Deprecated="Since 3.38. Use setInputBand() instead."/;
 %Docstring
 Sets the band used by the renderer.
 

--- a/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -122,7 +122,7 @@ Returns optional category label
 Set category label
 %End
 
- int band() const /Deprecated/;
+ int band() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 Returns the raster band used for rendering the raster.
 

--- a/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -73,7 +73,7 @@ The Field class represents a Raster Attribute Table field, including its name, u
 Creates a new Field with ``name``, ``type`` and ``usage``.
 %End
 
- Field( const QString &name, const Qgis::RasterAttributeTableFieldUsage &usage, const QVariant::Type type ) /Deprecated/;
+ Field( const QString &name, const Qgis::RasterAttributeTableFieldUsage &usage, const QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Creates a new Field with ``name``, ``type`` and ``usage``.
 
@@ -264,7 +264,7 @@ Inserts a new ``field`` at ``position``, optionally reporting any error in ``err
 Creates a new field from ``name``, ``usage`` and ``type`` and inserts it at ``position``, optionally reporting any error in ``errorMessage``, returns ``True`` on success.
 %End
 
- bool insertField( int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated/;
+ bool insertField( int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Creates a new field from ``name``, ``usage`` and ``type`` and inserts it at ``position``, optionally reporting any error in ``errorMessage``, returns ``True`` on success.
 

--- a/python/core/auto_generated/raster/qgsrasterdrawer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdrawer.sip.in
@@ -21,7 +21,7 @@ The drawing pipe for raster layers.
 %End
   public:
 
- QgsRasterDrawer( QgsRasterIterator *iterator, double dpiTarget ) /Deprecated/;
+ QgsRasterDrawer( QgsRasterIterator *iterator, double dpiTarget ) /Deprecated="Since 3.28. Use the constructor without the ``dpiTarget`` argument instead, as DPI is now handled by the draw() method which accepts a QgsRenderContext."/;
 %Docstring
 The QgsRasterDrawer constructor.
 

--- a/python/core/auto_generated/raster/qgsrasterfilewriter.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterfilewriter.sip.in
@@ -69,7 +69,7 @@ Ownership of the returned provider is passed to the caller.
 
 
  Qgis::RasterFileWriterResult writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
-        const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated/;
+        const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated="Since 3.8. Use version with transformContext instead."/;
 %Docstring
 Write raster file
 

--- a/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
@@ -30,7 +30,7 @@ QGIS interface.
  QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe /Transfer/,
         int columns, int rows,
         const QgsRectangle &outputExtent,
-        const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+        const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.8. Use version with transformContext instead."/;
 %Docstring
 Constructor for QgsRasterFileWriterTask. Takes a source ``writer``,
 ``columns``, ``rows``, ``outputExtent`` and destination ``crs``.

--- a/python/core/auto_generated/raster/qgsrasterinterface.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterinterface.sip.in
@@ -184,7 +184,7 @@ Clone itself, create deep copy
 Returns the capabilities supported by the interface.
 %End
 
- QString capabilitiesString() const /Deprecated/;
+ QString capabilitiesString() const /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Returns the raster interface capabilities in friendly format.
 
@@ -295,7 +295,7 @@ It may be used to get info about original data, e.g. resolution to decide
 resampling etc.
 %End
 
- QgsRasterBandStats bandStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated/;
+ QgsRasterBandStats bandStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated="Since 3.40. Use Qgis.RasterBandStatistic instead of int for ``stats`` argument."/;
 %Docstring
 Returns the band statistics.
 
@@ -324,7 +324,7 @@ Returns the band statistics.
 :param feedback: optional feedback object
 %End
 
- bool hasStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0 ) /Deprecated/;
+ bool hasStatistics( int bandNo, int stats, const QgsRectangle &extent = QgsRectangle(), int sampleSize = 0 ) /Deprecated="Since 3.40. Use Qgis.RasterBandStatistic instead of int for ``stats`` argument."/;
 %Docstring
 Returns ``True`` if histogram is available (cached, already calculated).
 The parameters are the same as in :py:func:`~QgsRasterInterface.bandStatistics`
@@ -538,7 +538,7 @@ Fill in histogram defaults if not specified
 #endif
 %End
 
- void initStatistics( QgsRasterBandStats &statistics, int bandNo, int stats, const QgsRectangle &boundingBox = QgsRectangle(), int binCount = 0 ) const /Deprecated/;
+ void initStatistics( QgsRasterBandStats &statistics, int bandNo, int stats, const QgsRectangle &boundingBox = QgsRectangle(), int binCount = 0 ) const /Deprecated="Since 3.40. Use Qgis.RasterBandStatistic instead of int for ``stats`` argument."/;
 %Docstring
 Fill in statistics defaults if not specified
 

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -124,7 +124,7 @@ returned in ``retError``.
 Returns time stamp for given file name
 %End
 
- void setDataProvider( const QString &provider ) /Deprecated/;
+ void setDataProvider( const QString &provider ) /Deprecated="Since 3.40. Use the version with ProviderOptions instead."/;
 %Docstring
 Set the data provider.
 
@@ -286,7 +286,7 @@ This will be ``None`` if the layer is invalid.
 This is an overloaded version of the :py:func:`~QgsRasterLayer.draw` function that is called by both :py:func:`~QgsRasterLayer.draw` and thumbnailAsPixmap
 %End
 
- QgsLegendColorList legendSymbologyItems() const /Deprecated/;
+ QgsLegendColorList legendSymbologyItems() const /Deprecated="Since 3.40. Use QgsRasterRenderer.createLegendNodes() instead."/;
 %Docstring
 Returns a list with classification items (Text and color).
 

--- a/python/core/auto_generated/raster/qgsrasterprojector.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterprojector.sip.in
@@ -49,7 +49,7 @@ PROJ transformations for optimised bulk reprojection of points.
 
 
  void setCrs( const QgsCoordinateReferenceSystem &srcCRS, const QgsCoordinateReferenceSystem &destCRS,
-                                   int srcDatumTransform = -1, int destDatumTransform = -1 ) /Deprecated/;
+                                   int srcDatumTransform = -1, int destDatumTransform = -1 ) /Deprecated="Since 3.8. Use transformContext version instead."/;
 %Docstring
 Sets the source and destination CRS
 

--- a/python/core/auto_generated/raster/qgsrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterresampler.sip.in
@@ -32,7 +32,7 @@ Interface for resampling rasters (e.g. to have a smoother appearance)
   public:
     virtual ~QgsRasterResampler();
 
- virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0 /Deprecated/;
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0 /Deprecated="Since 3.10.1. Use the more efficient QgsRasterResamplerV2 interface instead."/;
 %Docstring
 Resamples a source image to a destination image.
 

--- a/python/core/auto_generated/raster/qgsrastertransparency.sip.in
+++ b/python/core/auto_generated/raster/qgsrastertransparency.sip.in
@@ -142,7 +142,7 @@ Sets the transparent three value pixel list, replacing the whole existing list.
 .. seealso:: :py:func:`transparentThreeValuePixelList`
 %End
 
- int alphaValue( double value, int globalTransparency = 255 ) const /Deprecated/;
+ int alphaValue( double value, int globalTransparency = 255 ) const /Deprecated="Since 3.40. Use opacityForValue() instead."/;
 %Docstring
 Returns the transparency value for a single ``value`` pixel.
 
@@ -167,7 +167,7 @@ the opacity corresponding to the value. Returns 1 if no matches are found.
 .. versionadded:: 3.38
 %End
 
- int alphaValue( double redValue, double greenValue, double blueValue, int globalTransparency = 255 ) const /Deprecated/;
+ int alphaValue( double redValue, double greenValue, double blueValue, int globalTransparency = 255 ) const /Deprecated="Since 3.40. Use opacityForRgbValues() instead."/;
 %Docstring
 Returns the transparency value for a RGB pixel.
 

--- a/python/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
@@ -43,7 +43,7 @@ QgsSingleBandGrayRenderer cannot be copied. Use :py:func:`~QgsSingleBandGrayRend
     virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = 0 ) /Factory/;
 
 
- int grayBand() const /Deprecated/;
+ int grayBand() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 
 .. deprecated:: 3.38
@@ -51,7 +51,7 @@ QgsSingleBandGrayRenderer cannot be copied. Use :py:func:`~QgsSingleBandGrayRend
    Use :py:func:`~QgsSingleBandGrayRenderer.inputBand` instead.
 %End
 
- void setGrayBand( int band ) /Deprecated/;
+ void setGrayBand( int band ) /Deprecated="Since 3.38. Use setInputBand() instead."/;
 %Docstring
 
 .. deprecated:: 3.38

--- a/python/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
@@ -90,7 +90,7 @@ Creates a color ramp shader
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
- int band() const /Deprecated/;
+ int band() const /Deprecated="Since 3.38. Use inputBand() instead."/;
 %Docstring
 Returns the band used by the renderer
 
@@ -99,7 +99,7 @@ Returns the band used by the renderer
    Use :py:func:`~QgsSingleBandPseudoColorRenderer.inputBand` instead.
 %End
 
- void setBand( int bandNo ) /Deprecated/;
+ void setBand( int bandNo ) /Deprecated="Since 3.38. Use setInputBand() instead."/;
 %Docstring
 Sets the band used by the renderer.
 

--- a/python/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
@@ -42,6 +42,12 @@ A scale bar style that draws text in the form of '1:XXXXX'.
 
  virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings, const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated/;
 
+%Docstring
+
+.. deprecated:: 3.14
+
+   Use the one with render context instead.
+%End
 
 };
 

--- a/python/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsnumericscalebarrenderer.sip.in
@@ -40,7 +40,7 @@ A scale bar style that draws text in the form of '1:XXXXX'.
                              const QgsScaleBarSettings &settings,
                              const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
 
- virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings, const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated/;
+ virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings, const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated="Since 3.14. Use the one with render context instead."/;
 
 %Docstring
 

--- a/python/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
@@ -67,7 +67,7 @@ Returns ``True`` if the context has valid settings.
     QgsScaleBarRenderer();
     virtual ~QgsScaleBarRenderer();
 
- QString name() const /Deprecated/;
+ QString name() const /Deprecated="Since 3.40. Use id() instead."/;
 %Docstring
 Returns the unique name for this style.
 
@@ -117,7 +117,7 @@ Draws the scalebar using the specified ``settings`` and ``scaleContext`` to a de
 %End
 
  virtual QSizeF calculateBoxSize( const QgsScaleBarSettings &settings,
-        const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated/;
+        const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const /Deprecated="Since 3.40. Use the version with a QgsRenderContext instead."/;
 %Docstring
 Calculates the required box size (in millimeters) for a scalebar using the specified ``settings`` and ``scaleContext``.
 
@@ -158,7 +158,7 @@ Draws default scalebar labels using the specified ``settings`` and ``scaleContex
 Returns the text used for the first label in the scalebar.
 %End
 
- double firstLabelXOffset( const QgsScaleBarSettings &settings ) const /Deprecated/;
+ double firstLabelXOffset( const QgsScaleBarSettings &settings ) const /Deprecated="Since 3.40. Use the version with QgsRenderContext instead."/;
 %Docstring
 Returns the x-offset (in millimeters) used for the first label in the scalebar.
 
@@ -174,7 +174,7 @@ Returns the x-offset (in render context painter units) used for the first label 
 .. versionadded:: 3.2
 %End
 
- QList<double> segmentPositions( const QgsScaleBarRenderer::ScaleBarContext &scaleContext, const QgsScaleBarSettings &settings ) const /Deprecated/;
+ QList<double> segmentPositions( const QgsScaleBarRenderer::ScaleBarContext &scaleContext, const QgsScaleBarSettings &settings ) const /Deprecated="Since 3.40. Use the version with a QgsRenderContext instead."/;
 %Docstring
 Returns a list of positions for each segment within the scalebar.
 

--- a/python/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
+++ b/python/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
@@ -259,7 +259,7 @@ Sets the text ``format`` used for drawing text in the scalebar.
 .. versionadded:: 3.2
 %End
 
- QFont font() const /Deprecated/;
+ QFont font() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the font used for drawing text in the scalebar.
 
@@ -270,7 +270,7 @@ Returns the font used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.textFormat` instead.
 %End
 
- void setFont( const QFont &font ) /Deprecated/;
+ void setFont( const QFont &font ) /Deprecated="Since 3.40. Use setTextFormat() instead."/;
 %Docstring
 Sets the ``font`` used for drawing text in the scalebar.
 
@@ -281,7 +281,7 @@ Sets the ``font`` used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setTextFormat` instead.
 %End
 
- QColor fontColor() const /Deprecated/;
+ QColor fontColor() const /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Returns the color used for drawing text in the scalebar.
 
@@ -294,7 +294,7 @@ Returns the color used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.textFormat` instead.
 %End
 
- void setFontColor( const QColor &color ) /Deprecated/;
+ void setFontColor( const QColor &color ) /Deprecated="Since 3.40. Use textFormat() instead."/;
 %Docstring
 Sets the ``color`` used for drawing text in the scalebar.
 
@@ -307,7 +307,7 @@ Sets the ``color`` used for drawing text in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.textFormat` instead.
 %End
 
- QColor fillColor() const /Deprecated/;
+ QColor fillColor() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the color used for fills in the scalebar.
 
@@ -320,7 +320,7 @@ Returns the color used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.fillSymbol` instead.
 %End
 
- void setFillColor( const QColor &color ) /Deprecated/;
+ void setFillColor( const QColor &color ) /Deprecated="Since 3.40. Use setFillSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for fills in the scalebar.
 
@@ -333,7 +333,7 @@ Sets the ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setFillSymbol` instead.
 %End
 
- QColor fillColor2() const /Deprecated/;
+ QColor fillColor2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary color used for fills in the scalebar.
 
@@ -346,7 +346,7 @@ Returns the secondary color used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.alternateFillSymbol` instead.
 %End
 
- void setFillColor2( const QColor &color ) /Deprecated/;
+ void setFillColor2( const QColor &color ) /Deprecated="Since 3.40. Use setAlternateFillSymbol() instead."/;
 %Docstring
 Sets the secondary ``color`` used for fills in the scalebar.
 
@@ -359,7 +359,7 @@ Sets the secondary ``color`` used for fills in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setAlternateFillSymbol` instead.
 %End
 
- QColor lineColor() const /Deprecated/;
+ QColor lineColor() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the color used for lines in the scalebar.
 
@@ -370,7 +370,7 @@ Returns the color used for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineColor( const QColor &color ) /Deprecated/;
+ void setLineColor( const QColor &color ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the ``color`` used for lines in the scalebar.
 
@@ -381,7 +381,7 @@ Sets the ``color`` used for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setLineSymbol` instead.
 %End
 
- double lineWidth() const /Deprecated/;
+ double lineWidth() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the line width in millimeters for lines in the scalebar.
 
@@ -392,7 +392,7 @@ Returns the line width in millimeters for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineWidth( double width ) /Deprecated/;
+ void setLineWidth( double width ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the line ``width`` in millimeters for lines in the scalebar.
 
@@ -403,7 +403,7 @@ Sets the line ``width`` in millimeters for lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setLineSymbol` instead.
 %End
 
- QPen pen() const /Deprecated/;
+ QPen pen() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the pen used for drawing outlines in the scalebar.
 
@@ -416,7 +416,7 @@ Returns the pen used for drawing outlines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setPen( const QPen &pen ) /Deprecated/;
+ void setPen( const QPen &pen ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the pen used for drawing outlines in the scalebar.
 
@@ -565,7 +565,7 @@ transferred to the scalebar.
 .. versionadded:: 3.14
 %End
 
- QBrush brush() const /Deprecated/;
+ QBrush brush() const /Deprecated="Since 3.40. Use fillSymbol() instead."/;
 %Docstring
 Returns the primary brush used for filling the scalebar.
 
@@ -580,7 +580,7 @@ Returns the primary brush used for filling the scalebar.
    Use :py:func:`~QgsScaleBarSettings.fillSymbol` instead.
 %End
 
- void setBrush( const QBrush &brush ) /Deprecated/;
+ void setBrush( const QBrush &brush ) /Deprecated="Since 3.40. Use setFillSymbol() instead."/;
 %Docstring
 Sets the primary brush used for filling the scalebar.
 
@@ -591,7 +591,7 @@ Sets the primary brush used for filling the scalebar.
    Use :py:func:`~QgsScaleBarSettings.setFillSymbol` instead.
 %End
 
- QBrush brush2() const /Deprecated/;
+ QBrush brush2() const /Deprecated="Since 3.40. Use alternateFillSymbol() instead."/;
 %Docstring
 Returns the secondary brush for the scalebar. This is used for alternating color style scalebars, such
 as single and double box styles.
@@ -605,7 +605,7 @@ as single and double box styles.
    Use :py:func:`~QgsScaleBarSettings.alternateFillSymbol` instead.
 %End
 
- void setBrush2( const QBrush &brush ) /Deprecated/;
+ void setBrush2( const QBrush &brush ) /Deprecated="Since 3.40. Use setAlternateFillSymbol() instead."/;
 %Docstring
 Sets the secondary brush used for filling the scalebar.
 
@@ -708,7 +708,7 @@ Sets the scalebar ``alignment``.
 .. seealso:: :py:func:`alignment`
 %End
 
- Qt::PenJoinStyle lineJoinStyle() const /Deprecated/;
+ Qt::PenJoinStyle lineJoinStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the join style used for drawing lines in the scalebar.
 
@@ -719,7 +719,7 @@ Returns the join style used for drawing lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated/;
+ void setLineJoinStyle( Qt::PenJoinStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the join ``style`` used when drawing the lines in the scalebar
 
@@ -730,7 +730,7 @@ Sets the join ``style`` used when drawing the lines in the scalebar
    Use :py:func:`~QgsScaleBarSettings.setLineSymbol` instead.
 %End
 
- Qt::PenCapStyle lineCapStyle() const /Deprecated/;
+ Qt::PenCapStyle lineCapStyle() const /Deprecated="Since 3.40. Use lineSymbol() instead."/;
 %Docstring
 Returns the cap style used for drawing lines in the scalebar.
 
@@ -741,7 +741,7 @@ Returns the cap style used for drawing lines in the scalebar.
    Use :py:func:`~QgsScaleBarSettings.lineSymbol` instead.
 %End
 
- void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated/;
+ void setLineCapStyle( Qt::PenCapStyle style ) /Deprecated="Since 3.40. Use setLineSymbol() instead."/;
 %Docstring
 Sets the cap ``style`` used when drawing the lines in the scalebar.
 

--- a/python/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -246,7 +246,7 @@ Returns settings value.
 .. versionadded:: 3.26
 %End
 
- QVariant valueAsVariant( const QString &dynamicKeyPart, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated/;
+ QVariant valueAsVariant( const QString &dynamicKeyPart, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated="Since 3.26. Use valueAsVariantWithDefaultOverride() instead."/;
 %Docstring
 Returns settings value with an optional default value override
 
@@ -255,7 +255,7 @@ Returns settings value with an optional default value override
    Use :py:func:`~QgsSettingsEntryBase.valueAsVariantWithDefaultOverride` instead.
 %End
 
- QVariant valueAsVariant( const QStringList &dynamicKeyPartList, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated/;
+ QVariant valueAsVariant( const QStringList &dynamicKeyPartList, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const /Deprecated="Since 3.26. Use valueAsVariantWithDefaultOverride() instead."/;
 %Docstring
 Returns settings value with an optional default value override
 

--- a/python/core/auto_generated/settings/qgssettingsentrygroup.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentrygroup.sip.in
@@ -11,7 +11,7 @@
 
 
 
-class QgsSettingsEntryGroup /Deprecated/
+class QgsSettingsEntryGroup /Deprecated="Since 3.30. Use QgsSettingsTreeNode instead."/
 {
 %Docstring(signature="appended")
 Creates a group of setting which have a common definition of base key

--- a/python/core/auto_generated/settings/qgssettingsregistry.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsregistry.sip.in
@@ -66,7 +66,7 @@ Returns the list of registered child QgsSettingsRegistry.
 Adds ``settingsEntry`` to the registry.
 %End
 
- void addSettingsEntryGroup( const QgsSettingsEntryGroup *settingsGroup ) /Deprecated/;
+ void addSettingsEntryGroup( const QgsSettingsEntryGroup *settingsGroup ) /Deprecated="Since 3.30. "/;
 %Docstring
 Adds a group of setting to the registry
 

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -479,7 +479,7 @@ output.
 hashtable for faster access to symbols
 %End
 
- QgsSymbol *skipRender() /Deprecated/;
+ QgsSymbol *skipRender() /Deprecated="Since 3.40. No longer used, will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -487,7 +487,7 @@ hashtable for faster access to symbols
    No longer used, will be removed in QGIS 4.0.
 %End
 
- QgsSymbol *symbolForValue( const QVariant &value ) const /Deprecated/;
+ QgsSymbol *symbolForValue( const QVariant &value ) const /Deprecated="Since 3.40. Use variant which takes a second bool argument instead."/;
 %Docstring
 Returns the matching symbol corresponding to an attribute ``value``.
 

--- a/python/core/auto_generated/symbology/qgscptcityarchive.sip.in
+++ b/python/core/auto_generated/symbology/qgscptcityarchive.sip.in
@@ -129,7 +129,7 @@ Removes a ``child`` item but doesn't delete it, signals to browser are emitted.
 Returns ``True`` if this item is equal to an ``other`` item.
 %End
 
- virtual QWidget *paramWidget() /Deprecated/;
+ virtual QWidget *paramWidget() /Deprecated="Since 3.40. Is unused and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -137,7 +137,7 @@ Returns ``True`` if this item is equal to an ``other`` item.
    Is unused and will be removed in QGIS 4.0.
 %End
 
- virtual bool acceptDrop() /Deprecated/;
+ virtual bool acceptDrop() /Deprecated="Since 3.40. Is unused and will be removed in QGIS 4.0."/;
 %Docstring
 Returns ``True`` if the item accepts drag & dropped layers - e.g. for import.
 
@@ -146,7 +146,7 @@ Returns ``True`` if the item accepts drag & dropped layers - e.g. for import.
    Is unused and will be removed in QGIS 4.0.
 %End
 
- virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) /Deprecated/;
+ virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) /Deprecated="Since 3.40. Is unused and will be removed in QGIS 4.0."/;
 %Docstring
 Tries to process the ``data`` dropped on this item.
 

--- a/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -86,7 +86,7 @@ Creates the symbol layer
     virtual bool writeDxf( QgsDxfExport &e, double mmMapUnitScaleFactor, const QString &layerName, QgsSymbolRenderContext &context, QPointF shift = QPointF( 0.0, 0.0 ) ) const;
 
 
- void setSymbolName( const QString &name ) /Deprecated/;
+ void setSymbolName( const QString &name ) /Deprecated="Since 3.20. "/;
 %Docstring
 Sets the rendered ellipse marker shape using a symbol ``name``.
 
@@ -97,7 +97,7 @@ Sets the rendered ellipse marker shape using a symbol ``name``.
 .. deprecated:: 3.20
 %End
 
- QString symbolName() const /Deprecated/;
+ QString symbolName() const /Deprecated="Since 3.20. "/;
 %Docstring
 Returns the shape name for the rendered ellipse marker symbol.
 

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -1138,7 +1138,7 @@ If the height is 0 then the height will be calculated automatically based on the
 .. versionadded:: 3.36
 %End
 
- void setWidthUnit( Qgis::RenderUnit unit ) /Deprecated/;
+ void setWidthUnit( Qgis::RenderUnit unit ) /Deprecated="Since 3.40. Use setSizeUnit() instead."/;
 %Docstring
 Sets the ``unit`` for the image's width.
 
@@ -1166,7 +1166,7 @@ Sets the ``unit`` for the image's width and height.
 .. versionadded:: 3.36
 %End
 
- Qgis::RenderUnit widthUnit() const /Deprecated/;
+ Qgis::RenderUnit widthUnit() const /Deprecated="Since 3.40. Use sizeUnit() instead."/;
 %Docstring
 Returns the units for the image's width.
 
@@ -1196,7 +1196,7 @@ Returns the units for the image's width and height.
 .. versionadded:: 3.36
 %End
 
- void setWidthMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated/;
+ void setWidthMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated="Since 3.40. Use setSizeMapUnitScale() instead."/;
 %Docstring
 Sets the map unit ``scale`` for the image's width.
 
@@ -1226,7 +1226,7 @@ Sets the map unit ``scale`` for the image's width and height.
 .. versionadded:: 3.36
 %End
 
- const QgsMapUnitScale &widthMapUnitScale() const /Deprecated/;
+ const QgsMapUnitScale &widthMapUnitScale() const /Deprecated="Since 3.40. Use sizeMapUnitScale() instead."/;
 %Docstring
 Returns the map unit scale for the image's width.
 

--- a/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -151,14 +151,14 @@ This will take ownership of the method
     };
 
 
- Mode mode() const /Deprecated/;
+ Mode mode() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 
 .. deprecated:: 3.10
 
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
- void setMode( Mode mode ) /Deprecated/;
+ void setMode( Mode mode ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 
 .. deprecated:: 3.10
@@ -166,7 +166,7 @@ This will take ownership of the method
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- bool useSymmetricMode() const /Deprecated/;
+ bool useSymmetricMode() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Returns if we want to classify symmetric around a given value
 
@@ -177,7 +177,7 @@ Returns if we want to classify symmetric around a given value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
-  void setUseSymmetricMode( bool useSymmetricMode ) /Deprecated/;
+  void setUseSymmetricMode( bool useSymmetricMode ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Set if we want to classify symmetric around a given value
 
@@ -188,7 +188,7 @@ Set if we want to classify symmetric around a given value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- double symmetryPoint() const /Deprecated/;
+ double symmetryPoint() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Returns the pivot value for symmetric classification
 
@@ -199,7 +199,7 @@ Returns the pivot value for symmetric classification
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- void setSymmetryPoint( double symmetryPoint ) /Deprecated/;
+ void setSymmetryPoint( double symmetryPoint ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Set the pivot point
 
@@ -211,7 +211,7 @@ Set the pivot point
 %End
 
 
- bool astride() const /Deprecated/;
+ bool astride() const /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Returns if we want to have a central class astride the pivot value
 
@@ -222,7 +222,7 @@ Returns if we want to have a central class astride the pivot value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- void setAstride( bool astride ) /Deprecated/;
+ void setAstride( bool astride ) /Deprecated="Since 3.10. Use classficationMethod() instead."/;
 %Docstring
 Set if we want a central class astride the pivot value
 
@@ -233,7 +233,7 @@ Set if we want a central class astride the pivot value
    Use :py:func:`~QgsGraduatedSymbolRenderer.classficationMethod` instead.
 %End
 
- static void makeBreaksSymmetric( QList<double> &breaks /In,Out/, double symmetryPoint, bool astride ) /Deprecated/;
+ static void makeBreaksSymmetric( QList<double> &breaks /In,Out/, double symmetryPoint, bool astride ) /Deprecated="Since 3.10. Use QgsClassificationMethod.makeBreaksSymmetric instead."/;
 %Docstring
 Remove the breaks that are above the existing opposite sign classes to keep colors symmetrically balanced around symmetryPoint
 Does not put a break on the symmetryPoint. This is done before.
@@ -249,7 +249,7 @@ Does not put a break on the symmetryPoint. This is done before.
    Use :py:class:`QgsClassificationMethod`.makeBreaksSymmetric instead.
 %End
 
- static QList<double> calcEqualIntervalBreaks( double minimum, double maximum, int classes, bool useSymmetricMode, double symmetryPoint, bool astride ) /Deprecated/;
+ static QList<double> calcEqualIntervalBreaks( double minimum, double maximum, int classes, bool useSymmetricMode, double symmetryPoint, bool astride ) /Deprecated="Since 3.10. Use QgsClassificationEqualInterval class instead."/;
 %Docstring
 Compute the equal interval classification
 
@@ -265,7 +265,7 @@ Compute the equal interval classification
    Use :py:class:`QgsClassificationEqualInterval` class instead.
 %End
 
- void updateClasses( QgsVectorLayer *vlayer, Mode mode, int nclasses, bool useSymmetricMode = false, double symmetryPoint = 0.0, bool astride = false ) /Deprecated/;
+ void updateClasses( QgsVectorLayer *vlayer, Mode mode, int nclasses, bool useSymmetricMode = false, double symmetryPoint = 0.0, bool astride = false ) /Deprecated="Since 3.10. "/;
 %Docstring
 Recalculate classes for a layer
 
@@ -290,7 +290,7 @@ Recalculate classes for a layer
 %End
 
 
- QgsRendererRangeLabelFormat labelFormat() const /Deprecated/;
+ QgsRendererRangeLabelFormat labelFormat() const /Deprecated="Since 3.10. Use classificationMethod() and QgsClassificationMethod.setLabelFormat instead."/;
 %Docstring
 Returns the label format used to generate default classification labels
 
@@ -299,7 +299,7 @@ Returns the label format used to generate default classification labels
    Use :py:func:`~QgsGraduatedSymbolRenderer.classificationMethod` and :py:class:`QgsClassificationMethod`.setLabelFormat instead.
 %End
 
- void setLabelFormat( const QgsRendererRangeLabelFormat &labelFormat, bool updateRanges = false ) /Deprecated/;
+ void setLabelFormat( const QgsRendererRangeLabelFormat &labelFormat, bool updateRanges = false ) /Deprecated="Since 3.10. Use classificationMethod() and QgsClassificationMethod.setLabelFormat instead."/;
 %Docstring
 Set the label format used to generate default classification labels
 
@@ -330,7 +330,7 @@ Reset the label decimal places to a numberbased on the minimum class interval
         bool useSymmetricMode = false,
         double symmetryPoint = 0.0,
         const QStringList &listForCboPrettyBreaks = QStringList(),
-        bool astride = false ) /Deprecated/;
+        bool astride = false ) /Deprecated="Since 3.10. "/;
 %Docstring
 Creates a new graduated renderer.
 

--- a/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -340,7 +340,7 @@ Creates the symbol layer
     virtual bool canCauseArtifactsBetweenAdjacentTiles() const;
 
 
- void setExpressionsStringForWidth( const QString &start, const QString &end ) /Deprecated/;
+ void setExpressionsStringForWidth( const QString &start, const QString &end ) /Deprecated="Since 3.40. Use setDataDefinedProperty( QgsSymbolLayer.PropertyLineStartWidthValue ) and setDataDefinedProperty( QgsSymbolLayer.PropertyLineEndWidthValue ) instead."/;
 %Docstring
 Sets the expressions (as string) that define the extremety values af the line feature for width.
 
@@ -349,7 +349,7 @@ Sets the expressions (as string) that define the extremety values af the line fe
    Use setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartWidthValue ) and setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineEndWidthValue ) instead.
 %End
 
- QString startValueExpressionForWidth() const /Deprecated/;
+ QString startValueExpressionForWidth() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineStartWidthValue ) instead."/;
 %Docstring
 Returns the epression related to the start extremity value for width.
 
@@ -358,7 +358,7 @@ Returns the epression related to the start extremity value for width.
    Use dataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartWidthValue ) instead.
 %End
 
- QString endValueExpressionForWidth() const /Deprecated/;
+ QString endValueExpressionForWidth() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineEndWidthValue ) instead."/;
 %Docstring
 Returns the expression related to the end extremity value for width.
 
@@ -396,7 +396,7 @@ Returns the interpolated width used to render the width of lines, see ``:py:clas
 .. seealso:: :py:func:`setInterpolatedWidth`
 %End
 
- void setExpressionsStringForColor( const QString &start, const QString &end ) /Deprecated/;
+ void setExpressionsStringForColor( const QString &start, const QString &end ) /Deprecated="Since 3.40. Use setDataDefinedProperty( QgsSymbolLayer.PropertyLineStartColorValue ) and setDataDefinedProperty( QgsSymbolLayer.PropertyLineEndColorValue ) instead."/;
 %Docstring
 Sets the expressions (as string) that define the extremety values af the line feature for color.
 
@@ -405,7 +405,7 @@ Sets the expressions (as string) that define the extremety values af the line fe
    Use setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartColorValue ) and setDataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineEndColorValue ) instead.
 %End
 
- QString startValueExpressionForColor() const /Deprecated/;
+ QString startValueExpressionForColor() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineStartColorValue ) instead."/;
 %Docstring
 Returns the epression related to the start extremity value for width for color
 
@@ -414,7 +414,7 @@ Returns the epression related to the start extremity value for width for color
    Use dataDefinedProperty( :py:class:`QgsSymbolLayer`.PropertyLineStartColorValue ) instead.
 %End
 
- QString endValueExpressionForColor() const /Deprecated/;
+ QString endValueExpressionForColor() const /Deprecated="Since 3.40. Use dataDefinedProperty( QgsSymbolLayer.PropertyLineEndColorValue ) instead."/;
 %Docstring
 Returns the expression related to the end extremity value for width for color
 

--- a/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -678,7 +678,7 @@ Returns the map unit scale for the interval between symbols.
 .. seealso:: :py:func:`interval`
 %End
 
- Qgis::MarkerLinePlacement placement() const /Deprecated/;
+ Qgis::MarkerLinePlacement placement() const /Deprecated="Since 3.40. Use placements() instead."/;
 %Docstring
 Returns the placement of the symbols.
 
@@ -689,7 +689,7 @@ Returns the placement of the symbols.
    Use :py:func:`~QgsTemplatedLineSymbolLayerBase.placements` instead.
 %End
 
- void setPlacement( Qgis::MarkerLinePlacement placement ) /Deprecated/;
+ void setPlacement( Qgis::MarkerLinePlacement placement ) /Deprecated="Since 3.40. Use setPlacements() instead."/;
 %Docstring
 Sets the ``placement`` of the symbols.
 
@@ -1041,7 +1041,7 @@ Creates a new QgsMarkerLineSymbolLayer from an SLD XML DOM ``element``.
     virtual void setDataDefinedProperty( QgsSymbolLayer::Property key, const QgsProperty &property );
 
 
- bool rotateMarker() const /Deprecated/;
+ bool rotateMarker() const /Deprecated="Since 3.40. Use rotateSymbols() instead."/;
 %Docstring
 Shall the marker be rotated.
 
@@ -1052,7 +1052,7 @@ Shall the marker be rotated.
    Use :py:func:`~QgsMarkerLineSymbolLayer.rotateSymbols` instead.
 %End
 
- void setRotateMarker( bool rotate ) /Deprecated/;
+ void setRotateMarker( bool rotate ) /Deprecated="Since 3.40. Use setRotateSymbols() instead."/;
 %Docstring
 Shall the marker be rotated.
 

--- a/python/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -183,7 +183,7 @@ Creates a DOM element representing the range in SLD format.
 typedef QList<QgsRendererRange> QgsRangeList;
 
 
-class QgsRendererRangeLabelFormat /Deprecated/
+class QgsRendererRangeLabelFormat /Deprecated="Since 3.10. Use QgsClassificationMethod instead."/
 {
 %Docstring(signature="appended")
 

--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -857,7 +857,7 @@ This function will load an on-disk database and populate styles.
 .. seealso:: :py:func:`errorString`
 %End
 
- bool save( const QString &filename = QString() ) /Deprecated/;
+ bool save( const QString &filename = QString() ) /Deprecated="Since 3.40. This function has no effect."/;
 %Docstring
 Saves style into a file.
 

--- a/python/core/auto_generated/symbology/qgssvgcache.sip.in
+++ b/python/core/auto_generated/symbology/qgssvgcache.sip.in
@@ -212,7 +212,7 @@ in the same thread to ensure provided the image.
 
   signals:
 
- void statusChanged( const QString  &statusQString ) /Deprecated/;
+ void statusChanged( const QString  &statusQString ) /Deprecated="Since 3.6. No longer emitted."/;
 %Docstring
 Emit a signal to be caught by qgisapp and display a msg on status bar.
 

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -530,7 +530,7 @@ Returns a large (roughly 100x100 pixel) preview image for the symbol.
 .. seealso:: :py:func:`drawPreviewIcon`
 %End
 
- QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, int flags = static_cast< int >( Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) ) /Deprecated/;
+ QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, int flags = static_cast< int >( Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) ) /Deprecated="Since 3.40. Use bigSymbolPreviewImageV2() instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -807,7 +807,7 @@ and returns ``True`` if any of the layers returned ``True``.
 .. versionadded:: 3.18
 %End
 
- void setLayer( const QgsVectorLayer *layer ) /Deprecated/;
+ void setLayer( const QgsVectorLayer *layer ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. note::
@@ -819,7 +819,7 @@ and returns ``True`` if any of the layers returned ``True``.
    Will be removed in QGIS 4.0.
 %End
 
- const QgsVectorLayer *layer() const /Deprecated/;
+ const QgsVectorLayer *layer() const /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/core/auto_generated/symbology/qgssymbollayerreference.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerreference.sip.in
@@ -105,7 +105,7 @@ Type used to refer to a specific symbol layer in a symbol of a layer.
 
     QgsSymbolLayerReference();
 
- QgsSymbolLayerReference( const QString &layerId, const QgsSymbolLayerId &symbolLayer ) /Deprecated/;
+ QgsSymbolLayerReference( const QString &layerId, const QgsSymbolLayerId &symbolLayer ) /Deprecated="Since 3.30. "/;
 %Docstring
 Constructor
 
@@ -130,7 +130,7 @@ Constructor
 The referenced vector layer / feature renderer
 %End
 
- QgsSymbolLayerId symbolLayerId() const /Deprecated/;
+ QgsSymbolLayerId symbolLayerId() const /Deprecated="Since 3.30. Use symbolLayerIdV2() instead."/;
 %Docstring
 The symbol layer's id
 

--- a/python/core/auto_generated/symbology/qgssymbolrendercontext.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbolrendercontext.sip.in
@@ -49,7 +49,7 @@ Sets the original value variable value for data defined symbology
               before any data defined overrides have been applied.
 %End
 
- Qgis::RenderUnit outputUnit() const /Deprecated/;
+ Qgis::RenderUnit outputUnit() const /Deprecated="Since 3.40. No longer used and will be removed in QGIS 4.0."/;
 %Docstring
 Returns the output unit for the context.
 
@@ -58,7 +58,7 @@ Returns the output unit for the context.
    No longer used and will be removed in QGIS 4.0.
 %End
 
- void setOutputUnit( Qgis::RenderUnit u ) /Deprecated/;
+ void setOutputUnit( Qgis::RenderUnit u ) /Deprecated="Since 3.40. No longer used and will be removed in QGIS 4.0."/;
 %Docstring
 Sets the output unit for the context.
 
@@ -67,7 +67,7 @@ Sets the output unit for the context.
    No longer used and will be removed in QGIS 4.0.
 %End
 
- QgsMapUnitScale mapUnitScale() const /Deprecated/;
+ QgsMapUnitScale mapUnitScale() const /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -75,7 +75,7 @@ Sets the output unit for the context.
    Will be removed in QGIS 4.0.
 %End
 
- void setMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated/;
+ void setMapUnitScale( const QgsMapUnitScale &scale ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -197,7 +197,7 @@ Part number of current geometry
 Sets the part number of current geometry
 %End
 
- double outputLineWidth( double width ) const /Deprecated/;
+ double outputLineWidth( double width ) const /Deprecated="Since 3.40. Use the size conversion methods in QgsRenderContext instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -205,7 +205,7 @@ Sets the part number of current geometry
    Use the size conversion methods in :py:class:`QgsRenderContext` instead.
 %End
 
- double outputPixelSize( double size ) const /Deprecated/;
+ double outputPixelSize( double size ) const /Deprecated="Since 3.40. Use the size conversion methods in QgsRenderContext instead."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/core/auto_generated/textrenderer/qgsfontmanager.sip.in
+++ b/python/core/auto_generated/textrenderer/qgsfontmanager.sip.in
@@ -209,7 +209,7 @@ Enables font downloads the the current QGIS session.
    Ensure that the :py:class:`QgsApplication` is fully initialized before calling this method.
 %End
 
- QString urlForFontDownload( const QString &family, QString &matchedFamily /Out/ ) const /Deprecated/;
+ QString urlForFontDownload( const QString &family, QString &matchedFamily /Out/ ) const /Deprecated="Since 3.38. Use detailsForFontDownload() instead."/;
 %Docstring
 Returns the URL at which the font ``family`` can be downloaded.
 
@@ -244,7 +244,7 @@ return an invalid :py:class:`QgsFontDownloadDetails` for any font families not p
 .. versionadded:: 3.38
 %End
 
- void downloadAndInstallFont( const QUrl &url, const QString &identifier = QString() ) /Deprecated/;
+ void downloadAndInstallFont( const QUrl &url, const QString &identifier = QString() ) /Deprecated="Since 3.38. Use the version which takes a QgsFontDownloadDetails argument instead."/;
 %Docstring
 Downloads a font and installs in the user's profile/fonts directory as an application font,
 where the font family can be downloaded via a single ``url``.

--- a/python/core/auto_generated/textrenderer/qgstextrenderer.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextrenderer.sip.in
@@ -200,7 +200,7 @@ Draws a text document along a line using the specified settings.
 
  static void drawPart( const QRectF &rect, double rotation, Qgis::TextHorizontalAlignment alignment, const QStringList &textLines,
                                             QgsRenderContext &context, const QgsTextFormat &format,
-                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated/;
+                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated="Since 3.40. Private API only, will be removed in 4.0."/;
 %Docstring
 Draws a single component of rendered text using the specified settings.
 
@@ -225,7 +225,7 @@ Draws a single component of rendered text using the specified settings.
 
  static void drawPart( QPointF origin, double rotation, Qgis::TextHorizontalAlignment alignment, const QStringList &textLines,
                                             QgsRenderContext &context, const QgsTextFormat &format,
-                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated/;
+                                            Qgis::TextComponent part, bool drawAsOutlines = true ) /Deprecated="Since 3.40. Private API only, will be removed in 4.0."/;
 %Docstring
 Draws a single component of rendered text using the specified settings.
 

--- a/python/core/auto_generated/vector/qgsfielddomain.sip.in
+++ b/python/core/auto_generated/vector/qgsfielddomain.sip.in
@@ -51,7 +51,7 @@ Constructor for QgsFieldDomain, with the specified ``name``, ``description`` and
 
  QgsFieldDomain( const QString &name,
                                       const QString &description,
-                                      QVariant::Type fieldType ) /Deprecated/;
+                                      QVariant::Type fieldType ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsFieldDomain, with the specified ``name``, ``description`` and ``fieldType``.
 
@@ -119,7 +119,7 @@ Sets the associated field ``type``.
 .. seealso:: :py:func:`fieldType`
 %End
 
- void setFieldType( QVariant::Type type ) /Deprecated/;
+ void setFieldType( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Sets the associated field ``type``.
 
@@ -240,7 +240,7 @@ appear only once, but it is the responsibility of the user to check this.
  QgsCodedFieldDomain( const QString &name,
                                            const QString &description,
                                            QVariant::Type fieldType,
-                                           const QList<QgsCodedValue> &values ) /Deprecated/;
+                                           const QList<QgsCodedValue> &values ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsCodedFieldDomain, with the associated ``name``, ``description`` and ``fieldType``.
 
@@ -317,7 +317,7 @@ Set an invalid QVariant for ``minimum`` or ``maximum`` respectively if no minimu
                                            const QVariant &minimum,
                                            bool minimumIsInclusive,
                                            const QVariant &maximum,
-                                           bool maximumIsInclusive ) /Deprecated/;
+                                           bool maximumIsInclusive ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsRangeFieldDomain, with the specified ``name``, ``description`` and ``fieldType``.
 
@@ -460,7 +460,7 @@ The ``glob`` argument specifies the content validation glob, e.g. ``*[a-z][0-1]?
  QgsGlobFieldDomain( const QString &name,
                                           const QString &description,
                                           QVariant::Type fieldType,
-                                          const QString &glob ) /Deprecated/;
+                                          const QString &glob ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsGlobFieldDomain, with the specified ``name``, ``description`` and ``fieldType``.
 

--- a/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -449,7 +449,7 @@ Returns the name of the column storing geometry, if applicable.
 .. versionadded:: 3.42
 %End
 
- QgsAttrPalIndexNameHash palAttributeIndexNames() const /Deprecated/;
+ QgsAttrPalIndexNameHash palAttributeIndexNames() const /Deprecated="Since 3.32. This method is unused and will always return an empty hash."/;
 %Docstring
 Returns list of indexes to names for :py:class:`QgsPalLabeling` fix
 
@@ -550,7 +550,7 @@ providers will return ``None``.
 Convert ``value`` to ``type``
 %End
 
- static QVariant convertValue( QVariant::Type type, const QString &value ) /Deprecated/;
+ static QVariant convertValue( QVariant::Type type, const QString &value ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Convert ``value`` to ``type``
 
@@ -564,7 +564,7 @@ Convert ``value`` to ``type``
 Returns the transaction this data provider is included in, if any.
 %End
 
- virtual void forceReload() /Deprecated/;
+ virtual void forceReload() /Deprecated="Since 3.12. Will be removed in QGIS 4.0 - use reloadData() instead."/;
 %Docstring
 
 .. deprecated:: 3.12

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1185,7 +1185,7 @@ Deletes the selected features
 :return: ``True`` in case of success and ``False`` otherwise
 %End
 
- Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, QgsFeatureId *featureId = 0 ) /Deprecated/;
+ Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, QgsFeatureId *featureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a ring to polygon/multipolygon features
 
@@ -1269,7 +1269,7 @@ Adds a ring to polygon/multipolygon features (takes ownership)
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- Qgis::GeometryOperationResult addPart( const QList<QgsPointXY> &ring ) /Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QList<QgsPointXY> &ring ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a new part polygon to a multipart feature
 
@@ -1297,7 +1297,7 @@ Adds a new part polygon to a multipart feature
 %End
 
 
- Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring ) /PyName=addPartV2,Deprecated/;
+ Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring ) /PyName=addPartV2,Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a new part polygon to a multipart feature
 
@@ -1388,7 +1388,7 @@ Translates feature by dx, dy
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+ Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits parts cut by the given line
 
@@ -1442,7 +1442,7 @@ Splits parts cut by the given line
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+ Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits features cut by the given line
 
@@ -1552,7 +1552,7 @@ Adds topological points for every vertex of the geometry.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
- int addTopologicalPoints( const QgsPointXY &p )  /Deprecated/;
+ int addTopologicalPoints( const QgsPointXY &p )  /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a vertex to segments which intersect point ``p`` but don't
 already have a vertex there. If a feature already has a vertex at position ``p``,
@@ -1953,7 +1953,7 @@ Sets a duplicate ``policy`` for the field with the specified index.
     }
 %End
 
- QSet<QString> excludeAttributesWms() const /Deprecated/;
+ QSet<QString> excludeAttributesWms() const /Deprecated="Since 3.16. Use fields().configurationFlags() instead."/;
 %Docstring
 A set of attributes that are not advertised in WMS requests with QGIS server.
 
@@ -1962,7 +1962,7 @@ A set of attributes that are not advertised in WMS requests with QGIS server.
    Use :py:func:`~QgsVectorLayer.fields`.configurationFlags() instead.
 %End
 
- void setExcludeAttributesWms( const QSet<QString> &att ) /Deprecated/;
+ void setExcludeAttributesWms( const QSet<QString> &att ) /Deprecated="Since 3.16. Use setFieldConfigurationFlag() instead."/;
 %Docstring
 A set of attributes that are not advertised in WMS requests with QGIS server.
 
@@ -1971,7 +1971,7 @@ A set of attributes that are not advertised in WMS requests with QGIS server.
    Use :py:func:`~QgsVectorLayer.setFieldConfigurationFlag` instead.
 %End
 
- QSet<QString> excludeAttributesWfs() const /Deprecated/;
+ QSet<QString> excludeAttributesWfs() const /Deprecated="Since 3.16. Use fields().configurationFlags() instead."/;
 %Docstring
 A set of attributes that are not advertised in WFS requests with QGIS server.
 
@@ -1980,7 +1980,7 @@ A set of attributes that are not advertised in WFS requests with QGIS server.
    Use :py:func:`~QgsVectorLayer.fields`.configurationFlags() instead.
 %End
 
- void setExcludeAttributesWfs( const QSet<QString> &att ) /Deprecated/;
+ void setExcludeAttributesWfs( const QSet<QString> &att ) /Deprecated="Since 3.16. Use setFieldConfigurationFlag() instead."/;
 %Docstring
 A set of attributes that are not advertised in WFS requests with QGIS server.
 

--- a/python/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -61,7 +61,7 @@ Deletes a vertex from a feature.
 :param vertex: index of vertex to delete
 %End
 
- Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated/;
+ Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a ring to polygon/multipolygon features
 
@@ -119,7 +119,7 @@ Adds a ring to polygon/multipolygon features
    available in python bindings as addCurvedRing
 %End
 
-  Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring, QgsFeatureId featureId ) /Deprecated/;
+  Qgis::GeometryOperationResult addPart( const QVector<QgsPointXY> &ring, QgsFeatureId featureId ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a new part polygon to a multipart feature
 
@@ -178,7 +178,7 @@ Translates feature by dx, dy
 :return: 0 in case of success
 %End
 
-  Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+  Qgis::GeometryOperationResult splitParts( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits parts cut by the given line
 
@@ -216,7 +216,7 @@ Splits parts cut by the given line
          - :py:class:`QgsGeometry`.SplitCannotSplitPoint
 %End
 
-  Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated/;
+  Qgis::GeometryOperationResult splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing = false ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Splits features cut by the given line
 

--- a/python/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerjoininfo.sip.in
@@ -146,7 +146,7 @@ join layer information.
 :return: the corresponding joined feature
 %End
 
- void setJoinFieldNamesBlackList( const QStringList &blackList ) /Deprecated/;
+ void setJoinFieldNamesBlackList( const QStringList &blackList ) /Deprecated="Since 3.40. Use setJoinFieldNamesBlockList() instead."/;
 %Docstring
 Sets a list of fields to ignore whatever happens.
 
@@ -155,7 +155,7 @@ Sets a list of fields to ignore whatever happens.
    Use :py:func:`~QgsVectorLayerJoinInfo.setJoinFieldNamesBlockList` instead.
 %End
 
- QStringList joinFieldNamesBlackList() const /Deprecated/;
+ QStringList joinFieldNamesBlackList() const /Deprecated="Since 3.40. Use joinFieldNamesBlockList() instead."/;
 %Docstring
 Returns the list of fields to ignore.
 

--- a/python/gui/auto_generated/actions/qgsmaplayeraction.sip.in
+++ b/python/gui/auto_generated/actions/qgsmaplayeraction.sip.in
@@ -50,7 +50,7 @@ Creates a map layer action which can run on a specific type of layer
 Layer behavior flags.
 %End
 
- virtual bool canRunUsingLayer( QgsMapLayer *layer ) const /Deprecated/;
+ virtual bool canRunUsingLayer( QgsMapLayer *layer ) const /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Returns ``True`` if the action can run using the specified layer.
 
@@ -70,7 +70,7 @@ Returns ``True`` if the action can run using the specified layer.
 .. versionadded:: 3.30
 %End
 
- virtual void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated/;
+ virtual void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggers the action with the specified layer and list of feature.
 
@@ -79,7 +79,7 @@ Triggers the action with the specified layer and list of feature.
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- virtual void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated/;
+ virtual void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggers the action with the specified layer and feature.
 
@@ -88,7 +88,7 @@ Triggers the action with the specified layer and feature.
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- virtual void triggerForLayer( QgsMapLayer *layer ) /Deprecated/;
+ virtual void triggerForLayer( QgsMapLayer *layer ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggers the action with the specified layer.
 
@@ -134,7 +134,7 @@ Returns ``True`` if the action is only enabled for layers in editable mode.
 
   signals:
 
- void triggeredForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated/;
+ void triggeredForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggered when action has been run for a specific list of features
 
@@ -143,7 +143,7 @@ Triggered when action has been run for a specific list of features
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- void triggeredForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated/;
+ void triggeredForFeature( QgsMapLayer *layer, const QgsFeature &feature ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggered when action has been run for a specific feature
 
@@ -152,7 +152,7 @@ Triggered when action has been run for a specific feature
    Use the version with :py:class:`QgsMapLayerActionContext` instead.
 %End
 
- void triggeredForLayer( QgsMapLayer *layer ) /Deprecated/;
+ void triggeredForLayer( QgsMapLayer *layer ) /Deprecated="Since 3.40. Use the version with QgsMapLayerActionContext instead."/;
 %Docstring
 Triggered when action has been run for a specific layer
 

--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -155,7 +155,7 @@ Emitted when a column in the view has been resized.
 :param width: new width in pixel
 %End
 
- void finished() /Deprecated/;
+ void finished() /Deprecated="Since 3.40. No longer used."/;
 %Docstring
 
 .. deprecated:: 3.40

--- a/python/gui/auto_generated/attributetable/qgsfieldconditionalformatwidget.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfieldconditionalformatwidget.sip.in
@@ -23,7 +23,7 @@ A widget for customizing conditional formatting options.
 Constructor for QgsFieldConditionalFormatWidget.
 %End
 
- void viewRules() /Deprecated/;
+ void viewRules() /Deprecated="Since 3.40. No longer used, will be removed in QGIS 4.0."/;
 %Docstring
 Switches the widget to the rules page.
 
@@ -45,7 +45,7 @@ where ``index`` is the index of the conditional style to edit
 and ``style`` is the initial definition of the style.
 %End
 
- void loadStyle( const QgsConditionalStyle &style ) /Deprecated/;
+ void loadStyle( const QgsConditionalStyle &style ) /Deprecated="Since 3.40. No longer used, use QgsEditConditionalFormatRuleWidget.loadStyle instead."/;
 %Docstring
 
 .. deprecated:: 3.40
@@ -53,7 +53,7 @@ and ``style`` is the initial definition of the style.
    No longer used, use :py:class:`QgsEditConditionalFormatRuleWidget`.loadStyle instead.
 %End
 
- void reset() /Deprecated/;
+ void reset() /Deprecated="Since 3.40. No longer used, will be removed in QGIS 4.0."/;
 %Docstring
 Resets the formatting options to their default state.
 

--- a/python/gui/auto_generated/callouts/qgscalloutwidget.sip.in
+++ b/python/gui/auto_generated/callouts/qgscalloutwidget.sip.in
@@ -58,7 +58,7 @@ Returns the context in which the symbol widget is shown, e.g., the associated ma
 .. seealso:: :py:func:`setContext`
 %End
 
- const QgsVectorLayer *vectorLayer() const /Deprecated/;
+ const QgsVectorLayer *vectorLayer() const /Deprecated="Since 3.40. Use layer() instead."/;
 %Docstring
 Returns the vector layer associated with the widget.
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -140,7 +140,7 @@ Returns a user-friendly, translated name of the specified script ``language``.
 .. versionadded:: 3.30
 %End
 
- void setMarginVisible( bool margin ) /Deprecated/;
+ void setMarginVisible( bool margin ) /Deprecated="Since 3.40. Use base class methods for individual margins instead, or setLineNumbersVisible()."/;
 %Docstring
 Set margin visible state
 
@@ -151,7 +151,7 @@ Set margin visible state
    Use base class methods for individual margins instead, or :py:func:`~QgsCodeEditor.setLineNumbersVisible`.
 %End
 
- bool marginVisible() /Deprecated/;
+ bool marginVisible() /Deprecated="Since 3.40. Use base class methods for individual margins instead, or lineNumbersVisible()."/;
 %Docstring
 Returns whether margins are in a visible state
 

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -279,7 +279,7 @@ Is forwarded to the slot :py:func:`~QgsEditorWidgetWrapper.setValues`
 %End
 
 
-    virtual void setValue( const QVariant &value ) /Deprecated/;
+    virtual void setValue( const QVariant &value ) /Deprecated="Since 3.10. "/;
 %Docstring
 Is called when the value of the widget needs to be changed. Updates the widget representation
 to reflect the new value.

--- a/python/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsJsonEditWidget : QWidget
 {
 %Docstring(signature="appended")

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
@@ -69,7 +69,7 @@ Returns the default flags (equalTo)
 
   public slots:
 
- void onValueChanged( const QVariant &value ) /Deprecated/;
+ void onValueChanged( const QVariant &value ) /Deprecated="Since 3.10. Made private."/;
 %Docstring
 Called when current value of search widget changes
 

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -45,7 +45,7 @@ class QgsRelationReferenceWidget : QWidget
 
     void setRelationEditable( bool editable );
 
- void setForeignKey( const QVariant &value ) /Deprecated/;
+ void setForeignKey( const QVariant &value ) /Deprecated="Since 3.10. Use setForeignKeys."/;
 %Docstring
 this sets the related feature using from the foreign key
 
@@ -61,7 +61,7 @@ Sets the related feature using the foreign keys
 .. versionadded:: 3.10
 %End
 
- QVariant foreignKey() const /Deprecated/;
+ QVariant foreignKey() const /Deprecated="Since 3.10. "/;
 %Docstring
 returns the related feature foreign key
 
@@ -270,7 +270,7 @@ unset the currently related feature
 
   signals:
 
- void foreignKeyChanged( const QVariant &key ) /Deprecated/;
+ void foreignKeyChanged( const QVariant &key ) /Deprecated="Since 3.10. "/;
 %Docstring
 Emitted when the foreign key changed
 

--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -39,7 +39,7 @@ Constructor for QgsRelationWidgetWrapper
 Constructor for QgsRelationWidgetWrapper
 %End
 
- bool showLabel() const /Deprecated/;
+ bool showLabel() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been called at least once.
@@ -49,7 +49,7 @@ Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been ca
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- void setShowLabel( bool showLabel ) /Deprecated/;
+ void setShowLabel( bool showLabel ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been called at least once.
@@ -59,7 +59,7 @@ Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been ca
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- bool showLinkButton() const /Deprecated/;
+ bool showLinkButton() const /Deprecated="Since 3.16. Use visibleButtons() instead."/;
 %Docstring
 Determines if the "link feature" button should be shown
 
@@ -68,7 +68,7 @@ Determines if the "link feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.visibleButtons` instead.
 %End
 
- void setShowLinkButton( bool showLinkButton ) /Deprecated/;
+ void setShowLinkButton( bool showLinkButton ) /Deprecated="Since 3.16. Use setVisibleButtons() instead."/;
 %Docstring
 Determines if the "link feature" button should be shown
 
@@ -77,7 +77,7 @@ Determines if the "link feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.setVisibleButtons` instead.
 %End
 
- bool showUnlinkButton() const /Deprecated/;
+ bool showUnlinkButton() const /Deprecated="Since 3.16. Use visibleButtons() instead."/;
 %Docstring
 Determines if the "unlink feature" button should be shown
 
@@ -86,7 +86,7 @@ Determines if the "unlink feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.visibleButtons` instead.
 %End
 
- void setShowUnlinkButton( bool showUnlinkButton ) /Deprecated/;
+ void setShowUnlinkButton( bool showUnlinkButton ) /Deprecated="Since 3.16. Use setVisibleButtons() instead."/;
 %Docstring
 Determines if the "unlink feature" button should be shown
 
@@ -95,7 +95,7 @@ Determines if the "unlink feature" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.setVisibleButtons` instead.
 %End
 
- void setShowSaveChildEditsButton( bool showChildEdits ) /Deprecated/;
+ void setShowSaveChildEditsButton( bool showChildEdits ) /Deprecated="Since 3.16. Use setVisibleButtons() instead."/;
 %Docstring
 Determines if the "Save child layer edits" button should be shown
 
@@ -106,7 +106,7 @@ Determines if the "Save child layer edits" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.setVisibleButtons` instead.
 %End
 
- bool showSaveChildEditsButton() const /Deprecated/;
+ bool showSaveChildEditsButton() const /Deprecated="Since 3.16. Use visibleButtons() instead."/;
 %Docstring
 Determines if the "Save child layer edits" button should be shown
 
@@ -117,7 +117,7 @@ Determines if the "Save child layer edits" button should be shown
    Use :py:func:`~QgsRelationWidgetWrapper.visibleButtons` instead.
 %End
 
- void setVisibleButtons( const QgsAttributeEditorRelation::Buttons &buttons ) /Deprecated/;
+ void setVisibleButtons( const QgsAttributeEditorRelation::Buttons &buttons ) /Deprecated="Since 3.18. Use setWidgetConfig() instead."/;
 %Docstring
 Defines the buttons which are shown
 
@@ -128,7 +128,7 @@ Defines the buttons which are shown
    Use :py:func:`~QgsRelationWidgetWrapper.setWidgetConfig` instead.
 %End
 
- QgsAttributeEditorRelation::Buttons visibleButtons() const /Deprecated/;
+ QgsAttributeEditorRelation::Buttons visibleButtons() const /Deprecated="Since 3.18. Use widgetConfig() instead."/;
 %Docstring
 Returns the buttons which are shown
 
@@ -188,7 +188,7 @@ If it's empty, then it's considered as a 1:M relationship.
 .. versionadded:: 3.16
 %End
 
- QString label() const /Deprecated/;
+ QString label() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Determines the label of this element
 
@@ -199,7 +199,7 @@ Determines the label of this element
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- void setLabel( const QString &label = QString() ) /Deprecated/;
+ void setLabel( const QString &label = QString() ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Sets ``label`` for this element
 If it's empty it takes the relation id as label

--- a/python/gui/auto_generated/layertree/qgslayertreemapcanvasbridge.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreemapcanvasbridge.sip.in
@@ -46,7 +46,7 @@ Associates overview canvas with the bridge, so the overview will be updated when
 %End
 
 
-    void setOvervewCanvas( QgsMapOverviewCanvas *overviewCanvas ) /Deprecated/; // TODO QGIS 4.0 remove
+    void setOvervewCanvas( QgsMapOverviewCanvas *overviewCanvas ) /Deprecated="Since 3.40. Use setOverviewCanvas() instead."/; // TODO QGIS 4.0 remove
 %MethodCode
     sipCpp->setOverviewCanvas( a0 );
 %End

--- a/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -47,7 +47,7 @@ Action to uncheck a group and all its children
 Action to check a group and all its parents
 %End
 
- QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory,Deprecated/;
+ QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory,Deprecated="Since 3.18. Use actionZoomToLayers()."/;
 %Docstring
 Action to zoom to the active layer from the layer tree.
 
@@ -109,7 +109,7 @@ Action to zoom to selected features of a vector layer
 Action to enable/disable mutually exclusive flag of a group (only one child node may be checked)
 %End
 
- void zoomToLayer( QgsMapCanvas *canvas ) /Deprecated/;
+ void zoomToLayer( QgsMapCanvas *canvas ) /Deprecated="Since 3.18. Use zoomToLayers()."/;
 %Docstring
 Zooms a map ``canvas`` to the extent of the active layer in the layer tree.
 
@@ -145,7 +145,7 @@ Zooms a map ``canvas`` to all the selected layer(s) in the layer tree
     void renameGroupOrLayer();
     void showFeatureCount();
 
- void zoomToLayer() /Deprecated/;
+ void zoomToLayer() /Deprecated="Since 3.18. Use zoomToLayers()."/;
 %Docstring
 Zooms to the extent of the active layer in the layer tree.
 
@@ -169,7 +169,7 @@ Zooms to the bounding box of all selected features of a vector layer.
 %End
     void zoomToGroup();
 
- void makeTopLevel() /Deprecated/;
+ void makeTopLevel() /Deprecated="Since 3.2. Use moveOutOfGroup()."/;
 %Docstring
 
 .. deprecated:: 3.2

--- a/python/gui/auto_generated/layout/qgslayoutcustomdrophandler.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutcustomdrophandler.sip.in
@@ -24,7 +24,7 @@ Abstract base class that may be implemented to handle new types of data to be dr
 Constructor for QgsLayoutCustomDropHandler.
 %End
 
- virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file ) /Deprecated/;
+ virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file ) /Deprecated="Since 3.40. Use the version which specifies a drop location instead."/;
 %Docstring
 Called when the specified ``file`` has been dropped onto a QGIS layout. If ``True``
 is returned, then the handler has accepted this file and it should not

--- a/python/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
@@ -169,7 +169,7 @@ WkbType of the current layer).
 
   public slots:
 
- void setCircularDigitizingEnabled( bool enable ) /Deprecated/;
+ void setCircularDigitizingEnabled( bool enable ) /Deprecated="Since 3.26. Use setCurrentCaptureTechnique() instead."/;
 %Docstring
 Enable the digitizing with curve
 
@@ -178,7 +178,7 @@ Enable the digitizing with curve
    Use :py:func:`~QgsMapToolCapture.setCurrentCaptureTechnique` instead.
 %End
 
- void setStreamDigitizingEnabled( bool enable ) /Deprecated/;
+ void setStreamDigitizingEnabled( bool enable ) /Deprecated="Since 3.26. Use setCurrentCaptureTechnique() instead."/;
 %Docstring
 Toggles the stream digitizing mode.
 
@@ -275,7 +275,7 @@ Number of points digitized
 :return: Number of points
 %End
 
- QVector<QgsPointXY> points() const /Deprecated/;
+ QVector<QgsPointXY> points() const /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant returns QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 List of digitized points
 
@@ -296,7 +296,7 @@ List of digitized points
 .. versionadded:: 3.12
 %End
 
- void setPoints( const QVector<QgsPointXY> &pointList ) /Deprecated/;
+ void setPoints( const QVector<QgsPointXY> &pointList ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Set the points on which to work
 

--- a/python/gui/auto_generated/maptools/qgsmaptooledit.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptooledit.sip.in
@@ -83,7 +83,7 @@ Returns the current vector layer of the map canvas or 0
       InvalidLayer,
     };
 
- TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &vertices ) /Deprecated/;
+ TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &vertices ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a list of ``vertices`` to other features to keep topology up to date, e.g. to neighbouring polygons.
 The ``vertices`` list specifies a set of topological points to add, in the layer's coordinate reference system.

--- a/python/gui/auto_generated/maptools/qgsmaptoolidentifyfeature.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptoolidentifyfeature.sip.in
@@ -43,7 +43,7 @@ change the layer used by the map tool to identify
 Emitted when a ``feature`` has been identified
 %End
 
- void featureIdentified( QgsFeatureId id ) /Deprecated/;
+ void featureIdentified( QgsFeatureId id ) /Deprecated="Since 3.40. Use the signal with a QgsFeature argument instead."/;
 %Docstring
 Emitted when a feature has been identified by its ``id``.
 

--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -33,7 +33,7 @@ Constructor
 :param fl: Window flags
 %End
 
- void saveDefaultStyle() /Deprecated/;
+ void saveDefaultStyle() /Deprecated="Since 3.40. Use saveStyleAsDefault() instead."/;
 %Docstring
 Saves the default style when appropriate button is pressed
 
@@ -42,7 +42,7 @@ Saves the default style when appropriate button is pressed
    Use :py:func:`~QgsMeshLayerProperties.saveStyleAsDefault` instead.
 %End
 
- void loadStyle() /Deprecated/;
+ void loadStyle() /Deprecated="Since 3.40. Use loadStyleFromFile() instead."/;
 %Docstring
 Loads a saved style when appropriate button is pressed
 
@@ -51,7 +51,7 @@ Loads a saved style when appropriate button is pressed
    Use :py:func:`~QgsMeshLayerProperties.loadStyleFromFile` instead.
 %End
 
- void saveStyleAs() /Deprecated/;
+ void saveStyleAs() /Deprecated="Since 3.40. Use saveStyleToFile() instead."/;
 %Docstring
 Saves a style when appriate button is pressed
 

--- a/python/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
+++ b/python/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
@@ -150,7 +150,7 @@ by the given Coordinate Reference Systems.
                   in the widget.
 %End
 
- void pushProjectionToFront() /Deprecated/;
+ void pushProjectionToFront() /Deprecated="Since 3.40. Has no effect since QGIS 3.20."/;
 %Docstring
 Marks the current selected projection for push to front of recent projections list.
 
@@ -173,7 +173,7 @@ Clear the list of recent projections.
 Emitted when a projection is selected in the widget.
 %End
 
- void initialized() /Deprecated/;
+ void initialized() /Deprecated="Since 3.40. No longer emitted."/;
 %Docstring
 Notifies others that the widget is now fully initialized, including deferred selection of projection.
 

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -615,7 +615,7 @@ Returns the native measure area action. Call :py:func:`~QgisInterface.trigger` o
 Returns the native zoom full extent action. Call :py:func:`~QgisInterface.trigger` on it to zoom to the full extent.
 %End
 
- virtual QAction *actionZoomToLayer() = 0 /Deprecated/;
+ virtual QAction *actionZoomToLayer() = 0 /Deprecated="Since 3.40. Use actionZoomToLayers() instead."/;
 %Docstring
 Returns the native zoom to layer action. Call :py:func:`~QgisInterface.trigger` on it to zoom to the active layer.
 
@@ -764,7 +764,7 @@ Returns the Hide Deselected Layers action.
     virtual QAction *actionAbout() = 0;
 
 
- virtual QAction *actionCircle2Points() /Deprecated/;
+ virtual QAction *actionCircle2Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 2 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -773,7 +773,7 @@ Returns the native add circle from 2 points action. Call :py:func:`~QgisInterfac
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircle3Points() /Deprecated/;
+ virtual QAction *actionCircle3Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 3 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -782,7 +782,7 @@ Returns the native add circle from 3 points action. Call :py:func:`~QgisInterfac
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircle3Tangents() /Deprecated/;
+ virtual QAction *actionCircle3Tangents() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 3 tangents action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -791,7 +791,7 @@ Returns the native add circle from 3 tangents action. Call :py:func:`~QgisInterf
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircle2TangentsPoint() /Deprecated/;
+ virtual QAction *actionCircle2TangentsPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from 2 tangents and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -800,7 +800,7 @@ Returns the native add circle from 2 tangents and a point action. Call :py:func:
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionCircleCenterPoint() /Deprecated/;
+ virtual QAction *actionCircleCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add circle from center action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -809,7 +809,7 @@ Returns the native add circle from center action. Call :py:func:`~QgisInterface.
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseCenter2Points() /Deprecated/;
+ virtual QAction *actionEllipseCenter2Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from center and 2 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -818,7 +818,7 @@ Returns the native add ellipse from center and 2 points action. Call :py:func:`~
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseCenterPoint() /Deprecated/;
+ virtual QAction *actionEllipseCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from center and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -827,7 +827,7 @@ Returns the native add ellipse from center and a point action. Call :py:func:`~Q
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseExtent() /Deprecated/;
+ virtual QAction *actionEllipseExtent() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from an extent action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -836,7 +836,7 @@ Returns the native add ellipse from an extent action. Call :py:func:`~QgisInterf
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionEllipseFoci() /Deprecated/;
+ virtual QAction *actionEllipseFoci() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add ellipse from foci action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -845,7 +845,7 @@ Returns the native add ellipse from foci action. Call :py:func:`~QgisInterface.t
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangleCenterPoint() /Deprecated/;
+ virtual QAction *actionRectangleCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from center and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -854,7 +854,7 @@ Returns the native add rectangle from center and a point action. Call :py:func:`
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangleExtent() /Deprecated/;
+ virtual QAction *actionRectangleExtent() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from extent action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -863,7 +863,7 @@ Returns the native add rectangle from extent action. Call :py:func:`~QgisInterfa
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangle3PointsDistance() /Deprecated/;
+ virtual QAction *actionRectangle3PointsDistance() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from 3 points (distance from 2nd and 3rd points) action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -872,7 +872,7 @@ Returns the native add rectangle from 3 points (distance from 2nd and 3rd points
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRectangle3PointsProjected() /Deprecated/;
+ virtual QAction *actionRectangle3PointsProjected() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add rectangle from 3 points (distance from projected 3rd point on segment p1 and p2) action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -881,7 +881,7 @@ Returns the native add rectangle from 3 points (distance from projected 3rd poin
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRegularPolygon2Points() /Deprecated/;
+ virtual QAction *actionRegularPolygon2Points() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add regular polygon from 2 points action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -890,7 +890,7 @@ Returns the native add regular polygon from 2 points action. Call :py:func:`~Qgi
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRegularPolygonCenterPoint() /Deprecated/;
+ virtual QAction *actionRegularPolygonCenterPoint() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add regular polygon from center and a point action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -899,7 +899,7 @@ Returns the native add regular polygon from center and a point action. Call :py:
    Shape digitizing is now part of the add feature tool. To enable the shape tool, use :py:func:`QgsMapToolCapture.setCurrentCaptureTechnique()` and then :py:func:`QgsMapToolCapture.setCurrentShapeMapTool()`.
 %End
 
- virtual QAction *actionRegularPolygonCenterCorner() /Deprecated/;
+ virtual QAction *actionRegularPolygonCenterCorner() /Deprecated="Since 3.26. Shape digitizing is now part of the add feature tool. To enable the shape tool, use QgsMapToolCapture.setCurrentCaptureTechnique() and then QgsMapToolCapture.setCurrentShapeMapTool()."/;
 %Docstring
 Returns the native add regular polygon from center and a corner action. Call :py:func:`~QgisInterface.trigger` on it to set the map tool.
 
@@ -1642,7 +1642,7 @@ Unregister a previously registered custom drop ``handler`` for layout windows.
 
 
 
-    virtual void openURL( const QString &url, bool useQgisDocDirectory = true ) = 0 /Deprecated/;
+    virtual void openURL( const QString &url, bool useQgisDocDirectory = true ) = 0 /Deprecated="Since 3.40. Use QDesktopServices instead."/;
 %Docstring
 Open a url in the users browser. By default the QGIS doc directory is used
 as the base for the URL. To open a URL that is not relative to the installed

--- a/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -105,7 +105,7 @@ This signal is normally forwarded the app and used to refresh browser items
 Emitted when a DB layer has been selected for addition
 %End
 
- void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey ) /Deprecated/;
+ void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a raster layer has been selected for addition
 
@@ -123,7 +123,7 @@ Emitted when one or more GDAL supported layers are selected for addition
 .. versionadded:: 3.20
 %End
 
- void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() ) /Deprecated/;
+ void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a vector layer has been selected for addition.
 
@@ -135,7 +135,7 @@ will be used.
    Use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
- void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated/;
+ void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a mesh layer has been selected for addition.
 
@@ -144,7 +144,7 @@ Emitted when a mesh layer has been selected for addition.
    Use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
- void addVectorTileLayer( const QString &url, const QString &baseName ) /Deprecated/;
+ void addVectorTileLayer( const QString &url, const QString &baseName ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a vector tile layer has been selected for addition.
 
@@ -153,7 +153,7 @@ Emitted when a vector tile layer has been selected for addition.
    Use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
- void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated/;
+ void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated="Since 3.40. Use addLayer() instead."/;
 %Docstring
 Emitted when a point cloud layer has been selected for addition.
 
@@ -195,7 +195,7 @@ Emitted when a layer needs to be replaced
 :param provider: key
 %End
 
- void progress( int, int ) /Deprecated/;
+ void progress( int, int ) /Deprecated="Since 3.4. This signal is no longer used. Use QgsProxyProgressTask instead to show progress reports."/;
 %Docstring
 Emitted when a progress dialog is shown by the provider dialog.
 

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -98,7 +98,7 @@ Sets the editor ``context``
 Returns the attribute editor context.
 %End
 
- bool showLabel() const /Deprecated/;
+ bool showLabel() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 
@@ -107,7 +107,7 @@ Defines if a title label should be shown for this widget.
    Label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
- void setShowLabel( bool showLabel ) /Deprecated/;
+ void setShowLabel( bool showLabel ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Defines if a title label should be shown for this widget.
 
@@ -127,7 +127,7 @@ Sets ``nmRelationId`` for the relation id of the second relation involved in an 
 If it's empty, then it's considered as a 1:M relationship.
 %End
 
- QString label() const /Deprecated/;
+ QString label() const /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Determines the label of this element
 
@@ -263,7 +263,7 @@ Duplicates features
 Refresh the UI when the widget becomes visible
 %End
 
- void updateTitle() /Deprecated/;
+ void updateTitle() /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Updates the title contents to reflect the current state of the widget
 
@@ -291,7 +291,7 @@ Should be used to refresh the UI regarding the new data.
 Check :py:class:`QgsRealationEditorWidget` as an example.
 %End
 
- virtual void setTitle( const QString &title ) /Deprecated/;
+ virtual void setTitle( const QString &title ) /Deprecated="Since 3.20. Label is handled directly in QgsAttributeForm."/;
 %Docstring
 Sets the title of the widget, if it is wrapped within a :py:class:`QgsCollapsibleGroupBox`
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -483,7 +483,7 @@ Returns the last CAD point, in a map ``layer``'s coordinates.
 .. versionadded:: 3.22
 %End
 
- QgsPointXY currentPoint( bool *exists = 0 ) const /Deprecated/;
+ QgsPointXY currentPoint( bool *exists = 0 ) const /Deprecated="Since 3.22. Use currentPointV2() instead."/;
 %Docstring
 The last point.
 Helper for the CAD point list. The CAD point list is the list of points
@@ -500,7 +500,7 @@ Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
- QgsPointXY previousPoint( bool *exists = 0 ) const /Deprecated/;
+ QgsPointXY previousPoint( bool *exists = 0 ) const /Deprecated="Since 3.22. Use previousPointV2() instead."/;
 %Docstring
 The previous point.
 Helper for the CAD point list. The CAD point list is the list of points
@@ -517,7 +517,7 @@ Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
- QgsPointXY penultimatePoint( bool *exists = 0 ) const /Deprecated/;
+ QgsPointXY penultimatePoint( bool *exists = 0 ) const /Deprecated="Since 3.22. Use penultimatePointV2() instead."/;
 %Docstring
 The penultimate point.
 Helper for the CAD point list. The CAD point list is the list of points
@@ -706,7 +706,7 @@ when a constraint is toggled.
 .. versionadded:: 3.22
 %End
 
- void pointChanged( const QgsPointXY &point ) /Deprecated/;
+ void pointChanged( const QgsPointXY &point ) /Deprecated="Since 3.22. No longer used, will be removed in QGIS 4.0. Use pointChangedV2() instead."/;
 %Docstring
 Sometimes a constraint may change the current point out of a mouse event. This happens normally
 when a constraint is toggled.

--- a/python/gui/auto_generated/qgsaggregatetoolbutton.sip.in
+++ b/python/gui/auto_generated/qgsaggregatetoolbutton.sip.in
@@ -31,7 +31,7 @@ Constructor
 Based on the ``type`` of underlying data, some aggregates will be available or not.
 %End
 
- void setType( QVariant::Type type ) /Deprecated/;
+ void setType( QVariant::Type type ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Based on the ``type`` of underlying data, some aggregates will be available or not.
 

--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -181,7 +181,7 @@ Returns ``True`` if any of the form widgets need feature geometry
 
   signals:
 
- void attributeChanged( const QString &attribute, const QVariant &value ) /Deprecated/;
+ void attributeChanged( const QString &attribute, const QVariant &value ) /Deprecated="Since 3.0. "/;
 %Docstring
 Notifies about changes of attributes, this signal is not emitted when the value is set
 back to the original one.

--- a/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -35,7 +35,7 @@ Returns a pointer to the :py:class:`QgsBrowserWidget` used by the dock widget.
 .. versionadded:: 3.22
 %End
 
- void addFavoriteDirectory( const QString &favDir, const QString &name = QString() ) /Deprecated/;
+ void addFavoriteDirectory( const QString &favDir, const QString &name = QString() ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Add directory to favorites.
 
@@ -80,7 +80,7 @@ Used in the proxy browser model to hide items
 
   public slots:
 
- bool addLayerAtIndex( const QModelIndex &index ) /Deprecated/;
+ bool addLayerAtIndex( const QModelIndex &index ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - retrieve the QgsLayerItem itself and manually add to project."/;
 %Docstring
 Adds the layer corresponding to the specified model ``index``.
 
@@ -92,7 +92,7 @@ Returns ``True`` if the index was successfully intrepreted as a map layer and lo
    Will be removed in QGIS 4.0 - retrieve the :py:class:`QgsLayerItem` itself and manually add to project.
 %End
 
- void showContextMenu( QPoint ) /Deprecated/;
+ void showContextMenu( QPoint ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Show context menu.
 
@@ -101,7 +101,7 @@ Show context menu.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void addFavorite() /Deprecated/;
+ void addFavorite() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Add current item to favorite.
 
@@ -110,7 +110,7 @@ Add current item to favorite.
    Will be removed in QGIS 4.0 - use the methods in :py:class:`QgsBrowserModel` instead.
 %End
 
- void addFavoriteDirectory() /Deprecated/;
+ void addFavoriteDirectory() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Add directory from file dialog to favorite.
 
@@ -119,7 +119,7 @@ Add directory from file dialog to favorite.
    Will be removed in QGIS 4.0 - use the methods in :py:class:`QgsBrowserModel` instead.
 %End
 
- void removeFavorite() /Deprecated/;
+ void removeFavorite() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 - use the methods in QgsBrowserModel instead."/;
 %Docstring
 Remove from favorite.
 
@@ -133,7 +133,7 @@ Remove from favorite.
 Refresh the browser model and view.
 %End
 
- void showFilterWidget( bool visible ) /Deprecated/;
+ void showFilterWidget( bool visible ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Show/hide filter widget.
 
@@ -142,7 +142,7 @@ Show/hide filter widget.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void enablePropertiesWidget( bool enable ) /Deprecated/;
+ void enablePropertiesWidget( bool enable ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Enable/disable properties widget.
 
@@ -151,7 +151,7 @@ Enable/disable properties widget.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setFilterSyntax( QAction * ) /Deprecated/;
+ void setFilterSyntax( QAction * ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Sets filter syntax.
 
@@ -160,7 +160,7 @@ Sets filter syntax.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setCaseSensitive( bool caseSensitive ) /Deprecated/;
+ void setCaseSensitive( bool caseSensitive ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Sets filter case sensitivity.
 
@@ -169,7 +169,7 @@ Sets filter case sensitivity.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setFilter() /Deprecated/;
+ void setFilter() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Apply filter to the model.
 
@@ -178,7 +178,7 @@ Apply filter to the model.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void setActiveIndex( const QModelIndex &index ) /Deprecated/;
+ void setActiveIndex( const QModelIndex &index ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Sets the selection to ``index`` and expand it.
 
@@ -187,7 +187,7 @@ Sets the selection to ``index`` and expand it.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void updateProjectHome() /Deprecated/;
+ void updateProjectHome() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Update project home directory.
 
@@ -196,7 +196,7 @@ Update project home directory.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void addSelectedLayers() /Deprecated/;
+ void addSelectedLayers() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Add selected layers to the project
 
@@ -205,7 +205,7 @@ Add selected layers to the project
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void showProperties() /Deprecated/;
+ void showProperties() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Show the layer properties.
 
@@ -214,7 +214,7 @@ Show the layer properties.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void hideItem() /Deprecated/;
+ void hideItem() /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Hide current item.
 
@@ -223,7 +223,7 @@ Hide current item.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void toggleFastScan() /Deprecated/;
+ void toggleFastScan() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Toggle fast scan
 
@@ -232,7 +232,7 @@ Toggle fast scan
    Will be removed in QGIS 4.0.
 %End
 
- void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected ) /Deprecated/;
+ void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0 -- this method is not intended for public use."/;
 %Docstring
 Selection has changed.
 
@@ -241,7 +241,7 @@ Selection has changed.
    Will be removed in QGIS 4.0 -- this method is not intended for public use.
 %End
 
- void splitterMoved() /Deprecated/;
+ void splitterMoved() /Deprecated="Since 3.40. No longer used."/;
 %Docstring
 Splitter has been moved.
 

--- a/python/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/gui/auto_generated/qgscolorwidgets.sip.in
@@ -72,7 +72,7 @@ Returns the color component which the widget controls
 .. seealso:: :py:func:`setComponent`
 %End
 
- int componentValue() const /Deprecated/;
+ int componentValue() const /Deprecated="Since 3.40. Use componentValueF() instead."/;
 %Docstring
 Returns the current value of the widget's color component
 
@@ -136,7 +136,7 @@ Sets the color component which the widget controls
 .. seealso:: :py:func:`component`
 %End
 
- virtual void setComponentValue( int value ) /Deprecated/;
+ virtual void setComponentValue( int value ) /Deprecated="Since 3.40. Use setComponentValueF() instead."/;
 %Docstring
 Alters the widget's color by setting the value for the widget's color component
 
@@ -208,7 +208,7 @@ Returns the range of valid values a color component
 :return: maximum value allowed for color component
 %End
 
- int componentValue( ColorComponent component ) const /Deprecated/;
+ int componentValue( ColorComponent component ) const /Deprecated="Since 3.40. Use componentValueF() instead."/;
 %Docstring
 Returns the value of a component of the widget's current color. This method correctly
 handles hue values when the color has an ambiguous hue (e.g., black or white shades)
@@ -239,7 +239,7 @@ handles hue values when the color has an ambiguous hue (e.g., black or white sha
 .. versionadded:: 3.40
 %End
 
- int hue() const /Deprecated/;
+ int hue() const /Deprecated="Since 3.40. Use hueF() instead."/;
 %Docstring
 Returns the hue for the widget. This may differ from the hue for the QColor returned by :py:func:`~QgsColorWidget.color`,
 as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the saturation is zero).
@@ -261,7 +261,7 @@ as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the satu
 .. versionadded:: 3.40
 %End
 
- static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) /Deprecated/;
+ static void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) /Deprecated="Since 3.40. Use alterColorF() instead."/;
 %Docstring
 Alters a color by modifying the value of a specific color component
 
@@ -568,7 +568,7 @@ Sets the size for drawing the triangular markers on the ramp
 
   signals:
 
- void valueChanged( int value ) /Deprecated/;
+ void valueChanged( int value ) /Deprecated="Since 3.40. Use valueChangedF() instead."/;
 %Docstring
 Emitted when the widget's color component value changes
 

--- a/python/gui/auto_generated/qgscustomdrophandler.sip.in
+++ b/python/gui/auto_generated/qgscustomdrophandler.sip.in
@@ -69,7 +69,7 @@ determine whether the drag action should be accepted.
 %End
 
 
- virtual void handleMimeData( const QMimeData *data ) /Deprecated/;
+ virtual void handleMimeData( const QMimeData *data ) /Deprecated="Since 3.10. Use handleMimeDataV2() instead."/;
 %Docstring
 Called when the specified mime ``data`` has been dropped onto QGIS.
 

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -76,7 +76,7 @@ Sets layer in order to get the fields and values
 Returns the current layer or a None.
 %End
 
- void loadFieldNames() /Deprecated/;
+ void loadFieldNames() /Deprecated="Since 3.14. This is now done automatically."/;
 %Docstring
 
 .. deprecated:: 3.14
@@ -84,7 +84,7 @@ Returns the current layer or a None.
    This is now done automatically.
 %End
 
- void loadFieldNames( const QgsFields &fields ) /Deprecated/;
+ void loadFieldNames( const QgsFields &fields ) /Deprecated="Since 3.14. Use expressionTree()->loadFieldNames() instead."/;
 %Docstring
 
 .. deprecated:: 3.14
@@ -92,7 +92,7 @@ Returns the current layer or a None.
    Use :py:func:`~QgsExpressionBuilderWidget.expressionTree`->:py:func:`~QgsExpressionBuilderWidget.loadFieldNames` instead.
 %End
 
- void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues ) /Deprecated/;
+ void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues ) /Deprecated="Since 3.14. This will not do anything, use setLayer() instead."/;
 %Docstring
 Loads field names and values from the specified map.
 
@@ -199,7 +199,7 @@ objects (i.e. for objects which aren't vector layer features).
 %End
 
 
- void saveToRecent( const QString &collection = "generic" ) /Deprecated/;
+ void saveToRecent( const QString &collection = "generic" ) /Deprecated="Since 3.14. Use expressionTree()->saveRecent() instead."/;
 %Docstring
 Adds the current expression to the given ``collection``.
 By default it is saved to the collection "generic".
@@ -209,7 +209,7 @@ By default it is saved to the collection "generic".
    Use :py:func:`~QgsExpressionBuilderWidget.expressionTree`->:py:func:`~QgsExpressionBuilderWidget.saveRecent` instead.
 %End
 
- void loadRecent( const QString &collection = QStringLiteral( "generic" ) ) /Deprecated/;
+ void loadRecent( const QString &collection = QStringLiteral( "generic" ) ) /Deprecated="Since 3.14. Use expressionTree()->loadRecent() instead."/;
 %Docstring
 Loads the recent expressions from the given ``collection``.
 By default it is loaded from the collection "generic".
@@ -226,7 +226,7 @@ Returns the expression tree
 .. versionadded:: 3.14
 %End
 
- void loadUserExpressions() /Deprecated/;
+ void loadUserExpressions() /Deprecated="Since 3.14. Use expressionTree()->loadUserExpressions() instead."/;
 %Docstring
 Loads the user expressions.
 
@@ -236,7 +236,7 @@ Loads the user expressions.
 .. versionadded:: 3.12
 %End
 
- void saveToUserExpressions( const QString &label, const QString &expression, const QString &helpText ) /Deprecated/;
+ void saveToUserExpressions( const QString &label, const QString &expression, const QString &helpText ) /Deprecated="Since 3.14. Use expressionTree()->saveToUserExpressions() instead."/;
 %Docstring
 Stores the user ``expression`` with given ``label`` and ``helpText``.
 
@@ -246,7 +246,7 @@ Stores the user ``expression`` with given ``label`` and ``helpText``.
 .. versionadded:: 3.12
 %End
 
- void removeFromUserExpressions( const QString &label ) /Deprecated/;
+ void removeFromUserExpressions( const QString &label ) /Deprecated="Since 3.14. Use expressionTree()->removeFromUserExpressions() instead."/;
 %Docstring
 Removes the expression ``label`` from the user stored expressions.
 
@@ -295,7 +295,7 @@ Saves the current function editor text to a project entry.
 .. versionadded:: 3.40
 %End
 
- QStandardItemModel *model() /Deprecated/;
+ QStandardItemModel *model() /Deprecated="Since 3.14. "/;
 %Docstring
 Returns a pointer to the dialog's function item model.
 This method is exposed for testing purposes only - it should not be used to modify the model.

--- a/python/gui/auto_generated/qgsexternalresourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsexternalresourcewidget.sip.in
@@ -62,7 +62,7 @@ documentPath returns the path of the current document in the widget
 :param type: determines the type of the returned null variant if the document is not defined yet
 %End
 
- QVariant documentPath( QVariant::Type type ) const /Deprecated/;
+ QVariant documentPath( QVariant::Type type ) const /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 documentPath returns the path of the current document in the widget
 

--- a/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -76,7 +76,7 @@ An additional expression to further restrict the available features.
 This can be used to integrate additional spatial or other constraints.
 %End
 
- QVariant identifierValue() const /Deprecated/;
+ QVariant identifierValue() const /Deprecated="Since 3.10. "/;
 %Docstring
 The identifier value of the currently selected feature. A value from the
 identifierField.
@@ -93,7 +93,7 @@ identifierField.
 %End
 
 
- void setIdentifierValue( const QVariant &identifierValue ) /Deprecated/;
+ void setIdentifierValue( const QVariant &identifierValue ) /Deprecated="Since 3.10. Use setIdentifierValues."/;
 %Docstring
 The identifier value of the currently selected feature. A value from the
 identifierField.
@@ -149,7 +149,7 @@ If set to 0, no limit is applied when fetching
 .. versionadded:: 3.32
 %End
 
- QString identifierField() const /Deprecated/;
+ QString identifierField() const /Deprecated="Since 3.10. "/;
 %Docstring
 Field name that will be used to uniquely identify the current feature.
 Normally the primary key of the layer.
@@ -165,7 +165,7 @@ Normally the primary key of the layer.
 .. versionadded:: 3.10
 %End
 
- void setIdentifierField( const QString &identifierField ) /Deprecated/;
+ void setIdentifierField( const QString &identifierField ) /Deprecated="Since 3.10. "/;
 %Docstring
 Field name that will be used to uniquely identify the current feature.
 Normally the primary key of the layer.

--- a/python/gui/auto_generated/qgshttpheaderwidget.sip.in
+++ b/python/gui/auto_generated/qgshttpheaderwidget.sip.in
@@ -43,7 +43,7 @@ Sets the widget from the headers
 .. versionadded:: 3.30
 %End
 
- void setFromSettings( const QgsSettings &settings, const QString &key ) /Deprecated/;
+ void setFromSettings( const QgsSettings &settings, const QString &key ) /Deprecated="Since 3.30. Use setFromHeaders() instead."/;
 %Docstring
 fill the inner header map from the settings defined at ``key``
 
@@ -57,7 +57,7 @@ fill the inner header map from the settings defined at ``key``
    Use :py:func:`~QgsHttpHeaderWidget.setFromHeaders` instead.
 %End
 
- void updateSettings( QgsSettings &settings, const QString &key ) const /Deprecated/;
+ void updateSettings( QgsSettings &settings, const QString &key ) const /Deprecated="Since 3.30. Use a variant map for settinds directly."/;
 %Docstring
 update the ``settings`` with the http headers present in the inner map.
 

--- a/python/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/gui/auto_generated/qgsidentifymenu.sip.in
@@ -154,7 +154,7 @@ exec
 :param pos: the position where the menu will be executed
 %End
 
- static void styleHighlight( QgsHighlight *highlight ) /Deprecated/;
+ static void styleHighlight( QgsHighlight *highlight ) /Deprecated="Since 3.40. Use QgsHighlight.applyDefaultStyle() instead."/;
 %Docstring
 Applies style from the settings to the highlight
 

--- a/python/gui/auto_generated/qgsmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/qgsmaplayercombobox.sip.in
@@ -36,7 +36,7 @@ This method allows filtering layers according to layer type and/or geometry type
 .. seealso:: :py:func:`filters`
 %End
 
- void setFilters( int filters ) /Deprecated/;
+ void setFilters( int filters ) /Deprecated="Since 3.34. Use the flag signature instead."/;
 %Docstring
 Filters according to layer type and/or geometry type.
 

--- a/python/gui/auto_generated/qgsnewvectorlayerdialog.sip.in
+++ b/python/gui/auto_generated/qgsnewvectorlayerdialog.sip.in
@@ -16,7 +16,7 @@ class QgsNewVectorLayerDialog : QDialog
 #include "qgsnewvectorlayerdialog.h"
 %End
   public:
- static QString runAndCreateLayer( QWidget *parent = 0, QString *enc = 0, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), const QString &initialPath = QString() ) /Deprecated/;
+ static QString runAndCreateLayer( QWidget *parent = 0, QString *enc = 0, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), const QString &initialPath = QString() ) /Deprecated="Since 3.4.5. Use execAndCreateLayer() instead."/;
 %Docstring
 Runs the dialog and creates a layer matching the dialog parameters.
 

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -93,7 +93,7 @@ Defines the buttons which are shown
 Returns the buttons which are shown
 %End
 
- void duplicateFeature() /Deprecated/;
+ void duplicateFeature() /Deprecated="Since 3.18. Use duplicateSelectedFeatures() instead."/;
 %Docstring
 Duplicates a feature
 

--- a/python/gui/auto_generated/qgsscalevisibilitydialog.sip.in
+++ b/python/gui/auto_generated/qgsscalevisibilitydialog.sip.in
@@ -53,7 +53,7 @@ The scale value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
 
   public slots:
 
- void setScaleVisiblity( bool hasScaleVisibility ) /Deprecated/;
+ void setScaleVisiblity( bool hasScaleVisibility ) /Deprecated="Since 3.40. Use setScaleVisibility()."/;
 %Docstring
 Set whether scale based visibility is enabled.
 

--- a/python/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/gui/auto_generated/qgssublayersdialog.sip.in
@@ -57,7 +57,7 @@ class QgsSublayersDialog : QDialog
     typedef QList<QgsSublayersDialog::LayerDefinition> LayerDefinitionList;
 
 
- QgsSublayersDialog( ProviderType providerType, const QString &name, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = Qt::WindowFlags(), const QString &dataSourceUri = QString() ) /Deprecated/;
+ QgsSublayersDialog( ProviderType providerType, const QString &name, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = Qt::WindowFlags(), const QString &dataSourceUri = QString() ) /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Construct a new QgsSublayersDialog object - a dialog to select which sub layers to be imported from a data source (e.g. from geopackage or zipfile)
 

--- a/python/gui/auto_generated/qgstextformatwidget.sip.in
+++ b/python/gui/auto_generated/qgstextformatwidget.sip.in
@@ -138,7 +138,7 @@ Sets the background color for the text preview widget.
 :param color: background color
 %End
 
- void enableDataDefinedAlignment( bool enable ) /Deprecated/;
+ void enableDataDefinedAlignment( bool enable ) /Deprecated="Since 3.24. "/;
 %Docstring
 Update the enabled state of the data defined alignment buttons.
 

--- a/python/gui/auto_generated/raster/qgsrasterattributetablemodel.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterattributetablemodel.sip.in
@@ -79,7 +79,7 @@ Inserts a field at the given position.
          - errorMessage: error message
 %End
 
- bool insertField( const int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated/;
+ bool insertField( const int position, const QString &name, const Qgis::RasterAttributeTableFieldUsage usage, const QVariant::Type type, QString *errorMessage /Out/ = 0 ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Inserts a field at the given position.
 

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -43,7 +43,7 @@ Constructor
     virtual bool eventFilter( QObject *obj, QEvent *ev );
 
 
- void saveDefaultStyle() /Deprecated/;
+ void saveDefaultStyle() /Deprecated="Since 3.40. Use saveStyleAsDefault() instead."/;
 %Docstring
 Saves the default style when appropriate button is pressed
 

--- a/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -79,7 +79,7 @@ vector layers have been changed. Will request the parent dialog
 to re-synchronize with the variables.
 %End
 
- void symbolLevelsChanged() /Deprecated/;
+ void symbolLevelsChanged() /Deprecated="Since 3.20. No longer emitted."/;
 %Docstring
 Emitted when the symbol levels settings have been changed.
 

--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -161,7 +161,7 @@ Closes the dialog
 Opens the associated help
 %End
 
- void itemChanged( QStandardItem *item ) /Deprecated/;
+ void itemChanged( QStandardItem *item ) /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -204,7 +204,7 @@ Toggles the interactive item tagging mode.
 Triggers the dialog for editing the selected smart group.
 %End
 
- void regrouped( QStandardItem * ) /Deprecated/;
+ void regrouped( QStandardItem * ) /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -266,7 +266,7 @@ Remove all tags from selected symbols
 %End
 
   protected:
- void populateTypes() /Deprecated/;
+ void populateTypes() /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 Populate combo box with known style items (symbols, color ramps).
 
@@ -280,7 +280,7 @@ Populate combo box with known style items (symbols, color ramps).
 populate the groups
 %End
 
- void setSymbolsChecked( const QStringList & ) /Deprecated/;
+ void setSymbolsChecked( const QStringList & ) /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -288,7 +288,7 @@ populate the groups
    Has no effect and will be removed in QGIS 4.0.
 %End
 
- void populateSymbols( const QStringList &symbolNames, bool checkable = false ) /Deprecated/;
+ void populateSymbols( const QStringList &symbolNames, bool checkable = false ) /Deprecated="Since 3.40. No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 Populates the list view with symbols of the current type with the given names.
 
@@ -297,7 +297,7 @@ Populates the list view with symbols of the current type with the given names.
    No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0.
 %End
 
- void populateColorRamps( const QStringList &colorRamps, bool checkable = false ) /Deprecated/;
+ void populateColorRamps( const QStringList &colorRamps, bool checkable = false ) /Deprecated="Since 3.40. No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 Populates the list view with color ramps of the current type with the given names.
 
@@ -317,7 +317,7 @@ add a new symbol to style
     bool editSymbol();
     bool editColorRamp();
 
- bool removeSymbol() /Deprecated/;
+ bool removeSymbol() /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6
@@ -325,7 +325,7 @@ add a new symbol to style
    Has no effect and will be removed in QGIS 4.0.
 %End
 
- bool removeColorRamp() /Deprecated/;
+ bool removeColorRamp() /Deprecated="Since 3.6. Has no effect and will be removed in QGIS 4.0."/;
 %Docstring
 
 .. deprecated:: 3.6

--- a/python/gui/auto_generated/symbology/qgssvgselectorwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssvgselectorwidget.sip.in
@@ -134,7 +134,7 @@ Defines if the group box to fill parameters is visible
 .. versionadded:: 3.18
 %End
 
- bool allowParamerters() const /Deprecated/;
+ bool allowParamerters() const /Deprecated="Since 3.40. Use allowParameters()."/;
 %Docstring
 Returns if the group box to fill parameters is visible
 

--- a/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -452,7 +452,7 @@ Sets the dynamic SVG parameters
 
   protected:
 
- void populateList() /Deprecated/;
+ void populateList() /Deprecated="Since 3.16. "/;
 %Docstring
 This method does nothing anymore, the loading is automatic
 

--- a/python/gui/auto_generated/symbology/qgssymbollevelsdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollevelsdialog.sip.in
@@ -54,7 +54,7 @@ Sets whether the level ordering is always forced on and hide the checkbox (used 
 
   public slots:
 
- void apply() /Deprecated/;
+ void apply() /Deprecated="Since 3.20. Use symbolLevels() and manually apply the changes to the renderer as appropriate."/;
 %Docstring
 Apply button.
 

--- a/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
+++ b/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
@@ -75,7 +75,7 @@ Returns ``True`` if the current selection has a mix of numeric formats.
 .. seealso:: :py:func:`selectionNumericFormat`
 %End
 
- QColor selectionForegroundColor() /Deprecated/;
+ QColor selectionForegroundColor() /Deprecated="Since 3.40. Use selectionTextFormat() instead."/;
 %Docstring
 Returns the foreground color for the currently selected cells.
 
@@ -295,7 +295,7 @@ current selected cells.
 Clears the contents of the currently selected cells.
 %End
 
- void setSelectionForegroundColor( const QColor &color ) /Deprecated/;
+ void setSelectionForegroundColor( const QColor &color ) /Deprecated="Since 3.40. Use setSelectionTextFormat() instead."/;
 %Docstring
 Sets the foreground color for the currently selected cells.
 

--- a/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
+++ b/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
@@ -27,7 +27,7 @@ Vectortile layer properties dialog
 Constructor
 %End
 
- void saveDefaultStyle() /Deprecated/;
+ void saveDefaultStyle() /Deprecated="Since 3.40. Use saveStyleAsDefault() instead."/;
 %Docstring
 Saves the default style when appropriate button is pressed
 
@@ -43,7 +43,7 @@ Loads a saved style when appropriate button is pressed
 .. versionadded:: 3.30
 %End
 
- void saveStyleAs() /Deprecated/;
+ void saveStyleAs() /Deprecated="Since 3.40. Use saveStyleToFile() instead."/;
 %Docstring
 Saves a style when appriate button is pressed
 

--- a/python/gui/gui.sip.in
+++ b/python/gui/gui.sip.in
@@ -12,6 +12,9 @@ ${DEFAULTDOCSTRINGSIGNATURE}
 %Import QtGui/QtGuimod.sip
 %Import QtXml/QtXmlmod.sip
 %Import QtMultimedia/QtMultimediamod.sip
-%Import ${QSCI_SIP_MOD_NAME}
+
+%If (HAVE_QSCI_SIP)
+    %Import ${QSCI_SIP_MOD_NAME}
+%End
 
 %Include gui_auto.sip

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -323,7 +323,9 @@
 %Include auto_generated/editorwidgets/qgsdefaultsearchwidgetwrapper.sip
 %Include auto_generated/editorwidgets/qgsdoublespinbox.sip
 %Include auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip
+%If ( HAVE_QSCI_SIP )
 %Include auto_generated/editorwidgets/qgsjsoneditwidget.sip
+%End
 %Include auto_generated/editorwidgets/qgsmultiedittoolbutton.sip
 %Include auto_generated/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
 %Include auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip

--- a/python/server/auto_generated/qgsserverapiutils.sip.in
+++ b/python/server/auto_generated/qgsserverapiutils.sip.in
@@ -136,7 +136,7 @@ Returns the list of CRSs (format: http://www.opengis.net/def/crs/OGC/1.3/CRS84) 
 Information is read from project WMS configuration.
 %End
 
- static QString crsToOgcUri( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
+ static QString crsToOgcUri( const QgsCoordinateReferenceSystem &crs ) /Deprecated="Since 3.30. Use QgsCoordinateReferenceSystem.toOgcUri() instead."/;
 %Docstring
 Returns a ``crs`` as OGC URI (format: http://www.opengis.net/def/crs/OGC/1.3/CRS84)
 Returns an empty string on failure.

--- a/python/server/auto_generated/qgsserverfilter.sip.in
+++ b/python/server/auto_generated/qgsserverfilter.sip.in
@@ -43,7 +43,7 @@ and must be passed to QgsServerFilter instances.
 Returns the :py:class:`QgsServerInterface` instance
 %End
 
- virtual void requestReady() /Deprecated/;
+ virtual void requestReady() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` is ready and populated with
 parameters, just before entering the main switch for core services.
@@ -56,7 +56,7 @@ be used instead.
    Will be removed in QGIS 4.0.
 %End
 
- virtual void responseComplete() /Deprecated/;
+ virtual void responseComplete() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` processing has done and
 the response is ready, just after the main switch for core services
@@ -70,7 +70,7 @@ be used instead.
    Will be removed in QGIS 4.0.
 %End
 
- virtual void sendResponse() /Deprecated/;
+ virtual void sendResponse() /Deprecated="Since 3.40. Will be removed in QGIS 4.0."/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` sends its data to FCGI stdout.
 This normally occurs at the end of core services processing just after

--- a/python/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/server/auto_generated/qgsserverogcapi.sip.in
@@ -124,7 +124,7 @@ Returns the string representation of a ``ct`` (Content-Type) attribute.
 Returns the file extension for a ``ct`` (Content-Type).
 %End
 
- static QgsServerOgcApi::ContentType contenTypeFromExtension( const std::string &extension ) /Deprecated/;
+ static QgsServerOgcApi::ContentType contenTypeFromExtension( const std::string &extension ) /Deprecated="Since 3.40. Use contentTypeFromExtension()."/;
 %Docstring
 Returns the Content-Type value corresponding to ``extension``.
 

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -30,7 +30,7 @@ Constructor for QgsServerParameterDefinition.
 %End
 
 
- QgsServerParameterDefinition( const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated/;
+ QgsServerParameterDefinition( const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsServerParameterDefinition.
 
@@ -241,7 +241,7 @@ Constructor for QgsServerParameter.
 :param defaultValue: The default value to use if not defined
 %End
 
- QgsServerParameter( const QgsServerParameter::Name name, const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated/;
+ QgsServerParameter( const QgsServerParameter::Name name, const QVariant::Type type, const QVariant defaultValue = QVariant( "" ) ) /Deprecated="Since 3.38. Use the method with a QMetaType.Type argument instead."/;
 %Docstring
 Constructor for QgsServerParameter.
 

--- a/scripts/sipify.py
+++ b/scripts/sipify.py
@@ -42,6 +42,7 @@ class MultiLineType(Enum):
 parser = argparse.ArgumentParser(description="Convert header file to SIP and Python")
 parser.add_argument("-debug", action="store_true", help="Enable debug mode")
 parser.add_argument("-qt6", action="store_true", help="Enable Qt6 mode")
+parser.add_argument("-generate_deprecated_message", action="store_true", help="Generate sip files with deprecated messages (supported only in SIP > 6.9.0)")
 parser.add_argument("-sip_output", help="SIP output file")
 parser.add_argument("-python_output", help="Python output file")
 parser.add_argument("-class_map", help="Class map file")
@@ -79,7 +80,7 @@ class Context:
         self.debug: bool = False
         self.is_qt6: bool = False
         self.header_file: str = ""
-
+        self.generate_deprecated_message = False
         self.current_line: str = ""
         self.sip_run: bool = False
         self.header_code: bool = False
@@ -127,6 +128,7 @@ class Context:
         self.static_methods = defaultdict(dict)
         self.current_signal_args = []
         self.signal_arguments = defaultdict(dict)
+        self.deprecated_message = None
 
     def current_fully_qualified_class_name(self) -> str:
         return ".".join(
@@ -145,6 +147,7 @@ class Context:
 CONTEXT = Context()
 CONTEXT.debug = args.debug
 CONTEXT.is_qt6 = args.qt6
+CONTEXT.generate_deprecated_message = args.generate_deprecated_message
 CONTEXT.header_file = args.headerfile
 CONTEXT.input_lines = input_lines
 CONTEXT.line_count = len(input_lines)
@@ -715,6 +718,14 @@ def create_class_links(line):
     return line
 
 
+def process_deprecated_message(message: str) -> str:
+    """
+    Remove all doxygen specific command from deprecated message
+    """
+    # SIP issue with ':' , see https://github.com/Python-SIP/sip/issues/59
+    return message.replace("\\see", "").replace(":", "")
+
+
 def process_doxygen_line(line: str) -> str:
     global CONTEXT
 
@@ -880,6 +891,7 @@ def process_doxygen_line(line: str) -> str:
             version = version[:-1]
         depr_line = f"\n.. deprecated:: {version}"
         message = deprecated_match.group("DEPR_MESSAGE")
+        CONTEXT.deprecated_message = f"Since {version}. {process_deprecated_message(message)}"
         if message:
             depr_line += "\n"
             depr_line += "\n".join(f"\n   {_m}" for _m in message.split("\n"))
@@ -1157,6 +1169,11 @@ def fix_annotations(line):
         CONTEXT.skipped_params_out.append(param)
         dbg_info(f"caught removed param: {CONTEXT.skipped_params_out[-1]}")
 
+    if "SIP_DEPRECATED" in line:
+
+        if CONTEXT.deprecated_message is None:
+            exit_with_error(f"Error in file {CONTEXT.header_file}: missing deprecated message for SIP_DEPRECATED instruction on line {CONTEXT.line_idx}. Please add \\deprecated instruction")
+
     # Printed annotations
     replacements = {
         r"//\s*SIP_ABSTRACT\b": "/Abstract/",
@@ -1164,7 +1181,6 @@ def fix_annotations(line):
         r"\bSIP_ALLOWNONE\b": "/AllowNone/",
         r"\bSIP_ARRAY\b": "/Array/",
         r"\bSIP_ARRAYSIZE\b": "/ArraySize/",
-        r"\bSIP_DEPRECATED\b": "/Deprecated/",
         r"\bSIP_CONSTRAINED\b": "/Constrained/",
         r"\bSIP_EXTERNAL\b": "/External/",
         r"\bSIP_FACTORY\b": "/Factory/",
@@ -1190,16 +1206,21 @@ def fix_annotations(line):
         # these have no effect (and aren't required) on sip >= 6
         replacements[r"SIP_THROW\(\s*([\w\s,]+?)\s*\)"] = ""
 
+    if CONTEXT.generate_deprecated_message:
+        # check deprecated message is not empty
+        replacements[r"\bSIP_DEPRECATED\b"] = f'/Deprecated="{CONTEXT.deprecated_message}"/'
+    else:
+        replacements[r"\bSIP_DEPRECATED\b"] = f"/Deprecated/"
+
     for _pattern, replacement in replacements.items():
         line = re.sub(_pattern, replacement, line)
 
     # Combine multiple annotations
     while True:
         new_line = re.sub(
-            r'/([\w,]+(="?[\w, \[\]]+"?)?)/\s*/([\w,]+(="?[\w, \[\]]+"?)?]?)/',
+            r'/([\w,]+(="?[^"]+"?)?)/\s*/([\w,]+(="?[^"]+"?)?]?)/',
             r"/\1,\3/",
-            line,
-        )
+            line)
         if new_line == line:
             break
         line = new_line

--- a/scripts/sipify.py
+++ b/scripts/sipify.py
@@ -1200,7 +1200,12 @@ def fix_annotations(line):
         # these have no effect (and aren't required) on sip >= 6
         replacements[r"SIP_THROW\(\s*([\w\s,]+?)\s*\)"] = ""
 
-    replacements[r"\bSIP_DEPRECATED\b"] = f'/Deprecated="{CONTEXT.deprecated_message}"/'
+    if CONTEXT.deprecated_message:
+        replacements[r"\bSIP_DEPRECATED\b"] = (
+            f'/Deprecated="{CONTEXT.deprecated_message}"/'
+        )
+    else:
+        replacements[r"\bSIP_DEPRECATED\b"] = f"/Deprecated/"
 
     for _pattern, replacement in replacements.items():
         line = re.sub(_pattern, replacement, line)

--- a/scripts/sipify_all.sh
+++ b/scripts/sipify_all.sh
@@ -16,14 +16,10 @@
 set -e
 
 CLASS_MAP=0
-DEPRECATED_MESSAGE=0
-while getopts "md" opt; do
+while getopts "m" opt; do
   case $opt in
   m)
     CLASS_MAP=1
-    ;;
-  d)
-    DEPRECATED_MESSAGE=1
     ;;
   \?)
     echo "Invalid option: -$OPTARG" >&2
@@ -53,11 +49,6 @@ fi
 
 pids=()
 iPid=0
-
-GENERATE_DEPRECATED_MESSAGE=""
-if [[ ${DEPRECATED_MESSAGE} -eq 1 ]]; then
-  GENERATE_DEPRECATED_MESSAGE="-generate_deprecated_message"
-fi
 
 for root_dir in python python/PyQt6; do
 
@@ -95,7 +86,7 @@ It is not aimed to be manually edited
         if [[ ${CLASS_MAP} -eq 1 ]]; then
           CLASS_MAP_CALL="-c ${module_dir}/class_map.yaml"
         fi
-        ./scripts/sipify.py $IS_QT6 $GENERATE_DEPRECATED_MESSAGE -s ${root_dir}/${sipfile}.in -p ${module_dir}/auto_additions/${pyfile} ${CLASS_MAP_CALL} ${header} &
+        ./scripts/sipify.py $IS_QT6 -s ${root_dir}/${sipfile}.in -p ${module_dir}/auto_additions/${pyfile} ${CLASS_MAP_CALL} ${header} &
         pids[iPid]=$!
         iPid=$((iPid+1))
 

--- a/src/core/browser/qgsdirectoryitem.h
+++ b/src/core/browser/qgsdirectoryitem.h
@@ -120,6 +120,9 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
      */
     static void setCustomColor( const QString &directory, const QColor &color );
 
+    /**
+     * \deprecated QGIS 3.20
+     */
     Q_DECL_DEPRECATED QWidget *paramWidget() override SIP_FACTORY SIP_DEPRECATED;
     bool hasDragEnabled() const override { return true; }
     QgsMimeDataUtils::UriList mimeUris() const override;
@@ -273,5 +276,3 @@ class CORE_EXPORT QgsProjectHomeItem : public QgsDirectoryItem
 #endif
 
 #endif // QGSDATAITEM_H
-
-

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -227,7 +227,6 @@ class CORE_EXPORT QgsGeometry
      *
      * \see get()
      * \see constGet()
-     * \deprecated QGIS 3.0
      */
     void set( QgsAbstractGeometry *geometry SIP_TRANSFER ) SIP_DEPRECATED;
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -227,6 +227,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \see get()
      * \see constGet()
+     * \deprecated QGIS 3.0
      */
     void set( QgsAbstractGeometry *geometry SIP_TRANSFER ) SIP_DEPRECATED;
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -396,7 +396,12 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
 
     // for now, map items behave a bit differently and don't implement draw. TODO - see if we can avoid this
     void paint( QPainter *painter, const QStyleOptionGraphicsItem *itemStyle, QWidget *pWidget ) override;
+
+    /**
+     * \deprecated QGIS 3.10
+     */
     Q_DECL_DEPRECATED int numberExportLayers() const override SIP_DEPRECATED;
+
     void startLayeredExport() override;
     void stopLayeredExport() override;
     bool nextExportPart() override;

--- a/src/core/raster/qgsbilinearrasterresampler.h
+++ b/src/core/raster/qgsbilinearrasterresampler.h
@@ -35,6 +35,10 @@ class CORE_EXPORT QgsBilinearRasterResampler: public QgsRasterResamplerV2
   public:
 
     QgsBilinearRasterResampler() = default;
+
+    /**
+     * \deprecated QGIS 3.12. Use resampleV2() instead.
+     */
     Q_DECL_DEPRECATED void resample( const QImage &srcImage, QImage &dstImage ) override SIP_DEPRECATED;
 
     QImage resampleV2( const QImage &source, const QSize &size ) override;

--- a/src/core/raster/qgscubicrasterresampler.h
+++ b/src/core/raster/qgscubicrasterresampler.h
@@ -37,6 +37,10 @@ class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResamplerV2
     QgsCubicRasterResampler *clone() const override SIP_FACTORY;
 
     QImage resampleV2( const QImage &source, const QSize &size ) override;
+
+    /**
+     * \deprecated QGIS 3.12. Use resampleV2() instead.
+     */
     Q_DECL_DEPRECATED void resample( const QImage &srcImage, QImage &dstImage ) override SIP_DEPRECATED;
     QString type() const override;
     int tileBufferPixels() const override;

--- a/src/core/scalebar/qgsnumericscalebarrenderer.h
+++ b/src/core/scalebar/qgsnumericscalebarrenderer.h
@@ -46,6 +46,9 @@ class CORE_EXPORT QgsNumericScaleBarRenderer: public QgsScaleBarRenderer
                              const QgsScaleBarSettings &settings,
                              const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const override;
 
+    /**
+     * \deprecated QGIS 3.14. Use the one with render context instead.
+     */
     Q_DECL_DEPRECATED QSizeF calculateBoxSize( const QgsScaleBarSettings &settings, const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const override SIP_DEPRECATED ;
 
   private:

--- a/src/gui/editorwidgets/qgsjsoneditwidget.h
+++ b/src/gui/editorwidgets/qgsjsoneditwidget.h
@@ -22,6 +22,8 @@
 #include "qgis_sip.h"
 #include "qgis_gui.h"
 
+SIP_IF_MODULE( HAVE_QSCI_SIP )
+
 /**
  * \ingroup gui
  * \class QgsJsonEditWidget


### PR DESCRIPTION


This PR implements the QGIS part of QEP [#287](https://github.com/qgis/QGIS-Enhancement-Proposals/issues/287)

It follows Python-SIP pull request [#46](https://github.com/Python-SIP/sip/pull/46) which allows to generate @deprecated decorator instruction in *pyi* files and support deprecated annotation with message. This new feature is only available in SIP 6.9.0.

As a result, if a python plugin use the deprecated function `QgsProject.fileInfo()` for instance,

When running, you'd get the following (same as before but with the \deprecated message)

```shell
/home/julien/work/QGIS/.worktrees/sip_deprecated/./deprecated_qgis.py:4: DeprecationWarning: QgsProject.fileInfo() is deprecated: Since 3.2. Use absoluteFilePath(), baseName() or lastModifiedTime() instead.
  p.fileInfo()
```

With using static Python linter *pyright*, you'd get the following 

```shell
  /home/julien/work/QGIS/.worktrees/sip_deprecated/deprecated_qgis.py:4:3 - error: The method "fileInfo" in class "QgsProject" is deprecated
    Since 3.2. Use absoluteFilePath(), baseName() or lastModifiedTime() instead. (reportDeprecated)
1 error, 0 warnings, 0 informations 
```

<details>
<summary>pyright configuration file pyproject.toml</summary>

```toml
[tool.pyright]
include = ["deprecated_qgis.py"]
reportDeprecated = true
````

</details>

It's not possible to activate the deprecated message only for version greater or equal than SIP 6.9.0 using %if directive (with either %Feature or SIP range version) because of this [issue](https://github.com/Python-SIP/sip/issues/47) fixed now (but would fail with all versions below 6.9.0).

So the only remaining option was to have a separate folder like we did for Qt6. This would lead to even more sip files, so I prefer not to. One solution would be, maybe, to generate those files at packaging time, before building.

This PR proposes also to:
- fail sipify_all.sh properly is sipify.py failed
- raise an error if SIP_DEPRECATED is used but no \deprecated instruction has been set in doxygen documentation
- fix missing \deprecated instruction
- Fix build without QSci Sip
