### PR TITLE
BUG: Fix metadata:plugin_dependencies parsing

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -413,12 +413,12 @@ def get_plugin_deps(plugin_id: str) -> dict[str, Optional[str]]:
         return result
 
     for dep in plugin_deps.split(","):
-        if dep.find("==") > 0:
+        if "==" in dep:
             name, version_required = dep.split("==")
         else:
-            name = dep
-            version_required = None
-        result[name] = version_required
+            name, version_required = dep, None
+        result[name.strip()] = version_required.strip() if version_required else None
+
     return result
 
 


### PR DESCRIPTION
## Description

When writing  a plugin, adding multiple values to the `plugin_depencies` field of the `metadata.txt` raises false positive errors when whitespaces are inserted in the line. One is supposed to split dependencies using a `,` comma, but if whitespaces are inserted (which is the 'standard' syntax ... at least in python with pip) it missread the name (false leading/trailling whitespaces).

This patch only commits a `.strip()` addition to the name and version parsed


## Exemple
current behavior:  
`plugin_dependencies = Plugin Reloader, QRestart`  # fails
`plugin_dependencies = Plugin Reloader,QRestart`  # success

patched behavior:  
`plugin_dependencies = Plugin Reloader, QRestart`  # success
`plugin_dependencies = Plugin Reloader,QRestart`  # success