### PR TITLE
Db manager table comment multiline

### DIFF
--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -434,7 +434,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
         supportCom = self.db.supportsComment()
         if self.chkCom.isEnabled() and self.chkCom.isChecked() and supportCom:
             # using connector executing COMMENT ON TABLE query (with editCome.text() value)
-            com = self.editCom.text()
+            com = self.editCom.toPlainText()
             self.db.connector.commentTable(schema, table, com)
 
         self.db.connection().reconnect()

--- a/python/plugins/db_manager/dlg_table_properties.py
+++ b/python/plugins/db_manager/dlg_table_properties.py
@@ -69,7 +69,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
 
         # Display comment in line edit
         m = self.table.comment
-        self.viewComment.setText(m)
+        self.viewComment.setPlainText(m)
 
         self.btnAddColumn.clicked.connect(self.addColumn)
         self.btnAddGeometryColumn.clicked.connect(self.addGeometryColumn)
@@ -384,7 +384,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         try:
             schem = self.table.schema().name
             tab = self.table.name
-            com = self.viewComment.text()
+            com = self.viewComment.toPlainText()
             self.db.connector.commentTable(schem, tab, com)
         except DbError as e:
             DlgDbError.showError(e, self)
@@ -406,7 +406,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
             return
         self.refresh()
         # Refresh line edit, put a void comment
-        self.viewComment.setText("")
+        self.viewComment.setPlainText("")
         # Display successful message
         QMessageBox.information(
             self, self.tr("Delete comment"), self.tr("Comment deleted")

--- a/python/plugins/db_manager/dlg_table_properties.py
+++ b/python/plugins/db_manager/dlg_table_properties.py
@@ -386,6 +386,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
             tab = self.table.name
             com = self.viewComment.toPlainText()
             self.db.connector.commentTable(schem, tab, com)
+            self.table.comment = com
         except DbError as e:
             DlgDbError.showError(e, self)
             return
@@ -407,6 +408,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         self.refresh()
         # Refresh line edit, put a void comment
         self.viewComment.setPlainText("")
+        self.table.comment = ""
         # Display successful message
         QMessageBox.information(
             self, self.tr("Delete comment"), self.tr("Comment deleted")

--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -258,7 +258,7 @@
        </widget>
       </item>
       <item row="10" column="1">
-       <widget class="QLineEdit" name="editCom">
+       <widget class="QTextEdit" name="editCom">
         <property name="enabled">
          <bool>false</bool>
         </property>

--- a/python/plugins/db_manager/ui/DlgTableProperties.ui
+++ b/python/plugins/db_manager/ui/DlgTableProperties.ui
@@ -212,7 +212,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="viewComment"/>
+        <widget class="QTextEdit" name="viewComment"/>
        </item>
        <item>
         <layout class="QHBoxLayout" name="_4">


### PR DESCRIPTION
## Description

Fixes #58946

Makes table comments in DB Manager multiline (turning original QLineEdit to QTextEdit)). Also fixes one minor error, where the comment was not properly updated on second open of the "Table properties" window.


![Screenshot from 2024-12-12 14-34-48](https://github.com/user-attachments/assets/bffa7117-bc19-41a6-952a-adc0ed6187ae)
![Screenshot from 2024-12-12 14-35-08](https://github.com/user-attachments/assets/9b082901-56a7-4465-ba46-d1c6c10b896a)

Funded by Ocean Winds