### PR TITLE
fix: workaround for missing libaio.so.1 on noble

### DIFF
--- a/.docker/docker-compose-testing-oracle.yml
+++ b/.docker/docker-compose-testing-oracle.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   oracle:

--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -130,6 +130,8 @@ RUN unzip -n instantclient-sqlplus-linux.x64-21.16.0.0.0dbru.zip
 
 ENV PATH="/instantclient_21_16:${PATH}"
 ENV LD_LIBRARY_PATH="/instantclient_21_16:${LD_LIBRARY_PATH}"
+# workaround noble libaio SONAME issue -- see https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
+RUN if [ -e /usr/lib/x86_64-linux-gnu/libaio.so.1t64 ] ; then ln -sf /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1 ; fi
 
 # Avoid sqlcmd termination due to locale -- see https://github.com/Microsoft/mssql-docker/issues/163
 RUN echo "nb_NO.UTF-8 UTF-8" > /etc/locale.gen


### PR DESCRIPTION
ubuntu 24.04 got screwed and only provides libaio.so.1t64
thus we need a workaround to get oracle binaries running as expected

see upstream bug report https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501