### PR TITLE
Postgreprovider hide raster overviews

### DIFF
--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -82,7 +82,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
     cb_geometryColumnsOnly->setChecked( settings.value( key + "/geometryColumnsOnly", true ).toBool() );
     cb_dontResolveType->setChecked( settings.value( key + "/dontResolveType", false ).toBool() );
     cb_allowGeometrylessTables->setChecked( settings.value( key + "/allowGeometrylessTables", false ).toBool() );
-    cb_showRasterOverviews->setChecked( settings.value( key + "/showRasterOverviews", false ).toBool() );
+    cb_allowRasterOverviewTables->setChecked( settings.value( key + "/allowRasterOverviewTables", false ).toBool() );
     // Ensure that cb_publicSchemaOnly is set correctly
     cb_geometryColumnsOnly_clicked();
 
@@ -178,7 +178,7 @@ void QgsPgNewConnection::accept()
   configuration.insert( "projectsInDatabase", cb_projectsInDatabase->isChecked() );
   configuration.insert( "metadataInDatabase", cb_metadataInDatabase->isChecked() );
   configuration.insert( "session_role", txtSessionRole->text() );
-  configuration.insert( "showRasterOverviews", cb_showRasterOverviews->isChecked() );
+  configuration.insert( "allowRasterOverviewTables", cb_allowRasterOverviewTables->isChecked() );
 
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
   std::unique_ptr<QgsPostgresProviderConnection> providerConnection( qgis::down_cast<QgsPostgresProviderConnection *>( providerMetadata->createConnection( txtName->text() ) ) );

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -82,7 +82,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
     cb_geometryColumnsOnly->setChecked( settings.value( key + "/geometryColumnsOnly", true ).toBool() );
     cb_dontResolveType->setChecked( settings.value( key + "/dontResolveType", false ).toBool() );
     cb_allowGeometrylessTables->setChecked( settings.value( key + "/allowGeometrylessTables", false ).toBool() );
-    cb_dontShowRasterOverviews->setChecked( settings.value( key + "/dontShowRasterOverviews", false ).toBool() );
+    cb_showRasterOverviews->setChecked( settings.value( key + "/showRasterOverviews", true ).toBool() );
     // Ensure that cb_publicSchemaOnly is set correctly
     cb_geometryColumnsOnly_clicked();
 
@@ -178,7 +178,7 @@ void QgsPgNewConnection::accept()
   configuration.insert( "projectsInDatabase", cb_projectsInDatabase->isChecked() );
   configuration.insert( "metadataInDatabase", cb_metadataInDatabase->isChecked() );
   configuration.insert( "session_role", txtSessionRole->text() );
-  configuration.insert( "dontShowRasterOverviews", cb_dontShowRasterOverviews->isChecked() );
+  configuration.insert( "showRasterOverviews", cb_showRasterOverviews->isChecked() );
 
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
   std::unique_ptr<QgsPostgresProviderConnection> providerConnection( qgis::down_cast<QgsPostgresProviderConnection *>( providerMetadata->createConnection( txtName->text() ) ) );

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -82,6 +82,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
     cb_geometryColumnsOnly->setChecked( settings.value( key + "/geometryColumnsOnly", true ).toBool() );
     cb_dontResolveType->setChecked( settings.value( key + "/dontResolveType", false ).toBool() );
     cb_allowGeometrylessTables->setChecked( settings.value( key + "/allowGeometrylessTables", false ).toBool() );
+    cb_dontShowRasterOverviews->setChecked( settings.value( key + "/dontShowRasterOverviews", false ).toBool() );
     // Ensure that cb_publicSchemaOnly is set correctly
     cb_geometryColumnsOnly_clicked();
 
@@ -177,6 +178,7 @@ void QgsPgNewConnection::accept()
   configuration.insert( "projectsInDatabase", cb_projectsInDatabase->isChecked() );
   configuration.insert( "metadataInDatabase", cb_metadataInDatabase->isChecked() );
   configuration.insert( "session_role", txtSessionRole->text() );
+  configuration.insert( "dontShowRasterOverviews", cb_dontShowRasterOverviews->isChecked() );
 
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
   std::unique_ptr<QgsPostgresProviderConnection> providerConnection( qgis::down_cast<QgsPostgresProviderConnection *>( providerMetadata->createConnection( txtName->text() ) ) );

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -82,7 +82,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
     cb_geometryColumnsOnly->setChecked( settings.value( key + "/geometryColumnsOnly", true ).toBool() );
     cb_dontResolveType->setChecked( settings.value( key + "/dontResolveType", false ).toBool() );
     cb_allowGeometrylessTables->setChecked( settings.value( key + "/allowGeometrylessTables", false ).toBool() );
-    cb_showRasterOverviews->setChecked( settings.value( key + "/showRasterOverviews", true ).toBool() );
+    cb_showRasterOverviews->setChecked( settings.value( key + "/showRasterOverviews", false ).toBool() );
     // Ensure that cb_publicSchemaOnly is set correctly
     cb_geometryColumnsOnly_clicked();
 

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1062,7 +1062,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
     QgsPostgresResult resultRasterOverviews;
     resultRasterOverviews = LoggedPQexec( "QgsPostgresConn", sqlRasterOverviews );
 
-    if ( resultRasterOverviews.result() )
+    if ( resultRasterOverviews.result() && resultRasterOverviews.PQntuples() > 0 )
     {
       QVector<QgsPostgresRasterOverviewLayerProperty> overviews;
       for ( int idx = 0; idx < resultRasterOverviews.PQntuples(); idx++ )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -2731,6 +2731,12 @@ bool QgsPostgresConn::allowProjectsInDatabase( const QString &connName )
   return settings.value( "/PostgreSQL/connections/" + connName + "/projectsInDatabase", false ).toBool();
 }
 
+bool QgsPostgresConn::removeRasterOverviewTables( const QString &connName )
+{
+  QgsSettings settings;
+  return settings.value( "/PostgreSQL/connections/" + connName + "/dontShowRasterOverviews", false ).toBool();
+}
+
 void QgsPostgresConn::deleteConnection( const QString &connName )
 {
   QgsSettings settings;
@@ -2755,6 +2761,7 @@ void QgsPostgresConn::deleteConnection( const QString &connName )
   settings.remove( key + "/metadataInDatabase" );
   settings.remove( key + "/dontResolveType" );
   settings.remove( key + "/session_role" );
+  settings.remove( key + "/dontShowRasterOverviews" );
   settings.remove( key );
 }
 
@@ -2782,6 +2789,7 @@ void QgsPostgresConn::duplicateConnection( const QString &src, const QString &ds
   settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
   settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
   settings.setValue( newKey + QStringLiteral( "/authcfg" ), settings.value( key + QStringLiteral( "/authcfg" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/dontShowRasterOverviews" ), settings.value( key + QStringLiteral( "/dontShowRasterOverviews" ) ).toString() );
 
   settings.sync();
 }

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1066,7 +1066,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
 
     if ( resultRasterOverviewsExist.result() && resultRasterOverviewsExist.PQntuples() > 0 )
     {
-      QString sqlRasterOverviews = QString( "SELECT o_table_schema, o_table_name FROM public.raster_overviews" );
+      const QString sqlRasterOverviews = QStringLiteral( "SELECT o_table_schema, o_table_name FROM public.raster_overviews" );
 
       QgsPostgresResult resultRasterOverviews;
       resultRasterOverviews = LoggedPQexec( "QgsPostgresConn", sqlRasterOverviews );

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -594,7 +594,7 @@ void QgsPostgresConn::addColumnInfo( QgsPostgresLayerProperty &layerProperty, co
   }
 }
 
-bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool showRasterOverviews, const QString &schema, const QString &name )
+bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool allowRasterOverviewTables, const QString &schema, const QString &name )
 {
   QMutexLocker locker( &mLock );
   int nColumns = 0;
@@ -1054,8 +1054,8 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
     }
   }
 
-  // remove raster overivews if showRasterOverviews is FALSE
-  if ( !showRasterOverviews )
+  // remove raster overivews if allowRasterOverviewTables is FALSE
+  if ( !allowRasterOverviewTables )
   {
     QString sqlRasterOverviewExist = QStringLiteral( "SELECT table_schema, table_name"
                                                      " FROM information_schema.views"
@@ -1119,14 +1119,14 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
   return true;
 }
 
-bool QgsPostgresConn::supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool showRasterOverviews, const QString &schema, const QString &table )
+bool QgsPostgresConn::supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool allowRasterOverviewTables, const QString &schema, const QString &table )
 {
   QMutexLocker locker( &mLock );
 
   mLayersSupported.clear();
 
   // Get the list of supported tables
-  if ( !getTableInfo( searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, showRasterOverviews, schema, table ) )
+  if ( !getTableInfo( searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, allowRasterOverviewTables, schema, table ) )
   {
     QgsMessageLog::logMessage( tr( "Unable to get list of spatially enabled tables from the database" ), tr( "PostGIS" ) );
     return false;
@@ -1515,9 +1515,9 @@ Qgis::PostgresRelKind QgsPostgresConn::relKindFromValue( const QString &value )
   return Qgis::PostgresRelKind::Unknown;
 }
 
-bool QgsPostgresConn::supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool showRasterOverviews, const QString &schema )
+bool QgsPostgresConn::supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool allowRasterOverviewTables, const QString &schema )
 {
-  return supportedLayersPrivate( layers, searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, showRasterOverviews, schema );
+  return supportedLayersPrivate( layers, searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, allowRasterOverviewTables, schema );
 }
 
 bool QgsPostgresConn::supportedLayer( QgsPostgresLayerProperty &layerProperty, const QString &schema, const QString &table )
@@ -2788,10 +2788,10 @@ bool QgsPostgresConn::allowProjectsInDatabase( const QString &connName )
   return settings.value( "/PostgreSQL/connections/" + connName + "/projectsInDatabase", false ).toBool();
 }
 
-bool QgsPostgresConn::showRasterOverviewTables( const QString &connName )
+bool QgsPostgresConn::allowRasterOverviewTables( const QString &connName )
 {
   QgsSettings settings;
-  return settings.value( "/PostgreSQL/connections/" + connName + "/showRasterOverviews", true ).toBool();
+  return settings.value( "/PostgreSQL/connections/" + connName + "/allowRasterOverviewTables", true ).toBool();
 }
 
 void QgsPostgresConn::deleteConnection( const QString &connName )
@@ -2818,7 +2818,7 @@ void QgsPostgresConn::deleteConnection( const QString &connName )
   settings.remove( key + "/metadataInDatabase" );
   settings.remove( key + "/dontResolveType" );
   settings.remove( key + "/session_role" );
-  settings.remove( key + "/showRasterOverviews" );
+  settings.remove( key + "/allowRasterOverviewTables" );
   settings.remove( key );
 }
 
@@ -2846,7 +2846,7 @@ void QgsPostgresConn::duplicateConnection( const QString &src, const QString &ds
   settings.setValue( newKey + QStringLiteral( "/saveUsername" ), settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() );
   settings.setValue( newKey + QStringLiteral( "/savePassword" ), settings.value( key + QStringLiteral( "/savePassword" ) ).toString() );
   settings.setValue( newKey + QStringLiteral( "/authcfg" ), settings.value( key + QStringLiteral( "/authcfg" ) ).toString() );
-  settings.setValue( newKey + QStringLiteral( "/showRasterOverviews" ), settings.value( key + QStringLiteral( "/showRasterOverviews" ) ).toString() );
+  settings.setValue( newKey + QStringLiteral( "/allowRasterOverviewTables" ), settings.value( key + QStringLiteral( "/allowRasterOverviewTables" ) ).toString() );
 
   settings.sync();
 }

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -594,7 +594,7 @@ void QgsPostgresConn::addColumnInfo( QgsPostgresLayerProperty &layerProperty, co
   }
 }
 
-bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, const QString &schema, const QString &name )
+bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool removeRasterOverviews, const QString &schema, const QString &name )
 {
   QMutexLocker locker( &mLock );
   int nColumns = 0;
@@ -1054,6 +1054,52 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
     }
   }
 
+  if ( removeRasterOverviews )
+  {
+    QString sqlRasterOverviews = QString( "SELECT o_table_schema, o_table_name FROM public.raster_overviews" );
+
+    QgsPostgresResult resultRasterOverviews;
+    resultRasterOverviews = LoggedPQexec( "QgsPostgresConn", sqlRasterOverviews );
+
+    if ( resultRasterOverviews.result() )
+    {
+      QVector<QgsPostgresRasterOverviewLayerProperty> overviews;
+      for ( int idx = 0; idx < resultRasterOverviews.PQntuples(); idx++ )
+      {
+        QgsPostgresRasterOverviewLayerProperty rasterOverviewProperty;
+        rasterOverviewProperty.schemaName = resultRasterOverviews.PQgetvalue( idx, 0 );
+        rasterOverviewProperty.tableName = resultRasterOverviews.PQgetvalue( idx, 1 );
+        overviews.append( rasterOverviewProperty );
+      }
+
+      QVector<QgsPostgresLayerProperty> layersToKeep;
+      for ( int i = 0; i < mLayersSupported.count(); i++ )
+      {
+        QgsPostgresLayerProperty property = mLayersSupported.at( i );
+
+        if ( !property.isRaster )
+        {
+          layersToKeep.append( property );
+        }
+        else
+        {
+          bool keepRasterTable = true;
+          for ( QgsPostgresRasterOverviewLayerProperty overview : overviews )
+          {
+            if ( property.schemaName == overview.schemaName && property.tableName == overview.tableName )
+            {
+              keepRasterTable = false;
+            }
+          }
+
+          if ( keepRasterTable )
+            layersToKeep.append( property );
+        }
+      }
+      mLayersSupported = layersToKeep;
+    }
+  }
+
   if ( nColumns == 0 && schema.isEmpty() )
   {
     QgsMessageLog::logMessage( tr( "Database connection was successful, but the accessible tables could not be determined." ), tr( "PostGIS" ) );
@@ -1062,14 +1108,14 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
   return true;
 }
 
-bool QgsPostgresConn::supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, const QString &schema, const QString &table )
+bool QgsPostgresConn::supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool removeRasterOverviews, const QString &schema, const QString &table )
 {
   QMutexLocker locker( &mLock );
 
   mLayersSupported.clear();
 
   // Get the list of supported tables
-  if ( !getTableInfo( searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, schema, table ) )
+  if ( !getTableInfo( searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, removeRasterOverviews, schema, table ) )
   {
     QgsMessageLog::logMessage( tr( "Unable to get list of spatially enabled tables from the database" ), tr( "PostGIS" ) );
     return false;
@@ -1458,15 +1504,15 @@ Qgis::PostgresRelKind QgsPostgresConn::relKindFromValue( const QString &value )
   return Qgis::PostgresRelKind::Unknown;
 }
 
-bool QgsPostgresConn::supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, const QString &schema )
+bool QgsPostgresConn::supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool removeRasterOverviews, const QString &schema )
 {
-  return supportedLayersPrivate( layers, searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, schema );
+  return supportedLayersPrivate( layers, searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, removeRasterOverviews, schema );
 }
 
 bool QgsPostgresConn::supportedLayer( QgsPostgresLayerProperty &layerProperty, const QString &schema, const QString &table )
 {
   QVector<QgsPostgresLayerProperty> layers;
-  if ( !supportedLayersPrivate( layers, false, false, true /* allowGeometrylessTables */, schema, table ) || layers.empty() )
+  if ( !supportedLayersPrivate( layers, false, false, true /* allowGeometrylessTables */, false, schema, table ) || layers.empty() )
   {
     return false;
   }

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1094,7 +1094,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
           else
           {
             bool keepRasterTable = true;
-            for ( QgsPostgresRasterOverviewLayerProperty overview : overviews )
+            for ( const QgsPostgresRasterOverviewLayerProperty &overview : std::as_const( overviews ) )
             {
               if ( property.schemaName == overview.schemaName && property.tableName == overview.tableName )
               {

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -68,6 +68,12 @@ struct QgsPostgresSchemaProperty
     QString owner;
 };
 
+//! Raster overview table properties structure
+struct QgsPostgresRasterOverviewLayerProperty
+{
+    QString schemaName;
+    QString tableName;
+};
 
 //! Layer Property structure
 // TODO: Fill to Postgres/PostGIS specifications
@@ -382,10 +388,11 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
+     * \param removeRasterOverviews do not list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, const QString &schema = QString() );
+    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool removeRasterOverviews = false, const QString &schema = QString() );
 
     /**
      * Get the information about a supported layer
@@ -418,11 +425,12 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
+     * \param removeRasterOverviews do not list raster layer overviews
      * \param schema restrict tables to those within specified schema
      * \param name restrict tables to those with specified name
      * \returns true if tables were successfully queried
      */
-    bool getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, const QString &schema = QString(), const QString &name = QString() );
+    bool getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool removeRasterOverviews = false, const QString &schema = QString(), const QString &name = QString() );
 
     qint64 getBinaryInt( QgsPostgresResult &queryResult, int row, int col );
 
@@ -544,11 +552,12 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
+     * \param removeRasterOverviews do not list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \param table restrict tables to those with specified table
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, const QString &schema = QString(), const QString &table = QString() );
+    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool removeRasterOverviews = false, const QString &schema = QString(), const QString &table = QString() );
 
     //! List of the supported layers
     QVector<QgsPostgresLayerProperty> mLayersSupported;

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -471,6 +471,7 @@ class QgsPostgresConn : public QObject
     static bool allowProjectsInDatabase( const QString &connName );
     static void deleteConnection( const QString &connName );
     static bool allowMetadataInDatabase( const QString &connName );
+    static bool removeRasterOverviewTables( const QString &connName );
 
     /**
      * Duplicates \a src connection settings to a new \a dst connection.

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -388,11 +388,11 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
-     * \param showRasterOverviews list raster layer overviews
+     * \param allowRasterOverviewTables list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool showRasterOverviews = false, const QString &schema = QString() );
+    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool allowRasterOverviewTables = false, const QString &schema = QString() );
 
     /**
      * Get the information about a supported layer
@@ -425,12 +425,12 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
-     * \param showRasterOverviews list raster layer overviews
+     * \param allowRasterOverviewTables list raster layer overviews
      * \param schema restrict tables to those within specified schema
      * \param name restrict tables to those with specified name
      * \returns true if tables were successfully queried
      */
-    bool getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool showRasterOverviews = false, const QString &schema = QString(), const QString &name = QString() );
+    bool getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool allowRasterOverviewTables = false, const QString &schema = QString(), const QString &name = QString() );
 
     qint64 getBinaryInt( QgsPostgresResult &queryResult, int row, int col );
 
@@ -479,7 +479,7 @@ class QgsPostgresConn : public QObject
     static bool allowProjectsInDatabase( const QString &connName );
     static void deleteConnection( const QString &connName );
     static bool allowMetadataInDatabase( const QString &connName );
-    static bool showRasterOverviewTables( const QString &connName );
+    static bool allowRasterOverviewTables( const QString &connName );
 
     /**
      * Duplicates \a src connection settings to a new \a dst connection.
@@ -552,12 +552,12 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
-     * \param showRasterOverviews list raster layer overviews
+     * \param allowRasterOverviewTables list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \param table restrict tables to those with specified table
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool showRasterOverviews = false, const QString &schema = QString(), const QString &table = QString() );
+    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool allowRasterOverviewTables = false, const QString &schema = QString(), const QString &table = QString() );
 
     //! List of the supported layers
     QVector<QgsPostgresLayerProperty> mLayersSupported;

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -388,11 +388,11 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
-     * \param removeRasterOverviews do not list raster layer overviews
+     * \param showRasterOverviews list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool removeRasterOverviews = false, const QString &schema = QString() );
+    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool showRasterOverviews = false, const QString &schema = QString() );
 
     /**
      * Get the information about a supported layer
@@ -425,12 +425,12 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
-     * \param removeRasterOverviews do not list raster layer overviews
+     * \param showRasterOverviews list raster layer overviews
      * \param schema restrict tables to those within specified schema
      * \param name restrict tables to those with specified name
      * \returns true if tables were successfully queried
      */
-    bool getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool removeRasterOverviews = false, const QString &schema = QString(), const QString &name = QString() );
+    bool getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool showRasterOverviews = false, const QString &schema = QString(), const QString &name = QString() );
 
     qint64 getBinaryInt( QgsPostgresResult &queryResult, int row, int col );
 
@@ -479,7 +479,7 @@ class QgsPostgresConn : public QObject
     static bool allowProjectsInDatabase( const QString &connName );
     static void deleteConnection( const QString &connName );
     static bool allowMetadataInDatabase( const QString &connName );
-    static bool removeRasterOverviewTables( const QString &connName );
+    static bool showRasterOverviewTables( const QString &connName );
 
     /**
      * Duplicates \a src connection settings to a new \a dst connection.
@@ -552,12 +552,12 @@ class QgsPostgresConn : public QObject
      * contained in the geometry_columns metatable
      * \param searchPublicOnly
      * \param allowGeometrylessTables
-     * \param removeRasterOverviews do not list raster layer overviews
+     * \param showRasterOverviews list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \param table restrict tables to those with specified table
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool removeRasterOverviews = false, const QString &schema = QString(), const QString &table = QString() );
+    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool showRasterOverviews = false, const QString &schema = QString(), const QString &table = QString() );
 
     //! List of the supported layers
     QVector<QgsPostgresLayerProperty> mLayersSupported;

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -413,7 +413,7 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
   }
 
   QVector<QgsPostgresLayerProperty> layerProperties;
-  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::publicSchemaOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), QgsPostgresConn::removeRasterOverviewTables( mConnectionName ), mName );
+  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::publicSchemaOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), QgsPostgresConn::showRasterOverviewTables( mConnectionName ), mName );
 
   if ( !ok )
   {

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -413,7 +413,7 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
   }
 
   QVector<QgsPostgresLayerProperty> layerProperties;
-  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::publicSchemaOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), mName );
+  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::publicSchemaOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), QgsPostgresConn::removeRasterOverviewTables( mConnectionName ), mName );
 
   if ( !ok )
   {

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -413,7 +413,7 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
   }
 
   QVector<QgsPostgresLayerProperty> layerProperties;
-  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::publicSchemaOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), QgsPostgresConn::showRasterOverviewTables( mConnectionName ), mName );
+  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::publicSchemaOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), QgsPostgresConn::allowRasterOverviewTables( mConnectionName ), mName );
 
   if ( !ok )
   {

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -45,7 +45,7 @@ const QStringList QgsPostgresProviderConnection::CONFIGURATION_PARAMETERS = {
   QStringLiteral( "projectsInDatabase" ),
   QStringLiteral( "metadataInDatabase" ),
   QStringLiteral( "session_role" ),
-  QStringLiteral( "dontShowRasterOverviews" ),
+  QStringLiteral( "showRasterOverviews" ),
 };
 
 const QString QgsPostgresProviderConnection::SETTINGS_BASE_KEY = QStringLiteral( "/PostgreSQL/connections/" );

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -240,7 +240,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsPostgresProviderC
     }
     else
     {
-      ok = conn->supportedLayers( properties, false, schema == QStringLiteral( "public" ), aspatial, schema );
+      ok = conn->supportedLayers( properties, false, schema == QStringLiteral( "public" ), aspatial, false, schema );
     }
 
     if ( !ok )

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -45,7 +45,7 @@ const QStringList QgsPostgresProviderConnection::CONFIGURATION_PARAMETERS = {
   QStringLiteral( "projectsInDatabase" ),
   QStringLiteral( "metadataInDatabase" ),
   QStringLiteral( "session_role" ),
-  QStringLiteral( "showRasterOverviews" ),
+  QStringLiteral( "allowRasterOverviewTables" ),
 };
 
 const QString QgsPostgresProviderConnection::SETTINGS_BASE_KEY = QStringLiteral( "/PostgreSQL/connections/" );

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -45,6 +45,7 @@ const QStringList QgsPostgresProviderConnection::CONFIGURATION_PARAMETERS = {
   QStringLiteral( "projectsInDatabase" ),
   QStringLiteral( "metadataInDatabase" ),
   QStringLiteral( "session_role" ),
+  QStringLiteral( "dontShowRasterOverviews" ),
 };
 
 const QString QgsPostgresProviderConnection::SETTINGS_BASE_KEY = QStringLiteral( "/PostgreSQL/connections/" );

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>510</height>
+    <height>573</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -233,6 +233,13 @@
        <widget class="QCheckBox" name="cb_metadataInDatabase">
         <property name="text">
          <string>Allow saving/loading QGIS layer metadata in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cb_dontShowRasterOverviews">
+        <property name="text">
+         <string>Don't list raster overview tables</string>
         </property>
        </widget>
       </item>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -237,9 +237,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="cb_showRasterOverviews">
+       <widget class="QCheckBox" name="cb_allowRasterOverviewTables">
         <property name="text">
-         <string>List raster overview tables</string>
+         <string>Also list raster overview tables</string>
         </property>
        </widget>
       </item>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -237,9 +237,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="cb_dontShowRasterOverviews">
+       <widget class="QCheckBox" name="cb_showRasterOverviews">
         <property name="text">
-         <string>Don't list raster overview tables</string>
+         <string>List raster overview tables</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Description

Ads option to **PostGIS Connection** to not list raster overview tables from **Browser**. The list of raster overviews tables is obtained from PostGIS view **raster_overviews**. 

Fixes #53829

![Screenshot from 2025-01-09 13-06-11](https://github.com/user-attachments/assets/4fab3810-07d9-453e-beb0-9efe1e397bfd)

Funded by Ocean Winds
