### PR TITLE
Run oauth2 python test on qt6 builds (3.40 backport)

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -37,7 +37,6 @@ PyQgsStyleStorageMssql
 PyQgsPythonProvider
 PyQgsAnnotation
 PyQgsAuthenticationSystem
-PyQgsAuthManagerOAuth2OWSTest
 PyQgsCodeEditor
 PyQgsDelimitedTextProvider
 PyQgsEditWidgets

--- a/.docker/qgis3-qt6-build-deps.dockerfile
+++ b/.docker/qgis3-qt6-build-deps.dockerfile
@@ -46,6 +46,7 @@ RUN dnf -y --refresh install \
     protobuf-lite-devel \
     python3-devel \
     python3-mock \
+    python3-oauthlib \
     python3-OWSLib \
     python3-pyqt6 \
     python3-pyqt6-devel \


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/59873