### PR TITLE
[Georeferencer] Fix setting target CRS (Fix #59902)

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -87,6 +87,8 @@ const QgsSettingsEntryString *QgsGeoreferencerMainWindow::settingLastSourceFolde
 
 const QgsSettingsEntryString *QgsGeoreferencerMainWindow::settingLastRasterFileFilter = new QgsSettingsEntryString( QStringLiteral( "last-raster-file-filter" ), sTreeGeoreferencer, QString(), QObject::tr( "Last used raster file filter for georeferencer source files" ) );
 
+const QgsSettingsEntryString *QgsGeoreferencerMainWindow::settingLastTargetCrs = new QgsSettingsEntryString( QStringLiteral( "last-target-crs" ), sTreeGeoreferencer, QString(), QObject::tr( "Last used georeferencer target CRS" ) );
+
 QgsGeorefDockWidget::QgsGeorefDockWidget( const QString &title, QWidget *parent, Qt::WindowFlags flags )
   : QgsDockWidget( title, parent, flags )
 {
@@ -108,9 +110,6 @@ QgsGeoreferencerMainWindow::QgsGeoreferencerMainWindow( QWidget *parent, Qt::Win
   mCentralLayout->setContentsMargins( 0, 0, 0, 0 );
 
   QgsSettings settings;
-  // default to last used target CRS
-  QString targetCRSString = settings.value( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ) ).toString();
-  mTargetCrs = QgsCoordinateReferenceSystem( targetCRSString );
 
   createActions();
   createActionGroups();
@@ -1376,6 +1375,7 @@ void QgsGeoreferencerMainWindow::readSettings()
   mTransformMethod = settingTransformMethod->value();
   mSaveGcp = settingSaveGcps->value();
   mLoadInQgis = settingLoadInProject->value();
+  mTargetCrs = QgsCoordinateReferenceSystem( settingLastTargetCrs->value() );
 }
 
 void QgsGeoreferencerMainWindow::writeSettings()
@@ -1389,6 +1389,7 @@ void QgsGeoreferencerMainWindow::writeSettings()
   settingUseZeroForTransparent->setValue( mUseZeroForTrans );
   settingSaveGcps->setValue( mSaveGcp );
   settingLoadInProject->setValue( mLoadInQgis );
+  settingLastTargetCrs->setValue( mTargetCrs.authid() );
 }
 
 bool QgsGeoreferencerMainWindow::loadGCPs( QString &error )

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -75,6 +75,7 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     static const QgsSettingsEntryBool *settingLoadInProject;
     static const QgsSettingsEntryString *settingLastSourceFolder;
     static const QgsSettingsEntryString *settingLastRasterFileFilter;
+    static const QgsSettingsEntryString *settingLastTargetCrs;
 
     QgsGeoreferencerMainWindow( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags() );
     ~QgsGeoreferencerMainWindow() override;


### PR DESCRIPTION
## Description

Fixes an oversight in https://github.com/qgis/QGIS/pull/47279 where the target CRS set in the Georeferencer's "Transformation Settings" dialog window was not actually saved in the "QGIS3.ini" settings file.

I've remapped the setting from `targetsrs` in the `[Plugin-GeoReferencer]` section to `georeferencer\last-target-crs` in the `[app]` section for consistency with other settings in the same dialog window. This shouldn't create a backward incompatibility since the previous settings was never actually written in the "QGIS3.ini" settings file.

The setting is stored as a `QgsCoordinateReferenceSystem::authid()` string.

Fixes https://github.com/qgis/QGIS/issues/59902.

Side note: the Georeferencer stores it's settings in both the `[Plugin-GeoReferencer]` section and the `[app]` section. @3nids, is that intended?

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
