### PR TITLE
Simplify code for rotation and zoom around pivot in 3D

### DIFF
--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -183,6 +183,15 @@ to the given new pitch and heading angle.
 .. versionadded:: 3.42
 %End
 
+    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
+%Docstring
+Zooms camera by given zoom factor (higher than one means zoom in)
+while keeping the pivot point (given in world coordinates) at the
+same screen coordinates after the zoom.
+
+.. versionadded:: 3.42
+%End
+
     bool willHandleKeyEvent( QKeyEvent *event );
 %Docstring
 Returns ``True`` if the camera controller will handle the specified key ``event``,

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -185,7 +185,7 @@ to the given new pitch and heading angle.
 
     void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
 %Docstring
-Zooms camera by given zoom factor (higher than one means zoom in)
+Zooms camera by given zoom factor (>1 one means zoom in)
 while keeping the pivot point (given in world coordinates) at the
 same screen coordinates after the zoom.
 

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -175,6 +175,14 @@ Rotates the camera on itself.
 .. versionadded:: 3.30
 %End
 
+    void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
+%Docstring
+Rotates the camera around the pivot point (in world coordinates)
+to the given new pitch and heading angle.
+
+.. versionadded:: 3.42
+%End
+
     bool willHandleKeyEvent( QKeyEvent *event );
 %Docstring
 Returns ``True`` if the camera controller will handle the specified key ``event``,

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -183,6 +183,15 @@ to the given new pitch and heading angle.
 .. versionadded:: 3.42
 %End
 
+    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
+%Docstring
+Zooms camera by given zoom factor (higher than one means zoom in)
+while keeping the pivot point (given in world coordinates) at the
+same screen coordinates after the zoom.
+
+.. versionadded:: 3.42
+%End
+
     bool willHandleKeyEvent( QKeyEvent *event );
 %Docstring
 Returns ``True`` if the camera controller will handle the specified key ``event``,

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -185,7 +185,7 @@ to the given new pitch and heading angle.
 
     void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
 %Docstring
-Zooms camera by given zoom factor (higher than one means zoom in)
+Zooms camera by given zoom factor (>1 one means zoom in)
 while keeping the pivot point (given in world coordinates) at the
 same screen coordinates after the zoom.
 

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -175,6 +175,14 @@ Rotates the camera on itself.
 .. versionadded:: 3.30
 %End
 
+    void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
+%Docstring
+Rotates the camera around the pivot point (in world coordinates)
+to the given new pitch and heading angle.
+
+.. versionadded:: 3.42
+%End
+
     bool willHandleKeyEvent( QKeyEvent *event );
 %Docstring
 Returns ``True`` if the camera controller will handle the specified key ``event``,

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -988,6 +988,5 @@ int Qgs3DUtils::openGlMaxClipPlanes( QSurface *surface )
 
 QQuaternion Qgs3DUtils::rotationFromPitchHeadingAngles( float pitchAngle, float headingAngle )
 {
-  return QQuaternion::fromAxisAndAngle( QVector3D( 0, 0, 1 ), headingAngle ) *
-         QQuaternion::fromAxisAndAngle( QVector3D( 1, 0, 0 ), pitchAngle );
+  return QQuaternion::fromAxisAndAngle( QVector3D( 0, 0, 1 ), headingAngle ) * QQuaternion::fromAxisAndAngle( QVector3D( 1, 0, 0 ), pitchAngle );
 }

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -985,3 +985,10 @@ int Qgs3DUtils::openGlMaxClipPlanes( QSurface *surface )
 
   return numPlanes;
 }
+
+QQuaternion Qgs3DUtils::rotationFromPitchHeadingAngles( float pitchAngle, float headingAngle )
+{
+  // we use two separate fromEulerAngles() calls because one would not do rotations in order we need
+  return QQuaternion::fromEulerAngles( 0, 0, headingAngle ) *
+         QQuaternion::fromEulerAngles( pitchAngle, 0, 0 );
+}

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -988,7 +988,6 @@ int Qgs3DUtils::openGlMaxClipPlanes( QSurface *surface )
 
 QQuaternion Qgs3DUtils::rotationFromPitchHeadingAngles( float pitchAngle, float headingAngle )
 {
-  // we use two separate fromEulerAngles() calls because one would not do rotations in order we need
-  return QQuaternion::fromEulerAngles( 0, 0, headingAngle ) *
-         QQuaternion::fromEulerAngles( pitchAngle, 0, 0 );
+  return QQuaternion::fromAxisAndAngle( QVector3D( 0, 0, 1 ), headingAngle ) *
+         QQuaternion::fromAxisAndAngle( QVector3D( 1, 0, 0 ), pitchAngle );
 }

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -976,9 +976,11 @@ int Qgs3DUtils::openGlMaxClipPlanes( QSurface *surface )
   context.setFormat( QSurfaceFormat::defaultFormat() );
   if ( context.create() )
   {
-    context.makeCurrent( surface );
-    QOpenGLFunctions *funcs = context.functions();
-    funcs->glGetIntegerv( GL_MAX_CLIP_PLANES, &numPlanes );
+    if ( context.makeCurrent( surface ) )
+    {
+      QOpenGLFunctions *funcs = context.functions();
+      funcs->glGetIntegerv( GL_MAX_CLIP_PLANES, &numPlanes );
+    }
   }
 
   return numPlanes;

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -340,6 +340,14 @@ class _3D_EXPORT Qgs3DUtils
      * \since QGIS 3.42
      */
     static int openGlMaxClipPlanes( QSurface *surface );
+
+    /**
+     * Returns rotation quaternion that performs rotation around X axis by pitchAngle,
+     * followed by rotation around Z axis by headingAngle (both angles in degrees).
+     *
+     * \since QGIS 3.42
+     */
+    static QQuaternion rotationFromPitchHeadingAngles( float pitchAngle, float headingAngle );
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -100,7 +100,7 @@ void QgsCameraController::rotateCamera( float diffPitch, float diffHeading )
   float newPitch = oldPitch + diffPitch;
   float newHeading = oldHeading + diffHeading;
 
-  newPitch = std::clamp( newPitch, 0.f, 180.f );  // prevent going over the head
+  newPitch = std::clamp( newPitch, 0.f, 180.f ); // prevent going over the head
 
   // First undo the previously applied rotation, then apply the new rotation
   // (We can't just apply our euler angles difference because the camera may be already rotated)
@@ -126,7 +126,7 @@ void QgsCameraController::rotateCameraAroundPivot( float newPitch, float newHead
   const float oldPitch = mCameraPose.pitchAngle();
   const float oldHeading = mCameraPose.headingAngle();
 
-  newPitch = std::clamp( newPitch, 0.f, 180.f );  // prevent going over the head
+  newPitch = std::clamp( newPitch, 0.f, 180.f ); // prevent going over the head
 
   // First undo the previously applied rotation, then apply the new rotation
   // (We can't just apply our euler angles difference because the camera may be already rotated)

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -197,6 +197,14 @@ class _3D_EXPORT QgsCameraController : public QObject
     void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
 
     /**
+     * Zooms camera by given zoom factor (higher than one means zoom in)
+     * while keeping the pivot point (given in world coordinates) at the
+     * same screen coordinates after the zoom.
+     * \since QGIS 3.42
+     */
+    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
+
+    /**
      * Returns TRUE if the camera controller will handle the specified key \a event,
      * preventing it from being instead handled by parents of the 3D window before
      * the controller ever receives it.

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -197,7 +197,7 @@ class _3D_EXPORT QgsCameraController : public QObject
     void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
 
     /**
-     * Zooms camera by given zoom factor (higher than one means zoom in)
+     * Zooms camera by given zoom factor (>1 one means zoom in)
      * while keeping the pivot point (given in world coordinates) at the
      * same screen coordinates after the zoom.
      * \since QGIS 3.42

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -190,6 +190,13 @@ class _3D_EXPORT QgsCameraController : public QObject
     void rotateCamera( float diffPitch, float diffYaw );
 
     /**
+     * Rotates the camera around the pivot point (in world coordinates)
+     * to the given new pitch and heading angle.
+     * \since QGIS 3.42
+     */
+    void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
+
+    /**
      * Returns TRUE if the camera controller will handle the specified key \a event,
      * preventing it from being instead handled by parents of the 3D window before
      * the controller ever receives it.

--- a/src/3d/qgscamerapose.cpp
+++ b/src/3d/qgscamerapose.cpp
@@ -15,6 +15,8 @@
 
 #include "qgscamerapose.h"
 
+#include "qgs3dutils.h"
+
 #include <Qt3DRender/QCamera>
 
 #include <QDomDocument>
@@ -74,8 +76,7 @@ void QgsCameraPose::setPitchAngle( float pitch )
 void QgsCameraPose::updateCamera( Qt3DRender::QCamera *camera )
 {
   // first rotate by pitch angle around X axis, then by heading angle around Z axis
-  // (we use two separate fromEulerAngles() calls because one would not do rotations in order we need)
-  QQuaternion q = QQuaternion::fromEulerAngles( 0, 0, mHeadingAngle ) * QQuaternion::fromEulerAngles( mPitchAngle, 0, 0 );
+  QQuaternion q = Qgs3DUtils::rotationFromPitchHeadingAngles( mPitchAngle, mHeadingAngle );
   QVector3D cameraToCenter = q * QVector3D( 0, 0, -mDistanceFromCenterPoint );
   camera->setUpVector( q * QVector3D( 0, 1, 0 ) );
   camera->setPosition( mCenterPoint.toVector3D() - cameraToCenter );

--- a/src/3d/qgscamerapose.cpp
+++ b/src/3d/qgscamerapose.cpp
@@ -62,15 +62,7 @@ void QgsCameraPose::setDistanceFromCenterPoint( float distance )
 void QgsCameraPose::setPitchAngle( float pitch )
 {
   // prevent going over the head
-  // prevent bug in QgsCameraPose::updateCamera when updating camera rotation.
-  // With a mPitchAngle < 0.2 or > 179.8, QQuaternion::fromEulerAngles( mPitchAngle, mHeadingAngle, 0 )
-  // will return bad rotation angle in Qt5.
-  // See https://bugreports.qt.io/browse/QTBUG-72103
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  mPitchAngle = std::clamp( pitch, 0.2f, 179.8f );
-#else
   mPitchAngle = std::clamp( pitch, 0.0f, 180.0f );
-#endif
 }
 
 void QgsCameraPose::updateCamera( Qt3DRender::QCamera *camera )

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -219,7 +219,7 @@ void TestQgs3DCameraController::testZoom()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Zoom );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 0.0, 0.0, 10.3 ), 1.5 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 0.0, 0.0, 3.4 ), 1.5 );
   QVector3D diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
   QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 0.0, 1.5, -850.4 ), 1.5 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
@@ -272,8 +272,8 @@ void TestQgs3DCameraController::testZoomWheel()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( -1381.3, 1036.7, 1.0 ), 5.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -480.0, 360.6, -351.7 ), 5.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1982.3, 5.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -479.2, 359.4, 1.6 ), 5.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1631.9, 5.0 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
   QCOMPARE( scene->cameraController()->mClickPoint, QPoint() );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::None );
@@ -523,8 +523,8 @@ void TestQgs3DCameraController::testRotationCenterZoomWheelRotationCenter()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( 283.2, -923.1, -27.0 ), 1.5 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( 120.3, -308.9, -116.8 ), 2.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1742.9, 2.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( 99.4, -319.9, -8.8 ), 2.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1631.9, 2.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
@@ -558,7 +558,7 @@ void TestQgs3DCameraController::testRotationCenterZoomWheelRotationCenter()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::RotationCenter );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 30.6, 8.2, 6.4 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 25.9, 7.1, 5.2 ), 1.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
   QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -44.3, -9.1, -11.7 ), 1.0 );
   diffPitch = scene->cameraController()->pitch() - initialPitch;
@@ -816,8 +816,8 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( 4.8, -4.4, 9.9 ), 1.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -615.0, 116.6, -108.0 ), 4.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1743.4, 2.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -615.5, 116.2, 3.4 ), 4.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1631.9, 2.0 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
   QCOMPARE( scene->cameraController()->mClickPoint, QPoint() );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::None );

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -2107,8 +2107,8 @@ void TestQgs3DRendering::testDepthBuffer()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( -32.7, -185.5, 224.6 ), 1.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -32.7, -185.5, 224.6 ), 1.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 955.4, 1.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -6.8, -38.6, 46.7 ), 1.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1187.5, 1.0 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
 
   // Checking second wheel action
@@ -2124,8 +2124,8 @@ void TestQgs3DRendering::testDepthBuffer()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( -32.5, -184.7, 223.5 ), 1.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -32.5, -184.7, 223.5 ), 1.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 757.4, 1.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -12.1, -69.0, 83.5 ), 1.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 940.1, 1.0 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
 
   // Checking third wheel action
@@ -2141,8 +2141,8 @@ void TestQgs3DRendering::testDepthBuffer()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( -32.4, -184.1, 222.8 ), 1.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -32.4, -184.1, 222.8 ), 1.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 126.4, 0.1 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -29.0, -164.9, 199.6 ), 1.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 156.6, 0.1 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
 
   // Checking fourth wheel action
@@ -2158,8 +2158,8 @@ void TestQgs3DRendering::testDepthBuffer()
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( -32.3, -183.2, 221.7 ), 1.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -32.3, -183.2, 221.7 ), 1.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 101.1, 0.1 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -29.7, -168.7, 204.2 ), 1.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 124.0, 0.1 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
 
   // Checking camera position


### PR DESCRIPTION
The code for rotation and zoom with a pivot point in 3D views has been quite messy - both rotation and zoom were composed of two camera updates (plus casting a ray from screen point in between them), while it can be replaced with much simpler math (which could be even simpler if I picked a better camera representation when starting work on qgis 3d).

There should be no functionality changes, just code cleanups. The adjustments in tests for camera controller are just for the view center, which can be an arbitrary point on the ray from camera's position in the direction of the camera's rotation.

Includes a minor fix so that Qgs3DUtils::openGlMaxClipPlanes() does not crash in qgis sandbox.