### PR TITLE
[api] Add QgsVectorDataProvider::geometryColumnName

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -442,6 +442,13 @@ Returns list of indexes to fetch all attributes in :py:func:`~QgsVectorDataProvi
 Returns list of indexes of fields that make up the primary key
 %End
 
+    virtual QString geometryColumnName() const;
+%Docstring
+Returns the name of the column storing geometry, if applicable.
+
+.. versionadded:: 3.42
+%End
+
  QgsAttrPalIndexNameHash palAttributeIndexNames() const /Deprecated/;
 %Docstring
 Returns list of indexes to names for :py:class:`QgsPalLabeling` fix

--- a/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -442,6 +442,13 @@ Returns list of indexes to fetch all attributes in :py:func:`~QgsVectorDataProvi
 Returns list of indexes of fields that make up the primary key
 %End
 
+    virtual QString geometryColumnName() const;
+%Docstring
+Returns the name of the column storing geometry, if applicable.
+
+.. versionadded:: 3.42
+%End
+
  QgsAttrPalIndexNameHash palAttributeIndexNames() const /Deprecated/;
 %Docstring
 Returns list of indexes to names for :py:class:`QgsPalLabeling` fix

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -40,6 +40,7 @@ email                : sherman at mrcc.com
 #include "qgsvariantutils.h"
 #include "qgsjsonutils.h"
 #include "qgssetrequestinitiator_p.h"
+#include "qgsthreadingutils.h"
 
 #include <nlohmann/json.hpp>
 
@@ -3500,6 +3501,27 @@ Qgis::VectorProviderCapabilities QgsOgrProvider::capabilities() const
 Qgis::VectorDataProviderAttributeEditCapabilities QgsOgrProvider::attributeEditCapabilities() const
 {
   return mAttributeEditCapabilities;
+}
+
+QgsAttributeList QgsOgrProvider::pkAttributeIndexes() const
+{
+  return mPrimaryKeyAttrs;
+}
+
+QString QgsOgrProvider::geometryColumnName() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  if ( !mOgrLayer )
+    return QString();
+
+  QgsOgrFeatureDefn &featureDefinition = mOgrLayer->GetLayerDefn();
+  if ( featureDefinition.GetGeomFieldCount() )
+  {
+    OGRGeomFieldDefnH geomH = featureDefinition.GetGeomFieldDefn( 0 );
+    return QString::fromUtf8( OGR_GFld_GetNameRef( geomH ) );
+  }
+  return QString();
 }
 
 void QgsOgrProvider::computeCapabilities()

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -118,7 +118,8 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     bool createAttributeIndex( int field ) override;
     Qgis::VectorProviderCapabilities capabilities() const override;
     Qgis::VectorDataProviderAttributeEditCapabilities attributeEditCapabilities() const override;
-    QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
+    QgsAttributeList pkAttributeIndexes() const override;
+    QString geometryColumnName() const override;
     void setEncoding( const QString &e ) override;
     bool enterUpdateMode() override { return _enterUpdateMode(); }
     bool leaveUpdateMode() override;

--- a/src/core/vector/qgsvectordataprovider.cpp
+++ b/src/core/vector/qgsvectordataprovider.cpp
@@ -452,6 +452,13 @@ QgsAttributeList QgsVectorDataProvider::pkAttributeIndexes() const
   return QgsAttributeList();
 }
 
+QString QgsVectorDataProvider::geometryColumnName() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QString();
+}
+
 QList<QgsVectorDataProvider::NativeType> QgsVectorDataProvider::nativeTypes() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/vector/qgsvectordataprovider.h
+++ b/src/core/vector/qgsvectordataprovider.h
@@ -425,6 +425,13 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     virtual QgsAttributeList pkAttributeIndexes() const;
 
     /**
+     * Returns the name of the column storing geometry, if applicable.
+     *
+     * \since QGIS 3.42
+     */
+    virtual QString geometryColumnName() const;
+
+    /**
      * Returns list of indexes to names for QgsPalLabeling fix
      *
      * \deprecated QGIS 3.32. This method is unused and will always return an empty hash.

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -37,6 +37,7 @@
 #include "qgshanadataitems.h"
 #include "qgslogger.h"
 #include "qgsrectangle.h"
+#include "qgsthreadingutils.h"
 
 #include <QtGlobal>
 
@@ -492,6 +493,13 @@ long long QgsHanaProvider::featureCount() const
   }
 
   return mFeaturesCount;
+}
+
+QString QgsHanaProvider::geometryColumnName() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mGeometryColumn;
 }
 
 QgsFields QgsHanaProvider::fields() const

--- a/src/providers/hana/qgshanaprovider.h
+++ b/src/providers/hana/qgshanaprovider.h
@@ -58,6 +58,7 @@ class QgsHanaProvider final : public QgsVectorDataProvider
     QString dataComment() const override;
     long long featureCount() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
+    QString geometryColumnName() const override;
     QgsFields fields() const override;
     QVariant minimumValue( int index ) const override;
     QVariant maximumValue( int index ) const override;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -24,6 +24,7 @@
 #include "qgsdbquerylog.h"
 #include "qgsdbquerylog_p.h"
 #include "qgsvariantutils.h"
+#include "qgsthreadingutils.h"
 
 #include <QtGlobal>
 #include <QFileInfo>
@@ -2032,6 +2033,13 @@ QString QgsMssqlProvider::description() const
 QgsAttributeList QgsMssqlProvider::pkAttributeIndexes() const
 {
   return mPrimaryKeyAttrs;
+}
+
+QString QgsMssqlProvider::geometryColumnName() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mGeometryColName;
 }
 
 QStringList QgsMssqlProvider::subLayers() const

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -107,7 +107,7 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
     QString description() const override;
 
     QgsAttributeList pkAttributeIndexes() const override;
-
+    QString geometryColumnName() const override;
     QgsRectangle extent() const override;
 
     bool isValid() const override;

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -32,6 +32,7 @@
 #include "qgsprojectstorageguiprovider.h"
 #include "qgsprojectstorageregistry.h"
 #include "qgsvectorlayer.h"
+#include "qgsthreadingutils.h"
 
 #include "qgsoracleprovider.h"
 #include "moc_qgsoracleprovider.cpp"
@@ -1182,6 +1183,13 @@ QVariant QgsOracleProvider::maximumValue( int index ) const
 bool QgsOracleProvider::isValid() const
 {
   return mValid;
+}
+
+QString QgsOracleProvider::geometryColumnName() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mGeometryColumn;
 }
 
 QVariant QgsOracleProvider::defaultValue( int fieldId ) const

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -157,6 +157,7 @@ class QgsOracleProvider final : public QgsVectorDataProvider
     QSet<QVariant> uniqueValues( int index, int limit = -1 ) const override;
     bool isValid() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
+    QString geometryColumnName() const override;
     QVariant defaultValue( QString fieldName, QString tableName = QString(), QString schemaName = QString() );
     QVariant defaultValue( int fieldId ) const override;
     QString defaultValueClause( int fieldId ) const override;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -43,6 +43,7 @@
 #include "qgsdbquerylog.h"
 #include "qgsdbquerylog_p.h"
 #include "qgspostgreslayermetadataprovider.h"
+#include "qgsthreadingutils.h"
 
 #include "qgspostgresprovider.h"
 #include "qgsprovidermetadata.h"
@@ -3657,6 +3658,13 @@ QgsAttributeList QgsPostgresProvider::attributeIndexes() const
   for ( int i = 0; i < mAttributeFields.count(); ++i )
     lst.append( i );
   return lst;
+}
+
+QString QgsPostgresProvider::geometryColumnName() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mGeometryColumn;
 }
 
 Qgis::VectorProviderCapabilities QgsPostgresProvider::capabilities() const

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -156,6 +156,7 @@ class QgsPostgresProvider final : public QgsVectorDataProvider
     Qgis::ProviderStyleStorageCapabilities styleStorageCapabilities() const override;
     QgsAttributeList attributeIndexes() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
+    QString geometryColumnName() const override;
     QString defaultValueClause( int fieldId ) const override;
     QVariant defaultValue( int fieldId ) const override;
     bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value = QVariant() ) const override;

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -33,7 +33,7 @@ email                : a.furieri@lqt.it
 #include "qgsspatialiteproviderconnection.h"
 #include "qgsdbquerylog.h"
 #include "qgsdbquerylog_p.h"
-
+#include "qgsthreadingutils.h"
 #include "qgsjsonutils.h"
 #include "qgsvectorlayer.h"
 
@@ -5887,6 +5887,13 @@ bool QgsSpatiaLiteProviderMetadata::createDb( const QString &dbPath, QString &er
 QgsAttributeList QgsSpatiaLiteProvider::pkAttributeIndexes() const
 {
   return mPrimaryKeyAttrs;
+}
+
+QString QgsSpatiaLiteProvider::geometryColumnName() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mGeometryColumn;
 }
 
 QList<QgsVectorLayer *> QgsSpatiaLiteProvider::searchLayers( const QList<QgsVectorLayer *> &layers, const QString &connectionInfo, const QString &tableName )

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -138,6 +138,7 @@ class QgsSpatiaLiteProvider final : public QgsVectorDataProvider
     QString name() const override;
     QString description() const override;
     QgsAttributeList pkAttributeIndexes() const override;
+    QString geometryColumnName() const override;
     void invalidateConnections( const QString &connection ) override;
     QList<QgsRelation> discoverRelations( const QgsVectorLayer *target, const QList<QgsVectorLayer *> &layers ) const override;
 

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -478,6 +478,14 @@ class PyQgsOGRProvider(QgisTestCase):
             self.assertTrue(f.geometry())
             self.assertEqual(f.geometry().constGet().asWkt(), row[2])
 
+    def test_geometry_column_name(self):
+        """Test geometry column name from shapefile"""
+        vl = QgsVectorLayer(
+            self.get_test_data_path("points.shp").as_posix(), "test", "ogr"
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "")
+
     def testSetupProxy(self):
         """Test proxy setup"""
         settings = QgsSettings()

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -1246,6 +1246,17 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
             & QgsFieldConstraints.Constraint.ConstraintUnique
         )
 
+    def test_geometry_column_name(self):
+        """Test geometry column name from geopackage"""
+        vl = QgsVectorLayer(
+            self.get_test_data_path("points_gpkg.gpkg").as_posix()
+            + "|layername=points_gpkg",
+            "test",
+            "ogr",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "geom")
+
     def testSublayerWithComplexLayerName(self):
         """Test reading a gpkg with a sublayer name containing :"""
         tmpfile = os.path.join(self.basetestpath, "testGeopackageComplexLayerName.gpkg")

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1004,6 +1004,18 @@ class TestQgsSpatialiteProvider(QgisTestCase, ProviderTestCase):
             QgsFieldConstraints.ConstraintOrigin.ConstraintOriginProvider,
         )
 
+    def test_geometry_column_name(self):
+        """Test geometry column name from geopackage"""
+        vl = QgsVectorLayer(
+            """dbname='{}' table="somedata" (geom)""".format(
+                self.get_test_data_path("provider/spatialite.db").as_posix()
+            ),
+            "test",
+            "spatialite",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "geom")
+
     def testSkipConstraintCheck(self):
         vl = QgsVectorLayer(
             f"dbname={self.dbname} table=test_autoincrement",


### PR DESCRIPTION
Allows easy retrieval of the geometry column name from the data provider, if applicable.

(This was NOT possible to retrieve in a consistent, provider independant way before)
