### PR TITLE
Processing metadata tools

### DIFF
--- a/src/analysis/processing/qgsmetadataalgorithms.cpp
+++ b/src/analysis/processing/qgsmetadataalgorithms.cpp
@@ -248,4 +248,75 @@ QVariantMap QgsExportLayerMetadataAlgorithm::processAlgorithm( const QVariantMap
   return results;
 }
 
+///
+
+QString QgsAddHistoryMetadataAlgorithm::name() const
+{
+  return QStringLiteral( "addhistorymetadata" );
+}
+
+QString QgsAddHistoryMetadataAlgorithm::displayName() const
+{
+  return QObject::tr( "Add history metadata" );
+}
+
+QStringList QgsAddHistoryMetadataAlgorithm::tags() const
+{
+  return QObject::tr( "add,history,metadata" ).split( ',' );
+}
+
+QString QgsAddHistoryMetadataAlgorithm::group() const
+{
+  return QObject::tr( "Metadata tools" );
+}
+
+QString QgsAddHistoryMetadataAlgorithm::groupId() const
+{
+  return QStringLiteral( "metadatatools" );
+}
+
+QString QgsAddHistoryMetadataAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "Adds a new history entry to the layer's metadata." );
+}
+
+QgsAddHistoryMetadataAlgorithm *QgsAddHistoryMetadataAlgorithm::createInstance() const
+{
+  return new QgsAddHistoryMetadataAlgorithm();
+}
+
+void QgsAddHistoryMetadataAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "INPUT" ), QObject::tr( "Layer" ) ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "HISTORY" ), QObject::tr( "History entry" ) ) );
+  addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Updated" ) ) );
+}
+
+bool QgsAddHistoryMetadataAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsMapLayer *layer = parameterAsLayer( parameters, QStringLiteral( "INPUT" ), context );
+  const QString history = parameterAsString( parameters, QStringLiteral( "HISTORY" ), context );
+
+  if ( !layer )
+    throw QgsProcessingException( QObject::tr( "Invalid input layer" ) );
+
+  mLayerId = layer->id();
+
+  std::unique_ptr<QgsLayerMetadata> md( layer->metadata().clone() );
+  md->addHistoryItem( history );
+  layer->setMetadata( *md.get() );
+
+  return true;
+}
+
+QVariantMap QgsAddHistoryMetadataAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  Q_UNUSED( parameters );
+  Q_UNUSED( context );
+
+  QVariantMap results;
+  results.insert( QStringLiteral( "OUTPUT" ), mLayerId );
+  return results;
+}
+
 ///@endcond

--- a/src/analysis/processing/qgsmetadataalgorithms.cpp
+++ b/src/analysis/processing/qgsmetadataalgorithms.cpp
@@ -525,7 +525,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "CRS" ) ).isValid() )
   {
     const QgsCoordinateReferenceSystem crs = parameterAsCrs( parameters, QStringLiteral( "CRS" ), context );
-    if ( crs.isValid() || ( !crs.isValid() && !ignoreEmpty ) )
+    if ( crs.isValid() || !ignoreEmpty )
     {
       md->setCrs( crs );
     }

--- a/src/analysis/processing/qgsmetadataalgorithms.cpp
+++ b/src/analysis/processing/qgsmetadataalgorithms.cpp
@@ -442,6 +442,7 @@ void QgsSetMetadataFieldsAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterString( QStringLiteral( "ABSTRACT" ), QObject::tr( "Abstract" ), QVariant(), true, true ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "Coordinatem reference system" ), QVariant(), true ) );
   addParameter( new QgsProcessingParameterString( QStringLiteral( "FEES" ), QObject::tr( "Fees" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "IGNORE_EMPTY" ), QObject::tr( "Ignore empty fields" ), false ) );
   addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Updated" ) ) );
 }
 
@@ -454,51 +455,89 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
 
   mLayerId = layer->id();
 
+  const bool ignoreEmpty = parameterAsBool( parameters, QStringLiteral( "IGNORE_EMPTY" ), context );
+
   std::unique_ptr<QgsLayerMetadata> md( layer->metadata().clone() );
 
   if ( parameters.value( QStringLiteral( "IDENTIFIER" ) ).isValid() )
   {
-    md->setIdentifier( parameterAsString( parameters, QStringLiteral( "IDENTIFIER" ), context ) );
+    const QString identifier = parameterAsString( parameters, QStringLiteral( "IDENTIFIER" ), context );
+    if ( !identifier.isEmpty() || ( identifier.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setIdentifier( identifier );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "PARENT_IDENTIFIER" ) ).isValid() )
   {
-    md->setParentIdentifier( parameterAsString( parameters, QStringLiteral( "PARENT_IDENTIFIER" ), context ) );
+    const QString parentIdentifier = parameterAsString( parameters, QStringLiteral( "PARENT_IDENTIFIER" ), context );
+    if ( !parentIdentifier.isEmpty() || ( parentIdentifier.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setParentIdentifier( parentIdentifier );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "TITLE" ) ).isValid() )
   {
-    md->setTitle( parameterAsString( parameters, QStringLiteral( "TITLE" ), context ) );
+    const QString title = parameterAsString( parameters, QStringLiteral( "TITLE" ), context );
+    if ( !title.isEmpty() || ( title.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setTitle( title );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "TYPE" ) ).isValid() )
   {
-    md->setType( parameterAsString( parameters, QStringLiteral( "TYPE" ), context ) );
+    const QString type = parameterAsString( parameters, QStringLiteral( "TYPE" ), context );
+    if ( !type.isEmpty() || ( type.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setType( type );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "LANGUAGE" ) ).isValid() )
   {
-    md->setLanguage( parameterAsString( parameters, QStringLiteral( "LANGUAGE" ), context ) );
+    const QString language = parameterAsString( parameters, QStringLiteral( "LANGUAGE" ), context );
+    if ( !language.isEmpty() || ( language.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setLanguage( language );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "ENCODING" ) ).isValid() )
   {
-    md->setEncoding( parameterAsString( parameters, QStringLiteral( "ENCODING" ), context ) );
+    const QString encoding = parameterAsString( parameters, QStringLiteral( "ENCODING" ), context );
+    if ( !encoding.isEmpty() || ( encoding.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setEncoding( encoding );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "ABSTRACT" ) ).isValid() )
   {
-    md->setAbstract( parameterAsString( parameters, QStringLiteral( "ABSTRACT" ), context ) );
+    const QString abstract = parameterAsString( parameters, QStringLiteral( "ABSTRACT" ), context );
+    if ( !abstract.isEmpty() || ( abstract.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setAbstract( abstract );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "CRS" ) ).isValid() )
   {
-    md->setCrs( parameterAsCrs( parameters, QStringLiteral( "CRS" ), context ) );
+    const QgsCoordinateReferenceSystem crs = parameterAsCrs( parameters, QStringLiteral( "CRS" ), context );
+    if ( crs.isValid() || ( !crs.isValid() && !ignoreEmpty ) )
+    {
+      md->setCrs( crs );
+    }
   }
 
   if ( parameters.value( QStringLiteral( "FEES" ) ).isValid() )
   {
-    md->setFees( parameterAsString( parameters, QStringLiteral( "FEES" ), context ) );
+    const QString fees = parameterAsString( parameters, QStringLiteral( "FEES" ), context );
+    if ( !fees.isEmpty() || ( fees.isEmpty() && !ignoreEmpty ) )
+    {
+      md->setFees( fees );
+    }
   }
 
   layer->setMetadata( *md.get() );

--- a/src/analysis/processing/qgsmetadataalgorithms.cpp
+++ b/src/analysis/processing/qgsmetadataalgorithms.cpp
@@ -393,4 +393,127 @@ QVariantMap QgsUpdateLayerMetadataAlgorithm::processAlgorithm( const QVariantMap
   return results;
 }
 
+///
+
+QString QgsSetMetadataFieldsAlgorithm::name() const
+{
+  return QStringLiteral( "setmetadatafields" );
+}
+
+QString QgsSetMetadataFieldsAlgorithm::displayName() const
+{
+  return QObject::tr( "Set metadata fields" );
+}
+
+QStringList QgsSetMetadataFieldsAlgorithm::tags() const
+{
+  return QObject::tr( "set,metadata,title,abstract,identifier" ).split( ',' );
+}
+
+QString QgsSetMetadataFieldsAlgorithm::group() const
+{
+  return QObject::tr( "Metadata tools" );
+}
+
+QString QgsSetMetadataFieldsAlgorithm::groupId() const
+{
+  return QStringLiteral( "metadatatools" );
+}
+
+QString QgsSetMetadataFieldsAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "Sets various metadata fields for a layer." );
+}
+
+QgsSetMetadataFieldsAlgorithm *QgsSetMetadataFieldsAlgorithm::createInstance() const
+{
+  return new QgsSetMetadataFieldsAlgorithm();
+}
+
+void QgsSetMetadataFieldsAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "INPUT" ), QObject::tr( "Layer" ) ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "IDENTIFIER" ), QObject::tr( "Identifier" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "PARENT_IDENTIFIER" ), QObject::tr( "Parent identifier" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "TITLE" ), QObject::tr( "Title" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "TYPE" ), QObject::tr( "Type" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "LANGUAGE" ), QObject::tr( "Language" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "ENCODING" ), QObject::tr( "Encoding" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "ABSTRACT" ), QObject::tr( "Abstract" ), QVariant(), true, true ) );
+  addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "Coordinatem reference system" ), QVariant(), true ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "FEES" ), QObject::tr( "Fees" ), QVariant(), false, true ) );
+  addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Updated" ) ) );
+}
+
+bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsMapLayer *layer = parameterAsLayer( parameters, QStringLiteral( "INPUT" ), context );
+
+  if ( !layer )
+    throw QgsProcessingException( QObject::tr( "Invalid input layer" ) );
+
+  mLayerId = layer->id();
+
+  std::unique_ptr<QgsLayerMetadata> md( layer->metadata().clone() );
+
+  if ( parameters.value( QStringLiteral( "IDENTIFIER" ) ).isValid() )
+  {
+    md->setIdentifier( parameterAsString( parameters, QStringLiteral( "IDENTIFIER" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "PARENT_IDENTIFIER" ) ).isValid() )
+  {
+    md->setParentIdentifier( parameterAsString( parameters, QStringLiteral( "PARENT_IDENTIFIER" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "TITLE" ) ).isValid() )
+  {
+    md->setTitle( parameterAsString( parameters, QStringLiteral( "TITLE" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "TYPE" ) ).isValid() )
+  {
+    md->setType( parameterAsString( parameters, QStringLiteral( "TYPE" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "LANGUAGE" ) ).isValid() )
+  {
+    md->setLanguage( parameterAsString( parameters, QStringLiteral( "LANGUAGE" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "ENCODING" ) ).isValid() )
+  {
+    md->setEncoding( parameterAsString( parameters, QStringLiteral( "ENCODING" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "ABSTRACT" ) ).isValid() )
+  {
+    md->setAbstract( parameterAsString( parameters, QStringLiteral( "ABSTRACT" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "CRS" ) ).isValid() )
+  {
+    md->setCrs( parameterAsCrs( parameters, QStringLiteral( "CRS" ), context ) );
+  }
+
+  if ( parameters.value( QStringLiteral( "FEES" ) ).isValid() )
+  {
+    md->setFees( parameterAsString( parameters, QStringLiteral( "FEES" ), context ) );
+  }
+
+  layer->setMetadata( *md.get() );
+
+  return true;
+}
+
+QVariantMap QgsSetMetadataFieldsAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  Q_UNUSED( parameters );
+  Q_UNUSED( context );
+
+  QVariantMap results;
+  results.insert( QStringLiteral( "OUTPUT" ), mLayerId );
+  return results;
+}
+
 ///@endcond

--- a/src/analysis/processing/qgsmetadataalgorithms.cpp
+++ b/src/analysis/processing/qgsmetadataalgorithms.cpp
@@ -319,4 +319,78 @@ QVariantMap QgsAddHistoryMetadataAlgorithm::processAlgorithm( const QVariantMap 
   return results;
 }
 
+///
+
+QString QgsUpdateLayerMetadataAlgorithm::name() const
+{
+  return QStringLiteral( "updatelayermetadata" );
+}
+
+QString QgsUpdateLayerMetadataAlgorithm::displayName() const
+{
+  return QObject::tr( "Update layer metadata" );
+}
+
+QStringList QgsUpdateLayerMetadataAlgorithm::tags() const
+{
+  return QObject::tr( "change,update,layer,metadata,qmd" ).split( ',' );
+}
+
+QString QgsUpdateLayerMetadataAlgorithm::group() const
+{
+  return QObject::tr( "Metadata tools" );
+}
+
+QString QgsUpdateLayerMetadataAlgorithm::groupId() const
+{
+  return QStringLiteral( "metadatatools" );
+}
+
+QString QgsUpdateLayerMetadataAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "Copies all non-empty metadata fields from an input layer to a target layer.\n\nLeaves empty input fields unchaged in the target." );
+}
+
+QgsUpdateLayerMetadataAlgorithm *QgsUpdateLayerMetadataAlgorithm::createInstance() const
+{
+  return new QgsUpdateLayerMetadataAlgorithm();
+}
+
+void QgsUpdateLayerMetadataAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "INPUT" ), QObject::tr( "Source layer" ) ) );
+  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "TARGET" ), QObject::tr( "Target layer" ) ) );
+  addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Updated layer" ) ) );
+}
+
+bool QgsUpdateLayerMetadataAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsMapLayer *inputLayer = parameterAsLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsMapLayer *targetLayer = parameterAsLayer( parameters, QStringLiteral( "TARGET" ), context );
+
+  if ( !inputLayer )
+    throw QgsProcessingException( QObject::tr( "Invalid input layer" ) );
+
+  if ( !targetLayer )
+    throw QgsProcessingException( QObject::tr( "Invalid target layer" ) );
+
+  mLayerId = targetLayer->id();
+
+  std::unique_ptr<QgsLayerMetadata> md( targetLayer->metadata().clone() );
+  md->combine( &inputLayer->metadata() );
+  targetLayer->setMetadata( *md.get() );
+
+  return true;
+}
+
+QVariantMap QgsUpdateLayerMetadataAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  Q_UNUSED( parameters );
+  Q_UNUSED( context );
+
+  QVariantMap results;
+  results.insert( QStringLiteral( "OUTPUT" ), mLayerId );
+  return results;
+}
+
 ///@endcond

--- a/src/analysis/processing/qgsmetadataalgorithms.cpp
+++ b/src/analysis/processing/qgsmetadataalgorithms.cpp
@@ -462,7 +462,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "IDENTIFIER" ) ).isValid() )
   {
     const QString identifier = parameterAsString( parameters, QStringLiteral( "IDENTIFIER" ), context );
-    if ( !identifier.isEmpty() || ( identifier.isEmpty() && !ignoreEmpty ) )
+    if ( !identifier.isEmpty() || !ignoreEmpty )
     {
       md->setIdentifier( identifier );
     }
@@ -471,7 +471,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "PARENT_IDENTIFIER" ) ).isValid() )
   {
     const QString parentIdentifier = parameterAsString( parameters, QStringLiteral( "PARENT_IDENTIFIER" ), context );
-    if ( !parentIdentifier.isEmpty() || ( parentIdentifier.isEmpty() && !ignoreEmpty ) )
+    if ( !parentIdentifier.isEmpty() || !ignoreEmpty )
     {
       md->setParentIdentifier( parentIdentifier );
     }
@@ -480,7 +480,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "TITLE" ) ).isValid() )
   {
     const QString title = parameterAsString( parameters, QStringLiteral( "TITLE" ), context );
-    if ( !title.isEmpty() || ( title.isEmpty() && !ignoreEmpty ) )
+    if ( !title.isEmpty() || !ignoreEmpty )
     {
       md->setTitle( title );
     }
@@ -489,7 +489,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "TYPE" ) ).isValid() )
   {
     const QString type = parameterAsString( parameters, QStringLiteral( "TYPE" ), context );
-    if ( !type.isEmpty() || ( type.isEmpty() && !ignoreEmpty ) )
+    if ( !type.isEmpty() || !ignoreEmpty )
     {
       md->setType( type );
     }
@@ -498,7 +498,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "LANGUAGE" ) ).isValid() )
   {
     const QString language = parameterAsString( parameters, QStringLiteral( "LANGUAGE" ), context );
-    if ( !language.isEmpty() || ( language.isEmpty() && !ignoreEmpty ) )
+    if ( !language.isEmpty() || !ignoreEmpty )
     {
       md->setLanguage( language );
     }
@@ -507,7 +507,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "ENCODING" ) ).isValid() )
   {
     const QString encoding = parameterAsString( parameters, QStringLiteral( "ENCODING" ), context );
-    if ( !encoding.isEmpty() || ( encoding.isEmpty() && !ignoreEmpty ) )
+    if ( !encoding.isEmpty() || !ignoreEmpty )
     {
       md->setEncoding( encoding );
     }
@@ -516,7 +516,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "ABSTRACT" ) ).isValid() )
   {
     const QString abstract = parameterAsString( parameters, QStringLiteral( "ABSTRACT" ), context );
-    if ( !abstract.isEmpty() || ( abstract.isEmpty() && !ignoreEmpty ) )
+    if ( !abstract.isEmpty() || !ignoreEmpty )
     {
       md->setAbstract( abstract );
     }
@@ -534,7 +534,7 @@ bool QgsSetMetadataFieldsAlgorithm::prepareAlgorithm( const QVariantMap &paramet
   if ( parameters.value( QStringLiteral( "FEES" ) ).isValid() )
   {
     const QString fees = parameterAsString( parameters, QStringLiteral( "FEES" ), context );
-    if ( !fees.isEmpty() || ( fees.isEmpty() && !ignoreEmpty ) )
+    if ( !fees.isEmpty() || !ignoreEmpty )
     {
       md->setFees( fees );
     }

--- a/src/analysis/processing/qgsmetadataalgorithms.cpp
+++ b/src/analysis/processing/qgsmetadataalgorithms.cpp
@@ -46,7 +46,7 @@ QString QgsCopyLayerMetadataAlgorithm::groupId() const
 
 QString QgsCopyLayerMetadataAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Copies metadata from an input layer to a target layer.\n\nAny existing metadata in the target layer will be replaced." );
+  return QObject::tr( "Copies metadata from an source layer to a target layer.\n\nAny existing metadata in the target layer will be replaced." );
 }
 
 QgsCopyLayerMetadataAlgorithm *QgsCopyLayerMetadataAlgorithm::createInstance() const
@@ -56,7 +56,7 @@ QgsCopyLayerMetadataAlgorithm *QgsCopyLayerMetadataAlgorithm::createInstance() c
 
 void QgsCopyLayerMetadataAlgorithm::initAlgorithm( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "INPUT" ), QObject::tr( "Source layer" ) ) );
+  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "SOURCE" ), QObject::tr( "Source layer" ) ) );
   addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "TARGET" ), QObject::tr( "Target layer" ) ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "DEFAULT" ), QObject::tr( "Save metadata as default" ), false ) );
   addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Updated layer" ) ) );
@@ -64,19 +64,19 @@ void QgsCopyLayerMetadataAlgorithm::initAlgorithm( const QVariantMap & )
 
 bool QgsCopyLayerMetadataAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
-  QgsMapLayer *inputLayer = parameterAsLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsMapLayer *sourceLayer = parameterAsLayer( parameters, QStringLiteral( "SOURCE" ), context );
   QgsMapLayer *targetLayer = parameterAsLayer( parameters, QStringLiteral( "TARGET" ), context );
   const bool saveAsDefault = parameterAsBool( parameters, QStringLiteral( "DEFAULT" ), context );
 
-  if ( !inputLayer )
-    throw QgsProcessingException( QObject::tr( "Invalid input layer" ) );
+  if ( !sourceLayer )
+    throw QgsProcessingException( QObject::tr( "Invalid source layer" ) );
 
   if ( !targetLayer )
     throw QgsProcessingException( QObject::tr( "Invalid target layer" ) );
 
   mLayerId = targetLayer->id();
 
-  targetLayer->setMetadata( inputLayer->metadata() );
+  targetLayer->setMetadata( sourceLayer->metadata() );
   if ( saveAsDefault )
   {
     bool ok;
@@ -348,7 +348,7 @@ QString QgsUpdateLayerMetadataAlgorithm::groupId() const
 
 QString QgsUpdateLayerMetadataAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Copies all non-empty metadata fields from an input layer to a target layer.\n\nLeaves empty input fields unchaged in the target." );
+  return QObject::tr( "Copies all non-empty metadata fields from an source layer to a target layer.\n\nLeaves empty input fields unchanged in the target." );
 }
 
 QgsUpdateLayerMetadataAlgorithm *QgsUpdateLayerMetadataAlgorithm::createInstance() const
@@ -358,18 +358,18 @@ QgsUpdateLayerMetadataAlgorithm *QgsUpdateLayerMetadataAlgorithm::createInstance
 
 void QgsUpdateLayerMetadataAlgorithm::initAlgorithm( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "INPUT" ), QObject::tr( "Source layer" ) ) );
+  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "SOURCE" ), QObject::tr( "Source layer" ) ) );
   addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "TARGET" ), QObject::tr( "Target layer" ) ) );
   addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Updated layer" ) ) );
 }
 
 bool QgsUpdateLayerMetadataAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
-  QgsMapLayer *inputLayer = parameterAsLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsMapLayer *sourceLayer = parameterAsLayer( parameters, QStringLiteral( "SOURCE" ), context );
   QgsMapLayer *targetLayer = parameterAsLayer( parameters, QStringLiteral( "TARGET" ), context );
 
-  if ( !inputLayer )
-    throw QgsProcessingException( QObject::tr( "Invalid input layer" ) );
+  if ( !sourceLayer )
+    throw QgsProcessingException( QObject::tr( "Invalid source layer" ) );
 
   if ( !targetLayer )
     throw QgsProcessingException( QObject::tr( "Invalid target layer" ) );
@@ -377,7 +377,7 @@ bool QgsUpdateLayerMetadataAlgorithm::prepareAlgorithm( const QVariantMap &param
   mLayerId = targetLayer->id();
 
   std::unique_ptr<QgsLayerMetadata> md( targetLayer->metadata().clone() );
-  md->combine( &inputLayer->metadata() );
+  md->combine( &sourceLayer->metadata() );
   targetLayer->setMetadata( *md.get() );
 
   return true;

--- a/src/analysis/processing/qgsmetadataalgorithms.h
+++ b/src/analysis/processing/qgsmetadataalgorithms.h
@@ -144,6 +144,31 @@ class QgsUpdateLayerMetadataAlgorithm : public QgsProcessingAlgorithm
     QString mLayerId;
 };
 
+
+/**
+ * Native set metadata fields algorithm.
+ */
+class QgsSetMetadataFieldsAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsSetMetadataFieldsAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QgsSetMetadataFieldsAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+  private:
+    QString mLayerId;
+};
+
 ///@endcond PRIVATE
 
 #endif // QGSMETADATAALGORITHMS_H

--- a/src/analysis/processing/qgsmetadataalgorithms.h
+++ b/src/analysis/processing/qgsmetadataalgorithms.h
@@ -97,6 +97,30 @@ class QgsExportLayerMetadataAlgorithm : public QgsProcessingAlgorithm
     QString mLayerId;
 };
 
+/**
+ * Native add history metadata algorithm.
+ */
+class QgsAddHistoryMetadataAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsAddHistoryMetadataAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QgsAddHistoryMetadataAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+  private:
+    QString mLayerId;
+};
+
 ///@endcond PRIVATE
 
 #endif // QGSMETADATAALGORITHMS_H

--- a/src/analysis/processing/qgsmetadataalgorithms.h
+++ b/src/analysis/processing/qgsmetadataalgorithms.h
@@ -73,7 +73,6 @@ class QgsApplyLayerMetadataAlgorithm : public QgsProcessingAlgorithm
     QString mLayerId;
 };
 
-
 /**
  * Native export layer metadata algorithm.
  */
@@ -112,6 +111,30 @@ class QgsAddHistoryMetadataAlgorithm : public QgsProcessingAlgorithm
     QString shortHelpString() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QgsAddHistoryMetadataAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+  private:
+    QString mLayerId;
+};
+
+/**
+ * Native update layer metadata algorithm.
+ */
+class QgsUpdateLayerMetadataAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsUpdateLayerMetadataAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QgsUpdateLayerMetadataAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -555,6 +555,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsTranslateAlgorithm() );
   addAlgorithm( new QgsTruncateTableAlgorithm() );
   addAlgorithm( new QgsUnionAlgorithm() );
+  addAlgorithm( new QgsUpdateLayerMetadataAlgorithm() );
   addAlgorithm( new QgsOpenUrlAlgorithm() );
   addAlgorithm( new QgsHttpRequestAlgorithm() );
   addAlgorithm( new QgsVariableWidthBufferByMAlgorithm() );

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -520,6 +520,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsServiceAreaFromLayerAlgorithm() );
   addAlgorithm( new QgsServiceAreaFromPointAlgorithm() );
   addAlgorithm( new QgsSetLayerEncodingAlgorithm() );
+  addAlgorithm( new QgsSetMetadataFieldsAlgorithm() );
   addAlgorithm( new QgsSetMValueAlgorithm() );
   addAlgorithm( new QgsSetProjectVariableAlgorithm() );
   addAlgorithm( new QgsSetZValueAlgorithm() );

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -292,6 +292,7 @@ Qgis::ProcessingProviderFlags QgsNativeAlgorithms::flags() const
 void QgsNativeAlgorithms::loadAlgorithms()
 {
   const QgsScopedRuntimeProfile profile( QObject::tr( "QGIS native provider" ) );
+  addAlgorithm( new QgsAddHistoryMetadataAlgorithm() );
   addAlgorithm( new QgsAddIncrementalFieldAlgorithm() );
   addAlgorithm( new QgsAddTableFieldAlgorithm() );
   addAlgorithm( new QgsAddXYFieldsAlgorithm() );

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -1885,8 +1885,8 @@ void TestQgsProcessingAlgsPt2::generateElevationProfileImage()
 
 void TestQgsProcessingAlgsPt2::copyMetadata()
 {
-  std::unique_ptr<QgsVectorLayer> inputLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "input" ), QStringLiteral( "memory" ) );
-  QVERIFY( inputLayer->isValid() );
+  std::unique_ptr<QgsVectorLayer> sourceLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "input" ), QStringLiteral( "memory" ) );
+  QVERIFY( sourceLayer->isValid() );
 
   std::unique_ptr<QgsVectorLayer> targetLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "target" ), QStringLiteral( "memory" ) );
   QVERIFY( targetLayer->isValid() );
@@ -1894,13 +1894,13 @@ void TestQgsProcessingAlgsPt2::copyMetadata()
   QgsLayerMetadata md;
   md.setTitle( QStringLiteral( "Title" ) );
   md.setAbstract( QStringLiteral( "Abstract" ) );
-  inputLayer->setMetadata( md );
+  sourceLayer->setMetadata( md );
 
   std::unique_ptr<QgsProcessingAlgorithm> alg( QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:copylayermetadata" ) ) );
   QVERIFY( alg != nullptr );
 
   QVariantMap parameters;
-  parameters.insert( QStringLiteral( "INPUT" ), QVariant::fromValue( inputLayer.get() ) );
+  parameters.insert( QStringLiteral( "SOURCE" ), QVariant::fromValue( sourceLayer.get() ) );
   parameters.insert( QStringLiteral( "TARGET" ), QVariant::fromValue( targetLayer.get() ) );
 
   bool ok = false;
@@ -2037,8 +2037,8 @@ void TestQgsProcessingAlgsPt2::addHistoryMetadata()
 
 void TestQgsProcessingAlgsPt2::updateMetadata()
 {
-  std::unique_ptr<QgsVectorLayer> inputLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "input" ), QStringLiteral( "memory" ) );
-  QVERIFY( inputLayer->isValid() );
+  std::unique_ptr<QgsVectorLayer> sourceLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "input" ), QStringLiteral( "memory" ) );
+  QVERIFY( sourceLayer->isValid() );
 
   std::unique_ptr<QgsVectorLayer> targetLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "target" ), QStringLiteral( "memory" ) );
   QVERIFY( targetLayer->isValid() );
@@ -2047,7 +2047,7 @@ void TestQgsProcessingAlgsPt2::updateMetadata()
   mdInput.setTitle( QStringLiteral( "New title" ) );
   mdInput.setAbstract( QStringLiteral( "New abstract" ) );
   mdInput.setLanguage( QStringLiteral( "Language" ) );
-  inputLayer->setMetadata( mdInput );
+  sourceLayer->setMetadata( mdInput );
 
   QgsLayerMetadata mdTarget;
   mdTarget.setTitle( QStringLiteral( "Title" ) );
@@ -2059,7 +2059,7 @@ void TestQgsProcessingAlgsPt2::updateMetadata()
   QVERIFY( alg != nullptr );
 
   QVariantMap parameters;
-  parameters.insert( QStringLiteral( "INPUT" ), QVariant::fromValue( inputLayer.get() ) );
+  parameters.insert( QStringLiteral( "SOURCE" ), QVariant::fromValue( sourceLayer.get() ) );
   parameters.insert( QStringLiteral( "TARGET" ), QVariant::fromValue( targetLayer.get() ) );
 
   bool ok = false;

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -2116,6 +2116,34 @@ void TestQgsProcessingAlgsPt2::setMetadataFields()
   QCOMPARE( layer->metadata().fees(), QStringLiteral( "Enormous fee" ) );
   QVERIFY( layer->metadata().crs().isValid() );
   QCOMPARE( layer->metadata().crs().authid(), QStringLiteral( "EPSG:4326" ) );
+
+  // ignore empty field
+  parameters[QStringLiteral( "TITLE" )] = QStringLiteral( "" );
+  parameters.insert( QStringLiteral( "IGNORE_EMPTY" ), true );
+
+  ok = false;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QCOMPARE( results.value( QStringLiteral( "OUTPUT" ) ), layer->id() );
+  QCOMPARE( layer->metadata().title(), QStringLiteral( "New title" ) );
+  QCOMPARE( layer->metadata().abstract(), QStringLiteral( "Abstract" ) );
+  QCOMPARE( layer->metadata().fees(), QStringLiteral( "Enormous fee" ) );
+  QVERIFY( layer->metadata().crs().isValid() );
+  QCOMPARE( layer->metadata().crs().authid(), QStringLiteral( "EPSG:4326" ) );
+
+  parameters[QStringLiteral( "IGNORE_EMPTY" )] = false;
+
+  ok = false;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QCOMPARE( results.value( QStringLiteral( "OUTPUT" ) ), layer->id() );
+  QCOMPARE( layer->metadata().title(), QStringLiteral( "" ) );
+  QCOMPARE( layer->metadata().abstract(), QStringLiteral( "Abstract" ) );
+  QCOMPARE( layer->metadata().fees(), QStringLiteral( "Enormous fee" ) );
+  QVERIFY( layer->metadata().crs().isValid() );
+  QCOMPARE( layer->metadata().crs().authid(), QStringLiteral( "EPSG:4326" ) );
 }
 
 QGSTEST_MAIN( TestQgsProcessingAlgsPt2 )

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -2118,7 +2118,7 @@ void TestQgsProcessingAlgsPt2::setMetadataFields()
   QCOMPARE( layer->metadata().crs().authid(), QStringLiteral( "EPSG:4326" ) );
 
   // ignore empty field
-  parameters[QStringLiteral( "TITLE" )] = QStringLiteral( "" );
+  parameters[QStringLiteral( "TITLE" )] = QLatin1String( "" );
   parameters.insert( QStringLiteral( "IGNORE_EMPTY" ), true );
 
   ok = false;
@@ -2139,7 +2139,7 @@ void TestQgsProcessingAlgsPt2::setMetadataFields()
   QVERIFY( ok );
 
   QCOMPARE( results.value( QStringLiteral( "OUTPUT" ) ), layer->id() );
-  QCOMPARE( layer->metadata().title(), QStringLiteral( "" ) );
+  QCOMPARE( layer->metadata().title(), QLatin1String( "" ) );
   QCOMPARE( layer->metadata().abstract(), QStringLiteral( "Abstract" ) );
   QCOMPARE( layer->metadata().fees(), QStringLiteral( "Enormous fee" ) );
   QVERIFY( layer->metadata().crs().isValid() );


### PR DESCRIPTION
## Description

Add a few more native algorithms to deal with layer metadata:

- Add history metadata to add a new history entry to existing entries defined for a layer
- Update layer metadata to copy non-empty metadata fields from input layer to a target layer and keeping empty fields from input unchanged in the target
- Set metadata fields to set simple metadata fields (identifier, parent identifier, title, type, encoding, language, crs, abstract, fees)

Followup #59411.