### PR TITLE
Format alg helpUrl to match actually generated URL

### DIFF
--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -492,7 +492,7 @@ void QgsProcessingAlgorithmDialogBase::openHelp()
   QUrl algHelp = mAlgorithm->helpUrl();
   if ( algHelp.isEmpty() && mAlgorithm->provider() )
   {
-    algHelp = QgsHelp::helpUrl( QStringLiteral( "processing_algs/%1/%2.html#%3" ).arg( mAlgorithm->provider()->helpId(), mAlgorithm->groupId(), QStringLiteral( "%1%2" ).arg( mAlgorithm->provider()->helpId() ).arg( mAlgorithm->name() ) ) );
+    algHelp = QgsHelp::helpUrl( QStringLiteral( "processing_algs/%1/%2.html#%3" ).arg( mAlgorithm->provider()->helpId(), mAlgorithm->groupId(), QStringLiteral( "%1%2" ).arg( mAlgorithm->provider()->helpId() ).arg( mAlgorithm->name().replace( "_", "-" ) ) ) );
   }
 
   if ( !algHelp.isEmpty() )


### PR DESCRIPTION
replacing "_" characters by "-"
Fixes https://github.com/qgis/QGIS-Documentation/issues/9479 (also affects at least rearrange_bands, writevectortiles_xyz, writevectortiles_mbtiles, contour_polygon)

I don't know how/if this may affect third-party providers algs or not.
And things would be simpler if we only use letters in our algs ids.

If OK, backport would be nice.