### PR TITLE
Avoid unclosed file warning in test

### DIFF
--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -605,8 +605,11 @@ class TestPyQgsShapefileProvider(QgisTestCase, ProviderTestCase):
 
         vl = None
 
+        f_shp.close()
         del f_shp
+        f_shx.close()
         del f_shx
+        f_dbf.close()
         del f_dbf
 
         # Test repacking has been done


### PR DESCRIPTION
Maybe will help with test fragility
