### PR TITLE
Highlight Trim/Extend plane of intersection

### DIFF
--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -141,10 +141,20 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
         if ( !getPoints( match, pExtend1, pExtend2 ) )
           break;
 
-        QgsPoint pLimit1Projected, pLimit2Projected;
         QgsCoordinateTransform transform( mLimitLayer->crs(), mVlayer->crs(), mCanvas->mapSettings().transformContext() );
-        pLimit1Projected = QgsPoint( transform.transform( pLimit1 ) );
-        pLimit2Projected = QgsPoint( transform.transform( pLimit2 ) );
+
+        QgsPoint pLimit1Projected( pLimit1 );
+        QgsPoint pLimit2Projected( pLimit2 );
+        if ( !transform.isShortCircuited() )
+        {
+          const QgsPointXY transformedP1 = transform.transform( pLimit1 );
+          const QgsPointXY transformedP2 = transform.transform( pLimit2 );
+          pLimit1Projected.setX( transformedP1.x() );
+          pLimit1Projected.setY( transformedP1.y() );
+          pLimit2Projected.setX( transformedP2.x() );
+          pLimit2Projected.setY( transformedP2.y() );
+        }
+
         // No need to trim/extend if segments are continuous
         if ( ( ( pLimit1Projected == pExtend1 ) || ( pLimit1Projected == pExtend2 ) ) || ( ( pLimit2Projected == pExtend1 ) || ( pLimit2Projected == pExtend2 ) ) )
           break;

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -136,16 +136,20 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
         if ( !getPoints( match, pExtend1, pExtend2 ) )
           break;
 
+        QgsPoint pLimit1Projected, pLimit2Projected;
+        QgsCoordinateTransform transform( mLimitLayer->crs(), mVlayer->crs(), mCanvas->mapSettings().transformContext() );
+        pLimit1Projected = QgsPoint( transform.transform( pLimit1 ) );
+        pLimit2Projected = QgsPoint( transform.transform( pLimit2 ) );
         // No need to trim/extend if segments are continuous
-        if ( ( ( pLimit1 == pExtend1 ) || ( pLimit1 == pExtend2 ) ) || ( ( pLimit2 == pExtend1 ) || ( pLimit2 == pExtend2 ) ) )
+        if ( ( ( pLimit1Projected == pExtend1 ) || ( pLimit1Projected == pExtend2 ) ) || ( ( pLimit2Projected == pExtend1 ) || ( pLimit2Projected == pExtend2 ) ) )
           break;
 
-        mSegmentIntersects = QgsGeometryUtils::segmentIntersection( pLimit1, pLimit2, pExtend1, pExtend2, mIntersection, mIsIntersection, 1e-8, true );
+        mSegmentIntersects = QgsGeometryUtils::segmentIntersection( pLimit1Projected, pLimit2Projected, pExtend1, pExtend2, mIntersection, mIsIntersection, 1e-8, true );
 
         if ( mIs3DLayer && QgsWkbTypes::hasZ( match.layer()->wkbType() ) )
         {
           /* Z Interpolation */
-          const QgsLineString line( pLimit1, pLimit2 );
+          const QgsLineString line( pLimit1Projected, pLimit2Projected );
 
           mIntersection = QgsGeometryUtils::closestPoint( line, QgsPoint( mIntersection ) );
         }
@@ -168,7 +172,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
               index += 1;
           }
           // TRIM PART
-          else if ( QgsGeometryUtils::leftOfLine( QgsPoint( mMapPoint ), pLimit1, pLimit2 ) != QgsGeometryUtils::leftOfLine( pExtend1, pLimit1, pLimit2 ) )
+          else if ( QgsGeometryUtils::leftOfLine( QgsPoint( mMapPoint ), pLimit1Projected, pLimit2Projected ) != QgsGeometryUtils::leftOfLine( pExtend1, pLimit1Projected, pLimit2Projected ) )
           {
             // Part where the mouse is (+) will be trimmed
             /*     |

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -387,8 +387,25 @@ void QgsMapToolTrimExtendFeature::reset()
   mVlayer = nullptr;
   mLimitLayer = nullptr;
 }
+void QgsMapToolTrimExtendFeature::activate()
+{
+  QgsMapTool::activate();
+
+  // Save the original snapping configuration
+  mOriginalSnappingConfig = mCanvas->snappingUtils()->config();
+
+  // Enable Snapping & Snapping on Segment
+  QgsSnappingConfig snappingConfig = mOriginalSnappingConfig;
+  snappingConfig.setEnabled( true );
+  Qgis::SnappingTypes flags = snappingConfig.typeFlag();
+  flags |= Qgis::SnappingType::Segment;
+  snappingConfig.setTypeFlag( flags );
+  mCanvas->snappingUtils()->setConfig( snappingConfig );
+}
 void QgsMapToolTrimExtendFeature::deactivate()
 {
   reset();
+  // Restore the original snapping configuration
+  mCanvas->snappingUtils()->setConfig( mOriginalSnappingConfig );
   QgsMapTool::deactivate();
 }

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -265,8 +265,8 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
           emit messageEmitted( tr( "Couldn't trim or extend the feature." ) );
         }
 
-        // If Ctrl or Shift is pressed, keep the tool active with its reference feature
-        if ( !( e->modifiers() & ( Qt::ControlModifier | Qt::ShiftModifier ) ) )
+        // If Shift is pressed, keep the tool active with its reference feature
+        if ( !( e->modifiers() & Qt::ShiftModifier ) )
           deactivate();
         break;
     }

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -278,13 +278,13 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
 
         // If Shift is pressed, keep the tool active with its reference feature
         if ( !( e->modifiers() & Qt::ShiftModifier ) )
-          deactivate();
+          reset();
         break;
     }
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate();
+    reset();
   }
 }
 
@@ -297,7 +297,7 @@ void QgsMapToolTrimExtendFeature::keyPressEvent( QKeyEvent *e )
 
   if ( e && e->key() == Qt::Key_Escape )
   {
-    deactivate();
+    reset();
   }
 }
 
@@ -354,7 +354,7 @@ void QgsMapToolTrimExtendFeature::extendLimit()
   const int p1Idx = points.indexOf( p1 );
   const int p2Idx = points.indexOf( p2 );
   const int first = std::max( 0, std::min( p1Idx, p2Idx ) - 1 );
-  const int last = std::min( points.size() - 1, std::max( p1Idx, p2Idx ) + 1 );
+  const int last = std::min( static_cast<int>( points.size() ) - 1, std::max( p1Idx, p2Idx ) + 1 );
   const QgsPolylineXY polyline = points.mid( first, last - first + 1 ).toVector();
 
   // Densify the polyline to display a more accurate prediction when layer crs != canvas crs
@@ -363,8 +363,7 @@ void QgsMapToolTrimExtendFeature::extendLimit()
   mRubberBandLimitExtend->setToGeometry( geom, refLayer );
   mRubberBandLimitExtend->show();
 }
-
-void QgsMapToolTrimExtendFeature::deactivate()
+void QgsMapToolTrimExtendFeature::reset()
 {
   mStep = StepLimit;
   mIsModified = false;
@@ -375,7 +374,11 @@ void QgsMapToolTrimExtendFeature::deactivate()
   mRubberBandLimitExtend.reset();
   mRubberBandExtend.reset();
   mRubberBandIntersection.reset();
-  QgsMapTool::deactivate();
   mVlayer = nullptr;
   mLimitLayer = nullptr;
+}
+void QgsMapToolTrimExtendFeature::deactivate()
+{
+  reset();
+  QgsMapTool::deactivate();
 }

--- a/src/app/qgsmaptooltrimextendfeature.h
+++ b/src/app/qgsmaptooltrimextendfeature.h
@@ -19,6 +19,7 @@
 #include "qgsmaptooledit.h"
 #include "qgis_app.h"
 #include "qgsrubberband.h"
+#include "qgssnappingconfig.h"
 
 class APP_EXPORT QgsMapToolTrimExtendFeature : public QgsMapToolEdit
 {
@@ -34,6 +35,9 @@ class APP_EXPORT QgsMapToolTrimExtendFeature : public QgsMapToolEdit
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
 
     void keyPressEvent( QKeyEvent *e ) override;
+
+    //! called when map tool is being activated
+    void activate() override;
 
     //! called when map tool is being deactivated
     void deactivate() override;
@@ -81,6 +85,9 @@ class APP_EXPORT QgsMapToolTrimExtendFeature : public QgsMapToolEdit
     };
     //! The first step (0): choose the limit. The second step (1): choose the segment to trim/extend
     Step mStep = StepLimit;
+
+    //! Snapping config that will be restored on deactivation
+    QgsSnappingConfig mOriginalSnappingConfig;
 };
 
 #endif // QGSMAPTOOLTRIMEXTENDFEATURE_H

--- a/src/app/qgsmaptooltrimextendfeature.h
+++ b/src/app/qgsmaptooltrimextendfeature.h
@@ -41,6 +41,7 @@ class APP_EXPORT QgsMapToolTrimExtendFeature : public QgsMapToolEdit
   private slots:
     // Recompute the extended limit
     void extendLimit();
+    void reset();
 
   private:
     //!  Rubberband that highlights the limit segment

--- a/src/app/qgsmaptooltrimextendfeature.h
+++ b/src/app/qgsmaptooltrimextendfeature.h
@@ -38,9 +38,15 @@ class APP_EXPORT QgsMapToolTrimExtendFeature : public QgsMapToolEdit
     //! called when map tool is being deactivated
     void deactivate() override;
 
+  private slots:
+    // Recompute the extended limit
+    void extendLimit();
+
   private:
-    //!  Rubberband that shows the limit
+    //!  Rubberband that highlights the limit segment
     std::unique_ptr<QgsRubberBand> mRubberBandLimit;
+    //!  Rubberband that extends the limit segment
+    std::unique_ptr<QgsRubberBand> mRubberBandLimitExtend;
     //! Rubberband that shows the feature being extended
     std::unique_ptr<QgsRubberBand> mRubberBandExtend;
     //!  Rubberband that shows the intersection point

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1181,7 +1181,7 @@ Shift+O to turn segments into straight or curve lines.</string>
    <property name="toolTip">
     <string>Trim/Extend Feature
 - Click to set the reference segment
-- Click on another segment to trim it or extend it to the reference segment (Use Shift or Ctrl to keep the reference segment active)
+- Click on another segment to trim it or extend it to the reference segment (Use Shift to keep the reference segment active)
 Note : Segment snapping must be enabled in the snapping Toolbar</string>
    </property>
   </action>

--- a/tests/src/app/testqgsmaptooltrimextendfeature.cpp
+++ b/tests/src/app/testqgsmaptooltrimextendfeature.cpp
@@ -65,7 +65,7 @@ class TestQgsMapToolTrimExtendFeature : public QObject
       //       |          \|       |
       //       |           + (2,1) |
       // (0,0) +-------------------+ (3,0)
-      vlPolygon.reset( new QgsVectorLayer( QStringLiteral( "MultiPolygon?field=fld:int" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) ) );
+      vlPolygon.reset( new QgsVectorLayer( QStringLiteral( "MultiPolygon?crs=EPSG:3946&field=fld:int" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) ) );
       const int idx = vlPolygon->fields().indexFromName( QStringLiteral( "fld" ) );
       QVERIFY( idx != -1 );
       f1.initAttributes( 1 );
@@ -606,7 +606,7 @@ class TestQgsMapToolTrimExtendFeature : public QObject
         pt.toQPointF().toPoint(),
         Qt::LeftButton,
         Qt::NoButton,
-        Qt::ControlModifier
+        Qt::ShiftModifier
       ) );
       tool->canvasReleaseEvent( event.get() );
 


### PR DESCRIPTION
- Fix #59683

## Description

- Discard the Control modifier for multi trim/extend (see https://github.com/qgis/QGIS/pull/59676#issuecomment-2539239943)
- Fix the tool when the limit segment and the trimmed/extended segment belong to layers that do not have the same CRS
- Extend the limit segment to the canvas border
- Auto enable snapping when activating the tool. Original snapping configuration is restored on tool deactivation

![trim_extend_line](https://github.com/user-attachments/assets/3cf003f4-9aed-4da8-9aa5-13e15e773f73)
