### PR TITLE
Use GDAL entrypoints instead of .py/.bat scripts

### DIFF
--- a/python/plugins/processing/algs/gdal/AssignProjection.py
+++ b/python/plugins/processing/algs/gdal/AssignProjection.py
@@ -110,7 +110,7 @@ class AssignProjection(GdalAlgorithm):
         self.setOutputValue(self.OUTPUT, fileName)
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]
 

--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -204,6 +204,6 @@ class fillnodata(GdalAlgorithm):
             arguments.extend(GdalUtils.parseCreationOptions(options))
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/gdal2tiles.py
+++ b/python/plugins/processing/algs/gdal/gdal2tiles.py
@@ -283,6 +283,6 @@ class gdal2tiles(GdalAlgorithm):
             arguments.extend(input_details.credential_options_as_arguments())
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/gdal2xyz.py
+++ b/python/plugins/processing/algs/gdal/gdal2xyz.py
@@ -168,6 +168,6 @@ class gdal2xyz(GdalAlgorithm):
             arguments.extend(input_details.credential_options_as_arguments())
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -462,6 +462,6 @@ class gdalcalc(GdalAlgorithm):
         arguments.append(out)
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -245,6 +245,6 @@ class merge(GdalAlgorithm):
         arguments.append(list_file)
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/pansharp.py
+++ b/python/plugins/processing/algs/gdal/pansharp.py
@@ -174,6 +174,6 @@ class pansharp(GdalAlgorithm):
             arguments.append(extra)
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/pct2rgb.py
+++ b/python/plugins/processing/algs/gdal/pct2rgb.py
@@ -119,6 +119,6 @@ class pct2rgb(GdalAlgorithm):
             arguments.extend(input_details.credential_options_as_arguments())
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/polygonize.py
+++ b/python/plugins/processing/algs/gdal/polygonize.py
@@ -153,6 +153,6 @@ class polygonize(GdalAlgorithm):
             arguments.extend(input_details.credential_options_as_arguments())
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/proximity.py
+++ b/python/plugins/processing/algs/gdal/proximity.py
@@ -271,6 +271,6 @@ class proximity(GdalAlgorithm):
             arguments.extend(input_details.credential_options_as_arguments())
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/retile.py
+++ b/python/plugins/processing/algs/gdal/retile.py
@@ -294,6 +294,6 @@ class retile(GdalAlgorithm):
         arguments.extend(credential_options)
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/rgb2pct.py
+++ b/python/plugins/processing/algs/gdal/rgb2pct.py
@@ -112,6 +112,6 @@ class rgb2pct(GdalAlgorithm):
             arguments.extend(input_details.credential_options_as_arguments())
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]

--- a/python/plugins/processing/algs/gdal/sieve.py
+++ b/python/plugins/processing/algs/gdal/sieve.py
@@ -166,6 +166,6 @@ class sieve(GdalAlgorithm):
             arguments.extend(input_details.credential_options_as_arguments())
 
         return [
-            self.commandName() + (".bat" if isWindows() else ".py"),
+            self.commandName(),
             GdalUtils.escapeAndJoin(arguments),
         ]


### PR DESCRIPTION
## Call entrypoint versions of the GDAL Python scripts for better cross platform compatibility

As discussed in https://github.com/conda-forge/qgis-feedstock/issues/487, current QGIS expects a `.bat` wrapper on Windows for each of the GDAL Python scripts. This is less than ideal for 2 reasons:

1. Only OSGeo4W actually installs the `.bat` files. They aren't provided by GDAL and they aren't provided in other package managers or when building from source.
2. Since GDAL 3.9 "entrypoints" have been created for each of the Python scripts. This PR uses them instead. On Unix, a file is created without an extension (ie `gdal_polygonize`) that is a script than can be executed. On Windows a wrapper `.exe` file is created (ie `gdal_polygonize.exe`). When executing the command without an extension on Windows the default behaviour is to search for a `.exe` file (ie executing `gdal_polygonize` will result in `gdal_polygonize.exe` being run).

So the current behaviour is incorrect on Windows. This PR attempts to make the code tidier using entrypoints.
