### PR TITLE
Merge features: immediately update widgets for attributes with a provider default value

### DIFF
--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -267,6 +267,11 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
         currentComboBox->setCurrentIndex( currentComboBox->findData( QStringLiteral( "manual" ) ) );
         currentComboBox->blockSignals( false );
       }
+
+      const QgsEditorWidgetSetup setup = mFields.at( idx ).editorWidgetSetup();
+
+      if ( !setup.type().isEmpty() && !setup.isNull() )
+        updateManualWidget( j, true );
     }
   }
 

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -270,7 +270,7 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
 
       const QgsEditorWidgetSetup setup = mFields.at( idx ).editorWidgetSetup();
 
-      if ( !setup.type().isEmpty() && !setup.isNull() )
+      if ( !setup.isNull() && !setup.type().isEmpty() )
         updateManualWidget( j, true );
     }
   }


### PR DESCRIPTION
Apply for widgets which show a key/description instead of the actual values. Addresses part of #59494 (the additional context part, the main part AFAIK is the intended behavior and is meant to be addressed with a "merge policy" feature)

Backport to 3.40 requested.

before:
![before](https://github.com/user-attachments/assets/d82f3b2e-45ff-46d0-86ab-33f57c8473b5)

after:
![after](https://github.com/user-attachments/assets/433fc10b-6325-44b4-8333-12ccd32faa46)
