### PR TITLE
Fixing WFS boolean QGIS expressions issues

### DIFF
--- a/src/core/qgssqliteutils.cpp
+++ b/src/core/qgssqliteutils.cpp
@@ -281,9 +281,6 @@ QString QgsSqliteUtils::quotedValue( const QVariant &value )
     case QMetaType::Type::Double:
       return value.toString();
 
-    case QMetaType::Type::Bool:
-      //SQLite has no boolean literals
-      return value.toBool() ? QStringLiteral( "1" ) : QStringLiteral( "0" );
 
     default:
     case QMetaType::Type::QString:


### PR DESCRIPTION
## Description

WFS boolean fields have textual 'true' or 'false' values written in a varchar column inside the sqlite cache database.

We must treat QGIS expressions with booleans with the correct values.