### PR TITLE
fix(QgsMapBoxGlStyleConverter): also handle visibility when it is defined in "layout"

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -149,7 +149,18 @@ void QgsMapBoxGlStyleConverter::parseLayers( const QVariantList &layers, QgsMapB
     if ( maxZoom != -1 )
       maxZoom--;
 
-    const bool enabled = jsonLayer.value( QStringLiteral( "visibility" ) ).toString() != QLatin1String( "none" );
+    QString visibilyStr;
+    if ( jsonLayer.contains( QStringLiteral( "visibility" ) ) )
+    {
+      visibilyStr = jsonLayer.value( QStringLiteral( "visibility" ) ).toString();
+    }
+    else if ( jsonLayer.contains( QStringLiteral( "layout" ) ) && jsonLayer.value( QStringLiteral( "layout" ) ).userType() == QMetaType::Type::QVariantMap )
+    {
+      const QVariantMap jsonLayout = jsonLayer.value( QStringLiteral( "layout" ) ).toMap();
+      visibilyStr = jsonLayout.value( QStringLiteral( "visibility" ) ).toString();
+    }
+
+    const bool enabled = visibilyStr != QLatin1String( "none" );
 
     QString filterExpression;
     if ( jsonLayer.contains( QStringLiteral( "filter" ) ) )

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -2209,6 +2209,88 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             '"direction"',
         )
 
+    def test_parse_visibility(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "sources": {"Basemaps": {"type": "vector", "url": "https://xxxxxx"}},
+            "layers": [
+                {
+                    "id": "at-layout-level-true",
+                    "source": "streets",
+                    "source-layer": "water",
+                    "type": "fill",
+                    "paint": {"fill-color": "#00ffff"},
+                    "layout": {
+                        "visibility": "visible",
+                        "text-field": "{substance}",
+                    },
+                },
+                {
+                    "id": "at-layout-level-other",
+                    "source": "streets",
+                    "source-layer": "water",
+                    "type": "fill",
+                    "paint": {"fill-color": "#00ffff"},
+                    "layout": {
+                        "visibility": "anOtherText",
+                        "text-field": "{substance}",
+                    },
+                },
+                {
+                    "id": "at-layout-level-false",
+                    "source": "streets",
+                    "source-layer": "water",
+                    "type": "fill",
+                    "paint": {"fill-color": "#00ffff"},
+                    "layout": {
+                        "visibility": "none",
+                        "text-field": "{substance}",
+                    },
+                },
+                {
+                    "id": "at-root-level-true",
+                    "source": "streets",
+                    "source-layer": "water",
+                    "type": "fill",
+                    "paint": {"fill-color": "#00ffff"},
+                    "visibility": "visible",
+                },
+                {
+                    "id": "at-root-level-other",
+                    "source": "streets",
+                    "source-layer": "water",
+                    "type": "fill",
+                    "paint": {"fill-color": "#00ffff"},
+                    "visibility": "anOtherText",
+                },
+                {
+                    "id": "at-root-level-false",
+                    "source": "streets",
+                    "source-layer": "water",
+                    "type": "fill",
+                    "paint": {"fill-color": "#00ffff"},
+                    "visibility": "none",
+                },
+            ],
+        }
+
+        converter = QgsMapBoxGlStyleConverter()
+        converter.convert(style, context)
+
+        renderer = converter.renderer()
+        style = renderer.style(0)
+        self.assertEqual(style.isEnabled(), True)
+        style = renderer.style(1)
+        self.assertEqual(style.isEnabled(), True)
+        style = renderer.style(2)
+        self.assertEqual(style.isEnabled(), False)
+        style = renderer.style(3)
+        self.assertEqual(style.isEnabled(), True)
+        style = renderer.style(4)
+        self.assertEqual(style.isEnabled(), True)
+        style = renderer.style(5)
+        self.assertEqual(style.isEnabled(), False)
+
     def test_parse_zoom_levels(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {


### PR DESCRIPTION
In json style, "visibility" can be defined in the "layout" sub object. This PR add the ability to handle the visibility at the root level of the style object and in the "layout" sub object.

Closes #58943 