### PR TITLE
fix(QgsMapBoxGlStyleConverter): also handle text-rotate from property field

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -1713,6 +1713,19 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
       }
 
+      case QMetaType::Type::QVariantMap:
+      {
+        QVariantMap rotateMap = jsonTextRotate.toMap();
+        if ( rotateMap.contains( QStringLiteral( "property" ) ) && rotateMap[QStringLiteral( "type" )].toString() == QStringLiteral( "identity" ) )
+        {
+          const QgsProperty property = QgsProperty::fromExpression( rotateMap[QStringLiteral( "property" )].toString() );
+          ddLabelProperties.setProperty( QgsPalLayerSettings::Property::LabelRotation, property );
+        }
+        else
+          context.pushWarning( QObject::tr( "%1: Skipping unsupported text-rotate map content (%2)" ).arg( context.layerId(), QString( QJsonDocument::fromVariant( rotateMap ).toJson() ) ) );
+        break;
+      }
+
       default:
         context.pushWarning( QObject::tr( "%1: Skipping unsupported text-rotate type (%2)" ).arg( context.layerId(), QMetaType::typeName( static_cast<QMetaType::Type>( jsonTextRotate.userType() ) ) ) );
         break;

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -2209,6 +2209,33 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             '"direction"',
         )
 
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "visibility": "visible",
+                "text-field": "{substance}",
+                "text-rotate": {
+                    "property": "label_angle1",
+                    "default": 0,
+                    "type": "identity",
+                },
+            },
+            "paint": {
+                "text-color": "rgba(47, 47, 47, 1)",
+            },
+            "type": "symbol",
+        }
+        rendererStyle, has_renderer, labeling_style, has_labeling = (
+            QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        )
+        self.assertTrue(has_labeling)
+        ls = labeling_style.labelSettings()
+        ddp = ls.dataDefinedProperties()
+        self.assertEqual(
+            ddp.property(QgsPalLayerSettings.Property.LabelRotation).asExpression(),
+            "label_angle1",
+        )
+
     def test_parse_visibility(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {


### PR DESCRIPTION
Fix issue when a text-rotate is defined according a field value as this example:

```json
 {
            "id": "World",
            "type": "symbol",
            "source": "esri",
            "layout": {
                "text-size": 13.3333,
                "text-rotate": {
                    "property": "_label_angle1",
                    "default": 0,
                    "type": "identity"
                },
                "text-field": "{_name1}",
                "text-optional": true,
                "visibility": "none"
            },

},
```