### PR TITLE
Mesh Layer Rendering with Updated Canvas Fix

### DIFF
--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -234,9 +234,13 @@ Gets native mesh and updates (creates if it doesn't exist) the base triangular m
 %Docstring
 Returns renderer settings
 %End
-    void setRendererSettings( const QgsMeshRendererSettings &settings );
+
+    void setRendererSettings( const QgsMeshRendererSettings &settings, const bool repaint = true );
 %Docstring
 Sets new renderer settings
+
+:param settings:
+:param repaint: should the update of renderer settings trigger repaint and emit rendererChanged signal
 %End
 
     QgsMeshTimeSettings timeSettings() const;

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -234,9 +234,13 @@ Gets native mesh and updates (creates if it doesn't exist) the base triangular m
 %Docstring
 Returns renderer settings
 %End
-    void setRendererSettings( const QgsMeshRendererSettings &settings );
+
+    void setRendererSettings( const QgsMeshRendererSettings &settings, const bool repaint = true );
 %Docstring
 Sets new renderer settings
+
+:param settings:
+:param repaint: should the update of renderer settings trigger repaint and emit rendererChanged signal
 %End
 
     QgsMeshTimeSettings timeSettings() const;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -17184,8 +17184,13 @@ void QgisApp::handleRenderedLayerStatistics() const
       QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( QgsProject::instance()->mapLayer( layerStatistics->layerId() ) );
       if ( meshLayer )
       {
-        meshLayer->emitStyleChanged();
-        emit meshLayer->rendererChanged();
+        QgsMeshRendererSettings rendererSettings = meshLayer->rendererSettings();
+        QgsMeshRendererScalarSettings scalarRendererSettings = rendererSettings.scalarSettings( rendererSettings.activeScalarDatasetGroup() );
+
+        scalarRendererSettings.setClassificationMinimumMaximum( layerStatistics->minimum( 0 ), layerStatistics->maximum( 0 ) );
+        rendererSettings.setScalarSettings( rendererSettings.activeScalarDatasetGroup(), scalarRendererSettings );
+        meshLayer->setRendererSettings( rendererSettings );
+
         emit meshLayer->legendChanged();
       }
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -17184,12 +17184,6 @@ void QgisApp::handleRenderedLayerStatistics() const
       QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( QgsProject::instance()->mapLayer( layerStatistics->layerId() ) );
       if ( meshLayer )
       {
-        QgsMeshRendererSettings rendererSettings = meshLayer->rendererSettings();
-        QgsMeshRendererScalarSettings scalarRendererSettings = rendererSettings.scalarSettings( rendererSettings.activeScalarDatasetGroup() );
-        scalarRendererSettings.setClassificationMinimumMaximum( layerStatistics->minimum( 0 ), layerStatistics->maximum( 0 ) );
-        rendererSettings.setScalarSettings( rendererSettings.activeScalarDatasetGroup(), scalarRendererSettings );
-        meshLayer->setRendererSettings( rendererSettings );
-
         meshLayer->emitStyleChanged();
         emit meshLayer->rendererChanged();
         emit meshLayer->legendChanged();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -17192,7 +17192,6 @@ void QgisApp::handleRenderedLayerStatistics() const
         meshLayer->setRendererSettings( rendererSettings, false );
 
         meshLayer->emitStyleChanged();
-        emit meshLayer->legendChanged();
       }
     }
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -17189,8 +17189,9 @@ void QgisApp::handleRenderedLayerStatistics() const
 
         scalarRendererSettings.setClassificationMinimumMaximum( layerStatistics->minimum( 0 ), layerStatistics->maximum( 0 ) );
         rendererSettings.setScalarSettings( rendererSettings.activeScalarDatasetGroup(), scalarRendererSettings );
-        meshLayer->setRendererSettings( rendererSettings );
+        meshLayer->setRendererSettings( rendererSettings, false );
 
+        meshLayer->emitStyleChanged();
         emit meshLayer->legendChanged();
       }
     }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -418,7 +418,7 @@ QgsMeshRendererSettings QgsMeshLayer::rendererSettings() const
   return mRendererSettings;
 }
 
-void QgsMeshLayer::setRendererSettings( const QgsMeshRendererSettings &settings )
+void QgsMeshLayer::setRendererSettings( const QgsMeshRendererSettings &settings, const bool repaint )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
@@ -432,8 +432,11 @@ void QgsMeshLayer::setRendererSettings( const QgsMeshRendererSettings &settings 
   if ( oldActiveVector != mRendererSettings.activeVectorDatasetGroup() )
     emit activeVectorDatasetGroupChanged( mRendererSettings.activeVectorDatasetGroup() );
 
-  emit rendererChanged();
-  triggerRepaint();
+  if ( repaint )
+  {
+    emit rendererChanged();
+    triggerRepaint();
+  }
 }
 
 QgsMeshTimeSettings QgsMeshLayer::timeSettings() const

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -432,9 +432,10 @@ void QgsMeshLayer::setRendererSettings( const QgsMeshRendererSettings &settings,
   if ( oldActiveVector != mRendererSettings.activeVectorDatasetGroup() )
     emit activeVectorDatasetGroupChanged( mRendererSettings.activeVectorDatasetGroup() );
 
+  emit rendererChanged();
+
   if ( repaint )
   {
-    emit rendererChanged();
     triggerRepaint();
   }
 }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1704,6 +1704,11 @@ bool QgsMeshLayer::minimumMaximumActiveScalarDataset( const QgsRectangle &extent
 
   QgsTriangularMesh *tMesh = triangularMesh();
 
+  if ( ! tMesh )
+  {
+    return false;
+  }
+
   QVector<double> scalarDatasetValues;
   const QgsMeshDatasetGroupMetadata metadata = datasetGroupMetadata( datasetIndex.group() );
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -309,8 +309,14 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
 
     //! Returns renderer settings
     QgsMeshRendererSettings rendererSettings() const;
-    //! Sets new renderer settings
-    void setRendererSettings( const QgsMeshRendererSettings &settings );
+
+    /**
+     * Sets new renderer settings
+     *
+     * \param settings
+     * \param repaint should the update of renderer settings trigger repaint and emit rendererChanged signal
+     */
+    void setRendererSettings( const QgsMeshRendererSettings &settings, const bool repaint = true );
 
     /**
      * Returns time format settings

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -168,7 +168,7 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
 
     if ( activeDatasetIndex.isValid() )
     {
-      const QgsMeshRendererScalarSettings scalarRendererSettings = mRendererSettings.scalarSettings( activeDatasetIndex.group() );
+      QgsMeshRendererScalarSettings scalarRendererSettings = mRendererSettings.scalarSettings( activeDatasetIndex.group() );
       const double previousMin = scalarRendererSettings.classificationMinimum();
       const double previousMax = scalarRendererSettings.classificationMaximum();
 
@@ -183,6 +183,10 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
         {
           if ( previousMin != min || previousMax != max )
           {
+
+            scalarRendererSettings.setClassificationMinimumMaximum( min, max );
+            mRendererSettings.setScalarSettings( activeDatasetIndex.group(), scalarRendererSettings );
+
             QgsRenderedLayerStatistics *layerStatistics = new QgsRenderedLayerStatistics( layer->id(), previousMin, previousMax );
 
             layerStatistics->setBoundingBox( context.extent() );

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -171,9 +171,6 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
       double previousMin = scalarRendererSettings.classificationMinimum();
       double previousMax = scalarRendererSettings.classificationMaximum();
 
-      QgsRenderedLayerStatistics *layerStatistics = new QgsRenderedLayerStatistics( layer->id(), previousMin, previousMax );
-      layerStatistics->setBoundingBox( layer->extent() );
-
       if ( scalarRendererSettings.extent() == Qgis::MeshRangeExtent::UpdatedCanvas &&
            scalarRendererSettings.limits() == Qgis::MeshRangeLimit::MinimumMaximum )
       {
@@ -185,17 +182,19 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
         {
           if ( previousMin != min || previousMax != max )
           {
+            QgsRenderedLayerStatistics *layerStatistics = new QgsRenderedLayerStatistics( layer->id(), previousMin, previousMax );
+
             layerStatistics->setBoundingBox( context.extent() );
             layerStatistics->setMaximum( 0, max );
             layerStatistics->setMinimum( 0, min );
 
             scalarRendererSettings.setClassificationMinimumMaximum( min, max );
             mRendererSettings.setScalarSettings( activeDatasetIndex.group(), scalarRendererSettings );
+
+            appendRenderedItemDetails( layerStatistics );
           }
         }
       }
-
-      appendRenderedItemDetails( layerStatistics );
     }
   }
 

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -188,9 +188,6 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
             layerStatistics->setMaximum( 0, max );
             layerStatistics->setMinimum( 0, min );
 
-            scalarRendererSettings.setClassificationMinimumMaximum( min, max );
-            mRendererSettings.setScalarSettings( activeDatasetIndex.group(), scalarRendererSettings );
-
             appendRenderedItemDetails( layerStatistics );
           }
         }

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -161,7 +161,8 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
 
   mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( *renderContext(), layer );
 
-  if ( !context.testFlag( Qgis::RenderContextFlag::RenderPreviewJob ) )
+  if ( !context.testFlag( Qgis::RenderContextFlag::RenderPreviewJob )
+       && !( context.flags() & Qgis::RenderContextFlag::Render3DMap ) )
   {
     const QgsMeshDatasetIndex activeDatasetIndex = layer->activeScalarDatasetIndex( context );
 

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -188,6 +188,9 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
             layerStatistics->setMaximum( 0, max );
             layerStatistics->setMinimum( 0, min );
 
+            scalarRendererSettings.setClassificationMinimumMaximum( min, max );
+            mRendererSettings.setScalarSettings( activeDatasetIndex.group(), scalarRendererSettings );
+
             appendRenderedItemDetails( layerStatistics );
           }
         }

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -163,20 +163,20 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
 
   if ( !context.testFlag( Qgis::RenderContextFlag::RenderPreviewJob ) )
   {
-    QgsMeshDatasetIndex activeDatasetIndex = layer->activeScalarDatasetIndex( context );
+    const QgsMeshDatasetIndex activeDatasetIndex = layer->activeScalarDatasetIndex( context );
 
     if ( activeDatasetIndex.isValid() )
     {
-      QgsMeshRendererScalarSettings scalarRendererSettings = mRendererSettings.scalarSettings( activeDatasetIndex.group() );
-      double previousMin = scalarRendererSettings.classificationMinimum();
-      double previousMax = scalarRendererSettings.classificationMaximum();
+      const QgsMeshRendererScalarSettings scalarRendererSettings = mRendererSettings.scalarSettings( activeDatasetIndex.group() );
+      const double previousMin = scalarRendererSettings.classificationMinimum();
+      const double previousMax = scalarRendererSettings.classificationMaximum();
 
       if ( scalarRendererSettings.extent() == Qgis::MeshRangeExtent::UpdatedCanvas &&
            scalarRendererSettings.limits() == Qgis::MeshRangeLimit::MinimumMaximum )
       {
         double min, max;
 
-        bool found  = layer->minimumMaximumActiveScalarDataset( context.extent(), activeDatasetIndex, min, max );
+        const bool found  = layer->minimumMaximumActiveScalarDataset( context.extent(), activeDatasetIndex, min, max );
 
         if ( found )
         {

--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -147,7 +147,7 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer()
   whileBlocking( mScalarMinSpinBox )->setValue( min );
   whileBlocking( mScalarMaxSpinBox )->setValue( max );
 
-  mMinMaxValueTypeComboBox->setCurrentIndex( mMinMaxValueTypeComboBox->findData( QVariant::fromValue( settings.extent() ) ) );
+  whileBlocking( mMinMaxValueTypeComboBox )->setCurrentIndex( mMinMaxValueTypeComboBox->findData( QVariant::fromValue( settings.extent() ) ) );
 
   if ( settings.limits() == Qgis::MeshRangeLimit::MinimumMaximum )
   {

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -2423,9 +2423,16 @@ void TestQgsMeshLayer::testMinimumMaximumActiveScalarDataset()
     QStringLiteral( "mdal" )
   );
   QVERIFY( layer.isValid() );
-  layer.updateTriangularMesh();
 
   datasetIndex = QgsMeshDatasetIndex( 0, 0 );
+
+  // if triangular mesh does not exist cannot extract values
+  extent = layer.extent();
+  found = layer.minimumMaximumActiveScalarDataset( extent, datasetIndex, min, max );
+  QCOMPARE( found, false );
+
+  // crete triangular mesh for layer
+  layer.updateTriangularMesh();
 
   // tests for basic dataset
   extent = layer.extent();

--- a/tests/src/core/testqgsmeshlayerrenderer.cpp
+++ b/tests/src/core/testqgsmeshlayerrenderer.cpp
@@ -886,7 +886,11 @@ void TestQgsMeshRenderer::test_color_scale_based_on_canvas_extent()
   layer.temporalProperties()->setIsActive( false );
 
   int groupIndex = 0;
-  layer.setStaticScalarDatasetIndex( QgsMeshDatasetIndex( groupIndex, 0 ) );
+  QgsMeshDatasetIndex meshDatasetIndex = QgsMeshDatasetIndex( groupIndex, 0 );
+  layer.setStaticScalarDatasetIndex( meshDatasetIndex );
+
+  double min, max;
+  bool found;
 
   QgsProject::instance()->addMapLayer( &layer );
   mMapSettings->setLayers( QList<QgsMapLayer *>() << &layer );
@@ -894,31 +898,52 @@ void TestQgsMeshRenderer::test_color_scale_based_on_canvas_extent()
   mMapSettings->setOutputDpi( 96 );
   mMapSettings->setRotation( 0 );
 
+  QgsMeshRendererSettings defaultRendererSettings = layer.rendererSettings();
+
   // min max from current canvas settings for group
   QgsMeshRendererSettings rendererSettings = layer.rendererSettings();
   QgsMeshRendererScalarSettings scalarRendererSettings = rendererSettings.scalarSettings( groupIndex );
   scalarRendererSettings.setLimits( Qgis::MeshRangeLimit::MinimumMaximum );
   scalarRendererSettings.setExtent( Qgis::MeshRangeExtent::UpdatedCanvas );
-  rendererSettings.setScalarSettings( groupIndex, scalarRendererSettings );
-  layer.setRendererSettings( rendererSettings );
 
   QgsRectangle extent = layer.extent();
   extent.grow( 0.1 );
+
+  found = layer.minimumMaximumActiveScalarDataset( extent, meshDatasetIndex, min, max );
+  QVERIFY( found );
+  scalarRendererSettings.setClassificationMinimumMaximum( min, max );
+  rendererSettings.setScalarSettings( groupIndex, scalarRendererSettings );
+  layer.setRendererSettings( rendererSettings );
+
   mMapSettings->setExtent( extent );
   QGSRENDERMAPSETTINGSCHECK( "scale_interactive_from_canvas_1", "scale_interactive_from_canvas_1", *mMapSettings, 0, 5 );
 
   extent = QgsRectangle( 0, 8, 2, 10 );
   extent.grow( 0.1 );
+
+  found = layer.minimumMaximumActiveScalarDataset( extent, meshDatasetIndex, min, max );
+  QVERIFY( found );
+  scalarRendererSettings.setClassificationMinimumMaximum( min, max );
+  rendererSettings.setScalarSettings( groupIndex, scalarRendererSettings );
+  layer.setRendererSettings( rendererSettings );
+
   mMapSettings->setExtent( extent );
   QGSRENDERMAPSETTINGSCHECK( "scale_interactive_from_canvas_2", "scale_interactive_from_canvas_2", *mMapSettings, 0, 5 );
 
   extent = QgsRectangle( 8, 8, 10, 10 );
   extent.grow( 0.1 );
+
+  found = layer.minimumMaximumActiveScalarDataset( extent, meshDatasetIndex, min, max );
+  QVERIFY( found );
+  scalarRendererSettings.setClassificationMinimumMaximum( min, max );
+  rendererSettings.setScalarSettings( groupIndex, scalarRendererSettings );
+  layer.setRendererSettings( rendererSettings );
+
   mMapSettings->setExtent( extent );
   QGSRENDERMAPSETTINGSCHECK( "scale_interactive_from_canvas_3", "scale_interactive_from_canvas_3", *mMapSettings, 0, 5 );
 
   // min max from whole mesh settings for group
-  rendererSettings = layer.rendererSettings();
+  rendererSettings = defaultRendererSettings;
   scalarRendererSettings = rendererSettings.scalarSettings( groupIndex );
   scalarRendererSettings.setLimits( Qgis::MeshRangeLimit::MinimumMaximum );
   scalarRendererSettings.setExtent( Qgis::MeshRangeExtent::WholeMesh );


### PR DESCRIPTION
## Description

There was a regression in Mesh Layer rendering for scalar datasets in case of "Updated Canvas" extent. This PR fixes it and also fixes fixes issue with style setting panel that could cause QGIS crash (test case was for this was added).

cc @uclaros 