### PR TITLE
fix sid build with sip 6.9.1

### DIFF
--- a/python/3d/pyproject.toml.in
+++ b/python/3d/pyproject.toml.in
@@ -2,6 +2,7 @@
 [build-system]
 requires = ["sip >=5.0.0, <7", "PyQt-builder >=1.6, <2"]
 build-backend = "sipbuild.api"
+@sipabi@
 
 # Specify the PEP 566 metadata for the project.
 [tool.sip.metadata]

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -178,6 +178,15 @@ if(NOT WITH_QTWEBENGINE)
   set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} HAVE_WEBENGINE_SIP)
 endif()
 
+# Deprecated annotation supports message only since version 6.9.0 with abi-version 12.16 / 13.9 and above
+if(${SIP_VERSION_STR} VERSION_LESS 6.9.0)
+  set(sipabi "")
+elseif(BUILD_WITH_QT6)
+  set(sipabi "\n[tool.sip.project]\nabi-version = \"13.9\"")
+else()
+  set(sipabi "\n[tool.sip.project]\nabi-version = \"12.16\"")
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/core/project.py.in ${CMAKE_CURRENT_BINARY_DIR}/core/project.py @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/core/pyproject.toml.in ${CMAKE_CURRENT_BINARY_DIR}/core/pyproject.toml @ONLY)
 GENERATE_SIP_PYTHON_MODULE_CODE(qgis._core core/core.sip "${sip_files_core}" cpp_files)

--- a/python/analysis/pyproject.toml.in
+++ b/python/analysis/pyproject.toml.in
@@ -2,6 +2,7 @@
 [build-system]
 requires = ["sip >=5.0.0, <7", "PyQt-builder >=1.6, <2"]
 build-backend = "sipbuild.api"
+@sipabi@
 
 # Specify the PEP 566 metadata for the project.
 [tool.sip.metadata]

--- a/python/core/pyproject.toml.in
+++ b/python/core/pyproject.toml.in
@@ -2,6 +2,7 @@
 [build-system]
 requires = ["sip >=5.0.0, <7", "PyQt-builder >=1.6, <2"]
 build-backend = "sipbuild.api"
+@sipabi@
 
 # Specify the PEP 566 metadata for the project.
 [tool.sip.metadata]

--- a/python/gui/pyproject.toml.in
+++ b/python/gui/pyproject.toml.in
@@ -2,6 +2,7 @@
 [build-system]
 requires = ["sip >=5.0.0, <7", "PyQt-builder >=1.6, <2"]
 build-backend = "sipbuild.api"
+@sipabi@
 
 # Specify the PEP 566 metadata for the project.
 [tool.sip.metadata]

--- a/python/server/pyproject.toml.in
+++ b/python/server/pyproject.toml.in
@@ -2,6 +2,7 @@
 [build-system]
 requires = ["sip >=5.0.0, <7", "PyQt-builder >=1.6, <2"]
 build-backend = "sipbuild.api"
+@sipabi@
 
 # Specify the PEP 566 metadata for the project.
 [tool.sip.metadata]


### PR DESCRIPTION
The build on debian sid is currently broken, because it has sip 6.9.1, hence uses the deprecation messages for sip, which also requires a minimal sip abi of 12.16 / 13.9. 

But sip-build defaults to 12.13 / 13.6 from pyqtbuild:

https://github.com/Python-PyQt/PyQt-builder/blob/82162b4966d94054733ff9aa53f4ef4ec63d2222/pyqtbuild/builder.py#L137-L144

although it requires 12.16 / 13.9 for deprecation messages:

https://github.com/Python-SIP/sip/blob/a619d79626cfff6678d194c7dd8d0d948bb644c0/sipbuild/generator/utils.py#L496-L499

The patch adds the required abi-version to the `pyproject.toml`s.