### PR TITLE
[processing][grass] Fix v.mkgrid: use parameter "type" instead of flag "-p" and add missing "-a" flag (Fix #59996)

### DIFF
--- a/python/plugins/grassprovider/description/v.mkgrid.txt
+++ b/python/plugins/grassprovider/description/v.mkgrid.txt
@@ -7,6 +7,7 @@ QgsProcessingParameterPoint|coordinates|Lower left easting and northing coordina
 QgsProcessingParameterString|box|Width and height of boxes in grid|
 QgsProcessingParameterNumber|angle|Angle of rotation (in degrees counter-clockwise)|QgsProcessingParameterNumber.Double|0.0|True|0.0|360.0
 QgsProcessingParameterNumber|breaks|Number of vertex points per grid cell|QgsProcessingParameterNumber.Integer|0|True|0|60
+QgsProcessingParameterEnum|type|Output feature type|point;line;area|False|2|True
 QgsProcessingParameterBoolean|-h|Create hexagons (default: rectangles)|False
-QgsProcessingParameterBoolean|-p|Create grid of points instead of areas and centroids|False
+QgsProcessingParameterBoolean|-a|Allow asymmetric hexagons|False
 QgsProcessingParameterVectorDestination|map|Grid


### PR DESCRIPTION
## Description

Since GRASS-GIS version 7.0, the flag "-p" was removed and replaced by the "type" parameter and the "-a" flag was added for the v.mkgrid command.
This PR reflects those changes in the GRASS provider processing algorithm "v.mkgrid".

Fixes #59996.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
