### PR TITLE
[Processing] Fix regression in "Generate XYZ tiles (MBTiles)" algorithm (Fix #59986)

### DIFF
--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -494,6 +494,7 @@ QVariantMap QgsXyzTilesMbtilesAlgorithm::processAlgorithm( const QVariantMap &pa
   }
   mMbtilesWriter->setMetadataValue( "format", mTileFormat.toLower() );
   mMbtilesWriter->setMetadataValue( "name", QFileInfo( outputFile ).baseName() );
+  mMbtilesWriter->setMetadataValue( "description", QFileInfo( outputFile ).baseName() );
   mMbtilesWriter->setMetadataValue( "version", QStringLiteral( "1.1" ) );
   mMbtilesWriter->setMetadataValue( "type", QStringLiteral( "overlay" ) );
   mMbtilesWriter->setMetadataValue( "minzoom", QString::number( mMinZoom ) );


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in the "Generate XYZ tiles (MBTiles)" (`native:tilesxyzmbtiles`) processing algorithm since QGIS 3.34.0, probably an oversight in https://github.com/qgis/QGIS/pull/54321 where it was forgotten to add the "description" key to the metadata table.

This PR restores the previous behaviour (which was based on GDAL https://github.com/OSGeo/gdal/blob/f314d4b6bc0b70582fd1cb07f8ae95d01e9c8a86/frmts/mbtiles/mbtilesdataset.cpp#L3070-L3076) just re-adding the missing "description" key to the metadata table.

Fixes #59986.
See also https://www.reddit.com/r/UAVmapping/comments/1c651ze/comment/l014q5n/.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
