### PR TITLE
CI: Run MINGW64 job on Fedora 41

### DIFF
--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -29,7 +29,7 @@ jobs:
     name: MinGW64 Windows Build
     runs-on: ubuntu-latest
     container:
-      image: fedora:39
+      image: fedora:41
       options: --security-opt seccomp=unconfined
       volumes:
         - ${{ github.workspace }}:/w


### PR DESCRIPTION
## Description

Build MINGW64 on fedora 41 to use newer versions of tools and dependencies.