### PR TITLE
Fix examples of the scale_exponential expression function

### DIFF
--- a/resources/function_help/json/scale_exponential
+++ b/resources/function_help/json/scale_exponential
@@ -23,12 +23,12 @@
     "description": "A positive value (greater than 0), which dictates the way input values are mapped to the output range. Large exponents will cause the output values to 'ease in', starting slowly before accelerating as the input values approach the domain maximum. Smaller exponents (less than 1) will cause output values to 'ease out', where the mapping starts quickly but slows as it approaches the domain maximum."
   }],
   "examples": [{
-    "expression": "scale_exp(5,0,10,0,100,2)",
-    "returns": "25",
+    "expression": "scale_exponential(5,0,10,0,100,2)",
+    "returns": "3.030",
     "note": "easing in, using an exponent of 2"
   }, {
-    "expression": "scale_exp(3,0,10,0,100,0.5)",
-    "returns": "54.772",
+    "expression": "scale_exponential(3,0,10,0,100,0.5)",
+    "returns": "87.585",
     "note": "easing out, using an exponent of 0.5"
   }],
   "tags": ["exponential", "curve", "ease", "transforms", "output", "given", "input", "domain", "range", "specified", "values"]

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1000,7 +1000,8 @@ class TestQgsExpression : public QObject
       QTest::newRow( "scale_linear(10,0,10,100,200)" ) << "scale_linear(10,0,10,100,200)" << false << QVariant( 200. );
       QTest::newRow( "scale_linear(-1,0,10,100,200)" ) << "scale_linear(-1,0,10,100,200)" << false << QVariant( 100. );
       QTest::newRow( "scale_linear(11,0,10,100,200)" ) << "scale_linear(11,0,10,100,200)" << false << QVariant( 200. );
-      QTest::newRow( "scale_linear(5,0,10,0,100,2)" ) << "scale_linear(5,0,10,0,100,2)" << false << QVariant( 50. );
+      QTest::newRow( "scale_linear(5,0,10,0,100)" ) << "scale_linear(5,0,10,0,100)" << false << QVariant( 50. );
+      QTest::newRow( "scale_linear(0.2,0,1,0,360)" ) << "scale_linear(0.2,0,1,0,360)" << false << QVariant( 72. );
       QTest::newRow( "scale_linear(1500,1000,10000,9,20)" ) << "scale_linear(1500,1000,10000,9,20)" << false << QVariant( 9.61111111111111 );
 
       // previously had name scale_exp, but renamed to scale_polynomial as it uses polynomial interpolation formula

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1000,6 +1000,8 @@ class TestQgsExpression : public QObject
       QTest::newRow( "scale_linear(10,0,10,100,200)" ) << "scale_linear(10,0,10,100,200)" << false << QVariant( 200. );
       QTest::newRow( "scale_linear(-1,0,10,100,200)" ) << "scale_linear(-1,0,10,100,200)" << false << QVariant( 100. );
       QTest::newRow( "scale_linear(11,0,10,100,200)" ) << "scale_linear(11,0,10,100,200)" << false << QVariant( 200. );
+      QTest::newRow( "scale_linear(5,0,10,0,100,2)" ) << "scale_linear(5,0,10,0,100,2)" << false << QVariant( 50. );
+      QTest::newRow( "scale_linear(1500,1000,10000,9,20)" ) << "scale_linear(1500,1000,10000,9,20)" << false << QVariant( 9.61111111111111 );
 
       // previously had name scale_exp, but renamed to scale_polynomial as it uses polynomial interpolation formula
       // see https://github.com/qgis/QGIS/pull/53164 for more details
@@ -1009,6 +1011,8 @@ class TestQgsExpression : public QObject
       QTest::newRow( "scale_polynomial(10,0,10,100,200,0.5)" ) << "scale_polynomial(10,0,10,100,200,0.5)" << false << QVariant( 200. );
       QTest::newRow( "scale_polynomial(-1,0,10,100,200,0.5)" ) << "scale_polynomial(-1,0,10,100,200,0.5)" << false << QVariant( 100. );
       QTest::newRow( "scale_polynomial(4,0,9,0,90,0.5)" ) << "scale_polynomial(4,0,9,0,90,0.5)" << false << QVariant( 60. );
+      QTest::newRow( "scale_polynomial(5,0,10,0,100,2)" ) << "scale_polynomial(5,0,10,0,100,2)" << false << QVariant( 25. );
+      QTest::newRow( "scale_polynomial(3,0,10,0,100,0.5)" ) << "scale_polynomial(3,0,10,0,100,0.5)" << false << QVariant( 54.77225575051661 );
       // this is an alias for scale_polynomial to preserve backward compatibility
       QTest::newRow( "scale_exp(0.5,0,1,0,1,2)" ) << "scale_exp(0.5,0,1,0,1,2)" << false << QVariant( 0.25 );
       QTest::newRow( "scale_exp(0,0,10,100,200,2)" ) << "scale_exp(0,0,10,100,200,2)" << false << QVariant( 100. );
@@ -1023,6 +1027,8 @@ class TestQgsExpression : public QObject
       QTest::newRow( "scale_exponential(10,0,10,100,200,0.5)" ) << "scale_exponential(10,0,10,100,200,0.5)" << false << QVariant( 200. );
       QTest::newRow( "scale_exponential(-1,0,10,100,200,0.5)" ) << "scale_exponential(-1,0,10,100,200,0.5)" << false << QVariant( 100. );
       QTest::newRow( "scale_exponential(4,0,9,0,90,0.5)" ) << "scale_exponential(4,0,9,0,90,0.5)" << false << QVariant( 84.5401174168 );
+      QTest::newRow( "scale_exponential(5,0,10,0,100,2)" ) << "scale_exponential(5,0,10,0,100,2)" << false << QVariant( 3.0303030303030303 );
+      QTest::newRow( "scale_exponential(3,0,10,0,100,0.5)" ) << "scale_exponential(3,0,10,0,100,0.5)" << false << QVariant( 87.58553274682306 );
 
       // cast functions
       QTest::newRow( "double to int" ) << "toint(3.2)" << false << QVariant( 3 );


### PR DESCRIPTION
## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
