### PR TITLE
[Backport release-3_34] [Processing] Fix regression in "Generate XYZ tiles (MBTiles)" algorithm (Fix #59986)

### DIFF
--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -490,6 +490,7 @@ QVariantMap QgsXyzTilesMbtilesAlgorithm::processAlgorithm( const QVariantMap &pa
   }
   mMbtilesWriter->setMetadataValue( "format", mTileFormat.toLower() );
   mMbtilesWriter->setMetadataValue( "name",  QFileInfo( outputFile ).baseName() );
+  mMbtilesWriter->setMetadataValue( "description", QFileInfo( outputFile ).baseName() );
   mMbtilesWriter->setMetadataValue( "version",  QStringLiteral( "1.1" ) );
   mMbtilesWriter->setMetadataValue( "type", QStringLiteral( "overlay" ) );
   mMbtilesWriter->setMetadataValue( "minzoom", QString::number( mMinZoom ) );


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/60001 to release-3_34.