### PR TITLE
clean up SIP_INCLUDE_DIR redundancy

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -67,7 +67,6 @@ add_subdirectory(processing)
 
 include_directories(SYSTEM
   ${Python_INCLUDE_DIRS}
-  ${SIP_INCLUDE_DIR}
   ${QT_QTCORE_INCLUDE_DIR}
   ${QT_QTGUI_INCLUDE_DIR}
   ${QT_QTNETWORK_INCLUDE_DIR}


### PR DESCRIPTION
See https://github.com/qgis/QGIS/commit/d0c4e0de9d3f771d6ac6b79c4105b911ea35cb0d

this line is only used with SIP v4 which already is included below 