### PR TITLE
Remove reference to obsolete methods in QgsServerFilter class header

### DIFF
--- a/python/PyQt6/server/auto_generated/qgsserverfilter.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverfilter.sip.in
@@ -17,12 +17,6 @@ class QgsServerFilter
 %Docstring(signature="appended")
 Class defining I/O filters for QGIS Server and
 implemented in plugins.
-
-Filters can define any (or none) of the following hooks:
-
-- :py:func:`~requestReady` - called when request is ready
-- :py:func:`~responseComplete` - called when the response is complete after core services have returned to main loop
-- :py:func:`~sendResponse` - called just before sending output to FGCI
 %End
 
 %TypeHeaderCode

--- a/python/server/auto_generated/qgsserverfilter.sip.in
+++ b/python/server/auto_generated/qgsserverfilter.sip.in
@@ -17,12 +17,6 @@ class QgsServerFilter
 %Docstring(signature="appended")
 Class defining I/O filters for QGIS Server and
 implemented in plugins.
-
-Filters can define any (or none) of the following hooks:
-
-- :py:func:`~requestReady` - called when request is ready
-- :py:func:`~responseComplete` - called when the response is complete after core services have returned to main loop
-- :py:func:`~sendResponse` - called just before sending output to FGCI
 %End
 
 %TypeHeaderCode

--- a/src/server/qgsserverfilter.h
+++ b/src/server/qgsserverfilter.h
@@ -34,11 +34,6 @@ class QgsServerInterface;
  * \brief Class defining I/O filters for QGIS Server and
  * implemented in plugins.
  *
- * Filters can define any (or none) of the following hooks:
- *
- * - requestReady() - called when request is ready
- * - responseComplete() - called when the response is complete after core services have returned to main loop
- * - sendResponse() - called just before sending output to FGCI
  */
 class SERVER_EXPORT QgsServerFilter
 {


### PR DESCRIPTION
refs https://qgis.org/pyqgis/master/server/QgsServerFilter.html

* The listed methods are deprecated
* The replacement methods are few lines below
* and I don't think we want to keep updating this kind of things

![image](https://github.com/user-attachments/assets/9ea79cd5-9fbf-4a3b-b4fb-75755bcd6b7c)