### PR TITLE
Allow to query larger tiles than the default max size with stepWidth/…

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3850,7 +3850,7 @@ QSize QgsWmsProvider::maximumTileSize() const
   {
     return QSize( capsMaxWidth, capsMaxHeight );
   }
-  else if( mSettings.mStepWidth > 0 && mSettings.mStepHeight > 0 ) //The chosen step size can be higher than the default max size
+  else if ( mSettings.mStepWidth > 0 && mSettings.mStepHeight > 0 ) //The chosen step size can be higher than the default max size
   {
     return QSize( mSettings.mStepWidth, mSettings.mStepHeight );
   }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3850,6 +3850,10 @@ QSize QgsWmsProvider::maximumTileSize() const
   {
     return QSize( capsMaxWidth, capsMaxHeight );
   }
+  else if( mSettings.mStepWidth > 0 && mSettings.mStepHeight > 0 ) //The chosen step size can be higher than the default max size
+  {
+    return QSize( mSettings.mStepWidth, mSettings.mStepHeight );
+  }
   else // default fallback
   {
     return QgsRasterDataProvider::maximumTileSize();

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -637,6 +637,12 @@ void TestQgsWmsProvider::testMaxTileSize()
   const QSize maxTileSize5 = provider5.maximumTileSize();
   QCOMPARE( maxTileSize5.width(), 3000 );
   QCOMPARE( maxTileSize5.height(), 3000 );
+
+  // test that max tile size is set to mStepWidth/mStepHeight if max tile size is not set
+  QgsWmsProvider provider6( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=buildings&styles=&format=image/jpg&stepWidth=4000&stepHeight=4000" ), QgsDataProvider::ProviderOptions(), &capabilities);
+  const QSize maxTileSize6 = provider6.maximumTileSize();
+  QCOMPARE( maxTileSize6.width(), 4000 );
+  QCOMPARE( maxTileSize6.height(), 4000 );
 }
 
 QGSTEST_MAIN( TestQgsWmsProvider )

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -639,7 +639,7 @@ void TestQgsWmsProvider::testMaxTileSize()
   QCOMPARE( maxTileSize5.height(), 3000 );
 
   // test that max tile size is set to mStepWidth/mStepHeight if max tile size is not set
-  QgsWmsProvider provider6( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=buildings&styles=&format=image/jpg&stepWidth=4000&stepHeight=4000" ), QgsDataProvider::ProviderOptions(), &capabilities);
+  QgsWmsProvider provider6( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=buildings&styles=&format=image/jpg&stepWidth=4000&stepHeight=4000" ), QgsDataProvider::ProviderOptions(), &capabilities );
   const QSize maxTileSize6 = provider6.maximumTileSize();
   QCOMPARE( maxTileSize6.width(), 4000 );
   QCOMPARE( maxTileSize6.height(), 4000 );


### PR DESCRIPTION
QgsWMSCapabilities has mMaxWidth/mMaxHeight as the server width/height limit and mStepWidth/mStepHeight as raster size to iterate the layer. After commit https://github.com/qgis/QGIS/commit/2078ef5c03b93bf41d1ce090f1e34e7e25c574ce#diff-d88af508cce11c2b59f0ad9c1ddb29824f7cce111807af3289eec2663930e39e , it is not possible anymore to make GetMap-Requests with step sizes larger than the default maximum tile size (2000x2000). This PR makes a small change to take the step width as size limit if there is no size limit set.
