### PR TITLE
fix typo: contrastEnhancementAlgorithm() 254 -> 255

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgscontrastenhancement.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscontrastenhancement.sip.in
@@ -75,7 +75,7 @@ Returns the minimum value for the contrast enhancement range.
 
     int enhanceContrast( double value );
 %Docstring
-Applies the contrast enhancement to a ``value``. Return values are 0 - 254, -1 means the pixel was clipped and should not be displayed.
+Applies the contrast enhancement to a ``value``. Return values are 0 - 255, -1 means the pixel was clipped and should not be displayed.
 %End
 
     bool isValueInDisplayableRange( double value );

--- a/python/core/auto_generated/raster/qgscontrastenhancement.sip.in
+++ b/python/core/auto_generated/raster/qgscontrastenhancement.sip.in
@@ -75,7 +75,7 @@ Returns the minimum value for the contrast enhancement range.
 
     int enhanceContrast( double value );
 %Docstring
-Applies the contrast enhancement to a ``value``. Return values are 0 - 254, -1 means the pixel was clipped and should not be displayed.
+Applies the contrast enhancement to a ``value``. Return values are 0 - 255, -1 means the pixel was clipped and should not be displayed.
 %End
 
     bool isValueInDisplayableRange( double value );

--- a/src/core/raster/qgscontrastenhancement.h
+++ b/src/core/raster/qgscontrastenhancement.h
@@ -164,7 +164,7 @@ class CORE_EXPORT QgsContrastEnhancement
     ContrastEnhancementAlgorithm contrastEnhancementAlgorithm() const { return mContrastEnhancementAlgorithm; }
 
     /**
-     * Applies the contrast enhancement to a \a value. Return values are 0 - 254, -1 means the pixel was clipped and should not be displayed.
+     * Applies the contrast enhancement to a \a value. Return values are 0 - 255, -1 means the pixel was clipped and should not be displayed.
      */
     int enhanceContrast( double value );
 


### PR DESCRIPTION
## Description

The function contrastEnhancementAlgorithm() can return values up to 255 (I manually tried it) so I fixed it in the docs. 

The code compiles and I ran sipify_all.sh to make the changes in the .sip files.
