### PR TITLE
[GUI] Fix progressbar in the main window's status bar

### DIFF
--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -87,7 +87,7 @@ void QgsTaskManagerWidget::modelRowsInserted( const QModelIndex &, int start, in
       if ( progress > 0 )
       {
         progressBar->setMaximum( 100 );
-        progressBar->setValue( static_cast<int>( std::round( progress ) ) );
+        progressBar->setValue( static_cast<int>( progress ) );
       }
       else
         progressBar->setMaximum( 0 );
@@ -641,7 +641,7 @@ void QgsTaskManagerStatusBarWidget::toggleDisplay()
 
 void QgsTaskManagerStatusBarWidget::overallProgressChanged( double progress )
 {
-  mProgressBar->setValue( static_cast<int>( std::round( progress ) ) );
+  mProgressBar->setValue( static_cast<int>( progress ) );
   if ( qgsDoubleNear( progress, 0.0 ) )
     mProgressBar->setMaximum( 0 );
   else if ( mProgressBar->maximum() == 0 )


### PR DESCRIPTION
## Description

The value of the percentage displayed by the progressbar in the main window's status bar differs (+1), half of the time, from that displayed by the progressbar in the Processing dialog window. This also means that it reaches 100% before the process actually completes.

This is due to the fact that the code for the progressbar in the main window's status bar rounds the value, while the value is truncated (with an implicit cast to int) for the progressbar in the Processing dialog window.

Before:
![image](https://github.com/user-attachments/assets/0f923540-7f0d-4949-87ed-b407816e2fe0)

After:
![image](https://github.com/user-attachments/assets/f6e926a2-77fc-49f2-b328-340f51a35d86)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
