### PR TITLE
[metasearch] Add INSPIRE protocol values

### DIFF
--- a/python/plugins/MetaSearch/link_types.py
+++ b/python/plugins/MetaSearch/link_types.py
@@ -31,6 +31,8 @@ WMSWMST_LINK_TYPES = [
     "OGC:WMS-1.3.0-http-get-capabilities",
     "urn:x-esri:specification:ServiceType:wms:url",
     "urn:x-esri:specification:ServiceType:Gmd:URL.wms",
+    "OGC Web Map Service",
+    "OGC Web Map Tile Service",
 ]
 
 WFS_LINK_TYPES = [
@@ -40,6 +42,7 @@ WFS_LINK_TYPES = [
     "OGC:WFS-1.1.0-http-get-capabilities",
     "urn:x-esri:specification:ServiceType:wfs:url",
     "urn:x-esri:specification:ServiceType:Gmd:URL.wfs",
+    "OGC Web Feature Service",
 ]
 
 WCS_LINK_TYPES = [
@@ -48,6 +51,7 @@ WCS_LINK_TYPES = [
     "OGC:WCS-1.1.0-http-get-capabilities",
     "urn:x-esri:specification:ServiceType:wcs:url",
     "urn:x-esri:specification:ServiceType:Gmd:URL.wcs",
+    "OGC Web Coverage Service",
 ]
 
 AMS_LINK_TYPES = ["ESRI:ArcGIS:MapServer", "Esri REST: Map Service", "ESRI REST"]


### PR DESCRIPTION
Source: https://inspire.ec.europa.eu/metadata-codelist/ProtocolValue

These are used e.g. by InGrid CSWs (https://www.ingrid-oss.eu):

![image](https://github.com/user-attachments/assets/69ee1529-5f49-44d0-b1de-8ed12f21f844)
