### PR TITLE
[MetaSearch] Allow the user to enable or disable the logging of the debug messages

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -119,6 +119,9 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.disable_ssl_verification = self.settings.value(
             "/MetaSearch/disableSSL", False, bool
         )
+        self.log_debugging_messages = self.settings.value(
+            "/MetaSearch/logDebugging", False, bool
+        )
 
         # Services tab
         self.cmbConnectionsServices.activated.connect(self.save_connection)
@@ -181,6 +184,10 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             self.settings.setValue("/MetaSearch/disableSSL", bool(state))
             self.disable_ssl_verification = bool(state)
 
+        def _on_debugging_state_change(state):
+            self.settings.setValue("/MetaSearch/logDebugging", bool(state))
+            self.log_debugging_messages = bool(state)
+
         self.tabWidget.setCurrentIndex(0)
         self.populate_connection_list()
         self.btnRawAPIResponse.setEnabled(False)
@@ -192,6 +199,8 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.spnTimeout.valueChanged.connect(_on_timeout_change)
         self.disableSSLVerification.setChecked(self.disable_ssl_verification)
         self.disableSSLVerification.stateChanged.connect(_on_ssl_state_change)
+        self.logDebuggingMessages.setChecked(self.log_debugging_messages)
+        self.logDebuggingMessages.stateChanged.connect(_on_debugging_state_change)
 
         key = "/MetaSearch/%s" % self.cmbConnectionsSearch.currentText()
         self.catalog_url = self.settings.value("%s/url" % key)

--- a/python/plugins/MetaSearch/ui/maindialog.ui
+++ b/python/plugins/MetaSearch/ui/maindialog.ui
@@ -559,6 +559,36 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Debugging</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Log debugging messages</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="logDebuggingMessages">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/python/plugins/MetaSearch/util.py
+++ b/python/plugins/MetaSearch/util.py
@@ -174,4 +174,8 @@ def clean_ows_url(url):
 def log_message(message, level=Qgis.MessageLevel.Info):
     """helper function to emit logging messages"""
 
-    LOGGER.logMessage(message, "MetaSearch", level)
+    logging = QgsSettings().value(
+        "/MetaSearch/logDebugging", False, bool
+    )
+    if logging:
+        LOGGER.logMessage(message, "MetaSearch", level)

--- a/python/plugins/MetaSearch/util.py
+++ b/python/plugins/MetaSearch/util.py
@@ -174,8 +174,6 @@ def clean_ows_url(url):
 def log_message(message, level=Qgis.MessageLevel.Info):
     """helper function to emit logging messages"""
 
-    logging = QgsSettings().value(
-        "/MetaSearch/logDebugging", False, bool
-    )
+    logging = QgsSettings().value("/MetaSearch/logDebugging", False, bool)
     if logging:
         LOGGER.logMessage(message, "MetaSearch", level)


### PR DESCRIPTION
## Description

Following up https://github.com/qgis/QGIS/pull/58924/, this PR adds the "Log debugging messages" checkbox in the "Settings" tab of the main dialog window in order to let the user choose to enable or disable (default) the logging of the debug messages.

![image](https://github.com/user-attachments/assets/9233426b-9092-4a9a-b5c2-4911a85e25ab)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
