### PR TITLE
Fix point cloud refactoring regressions

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudindex.h
+++ b/src/core/pointcloud/qgscopcpointcloudindex.h
@@ -104,6 +104,9 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsAbstractPointCloudIndex
 
     void populateHierarchy( const char *hierarchyPageData, uint64_t byteSize ) const;
 
+    //! Utility function for reading sub-range of mUri
+    QByteArray readRange( uint64_t offset, uint64_t length ) const;
+
     QByteArray fetchCopcStatisticsEvlrData() const;
 
     bool mIsValid = false;

--- a/src/core/pointcloud/qgseptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgseptpointcloudindex.cpp
@@ -657,6 +657,7 @@ void QgsEptPointCloudIndex::copyCommonProperties( QgsEptPointCloudIndex *destina
 
   // QgsEptPointCloudIndex specific fields
   destination->mIsValid = mIsValid;
+  destination->mAccessType = mAccessType;
   destination->mDataType = mDataType;
   destination->mUrlDirectoryPart = mUrlDirectoryPart;
   destination->mWkt = mWkt;


### PR DESCRIPTION
## Description

This PR fixes two significant regressions that were introduced by #59279 and #59418:
- Loading remote COPC files crashed on an assert.
- Remote EPT layers weren't displayed, since statistics weren't computed.

In the process, I implemented loading QGIS-specific statistics from COPC files over HTTP as well (previously they were only loaded when the file was accessed locally).

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
