### PR TITLE
Vertical anchor on font symbols to the bounds

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmarkersymbollayer.py
+++ b/python/PyQt6/core/auto_additions/qgsmarkersymbollayer.py
@@ -1,11 +1,13 @@
 # The following has been generated automatically from src/core/symbology/qgsmarkersymbollayer.h
 # monkey patching scoped based enum
-QgsFontMarkerSymbolLayer.VerticalAnchorMode.Legacy.__doc__ = "Calculate anchor points with different offsets"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Bounds.__doc__ = "Calculate anchor points according to character bounds"
 QgsFontMarkerSymbolLayer.VerticalAnchorMode.Baseline.__doc__ = "Calculate anchor points with fix baseline"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Legacy.__doc__ = "Calculate anchor points with different offsets"
 QgsFontMarkerSymbolLayer.VerticalAnchorMode.__doc__ = """Vertical anchor modes
 
-* ``Legacy``: Calculate anchor points with different offsets
+* ``Bounds``: Calculate anchor points according to character bounds
 * ``Baseline``: Calculate anchor points with fix baseline
+* ``Legacy``: Calculate anchor points with different offsets
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgsmarkersymbollayer.py
+++ b/python/PyQt6/core/auto_additions/qgsmarkersymbollayer.py
@@ -1,4 +1,14 @@
 # The following has been generated automatically from src/core/symbology/qgsmarkersymbollayer.h
+# monkey patching scoped based enum
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Legacy.__doc__ = "Calculate anchor points with different offsets"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Baseline.__doc__ = "Calculate anchor points with fix baseline"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.__doc__ = """Vertical anchor modes
+
+* ``Legacy``: Calculate anchor points with different offsets
+* ``Baseline``: Calculate anchor points with fix baseline
+
+"""
+# --
 try:
     QgsSimpleMarkerSymbolLayerBase.availableShapes = staticmethod(QgsSimpleMarkerSymbolLayerBase.availableShapes)
     QgsSimpleMarkerSymbolLayerBase.shapeIsFilled = staticmethod(QgsSimpleMarkerSymbolLayerBase.shapeIsFilled)

--- a/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -1123,9 +1123,9 @@ Sets the stroke join ``style``.
 
     void setVerticalAnchorMode( VerticalAnchorMode verticalAnchorMode );
 %Docstring
-Sets the vertical anchor mode wheter it should considers the baseline as fix point
+Sets the vertical anchor mode whether it should considers the baseline as fix point
 
-:param vertical: anchor mode how to handle the anchor point
+:param verticalAnchorMode: the mode how to handle the anchor point
 
 .. seealso:: :py:func:`verticalAnchorMode`
 
@@ -1134,7 +1134,7 @@ Sets the vertical anchor mode wheter it should considers the baseline as fix poi
 
     VerticalAnchorMode verticalAnchorMode() const;
 %Docstring
-Returns wheter it should considers the baseline as fix point
+Returns whether it should considers the baseline as fix point
 
 .. seealso:: :py:func:`setVerticalAnchorMode`
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -929,8 +929,9 @@ class QgsFontMarkerSymbolLayer : QgsMarkerSymbolLayer
 
     enum class VerticalAnchorMode /BaseType=IntEnum/
     {
-      Legacy,
+      Bounds,
       Baseline,
+      Legacy,
     };
 
     QgsFontMarkerSymbolLayer( const QString &fontFamily = DEFAULT_FONTMARKER_FONT,

--- a/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -1115,6 +1115,26 @@ Sets the stroke join ``style``.
 .. seealso:: :py:func:`penJoinStyle`
 %End
 
+    void setFixVerticalAnchor( const bool fixVerticalAnchor );
+%Docstring
+Set fixVerticalAnchor that means it considers the baseline position for all the characters
+
+:param fixVerticalAnchor: the bool
+
+.. seealso:: :py:func:`fixVerticalAnchor`
+
+.. versionadded:: 3.42
+%End
+
+    bool fixVerticalAnchor() const;
+%Docstring
+Returns wheter it considers teh baseline position for all the characters
+
+.. seealso:: :py:func:`setFixVerticalAnchor`
+
+.. versionadded:: 3.42
+%End
+
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context );
 
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -927,6 +927,12 @@ class QgsFontMarkerSymbolLayer : QgsMarkerSymbolLayer
 %End
   public:
 
+    enum class VerticalAnchorMode /BaseType=IntEnum/
+    {
+      Legacy,
+      Baseline,
+    };
+
     QgsFontMarkerSymbolLayer( const QString &fontFamily = DEFAULT_FONTMARKER_FONT,
                               QString chr = DEFAULT_FONTMARKER_CHR,
                               double pointSize = DEFAULT_FONTMARKER_SIZE,
@@ -1115,22 +1121,22 @@ Sets the stroke join ``style``.
 .. seealso:: :py:func:`penJoinStyle`
 %End
 
-    void setFixVerticalAnchor( const bool fixVerticalAnchor );
+    void setVerticalAnchorMode( VerticalAnchorMode verticalAnchorMode );
 %Docstring
-Set fixVerticalAnchor that means it considers the baseline position for all the characters
+Sets the vertical anchor mode wheter it should considers the baseline as fix point
 
-:param fixVerticalAnchor: the bool
+:param vertical: anchor mode how to handle the anchor point
 
-.. seealso:: :py:func:`fixVerticalAnchor`
+.. seealso:: :py:func:`verticalAnchorMode`
 
 .. versionadded:: 3.42
 %End
 
-    bool fixVerticalAnchor() const;
+    VerticalAnchorMode verticalAnchorMode() const;
 %Docstring
-Returns wheter it considers teh baseline position for all the characters
+Returns wheter it should considers the baseline as fix point
 
-.. seealso:: :py:func:`setFixVerticalAnchor`
+.. seealso:: :py:func:`setVerticalAnchorMode`
 
 .. versionadded:: 3.42
 %End

--- a/python/core/auto_additions/qgsmarkersymbollayer.py
+++ b/python/core/auto_additions/qgsmarkersymbollayer.py
@@ -1,11 +1,13 @@
 # The following has been generated automatically from src/core/symbology/qgsmarkersymbollayer.h
 # monkey patching scoped based enum
-QgsFontMarkerSymbolLayer.VerticalAnchorMode.Legacy.__doc__ = "Calculate anchor points with different offsets"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Bounds.__doc__ = "Calculate anchor points according to character bounds"
 QgsFontMarkerSymbolLayer.VerticalAnchorMode.Baseline.__doc__ = "Calculate anchor points with fix baseline"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Legacy.__doc__ = "Calculate anchor points with different offsets"
 QgsFontMarkerSymbolLayer.VerticalAnchorMode.__doc__ = """Vertical anchor modes
 
-* ``Legacy``: Calculate anchor points with different offsets
+* ``Bounds``: Calculate anchor points according to character bounds
 * ``Baseline``: Calculate anchor points with fix baseline
+* ``Legacy``: Calculate anchor points with different offsets
 
 """
 # --

--- a/python/core/auto_additions/qgsmarkersymbollayer.py
+++ b/python/core/auto_additions/qgsmarkersymbollayer.py
@@ -1,4 +1,14 @@
 # The following has been generated automatically from src/core/symbology/qgsmarkersymbollayer.h
+# monkey patching scoped based enum
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Legacy.__doc__ = "Calculate anchor points with different offsets"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.Baseline.__doc__ = "Calculate anchor points with fix baseline"
+QgsFontMarkerSymbolLayer.VerticalAnchorMode.__doc__ = """Vertical anchor modes
+
+* ``Legacy``: Calculate anchor points with different offsets
+* ``Baseline``: Calculate anchor points with fix baseline
+
+"""
+# --
 try:
     QgsSimpleMarkerSymbolLayerBase.availableShapes = staticmethod(QgsSimpleMarkerSymbolLayerBase.availableShapes)
     QgsSimpleMarkerSymbolLayerBase.shapeIsFilled = staticmethod(QgsSimpleMarkerSymbolLayerBase.shapeIsFilled)

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -1123,9 +1123,9 @@ Sets the stroke join ``style``.
 
     void setVerticalAnchorMode( VerticalAnchorMode verticalAnchorMode );
 %Docstring
-Sets the vertical anchor mode wheter it should considers the baseline as fix point
+Sets the vertical anchor mode whether it should considers the baseline as fix point
 
-:param vertical: anchor mode how to handle the anchor point
+:param verticalAnchorMode: the mode how to handle the anchor point
 
 .. seealso:: :py:func:`verticalAnchorMode`
 
@@ -1134,7 +1134,7 @@ Sets the vertical anchor mode wheter it should considers the baseline as fix poi
 
     VerticalAnchorMode verticalAnchorMode() const;
 %Docstring
-Returns wheter it should considers the baseline as fix point
+Returns whether it should considers the baseline as fix point
 
 .. seealso:: :py:func:`setVerticalAnchorMode`
 

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -927,6 +927,12 @@ class QgsFontMarkerSymbolLayer : QgsMarkerSymbolLayer
 %End
   public:
 
+    enum class VerticalAnchorMode
+    {
+      Legacy,
+      Baseline,
+    };
+
     QgsFontMarkerSymbolLayer( const QString &fontFamily = DEFAULT_FONTMARKER_FONT,
                               QString chr = DEFAULT_FONTMARKER_CHR,
                               double pointSize = DEFAULT_FONTMARKER_SIZE,
@@ -1115,22 +1121,22 @@ Sets the stroke join ``style``.
 .. seealso:: :py:func:`penJoinStyle`
 %End
 
-    void setFixVerticalAnchor( const bool fixVerticalAnchor );
+    void setVerticalAnchorMode( VerticalAnchorMode verticalAnchorMode );
 %Docstring
-Set fixVerticalAnchor that means it considers the baseline position for all the characters
+Sets the vertical anchor mode wheter it should considers the baseline as fix point
 
-:param fixVerticalAnchor: the bool
+:param vertical: anchor mode how to handle the anchor point
 
-.. seealso:: :py:func:`fixVerticalAnchor`
+.. seealso:: :py:func:`verticalAnchorMode`
 
 .. versionadded:: 3.42
 %End
 
-    bool fixVerticalAnchor() const;
+    VerticalAnchorMode verticalAnchorMode() const;
 %Docstring
-Returns wheter it considers teh baseline position for all the characters
+Returns wheter it should considers the baseline as fix point
 
-.. seealso:: :py:func:`setFixVerticalAnchor`
+.. seealso:: :py:func:`setVerticalAnchorMode`
 
 .. versionadded:: 3.42
 %End

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -929,8 +929,9 @@ class QgsFontMarkerSymbolLayer : QgsMarkerSymbolLayer
 
     enum class VerticalAnchorMode
     {
-      Legacy,
+      Bounds,
       Baseline,
+      Legacy,
     };
 
     QgsFontMarkerSymbolLayer( const QString &fontFamily = DEFAULT_FONTMARKER_FONT,

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -1115,6 +1115,26 @@ Sets the stroke join ``style``.
 .. seealso:: :py:func:`penJoinStyle`
 %End
 
+    void setFixVerticalAnchor( const bool fixVerticalAnchor );
+%Docstring
+Set fixVerticalAnchor that means it considers the baseline position for all the characters
+
+:param fixVerticalAnchor: the bool
+
+.. seealso:: :py:func:`fixVerticalAnchor`
+
+.. versionadded:: 3.42
+%End
+
+    bool fixVerticalAnchor() const;
+%Docstring
+Returns wheter it considers teh baseline position for all the characters
+
+.. seealso:: :py:func:`setFixVerticalAnchor`
+
+.. versionadded:: 3.42
+%End
+
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context );
 
 

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3521,8 +3521,8 @@ QgsSymbolLayer *QgsFontMarkerSymbolLayer::create( const QVariantMap &props )
     m->setHorizontalAnchorPoint( QgsMarkerSymbolLayer::HorizontalAnchorPoint( props[ QStringLiteral( "horizontal_anchor_point" )].toInt() ) );
   if ( props.contains( QStringLiteral( "vertical_anchor_point" ) ) )
     m->setVerticalAnchorPoint( QgsMarkerSymbolLayer::VerticalAnchorPoint( props[ QStringLiteral( "vertical_anchor_point" )].toInt() ) );
-  if ( props.contains( QStringLiteral( "fix_vertical_anchor" ) ) )
-    m->setFixVerticalAnchor( props[ QStringLiteral( "fix_vertical_anchor" )].toBool() );
+  if ( props.contains( QStringLiteral( "vertical_anchor_mode" ) ) )
+    m->setVerticalAnchorMode( VerticalAnchorMode( props[ QStringLiteral( "vertical_anchor_mode" )].toInt() ) );
 
   m->restoreOldDataDefinedProperties( props );
 
@@ -3577,7 +3577,7 @@ void QgsFontMarkerSymbolLayer::startRender( QgsSymbolRenderContext &context )
   mFont.setPixelSize( std::max( 2, static_cast< int >( std::round( sizePixels ) ) ) );
   mFontMetrics.reset( new QFontMetrics( mFont ) );
   mChrWidth = mFontMetrics->horizontalAdvance( mString );
-  if ( mFixVerticalAnchor )
+  if ( mVerticalAnchorMode == VerticalAnchorMode::Baseline )
   {
     mChrOffset = QPointF( mChrWidth / 2.0, -sizePixels / 2.0 );
   }
@@ -3617,7 +3617,7 @@ QString QgsFontMarkerSymbolLayer::characterToRender( QgsSymbolRenderContext &con
     if ( stringToRender != mString )
     {
       charWidth = mFontMetrics->horizontalAdvance( stringToRender );
-      if ( mFixVerticalAnchor )
+      if ( mVerticalAnchorMode == VerticalAnchorMode::Baseline )
       {
         const double sizePixels = context.renderContext().convertToPainterUnits( mSize, mSizeUnit, mSizeMapUnitScale );
         charOffset = QPointF( mChrWidth / 2.0, -sizePixels / 2.0 );
@@ -3855,7 +3855,7 @@ QVariantMap QgsFontMarkerSymbolLayer::properties() const
   props[QStringLiteral( "offset_map_unit_scale" )] = QgsSymbolLayerUtils::encodeMapUnitScale( mOffsetMapUnitScale );
   props[QStringLiteral( "horizontal_anchor_point" )] = QString::number( mHorizontalAnchorPoint );
   props[QStringLiteral( "vertical_anchor_point" )] = QString::number( mVerticalAnchorPoint );
-  props[QStringLiteral( "fix_vertical_anchor" )] = mFixVerticalAnchor;
+  props[QStringLiteral( "vertical_anchor_mode" )] = static_cast< int >( mVerticalAnchorMode );
   return props;
 }
 
@@ -3875,7 +3875,7 @@ QgsFontMarkerSymbolLayer *QgsFontMarkerSymbolLayer::clone() const
   m->setSizeMapUnitScale( mSizeMapUnitScale );
   m->setHorizontalAnchorPoint( mHorizontalAnchorPoint );
   m->setVerticalAnchorPoint( mVerticalAnchorPoint );
-  m->setFixVerticalAnchor( mFixVerticalAnchor );
+  m->setVerticalAnchorMode( mVerticalAnchorMode );
   copyDataDefinedProperties( m );
   copyPaintEffect( m );
   return m;

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3806,9 +3806,11 @@ void QgsFontMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContex
   const double sizeToRender = calculateSize( context );
   double sizeToCalculateOffsets = sizeToRender;
 
-  //if we use the bounds, the font metric boundings are used
   if ( mVerticalAnchorMode == VerticalAnchorMode::Bounds )
-    sizeToCalculateOffsets = mFontMetrics->boundingRect( mString.at( 0 ) ).height() / static_cast<double>( mFontMetrics->ascent() ) * sizeToRender;
+  {
+    // when we use the bounds, the font metrics used are already scaled. To be able to deal with this, they should not be scaled, so we scale them back beforehand.
+    sizeToCalculateOffsets = context.renderContext().convertFromPainterUnits( mFontMetrics->boundingRect( mString.at( 0 ) ).height(), mSizeUnit );
+  }
 
   bool hasDataDefinedRotation = false;
   QPointF offset;

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3578,10 +3578,11 @@ void QgsFontMarkerSymbolLayer::startRender( QgsSymbolRenderContext &context )
   mFontMetrics.reset( new QFontMetrics( mFont ) );
   mChrWidth = mFontMetrics->horizontalAdvance( mString );
 
+  double centerOfCharBound = mFontMetrics->boundingRect( mString.at( 0 ) ).bottom() - mFontMetrics->boundingRect( mString.at( 0 ) ).height() / 2.0;
   switch ( mVerticalAnchorMode )
   {
     case VerticalAnchorMode::Bounds:
-      mChrOffset = QPointF( mChrWidth / 2.0, ( mFontMetrics->boundingRect( mString.at( 0 ) ).bottom() - mFontMetrics->boundingRect( mString.at( 0 ) ).height() / 2.0 ) );
+      mChrOffset = QPointF( mChrWidth / 2.0, centerOfCharBound / static_cast<double>( mFontMetrics->ascent() ) * sizePixels );
       break;
     case VerticalAnchorMode::Baseline:
       mChrOffset = QPointF( mChrWidth / 2.0, -sizePixels / 2.0 );
@@ -3623,10 +3624,11 @@ QString QgsFontMarkerSymbolLayer::characterToRender( QgsSymbolRenderContext &con
     {
       charWidth = mFontMetrics->horizontalAdvance( stringToRender );
       const double sizePixels = context.renderContext().convertToPainterUnits( mSize, mSizeUnit, mSizeMapUnitScale );
+      double centerOfCharBound = mFontMetrics->boundingRect( mString.at( 0 ) ).bottom() - mFontMetrics->boundingRect( mString.at( 0 ) ).height() / 2.0;
       switch ( mVerticalAnchorMode )
       {
         case VerticalAnchorMode::Bounds:
-          charOffset = QPointF( charWidth / 2.0, ( mFontMetrics->boundingRect( mString.at( 0 ) ).bottom() - mFontMetrics->boundingRect( mString.at( 0 ) ).height() / 2 ) );
+          charOffset = QPointF( charWidth / 2.0, centerOfCharBound / static_cast<double>( mFontMetrics->ascent() ) * sizePixels );
           break;
         case VerticalAnchorMode::Baseline:
           charOffset = QPointF( charWidth / 2.0, -sizePixels / 2.0 );
@@ -3805,8 +3807,10 @@ void QgsFontMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContex
 
   //if we use the bounds, the font metric boundings are used
   if ( mVerticalAnchorMode == VerticalAnchorMode::Bounds )
-    sizeToCalculateOffsets =  mFontMetrics->boundingRect( mString.at( 0 ) ).height();
+  {
+    sizeToCalculateOffsets = mFontMetrics->boundingRect( mString.at( 0 ) ).height() / static_cast<double>( mFontMetrics->ascent() ) * sizeToRender;
 
+  }
   bool hasDataDefinedRotation = false;
   QPointF offset;
   double angle = 0;

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3579,10 +3579,11 @@ void QgsFontMarkerSymbolLayer::startRender( QgsSymbolRenderContext &context )
   mChrWidth = mFontMetrics->horizontalAdvance( mString );
 
   double centerOfCharBound = mFontMetrics->boundingRect( mString.at( 0 ) ).bottom() - mFontMetrics->boundingRect( mString.at( 0 ) ).height() / 2.0;
+
   switch ( mVerticalAnchorMode )
   {
     case VerticalAnchorMode::Bounds:
-      mChrOffset = QPointF( mChrWidth / 2.0, centerOfCharBound / static_cast<double>( mFontMetrics->ascent() ) * sizePixels );
+      mChrOffset = QPointF( mChrWidth / 2.0, centerOfCharBound );
       break;
     case VerticalAnchorMode::Baseline:
       mChrOffset = QPointF( mChrWidth / 2.0, -sizePixels / 2.0 );
@@ -3628,7 +3629,7 @@ QString QgsFontMarkerSymbolLayer::characterToRender( QgsSymbolRenderContext &con
       switch ( mVerticalAnchorMode )
       {
         case VerticalAnchorMode::Bounds:
-          charOffset = QPointF( charWidth / 2.0, centerOfCharBound / static_cast<double>( mFontMetrics->ascent() ) * sizePixels );
+          charOffset = QPointF( charWidth / 2.0, centerOfCharBound );
           break;
         case VerticalAnchorMode::Baseline:
           charOffset = QPointF( charWidth / 2.0, -sizePixels / 2.0 );
@@ -3807,10 +3808,8 @@ void QgsFontMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContex
 
   //if we use the bounds, the font metric boundings are used
   if ( mVerticalAnchorMode == VerticalAnchorMode::Bounds )
-  {
     sizeToCalculateOffsets = mFontMetrics->boundingRect( mString.at( 0 ) ).height() / static_cast<double>( mFontMetrics->ascent() ) * sizeToRender;
 
-  }
   bool hasDataDefinedRotation = false;
   QPointF offset;
   double angle = 0;

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3521,6 +3521,8 @@ QgsSymbolLayer *QgsFontMarkerSymbolLayer::create( const QVariantMap &props )
     m->setHorizontalAnchorPoint( QgsMarkerSymbolLayer::HorizontalAnchorPoint( props[ QStringLiteral( "horizontal_anchor_point" )].toInt() ) );
   if ( props.contains( QStringLiteral( "vertical_anchor_point" ) ) )
     m->setVerticalAnchorPoint( QgsMarkerSymbolLayer::VerticalAnchorPoint( props[ QStringLiteral( "vertical_anchor_point" )].toInt() ) );
+  if ( props.contains( QStringLiteral( "fix_vertical_anchor" ) ) )
+    m->setFixVerticalAnchor( props[ QStringLiteral( "fix_vertical_anchor" )].toBool() );
 
   m->restoreOldDataDefinedProperties( props );
 
@@ -3575,7 +3577,14 @@ void QgsFontMarkerSymbolLayer::startRender( QgsSymbolRenderContext &context )
   mFont.setPixelSize( std::max( 2, static_cast< int >( std::round( sizePixels ) ) ) );
   mFontMetrics.reset( new QFontMetrics( mFont ) );
   mChrWidth = mFontMetrics->horizontalAdvance( mString );
-  mChrOffset = QPointF( mChrWidth / 2.0, -mFontMetrics->ascent() / 2.0 );
+  if ( mFixVerticalAnchor )
+  {
+    mChrOffset = QPointF( mChrWidth / 2.0, -sizePixels / 2.0 );
+  }
+  else
+  {
+    mChrOffset = QPointF( mChrWidth / 2.0, -mFontMetrics->ascent() / 2.0 );
+  }
   mOrigSize = mSize; // save in case the size would be data defined
 
   // use caching only when not using a data defined character
@@ -3608,7 +3617,15 @@ QString QgsFontMarkerSymbolLayer::characterToRender( QgsSymbolRenderContext &con
     if ( stringToRender != mString )
     {
       charWidth = mFontMetrics->horizontalAdvance( stringToRender );
-      charOffset = QPointF( charWidth / 2.0, -mFontMetrics->ascent() / 2.0 );
+      if ( mFixVerticalAnchor )
+      {
+        const double sizePixels = context.renderContext().convertToPainterUnits( mSize, mSizeUnit, mSizeMapUnitScale );
+        charOffset = QPointF( mChrWidth / 2.0, -sizePixels / 2.0 );
+      }
+      else
+      {
+        charOffset = QPointF( charWidth / 2.0, -mFontMetrics->ascent() / 2.0 );
+      }
     }
   }
   return stringToRender;
@@ -3838,6 +3855,7 @@ QVariantMap QgsFontMarkerSymbolLayer::properties() const
   props[QStringLiteral( "offset_map_unit_scale" )] = QgsSymbolLayerUtils::encodeMapUnitScale( mOffsetMapUnitScale );
   props[QStringLiteral( "horizontal_anchor_point" )] = QString::number( mHorizontalAnchorPoint );
   props[QStringLiteral( "vertical_anchor_point" )] = QString::number( mVerticalAnchorPoint );
+  props[QStringLiteral( "fix_vertical_anchor" )] = mFixVerticalAnchor;
   return props;
 }
 
@@ -3857,6 +3875,7 @@ QgsFontMarkerSymbolLayer *QgsFontMarkerSymbolLayer::clone() const
   m->setSizeMapUnitScale( mSizeMapUnitScale );
   m->setHorizontalAnchorPoint( mHorizontalAnchorPoint );
   m->setVerticalAnchorPoint( mVerticalAnchorPoint );
+  m->setFixVerticalAnchor( mFixVerticalAnchor );
   copyDataDefinedProperties( m );
   copyPaintEffect( m );
   return m;

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3620,7 +3620,7 @@ QString QgsFontMarkerSymbolLayer::characterToRender( QgsSymbolRenderContext &con
       if ( mVerticalAnchorMode == VerticalAnchorMode::Baseline )
       {
         const double sizePixels = context.renderContext().convertToPainterUnits( mSize, mSizeUnit, mSizeMapUnitScale );
-        charOffset = QPointF( mChrWidth / 2.0, -sizePixels / 2.0 );
+        charOffset = QPointF( charWidth / 2.0, -sizePixels / 2.0 );
       }
       else
       {

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -1061,7 +1061,7 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
 
     double mChrWidth = 0;
     QPointF mChrOffset;
-    VerticalAnchorMode mVerticalAnchorMode = VerticalAnchorMode::Baseline;
+    VerticalAnchorMode mVerticalAnchorMode = VerticalAnchorMode::Legacy;
 
     //! Scaling for font sizes, used if font size grows too large
     double mFontSizeScale = 1.0;

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -854,6 +854,13 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
 {
   public:
 
+    //! Vertical anchor modes
+    enum class VerticalAnchorMode : int
+    {
+      Legacy = 0, //!< Calculate anchor points with different offsets
+      Baseline = 1, //!< Calculate anchor points with fix baseline
+    };
+
     //! Constructs a font marker symbol layer.
     QgsFontMarkerSymbolLayer( const QString &fontFamily = DEFAULT_FONTMARKER_FONT,
                               QString chr = DEFAULT_FONTMARKER_CHR,
@@ -1027,19 +1034,19 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     void setPenJoinStyle( Qt::PenJoinStyle style ) { mPenJoinStyle = style; }
 
     /**
-     * Set fixVerticalAnchor that means it considers the baseline position for all the characters
-     * \param fixVerticalAnchor the bool
-     * \see fixVerticalAnchor()
+     * Sets the vertical anchor mode wheter it should considers the baseline as fix point
+     * \param vertical anchor mode how to handle the anchor point
+     * \see verticalAnchorMode()
      * \since QGIS 3.42
      */
-    void setFixVerticalAnchor( const bool fixVerticalAnchor ) { mFixVerticalAnchor = fixVerticalAnchor;}
+    void setVerticalAnchorMode( VerticalAnchorMode verticalAnchorMode ) { mVerticalAnchorMode = verticalAnchorMode;}
 
     /**
-     * Returns wheter it considers teh baseline position for all the characters
-     * \see setFixVerticalAnchor()
+     * Returns wheter it should considers the baseline as fix point
+     * \see setVerticalAnchorMode()
      * \since QGIS 3.42
      */
-    bool fixVerticalAnchor() const { return mFixVerticalAnchor; }
+    VerticalAnchorMode verticalAnchorMode() const { return mVerticalAnchorMode; }
 
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
 
@@ -1054,7 +1061,7 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
 
     double mChrWidth = 0;
     QPointF mChrOffset;
-    bool mFixVerticalAnchor = false;
+    VerticalAnchorMode mVerticalAnchorMode = VerticalAnchorMode::Baseline;
 
     //! Scaling for font sizes, used if font size grows too large
     double mFontSizeScale = 1.0;

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -1026,6 +1026,21 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     */
     void setPenJoinStyle( Qt::PenJoinStyle style ) { mPenJoinStyle = style; }
 
+    /**
+     * Set fixVerticalAnchor that means it considers the baseline position for all the characters
+     * \param fixVerticalAnchor the bool
+     * \see fixVerticalAnchor()
+     * \since QGIS 3.42
+     */
+    void setFixVerticalAnchor( const bool fixVerticalAnchor ) { mFixVerticalAnchor = fixVerticalAnchor;}
+
+    /**
+     * Returns wheter it considers teh baseline position for all the characters
+     * \see setFixVerticalAnchor()
+     * \since QGIS 3.42
+     */
+    bool fixVerticalAnchor() const { return mFixVerticalAnchor; }
+
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
 
   private:
@@ -1039,6 +1054,8 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
 
     double mChrWidth = 0;
     QPointF mChrOffset;
+    bool mFixVerticalAnchor = false;
+
     //! Scaling for font sizes, used if font size grows too large
     double mFontSizeScale = 1.0;
     double mOrigSize;

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -857,8 +857,9 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     //! Vertical anchor modes
     enum class VerticalAnchorMode : int
     {
-      Legacy = 0, //!< Calculate anchor points with different offsets
+      Bounds = 0, //!< Calculate anchor points according to character bounds
       Baseline = 1, //!< Calculate anchor points with fix baseline
+      Legacy = 2, //!< Calculate anchor points with different offsets
     };
 
     //! Constructs a font marker symbol layer.
@@ -1061,7 +1062,7 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
 
     double mChrWidth = 0;
     QPointF mChrOffset;
-    VerticalAnchorMode mVerticalAnchorMode = VerticalAnchorMode::Legacy;
+    VerticalAnchorMode mVerticalAnchorMode = VerticalAnchorMode::Bounds;
 
     //! Scaling for font sizes, used if font size grows too large
     double mFontSizeScale = 1.0;

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -1034,15 +1034,15 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     void setPenJoinStyle( Qt::PenJoinStyle style ) { mPenJoinStyle = style; }
 
     /**
-     * Sets the vertical anchor mode wheter it should considers the baseline as fix point
-     * \param vertical anchor mode how to handle the anchor point
+     * Sets the vertical anchor mode whether it should considers the baseline as fix point
+     * \param verticalAnchorMode the mode how to handle the anchor point
      * \see verticalAnchorMode()
      * \since QGIS 3.42
      */
     void setVerticalAnchorMode( VerticalAnchorMode verticalAnchorMode ) { mVerticalAnchorMode = verticalAnchorMode;}
 
     /**
-     * Returns wheter it should considers the baseline as fix point
+     * Returns whether it should considers the baseline as fix point
      * \see setVerticalAnchorMode()
      * \since QGIS 3.42
      */

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -3644,6 +3644,8 @@ void QgsFontMarkerSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   int verticalAnchorIndex = mLayer->verticalAnchorPoint();
   if ( mLayer->verticalAnchorMode() == QgsFontMarkerSymbolLayer::VerticalAnchorMode::Baseline )
     verticalAnchorIndex = 3;
+  if ( mLayer->verticalAnchorMode() == QgsFontMarkerSymbolLayer::VerticalAnchorMode::Legacy )
+    verticalAnchorIndex = verticalAnchorIndex + 4;
   whileBlocking( mVerticalAnchorComboBox )->setCurrentIndex( verticalAnchorIndex );
 
   registerDataDefinedButton( mFontFamilyDDBtn, QgsSymbolLayer::Property::FontFamily );
@@ -3854,15 +3856,22 @@ void QgsFontMarkerSymbolLayerWidget::mVerticalAnchorComboBox_currentIndexChanged
 {
   if ( mLayer )
   {
-    if ( index >= 3 )
+    if ( index == 3 )
     {
       // Bottom on Baseline is selected
       mLayer->setVerticalAnchorMode( QgsFontMarkerSymbolLayer::VerticalAnchorMode::Baseline );
       mLayer->setVerticalAnchorPoint( QgsMarkerSymbolLayer::Bottom );
     }
+    else if ( index >= 4 )
+    {
+      // Legacy is selected
+      mLayer->setVerticalAnchorMode( QgsFontMarkerSymbolLayer::VerticalAnchorMode::Legacy );
+      mLayer->setVerticalAnchorPoint( QgsMarkerSymbolLayer::VerticalAnchorPoint( index - 4 ) );
+    }
     else
     {
-      mLayer->setVerticalAnchorMode( QgsFontMarkerSymbolLayer::VerticalAnchorMode::Legacy );
+      // Bounds are selected
+      mLayer->setVerticalAnchorMode( QgsFontMarkerSymbolLayer::VerticalAnchorMode::Bounds );
       mLayer->setVerticalAnchorPoint( QgsMarkerSymbolLayer::VerticalAnchorPoint( index ) );
     }
     emit changed();

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -3642,8 +3642,8 @@ void QgsFontMarkerSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   //anchor points
   whileBlocking( mHorizontalAnchorComboBox )->setCurrentIndex( mLayer->horizontalAnchorPoint() );
   int verticalAnchorIndex = mLayer->verticalAnchorPoint();
-  if ( mLayer->fixVerticalAnchor() )
-    verticalAnchorIndex += 3;
+  if ( mLayer->verticalAnchorMode() == QgsFontMarkerSymbolLayer::VerticalAnchorMode::Baseline )
+    verticalAnchorIndex = 3;
   whileBlocking( mVerticalAnchorComboBox )->setCurrentIndex( verticalAnchorIndex );
 
   registerDataDefinedButton( mFontFamilyDDBtn, QgsSymbolLayer::Property::FontFamily );
@@ -3856,16 +3856,15 @@ void QgsFontMarkerSymbolLayerWidget::mVerticalAnchorComboBox_currentIndexChanged
   {
     if ( index >= 3 )
     {
-      mLayer->setFixVerticalAnchor( true );
-      //pass original types
-      index -= 3;
+      // Bottom on Baseline is selected
+      mLayer->setVerticalAnchorMode( QgsFontMarkerSymbolLayer::VerticalAnchorMode::Baseline );
+      mLayer->setVerticalAnchorPoint( QgsMarkerSymbolLayer::Bottom );
     }
     else
     {
-
-      mLayer->setFixVerticalAnchor( false );
+      mLayer->setVerticalAnchorMode( QgsFontMarkerSymbolLayer::VerticalAnchorMode::Legacy );
+      mLayer->setVerticalAnchorPoint( QgsMarkerSymbolLayer::VerticalAnchorPoint( index ) );
     }
-    mLayer->setVerticalAnchorPoint( QgsMarkerSymbolLayer::VerticalAnchorPoint( index ) );
     emit changed();
   }
 }

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -3641,7 +3641,10 @@ void QgsFontMarkerSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
 
   //anchor points
   whileBlocking( mHorizontalAnchorComboBox )->setCurrentIndex( mLayer->horizontalAnchorPoint() );
-  whileBlocking( mVerticalAnchorComboBox )->setCurrentIndex( mLayer->verticalAnchorPoint() );
+  int verticalAnchorIndex = mLayer->verticalAnchorPoint();
+  if ( mLayer->fixVerticalAnchor() )
+    verticalAnchorIndex += 3;
+  whileBlocking( mVerticalAnchorComboBox )->setCurrentIndex( verticalAnchorIndex );
 
   registerDataDefinedButton( mFontFamilyDDBtn, QgsSymbolLayer::Property::FontFamily );
   registerDataDefinedButton( mFontStyleDDBtn, QgsSymbolLayer::Property::FontStyle );
@@ -3851,6 +3854,17 @@ void QgsFontMarkerSymbolLayerWidget::mVerticalAnchorComboBox_currentIndexChanged
 {
   if ( mLayer )
   {
+    if ( index >= 3 )
+    {
+      mLayer->setFixVerticalAnchor( true );
+      //pass original types
+      index -= 3;
+    }
+    else
+    {
+
+      mLayer->setFixVerticalAnchor( false );
+    }
     mLayer->setVerticalAnchorPoint( QgsMarkerSymbolLayer::VerticalAnchorPoint( index ) );
     emit changed();
   }

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -307,6 +307,21 @@
        <string>Bottom</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Top considering Baseline</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>VCenter considering Baseline</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Bottom considering Baseline</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="3" column="4">
@@ -463,7 +478,7 @@
        <property name="value">
         <double>0.200000000000000</double>
        </property>
-       <property name="showClearButton" stdset="0">
+       <property name="showClearButton">
         <bool>false</bool>
        </property>
       </widget>
@@ -508,7 +523,7 @@
        <property name="value">
         <double>12.000000000000000</double>
        </property>
-       <property name="showClearButton" stdset="0">
+       <property name="showClearButton">
         <bool>false</bool>
        </property>
       </widget>
@@ -550,15 +565,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsPropertyOverrideButton</class>
@@ -566,9 +581,9 @@
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -309,17 +309,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Top considering Baseline</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>VCenter considering Baseline</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bottom considering Baseline</string>
+       <string>Bottom on Baseline</string>
       </property>
      </item>
     </widget>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -312,6 +312,21 @@
        <string>Bottom on Baseline</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Legacy Top</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Legacy VCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Legacy Bottom</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="3" column="4">


### PR DESCRIPTION
Requires (branch of) #60044

And concerns bounds part from here #59732

Anchor can be set according to the bounds and not the line top and bottom.

![image](https://github.com/user-attachments/assets/f05a1860-a8a5-401c-9910-7c0dc9030719)

The "old" anchors persists but are marked in the GUI (only in the GUI) as legacy.

## Technical details
To evaluate the character offset we get the font metric bounds bottom and add the half of the bounds's height.

![IMG_20250108_102708_1](https://github.com/user-attachments/assets/fe2f03f9-115a-4c4d-ad56-f248e3de984b)

To evaluate the top and bottom anchor then we don't concern the whole size but only the font metric bounds's height (there we need to "unscale" it first, to be able to use the standard markerOffset function).

## Problems

- Only works when the if the maximum font size is not exceeded: 
   [Screencast from 08.01.2025 10:21:22.webm](https://github.com/user-attachments/assets/195c113f-6eb0-4bbe-8d4f-dd95b973cf0f)
  Could be fixed by raising this https://github.com/qgis/QGIS/blob/master/src/core/symbology/qgsmarkersymbollayer.cpp#L44 but I don't know the effects.

- Not working on "Meters at Scale". Don't know the exact reason. Would work with this "hack" https://github.com/qgis/QGIS/pull/60080/files#r1906881851

    