### PR TITLE
Don't keep pointer to QgsPointCloudLayer in QgsPointCloudLayerRenderer and QgsPointCloudLayerProfileGenerator

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -133,8 +133,7 @@ QgsAbstractProfileGenerator *QgsPointCloudLayer::createProfileGenerator( const Q
 
 QgsPointCloudDataProvider *QgsPointCloudLayer::dataProvider()
 {
-  // BAD! 2D rendering of point clouds is NOT thread safe
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return mDataProvider.get();
 }

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -1080,7 +1080,7 @@ bool QgsPointCloudLayer::changeAttributeValue( const QgsPointCloudNodeId &n, con
 
 QgsPointCloudIndex QgsPointCloudLayer::index() const
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
   if ( mEditIndex )
     return mEditIndex;
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -341,7 +341,7 @@ void QgsPointCloudLayerProfileResults::copyPropertiesFromGenerator( const QgsAbs
 
 QgsPointCloudLayerProfileGenerator::QgsPointCloudLayerProfileGenerator( QgsPointCloudLayer *layer, const QgsProfileRequest &request )
   : mLayer( layer )
-  , mIndex( layer->dataProvider()->index() )
+  , mIndex( layer->index() )
   , mSubIndexes( layer->dataProvider()->subIndexes() )
   , mLayerAttributes( layer->attributes() )
   , mRenderer( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->respectLayerColors() && mLayer->renderer() ? mLayer->renderer()->clone() : nullptr )
@@ -363,10 +363,10 @@ QgsPointCloudLayerProfileGenerator::QgsPointCloudLayerProfileGenerator( QgsPoint
   , mZScale( layer->elevationProperties()->zScale() )
   , mStepDistance( request.stepDistance() )
 {
-  if ( mLayer->index() )
+  if ( mIndex )
   {
-    mScale = mLayer->index().scale();
-    mOffset = mLayer->index().offset();
+    mScale = mIndex.scale();
+    mOffset = mIndex.offset();
   }
 }
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -341,6 +341,8 @@ void QgsPointCloudLayerProfileResults::copyPropertiesFromGenerator( const QgsAbs
 
 QgsPointCloudLayerProfileGenerator::QgsPointCloudLayerProfileGenerator( QgsPointCloudLayer *layer, const QgsProfileRequest &request )
   : mLayer( layer )
+  , mIndex( layer->dataProvider()->index() )
+  , mSubIndexes( layer->dataProvider()->subIndexes() )
   , mLayerAttributes( layer->attributes() )
   , mRenderer( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->respectLayerColors() && mLayer->renderer() ? mLayer->renderer()->clone() : nullptr )
   , mMaximumScreenError( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->maximumScreenError() )
@@ -386,17 +388,13 @@ bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenera
   if ( !mLayer || !mProfileCurve || mFeedback->isCanceled() )
     return false;
 
-  // this is not AT ALL thread safe, but it's what QgsPointCloudLayerRenderer does !
-  // TODO: fix when QgsPointCloudLayerRenderer is made thread safe to use same approach
-
   QVector<QgsPointCloudIndex> indexes;
-  QgsPointCloudIndex mainIndex = mLayer->index();
-  if ( mainIndex && mainIndex.isValid() )
-    indexes.append( mainIndex );
+  if ( mIndex && mIndex.isValid() )
+    indexes.append( mIndex );
 
   // Gather all relevant sub-indexes
   const QgsRectangle profileCurveBbox = mProfileCurve->boundingBox();
-  for ( const QgsPointCloudSubIndex &subidx : mLayer->dataProvider()->subIndexes() )
+  for ( const QgsPointCloudSubIndex &subidx : mSubIndexes )
   {
     QgsPointCloudIndex index = subidx.index();
     if ( index && index.isValid() && subidx.polygonBounds().intersects( profileCurveBbox ) )

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -25,6 +25,8 @@
 #include "qgscoordinatetransform.h"
 #include "qgspointcloudattribute.h"
 #include "qgslinesymbol.h"
+#include "qgspointcloudindex.h"
+#include "qgspointcloudsubindex.h"
 #include "qgsvector3d.h"
 #include "qgsgeos.h"
 
@@ -150,6 +152,8 @@ class CORE_EXPORT QgsPointCloudLayerProfileGenerator : public QgsAbstractProfile
     void visitBlock( const QgsPointCloudBlock *block, const QgsDoubleRange &zRange );
 
     QPointer< QgsPointCloudLayer > mLayer;
+    QgsPointCloudIndex mIndex;
+    const QVector< QgsPointCloudSubIndex > mSubIndexes;
     QgsPointCloudAttributeCollection mLayerAttributes;
     std::unique_ptr< QgsPointCloudRenderer > mRenderer;
     double mMaximumScreenError = 0.3;

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -52,7 +52,7 @@ QgsPointCloudLayerRenderer::QgsPointCloudLayerRenderer( QgsPointCloudLayer *laye
   if ( !layer->dataProvider() || !layer->renderer() )
     return;
 
-  mIndex = layer->dataProvider()->index();
+  mIndex = layer->index();
 
   QElapsedTimer timer;
   timer.start();

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -43,22 +43,20 @@
 
 QgsPointCloudLayerRenderer::QgsPointCloudLayerRenderer( QgsPointCloudLayer *layer, QgsRenderContext &context )
   : QgsMapLayerRenderer( layer->id(), &context )
-  , mLayer( layer )
+  , mIndex( layer->dataProvider()->index() )
   , mLayerName( layer->name() )
   , mLayerAttributes( layer->attributes() )
   , mSubIndexes( layer && layer->dataProvider() ? layer->dataProvider()->subIndexes() : QVector<QgsPointCloudSubIndex>() )
   , mFeedback( new QgsFeedback )
   , mEnableProfile( context.flags() & Qgis::RenderContextFlag::RecordProfile )
 {
-  // TODO: we must not keep pointer to mLayer (it's dangerous) - we must copy anything we need for rendering
-  // or use some locking to prevent read/write from multiple threads
-  if ( !mLayer || !mLayer->dataProvider() || !mLayer->renderer() )
+  if ( !layer->dataProvider() || !layer->renderer() )
     return;
 
   QElapsedTimer timer;
   timer.start();
 
-  mRenderer.reset( mLayer->renderer()->clone() );
+  mRenderer.reset( layer->renderer()->clone() );
   if ( !mSubIndexes.isEmpty() )
   {
     mSubIndexExtentRenderer.reset( new QgsPointCloudExtentRenderer() );
@@ -66,19 +64,26 @@ QgsPointCloudLayerRenderer::QgsPointCloudLayerRenderer( QgsPointCloudLayer *laye
     mSubIndexExtentRenderer->setLabelTextFormat( mRenderer->labelTextFormat() );
   }
 
-  if ( mLayer->index() )
+  if ( mIndex )
   {
-    mScale = mLayer->index().scale();
-    mOffset = mLayer->index().offset();
+    mScale = mIndex.scale();
+    mOffset = mIndex.offset();
   }
 
-  if ( const QgsPointCloudLayerElevationProperties *elevationProps = qobject_cast< const QgsPointCloudLayerElevationProperties * >( mLayer->elevationProperties() ) )
+  if ( const QgsPointCloudLayerElevationProperties *elevationProps = qobject_cast< const QgsPointCloudLayerElevationProperties * >( layer->elevationProperties() ) )
   {
     mZOffset = elevationProps->zOffset();
     mZScale = elevationProps->zScale();
   }
 
-  mCloudExtent = mLayer->dataProvider()->polygonBounds();
+  if ( const QgsVirtualPointCloudProvider *vpcProvider = dynamic_cast<QgsVirtualPointCloudProvider *>( layer->dataProvider() ) )
+  {
+    mAverageSubIndexWidth = vpcProvider->averageSubIndexWidth();
+    mAverageSubIndexHeight = vpcProvider->averageSubIndexHeight();
+    mOverviewIndex = vpcProvider->overview();
+  }
+
+  mCloudExtent = layer->dataProvider()->polygonBounds();
 
   mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( *renderContext(), layer );
 
@@ -129,9 +134,7 @@ bool QgsPointCloudLayerRenderer::render()
     return true;
   }
 
-  // TODO cache!?
-  QgsPointCloudIndex pc = mLayer->index();
-  if ( mSubIndexes.isEmpty() && ( !pc || !pc.isValid() ) )
+  if ( mSubIndexes.isEmpty() && ( !mIndex || !mIndex.isValid() ) )
   {
     mReadyToCompose = true;
     return false;
@@ -195,9 +198,9 @@ bool QgsPointCloudLayerRenderer::render()
   bool canceled = false;
   if ( mSubIndexes.isEmpty() )
   {
-    canceled = !renderIndex( pc );
+    canceled = !renderIndex( mIndex );
   }
-  else if ( const QgsVirtualPointCloudProvider *vpcProvider = dynamic_cast<QgsVirtualPointCloudProvider *>( mLayer->dataProvider() ) )
+  else if ( mOverviewIndex )
   {
     QVector< QgsPointCloudSubIndex > visibleIndexes;
     for ( const QgsPointCloudSubIndex &si : mSubIndexes )
@@ -207,23 +210,22 @@ bool QgsPointCloudLayerRenderer::render()
         visibleIndexes.append( si );
       }
     }
-    const bool zoomedOut = renderExtent.width() > vpcProvider->averageSubIndexWidth() ||
-                           renderExtent.height() > vpcProvider->averageSubIndexHeight();
-    QgsPointCloudIndex overviewIndex = vpcProvider->overview();
+    const bool zoomedOut = renderExtent.width() > mAverageSubIndexWidth ||
+                           renderExtent.height() > mAverageSubIndexHeight;
     // if the overview of virtual point cloud exists, and we are zoomed out, we render just overview
-    if ( vpcProvider->overview() && zoomedOut &&
+    if ( mOverviewIndex && zoomedOut &&
          mRenderer->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverview )
     {
-      renderIndex( overviewIndex );
+      renderIndex( *mOverviewIndex );
     }
     else
     {
       // if the overview of virtual point cloud exists, and we are zoomed out, but we want both overview and extents,
       // we render overview
-      if ( vpcProvider->overview() && zoomedOut &&
+      if ( mOverviewIndex && zoomedOut &&
            mRenderer->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverviewAndExtents )
       {
-        renderIndex( overviewIndex );
+        renderIndex( *mOverviewIndex );
       }
       mSubIndexExtentRenderer->startRender( context );
       for ( const QgsPointCloudSubIndex &si : visibleIndexes )

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -43,7 +43,6 @@
 
 QgsPointCloudLayerRenderer::QgsPointCloudLayerRenderer( QgsPointCloudLayer *layer, QgsRenderContext &context )
   : QgsMapLayerRenderer( layer->id(), &context )
-  , mIndex( layer->dataProvider()->index() )
   , mLayerName( layer->name() )
   , mLayerAttributes( layer->attributes() )
   , mSubIndexes( layer && layer->dataProvider() ? layer->dataProvider()->subIndexes() : QVector<QgsPointCloudSubIndex>() )
@@ -52,6 +51,8 @@ QgsPointCloudLayerRenderer::QgsPointCloudLayerRenderer( QgsPointCloudLayer *laye
 {
   if ( !layer->dataProvider() || !layer->renderer() )
     return;
+
+  mIndex = layer->dataProvider()->index();
 
   QElapsedTimer timer;
   timer.start();

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.h
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.h
@@ -98,8 +98,8 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
 
     const QVector< QgsPointCloudSubIndex > mSubIndexes;
     std::optional<QgsPointCloudIndex> mOverviewIndex;
-    double mAverageSubIndexWidth;
-    double mAverageSubIndexHeight;
+    double mAverageSubIndexWidth = 0;
+    double mAverageSubIndexHeight = 0;
 
     int mRenderTimeHint = 0;
     bool mBlockRenderUpdates = false;

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.h
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.h
@@ -37,6 +37,7 @@
 #include <QString>
 #include <QPainter>
 #include <QElapsedTimer>
+#include <optional>
 
 class QgsRenderContext;
 class QgsPointCloudLayer;
@@ -79,7 +80,7 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
     void renderTriangulatedSurface( QgsPointCloudRenderContext &context );
     bool renderIndex( QgsPointCloudIndex &pc );
 
-    QgsPointCloudLayer *mLayer = nullptr;
+    QgsPointCloudIndex mIndex;
     QString mLayerName;
 
     std::unique_ptr< QgsPointCloudRenderer > mRenderer;
@@ -94,7 +95,11 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
     QgsPointCloudAttributeCollection mAttributes;
     QgsGeometry mCloudExtent;
     QList< QgsMapClippingRegion > mClippingRegions;
+
     const QVector< QgsPointCloudSubIndex > mSubIndexes;
+    std::optional<QgsPointCloudIndex> mOverviewIndex;
+    double mAverageSubIndexWidth;
+    double mAverageSubIndexHeight;
 
     int mRenderTimeHint = 0;
     bool mBlockRenderUpdates = false;


### PR DESCRIPTION
## Description

This is a quick change that refactors a small problem in `QgsPointCloudLayerRenderer`. Previously `render()` used a saved `QgsPointCloudLayer` object (and called methods on it and `QgsPointCloudDataProvider`, generating warnings), but that object is not thread safe. Instead we now get everything we need up-front and only keep a refcounted pointer to the thread-safe layer index.

EDIT: I've also made a similar change to `QgsPointCloudLayerProfileGenerator`, since it was pointed out it had the same issue.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
