### PR TITLE
[forms] Copy and paste widget configuration when designing forms

### DIFF
--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -175,12 +175,18 @@ const QVariantMap QgsAttributeTypeDialog::editorWidgetConfig()
   return QVariantMap();
 }
 
-void QgsAttributeTypeDialog::setEditorWidgetType( const QString &type )
+void QgsAttributeTypeDialog::setEditorWidgetType( const QString &type, bool forceWidgetRefresh )
 {
   mWidgetTypeComboBox->setCurrentIndex( mWidgetTypeComboBox->findData( type ) );
 
   if ( mEditorConfigWidgets.contains( type ) && mEditorConfigWidgets.value( type ) /* may be a null pointer */ )
   {
+    if ( forceWidgetRefresh )
+    {
+      // Force to reset the config, even if
+      // if the type matches the current one
+      mEditorConfigWidgets.value( type )->setConfig( mWidgetConfig );
+    }
     stackedWidget->setCurrentWidget( mEditorConfigWidgets[type] );
   }
   else

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -27,6 +27,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgshelp.h"
 #include "qgis_gui.h"
+#include "qgsxmlutils.h"
 
 class QWidget;
 class QStandardItem;

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -27,7 +27,6 @@
 #include "qgsvectordataprovider.h"
 #include "qgshelp.h"
 #include "qgis_gui.h"
-#include "qgsxmlutils.h"
 
 class QWidget;
 class QStandardItem;

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -49,7 +49,15 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
 
     const QString editorWidgetText();
 
-    void setEditorWidgetType( const QString &type );
+    /**
+     * Sets the \a type in the widget combobox. Widget config is remembered,
+     * allowing users to switch between types without losing configs, unless
+     * \a forceWidgetRefresh is passed as true.
+     *
+     * \param type Editor widget type to be set
+     * \param forceWidgetRefresh Always sets the config, ensuring a widget refresh
+     */
+    void setEditorWidgetType( const QString &type, bool forceWidgetRefresh = false );
 
     const QVariantMap editorWidgetConfig();
 

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -101,6 +101,27 @@ void QgsAttributeWidgetEdit::updateItemData()
   mTreeItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, itemData );
 }
 
+
+void QgsAttributeWidgetEdit::setLabelStyle( const QgsAttributeEditorElement::LabelStyle &labelStyle )
+{
+  mFormLabelFormatWidget->setLabelStyle( labelStyle );
+}
+
+void QgsAttributeWidgetEdit::setShowLabel( bool showLabel )
+{
+  mShowLabelCheckBox->setChecked( showLabel );
+}
+
+void QgsAttributeWidgetEdit::setHorizontalStretch( const int horizontalStretch )
+{
+  mHozStretchSpin->setValue( horizontalStretch );
+}
+
+void QgsAttributeWidgetEdit::setVerticalStretch( const int verticalStretch )
+{
+  mVertStretchSpin->setValue( verticalStretch );
+}
+
 // Relation Widget Specific Edit
 
 QgsAttributeWidgetRelationEditWidget::QgsAttributeWidgetRelationEditWidget( QWidget *parent )

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.h
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.h
@@ -45,6 +45,12 @@ class GUI_EXPORT QgsAttributeWidgetEdit : public QgsCollapsibleGroupBox, private
 
     void updateItemData();
 
+    // Methods to update widget status
+    void setLabelStyle( const QgsAttributeEditorElement::LabelStyle &labelStyle );
+    void setShowLabel( bool showLabel );
+    void setHorizontalStretch( const int horizontalStretch );
+    void setVerticalStretch( const int verticalStretch );
+
   private:
     void showRelationButtons( bool show );
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -2040,8 +2040,6 @@ void QgsAttributesFormProperties::onContextMenuRequested( QPoint point )
 
 void QgsAttributesFormProperties::copyWidgetConfiguration()
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
   if ( mAvailableWidgetsTree->selectedItems().count() != 1 )
     return;
 
@@ -2139,8 +2137,6 @@ void QgsAttributesFormProperties::copyWidgetConfiguration()
 
 void QgsAttributesFormProperties::pasteWidgetConfiguration()
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
   if ( mAvailableWidgetsTree->selectedItems().count() != 1 )
     return;
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -353,8 +353,10 @@ void QgsAttributesFormProperties::loadAttributeTypeDialogFromConfiguration( cons
   mAttributeTypeDialog->setConstraintExpressionDescription( constraints.constraintDescription() );
   mAttributeTypeDialog->setConstraintExpressionEnforced( constraints.constraintStrength( QgsFieldConstraints::ConstraintExpression ) == QgsFieldConstraints::ConstraintStrengthHard );
 
+  // Make sure the widget is refreshed, even if
+  // the new widget type matches the current one
   mAttributeTypeDialog->setEditorWidgetConfig( config.mEditorWidgetConfig );
-  mAttributeTypeDialog->setEditorWidgetType( config.mEditorWidgetType );
+  mAttributeTypeDialog->setEditorWidgetType( config.mEditorWidgetType, true );
 }
 
 void QgsAttributesFormProperties::storeAttributeTypeDialog()

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -2163,11 +2163,6 @@ void QgsAttributesFormProperties::pasteWidgetConfiguration()
     if ( docElem.tagName() != QLatin1String( "FormWidgetClipboard" ) )
       return;
 
-    // We avoid pasting if origin and target fields are the same
-    const QString sourceFieldName = docElem.attribute( QStringLiteral( "name" ) );
-    if ( sourceFieldName == fieldName )
-      return;
-
     // When pasting, the target item has already been selected and
     // has triggered attribute type dialog loading. Therefore, we'll
     // only overwrite GUI settings instead of destroying and recreating

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -104,6 +104,10 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
 
   mAvailableWidgetsTreeContextMenu->addAction( mActionCopyWidgetConfiguration );
   mAvailableWidgetsTreeContextMenu->addAction( mActionPasteWidgetConfiguration );
+
+  mMessageBar = new QgsMessageBar();
+  mMessageBar->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Fixed );
+  gridLayout->addWidget( mMessageBar, 0, 0 );
 }
 
 void QgsAttributesFormProperties::init()
@@ -2193,6 +2197,10 @@ void QgsAttributesFormProperties::pasteWidgetConfiguration()
           config.mEditorWidgetType = widgetType;
           config.mEditorWidgetConfig = optionsMap;
         }
+      }
+      else
+      {
+        mMessageBar->pushMessage( QString(), tr( "Unable to paste widget configuration. The target field (%1) does not support the %2 widget type." ).arg( fieldName, widgetType ), Qgis::MessageLevel::Warning );
       }
     }
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -44,6 +44,7 @@
 #include "qgsexpressionfinder.h"
 #include "qgsexpressionbuilderdialog.h"
 #include "qgshelp.h"
+#include "qgsxmlutils.h"
 
 QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )
@@ -2026,9 +2027,8 @@ void QgsAttributesFormProperties::onContextMenuRequested( QPoint point )
 
   QTreeWidgetItem *item = mAvailableWidgetsTree->itemAt( point );
   const DnDTreeItemData itemData = item->data( 0, DnDTreeRole ).value<DnDTreeItemData>();
-  if ( itemData.type() == DnDTreeItemData::Field || itemData.type() == DnDTreeItemData::Relation )
+  if ( itemData.type() == DnDTreeItemData::Field )
   {
-    // TODO: Data should come from the same item type (Field or Relation)
     const QClipboard *clipboard = QApplication::clipboard();
     const bool pasteEnabled = clipboard->mimeData()->hasFormat( QStringLiteral( "application/x-qgsattributetabledesignerelementclipboard" ) );
     mActionPasteWidgetConfiguration->setEnabled( pasteEnabled );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -2230,16 +2230,31 @@ void QgsAttributesFormProperties::pasteWidgetConfiguration()
     const QDomElement constraintElement = docElem.firstChildElement( QStringLiteral( "constraint" ) );
     if ( !constraintElement.isNull() )
     {
-      int intConstraints = constraintElement.attribute( QStringLiteral( "constraints" ), QStringLiteral( "0" ) ).toInt();
+      const int intConstraints = constraintElement.attribute( QStringLiteral( "constraints" ), QStringLiteral( "0" ) ).toInt();
       QgsFieldConstraints::Constraints constraints = static_cast< QgsFieldConstraints::Constraints >( intConstraints );
 
       // always keep provider constraints intact
-      if ( !( fieldConstraints.constraints() & QgsFieldConstraints::ConstraintNotNull ) && ( constraints & QgsFieldConstraints::ConstraintNotNull ) )
-        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginLayer );
-      if ( !( fieldConstraints.constraints() & QgsFieldConstraints::ConstraintUnique ) && ( constraints & QgsFieldConstraints::ConstraintUnique ) )
-        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginLayer );
-      if ( !( fieldConstraints.constraints() & QgsFieldConstraints::ConstraintExpression ) && ( constraints & QgsFieldConstraints::ConstraintExpression ) )
-        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintOriginLayer );
+      if ( fieldConstraints.constraintOrigin( QgsFieldConstraints::ConstraintNotNull ) != QgsFieldConstraints::ConstraintOriginProvider )
+      {
+        if ( constraints & QgsFieldConstraints::ConstraintNotNull )
+          fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginLayer );
+        else
+          fieldConstraints.removeConstraint( QgsFieldConstraints::ConstraintNotNull );
+      }
+      if ( fieldConstraints.constraintOrigin( QgsFieldConstraints::ConstraintUnique ) != QgsFieldConstraints::ConstraintOriginProvider )
+      {
+        if ( constraints & QgsFieldConstraints::ConstraintUnique )
+          fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginLayer );
+        else
+          fieldConstraints.removeConstraint( QgsFieldConstraints::ConstraintUnique );
+      }
+      if ( fieldConstraints.constraintOrigin( QgsFieldConstraints::ConstraintExpression ) != QgsFieldConstraints::ConstraintOriginProvider )
+      {
+        if ( constraints & QgsFieldConstraints::ConstraintExpression )
+          fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintOriginLayer );
+        else
+          fieldConstraints.removeConstraint( QgsFieldConstraints::ConstraintExpression );
+      }
 
       const int uniqueStrength = constraintElement.attribute( QStringLiteral( "unique_strength" ), QStringLiteral( "1" ) ).toInt();
       const int notNullStrength = constraintElement.attribute( QStringLiteral( "notnull_strength" ), QStringLiteral( "1" ) ).toInt();

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -2186,7 +2186,7 @@ void QgsAttributesFormProperties::pasteWidgetConfiguration()
           QgsReadWriteContext context;
           if ( widgetType == QLatin1String( "ValueRelation" ) )
           {
-            optionsMap[ QStringLiteral( "Value" ) ] = context.projectTranslator()->translate( QStringLiteral( "project:layers:%1:fields:%2:valuerelationvalue" ).arg( mLayer->id(), fieldName ), optionsMap[ QStringLiteral( "Value" ) ].toString() );
+            optionsMap[QStringLiteral( "Value" )] = context.projectTranslator()->translate( QStringLiteral( "project:layers:%1:fields:%2:valuerelationvalue" ).arg( mLayer->id(), fieldName ), optionsMap[QStringLiteral( "Value" )].toString() );
           }
 
           config.mEditorWidgetType = widgetType;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -33,6 +33,9 @@
 #include <QHBoxLayout>
 #include <QFormLayout>
 #include <QPlainTextEdit>
+#include <QAction>
+#include <QMenu>
+#include <QClipboard>
 
 #include "ui_qgsattributesformproperties.h"
 #include "qgis_gui.h"
@@ -431,6 +434,9 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void onAttributeSelectionChanged();
     void onFormLayoutSelectionChanged();
 
+    //! Context menu for Fields and Relations to enable Copy&Paste
+    void onContextMenuRequested( QPoint );
+
     void updatedFields();
 
   private:
@@ -441,12 +447,16 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void storeAttributeWidgetEdit();
 
     void loadAttributeTypeDialog();
+    void loadAttributeTypeDialogFromConfiguration( const FieldConfig cfg );
     void storeAttributeTypeDialog();
 
     void storeAttributeContainerEdit();
     void loadAttributeContainerEdit();
 
     void loadInfoWidget( const QString &infoText );
+
+    void copyWidgetConfiguration();
+    void pasteWidgetConfiguration();
 
     QTreeWidgetItem *loadAttributeEditorTreeItem( QgsAttributeEditorElement *widgetDef, QTreeWidgetItem *parent, QgsAttributesDnDTree *tree );
 
@@ -455,6 +465,12 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QString mInitFilePath;
     QString mInitCode;
     int mBlockUpdates = 0;
+
+    //! Context menu for Fields and Relations
+    QMenu *mAvailableWidgetsTreeContextMenu = nullptr;
+    QAction *mActionCopyWidgetConfiguration = nullptr;
+    QAction *mActionPasteWidgetConfiguration = nullptr;
+
 };
 
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -473,7 +473,6 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QMenu *mAvailableWidgetsTreeContextMenu = nullptr;
     QAction *mActionCopyWidgetConfiguration = nullptr;
     QAction *mActionPasteWidgetConfiguration = nullptr;
-
 };
 
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -434,7 +434,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void onAttributeSelectionChanged();
     void onFormLayoutSelectionChanged();
 
-    //! Context menu for Fields and Relations to enable Copy&Paste
+    //! Context menu for Fields to enable Copy&Paste
     void onContextMenuRequested( QPoint );
 
     void updatedFields();
@@ -466,7 +466,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QString mInitCode;
     int mBlockUpdates = 0;
 
-    //! Context menu for Fields and Relations
+    //! Context menu for Fields
     QMenu *mAvailableWidgetsTreeContextMenu = nullptr;
     QAction *mActionCopyWidgetConfiguration = nullptr;
     QAction *mActionPasteWidgetConfiguration = nullptr;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -43,6 +43,7 @@
 #include "qgsexpressioncontextgenerator.h"
 #include "qgsattributeeditorelement.h"
 #include "qgspropertycollection.h"
+#include "qgsmessagebar.h"
 
 class QgsAttributesDnDTree;
 class QgsAttributeFormContainerEdit;
@@ -459,6 +460,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void pasteWidgetConfiguration();
 
     QTreeWidgetItem *loadAttributeEditorTreeItem( QgsAttributeEditorElement *widgetDef, QTreeWidgetItem *parent, QgsAttributesDnDTree *tree );
+
+    QgsMessageBar *mMessageBar = nullptr;
 
     Qgis::AttributeFormPythonInitCodeSource mInitCodeSource = Qgis::AttributeFormPythonInitCodeSource::NoSource;
     QString mInitFunction;


### PR DESCRIPTION

When designing forms (e.g., using the `Drag and Drop Designer`) in layers with multiple fields, chances are we want to set similar or even the same configurations for some of them that are somehow related (e.g., configuring latitude and longitude field widgets). This process is currently manual, which ends up being a bit tedious and error prone.

This PR adds a handy context menu (in the `Vector properties` dialog, `Attributes Form` tab, `Available Widgets` tree, `Fields` category, :) ),  allowing users to copy widget configurations between fields, and thus, saving time and making sure we'll not miss any particular setting by mistake.

![image](https://github.com/user-attachments/assets/e8fa40e0-c1bc-4a8e-ac7c-5ebaab7ceb90)


Implementation details:

 * Copy&paste of widget configuration can be done between fields of the same layer, between fields from different layers in the QGIS project, or between fields from layers in different QGIS instances.
 * Pasted widget configuration overwrites the target one, but is not applied automatically, so that users can see the pasted configuration and possibly tune it and apply it or avoid saving it by cancelling the dialog or just selecting another field.
 * We avoid copying aliases and comments. The target field ones are respected.
 * A widget configuration can be copied and pasted on the very same field, thus adding support for keeping a widget config in the clipboard, making and testing changes and eventually reverting them by pasting the clipboard content in the same field.
 * We only paste "editor widget configs" when the target field supports the source editor widget type. Otherwise, we leave the target editor widget type and config intact, while showing a warning message (in dialog's message bar) explaining why the config could not be pasted.
   ![image](https://github.com/user-attachments/assets/e83bc05d-0cb0-42d4-82a1-1e36e8ad4a22)
 * Target provider constraints are kept, we only paste constraints with layer origin.

Fix #58971

------------

Funded by Ville de Pully (Switzerland)