### PR TITLE
Fix layer datasources incorrectly resolving to matching working directory names

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -779,8 +779,7 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   QDomElement dataSource = document.createElement( QStringLiteral( "datasource" ) );
   const QgsDataProvider *provider = dataProvider();
   const QString providerKey = provider ? provider->name() : QString();
-  const QString srcRaw = encodedSource( source(), context );
-  const QString src = providerKey.isEmpty() ? srcRaw : QgsProviderRegistry::instance()->absoluteToRelativeUri( providerKey, srcRaw, context );
+  const QString src = encodedSource( source(), context );
   const QDomText dataSourceText = document.createTextNode( src );
   dataSource.appendChild( dataSourceText );
   layerElement.appendChild( dataSource );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -777,7 +777,6 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   // data source
   QDomElement dataSource = document.createElement( QStringLiteral( "datasource" ) );
   const QgsDataProvider *provider = dataProvider();
-  const QString providerKey = provider ? provider->name() : QString();
   const QString src = encodedSource( source(), context );
   const QDomText dataSourceText = document.createTextNode( src );
   dataSource.appendChild( dataSourceText );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -565,17 +565,16 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   mnl = layerElement.namedItem( QStringLiteral( "datasource" ) );
   mne = mnl.toElement();
   const QString dataSourceRaw = mne.text();
-  mDataSource = provider.isEmpty() ? dataSourceRaw : QgsProviderRegistry::instance()->relativeToAbsoluteUri( provider, dataSourceRaw, context );
 
   // if the layer needs authentication, ensure the master password is set
   const thread_local QRegularExpression rx( "authcfg=([a-z]|[A-Z]|[0-9]){7}" );
-  if ( rx.match( mDataSource ).hasMatch()
+  if ( rx.match( dataSourceRaw ).hasMatch()
        && !QgsApplication::authManager()->setMasterPassword( true ) )
   {
     return false;
   }
 
-  mDataSource = decodedSource( mDataSource, provider, context );
+  mDataSource = decodedSource( dataSourceRaw, provider, context );
 
   // Set the CRS from project file, asking the user if necessary.
   // Make it the saved CRS to have WMS layer projected correctly.

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -776,7 +776,6 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 
   // data source
   QDomElement dataSource = document.createElement( QStringLiteral( "datasource" ) );
-  const QgsDataProvider *provider = dataProvider();
   const QString src = encodedSource( source(), context );
   const QDomText dataSourceText = document.createTextNode( src );
   dataSource.appendChild( dataSourceText );

--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -291,6 +291,12 @@ QString QgsPathResolver::writePath( const QString &s ) const
   }
 
   const QFileInfo srcFileInfo( srcPath );
+  // Guard against relative paths: If srcPath is already relative, QFileInfo will match
+  // files in the working directory, instead of project directory. Avoid by returning early.
+  if ( !srcFileInfo.isAbsolute() )
+  {
+    return srcPath;
+  }
   if ( srcFileInfo.exists() )
     // Do NOT resolve symlinks, but do remove '..' and '.'
     srcPath = QDir::cleanPath( srcFileInfo.absoluteFilePath() );

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -1537,7 +1537,7 @@ void TestQgsProject::testSymlinks6ProjectFolder()
 
 void TestQgsProject::regression60100()
 {
-/*
+  /*
  * Regression test for QGIS issue #60100 (https://github.com/qgis/QGIS/issues/60100)
  * This test ensures that when saving a QGIS project with relative paths,
  * the correct layer datasource is preserved, even when the current working
@@ -1584,7 +1584,7 @@ void TestQgsProject::regression60100()
     projDirPath + QStringLiteral( "/points.geojson" ),
     QStringLiteral( "Test Points" ),
     QStringLiteral( "ogr" )
-    );
+  );
   project->addMapLayer( layer.release() );
 
   // Write (save) the project to disk. This used to pick up the WRONG file and save it to the proj.

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -1538,25 +1538,24 @@ void TestQgsProject::testSymlinks6ProjectFolder()
 void TestQgsProject::regression60100()
 {
   /*
- * Regression test for QGIS issue #60100 (https://github.com/qgis/QGIS/issues/60100)
- * This test ensures that when saving a QGIS project with relative paths,
- * the correct layer datasource is preserved, even when the current working
- * directory (CWD) contains a file with the same name as the layer datasource.
- *
- * Previous behavior:
- * - If a file with the same name as a layer datasource existed in the CWD,
- *   the layer path in the saved project would point to the file in the CWD,
- *   rather than the intended file in the project directory (PROJDIR).
- *
- * Test steps:
- * 1. Create a temporary directory structure with two subfolders: WORKDIR and PROJDIR.
- * 2. Copy a `points.geojson` file to both WORKDIR and PROJDIR.
- * 3. Create a new QGIS project in PROJDIR and add the `points.geojson` file from PROJDIR as a layer.
- * 4. Change the working directory to WORKDIR and save the project.
- * 5. Verify that the saved project references the correct datasource (`./points.geojson` in PROJDIR)
- *    and does not erroneously reference the file in WORKDIR.
- */
-
+  * Regression test for QGIS issue #60100 (https://github.com/qgis/QGIS/issues/60100)
+  * This test ensures that when saving a QGIS project with relative paths,
+  * the correct layer datasource is preserved, even when the current working
+  * directory (CWD) contains a file with the same name as the layer datasource.
+  *
+  * Previous behavior:
+  * - If a file with the same name as a layer datasource existed in the CWD,
+  *   the layer path in the saved project would point to the file in the CWD,
+  *   rather than the intended file in the project directory (PROJDIR).
+  *
+  * Test steps:
+  * 1. Create a temporary directory structure with two subfolders: WORKDIR and PROJDIR.
+  * 2. Copy a `points.geojson` file to both WORKDIR and PROJDIR.
+  * 3. Create a new QGIS project in PROJDIR and add the `points.geojson` file from PROJDIR as a layer.
+  * 4. Change the working directory to WORKDIR and save the project.
+  * 5. Verify that the saved project references the correct datasource (`./points.geojson` in PROJDIR)
+  *    and does not erroneously reference the file in WORKDIR.
+  */
   // Create directory structure with 2 subfolders
   const QTemporaryDir baseDir;
   const QDir base( baseDir.path() );


### PR DESCRIPTION
## Description

In short, this addresses the issue outlined here: https://github.com/qgis/QGIS/issues/60100

- Remove redundant second call to `absoluteToRelativeUri` in `QgsMapLayer::writeLayerXml` which was the cause of the original bug
- Add a guard in `QgsPathResolver::writePath` to prevent this happening again. Now, if `absoluteToRelativeUri` is called on the relative path, the function will return early
- Remove redundant second call to `relativeToAbsoluteUri`. `QgsPathResolver::readPath` already contains a guard that returns early when absolute path is supplied. Still, makes sense to remove the call, as it tries to call `relativeToAbsoluteUri` with an absolute path argument and was introduced in the same commit https://github.com/qgis/QGIS/commit/b9c1c2c4e97efce0c603751d3bdef7a5561db47b as the redundant call causing issues above.
- Add a regression test, replicating the scenario outlined in the issue.


I think that the PR should be backported to the latest version, as this is an annoying bug for Linux users (#60100, possibly #59282).
