### PR TITLE
chore(spatial index): Remove duplicate rectangleToRegion code

### DIFF
--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsmeshspatialindex.h"
 #include "qgsrectangle.h"
+#include "qgsspatialindexutils.h"
 #include "qgslogger.h"
 #include "qgsfeedback.h"
 
@@ -71,13 +72,6 @@ static Region edgeToRegion( const QgsMesh &mesh, int id, bool &ok )
   double pt1[2] = { xMinimum, yMinimum };
   double pt2[2] = { xMaximum, yMaximum };
   ok = true;
-  return SpatialIndex::Region( pt1, pt2, 2 );
-}
-
-static Region rectToRegion( const QgsRectangle &rect )
-{
-  double pt1[2] = { rect.xMinimum(), rect.yMinimum() };
-  double pt2[2] = { rect.xMaximum(), rect.yMaximum() };
   return SpatialIndex::Region( pt1, pt2, 2 );
 }
 
@@ -376,7 +370,7 @@ QList<int> QgsMeshSpatialIndex::intersects( const QgsRectangle &rect ) const
   QList<int> list;
   QgisMeshVisitor visitor( list );
 
-  const SpatialIndex::Region r = rectToRegion( rect );
+  const SpatialIndex::Region r = QgsSpatialIndexUtils::rectangleToRegion( rect );
 
   const QMutexLocker locker( &d->mMutex );
   d->mRTree->intersectsWithQuery( r, visitor );


### PR DESCRIPTION
## Description

`rectToRegion` and `rect2region` are the same functions as better named `rectangleToRegion` in `QgsSpatialIndexUtils`. This PR removes the duplicated code and uses only one from `QgsSpatialIndexUtils`

cc @ptitjano 