### PR TITLE
Allow closed polygon shapes in 3d rubber bands

### DIFF
--- a/src/3d/qgsrubberband3d.h
+++ b/src/3d/qgsrubberband3d.h
@@ -120,6 +120,8 @@ class _3D_EXPORT QgsRubberBand3D
 
     void addPoint( const QgsPoint &pt );
 
+    void setPoints( const QgsLineString &points );
+
     void removeLastPoint();
 
     void moveLastPoint( const QgsPoint &pt );

--- a/src/3d/symbols/qgslinevertexdata_p.cpp
+++ b/src/3d/symbols/qgslinevertexdata_p.cpp
@@ -117,7 +117,7 @@ Qt3DQGeometry *QgsLineVertexData::createGeometry( Qt3DCore::QNode *parent )
   return geom;
 }
 
-void QgsLineVertexData::addLineString( const QgsLineString &lineString, float extraHeightOffset )
+void QgsLineVertexData::addLineString( const QgsLineString &lineString, float extraHeightOffset, bool closePolygon )
 {
   if ( withAdjacency )
     indexes << vertices.count(); // add the following vertex (for adjacency)
@@ -132,6 +132,8 @@ void QgsLineVertexData::addLineString( const QgsLineString &lineString, float ex
       break;
   }
 
+  const int firstIndex = vertices.count();
+
   for ( int i = 0; i < lineString.vertexCount(); ++i )
   {
     QgsPoint p = lineString.pointN( i );
@@ -140,6 +142,9 @@ void QgsLineVertexData::addLineString( const QgsLineString &lineString, float ex
     vertices << QVector3D( static_cast<float>( p.x() - origin.x() ), static_cast<float>( p.y() - origin.y() ), z );
     indexes << vertices.count() - 1;
   }
+
+  if ( closePolygon )
+    indexes << firstIndex; // repeat the first vertex
 
   if ( withAdjacency )
     indexes << vertices.count() - 1; // add the last vertex (for adjacency)

--- a/src/3d/symbols/qgslinevertexdata_p.h
+++ b/src/3d/symbols/qgslinevertexdata_p.h
@@ -95,7 +95,7 @@ struct QgsLineVertexData
     Qt3DCore::QGeometry *createGeometry( Qt3DCore::QNode *parent );
 #endif
 
-    void addLineString( const QgsLineString &lineString, float extraHeightOffset = 0 );
+    void addLineString( const QgsLineString &lineString, float extraHeightOffset = 0, bool closePolygon = false );
     void addVerticalLines( const QgsLineString &lineString, float verticalLength, float extraHeightOffset = 0 );
 };
 


### PR DESCRIPTION
## Description
This allows polygons to be used in 3d rubber bands, rendered as a closed polyline, with optional rendering of vertex markers.
Will be used in 3d map canvas point selection tools for point cloud editing.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
