### PR TITLE
Revert "CI: Run MINGW64 job on Fedora 41" (Fix #60035)

### DIFF
--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -29,7 +29,7 @@ jobs:
     name: MinGW64 Windows Build
     runs-on: ubuntu-latest
     container:
-      image: fedora:41
+      image: fedora:39
       options: --security-opt seccomp=unconfined
       volumes:
         - ${{ github.workspace }}:/w


### PR DESCRIPTION
Reverts qgis/QGIS#60006.
Fixes https://github.com/qgis/QGIS/issues/60035.
What do you think @MehdiChinoune?