### PR TITLE
Point cloud editing: rewrite COPC when committing changes

### DIFF
--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
@@ -169,6 +169,7 @@ index is memory safe.
 
     operator bool() const;
 
+
     void load( const QString &fileName );
 %Docstring
 Loads the index from the file
@@ -355,9 +356,11 @@ in an implementation-specific dynamic structure.
 .. seealso:: :py:func:`QgsAbstractPointCloudIndex.extraMetadata`
 %End
 
-    bool commitChanges();
+    bool commitChanges( QString *errorMessage /Out/ = 0 );
 %Docstring
 Tries to store pending changes to the data provider.
+If errorMessage is not a null pointer, it will receive
+an error message in case the call failed.
 
 :return: ``True`` on success, otherwise ``False``
 %End

--- a/python/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
@@ -169,6 +169,7 @@ index is memory safe.
 
     operator bool() const;
 
+
     void load( const QString &fileName );
 %Docstring
 Loads the index from the file
@@ -355,9 +356,11 @@ in an implementation-specific dynamic structure.
 .. seealso:: :py:func:`QgsAbstractPointCloudIndex.extraMetadata`
 %End
 
-    bool commitChanges();
+    bool commitChanges( QString *errorMessage /Out/ = 0 );
 %Docstring
 Tries to store pending changes to the data provider.
+If errorMessage is not a null pointer, it will receive
+an error message in case the call failed.
 
 :return: ``True`` on success, otherwise ``False``
 %End

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -713,6 +713,7 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
     QgsPointCloudLayer *pclayer = qobject_cast<QgsPointCloudLayer *>( layer );
     connect( pclayer, &QgsPointCloudLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
     connect( pclayer, &QgsPointCloudLayer::subsetStringChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
+    connect( pclayer, &QgsPointCloudLayer::layerModified, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
 }
 
@@ -748,6 +749,7 @@ void Qgs3DMapScene::removeLayerEntity( QgsMapLayer *layer )
     QgsPointCloudLayer *pclayer = qobject_cast<QgsPointCloudLayer *>( layer );
     disconnect( pclayer, &QgsPointCloudLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
     disconnect( pclayer, &QgsPointCloudLayer::subsetStringChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
+    disconnect( pclayer, &QgsPointCloudLayer::layerModified, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2280,6 +2280,7 @@ if (WITH_EPT OR WITH_COPC)
     ${CMAKE_SOURCE_DIR}/external/lazperf/header.cpp
     ${CMAKE_SOURCE_DIR}/external/lazperf/lazperf.cpp
     ${CMAKE_SOURCE_DIR}/external/lazperf/readers.cpp
+    ${CMAKE_SOURCE_DIR}/external/lazperf/writers.cpp
     ${CMAKE_SOURCE_DIR}/external/lazperf/vlr.cpp
     ${CMAKE_SOURCE_DIR}/external/lazperf/detail/field_byte10.cpp
     ${CMAKE_SOURCE_DIR}/external/lazperf/detail/field_byte14.cpp
@@ -2296,11 +2297,13 @@ if (WITH_EPT OR WITH_COPC)
       pointcloud/qgseptdecoder.cpp
       pointcloud/qgslazdecoder.cpp
       pointcloud/qgslazinfo.cpp
+      pointcloud/qgscopcupdate.cpp
   )
   set(QGIS_CORE_HDRS ${QGIS_CORE_HDRS}
       pointcloud/qgseptdecoder.h
       pointcloud/qgslazdecoder.h
       pointcloud/qgslazinfo.h
+      pointcloud/qgscopcupdate.h
   )
 endif()
 

--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -512,6 +512,32 @@ QByteArray QgsCopcPointCloudIndex::fetchCopcStatisticsEvlrData() const
   return statisticsEvlrData;
 }
 
+void QgsCopcPointCloudIndex::reset()
+{
+  // QgsAbstractPointCloudIndex
+  mExtent = QgsRectangle();
+  mZMin = 0;
+  mZMax = 0;
+  mHierarchy.clear();
+  mScale = QgsVector3D();
+  mOffset = QgsVector3D();
+  mRootBounds = QgsBox3D();
+  mAttributes = QgsPointCloudAttributeCollection();
+  mSpan = 0;
+  //mFilterExpression
+  mError.clear();
+  //mUri
+
+  // QgsCopcPointCloudIndex
+  mIsValid = false;
+  mAccessType = Qgis::PointCloudAccessType::Local;
+  mCopcFile.close();
+  mOriginalMetadata.clear();
+  mStatistics.reset();
+  mLazInfo.reset();
+  mHierarchyNodePos.clear();
+}
+
 QVariantMap QgsCopcPointCloudIndex::extraMetadata() const
 {
   return

--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -524,9 +524,7 @@ void QgsCopcPointCloudIndex::reset()
   mRootBounds = QgsBox3D();
   mAttributes = QgsPointCloudAttributeCollection();
   mSpan = 0;
-  //mFilterExpression
   mError.clear();
-  //mUri
 
   // QgsCopcPointCloudIndex
   mIsValid = false;

--- a/src/core/pointcloud/qgscopcpointcloudindex.h
+++ b/src/core/pointcloud/qgscopcpointcloudindex.h
@@ -109,6 +109,8 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsAbstractPointCloudIndex
 
     QByteArray fetchCopcStatisticsEvlrData() const;
 
+    void reset();
+
     bool mIsValid = false;
     Qgis::PointCloudAccessType mAccessType = Qgis::PointCloudAccessType::Local;
     mutable std::ifstream mCopcFile;
@@ -119,6 +121,9 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsAbstractPointCloudIndex
     mutable std::optional<QgsPointCloudStatistics> mStatistics;
 
     std::unique_ptr<QgsLazInfo> mLazInfo = nullptr;
+
+    friend class QgsPointCloudLayerEditUtils;
+    friend class QgsPointCloudEditingIndex;
 };
 
 ///@endcond

--- a/src/core/pointcloud/qgscopcupdate.cpp
+++ b/src/core/pointcloud/qgscopcupdate.cpp
@@ -124,7 +124,7 @@ bool QgsCopcUpdate::write( QString outputFilename, const QHash<QgsPointCloudNode
       const UpdatedChunk &updatedChunk = updatedChunks[k];
 
       // use updated one and skip in the original file
-      mFile.seekg( mFile.tellg() + static_cast<long>( ch.offset ) );
+      mFile.seekg( static_cast<long>( mFile.tellg() ) + static_cast<long>( ch.offset ) );
 
       m_f.write( updatedChunk.chunkData.constData(), updatedChunk.chunkData.size() );
 

--- a/src/core/pointcloud/qgscopcupdate.cpp
+++ b/src/core/pointcloud/qgscopcupdate.cpp
@@ -1,0 +1,392 @@
+/***************************************************************************
+    qgscopcupdate.cpp
+    ---------------------
+    begin                : January 2025
+    copyright            : (C) 2025 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscopcupdate.h"
+
+#include "qgslazdecoder.h"
+
+#include <fstream>
+#include <iostream>
+
+#include <lazperf/header.hpp>
+#include <lazperf/vlr.hpp>
+#include <lazperf/Extractor.hpp>
+#include <lazperf/filestream.hpp>
+#include <lazperf/readers.hpp>
+#include <lazperf/writers.hpp>
+
+
+//! Keeps one entry of COPC hierarchy
+struct HierarchyEntry
+{
+  //! Key of the data to which this entry corresponds
+  QgsPointCloudNodeId key;
+
+  /**
+   * Absolute offset to the data chunk if the pointCount > 0.
+   * Absolute offset to a child hierarchy page if the pointCount is -1.
+   * 0 if the pointCount is 0.
+   */
+  uint64_t offset;
+
+  /**
+   * Size of the data chunk in bytes (compressed size) if the pointCount > 0.
+   * Size of the hierarchy page if the pointCount is -1.
+   * 0 if the pointCount is 0.
+   */
+  int32_t byteSize;
+
+  /**
+   * If > 0, represents the number of points in the data chunk.
+   * If -1, indicates the information for this octree node is found in another hierarchy page.
+   * If 0, no point data exists for this key, though may exist for child entries.
+   */
+  int32_t pointCount;
+};
+
+typedef QVector<HierarchyEntry> HierarchyEntries;
+
+
+HierarchyEntries getHierarchyPage( std::ifstream &file, uint64_t offset, uint64_t size )
+{
+  HierarchyEntries page;
+  std::vector<char> buf( 32 );
+  int numEntries = size / 32;
+  file.seekg( offset );
+  while ( numEntries-- )
+  {
+    file.read( buf.data(), buf.size() );
+    lazperf::LeExtractor s( buf.data(), buf.size() );
+
+    HierarchyEntry e;
+    int d, x, y, z;
+    s >> d >> x >> y >> z;
+    s >> e.offset >> e.byteSize >> e.pointCount;
+    e.key = QgsPointCloudNodeId( d, x, y, z );
+
+    page.push_back( e );
+  }
+  return page;
+}
+
+
+bool QgsCopcUpdate::write( QString outputFilename, const QHash<QgsPointCloudNodeId, UpdatedChunk> &updatedChunks )
+{
+
+  std::ofstream m_f;
+  m_f.open( QgsLazDecoder::toNativePath( outputFilename ), std::ios::out | std::ios::binary );
+
+  // write header and all VLRs all the way to point offset
+  // (then we patch what we need)
+  mFile.seekg( 0 );
+  std::vector<char> allHeaderData;
+  allHeaderData.resize( mHeader.point_offset );
+  mFile.read( allHeaderData.data(), allHeaderData.size() );
+  m_f.write( allHeaderData.data(), allHeaderData.size() );
+
+  m_f.write( "XXXXXXXX", 8 ); // placeholder for chunk table offset
+
+  uint64_t currentChunkOffset = mHeader.point_offset + 8;
+  mFile.seekg( currentChunkOffset ); // this is where first chunk starts
+
+  // now, let's write chunks:
+  // - iterate through original chunk table, write out chunks
+  //   - if chunk is updated, use that instead
+  //   - keep updating hierarchy as we go
+  //   - keep updating chunk table as we go
+
+  QHash<QgsPointCloudNodeId, uint64_t> voxelToNewOffset;
+
+  int chIndex = 0;
+  for ( lazperf::chunk ch : mChunks )
+  {
+    Q_ASSERT( mOffsetToVoxel.contains( currentChunkOffset ) );
+    QgsPointCloudNodeId k = mOffsetToVoxel[currentChunkOffset];
+
+    uint64_t newOffset = m_f.tellp();
+    voxelToNewOffset[k] = newOffset;
+
+    // check whether the chunk is modified
+    if ( updatedChunks.contains( k ) )
+    {
+      const UpdatedChunk &updatedChunk = updatedChunks[k];
+
+      // use updated one and skip in the original file
+      mFile.seekg( ( uint64_t )mFile.tellg() + ch.offset );
+
+      m_f.write( updatedChunk.chunkData.constData(), updatedChunk.chunkData.size() );
+
+      // update sizes
+      mChunks[chIndex].offset = updatedChunk.chunkData.size();
+    }
+    else
+    {
+      // use as is
+      std::vector<char> chunkDataX;
+      chunkDataX.resize( ch.offset );
+      mFile.read( chunkDataX.data(), chunkDataX.size() );
+      m_f.write( chunkDataX.data(), chunkDataX.size() );
+    }
+
+    currentChunkOffset += ch.offset;
+    ++chIndex;
+  }
+
+  // write chunk table: size in bytes + point count of each chunk
+
+  uint64_t newChunkTableOffset = m_f.tellp();
+
+  m_f.write( "\0\0\0\0", 4 ); // chunk table version
+  m_f.write( ( char * )&mChunkCount, sizeof( mChunkCount ) );
+
+  lazperf::OutFileStream outStream( m_f );
+  lazperf::compress_chunk_table( outStream.cb(), mChunks, true );
+
+  // update hierarchy
+
+  // NOTE: one big assumption we're doing here is that existing hierarchy pages
+  // are packed one after another, with no gaps. if that's not the case, things
+  // will break apart
+
+  int hierPositionShift = ( uint64_t )m_f.tellp() + 60 - mHierarchyOffset;
+
+  HierarchyEntry *oldCopcHierarchyBlobEntries = ( HierarchyEntry * ) mHierarchyBlob.data();
+  int nEntries = mHierarchyBlob.size() / 32;
+  for ( int i = 0; i < nEntries; ++i )
+  {
+    HierarchyEntry &e = oldCopcHierarchyBlobEntries[i];
+    if ( e.pointCount > 0 )
+    {
+      // update entry to new offset
+      Q_ASSERT( voxelToNewOffset.contains( e.key ) );
+      e.offset = voxelToNewOffset[e.key];
+
+      if ( updatedChunks.contains( e.key ) )
+      {
+        uint64_t newByteSize = updatedChunks[e.key].chunkData.size();
+        e.byteSize = newByteSize;
+      }
+    }
+    else if ( e.pointCount < 0 )
+    {
+      // move hierarchy pages to new offset
+      e.offset += hierPositionShift;
+    }
+    else  // pointCount == 0
+    {
+      // nothing to do - byte size and offset should be zero
+    }
+
+  }
+
+  // write hierarchy eVLR
+
+  uint64_t newEvlrOffset = m_f.tellp();
+
+  lazperf::evlr_header outCopcHierEvlr;
+  outCopcHierEvlr.reserved = 0;
+  outCopcHierEvlr.user_id = "copc";
+  outCopcHierEvlr.record_id = 1000;
+  outCopcHierEvlr.data_length = mHierarchyBlob.size();
+  outCopcHierEvlr.description = "EPT Hierarchy";
+
+  outCopcHierEvlr.write( m_f );
+  m_f.write( mHierarchyBlob.data(), mHierarchyBlob.size() );
+
+  // write other eVLRs
+
+  for ( size_t i = 0; i < mEvlrHeaders.size(); ++i )
+  {
+    lazperf::evlr_header evlrHeader = mEvlrHeaders[i];
+    std::vector<char> evlrBody = mEvlrData[i];
+
+    evlrHeader.write( m_f );
+    m_f.write( evlrBody.data(), evlrBody.size() );
+  }
+
+  // patch header
+
+  m_f.seekp( 235 );
+  m_f.write( ( const char * )&newEvlrOffset, 8 );
+
+  uint64_t newRootHierOffset = mCopcVlr.root_hier_offset + hierPositionShift;
+  m_f.seekp( 469 );
+  m_f.write( ( const char * )&newRootHierOffset, 8 );
+
+  m_f.seekp( mHeader.point_offset );
+  m_f.write( ( const char * )&newChunkTableOffset, 8 );
+
+  return true;
+}
+
+
+
+bool QgsCopcUpdate::read( QString inputFilename )
+{
+  mInputFilename = inputFilename;
+
+  mFile.open( QgsLazDecoder::toNativePath( inputFilename ), std::ios::binary | std::ios::in );
+  if ( mFile.fail() )
+  {
+    mErrorMessage = "Could not open file for reading: " + inputFilename;
+    return false;
+  }
+
+  if ( !readHeader() )
+    return false;
+
+  readChunkTable();
+  readHierarchy();
+
+  return true;
+}
+
+
+bool QgsCopcUpdate::readHeader()
+{
+  // read header and COPC VLR
+  mHeader = lazperf::header14::create( mFile );
+  if ( !mFile )
+  {
+    mErrorMessage = "Error reading COPC header";
+    return false;
+  }
+
+  lazperf::vlr_header vh = lazperf::vlr_header::create( mFile );
+  mCopcVlr = lazperf::copc_info_vlr::create( mFile );
+
+  int baseCount = lazperf::baseCount( mHeader.point_format_id );
+  if ( baseCount == 0 )
+  {
+    mErrorMessage = QString( "Bad point record format: %1" ).arg( mHeader.point_format_id );
+    return false;
+  }
+
+  return true;
+}
+
+
+void QgsCopcUpdate::readChunkTable()
+{
+  uint64_t chunkTableOffset;
+
+  mFile.seekg( mHeader.point_offset );
+  mFile.read( ( char * )&chunkTableOffset, sizeof( chunkTableOffset ) );
+  mFile.seekg( chunkTableOffset + 4 ); // The first 4 bytes are the version, then the chunk count.
+  mFile.read( ( char * )&mChunkCount, sizeof( mChunkCount ) );
+
+  //
+  // read chunk table
+  //
+
+  bool variable = true;
+
+  // TODO: not sure why, but after decompress_chunk_table() the input stream seems to be dead, so we create a temporary one
+  std::ifstream copcFileTmp;
+  copcFileTmp.open( QgsLazDecoder::toNativePath( mInputFilename ), std::ios::binary | std::ios::in );
+  copcFileTmp.seekg( mFile.tellg() );
+  lazperf::InFileStream copcInFileStream( copcFileTmp );
+
+  mChunks = lazperf::decompress_chunk_table( copcInFileStream.cb(), mChunkCount, variable );
+  std::vector<lazperf::chunk> chunksWithAbsoluteOffsets;
+  uint64_t nextChunkOffset = mHeader.point_offset + 8;
+  for ( lazperf::chunk ch : mChunks )
+  {
+    chunksWithAbsoluteOffsets.push_back( {nextChunkOffset, ch.count} );
+    nextChunkOffset += ch.offset;
+  }
+}
+
+
+void QgsCopcUpdate::readHierarchy()
+{
+
+  // get all hierarchy pages
+
+  HierarchyEntries childEntriesToProcess;
+  childEntriesToProcess.push_back( HierarchyEntry{ QgsPointCloudNodeId( 0, 0, 0, 0 ), mCopcVlr.root_hier_offset, ( int32_t )mCopcVlr.root_hier_size, -1 } );
+
+  while ( !childEntriesToProcess.empty() )
+  {
+    HierarchyEntry childEntry = childEntriesToProcess.back();
+    childEntriesToProcess.pop_back();
+
+    HierarchyEntries page = getHierarchyPage( mFile, childEntry.offset, childEntry.byteSize );
+
+    for ( const HierarchyEntry &e : page )
+    {
+      if ( e.pointCount > 0 ) // it's a non-empty node
+      {
+        Q_ASSERT( !mOffsetToVoxel.contains( e.offset ) );
+        mOffsetToVoxel[e.offset] = e.key;
+      }
+      else if ( e.pointCount < 0 ) // referring to a child page
+      {
+        childEntriesToProcess.push_back( e );
+      }
+    }
+  }
+
+  lazperf::evlr_header evlr1;
+  mFile.seekg( mHeader.evlr_offset );
+
+  mHierarchyOffset = 0;  // where the hierarchy eVLR payload starts
+
+  for ( uint32_t i = 0; i < mHeader.evlr_count; ++i )
+  {
+    evlr1.read( mFile );
+    if ( evlr1.user_id == "copc" && evlr1.record_id == 1000 )
+    {
+      mHierarchyBlob.resize( evlr1.data_length );
+      mHierarchyOffset = mFile.tellg();
+      mFile.read( mHierarchyBlob.data(), evlr1.data_length );
+    }
+    else
+    {
+      // keep for later
+      mEvlrHeaders.push_back( evlr1 );
+      std::vector<char> evlrBlob;
+      evlrBlob.resize( evlr1.data_length );
+      mFile.read( evlrBlob.data(), evlrBlob.size() );
+      mEvlrData.push_back( evlrBlob );
+    }
+  }
+
+  Q_ASSERT( !mHierarchyBlob.empty() );
+}
+
+
+bool QgsCopcUpdate::writeUpdatedFile( const QString &inputFilename,
+                                      const QString &outputFilename,
+                                      const QHash<QgsPointCloudNodeId, UpdatedChunk> &updatedChunks,
+                                      QString *errorMessage )
+{
+  QgsCopcUpdate copcUpdate;
+  if ( !copcUpdate.read( inputFilename ) )
+  {
+    if ( errorMessage )
+      *errorMessage = copcUpdate.errorMessage();
+    return false;
+  }
+
+  if ( !copcUpdate.write( outputFilename, updatedChunks ) )
+  {
+    if ( errorMessage )
+      *errorMessage = copcUpdate.errorMessage();
+    return false;
+  }
+
+  return true;
+}

--- a/src/core/pointcloud/qgscopcupdate.h
+++ b/src/core/pointcloud/qgscopcupdate.h
@@ -23,10 +23,16 @@
 
 #include "qgspointcloudindex.h"
 
+#define SIP_NO_FILE
+
 
 /**
+ * \ingroup core
+ *
  * This class takes an existing COPC file and a list of chunks that should be modified,
  * and outputs an updated COPC file where the modified chunks replace the original chunks.
+ *
+ * \note The API is considered EXPERIMENTAL and can be changed without a notice
  *
  * \since QGIS 3.42
  */

--- a/src/core/pointcloud/qgscopcupdate.h
+++ b/src/core/pointcloud/qgscopcupdate.h
@@ -17,11 +17,10 @@
 #define QGSCOPCUPDATE_H
 
 #include "qgis_core.h"
+#include "qgspointcloudindex.h"
 
 #include <lazperf/header.hpp>
 #include <lazperf/vlr.hpp>
-
-#include "qgspointcloudindex.h"
 
 #define SIP_NO_FILE
 
@@ -50,10 +49,10 @@ class CORE_EXPORT QgsCopcUpdate
     };
 
     //! Reads input COPC file and initializes all the members
-    bool read( QString inputFilename );
+    bool read( const QString &inputFilename );
 
     //! Writes a COPC file with updated chunks
-    bool write( QString outputFilename, const QHash<QgsPointCloudNodeId, UpdatedChunk> &updatedChunks );
+    bool write( const QString &outputFilename, const QHash<QgsPointCloudNodeId, UpdatedChunk> &updatedChunks );
 
     //! Returns error message
     QString errorMessage() const { return mErrorMessage; }
@@ -81,7 +80,7 @@ class CORE_EXPORT QgsCopcUpdate
     lazperf::header14 mHeader;
     lazperf::copc_info_vlr mCopcVlr;
     std::vector<lazperf::chunk> mChunks;
-    uint32_t mChunkCount;
+    uint32_t mChunkCount = 0;
     uint64_t mHierarchyOffset = 0;
     std::vector<char> mHierarchyBlob;
     std::vector<lazperf::evlr_header> mEvlrHeaders;

--- a/src/core/pointcloud/qgscopcupdate.h
+++ b/src/core/pointcloud/qgscopcupdate.h
@@ -1,0 +1,88 @@
+/***************************************************************************
+    qgscopcupdate.h
+    ---------------------
+    begin                : January 2025
+    copyright            : (C) 2025 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCOPCUPDATE_H
+#define QGSCOPCUPDATE_H
+
+#include "qgis_core.h"
+
+#include <lazperf/header.hpp>
+#include <lazperf/vlr.hpp>
+
+#include "qgspointcloudindex.h"
+
+
+/**
+ * This class takes an existing COPC file and a list of chunks that should be modified,
+ * and outputs an updated COPC file where the modified chunks replace the original chunks.
+ *
+ * \since QGIS 3.42
+ */
+class CORE_EXPORT QgsCopcUpdate
+{
+  public:
+
+    //! Keeps information how points of a single chunk has been modified
+    struct UpdatedChunk
+    {
+      //! Number of points in the updated chunk
+      int32_t pointCount;
+      //! Data of the chunk (compressed already with LAZ compressor)
+      QByteArray chunkData;
+    };
+
+    //! Reads input COPC file and initializes all the members
+    bool read( QString inputFilename );
+
+    //! Writes a COPC file with updated chunks
+    bool write( QString outputFilename, const QHash<QgsPointCloudNodeId, UpdatedChunk> &updatedChunks );
+
+    //! Returns error message
+    QString errorMessage() const { return mErrorMessage; }
+
+    /**
+     * Convenience function to do the whole process in one go:
+     * load a COPC file, then write a new COPC file with updated
+     * chunks. Returns TRUE on success. If errorMessage is not
+     * a null pointer, it will be set to an error message in case
+     * of failure (i.e. FALSE is returned).
+     */
+    static bool writeUpdatedFile( const QString &inputFilename,
+                                  const QString &outputFilename,
+                                  const QHash<QgsPointCloudNodeId, UpdatedChunk> &updatedChunks,
+                                  QString *errorMessage = nullptr );
+
+  private:
+    bool readHeader();
+    void readChunkTable();
+    void readHierarchy();
+
+  private:
+    QString mInputFilename;
+    std::ifstream mFile;
+    lazperf::header14 mHeader;
+    lazperf::copc_info_vlr mCopcVlr;
+    std::vector<lazperf::chunk> mChunks;
+    uint32_t mChunkCount;
+    uint64_t mHierarchyOffset = 0;
+    std::vector<char> mHierarchyBlob;
+    std::vector<lazperf::evlr_header> mEvlrHeaders;
+    std::vector<std::vector<char>> mEvlrData;
+    QHash<uint64_t, QgsPointCloudNodeId> mOffsetToVoxel;
+
+    QString mErrorMessage;
+};
+
+#endif // QGSCOPCUPDATE_H

--- a/src/core/pointcloud/qgspointcloudeditingindex.h
+++ b/src/core/pointcloud/qgspointcloudeditingindex.h
@@ -57,9 +57,11 @@ class CORE_EXPORT QgsPointCloudEditingIndex : public QgsAbstractPointCloudIndex
 
     /**
      * Tries to store pending changes to the data provider.
+     * If errorMessage is not a null pointer, it will receive
+     * an error message in case the call failed.
      * \return TRUE on success, otherwise FALSE
      */
-    bool commitChanges();
+    bool commitChanges( QString *errorMessage = nullptr );
 
     //! Returns TRUE if there are uncommitted changes, FALSE otherwise
     bool isModified() const;
@@ -69,6 +71,8 @@ class CORE_EXPORT QgsPointCloudEditingIndex : public QgsAbstractPointCloudIndex
     QgsPointCloudIndex mIndex;
     bool mIsValid = false;
     QHash<QgsPointCloudNodeId, QByteArray> mEditedNodeData;
+
+    friend class QgsPointCloudLayerEditUtils;
 };
 
 #endif // QGSPOINTCLOUDEDITINGINDEX_H

--- a/src/core/pointcloud/qgspointcloudindex.cpp
+++ b/src/core/pointcloud/qgspointcloudindex.cpp
@@ -504,11 +504,11 @@ QVariantMap QgsPointCloudIndex::extraMetadata() const
   return mIndex->extraMetadata();
 }
 
-bool QgsPointCloudIndex::commitChanges()
+bool QgsPointCloudIndex::commitChanges( QString *errorMessage )
 {
   Q_ASSERT( mIndex );
   if ( QgsPointCloudEditingIndex *index = dynamic_cast<QgsPointCloudEditingIndex *>( mIndex.get() ) )
-    return index->commitChanges();
+    return index->commitChanges( errorMessage );
 
   return false;
 }

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -422,6 +422,9 @@ class CORE_EXPORT QgsPointCloudIndex SIP_NODEFAULTCTORS
     //! Checks if index is non-null
     operator bool() const;
 
+    //! Returns pointer to the implementation class
+    QgsAbstractPointCloudIndex *get() SIP_SKIP { return mIndex.get(); }
+
     /**
     * Loads the index from the file
     *
@@ -643,9 +646,11 @@ class CORE_EXPORT QgsPointCloudIndex SIP_NODEFAULTCTORS
 
     /**
      * Tries to store pending changes to the data provider.
+     * If errorMessage is not a null pointer, it will receive
+     * an error message in case the call failed.
      * \return TRUE on success, otherwise FALSE
      */
-    bool commitChanges();
+    bool commitChanges( QString *errorMessage SIP_OUT = nullptr );
 
     //! Returns TRUE if there are uncommitted changes, FALSE otherwise
     bool isModified() const;
@@ -654,6 +659,8 @@ class CORE_EXPORT QgsPointCloudIndex SIP_NODEFAULTCTORS
     std::shared_ptr<QgsAbstractPointCloudIndex> mIndex;
 
     friend class TestQgsPointCloudEditing;
+    friend class QgsPointCloudLayerEditUtils;
+    friend class QgsPointCloudEditingIndex;
 };
 
 

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -659,8 +659,6 @@ class CORE_EXPORT QgsPointCloudIndex SIP_NODEFAULTCTORS
     std::shared_ptr<QgsAbstractPointCloudIndex> mIndex;
 
     friend class TestQgsPointCloudEditing;
-    friend class QgsPointCloudLayerEditUtils;
-    friend class QgsPointCloudEditingIndex;
 };
 
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -1001,9 +1001,17 @@ bool QgsPointCloudLayer::startEditing()
 bool QgsPointCloudLayer::commitChanges( bool stopEditing )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-  if ( !mEditIndex ||
-       !mEditIndex.commitChanges() )
+  if ( !mEditIndex )
     return false;
+
+  if ( mEditIndex.isModified() )
+  {
+    if ( !mEditIndex.commitChanges( &mCommitError ) )
+      return false;
+
+    emit layerModified();
+    triggerRepaint();
+  }
 
   if ( stopEditing )
   {

--- a/src/core/pointcloud/qgspointcloudlayereditutils.cpp
+++ b/src/core/pointcloud/qgspointcloudlayereditutils.cpp
@@ -16,11 +16,11 @@
 #include "qgspointcloudlayereditutils.h"
 #include "qgspointcloudlayer.h"
 #include "qgslazdecoder.h"
-
 #include "qgscopcpointcloudindex.h"
+#include "qgspointcloudeditingindex.h"
+
 #include <lazperf/readers.hpp>
 #include <lazperf/writers.hpp>
-#include "qgspointcloudeditingindex.h"
 
 
 QgsPointCloudLayerEditUtils::QgsPointCloudLayerEditUtils( QgsPointCloudLayer *layer )
@@ -88,70 +88,70 @@ static void updatePoint( char *pointBuffer, int pointFormat, const QString &attr
 {
   if ( attributeName == QLatin1String( "Intensity" ) )  // unsigned short
   {
-    quint16 newValueShort = ( quint16 ) newValue;
+    quint16 newValueShort = static_cast<quint16>( newValue );
     memcpy( pointBuffer + 12, &newValueShort, sizeof( qint16 ) );
   }
   else if ( attributeName == QLatin1String( "ReturnNumber" ) )  // bits 0-3
   {
-    uchar newByteValue = ( ( uchar )newValue ) & 0xf;
-    pointBuffer[14] = ( char )( ( pointBuffer[14] & 0xf0 ) | newByteValue );
+    uchar newByteValue = static_cast<uchar>( newValue ) & 0xf;
+    pointBuffer[14] = static_cast<char>( ( pointBuffer[14] & 0xf0 ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "NumberOfReturns" ) )  // bits 4-7
   {
-    uchar newByteValue = ( ( ( uchar )newValue ) & 0xf ) << 4;
-    pointBuffer[14] = ( char )( ( pointBuffer[14] & 0xf ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0xf ) << 4;
+    pointBuffer[14] = static_cast<char>( ( pointBuffer[14] & 0xf ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "Synthetic" ) )  // bit 0
   {
-    uchar newByteValue = ( ( uchar )newValue & 0x1 );
-    pointBuffer[15] = ( char )( ( pointBuffer[15] & 0xfe ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0x1 );
+    pointBuffer[15] = static_cast<char>( ( pointBuffer[15] & 0xfe ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "KeyPoint" ) )  // bit 1
   {
-    uchar newByteValue = ( ( uchar )newValue & 0x1 ) << 1;
-    pointBuffer[15] = ( char )( ( pointBuffer[15] & 0xfd ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0x1 ) << 1;
+    pointBuffer[15] = static_cast<char>( ( pointBuffer[15] & 0xfd ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "Withheld" ) )  // bit 2
   {
-    uchar newByteValue = ( ( uchar )newValue & 0x1 ) << 2;
-    pointBuffer[15] = ( char )( ( pointBuffer[15] & 0xfb ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0x1 ) << 2;
+    pointBuffer[15] = static_cast<char>( ( pointBuffer[15] & 0xfb ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "Overlap" ) )  // bit 3
   {
-    uchar newByteValue = ( ( uchar )newValue & 0x1 ) << 3;
-    pointBuffer[15] = ( char )( ( pointBuffer[15] & 0xf7 ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0x1 ) << 3;
+    pointBuffer[15] = static_cast<char>( ( pointBuffer[15] & 0xf7 ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "ScannerChannel" ) )  // bits 4-5
   {
-    uchar newByteValue = ( ( uchar )newValue & 0x3 ) << 4;
-    pointBuffer[15] = ( char )( ( pointBuffer[15] & 0xcf ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0x3 ) << 4;
+    pointBuffer[15] = static_cast<char>( ( pointBuffer[15] & 0xcf ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "ScanDirectionFlag" ) )  // bit 6
   {
-    uchar newByteValue = ( ( uchar )newValue & 0x1 ) << 6;
-    pointBuffer[15] = ( char )( ( pointBuffer[15] & 0xbf ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0x1 ) << 6;
+    pointBuffer[15] = static_cast<char>( ( pointBuffer[15] & 0xbf ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "EdgeOfFlightLine" ) )  // bit 7
   {
-    uchar newByteValue = ( ( uchar )newValue & 0x1 ) << 7;
-    pointBuffer[15] = ( char )( ( pointBuffer[15] & 0x7f ) | newByteValue );
+    uchar newByteValue = ( static_cast<uchar>( newValue ) & 0x1 ) << 7;
+    pointBuffer[15] = static_cast<char>( ( pointBuffer[15] & 0x7f ) | newByteValue );
   }
   else if ( attributeName == QLatin1String( "Classification" ) )  // unsigned char
   {
-    pointBuffer[16] = ( char )( uchar )newValue;
+    pointBuffer[16] = static_cast<char>( static_cast<uchar>( newValue ) );
   }
   else if ( attributeName == QLatin1String( "UserData" ) )  // unsigned char
   {
-    pointBuffer[17] = ( char )( uchar )newValue;
+    pointBuffer[17] = static_cast<char>( static_cast<uchar>( newValue ) );
   }
   else if ( attributeName == QLatin1String( "ScanAngleRank" ) )  // short
   {
-    qint16 newValueShort = ( qint16 ) newValue;
+    qint16 newValueShort = static_cast<qint16>( newValue );
     memcpy( pointBuffer + 18, &newValueShort, sizeof( qint16 ) );
   }
   else if ( attributeName == QLatin1String( "PointSourceId" ) )  // unsigned short
   {
-    quint16 newValueShort = ( quint16 ) newValue;
+    quint16 newValueShort = static_cast<quint16>( newValue );
     memcpy( pointBuffer + 20, &newValueShort, sizeof( quint16 ) );
   }
   else if ( attributeName == QLatin1String( "GpsTime" ) )  // double
@@ -162,24 +162,24 @@ static void updatePoint( char *pointBuffer, int pointFormat, const QString &attr
   {
     if ( attributeName == QLatin1String( "Red" ) )  // unsigned short
     {
-      quint16 newValueShort = ( quint16 ) newValue;
+      quint16 newValueShort = static_cast<quint16>( newValue );
       memcpy( pointBuffer + 30, &newValueShort, sizeof( quint16 ) );
     }
     else if ( attributeName == QLatin1String( "Green" ) )  // unsigned short
     {
-      quint16 newValueShort = ( quint16 ) newValue;
+      quint16 newValueShort = static_cast<quint16>( newValue );
       memcpy( pointBuffer + 32, &newValueShort, sizeof( quint16 ) );
     }
     else if ( attributeName == QLatin1String( "Blue" ) )  // unsigned short
     {
-      quint16 newValueShort = ( quint16 ) newValue;
+      quint16 newValueShort = static_cast<quint16>( newValue );
       memcpy( pointBuffer + 34, &newValueShort, sizeof( quint16 ) );
     }
     else if ( pointFormat == 8 )
     {
       if ( attributeName == QLatin1String( "Infrared" ) )  // unsigned short
       {
-        quint16 newValueShort = ( quint16 ) newValue;
+        quint16 newValueShort = static_cast<quint16>( newValue );
         memcpy( pointBuffer + 36, &newValueShort, sizeof( quint16 ) );
       }
     }
@@ -187,14 +187,12 @@ static void updatePoint( char *pointBuffer, int pointFormat, const QString &attr
 }
 
 
-QByteArray QgsPointCloudLayerEditUtils::updateChunkValues( QgsCopcPointCloudIndex *copcIndex, const QByteArray &chunkData, const QgsPointCloudAttribute &attribute, double newValue, QgsPointCloudNodeId k, QVector<int> pointIndices )
+QByteArray QgsPointCloudLayerEditUtils::updateChunkValues( QgsCopcPointCloudIndex *copcIndex, const QByteArray &chunkData, const QgsPointCloudAttribute &attribute, double newValue, const QgsPointCloudNodeId &n, const QVector<int> &pointIndices )
 {
-  // set new classification value for the given points in voxel and return updated chunk data
+  Q_ASSERT( copcIndex->mHierarchy.contains( n ) );
+  Q_ASSERT( copcIndex->mHierarchyNodePos.contains( n ) );
 
-  Q_ASSERT( copcIndex->mHierarchy.contains( k ) );
-  Q_ASSERT( copcIndex->mHierarchyNodePos.contains( k ) );
-
-  int pointCount = copcIndex->mHierarchy[k];
+  int pointCount = copcIndex->mHierarchy[n];
 
   lazperf::header14 header = copcIndex->mLazInfo->header();
 

--- a/src/core/pointcloud/qgspointcloudlayereditutils.h
+++ b/src/core/pointcloud/qgspointcloudlayereditutils.h
@@ -30,6 +30,8 @@ class QgsPointCloudAttribute;
 class QgsPointCloudAttributeCollection;
 class QgsPointCloudRequest;
 
+class QgsCopcPointCloudIndex;
+
 /**
  * \ingroup core
  *
@@ -63,6 +65,9 @@ class CORE_EXPORT QgsPointCloudLayerEditUtils
     static bool isAttributeValueValid( const QgsPointCloudAttribute &attribute, double value );
 
   private:
+
+    QByteArray updateChunkValues( QgsCopcPointCloudIndex *copcIndex, const QByteArray &chunkData, const QgsPointCloudAttribute &attribute, double newClassValue, QgsPointCloudNodeId k, QVector<int> pointIndices );
+
     QgsPointCloudIndex mIndex;
 };
 

--- a/src/core/pointcloud/qgspointcloudlayereditutils.h
+++ b/src/core/pointcloud/qgspointcloudlayereditutils.h
@@ -66,7 +66,8 @@ class CORE_EXPORT QgsPointCloudLayerEditUtils
 
   private:
 
-    QByteArray updateChunkValues( QgsCopcPointCloudIndex *copcIndex, const QByteArray &chunkData, const QgsPointCloudAttribute &attribute, double newClassValue, QgsPointCloudNodeId k, QVector<int> pointIndices );
+    //! Sets new classification value for the given points in voxel and return updated chunk data
+    QByteArray updateChunkValues( QgsCopcPointCloudIndex *copcIndex, const QByteArray &chunkData, const QgsPointCloudAttribute &attribute, double newClassValue, const QgsPointCloudNodeId &n, const QVector<int> &pointIndices );
 
     QgsPointCloudIndex mIndex;
 };

--- a/tests/src/core/testqgspointcloudediting.cpp
+++ b/tests/src/core/testqgspointcloudediting.cpp
@@ -427,7 +427,7 @@ void TestQgsPointCloudEditing::testCommitChanges()
 
   // check values before any changes
   std::unique_ptr<QgsPointCloudBlock> block0 = layer->index().nodeData( n, request );
-  const char *block0Data =  block0->data();
+  const char *block0Data = block0->data();
   QCOMPARE( block0Data[0], 2 );
   QCOMPARE( block0Data[6], 2 );
   QCOMPARE( block0Data[11], 3 );
@@ -439,10 +439,10 @@ void TestQgsPointCloudEditing::testCommitChanges()
 
   // check values after change, before committing
   std::unique_ptr<QgsPointCloudBlock> block1 = layer->index().nodeData( n, request );
-  const char *block1Data =  block1->data();
+  const char *block1Data = block1->data();
   QCOMPARE( block1Data[0], 1 );
   QCOMPARE( block1Data[6], 2 );  // unchanged
-  QCOMPARE( block1Data[11], 3 );  // unchanged
+  QCOMPARE( block1Data[11], 3 ); // unchanged
   QCOMPARE( block1Data[14], 1 );
 
   QVERIFY( layer->commitChanges() );
@@ -450,10 +450,10 @@ void TestQgsPointCloudEditing::testCommitChanges()
 
   // check values after committing changes
   std::unique_ptr<QgsPointCloudBlock> block2 = layer->index().nodeData( n, request );
-  const char *block2Data =  block2->data();
+  const char *block2Data = block2->data();
   QCOMPARE( block2Data[0], 1 );
   QCOMPARE( block2Data[6], 2 );  // unchanged
-  QCOMPARE( block2Data[11], 3 );  // unchanged
+  QCOMPARE( block2Data[11], 3 ); // unchanged
   QCOMPARE( block2Data[14], 1 );
 
   // try to open the file as a new layer and check saved values
@@ -461,10 +461,10 @@ void TestQgsPointCloudEditing::testCommitChanges()
 
   // check values in the new layer
   std::unique_ptr<QgsPointCloudBlock> block3 = layerNew->index().nodeData( n, request );
-  const char *block3Data =  block3->data();
+  const char *block3Data = block3->data();
   QCOMPARE( block3Data[0], 1 );
   QCOMPARE( block3Data[6], 2 );  // unchanged
-  QCOMPARE( block3Data[11], 3 );  // unchanged
+  QCOMPARE( block3Data[11], 3 ); // unchanged
   QCOMPARE( block3Data[14], 1 );
 }
 


### PR DESCRIPTION
This PR extends work started in #59973 - it adds functionality to store changes to attributes of a point cloud to a COPC file.

There is a new class `QgsCopcUpdate` that:
1. reads and existing COPC file
2. writes a new COPC file with some chunks (nodes) with updated content

Writing of new COPC files is fast, because typically only a small amount of points are modified and so most of the chunks are copied as they were. There are also no changes to the hierarchy.

QgsPointCloudLayer::commitChanges() has been modified to use QgsCopcUpdate. A new file is created next to the original file. The original file is then renamed, and newly created file is renamed to effectively replace it. In the final step, the original file is removed.
