### PR TITLE
Allow PEP440 versions for python plugins

### DIFF
--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -126,9 +126,9 @@ def compareElements(s1, s2):
             return 2
     # if the strings aren't numeric or start from 0, compare them as a strings:
     # but first, set ALPHA < BETA < PREVIEW < RC < TRUNK < [NOTHING] < [ANYTHING_ELSE]
-    if s1 not in ["ALPHA", "BETA", "PREVIEW", "RC", "TRUNK"]:
+    if s1 not in ["A", "ALPHA", "B", "BETA", "PREVIEW", "RC", "TRUNK"]:
         s1 = "Z" + s1
-    if s2 not in ["ALPHA", "BETA", "PREVIEW", "RC", "TRUNK"]:
+    if s2 not in ["A", "ALPHA", "B", "BETA", "PREVIEW", "RC", "TRUNK"]:
         s2 = "Z" + s2
     # the final test:
     if s1 > s2:


### PR DESCRIPTION
## Description

Python allows for `1.0a1` style version syntax instead of `1.0.alpha1` semver style. 

This PR works with `setuptools_scm` syntax, but does not fixes every PEP440 syntaxes:
- `dev` versions are trickier to treat *(but we might ignore them since these versions should not be uploaded on repos)*
- mixing plain alpha/beta with shorthand a/b will missbehave `0.1alpha1` > `0.1a2` *(but coventions should be consistent inside a project)*
