### PR TITLE
Fix include/exclude in QgsRange

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsrange.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrange.sip.in
@@ -385,6 +385,8 @@ Returns ``True`` if this range contains a specified ``element``.
     bool overlaps( const QgsTemporalRange<T> &other ) const;
 %Docstring
 Returns ``True`` if this range overlaps another range.
+
+.. seealso:: :py:func:`contains`
 %End
 
     bool extend( const QgsTemporalRange<T> &other );

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -385,6 +385,8 @@ Returns ``True`` if this range contains a specified ``element``.
     bool overlaps( const QgsTemporalRange<T> &other ) const;
 %Docstring
 Returns ``True`` if this range overlaps another range.
+
+.. seealso:: :py:func:`contains`
 %End
 
     bool extend( const QgsTemporalRange<T> &other );

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -175,26 +175,21 @@ class QgsRange
      */
     bool overlaps( const QgsRange<T> &other ) const
     {
-      if ( ( ( mIncludeLower && mLower <= other.mLower ) || ( !mIncludeLower && mLower < other.mLower ) )
-           && ( ( mIncludeUpper  && mUpper >= other.mUpper ) || ( !mIncludeUpper && mUpper > other.mUpper ) ) )
+      // other range is completely before or completely after self range
+      if ( other.mUpper < mLower || other.mLower > mUpper )
+        return false;
+
+      // other overlaps self for sure
+      if ( other.mUpper > mLower && other.mLower < mUpper )
         return true;
 
-      if ( ( ( mIncludeLower && mLower <= other.mLower ) || ( !mIncludeLower && mLower < other.mLower ) )
-           && ( ( mIncludeUpper  && mUpper >= other.mLower ) || ( !mIncludeUpper && mUpper > other.mLower ) ) )
-        return true;
+      if ( other.mUpper == mLower )
+        return other.mIncludeUpper && mIncludeLower;
 
-      if ( ( ( mIncludeLower && mLower <= other.mUpper ) || ( !mIncludeLower && mLower < other.mUpper ) )
-           && ( ( mIncludeUpper && mUpper >= other.mUpper ) || ( !mIncludeUpper && mUpper > other.mUpper ) ) )
-        return true;
+      if ( other.mLower == mUpper )
+        return other.mIncludeLower && mIncludeUpper;
 
-      if ( ( ( mIncludeLower && mLower >= other.mLower ) || ( !mIncludeLower && mLower > other.mLower ) )
-           && ( ( mIncludeLower && mLower <= other.mUpper ) || ( !mIncludeLower && mLower < other.mUpper ) ) )
-        return true;
-
-      if ( mLower == other.mLower && mUpper == other.mUpper )
-        return true;
-
-      return false;
+      BUILTIN_UNREACHABLE
     }
 
     bool operator==( const QgsRange<T> &other ) const
@@ -574,26 +569,26 @@ class QgsTemporalRange
      */
     bool overlaps( const QgsTemporalRange<T> &other ) const
     {
-      if ( !mUpper.isValid() && ( ( mIncludeLower && mLower <= other.mUpper ) || ( !mIncludeLower && mLower < other.mUpper ) ) )
+      if ( !mUpper.isValid() && ( ( mIncludeLower && other.mIncludeUpper && mLower <= other.mUpper ) || ( ( !mIncludeLower || !other.mIncludeUpper ) && mLower < other.mUpper ) ) )
         return true;
 
-      if ( ( ( mIncludeLower && mLower <= other.mLower ) || ( !mIncludeLower && mLower < other.mLower ) )
-           && ( ( mIncludeUpper  && mUpper >= other.mUpper ) || ( !mIncludeUpper && mUpper > other.mUpper ) ) )
+      if ( ( ( mIncludeLower && other.mIncludeLower && mLower <= other.mLower ) || ( ( !mIncludeLower || !other.mIncludeLower ) && mLower < other.mLower ) )
+           && ( ( mIncludeUpper  && other.mIncludeUpper && mUpper >= other.mUpper ) || ( ( !mIncludeUpper || !other.mIncludeUpper ) && mUpper > other.mUpper ) ) )
         return true;
 
-      if ( ( ( mIncludeLower && mLower <= other.mLower ) || ( !mIncludeLower && mLower < other.mLower ) )
-           && ( ( mIncludeUpper  && mUpper >= other.mLower ) || ( !mIncludeUpper && mUpper > other.mLower ) ) )
+      if ( ( ( mIncludeLower && other.mIncludeLower && mLower <= other.mLower ) || ( ( !mIncludeLower || other.mIncludeLower ) && mLower < other.mLower ) )
+           && ( ( mIncludeUpper && other.mIncludeLower && mUpper >= other.mLower ) || ( ( !mIncludeUpper || !other.mIncludeLower ) && mUpper > other.mLower ) ) )
         return true;
 
-      if ( ( ( mIncludeLower && mLower <= other.mUpper ) || ( !mIncludeLower && mLower < other.mUpper ) )
-           && ( ( mIncludeUpper && mUpper >= other.mUpper ) || ( !mIncludeUpper && mUpper > other.mUpper ) ) )
+      if ( ( ( mIncludeLower && other.mIncludeUpper && mLower <= other.mUpper ) || ( ( !mIncludeLower || other.mIncludeUpper ) && mLower < other.mUpper ) )
+           && ( ( mIncludeUpper && other.mIncludeUpper && mUpper >= other.mUpper ) || ( ( !mIncludeUpper || !other.mIncludeUpper ) && mUpper > other.mUpper ) ) )
         return true;
 
-      if ( ( ( mIncludeLower && mLower >= other.mLower ) || ( !mIncludeLower && mLower > other.mLower ) )
-           && ( ( mIncludeLower && mLower <= other.mUpper ) || ( !mIncludeLower && mLower < other.mUpper ) ) )
+      if ( ( ( mIncludeLower && other.mIncludeLower && mLower >= other.mLower ) || ( ( !mIncludeLower || !other.mIncludeLower ) && mLower > other.mLower ) )
+           && ( ( mIncludeLower && other.mIncludeUpper && mLower <= other.mUpper ) || ( ( !mIncludeLower || !other.mIncludeUpper ) && mLower < other.mUpper ) ) )
         return true;
 
-      if ( mLower == other.mLower && mUpper == other.mUpper )
+      if ( mIncludeLower && other.mIncludeLower && mIncludeUpper && other.mIncludeUpper && mLower == other.mLower && mUpper == other.mUpper )
         return true;
 
       return false;

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -189,7 +189,8 @@ class QgsRange
       if ( other.mLower == mUpper )
         return other.mIncludeLower && mIncludeUpper;
 
-      BUILTIN_UNREACHABLE
+      // UNREACHABLE CODE
+      return false;
     }
 
     bool operator==( const QgsRange<T> &other ) const

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -571,7 +571,7 @@ class QgsTemporalRange
      */
     bool overlaps( const QgsTemporalRange<T> &other ) const
     {
-      // one of both range is infinite
+      // one or both range is infinite
       if ( isInfinite() || other.isInfinite() )
         return true;
 

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -567,31 +567,47 @@ class QgsTemporalRange
 
     /**
      * Returns TRUE if this range overlaps another range.
+     * \see contains()
      */
     bool overlaps( const QgsTemporalRange<T> &other ) const
     {
-      if ( !mUpper.isValid() && ( ( mIncludeLower && other.mIncludeUpper && mLower <= other.mUpper ) || ( ( !mIncludeLower || !other.mIncludeUpper ) && mLower < other.mUpper ) ) )
+      // one of both range is infinite
+      if ( isInfinite() || other.isInfinite() )
         return true;
 
-      if ( ( ( mIncludeLower && other.mIncludeLower && mLower <= other.mLower ) || ( ( !mIncludeLower || !other.mIncludeLower ) && mLower < other.mLower ) )
-           && ( ( mIncludeUpper  && other.mIncludeUpper && mUpper >= other.mUpper ) || ( ( !mIncludeUpper || !other.mIncludeUpper ) && mUpper > other.mUpper ) ) )
-        return true;
+      // all bounds are fixed
+      if ( mLower.isValid() && mUpper.isValid() && other.mLower.isValid() && other.mUpper.isValid() )
+      {
+        // other range is completely before or completely after self range
+        if ( other.mUpper < mLower || other.mLower > mUpper )
+          return false;
 
-      if ( ( ( mIncludeLower && other.mIncludeLower && mLower <= other.mLower ) || ( ( !mIncludeLower || other.mIncludeLower ) && mLower < other.mLower ) )
-           && ( ( mIncludeUpper && other.mIncludeLower && mUpper >= other.mLower ) || ( ( !mIncludeUpper || !other.mIncludeLower ) && mUpper > other.mLower ) ) )
-        return true;
+        // other overlaps self for sure
+        if ( other.mUpper > mLower && other.mLower < mUpper )
+          return true;
+      }
 
-      if ( ( ( mIncludeLower && other.mIncludeUpper && mLower <= other.mUpper ) || ( ( !mIncludeLower || other.mIncludeUpper ) && mLower < other.mUpper ) )
-           && ( ( mIncludeUpper && other.mIncludeUpper && mUpper >= other.mUpper ) || ( ( !mIncludeUpper || !other.mIncludeUpper ) && mUpper > other.mUpper ) ) )
-        return true;
+      // other is just before and has a bound in common
+      if ( other.mUpper == mLower && mLower.isValid() )
+        return other.mIncludeUpper && mIncludeLower;
 
-      if ( ( ( mIncludeLower && other.mIncludeLower && mLower >= other.mLower ) || ( ( !mIncludeLower || !other.mIncludeLower ) && mLower > other.mLower ) )
-           && ( ( mIncludeLower && other.mIncludeUpper && mLower <= other.mUpper ) || ( ( !mIncludeLower || !other.mIncludeUpper ) && mLower < other.mUpper ) ) )
-        return true;
+      // other is just after and has a bound in common
+      if ( other.mLower == mUpper && mUpper.isValid() )
+        return other.mIncludeLower && mIncludeUpper;
 
-      if ( mIncludeLower && other.mIncludeLower && mIncludeUpper && other.mIncludeUpper && mLower == other.mLower && mUpper == other.mUpper )
-        return true;
+      if ( !mLower.isValid() )
+        return other.mLower < mUpper || !other.mLower.isValid();
 
+      if ( !mUpper.isValid() )
+        return other.mUpper > mLower || !other.mUpper.isValid();
+
+      if ( !other.mLower.isValid() )
+        return other.mUpper > mLower || !mLower.isValid();
+
+      if ( !other.mUpper.isValid() )
+        return other.mLower < mUpper || !mUpper.isValid();
+
+      // UNREACHABLE CODE
       return false;
     }
 

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -286,7 +286,7 @@ bool QgsVectorLayerTemporalProperties::readXml( const QDomElement &element, cons
   const QDateTime beginDate = QDateTime::fromString( begin.toElement().text(), Qt::ISODate );
   const QDateTime endDate = QDateTime::fromString( end.toElement().text(), Qt::ISODate );
 
-  const QgsDateTimeRange range = QgsDateTimeRange( beginDate, endDate );
+  const QgsDateTimeRange range = QgsDateTimeRange( beginDate, endDate, true, mLimitMode == Qgis::VectorTemporalLimitMode::IncludeBeginIncludeEnd );
   setFixedTemporalRange( range );
 
   return true;

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
@@ -122,9 +122,13 @@ void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
 
   properties->setIsActive( mTemporalGroupBox->isChecked() );
   properties->setMode( static_cast<Qgis::VectorTemporalMode>( mModeComboBox->currentData().toInt() ) );
-  properties->setLimitMode( static_cast<Qgis::VectorTemporalLimitMode>( mLimitsComboBox->currentData().toInt() ) );
+  Qgis::VectorTemporalLimitMode limitMode = static_cast<Qgis::VectorTemporalLimitMode>( mLimitsComboBox->currentData().toInt() );
+  properties->setLimitMode( limitMode );
 
-  const QgsDateTimeRange normalRange = QgsDateTimeRange( mStartTemporalDateTimeEdit->dateTime(), mEndTemporalDateTimeEdit->dateTime() );
+  const QgsDateTimeRange normalRange = QgsDateTimeRange(
+    mStartTemporalDateTimeEdit->dateTime(), mEndTemporalDateTimeEdit->dateTime(),
+    true, limitMode == Qgis::VectorTemporalLimitMode::IncludeBeginIncludeEnd
+  );
 
   properties->setFixedTemporalRange( normalRange );
 

--- a/tests/src/python/test_qgsrange.py
+++ b/tests/src/python/test_qgsrange.py
@@ -178,12 +178,8 @@ class TestQgsIntRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsIntRange(
-                                refLower, refUpper, refIncLower, refIncUpper
-                            )
-                            otherRange = QgsIntRange(
-                                otherLower, otherUpper, otherIncLower, otherIncUpper
-                            )
+                            refRange = QgsIntRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsIntRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
                             self.assertFalse(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -211,12 +207,8 @@ class TestQgsIntRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsIntRange(
-                                refLower, refUpper, refIncLower, refIncUpper
-                            )
-                            otherRange = QgsIntRange(
-                                otherLower, otherUpper, otherIncLower, otherIncUpper
-                            )
+                            refRange = QgsIntRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsIntRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
                             self.assertTrue(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -231,7 +223,7 @@ class TestQgsIntRange(unittest.TestCase):
             refIncUpper,
             expected,
         ) in [
-            # reference range and other range are contiguous
+            # other range and reference range are contiguous
             [-3, 0, True, True, True, True, True],
             [-3, 0, True, True, True, False, True],
             [-3, 0, True, True, False, True, False],
@@ -248,7 +240,7 @@ class TestQgsIntRange(unittest.TestCase):
             [-3, 0, False, False, True, False, False],
             [-3, 0, False, False, False, True, False],
             [-3, 0, False, False, False, False, False],
-            # other range and reference range are contiguous
+            # reference range and other range are contiguous
             [10, 14, True, True, True, True, True],
             [10, 14, True, True, True, False, False],
             [10, 14, True, True, False, True, True],
@@ -267,12 +259,8 @@ class TestQgsIntRange(unittest.TestCase):
             [10, 14, False, False, False, False, False],
         ]:
             refRange = QgsIntRange(refLower, refUpper, refIncLower, refIncUpper)
-            otherRange = QgsIntRange(
-                otherLower, otherUpper, otherIncLower, otherIncUpper
-            )
-            self.assertEqual(
-                refRange.overlaps(otherRange), expected, f"{refRange=} {otherRange=}"
-            )
+            otherRange = QgsIntRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+            self.assertEqual(refRange.overlaps(otherRange), expected, f"{refRange=} {otherRange=}")
 
 
 class TestQgsDoubleRange(unittest.TestCase):
@@ -379,70 +367,34 @@ class TestQgsDateRange(unittest.TestCase):
     def testContains(self):
         # includes both ends
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
-        )
-        self.assertFalse(
-            range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertFalse(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
-        )
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))))
+        self.assertFalse(range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5))))
+        self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5))))
         self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate())))
         self.assertFalse(range.contains(QgsDateRange(QDate(), QDate(2010, 4, 1))))
 
         # infinite left end
         range = QgsDateRange(QDate(), QDate(2010, 6, 2))
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertFalse(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
-        )
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5))))
+        self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5))))
         self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate())))
         self.assertTrue(range.contains(QgsDateRange(QDate(), QDate(2010, 4, 1))))
 
         # infinite right end
         range = QgsDateRange(QDate(2010, 3, 1), QDate())
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
-        )
-        self.assertFalse(
-            range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
-        )
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))))
+        self.assertFalse(range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5))))
+        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5))))
         self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate())))
         self.assertFalse(range.contains(QgsDateRange(QDate(), QDate(2010, 4, 1))))
 
@@ -475,130 +427,296 @@ class TestQgsDateRange(unittest.TestCase):
         self.assertFalse(range.contains(QDate()))
 
     def testOverlaps(self):
-        # includes both ends
-        range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
-        )
-        self.assertTrue(range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate())))
-        self.assertTrue(range.overlaps(QgsDateRange(QDate(), QDate(2010, 4, 1))))
-        self.assertFalse(
-            range.overlaps(QgsDateRange(QDate(2009, 4, 1), QDate(2009, 8, 5)))
-        )
-        self.assertFalse(
-            range.overlaps(QgsDateRange(QDate(2019, 4, 1), QDate(2019, 8, 5)))
-        )
+        """
+        Test overlaps with every combination of include/exclude bounds
+        and infinite bounds.
+        """
 
-        range = QgsDateRange(QDate(), QDate(2010, 6, 2))
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
-        )
-        self.assertTrue(range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate())))
-        self.assertTrue(range.overlaps(QgsDateRange(QDate(), QDate(2010, 4, 1))))
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2009, 4, 1), QDate(2009, 8, 5)))
-        )
-        self.assertFalse(
-            range.overlaps(QgsDateRange(QDate(2019, 4, 1), QDate(2019, 8, 5)))
-        )
+        # -----------------------------------------------------------
+        # reference range has no infinite bounds
+        refLower, refUpper = QDate(2007, 4, 7), QDate(2013, 3, 2)
 
-        range = QgsDateRange(QDate(2010, 3, 1), QDate())
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
-        )
-        self.assertTrue(range.overlaps(QgsDateRange(QDate(2010, 4, 1), QDate())))
-        self.assertTrue(range.overlaps(QgsDateRange(QDate(), QDate(2010, 4, 1))))
-        self.assertFalse(
-            range.overlaps(QgsDateRange(QDate(2009, 4, 1), QDate(2009, 8, 5)))
-        )
-        self.assertTrue(
-            range.overlaps(QgsDateRange(QDate(2019, 4, 1), QDate(2019, 8, 5)))
-        )
+        # other range is completely before or after reference range
+        for otherLower, otherUpper in [
+            [QDate(), QDate(2000, 4, 6)],
+            [QDate(2018, 8, 9), QDate(2020, 9, 9)],
+            [QDate(2000, 1, 1), QDate(2004, 5, 7)],
+            [QDate(2024, 4, 3), QDate()],
+        ]:
+            for refIncLower in [True, False]:
+                for refIncUpper in [True, False]:
+                    for otherIncLower in [True, False]:
+                        for otherIncUpper in [True, False]:
+                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            self.assertFalse(
+                                refRange.overlaps(otherRange),
+                                f"{refRange=} {otherRange=}",
+                            )
+
+        # other range overlaps reference range
+        for otherLower, otherUpper in [
+            # parts of the ranges overlaps
+            [QDate(1999, 3, 2), QDate(2010, 8, 8)],
+            [QDate(2010, 8, 8), QDate(2024, 5, 9)],
+            [QDate(), QDate(2010, 8, 8)],
+            [QDate(2010, 8, 8), QDate()],
+            # full overlap and a bound in common
+            [QDate(1999, 3, 2), QDate(2013, 3, 2)],
+            [QDate(2007, 4, 7), QDate(2024, 5, 9)],
+            [QDate(2007, 4, 7), QDate()],
+            [QDate(), QDate(2013, 3, 2)],
+            # partial overlap and a bound in common
+            [QDate(2007, 4, 7), QDate(2010, 3, 1)],
+            [QDate(2010, 3, 1), QDate(2013, 3, 2)],
+            # same bounds
+            [QDate(2007, 4, 7), QDate(2013, 3, 2)],
+            # reference range is completely inside other range
+            [QDate(2005, 1, 1), QDate(2021, 10, 20)],
+            [QDate(), QDate(2021, 10, 20)],
+            [QDate(2005, 1, 1), QDate()],
+            [QDate(), QDate()],
+            # other range is completely inside reference range
+            [QDate(2010, 3, 1), QDate(2012, 8, 11)],
+        ]:
+            for refIncLower in [True, False]:
+                for refIncUpper in [True, False]:
+                    for otherIncLower in [True, False]:
+                        for otherIncUpper in [True, False]:
+                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            self.assertTrue(
+                                refRange.overlaps(otherRange),
+                                f"{refRange=} {otherRange=}",
+                            )
+
+        # other range and reference range are contiguous
+        otherUpper = QDate(2007, 4, 7)
+        for otherLower in [QDate(1999, 3, 4), QDate()]:
+            for (
+                otherIncLower,
+                otherIncUpper,
+                refIncLower,
+                refIncUpper,
+                expectedOverlaps,
+            ) in [
+                [True, True, True, True, True],
+                [True, True, True, False, True],
+                [True, True, False, True, False],
+                [True, True, False, False, False],
+                [True, False, True, True, False],
+                [True, False, True, False, False],
+                [True, False, False, True, False],
+                [True, False, False, False, False],
+                [False, True, True, True, True],
+                [False, True, True, False, True],
+                [False, True, False, True, False],
+                [False, True, False, False, False],
+                [False, False, True, True, False],
+                [False, False, True, False, False],
+                [False, False, False, True, False],
+                [False, False, False, False, False],
+            ]:
+                refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
+
+        # reference range and other range are contiguous
+        otherLower = QDate(2013, 3, 2)
+        for otherUpper in [QDate(2025, 2, 13), QDate()]:
+            for (
+                otherIncLower,
+                otherIncUpper,
+                refIncLower,
+                refIncUpper,
+                expectedOverlaps,
+            ) in [
+                [True, True, True, True, True],
+                [True, True, True, False, False],
+                [True, True, False, True, True],
+                [True, True, False, False, False],
+                [True, False, True, True, True],
+                [True, False, True, False, False],
+                [True, False, False, True, True],
+                [True, False, False, False, False],
+                [False, True, True, True, False],
+                [False, True, True, False, False],
+                [False, True, False, True, False],
+                [False, True, False, False, False],
+                [False, False, True, True, False],
+                [False, False, True, False, False],
+                [False, False, False, True, False],
+                [False, False, False, False, False],
+            ]:
+                refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
+
+        # -----------------------------------------------------------
+        # reference range has a left infinite bound
+        refLower, refUpper = QDate(), QDate(2013, 3, 2)
+
+        # other range is completely after reference range
+        for otherLower, otherUpper in [
+            [QDate(2018, 8, 9), QDate(2020, 9, 9)],
+            [QDate(2024, 4, 3), QDate()],
+        ]:
+            for refIncLower in [True, False]:
+                for refIncUpper in [True, False]:
+                    for otherIncLower in [True, False]:
+                        for otherIncUpper in [True, False]:
+                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            self.assertFalse(
+                                refRange.overlaps(otherRange),
+                                f"{refRange=} {otherRange=}",
+                            )
+
+        # other range overlaps reference range
+        for otherLower, otherUpper in [
+            # parts of the ranges overlaps
+            [QDate(2010, 8, 8), QDate(2024, 5, 9)],
+            [QDate(2010, 8, 8), QDate()],
+            # a bound in common
+            [QDate(1999, 8, 8), QDate(2013, 3, 2)],
+            # same bounds
+            [QDate(), QDate(2013, 3, 2)],
+            # reference range is completely inside other range
+            [QDate(), QDate(2020, 6, 6)],
+            # other range is completely inside reference range
+            [QDate(2010, 3, 1), QDate(2012, 8, 11)],
+            [QDate(), QDate(2010, 8, 8)],
+            # other range infinite
+            [QDate(), QDate()],
+        ]:
+            for refIncLower in [True, False]:
+                for refIncUpper in [True, False]:
+                    for otherIncLower in [True, False]:
+                        for otherIncUpper in [True, False]:
+                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            self.assertTrue(
+                                refRange.overlaps(otherRange),
+                                f"{refRange=} {otherRange=}",
+                            )
+
+        # reference range and other range are contiguous
+        otherLower = QDate(2013, 3, 2)
+        for otherUpper in [QDate(2025, 2, 13), QDate()]:
+            for otherIncLower, otherIncUpper, refIncLower, refIncUpper, expectedOverlaps in [
+                [True, True, True, True, True],
+                [True, True, True, False, False],
+                [True, True, False, True, True],
+                [True, True, False, False, False],
+                [True, False, True, True, True],
+                [True, False, True, False, False],
+                [True, False, False, True, True],
+                [True, False, False, False, False],
+                [False, True, True, True, False],
+                [False, True, True, False, False],
+                [False, True, False, True, False],
+                [False, True, False, False, False],
+                [False, False, True, True, False],
+                [False, False, True, False, False],
+                [False, False, False, True, False],
+                [False, False, False, False, False],
+            ]:
+                refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
+
+        # -----------------------------------------------------------
+        # reference range has a right infinite bound
+        refLower, refUpper = QDate(2013, 3, 2), QDate()
+
+        # other range is completely before reference range
+        for otherLower, otherUpper in [
+            [QDate(1993, 5, 9), QDate(2005, 9, 9)],
+            [QDate(), QDate(1999, 3, 9)],
+        ]:
+            for refIncLower in [True, False]:
+                for refIncUpper in [True, False]:
+                    for otherIncLower in [True, False]:
+                        for otherIncUpper in [True, False]:
+                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            self.assertFalse(
+                                refRange.overlaps(otherRange),
+                                f"{refRange=} {otherRange=}",
+                            )
+
+        # other range overlaps reference range
+        for otherLower, otherUpper in [
+            # parts of the ranges overlaps
+            [QDate(2010, 5, 9), QDate(2025, 1, 8)],
+            [QDate(), QDate(2025, 1, 8)],
+            # a bound in common
+            [QDate(2013, 3, 2), QDate(2025, 1, 2)],
+            # same bounds
+            [QDate(2013, 3, 2), QDate()],
+            # reference range is completely inside other range
+            [QDate(2013, 1, 1), QDate()],
+            # other range is completely inside reference range
+            [QDate(2016, 3, 1), QDate(2020, 8, 11)],
+            [QDate(2016, 3, 1), QDate()],
+            # other range infinite
+            [QDate(), QDate()],
+        ]:
+            for refIncLower in [True, False]:
+                for refIncUpper in [True, False]:
+                    for otherIncLower in [True, False]:
+                        for otherIncUpper in [True, False]:
+                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            self.assertTrue(
+                                refRange.overlaps(otherRange),
+                                f"{refRange=} {otherRange=}",
+                            )
+
+        # other range and reference range are contiguous
+        otherUpper = QDate(2013, 3, 2)
+        for otherLower in [QDate(), QDate(1998, 4, 8)]:
+            for otherIncLower, otherIncUpper, refIncLower, refIncUpper, expectedOverlaps in [
+                [True, True, True, True, True],
+                [True, True, True, False, True],
+                [True, True, False, True, False],
+                [True, True, False, False, False],
+                [True, False, True, True, False],
+                [True, False, True, False, False],
+                [True, False, False, True, False],
+                [True, False, False, False, False],
+                [False, True, True, True, True],
+                [False, True, True, False, True],
+                [False, True, False, True, False],
+                [False, True, False, False, False],
+                [False, False, True, True, False],
+                [False, False, True, False, False],
+                [False, False, False, True, False],
+                [False, False, False, False, False],
+            ]:
+                refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
+                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
 
     def testIsInstant(self):
         self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)).isInstant())
         self.assertTrue(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1)).isInstant())
-        self.assertFalse(
-            QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1), False, False).isInstant()
-        )
+        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1), False, False).isInstant())
         self.assertFalse(QgsDateRange(QDate(), QDate()).isInstant())
 
     def testIsInfinite(self):
-        self.assertFalse(
-            QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)).isInfinite()
-        )
-        self.assertFalse(
-            QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1)).isInfinite()
-        )
-        self.assertFalse(
-            QgsDateRange(
-                QDate(2010, 3, 1), QDate(2010, 3, 1), False, False
-            ).isInfinite()
-        )
+        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)).isInfinite())
+        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1)).isInfinite())
+        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1), False, False).isInfinite())
         self.assertTrue(QgsDateRange(QDate(), QDate()).isInfinite())
 
     def testEquality(self):
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertEqual(
-            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        )
-        self.assertNotEqual(
-            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)
-        )
-        self.assertNotEqual(
-            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), True, False)
-        )
-        self.assertNotEqual(
-            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 3), False, False)
-        )
-        self.assertNotEqual(
-            range, QgsDateRange(QDate(2010, 3, 2), QDate(2010, 6, 2), False, False)
-        )
+        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False))
+        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True))
+        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), True, False))
+        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 3), False, False))
+        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 2), QDate(2010, 6, 2), False, False))
 
     def testExtend(self):
         range_empty = QgsDateRange(QDate(2010, 6, 2), QDate(2010, 3, 1))
@@ -608,106 +726,48 @@ class TestQgsDateRange(unittest.TestCase):
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
         self.assertFalse(range.extend(range_empty))
         range = QgsDateRange(QDate(2010, 6, 2), QDate(2010, 3, 1))
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-            )
-        )
-        self.assertEqual(
-            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)))
+        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False))
 
         # Extend low
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False)
-            )
-        )
-        self.assertEqual(
-            range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False)
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False)))
+        self.assertEqual(range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False))
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 2, 1), QDate(2010, 5, 2), True, False)
-            )
-        )
-        self.assertEqual(
-            range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), True, False)
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 2, 1), QDate(2010, 5, 2), True, False)))
+        self.assertEqual(range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), True, False))
 
         # Extend high
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False)
-            )
-        )
-        self.assertEqual(
-            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False)
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False)))
+        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False))
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)
-            )
-        )
-        self.assertEqual(
-            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)))
+        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True))
 
         # Extend both
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False)
-            )
-        )
-        self.assertEqual(
-            range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False)
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False)))
+        self.assertEqual(range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False))
 
         # Extend none
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertFalse(
-            range.extend(
-                QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)
-            )
-        )
+        self.assertFalse(range.extend(QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)))
 
         # Test infinity
         range = QgsDateRange(QDate(), QDate())
-        self.assertFalse(
-            range.extend(
-                QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)
-            )
-        )
+        self.assertFalse(range.extend(QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)))
         range = QgsDateRange(QDate(), QDate(2010, 5, 2))
-        self.assertFalse(
-            range.extend(
-                QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)
-            )
-        )
+        self.assertFalse(range.extend(QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)))
         self.assertEqual(range, QgsDateRange(QDate(), QDate(2010, 5, 2), True, True))
         range = QgsDateRange(QDate(2010, 4, 6), QDate())
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 3, 6), QDate(2010, 5, 2), False, False)
-            )
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 6), QDate(2010, 5, 2), False, False)))
         self.assertEqual(range, QgsDateRange(QDate(2010, 3, 6), QDate(), False, True))
         range = QgsDateRange(QDate(), QDate(2010, 5, 2))
-        self.assertTrue(
-            range.extend(
-                QgsDateRange(QDate(2010, 3, 6), QDate(2010, 6, 2), False, False)
-            )
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 6), QDate(2010, 6, 2), False, False)))
         self.assertEqual(range, QgsDateRange(QDate(), QDate(2010, 6, 2), True, False))
         range = QgsDateRange(QDate(2010, 4, 6), QDate())
-        self.assertTrue(
-            range.extend(QgsDateRange(QDate(), QDate(2010, 5, 2), True, False))
-        )
+        self.assertTrue(range.extend(QgsDateRange(QDate(), QDate(2010, 5, 2), True, False)))
         self.assertEqual(range, QgsDateRange(QDate(), QDate(), True, True))
         range = QgsDateRange(QDate(), QDate(2010, 4, 6))
         self.assertTrue(range.extend(QgsDateRange(QDate(), QDate(), True, True)))

--- a/tests/src/python/test_qgsrange.py
+++ b/tests/src/python/test_qgsrange.py
@@ -178,8 +178,12 @@ class TestQgsIntRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsIntRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsIntRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsIntRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsIntRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertFalse(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -207,8 +211,12 @@ class TestQgsIntRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsIntRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsIntRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsIntRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsIntRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertTrue(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -259,8 +267,12 @@ class TestQgsIntRange(unittest.TestCase):
             [10, 14, False, False, False, False, False],
         ]:
             refRange = QgsIntRange(refLower, refUpper, refIncLower, refIncUpper)
-            otherRange = QgsIntRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
-            self.assertEqual(refRange.overlaps(otherRange), expected, f"{refRange=} {otherRange=}")
+            otherRange = QgsIntRange(
+                otherLower, otherUpper, otherIncLower, otherIncUpper
+            )
+            self.assertEqual(
+                refRange.overlaps(otherRange), expected, f"{refRange=} {otherRange=}"
+            )
 
 
 class TestQgsDoubleRange(unittest.TestCase):
@@ -367,34 +379,70 @@ class TestQgsDateRange(unittest.TestCase):
     def testContains(self):
         # includes both ends
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))))
-        self.assertFalse(range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5))))
-        self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5))))
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
+        )
+        self.assertFalse(
+            range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
+        )
+        self.assertFalse(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
+        )
         self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate())))
         self.assertFalse(range.contains(QgsDateRange(QDate(), QDate(2010, 4, 1))))
 
         # infinite left end
         range = QgsDateRange(QDate(), QDate(2010, 6, 2))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5))))
-        self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5))))
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
+        )
+        self.assertFalse(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
+        )
         self.assertFalse(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate())))
         self.assertTrue(range.contains(QgsDateRange(QDate(), QDate(2010, 4, 1))))
 
         # infinite right end
         range = QgsDateRange(QDate(2010, 3, 1), QDate())
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2))))
-        self.assertFalse(range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5))))
-        self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5))))
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 4, 5)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2010, 6, 2)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 4, 5)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)))
+        )
+        self.assertFalse(
+            range.contains(QgsDateRange(QDate(2009, 4, 1), QDate(2010, 4, 5)))
+        )
+        self.assertTrue(
+            range.contains(QgsDateRange(QDate(2010, 4, 1), QDate(2017, 4, 5)))
+        )
         self.assertTrue(range.contains(QgsDateRange(QDate(2010, 4, 1), QDate())))
         self.assertFalse(range.contains(QgsDateRange(QDate(), QDate(2010, 4, 1))))
 
@@ -447,8 +495,12 @@ class TestQgsDateRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsDateRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsDateRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertFalse(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -483,8 +535,12 @@ class TestQgsDateRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsDateRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsDateRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertTrue(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -518,8 +574,14 @@ class TestQgsDateRange(unittest.TestCase):
                 [False, False, False, False, False],
             ]:
                 refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
-                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
+                otherRange = QgsDateRange(
+                    otherLower, otherUpper, otherIncLower, otherIncUpper
+                )
+                self.assertEqual(
+                    refRange.overlaps(otherRange),
+                    expectedOverlaps,
+                    f"{refRange=} {otherRange=}",
+                )
 
         # reference range and other range are contiguous
         otherLower = QDate(2013, 3, 2)
@@ -549,8 +611,14 @@ class TestQgsDateRange(unittest.TestCase):
                 [False, False, False, False, False],
             ]:
                 refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
-                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
+                otherRange = QgsDateRange(
+                    otherLower, otherUpper, otherIncLower, otherIncUpper
+                )
+                self.assertEqual(
+                    refRange.overlaps(otherRange),
+                    expectedOverlaps,
+                    f"{refRange=} {otherRange=}",
+                )
 
         # -----------------------------------------------------------
         # reference range has a left infinite bound
@@ -565,8 +633,12 @@ class TestQgsDateRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsDateRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsDateRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertFalse(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -593,8 +665,12 @@ class TestQgsDateRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsDateRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsDateRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertTrue(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -603,7 +679,13 @@ class TestQgsDateRange(unittest.TestCase):
         # reference range and other range are contiguous
         otherLower = QDate(2013, 3, 2)
         for otherUpper in [QDate(2025, 2, 13), QDate()]:
-            for otherIncLower, otherIncUpper, refIncLower, refIncUpper, expectedOverlaps in [
+            for (
+                otherIncLower,
+                otherIncUpper,
+                refIncLower,
+                refIncUpper,
+                expectedOverlaps,
+            ) in [
                 [True, True, True, True, True],
                 [True, True, True, False, False],
                 [True, True, False, True, True],
@@ -622,8 +704,14 @@ class TestQgsDateRange(unittest.TestCase):
                 [False, False, False, False, False],
             ]:
                 refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
-                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
+                otherRange = QgsDateRange(
+                    otherLower, otherUpper, otherIncLower, otherIncUpper
+                )
+                self.assertEqual(
+                    refRange.overlaps(otherRange),
+                    expectedOverlaps,
+                    f"{refRange=} {otherRange=}",
+                )
 
         # -----------------------------------------------------------
         # reference range has a right infinite bound
@@ -638,8 +726,12 @@ class TestQgsDateRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsDateRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsDateRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertFalse(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -666,8 +758,12 @@ class TestQgsDateRange(unittest.TestCase):
                 for refIncUpper in [True, False]:
                     for otherIncLower in [True, False]:
                         for otherIncUpper in [True, False]:
-                            refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                            otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
+                            refRange = QgsDateRange(
+                                refLower, refUpper, refIncLower, refIncUpper
+                            )
+                            otherRange = QgsDateRange(
+                                otherLower, otherUpper, otherIncLower, otherIncUpper
+                            )
                             self.assertTrue(
                                 refRange.overlaps(otherRange),
                                 f"{refRange=} {otherRange=}",
@@ -676,7 +772,13 @@ class TestQgsDateRange(unittest.TestCase):
         # other range and reference range are contiguous
         otherUpper = QDate(2013, 3, 2)
         for otherLower in [QDate(), QDate(1998, 4, 8)]:
-            for otherIncLower, otherIncUpper, refIncLower, refIncUpper, expectedOverlaps in [
+            for (
+                otherIncLower,
+                otherIncUpper,
+                refIncLower,
+                refIncUpper,
+                expectedOverlaps,
+            ) in [
                 [True, True, True, True, True],
                 [True, True, True, False, True],
                 [True, True, False, True, False],
@@ -695,28 +797,54 @@ class TestQgsDateRange(unittest.TestCase):
                 [False, False, False, False, False],
             ]:
                 refRange = QgsDateRange(refLower, refUpper, refIncLower, refIncUpper)
-                otherRange = QgsDateRange(otherLower, otherUpper, otherIncLower, otherIncUpper)
-                self.assertEqual(refRange.overlaps(otherRange), expectedOverlaps, f"{refRange=} {otherRange=}")
+                otherRange = QgsDateRange(
+                    otherLower, otherUpper, otherIncLower, otherIncUpper
+                )
+                self.assertEqual(
+                    refRange.overlaps(otherRange),
+                    expectedOverlaps,
+                    f"{refRange=} {otherRange=}",
+                )
 
     def testIsInstant(self):
         self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)).isInstant())
         self.assertTrue(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1)).isInstant())
-        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1), False, False).isInstant())
+        self.assertFalse(
+            QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1), False, False).isInstant()
+        )
         self.assertFalse(QgsDateRange(QDate(), QDate()).isInstant())
 
     def testIsInfinite(self):
-        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)).isInfinite())
-        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1)).isInfinite())
-        self.assertFalse(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1), False, False).isInfinite())
+        self.assertFalse(
+            QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2)).isInfinite()
+        )
+        self.assertFalse(
+            QgsDateRange(QDate(2010, 3, 1), QDate(2010, 3, 1)).isInfinite()
+        )
+        self.assertFalse(
+            QgsDateRange(
+                QDate(2010, 3, 1), QDate(2010, 3, 1), False, False
+            ).isInfinite()
+        )
         self.assertTrue(QgsDateRange(QDate(), QDate()).isInfinite())
 
     def testEquality(self):
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False))
-        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True))
-        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), True, False))
-        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 3), False, False))
-        self.assertNotEqual(range, QgsDateRange(QDate(2010, 3, 2), QDate(2010, 6, 2), False, False))
+        self.assertEqual(
+            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
+        )
+        self.assertNotEqual(
+            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)
+        )
+        self.assertNotEqual(
+            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), True, False)
+        )
+        self.assertNotEqual(
+            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 3), False, False)
+        )
+        self.assertNotEqual(
+            range, QgsDateRange(QDate(2010, 3, 2), QDate(2010, 6, 2), False, False)
+        )
 
     def testExtend(self):
         range_empty = QgsDateRange(QDate(2010, 6, 2), QDate(2010, 3, 1))
@@ -726,48 +854,106 @@ class TestQgsDateRange(unittest.TestCase):
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
         self.assertFalse(range.extend(range_empty))
         range = QgsDateRange(QDate(2010, 6, 2), QDate(2010, 3, 1))
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)))
-        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
+            )
+        )
+        self.assertEqual(
+            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
+        )
 
         # Extend low
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False)))
-        self.assertEqual(range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False)
+            )
+        )
+        self.assertEqual(
+            range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), False, False)
+        )
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 2, 1), QDate(2010, 5, 2), True, False)))
-        self.assertEqual(range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), True, False))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 2, 1), QDate(2010, 5, 2), True, False)
+            )
+        )
+        self.assertEqual(
+            range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 6, 2), True, False)
+        )
 
         # Extend high
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False)))
-        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False)
+            )
+        )
+        self.assertEqual(
+            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 7, 2), False, False)
+        )
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)))
-        self.assertEqual(range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)
+            )
+        )
+        self.assertEqual(
+            range, QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, True)
+        )
 
         # Extend both
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False)))
-        self.assertEqual(range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False)
+            )
+        )
+        self.assertEqual(
+            range, QgsDateRange(QDate(2010, 2, 1), QDate(2010, 7, 2), False, False)
+        )
 
         # Extend none
         range = QgsDateRange(QDate(2010, 3, 1), QDate(2010, 6, 2), False, False)
-        self.assertFalse(range.extend(QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)))
+        self.assertFalse(
+            range.extend(
+                QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)
+            )
+        )
 
         # Test infinity
         range = QgsDateRange(QDate(), QDate())
-        self.assertFalse(range.extend(QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)))
+        self.assertFalse(
+            range.extend(
+                QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)
+            )
+        )
         range = QgsDateRange(QDate(), QDate(2010, 5, 2))
-        self.assertFalse(range.extend(QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)))
+        self.assertFalse(
+            range.extend(
+                QgsDateRange(QDate(2010, 4, 6), QDate(2010, 5, 2), False, False)
+            )
+        )
         self.assertEqual(range, QgsDateRange(QDate(), QDate(2010, 5, 2), True, True))
         range = QgsDateRange(QDate(2010, 4, 6), QDate())
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 6), QDate(2010, 5, 2), False, False)))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 3, 6), QDate(2010, 5, 2), False, False)
+            )
+        )
         self.assertEqual(range, QgsDateRange(QDate(2010, 3, 6), QDate(), False, True))
         range = QgsDateRange(QDate(), QDate(2010, 5, 2))
-        self.assertTrue(range.extend(QgsDateRange(QDate(2010, 3, 6), QDate(2010, 6, 2), False, False)))
+        self.assertTrue(
+            range.extend(
+                QgsDateRange(QDate(2010, 3, 6), QDate(2010, 6, 2), False, False)
+            )
+        )
         self.assertEqual(range, QgsDateRange(QDate(), QDate(2010, 6, 2), True, False))
         range = QgsDateRange(QDate(2010, 4, 6), QDate())
-        self.assertTrue(range.extend(QgsDateRange(QDate(), QDate(2010, 5, 2), True, False)))
+        self.assertTrue(
+            range.extend(QgsDateRange(QDate(), QDate(2010, 5, 2), True, False))
+        )
         self.assertEqual(range, QgsDateRange(QDate(), QDate(), True, True))
         range = QgsDateRange(QDate(), QDate(2010, 4, 6))
         self.assertTrue(range.extend(QgsDateRange(QDate(), QDate(), True, True)))

--- a/tests/src/python/test_qgsvectorlayertemporalproperties.py
+++ b/tests/src/python/test_qgsvectorlayertemporalproperties.py
@@ -35,10 +35,14 @@ class TestQgsVectorLayerTemporalProperties(QgisTestCase):
         props.setMode(
             QgsVectorLayerTemporalProperties.TemporalMode.ModeFeatureDateTimeInstantFromField
         )
+        props.setLimitMode(Qgis.VectorTemporalLimitMode.IncludeBeginExcludeEnd)
         props.setFixedTemporalRange(
             QgsDateTimeRange(
                 QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)),
                 QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)),
+                includeBeginning=True,
+                includeEnd=props.limitMode()
+                == Qgis.VectorTemporalLimitMode.IncludeBeginIncludeEnd,
             )
         )
         props.setStartField("start")
@@ -69,6 +73,7 @@ class TestQgsVectorLayerTemporalProperties(QgisTestCase):
         self.assertEqual(props2.accumulateFeatures(), props.accumulateFeatures())
         self.assertEqual(props2.startExpression(), props.startExpression())
         self.assertEqual(props2.endExpression(), props.endExpression())
+        self.assertEqual(props2.limitMode(), props.limitMode())
 
     def testModeFromProvider(self):
         caps = QgsVectorDataProviderTemporalCapabilities()


### PR DESCRIPTION
## Description

### fix QgsRange::overlaps()

When comparing 2 QgsRange objects for overlap, only the first include/exclude limits restrictions were considered.

This leads to errors like this, where range1.overlaps(range2) != range2.overlaps(range1):

```python
<QgsIntRange: [4, 8)>   # left end not included
<QgsIntRange: [8, 10)>  # left end not included
r1 overlaps r2: False
r2 overlaps r1: True

<QgsIntRange: (4, 8)>  # both ends included
<QgsIntRange: [8, 10]>  # left end not included
r1 overlaps r2: False
r2 overlaps r1: True
```

### fix time limits include/exclude for vector layer properties

In **fixed mode** the include/exclude limits parameter was not used (always considered include both).

---

Co-funded by [CNES](https://cnes.fr) and QGIS.org