### PR TITLE
qgsvectorlayer: Expose 3D extent in htmlMetadata

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -5841,7 +5841,10 @@ QString QgsVectorLayer::htmlMetadata() const
     }
 
     // Extent
-    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QStringLiteral( "</td><td>" ) + extent().toString() + QStringLiteral( "</td></tr>\n" );
+    // Try to display extent 3D by default. If empty (probably because the data is 2D), fallback to the 2D version
+    const QgsBox3D extentBox3D = extent3D();
+    const QString extentAsStr = !extentBox3D.isEmpty() ? extentBox3D.toString() : extent().toString();
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QStringLiteral( "</td><td>" ) + extentAsStr + QStringLiteral( "</td></tr>\n" );
   }
 
   // feature count


### PR DESCRIPTION
## Description

Try to display extent 3D by default. If empty (probably because the data is 2D), fallback to the 2D version.

cc @lbartoletti 
