### PR TITLE
[Backport release-3_40] [GUI] Replace Italic Font with Monospaced Font in Expression Fields of Attribute Table (#59139)

### DIFF
--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -392,7 +392,8 @@ void QgsFieldExpressionWidget::updateLineEditStyle( const QString &expression )
       currentField( &isExpression, &isValid );
     }
     QFont font = mCombo->lineEdit()->font();
-    font.setItalic( isExpression );
+    font.setFamily( ( QgsCodeEditor::getMonospaceFont() ).family() );
+    font.setItalic( false );
     mCombo->lineEdit()->setFont( font );
 
     if ( isExpression && !isValid )


### PR DESCRIPTION
This PR backports the changes from [#59139](https://github.com/qgis/QGIS/pull/59139) to the release-3_40 branch to resolve [Issue #44638](https://github.com/qgis/QGIS/issues/44638). The update replaces italic fonts with a monospaced font in the expression fields of the attribute table, enhancing readability and ensuring visual consistency across the interface.