### PR TITLE
Add general expresion context in raster temporal properties

### DIFF
--- a/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
+++ b/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
@@ -236,6 +236,7 @@ void QgsRasterLayerTemporalPropertiesWidget::calculateRangeByExpression( bool is
   bandScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "band_description" ), mLayer->dataProvider()->bandDescription( 1 ), true, false, tr( "Band description" ) ) );
 
   expressionContext.appendScope( bandScope );
+  expressionContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
   expressionContext.setHighlightedVariables( { QStringLiteral( "band" ), QStringLiteral( "band_name" ), QStringLiteral( "band_description" ) } );
 
   QgsExpressionBuilderDialog dlg = QgsExpressionBuilderDialog( nullptr, isUpper ? mFixedRangeUpperExpression : mFixedRangeLowerExpression, this, QStringLiteral( "generic" ), expressionContext );


### PR DESCRIPTION
## Description

Add global contexts to start/end date expression in raster layer temporal properties "Fixed time range per band" mode.

As a result, variables like @layer_name can be used now.

---

Funded by [CNES](https://cnes.fr)
