### PR TITLE
qgsnewhttpconnection: Always enable paging options for WFS 1.1

### DIFF
--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -187,10 +187,10 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
 void QgsNewHttpConnection::wfsVersionCurrentIndexChanged( int index )
 {
   // For now 2019-06-06, leave paging checkable for some WFS version 1.1 servers with support
-  cmbFeaturePaging->setEnabled( index == WFS_VERSION_MAX || index >= WFS_VERSION_2_0 );
-  const bool pagingNotDisabled = cmbFeaturePaging->currentIndex() != static_cast<int>( QgsNewHttpConnection::WfsFeaturePagingIndex::DISABLED );
-  lblPageSize->setEnabled( pagingNotDisabled && ( index == WFS_VERSION_MAX || index >= WFS_VERSION_1_1 ) );
-  txtPageSize->setEnabled( pagingNotDisabled && ( index == WFS_VERSION_MAX || index >= WFS_VERSION_1_1 ) );
+  const bool pagingOptionsEnabled = ( index == WFS_VERSION_MAX || index >= WFS_VERSION_1_1 );
+  cmbFeaturePaging->setEnabled( pagingOptionsEnabled );
+  lblPageSize->setEnabled( pagingOptionsEnabled );
+  txtPageSize->setEnabled( pagingOptionsEnabled );
   cbxWfsIgnoreAxisOrientation->setEnabled( index != WFS_VERSION_1_0 && index != WFS_VERSION_API_FEATURES_1_0 );
   cbxWfsInvertAxisOrientation->setEnabled( index != WFS_VERSION_API_FEATURES_1_0 );
   wfsUseGml2EncodingForTransactions()->setEnabled( index == WFS_VERSION_1_1 );


### PR DESCRIPTION
## Description

Paging support is only handled by WFS 2.0. However, some servers handle paging even if they only expose WFS 1.1. At the moment, when changing the version number, it has the following effect on the paging options:
- "maximum": both options can be enabled
- "2.0": both options can be enabled
- "1.1": both options can be enabled
- "1.0": "feature paging" option is always disabled but the "page size" option can be enabled

With this change, both paging options can be enabled for version 1.1. This allows to try to enable paging for WFS 1.1 if the server handles it.

@rouault I'm not sure what the correct behavior is but I don't understand the current one. At the moment, if  the `1.1` version is selected, the `feature paging` option is disabled but `page size` is enabled if `feature paging != disabled`.   Why would the `page size` option be enabled if the `feature paging` option is not. The following behavior seems more logical to me: 
- always enable the `feature paging` option
- enable `page size` is enabled if `feature paging` is not `disabled`
