### PR TITLE
fix: empty vector layer reload() will never invalidate cache

### DIFF
--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -398,6 +398,7 @@ void QgsVectorLayerCache::invalidate()
     mCacheOrderedKeys.clear();
     mCacheUnorderedKeys.clear();
     mFullCache = false;
+    mCacheRequestCompleted = false;
     emit invalidated();
   }
 }

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -388,14 +388,11 @@ void QgsVectorLayerCache::layerDeleted()
 
 void QgsVectorLayerCache::invalidate()
 {
-  if ( ! mCache.isEmpty() )
-  {
-    mCache.clear();
-    mCacheOrderedKeys.clear();
-    mCacheUnorderedKeys.clear();
-    mFullCache = false;
-    emit invalidated();
-  }
+  mCache.clear();
+  mCacheOrderedKeys.clear();
+  mCacheUnorderedKeys.clear();
+  mFullCache = false;
+  emit invalidated();
 }
 
 bool QgsVectorLayerCache::canUseCacheForRequest( const QgsFeatureRequest &featureRequest, QgsFeatureIterator &it )

--- a/src/core/vector/qgsvectorlayercache.h
+++ b/src/core/vector/qgsvectorlayercache.h
@@ -439,6 +439,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
 
     bool mCacheGeometry = true;
     bool mFullCache = false;
+    bool mCacheRequestCompleted = false;
     QList<QgsAbstractCacheIndex *> mCacheIndices;
 
     QgsAttributeList mCachedAttributes;


### PR DESCRIPTION
empty layer will never reload cache after the external program inserts the data
