### PR TITLE
enable snapping in georeferenceer

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -11,6 +11,8 @@
 
 
 
+
+
 class QgsRectangle
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -11,6 +11,8 @@
 
 
 
+
+
 class QgsRectangle
 {
 %Docstring(signature="appended")

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -31,6 +31,7 @@ class QPlainTextEdit;
 class QLabel;
 
 class QgisInterface;
+class QgsAdvancedDigitizingDockWidget;
 class QgsDoubleSpinBox;
 class QgsGeorefDataPoint;
 class QgsGCPListWidget;
@@ -271,6 +272,7 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     QList<QgsGcpPoint> mSavedPoints;
 
     QgsMapCanvas *mCanvas = nullptr;
+    QgsAdvancedDigitizingDockWidget *mAdvancedDigitizingDockWidget = nullptr;
     std::unique_ptr<QgsMapLayer> mLayer;
 
     QgsMapTool *mToolZoomIn = nullptr;

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -37,6 +37,7 @@ class QgsGeorefDataPoint;
 class QgsGCPListWidget;
 class QgsMapTool;
 class QgsMapCanvas;
+class QgsMapCanvasSnappingUtils;
 class QgsMapCoordsDialog;
 class QgsPointXY;
 class QgsRasterLayer;
@@ -77,6 +78,8 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     static const QgsSettingsEntryString *settingLastSourceFolder;
     static const QgsSettingsEntryString *settingLastRasterFileFilter;
     static const QgsSettingsEntryString *settingLastTargetCrs;
+    static const QgsSettingsEntryBool *settingSnappingEnabled;
+    static const QgsSettingsEntryEnumFlag<Qgis::SnappingTypes> *settingSnappingTypes;
 
     QgsGeoreferencerMainWindow( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags() );
     ~QgsGeoreferencerMainWindow() override;
@@ -272,7 +275,10 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     QList<QgsGcpPoint> mSavedPoints;
 
     QgsMapCanvas *mCanvas = nullptr;
+    QgsMapCanvasSnappingUtils *mSnappingUtils = nullptr;
     QgsAdvancedDigitizingDockWidget *mAdvancedDigitizingDockWidget = nullptr;
+    QToolButton *mSnappingTypeButton = nullptr;
+    QList<QAction *> mSnappingTypeActions;
     std::unique_ptr<QgsMapLayer> mLayer;
 
     QgsMapTool *mToolZoomIn = nullptr;

--- a/src/app/georeferencer/qgsgeoreftooladdpoint.cpp
+++ b/src/app/georeferencer/qgsgeoreftooladdpoint.cpp
@@ -18,17 +18,12 @@
 #include "moc_qgsgeoreftooladdpoint.cpp"
 #include "qgsmapmouseevent.h"
 
-QgsGeorefToolAddPoint::QgsGeorefToolAddPoint( QgsMapCanvas *canvas )
-  : QgsMapToolEmitPoint( canvas )
+QgsGeorefToolAddPoint::QgsGeorefToolAddPoint( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *advancedDigitizingDockWidget )
+  : QgsMapToolCapture( canvas, advancedDigitizingDockWidget, QgsMapToolCapture::CaptureMode::CapturePoint )
 {
 }
 
-// Mouse press event for overriding
-void QgsGeorefToolAddPoint::canvasPressEvent( QgsMapMouseEvent *e )
+void QgsGeorefToolAddPoint::pointCaptured( const QgsPoint &point )
 {
-  // Only add point on Qt:LeftButton
-  if ( Qt::LeftButton == e->button() )
-  {
-    emit showCoordDialog( toMapCoordinates( e->pos() ) );
-  }
+  emit showCoordDialog( point );
 }

--- a/src/app/georeferencer/qgsgeoreftooladdpoint.h
+++ b/src/app/georeferencer/qgsgeoreftooladdpoint.h
@@ -17,20 +17,20 @@
 #define QGSGEOREFTOOLADDPOINT_H
 
 
-#include "qgsmaptoolemitpoint.h"
+#include "qgsmaptoolcapture.h"
 
 class QgsPointXY;
 class QgsMapCanvas;
+class QgsAdvancedDigitizingDockWidget;
 
-class QgsGeorefToolAddPoint : public QgsMapToolEmitPoint
+class QgsGeorefToolAddPoint : public QgsMapToolCapture
 {
     Q_OBJECT
 
   public:
-    explicit QgsGeorefToolAddPoint( QgsMapCanvas *canvas );
+    explicit QgsGeorefToolAddPoint( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *advancedDigitizingDockWidget );
 
-    // Mouse events for overriding
-    void canvasPressEvent( QgsMapMouseEvent *e ) override;
+    void pointCaptured( const QgsPoint &point );
 
   signals:
     void showCoordDialog( const QgsPointXY &sourceCoordinates );

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -37,8 +37,10 @@ class QgsScaleWidget;
 
 #include "qgssnappingconfig.h"
 
+#include <QMenu>
 #include <QWidget>
 #include <QSettings>
+
 #include "qgis_app.h"
 
 /**

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -18,16 +18,18 @@
 #ifndef QGSRECTANGLE_H
 #define QGSRECTANGLE_H
 
-#include "qgis_core.h"
-#include "qgis.h"
 #include <iosfwd>
 #include <QDomDocument>
 #include <QRectF>
 
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgspointxy.h"
+
+
 class QString;
 class QRectF;
 class QgsBox3D;
-#include "qgspointxy.h"
 
 
 /**

--- a/src/ui/georeferencer/qgsgeorefpluginguibase.ui
+++ b/src/ui/georeferencer/qgsgeorefpluginguibase.ui
@@ -121,6 +121,7 @@
    <addaction name="mActionAddPoint"/>
    <addaction name="mActionDeletePoint"/>
    <addaction name="mActionMoveGCPPoint"/>
+   <addaction name="mActionAdvancedDigitizingDock"/>
   </widget>
   <widget class="QToolBar" name="toolBarView">
    <property name="windowTitle">
@@ -150,7 +151,7 @@
   </widget>
   <widget class="QgsDockWidget" name="dockWidgetGCPpoints">
    <property name="allowedAreas">
-    <set>Qt::AllDockWidgetAreas</set>
+    <set>Qt::DockWidgetArea::AllDockWidgetAreas</set>
    </property>
    <property name="windowTitle">
     <string>GCP table</string>
@@ -396,6 +397,24 @@
     <string>Open Vector…</string>
    </property>
   </action>
+  <action name="mActionAdvancedDigitizingDock">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/cadtools/cad.svg</normaloff>:/images/themes/default/cadtools/cad.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Advanced Digitizing Dock</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Advanced Digitizing Dock</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::MenuRole::NoRole</enum>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -406,7 +425,6 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
This enables snapping and advanced dock widget in the georeferencer.

https://github.com/user-attachments/assets/a2dd1918-5f22-4913-998c-da1b01913963



Also fixes a regression from https://github.com/qgis/QGIS/pull/58755 where snapping in QgsMapToolCapture was not working anymore in a scenario without an active layer. 
Test added for this.