### PR TITLE
QgsVectorFileWriterMetadataContainer: remove FileGDB (SDK based) driver from proposed list if GDAL >= 3.11

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2251,6 +2251,7 @@ class QgsVectorFileWriterMetadataContainer
                              )
                            );
 
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,11,0)
       // ESRI FileGDB (using ESRI FileGDB API SDK)
       datasetOptions.clear();
       layerOptions.clear();
@@ -2282,6 +2283,7 @@ class QgsVectorFileWriterMetadataContainer
                                QStringLiteral( "UTF-8" )
                              )
                            );
+#endif
 
       // XLSX
       datasetOptions.clear();


### PR DESCRIPTION
In GDAL 3.11, write support of the FileGDB driver will go through the OpenFileGDB one, so no need to propose it and confuse users. Cf https://github.com/OSGeo/gdal/pull/11662
