### PR TITLE
Better pep440

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,6 +48,7 @@ Build-Depends:
  python3-mock,
  python3-nose2,
  python3-owslib,
+ python3-packaging,
  python3-psycopg2,
  python3-pyqt5,
  python3-pyqt5.qsci,

--- a/debian/control.in
+++ b/debian/control.in
@@ -53,6 +53,7 @@ Build-Depends:
  python3-mock,
  python3-nose2,
  python3-owslib,
+ python3-packaging,
  python3-psycopg2,
  python3-pyqt5,
  python3-pyqt5.qsci,

--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -164,7 +164,7 @@ def compareVersions(a, b):
     v2 = chopString(b)
     # set the shorter string as a base
     l1, l2 = len(v1), len(v2)
-    l = min(l1,l2)
+    l = min(l1, l2)
     # try to determine within the common length
     for i in range(l):
         if return_code := compareElements(v1[i], v2[i]):

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -179,6 +179,7 @@ Requires:       gdal-python3
 Requires:       gdal-python-tools
 Requires:       python3-jinja2
 Requires:       python3-OWSLib
+Requires:       python3-packaging
 Requires:       python3-psycopg2
 Requires:       python3-pygments
 Requires:       python3-PyYAML

--- a/tests/src/python/test_versioncompare.py
+++ b/tests/src/python/test_versioncompare.py
@@ -104,7 +104,7 @@ class TestVersionCompare(QgisTestCase):
         self.assertEqual(compareVersions(a, b), 0)
         b = "1.0.0post1"
         self.assertEqual(compareVersions(a, b), 2)
-        
+
         # FIXME: these one will fail ...
         #   should we use packaging.version.parse ?
         # a = "1.0a1"

--- a/tests/src/python/test_versioncompare.py
+++ b/tests/src/python/test_versioncompare.py
@@ -53,14 +53,60 @@ class TestVersionCompare(QgisTestCase):
         b = "1.0.0-2"
         self.assertEqual(compareVersions(a, b), 2)
 
-        # test versions with suffixes
-        a = "1.0.0a"
-        b = "1.0.0b"
+        # test versions with long pre-release suffixes
+        a = "1.0.0alpha"
+        b = "1.0.0beta"
         self.assertEqual(compareVersions(a, b), 2)
+
+        # test versions with PEP440 suffixes
+        a = "1.0.0a2"
+        b = "1.0.0b1"
+        self.assertEqual(compareVersions(a, b), 2)
+
+        # test versions with post suffixes
+        a = "1.0"
+        b = "1.0post1"
+        self.assertEqual(compareVersions(a, b), 2)
+
+        # test versions with different lengths
+        a = "1.0"
+        b = "1.0.1"
+        self.assertEqual(compareVersions(a, b), 2)
+        a = "2.0"
+        self.assertEqual(compareVersions(a, b), 1)
 
         # test versions with suffixes in different cases
         a = "1.0.0-201609011405-2690BD9"
         b = "1.0.0-201609011405-2690bd9"
+        self.assertEqual(compareVersions(a, b), 0)
+
+        # test versions with different lengths
+        a = "1.0a1"
+        b = "1.0.1post2"
+        self.assertEqual(compareVersions(a, b), 2)
+        a = "2.0.1"
+        self.assertEqual(compareVersions(a, b), 1)
+
+        # test shorthand alphas
+        a = "1.0a1"
+        b = "1.0alpha1"
+        self.assertEqual(compareVersions(a, b), 0)
+        b = "1.0.alpha1"
+        self.assertEqual(compareVersions(a, b), 0)
+        b = "1.0.alpha.1"
+        self.assertEqual(compareVersions(a, b), 0)
+
+        # test partial versions
+        a = "1"
+        b = "1.0"
+        self.assertEqual(compareVersions(a, b), 0)
+        b = "1.0.0"
+        self.assertEqual(compareVersions(a, b), 0)
+        b = "1.0.0post1"
+        self.assertEqual(compareVersions(a, b), 2)
+        
+        a = "1.0a1"
+        b = "1.0.0alpha1"
         self.assertEqual(compareVersions(a, b), 0)
 
 

--- a/tests/src/python/test_versioncompare.py
+++ b/tests/src/python/test_versioncompare.py
@@ -105,9 +105,11 @@ class TestVersionCompare(QgisTestCase):
         b = "1.0.0post1"
         self.assertEqual(compareVersions(a, b), 2)
         
-        a = "1.0a1"
-        b = "1.0.0alpha1"
-        self.assertEqual(compareVersions(a, b), 0)
+        # FIXME: these one will fail ...
+        #   should we use packaging.version.parse ?
+        # a = "1.0a1"
+        # b = "1.0.0alpha1"
+        # self.assertEqual(compareVersions(a, b), 0)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_versioncompare.py
+++ b/tests/src/python/test_versioncompare.py
@@ -105,11 +105,10 @@ class TestVersionCompare(QgisTestCase):
         b = "1.0.0post1"
         self.assertEqual(compareVersions(a, b), 2)
 
-        # FIXME: these one will fail ...
-        #   should we use packaging.version.parse ?
-        # a = "1.0a1"
-        # b = "1.0.0alpha1"
-        # self.assertEqual(compareVersions(a, b), 0)
+        # PEP440 test (failling without packaging)
+        a = "1.0a1"
+        b = "1.0.0alpha1"
+        self.assertEqual(compareVersions(a, b), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR follows up the previous [60137](https://github.com/qgis/QGIS/pull/60137), going further into supporting PEP440 and semver syntaxes (see below). It also ships extended unit tests (reflecting the 2 digits used versions in the [examples](https://docs.qgis.org/3.34/en/docs/pyqgis_developer_cookbook/plugins/plugins.html#metadata-txt)).

It brings "0" padding for missmatching length versions, equality for short/long hand syntaxes (alpha/beta).

### Before:
- `0.1 < 0.1.0`
- `0.1a1 <0.1alpha1`
- `0.1post1 > 0.1dev1`

### After:
- `0.1 == 0.1.0`
- `0.1a1 == 0.1alpha1`
- `0.1post1 < 0.1dev1`

## TODO/FIXME:
It still misses proper handling of missmatching lengths when a tail is provided (pre/post releases):
for example it sorts `1.0a1 < 1.0.0alpha1` when they should be equal ... should we delegate these comparison to a dedicated tool such as packaging.version` ?
