### PR TITLE
use default snapping options in georeferencer

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -37,6 +37,7 @@
 #include "qgsapplication.h"
 #include "qgsgui.h"
 #include "qgisapp.h"
+#include "qgssettingsregistrycore.h"
 
 #include "qgslayoutitemlabel.h"
 #include "qgslayoutitemmap.h"

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1116,8 +1116,8 @@ void QgsGeoreferencerMainWindow::createMapCanvas()
   QgsSnappingConfig snappingConfig;
   snappingConfig.setMode( Qgis::SnappingMode::AllLayers );
   snappingConfig.setTypeFlag( settingSnappingTypes->value() );
-  snappingConfig.setTolerance( 10 );
-  snappingConfig.setUnits( Qgis::MapToolUnit::Pixels );
+  snappingConfig.setTolerance( QgsSettingsRegistryCore::settingsDigitizingDefaultSnappingTolerance->value() );
+  snappingConfig.setUnits( QgsSettingsRegistryCore::settingsDigitizingDefaultSnappingToleranceUnit->value() );
   snappingConfig.setEnabled( settingSnappingEnabled->value() );
 
   mSnappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );


### PR DESCRIPTION
@lbartoletti  Here you go, follow-up from #60156 

I'm just not sure this is the right approach. If someone messes with these values, the tool becomes unusable and you have no idea why.
Looking at other places in the code, it doesn't seem to be much used where it cannot be altered.
And I think adding a GUI to play with snapping tolerance in the georeferencer window is an overkill.

