### PR TITLE
3d/elevation profile: Use absolute clamping for 3d data

### DIFF
--- a/src/3d/symbols/qgsline3dsymbol.h
+++ b/src/3d/symbols/qgsline3dsymbol.h
@@ -123,7 +123,7 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTORS
 
   private:
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
     //! how to handle clamping of vertices of individual features
     Qgis::AltitudeBinding mAltBinding = Qgis::AltitudeBinding::Centroid;
 

--- a/src/3d/symbols/qgslinevertexdata_p.h
+++ b/src/3d/symbols/qgslinevertexdata_p.h
@@ -77,7 +77,7 @@ struct QgsLineVertexData
     bool withAdjacency = false; //!< Whether line strip with adjacency primitive will be used
 
     // extra info to calculate elevation
-    Qgis::AltitudeClamping altClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping altClamping = Qgis::AltitudeClamping::Absolute;
     Qgis::AltitudeBinding altBinding = Qgis::AltitudeBinding::Vertex;
     float baseHeight = 0;
     Qgs3DRenderContext renderContext; // used for altitude clamping

--- a/src/3d/symbols/qgsmesh3dsymbol.h
+++ b/src/3d/symbols/qgsmesh3dsymbol.h
@@ -354,7 +354,7 @@ class _3D_EXPORT QgsMesh3DSymbol : public QgsAbstract3DSymbol
 #endif
 
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
     float mHeight = 0.0f;                                           //!< Base height of triangles
     std::unique_ptr<QgsAbstractMaterialSettings> mMaterialSettings; //!< Defines appearance of objects
     bool mAddBackFaces = false;

--- a/src/3d/symbols/qgspoint3dsymbol.h
+++ b/src/3d/symbols/qgspoint3dsymbol.h
@@ -175,7 +175,7 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
 
   private:
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
 
     std::unique_ptr<QgsAbstractMaterialSettings> mMaterialSettings; //!< Defines appearance of objects
     Qgis::Point3DShape mShape = Qgis::Point3DShape::Cylinder;       //!< What kind of shape to use

--- a/src/3d/symbols/qgspolygon3dsymbol.h
+++ b/src/3d/symbols/qgspolygon3dsymbol.h
@@ -186,7 +186,7 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCT
 
   private:
     //! how to handle altitude of vector features
-    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
     //! how to handle clamping of vertices of individual features
     Qgis::AltitudeBinding mAltBinding = Qgis::AltitudeBinding::Centroid;
 

--- a/src/core/vector/qgsvectorlayerelevationproperties.cpp
+++ b/src/core/vector/qgsvectorlayerelevationproperties.cpp
@@ -151,7 +151,7 @@ void QgsVectorLayerElevationProperties::setDefaultsFromLayer( QgsMapLayer *layer
 
   if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) )
   {
-    mClamping = Qgis::AltitudeClamping::Relative;
+    mClamping = Qgis::AltitudeClamping::Absolute;
   }
   else
   {

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -2003,6 +2003,15 @@ void TestQgs3DRendering::testAmbientOcclusion()
   mapSettings.setLightSources( { defaultPointLight.clone() } );
   mapSettings.setOutputDpi( 92 );
 
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setAmbient( Qt::lightGray );
+  QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
+  symbol3d->setMaterialSettings( materialSettings.clone() );
+  symbol3d->setExtrusionHeight( 10.f );
+  symbol3d->setAltitudeClamping( Qgis::AltitudeClamping::Relative );
+  QgsVectorLayer3DRenderer *renderer3d = new QgsVectorLayer3DRenderer( symbol3d );
+  mLayerBuildings->setRenderer3D( renderer3d );
+
   // =========== creating Qgs3DMapScene
   QPoint winSize = QPoint( 640, 480 ); // default window size
 

--- a/tests/src/python/test_qgsmesh3dsymbol.py
+++ b/tests/src/python/test_qgsmesh3dsymbol.py
@@ -38,9 +38,9 @@ class TestQgsQgsMesh3DSymbol(QgisTestCase):
         self.assertEqual(symbol.cullingMode(), Qgs3DTypes.Front)
 
         # Test altitude clamping
-        self.assertEqual(symbol.altitudeClamping(), Qgis.AltitudeClamping.Relative)
-        symbol.setAltitudeClamping(Qgis.AltitudeClamping.Absolute)
         self.assertEqual(symbol.altitudeClamping(), Qgis.AltitudeClamping.Absolute)
+        symbol.setAltitudeClamping(Qgis.AltitudeClamping.Relative)
+        self.assertEqual(symbol.altitudeClamping(), Qgis.AltitudeClamping.Relative)
 
         # Test height
         self.assertEqual(symbol.height(), 0.0)
@@ -152,9 +152,9 @@ class TestQgsQgsMesh3DSymbol(QgisTestCase):
         self.assertEqual(symbol1, symbol2)
 
         # Test altitude clamping
-        symbol2.setAltitudeClamping(Qgis.AltitudeClamping.Absolute)
-        self.assertNotEqual(symbol1, symbol2)
         symbol2.setAltitudeClamping(Qgis.AltitudeClamping.Relative)
+        self.assertNotEqual(symbol1, symbol2)
+        symbol2.setAltitudeClamping(Qgis.AltitudeClamping.Absolute)
         self.assertEqual(symbol1, symbol2)
 
         # Test height

--- a/tests/src/python/test_qgsvectorlayerelevationproperties.py
+++ b/tests/src/python/test_qgsvectorlayerelevationproperties.py
@@ -188,12 +188,12 @@ class TestQgsVectorLayerElevationProperties(QgisTestCase):
             vl.elevationProperties().clamping(), Qgis.AltitudeClamping.Terrain
         )
 
-        # a layer WITH z values present should default to relative mode
+        # a layer WITH z values present should default to absolute mode
         vl = QgsVectorLayer(unitTestDataPath() + "/3d/points_with_z.shp")
         self.assertTrue(vl.isValid())
 
         self.assertEqual(
-            vl.elevationProperties().clamping(), Qgis.AltitudeClamping.Relative
+            vl.elevationProperties().clamping(), Qgis.AltitudeClamping.Absolute
         )
 
     def test_show_by_default(self):


### PR DESCRIPTION
## Description

This is a second attempt based on https://github.com/qgis/QGIS/pull/59759 which was auto closed because of the lack of reaction

When providing a project DTM/DEM, the default behavior for vector feature with a z-component is to offset the $z coordinates from the terrain elevation model in the elevation profile view. However, the geometry coordinates are supposed to be absolute.

So it makes more sense, to only use the $z coordinate by default in that case.

See: https://github.com/qgis/QGIS/issues/59757

cc @T4mmi 
