### PR TITLE
[gui] Insure modified attribute form properties are stored when switching from one field to another

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -681,7 +681,7 @@ void QgsAttributesFormProperties::loadAttributeSpecificEditor( QgsAttributesDnDT
         if ( layout == Qgis::AttributeFormLayout::DragAndDrop )
         {
           loadAttributeWidgetEdit();
-	    }
+        }
         loadAttributeTypeDialog();
         break;
       }

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -643,7 +643,13 @@ void QgsAttributesFormProperties::loadAttributeSpecificEditor( QgsAttributesDnDT
   const Qgis::AttributeFormLayout layout = mEditorLayoutComboBox->currentData().value<Qgis::AttributeFormLayout>();
 
   if ( layout == Qgis::AttributeFormLayout::DragAndDrop )
+  {
     storeAttributeWidgetEdit();
+  }
+  if ( mAttributeTypeDialog )
+  {
+    storeAttributeTypeDialog();
+  }
 
   clearAttributeTypeFrame();
 
@@ -673,7 +679,9 @@ void QgsAttributesFormProperties::loadAttributeSpecificEditor( QgsAttributesDnDT
       {
         receiver->selectFirstMatchingItem( itemData );
         if ( layout == Qgis::AttributeFormLayout::DragAndDrop )
+        {
           loadAttributeWidgetEdit();
+	    }
         loadAttributeTypeDialog();
         break;
       }

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -473,6 +473,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QMenu *mAvailableWidgetsTreeContextMenu = nullptr;
     QAction *mActionCopyWidgetConfiguration = nullptr;
     QAction *mActionPasteWidgetConfiguration = nullptr;
+    
+    friend class TestQgsAttributesFormProperties;
 };
 
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -473,7 +473,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QMenu *mAvailableWidgetsTreeContextMenu = nullptr;
     QAction *mActionCopyWidgetConfiguration = nullptr;
     QAction *mActionPasteWidgetConfiguration = nullptr;
-    
+
     friend class TestQgsAttributesFormProperties;
 };
 

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TESTS
   testqgsdoublespinbox.cpp
   testqgsdualview.cpp
   testqgsattributeform.cpp
+  testqgsattributesformproperties.cpp
   testqgsdatetimeedit.cpp
   testqgsdockwidget.cpp
   testqgsfieldexpressionwidget.cpp

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -1,0 +1,89 @@
+/***************************************************************************
+    testqgsattributesformproperties.cpp
+     --------------------------------------
+    Date                 : 2025-01-21
+    Copyright            : (C) 2025 Mathieu Pellerin
+    Email                : paul dot blottiere at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+
+#include "qgsattributesformproperties.h"
+#include "qgsattributetypedialog.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataprovider.h"
+#include "qgsgui.h"
+
+class TestQgsAttributesFormProperties : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsAttributesFormProperties() = default;
+
+  private slots:
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init();            // will be called before each testfunction is executed.
+    void cleanup();         // will be called after every testfunction.
+
+    void testConfigStored();
+};
+
+void TestQgsAttributesFormProperties::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsAttributesFormProperties::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsAttributesFormProperties::init()
+{
+}
+
+void TestQgsAttributesFormProperties::cleanup()
+{
+}
+
+void TestQgsAttributesFormProperties::testConfigStored()
+{
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=col0:integer&field=col1:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  QgsAttributesFormProperties attributeFormProperties( layer );
+  attributeFormProperties.init();
+  
+  // Get the fields 
+  QVERIFY( attributeFormProperties.mAvailableWidgetsTree );
+  QTreeWidgetItem *fieldsItem = attributeFormProperties.mAvailableWidgetsTree->topLevelItem( 0 );
+  QVERIFY( fieldsItem );
+  QCOMPARE( fieldsItem->text( 0 ), QStringLiteral( "Fields" ) );
+  QCOMPARE( fieldsItem->childCount(), 2 );
+  
+  // Insure that the configuration was stored when switching from one available widgets tree item to another
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias0" ) );
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias1" ) );
+  
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias0" ) );
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias1" ) );
+}
+
+QGSTEST_MAIN( TestQgsAttributesFormProperties )
+#include "testqgsattributesformproperties.moc"

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -61,14 +61,14 @@ void TestQgsAttributesFormProperties::testConfigStored()
   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=col0:integer&field=col1:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
   QgsAttributesFormProperties attributeFormProperties( layer );
   attributeFormProperties.init();
-  
-  // Get the fields 
+
+  // Get the fields
   QVERIFY( attributeFormProperties.mAvailableWidgetsTree );
   QTreeWidgetItem *fieldsItem = attributeFormProperties.mAvailableWidgetsTree->topLevelItem( 0 );
   QVERIFY( fieldsItem );
   QCOMPARE( fieldsItem->text( 0 ), QStringLiteral( "Fields" ) );
   QCOMPARE( fieldsItem->childCount(), 2 );
-  
+
   // Insure that the configuration was stored when switching from one available widgets tree item to another
   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
@@ -76,7 +76,7 @@ void TestQgsAttributesFormProperties::testConfigStored()
   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
   attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias1" ) );
-  
+
   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
   QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias0" ) );


### PR DESCRIPTION
## Description

This PR fixes  #60181 . I've added a new test class to cover the attributes form properties widget, the regression is pretty bad and we don't want it to happen again silently.