### PR TITLE
[gui][processing] Fix inconsistent behavior with the map layer widget's selected features only checkbox

### DIFF
--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -42,6 +42,8 @@ QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
 
 void QgsMapLayerModel::setProject( QgsProject *project )
 {
+  if ( mProject == ( project ? project : QgsProject::instance() ) ) // skip-keyword-check
+    return;
 
   // remove layers from previous project
   if ( mProject )

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -221,7 +221,9 @@ QgsProcessingMapLayerComboBox::~QgsProcessingMapLayerComboBox() = default;
 void QgsProcessingMapLayerComboBox::setLayer( QgsMapLayer *layer )
 {
   if ( layer || mParameter->flags() & Qgis::ProcessingParameterFlag::Optional )
+  {
     mCombo->setLayer( layer );
+  }
 }
 
 QgsMapLayer *QgsProcessingMapLayerComboBox::currentLayer()


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/60108 whereas the processing map layer parameter widget's [x] selected features only checkbox was behaving inconsistently and would sporadically fail to reflect the selection state of the active layer assigned to the map layer combobox when opening an alg. dialog.

There are two fixes in there:
- due to an issue with layer changed signal with the map layer combo box (more on that later), when we call QgsProcessingMapLayerComboBox::setLayer , we block the combo box signal and manually trigger the onLayerChanged slot. 
- one issue I spotted while profiling this was that we were needlessly rebuilding the map layers model at least once per map layer parameter as setting the widget context's project to the map layer combo box was triggering a model reset, this has been fixed by skipping model reset when the project being set == old project.

Now, there's still an issue with the map layer combobox whereas the combobox will emit a layerChanged( nullptr ) when a model's project has changed and is removing all of its layers, whereas it won't re-emit a signal when the model has reloaded since we are adding more than one row and the rowsChanged count will be greater than 0.

The problematic logic is here: https://github.com/qgis/QGIS/blob/master/src/gui/qgsmaplayercombobox.cpp#L156-L167

Since the two patches above fix processing's algorithm dialog, I'm inclined not to touch the map layer combobox logic as it's used in a lot of other places.