### PR TITLE
[OGR] Fix transactional editing for GPKG/SQLite

### DIFF
--- a/python/PyQt6/core/auto_additions/qgstransaction.py
+++ b/python/PyQt6/core/auto_additions/qgstransaction.py
@@ -1,8 +1,8 @@
 # The following has been generated automatically from src/core/qgstransaction.h
 try:
-    QgsTransaction.__attribute_docs__ = {'afterRollback': 'Emitted after a rollback\n', 'dirtied': 'Emitted if a sql query is executed and the underlying data is modified\n'}
+    QgsTransaction.__attribute_docs__ = {'afterRollback': 'Emitted after a rollback\n', 'afterRollbackToSavepoint': 'Emitted after a rollback to savepoint\n\n.. versionadded:: 3.42\n', 'dirtied': 'Emitted if a sql query is executed and the underlying data is modified\n'}
     QgsTransaction.create = staticmethod(QgsTransaction.create)
     QgsTransaction.supportsTransaction = staticmethod(QgsTransaction.supportsTransaction)
-    QgsTransaction.__signal_arguments__ = {'dirtied': ['sql: str', 'name: str']}
+    QgsTransaction.__signal_arguments__ = {'afterRollbackToSavepoint': ['savepointName: str'], 'dirtied': ['sql: str', 'name: str']}
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/qgstransaction.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstransaction.sip.in
@@ -154,6 +154,13 @@ returns the last created savepoint
 Emitted after a rollback
 %End
 
+    void afterRollbackToSavepoint( const QString &savepointName );
+%Docstring
+Emitted after a rollback to savepoint
+
+.. versionadded:: 3.42
+%End
+
     void dirtied( const QString &sql, const QString &name );
 %Docstring
 Emitted if a sql query is executed and the underlying data is modified

--- a/python/core/auto_additions/qgstransaction.py
+++ b/python/core/auto_additions/qgstransaction.py
@@ -1,8 +1,8 @@
 # The following has been generated automatically from src/core/qgstransaction.h
 try:
-    QgsTransaction.__attribute_docs__ = {'afterRollback': 'Emitted after a rollback\n', 'dirtied': 'Emitted if a sql query is executed and the underlying data is modified\n'}
+    QgsTransaction.__attribute_docs__ = {'afterRollback': 'Emitted after a rollback\n', 'afterRollbackToSavepoint': 'Emitted after a rollback to savepoint\n\n.. versionadded:: 3.42\n', 'dirtied': 'Emitted if a sql query is executed and the underlying data is modified\n'}
     QgsTransaction.create = staticmethod(QgsTransaction.create)
     QgsTransaction.supportsTransaction = staticmethod(QgsTransaction.supportsTransaction)
-    QgsTransaction.__signal_arguments__ = {'dirtied': ['sql: str', 'name: str']}
+    QgsTransaction.__signal_arguments__ = {'afterRollbackToSavepoint': ['savepointName: str'], 'dirtied': ['sql: str', 'name: str']}
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/qgstransaction.sip.in
+++ b/python/core/auto_generated/qgstransaction.sip.in
@@ -154,6 +154,13 @@ returns the last created savepoint
 Emitted after a rollback
 %End
 
+    void afterRollbackToSavepoint( const QString &savepointName );
+%Docstring
+Emitted after a rollback to savepoint
+
+.. versionadded:: 3.42
+%End
+
     void dirtied( const QString &sql, const QString &name );
 %Docstring
 Emitted if a sql query is executed and the underlying data is modified

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -544,11 +544,11 @@ void QgsOgrProvider::setTransaction( QgsTransaction *transaction )
   QgsDebugMsgLevel( QStringLiteral( "set transaction %1" ).arg( transaction != nullptr ), 2 );
   // static_cast since layers cannot be added to a transaction of a non-matching provider
   mTransaction = static_cast<QgsOgrTransaction *>( transaction );
-  connect( mTransaction, &QgsTransaction::afterRollback, this, [ = ]( )
+  connect( mTransaction, &QgsTransaction::afterRollback, this, [ this ]( )
   {
     mFieldsRequireReload = true;
   } );
-  connect( mTransaction, &QgsTransaction::afterRollbackToSavepoint, this, [ = ]( const QString & )
+  connect( mTransaction, &QgsTransaction::afterRollbackToSavepoint, this, [ this ]( const QString & )
   {
     mFieldsRequireReload = true;
   } );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -544,14 +544,11 @@ void QgsOgrProvider::setTransaction( QgsTransaction *transaction )
   QgsDebugMsgLevel( QStringLiteral( "set transaction %1" ).arg( transaction != nullptr ), 2 );
   // static_cast since layers cannot be added to a transaction of a non-matching provider
   mTransaction = static_cast<QgsOgrTransaction *>( transaction );
-  connect( mTransaction, &QgsTransaction::afterRollback, this, [ this ]( )
+  if ( transaction )
   {
-    mFieldsRequireReload = true;
-  } );
-  connect( mTransaction, &QgsTransaction::afterRollbackToSavepoint, this, [ this ]( const QString & )
-  {
-    mFieldsRequireReload = true;
-  } );
+    connect( mTransaction, &QgsTransaction::afterRollback, this, &QgsOgrProvider::afterRollback );
+    connect( mTransaction, &QgsTransaction::afterRollbackToSavepoint, this, &QgsOgrProvider::afterRollbackToSavepoint );
+  }
 }
 
 QgsAbstractFeatureSource *QgsOgrProvider::featureSource() const
@@ -732,6 +729,17 @@ QList<QgsProviderSublayerDetails> QgsOgrProvider::_subLayers( Qgis::SublayerQuer
   }
 
   return mSubLayerList;
+}
+
+void QgsOgrProvider::afterRollbackToSavepoint( const QString &savepointName )
+{
+  Q_UNUSED( savepointName );
+  mFieldsRequireReload = true;
+}
+
+void QgsOgrProvider::afterRollback()
+{
+  mFieldsRequireReload = true;
 }
 
 void QgsOgrProvider::setEncoding( const QString &e )
@@ -1214,7 +1222,7 @@ void QgsOgrProvider::setRelevantFields( bool fetchGeometry, const QgsAttributeLi
   QRecursiveMutex *mutex = nullptr;
   OGRLayerH ogrLayer = mOgrLayer->getHandleAndMutex( mutex );
   QMutexLocker locker( mutex );
-  QgsOgrProviderUtils::setRelevantFields( ogrLayer, mAttributeFields.count(), fetchGeometry, fetchAttributes, mFirstFieldIsFid, QgsOgrProviderUtils::cleanSubsetString( mSubsetString ) );
+  QgsOgrProviderUtils::setRelevantFields( ogrLayer, fields().count(), fetchGeometry, fetchAttributes, mFirstFieldIsFid, QgsOgrProviderUtils::cleanSubsetString( mSubsetString ) );
 }
 
 QgsFeatureIterator QgsOgrProvider::getFeatures( const QgsFeatureRequest &request ) const
@@ -1461,7 +1469,7 @@ QVariant QgsOgrProvider::defaultValue( int fieldId ) const
   QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
   QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
 
-  if ( fieldId < 0 || fieldId >= mAttributeFields.count() )
+  if ( fieldId < 0 || fieldId >= fields().count() )
     return QVariant();
 
   QString defaultVal = mDefaultValues.value( fieldId, QString() );
@@ -1525,7 +1533,7 @@ QVariant QgsOgrProvider::defaultValue( int fieldId ) const
     }
   }
 
-  const bool compatible = mAttributeFields.at( fieldId ).convertCompatible( resultVar );
+  const bool compatible = fields().at( fieldId ).convertCompatible( resultVar );
   return compatible && !QgsVariantUtils::isNull( resultVar ) ? resultVar : QVariant();
 }
 
@@ -1816,6 +1824,8 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags, QgsFeatureId
     {
       bool errorEmitted = false;
       bool ok = false;
+      // Get an updated copy
+      const QgsFields fieldsCopy { f.fields() };
       switch ( type )
       {
         case OFTInteger:
@@ -1828,7 +1838,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags, QgsFeatureId
             if ( !ok )
             {
               pushError( tr( "wrong value for attribute %1 of feature %2: %3" )
-                         .arg( mAttributeFields.at( qgisAttributeId ).name() )
+                         .arg( fieldsCopy.at( qgisAttributeId ).name() )
                          .arg( f.id() )
                          .arg( strVal ) );
               errorEmitted = true;
@@ -2046,9 +2056,9 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags, QgsFeatureId
         if ( !errorEmitted )
         {
           pushError( tr( "wrong data type for attribute %1 of feature %2: Got %3, expected %4" )
-                     .arg( mAttributeFields.at( qgisAttributeId ).name() )
+                     .arg( fieldsCopy.at( qgisAttributeId ).name() )
                      .arg( f.id() )
-                     .arg( attrVal.typeName(), QVariant::typeToName( mAttributeFields.at( qgisAttributeId ).type() ) ) );
+                     .arg( attrVal.typeName(), QVariant::typeToName( fieldsCopy.at( qgisAttributeId ).type() ) ) );
         }
         returnValue = false;
       }
@@ -2317,8 +2327,9 @@ bool QgsOgrProvider::addAttributes( const QList<QgsField> &attributes )
   }
 
   // Backup existing fields. We need them to 'restore' field type, length, precision
-  QgsFields oldFields = mAttributeFields;
+  QgsFields oldFields = fields();
 
+  // Updates mAttributeFields
   loadFields();
 
   // The check in QgsVectorLayerEditBuffer::commitChanges() is questionable with
@@ -2426,13 +2437,13 @@ bool QgsOgrProvider::renameAttributes( const QgsFieldNameMap &renamedAttributes 
   for ( ; renameIt != renamedAttributes.constEnd(); ++renameIt )
   {
     int fieldIndex = renameIt.key();
-    if ( fieldIndex < 0 || fieldIndex >= mAttributeFields.count() )
+    if ( fieldIndex < 0 || fieldIndex >= fields().count() )
     {
       pushError( tr( "Invalid attribute index" ) );
       result = false;
       continue;
     }
-    if ( mAttributeFields.indexFromName( renameIt.value() ) >= 0 )
+    if ( fields().indexFromName( renameIt.value() ) >= 0 )
     {
       //field name already in use
       pushError( tr( "Error renaming field %1: name '%2' already exists" ).arg( fieldIndex ).arg( renameIt.value() ) );
@@ -3373,7 +3384,7 @@ bool QgsOgrProvider::createAttributeIndex( int field )
   QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
   QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
 
-  if ( field < 0 || field >= mAttributeFields.count() )
+  if ( field < 0 || field >= fields().count() )
     return false;
 
   if ( !doInitialActionsForEdition() )
@@ -3764,10 +3775,10 @@ QSet<QVariant> QgsOgrProvider::uniqueValues( int index, int limit ) const
 {
   QSet<QVariant> uniqueValues;
 
-  if ( !mValid || index < 0 || index >= mAttributeFields.count() )
+  if ( !mValid || index < 0 || index >= fields().count() )
     return uniqueValues;
 
-  const QgsField fld = mAttributeFields.at( index );
+  const QgsField fld = fields().at( index );
   if ( fld.name().isNull() )
   {
     return uniqueValues; //not a provider field
@@ -3829,10 +3840,10 @@ QStringList QgsOgrProvider::uniqueStringsMatching( int index, const QString &sub
 {
   QStringList results;
 
-  if ( !mValid || index < 0 || index >= mAttributeFields.count() )
+  if ( !mValid || index < 0 || index >= fields().count() )
     return results;
 
-  QgsField fld = mAttributeFields.at( index );
+  QgsField fld = fields().at( index );
   if ( fld.name().isNull() )
   {
     return results; //not a provider field
@@ -4110,7 +4121,7 @@ QList<QgsRelation> QgsOgrProvider::discoverRelations( const QgsVectorLayer *targ
 
 QVariant QgsOgrProvider::minimumValue( int index ) const
 {
-  if ( !mValid || index < 0 || index >= mAttributeFields.count() )
+  if ( !mValid || index < 0 || index >= fields().count() )
   {
     return QVariant();
   }
@@ -4118,7 +4129,7 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
   QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
   QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
 
-  const QgsField originalField = mAttributeFields.at( index );
+  const QgsField originalField = fields().at( index );
   QgsField fld = originalField;
 
   // can't use native date/datetime types -- OGR converts these to string in the MAX return value
@@ -4170,7 +4181,7 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
 
 QVariant QgsOgrProvider::maximumValue( int index ) const
 {
-  if ( !mValid || index < 0 || index >= mAttributeFields.count() )
+  if ( !mValid || index < 0 || index >= fields().count() )
   {
     return QVariant();
   }
@@ -4178,7 +4189,7 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
   QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
   QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
 
-  const QgsField originalField = mAttributeFields.at( index );
+  const QgsField originalField = fields().at( index );
   QgsField fld = originalField;
 
   // can't use native date/datetime types -- OGR converts these to string in the MAX return value
@@ -4721,7 +4732,10 @@ bool QgsOgrProvider::leaveUpdateMode()
       // Backup fields since if we created new fields, but didn't populate it
       // with any feature yet, it will disappear.
       const QgsFields oldFields = mAttributeFields;
+
+      // This will also update mAttributeFields
       reloadData();
+
       if ( mValid )
       {
         // Make sure that new fields we added, but didn't populate yet, are

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -221,6 +221,7 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     mutable std::unique_ptr< OGREnvelope > mExtent2D;
     mutable std::unique_ptr< OGREnvelope3D > mExtent3D;
     bool mForceRecomputeExtent = false;
+    bool mFieldsRequireReload = false;
 
     QList<int> mPrimaryKeyAttrs;
 

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -221,7 +221,13 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     mutable std::unique_ptr< OGREnvelope > mExtent2D;
     mutable std::unique_ptr< OGREnvelope3D > mExtent3D;
     bool mForceRecomputeExtent = false;
+
+    //! Flag set after a rollback to indicate that fields require reloading
     bool mFieldsRequireReload = false;
+
+    //! Called after a transaction rollback
+    void afterRollback();
+    void afterRollbackToSavepoint( const QString &savePointName );
 
     QList<int> mPrimaryKeyAttrs;
 

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -271,7 +271,12 @@ bool QgsTransaction::rollbackToSavepoint( const QString &name, QString &error SI
   // the status of the DB has changed between the previous savepoint and the
   // one we are rolling back to.
   mLastSavePointIsDirty = true;
-  return executeSql( QStringLiteral( "ROLLBACK TO SAVEPOINT %1" ).arg( QgsExpression::quotedColumnRef( name ) ), error );
+  if ( ! executeSql( QStringLiteral( "ROLLBACK TO SAVEPOINT %1" ).arg( QgsExpression::quotedColumnRef( name ) ), error ) )
+  {
+    return false;
+  }
+  emit afterRollbackToSavepoint( name );
+  return true;
 }
 
 void QgsTransaction::dirtyLastSavePoint()

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -174,6 +174,12 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     void afterRollback();
 
     /**
+     * Emitted after a rollback to savepoint
+     * \since QGIS 3.42
+     */
+    void afterRollbackToSavepoint( const QString &savepointName );
+
+    /**
      * Emitted if a sql query is executed and the underlying data is modified
      */
     void dirtied( const QString &sql, const QString &name );

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -852,7 +852,9 @@ class TestQgsVectorLayerEditBuffer(QgisTestCase):
         # THIS FUNCTIONALITY IS BROKEN ON NEWER GDAL VERSIONS, DUE TO INCORRECT
         # assumptions at time of development. See https://github.com/qgis/QGIS/pull/59797#issuecomment-2544133498
         # see also: https://github.com/OSGeo/gdal/pull/11695 for a GDAL 3.11 fix
-        if int(gdal.VersionInfo("VERSION_NUM")) < GDAL_COMPUTE_VERSION(3, 5, 0) or int(gdal.VersionInfo("VERSION_NUM")) >= GDAL_COMPUTE_VERSION(3, 11, 0):
+        if int(gdal.VersionInfo("VERSION_NUM")) < GDAL_COMPUTE_VERSION(3, 5, 0) or int(
+            gdal.VersionInfo("VERSION_NUM")
+        ) >= GDAL_COMPUTE_VERSION(3, 11, 0):
             _test(Qgis.TransactionMode.AutomaticGroups)
 
         _test(Qgis.TransactionMode.BufferedGroups)

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -851,7 +851,8 @@ class TestQgsVectorLayerEditBuffer(QgisTestCase):
 
         # THIS FUNCTIONALITY IS BROKEN ON NEWER GDAL VERSIONS, DUE TO INCORRECT
         # assumptions at time of development. See https://github.com/qgis/QGIS/pull/59797#issuecomment-2544133498
-        if int(gdal.VersionInfo("VERSION_NUM")) < GDAL_COMPUTE_VERSION(3, 5, 0):
+        # see also: https://github.com/OSGeo/gdal/pull/11695 for a GDAL 3.11 fix
+        if int(gdal.VersionInfo("VERSION_NUM")) < GDAL_COMPUTE_VERSION(3, 5, 0) or int(gdal.VersionInfo("VERSION_NUM")) >= GDAL_COMPUTE_VERSION(3, 11, 0):
             _test(Qgis.TransactionMode.AutomaticGroups)
 
         _test(Qgis.TransactionMode.BufferedGroups)


### PR DESCRIPTION
Tell the provider to reload the fields after a rollback and add some checks to verify if after the rollback the provider still needs to update the field.

Followup https://github.com/OSGeo/gdal/pull/11695
Followup https://github.com/qgis/QGIS/pull/59797

