### PR TITLE
QgsLayoutExporter: avoid to print the "ERROR 6: The PNG driver does not support update access to existing datasets." GDAL error message

### DIFF
--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1743,7 +1743,12 @@ bool QgsLayoutExporter::georeferenceOutputPrivate( const QString &file, QgsLayou
   // important - we need to manually specify the DPI in advance, as GDAL will otherwise
   // assume a DPI of 150
   CPLSetConfigOption( "GDAL_PDF_DPI", QString::number( dpi ).toUtf8().constData() );
+
+  CPLPushErrorHandler( CPLQuietErrorHandler );
+  CPLErrorReset();
   gdal::dataset_unique_ptr outputDS( GDALOpen( file.toUtf8().constData(), GA_Update ) );
+  CPLPopErrorHandler();
+
   if ( outputDS )
   {
     if ( t )

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1727,6 +1727,10 @@ bool QgsLayoutExporter::georeferenceOutputPrivate( const QString &file, QgsLayou
   if ( !mLayout )
     return false;
 
+  const char *const apszAllowedDrivers[] = { "GTiff", "PDF", nullptr };
+  if ( !GDALIdentifyDriverEx( file.toUtf8().constData(), GDAL_OF_RASTER, apszAllowedDrivers, nullptr ) )
+    return false;
+
   if ( !map && includeGeoreference )
     map = mLayout->referenceMap();
 
@@ -1743,12 +1747,7 @@ bool QgsLayoutExporter::georeferenceOutputPrivate( const QString &file, QgsLayou
   // important - we need to manually specify the DPI in advance, as GDAL will otherwise
   // assume a DPI of 150
   CPLSetConfigOption( "GDAL_PDF_DPI", QString::number( dpi ).toUtf8().constData() );
-
-  CPLPushErrorHandler( CPLQuietErrorHandler );
-  CPLErrorReset();
   gdal::dataset_unique_ptr outputDS( GDALOpen( file.toUtf8().constData(), GA_Update ) );
-  CPLPopErrorHandler();
-
   if ( outputDS )
   {
     if ( t )


### PR DESCRIPTION
## Description

When `QgsLayoutExporter.exportToImage` is executed, the "ERROR 6: The PNG driver does not support update access to existing datasets." error message may be thrown by the GDAL/OGR library, and displayed in the console window on some systems, because `QgsLayoutExporter.exportToImage` tries to open the already exported image file in "update mode" in order to add the georeferencing information inside it, while it is not possible for many image formats (e.g. PNG).

The error doesn't actually affects the exporting functionality.

Fixes #51947.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
