### PR TITLE
allow using generic vector layer (table) source type in the QgsProcessingParameterMapLayer (fix #56344)

### DIFF
--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -3294,6 +3294,10 @@ QString QgsProcessingParameterMapLayer::asScriptCode() const
   {
     switch ( static_cast< Qgis::ProcessingSourceType >( type ) )
     {
+      case Qgis::ProcessingSourceType::Vector:
+        code += QLatin1String( "table " );
+        break;
+
       case Qgis::ProcessingSourceType::VectorAnyGeometry:
         code += QLatin1String( "hasgeometry " );
         break;
@@ -3345,6 +3349,12 @@ QgsProcessingParameterMapLayer *QgsProcessingParameterMapLayer::fromScriptCode( 
   QString def = definition;
   while ( true )
   {
+    if ( def.startsWith( QLatin1String( "table" ), Qt::CaseInsensitive ) )
+    {
+      types << static_cast< int >( Qgis::ProcessingSourceType::Vector );
+      def = def.mid( 6 );
+      continue;
+    }
     if ( def.startsWith( QLatin1String( "hasgeometry" ), Qt::CaseInsensitive ) )
     {
       types << static_cast< int >( Qgis::ProcessingSourceType::VectorAnyGeometry );

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -161,6 +161,8 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
     QList<int> dataTypes;
     dataTypes = static_cast<QgsProcessingParameterMapLayer *>( mParameter.get() )->dataTypes();
 
+    if ( dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::Vector ) ) )
+      filters |= Qgis::LayerFilter::VectorLayer;
     if ( dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::VectorAnyGeometry ) ) )
       filters |= Qgis::LayerFilter::HasGeometry;
     if ( dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::VectorPoint ) ) )

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -6698,6 +6698,7 @@ QgsProcessingMapLayerParameterDefinitionWidget::QgsProcessingMapLayerParameterDe
   mLayerTypeComboBox->addItem( tr( "Vector (Line)" ), static_cast<int>( Qgis::ProcessingSourceType::VectorLine ) );
   mLayerTypeComboBox->addItem( tr( "Vector (Polygon)" ), static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon ) );
   mLayerTypeComboBox->addItem( tr( "Vector (Any Geometry Type)" ), static_cast<int>( Qgis::ProcessingSourceType::VectorAnyGeometry ) );
+  mLayerTypeComboBox->addItem( tr( "Vector (No Geometry Required)" ), static_cast<int>( Qgis::ProcessingSourceType::Vector ) );
   mLayerTypeComboBox->addItem( tr( "Raster" ), static_cast<int>( Qgis::ProcessingSourceType::Raster ) );
   mLayerTypeComboBox->addItem( tr( "Mesh" ), static_cast<int>( Qgis::ProcessingSourceType::Mesh ) );
   mLayerTypeComboBox->addItem( tr( "Plugin" ), static_cast<int>( Qgis::ProcessingSourceType::Plugin ) );


### PR DESCRIPTION
## Description

Expose `Qgis::ProcessingSourceType::Vector` as a valid option for `QgsProcessingParameterMapLayer` data type. This is not strictly necessary as the exactly the same result can be achieved by using vector layer or feature sink parameters, but probably there are use cases when algorithm should support vectors (including geometryless tables) and some other layer types as inputs simultaneously.

Fixes #56344.