### PR TITLE
[raster calculator] Fix output CRS not taken from first raster entry, safeguard from crash

### DIFF
--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -79,6 +79,11 @@ QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QS
   , mRasterEntries( rasterEntries )
   , mTransformContext( transformContext )
 {
+  //default to first layer's crs
+  if ( !mRasterEntries.isEmpty() )
+  {
+    mOutputCrs = mRasterEntries.at( 0 ).raster->crs();
+  }
 }
 
 QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries, const QgsCoordinateTransformContext &transformContext )
@@ -105,7 +110,10 @@ QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QS
   , mRasterEntries( rasterEntries )
 {
   //default to first layer's crs
-  mOutputCrs = mRasterEntries.at( 0 ).raster->crs();
+  if ( !mRasterEntries.isEmpty() )
+  {
+    mOutputCrs = mRasterEntries.at( 0 ).raster->crs();
+  }
   mTransformContext = QgsProject::instance()->transformContext();
 }
 

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -727,14 +727,14 @@ void TestQgsRasterCalculator::testOutputCrsFromRasterEntries()
 
   QVector<QgsRasterCalculatorEntry> entries;
   entries << entry1;
-  
+
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
-  
+
   QTemporaryFile tmpFile;
   tmpFile.open(); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
-  
+
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@0\"" ), tmpName, QStringLiteral( "GTiff" ), extent, 2, 3, entries, QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
   //open output file and check results


### PR DESCRIPTION
## Description

This PR fixes #59898 , whereas the constructor without a ouput CRS parameter but with  a transform context parameter failed to get the CRS from the first raster entry in the provided list.

The PR also safeguards QGIS from crashing when passing on an empty list.