### PR TITLE
remove option to define layer name from WMS, WFS and delimited text source select dialogs (fix #28857)

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -67,7 +67,6 @@ QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget *parent, Qt:
   mBooleanFalse->setEnabled( !mBooleanTrue->text().isEmpty() );
   updateFieldsAndEnable();
 
-  connect( txtLayerName, &QLineEdit::textChanged, this, &QgsDelimitedTextSourceSelect::enableAccept );
   connect( cmbEncoding, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsDelimitedTextSourceSelect::updateFieldsAndEnable );
 
   connect( delimiterCSV, &QAbstractButton::toggled, this, &QgsDelimitedTextSourceSelect::updateFieldsAndEnable );
@@ -119,12 +118,6 @@ QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget *parent, Qt:
 void QgsDelimitedTextSourceSelect::addButtonClicked()
 {
   // The following conditions should not be hit! OK will not be enabled...
-  if ( txtLayerName->text().isEmpty() )
-  {
-    QMessageBox::warning( this, tr( "No layer name" ), tr( "Please enter a layer name before adding the layer to the map" ) );
-    txtLayerName->setFocus();
-    return;
-  }
   if ( delimiterChars->isChecked() )
   {
     if ( selectedChars().isEmpty() )
@@ -159,17 +152,17 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
   saveSettings();
   saveSettingsForFile( mFileWidget->filePath() );
 
+  const QString layerName = QFileInfo( mFileWidget->filePath() ).completeBaseName();
 
   // add the layer to the map
   Q_NOWARN_DEPRECATED_PUSH
-  emit addVectorLayer( datasourceUrl, txtLayerName->text() );
+  emit addVectorLayer( datasourceUrl, layerName );
   Q_NOWARN_DEPRECATED_POP
-  emit addLayer( Qgis::LayerType::Vector, datasourceUrl, txtLayerName->text(), QStringLiteral( "delimitedtext" ) );
+  emit addLayer( Qgis::LayerType::Vector, datasourceUrl, layerName, QStringLiteral( "delimitedtext" ) );
 
   // clear the file and layer name show something has happened, ready for another file
 
   mFileWidget->setFilePath( QString() );
-  txtLayerName->setText( QString() );
 
   if ( widgetMode() == QgsProviderRegistry::WidgetMode::Standalone )
   {
@@ -722,7 +715,6 @@ void QgsDelimitedTextSourceSelect::updateFileName()
     settings.setValue( mSettingsKey + "/text_path", finfo.path() );
   }
 
-  txtLayerName->setText( finfo.completeBaseName() );
   loadSettingsForFile( filename );
   updateFieldsAndEnable();
 }
@@ -747,10 +739,6 @@ bool QgsDelimitedTextSourceSelect::validate()
   else if ( !QFileInfo::exists( mFileWidget->filePath() ) )
   {
     message = tr( "File %1 does not exist" ).arg( mFileWidget->filePath() );
-  }
-  else if ( txtLayerName->text().isEmpty() )
-  {
-    message = tr( "Please enter a layer name" );
   }
   else if ( delimiterChars->isChecked() && selectedChars().isEmpty() )
   {

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -527,9 +527,8 @@ void QgsWFSSourceSelect::addButtonClicked()
       continue;
     }
     int row = idx.row();
-    QString typeName = mModel->item( row, MODEL_IDX_NAME )->text();   //WFS repository's name for layer
-    QString titleName = mModel->item( row, MODEL_IDX_TITLE )->text(); //WFS type name title for layer name (if option is set)
-    QString sql = mModel->item( row, MODEL_IDX_SQL )->text();         //optional SqL specified by user
+    QString typeName = mModel->item( row, MODEL_IDX_NAME )->text(); //WFS repository's name for layer
+    QString sql = mModel->item( row, MODEL_IDX_SQL )->text();       //optional SqL specified by user
     QString layerName = typeName;
     QgsDebugMsgLevel( "Layer " + typeName + " SQL is " + sql, 3 );
 

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -95,7 +95,6 @@ QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   QgsSettings settings;
   QgsDebugMsgLevel( QStringLiteral( "restoring settings" ), 3 );
-  cbxUseTitleLayerName->setChecked( settings.value( QStringLiteral( "Windows/WFSSourceSelect/UseTitleLayerName" ), false ).toBool() );
   cbxFeatureCurrentViewExtent->setChecked( settings.value( QStringLiteral( "Windows/WFSSourceSelect/FeatureCurrentViewExtent" ), true ).toBool() );
   mHoldDialogOpen->setChecked( settings.value( QStringLiteral( "Windows/WFSSourceSelect/HoldDialogOpen" ), false ).toBool() );
 
@@ -122,7 +121,6 @@ QgsWFSSourceSelect::~QgsWFSSourceSelect()
 
   QgsSettings settings;
   QgsDebugMsgLevel( QStringLiteral( "saving settings" ), 3 );
-  settings.setValue( QStringLiteral( "Windows/WFSSourceSelect/UseTitleLayerName" ), cbxUseTitleLayerName->isChecked() );
   settings.setValue( QStringLiteral( "Windows/WFSSourceSelect/FeatureCurrentViewExtent" ), cbxFeatureCurrentViewExtent->isChecked() );
   settings.setValue( QStringLiteral( "Windows/WFSSourceSelect/HoldDialogOpen" ), mHoldDialogOpen->isChecked() );
 
@@ -533,10 +531,6 @@ void QgsWFSSourceSelect::addButtonClicked()
     QString titleName = mModel->item( row, MODEL_IDX_TITLE )->text(); //WFS type name title for layer name (if option is set)
     QString sql = mModel->item( row, MODEL_IDX_SQL )->text();         //optional SqL specified by user
     QString layerName = typeName;
-    if ( cbxUseTitleLayerName->isChecked() && !titleName.isEmpty() )
-    {
-      layerName = titleName;
-    }
     QgsDebugMsgLevel( "Layer " + typeName + " SQL is " + sql, 3 );
 
     mUri = QgsWFSDataSourceURI::build( connection.uri().uri( false ), typeName, pCrsString, isOapif() ? QString() : sql, isOapif() ? sql : QString(), cbxFeatureCurrentViewExtent->isChecked() );

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -78,9 +78,6 @@ QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   connect( mLayersFilterLineEdit, &QgsFilterLineEdit::textChanged, this, &QgsWMSSourceSelect::filterLayers );
   connect( mTilesetsFilterLineEdit, &QgsFilterLineEdit::textChanged, this, &QgsWMSSourceSelect::filterTiles );
-  connect( mLoadLayersIndividuallyCheckBox, &QCheckBox::toggled, leLayerName, &QLineEdit::setDisabled );
-
-  leLayerName->setDisabled( mLoadLayersIndividuallyCheckBox->isChecked() );
 
   // Creates and connects standard ok/apply buttons
   setupButtons( buttonBox );
@@ -651,9 +648,9 @@ void QgsWMSSourceSelect::addButtonClicked()
     uri.setParam( QStringLiteral( "styles" ), styles );
 
     Q_NOWARN_DEPRECATED_PUSH
-    emit addRasterLayer( uri.encodedUri(), leLayerName->text().isEmpty() ? titles.join( QLatin1Char( '/' ) ) : leLayerName->text(), QStringLiteral( "wms" ) );
+    emit addRasterLayer( uri.encodedUri(), titles.join( QLatin1Char( '/' ) ), QStringLiteral( "wms" ) );
     Q_NOWARN_DEPRECATED_POP
-    emit addLayer( Qgis::LayerType::Raster, uri.encodedUri(), leLayerName->text().isEmpty() ? titles.join( QLatin1Char( '/' ) ) : leLayerName->text(), QStringLiteral( "wms" ) );
+    emit addLayer( Qgis::LayerType::Raster, uri.encodedUri(), titles.join( QLatin1Char( '/' ) ), QStringLiteral( "wms" ) );
   }
 }
 
@@ -1043,18 +1040,12 @@ void QgsWMSSourceSelect::updateButtons()
       QString tileLayerName = item->data( Qt::UserRole + 5 ).toString();
       if ( tileLayerName.isEmpty() )
         tileLayerName = item->data( Qt::UserRole + 0 ).toString();
-      leLayerName->setText( tileLayerName );
     }
     else
     {
       QStringList layers, styles, titles;
       collectSelectedLayers( layers, styles, titles );
-      leLayerName->setText( titles.join( QLatin1Char( '/' ) ) );
     }
-  }
-  else
-  {
-    leLayerName->setText( "" );
   }
 }
 

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -80,32 +80,6 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="textLabelLayerName">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Layer name</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="txtLayerName">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Name to display in the map legend</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QLabel" name="lblEncoding">
           <property name="text">
            <string>Encoding</string>
@@ -121,7 +95,7 @@
            <string>Select the file encoding</string>
           </property>
           <property name="insertPolicy">
-           <enum>QComboBox::InsertAtTop</enum>
+           <enum>QComboBox::InsertPolicy::InsertAtTop</enum>
           </property>
          </widget>
         </item>
@@ -145,7 +119,7 @@
       </size>
      </property>
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -155,8 +129,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>703</width>
-        <height>647</height>
+        <width>698</width>
+        <height>655</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -179,14 +153,14 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="fileFormatGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="fileFormatGroupBox" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
+         <property name="title" stdset="0">
           <string>File Format</string>
          </property>
          <property name="collapsed" stdset="0">
@@ -297,10 +271,10 @@
                  </sizepolicy>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::StyledPanel</enum>
+                 <enum>QFrame::Shape::StyledPanel</enum>
                 </property>
                 <property name="frameShadow">
-                 <enum>QFrame::Raised</enum>
+                 <enum>QFrame::Shadow::Raised</enum>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_3">
                  <property name="spacing">
@@ -332,7 +306,7 @@
                       <string>Escape</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>txtEscapeChars</cstring>
@@ -348,10 +322,10 @@
                       </sizepolicy>
                      </property>
                      <property name="text">
-                      <string>Quote</string>
+                      <string>&amp;Quote</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignJustify|Qt::AlignVCenter</set>
+                      <set>Qt::AlignmentFlag::AlignJustify|Qt::AlignmentFlag::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>txtQuoteChars</cstring>
@@ -497,7 +471,7 @@
                       <string>Others</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>txtDelimiterOther</cstring>
@@ -544,10 +518,10 @@
               <item>
                <widget class="QFrame" name="frame">
                 <property name="frameShape">
-                 <enum>QFrame::StyledPanel</enum>
+                 <enum>QFrame::Shape::StyledPanel</enum>
                 </property>
                 <property name="frameShadow">
-                 <enum>QFrame::Raised</enum>
+                 <enum>QFrame::Shadow::Raised</enum>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_2">
                  <item>
@@ -603,14 +577,14 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="recordOptionsGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="recordOptionsGroupBox" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
+         <property name="title" stdset="0">
           <string>Record and Fields Options</string>
          </property>
          <property name="collapsed" stdset="0">
@@ -791,14 +765,14 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="geometryDefinitionGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="geometryDefinitionGroupBox" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
+         <property name="title" stdset="0">
           <string>Geometry Definition</string>
          </property>
          <property name="collapsed" stdset="0">
@@ -942,7 +916,7 @@
                      <string>X field</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                     </property>
                     <property name="buddy">
                      <cstring>cmbXField</cstring>
@@ -1246,7 +1220,7 @@
             <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1262,14 +1236,14 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="layerSettingsGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="layerSettingsGroupBox" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
+         <property name="title" stdset="0">
           <string>Layer Settings</string>
          </property>
          <property name="collapsed" stdset="0">
@@ -1370,7 +1344,7 @@
                <item>
                 <spacer name="horizontalSpacer">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1411,7 +1385,7 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1441,10 +1415,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::StandardButton::Help</set>
      </property>
     </widget>
    </item>
@@ -1453,8 +1427,20 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
+   <extends>QWidget</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
@@ -1468,20 +1454,8 @@
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
   </customwidget>
-  <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>txtLayerName</tabstop>
   <tabstop>cmbEncoding</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>delimiterCSV</tabstop>

--- a/src/ui/qgswfssourceselectbase.ui
+++ b/src/ui/qgswfssourceselectbase.ui
@@ -14,105 +14,50 @@
    <string>Add WFS Layer from a Server</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="6" column="0">
+    <widget class="QCheckBox" name="mHoldDialogOpen">
+     <property name="text">
+      <string>Keep dialog open</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QgsFilterLineEdit" name="lineFilter">
+     <property name="showSearchIcon" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="qgisRelation" stdset="0">
+      <string notr="true"/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QTreeView" name="treeView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="headerVisible">
+      <bool>true</bool>
+     </attribute>
+    </widget>
+   </item>
    <item row="7" column="0">
-    <widget class="QGroupBox" name="gbCRS">
-     <property name="title">
-      <string>Coordinate Reference System</string>
-     </property>
-     <layout class="QHBoxLayout">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="labelCoordRefSys">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Expanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>441</width>
-          <height>23</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnChangeSpatialRefSys">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Change…</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QCheckBox" name="cbxUseTitleLayerName">
-       <property name="text">
-        <string>Use title for layer name</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="mHoldDialogOpen">
-       <property name="text">
-        <string>Keep dialog open</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="8" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
+    <widget class="QCheckBox" name="cbxFeatureCurrentViewExtent">
+     <property name="text">
+      <string>Only request features overlapping the view extent</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="2" column="0">
     <widget class="QGroupBox" name="GroupBox1">
      <property name="title">
       <string>Server Connections</string>
@@ -175,10 +120,10 @@
         <item>
          <spacer>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
+           <enum>QSizePolicy::Policy::Expanding</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -213,43 +158,74 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QTreeView" name="treeView">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="headerVisible">
-      <bool>true</bool>
-     </attribute>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QCheckBox" name="cbxFeatureCurrentViewExtent">
-     <property name="text">
-      <string>Only request features overlapping the view extent</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayoutFilter"/>
    </item>
-   <item row="2" column="0">
-    <widget class="QgsFilterLineEdit" name="lineFilter">
-     <property name="showSearchIcon">
-      <bool>true</bool>
+   <item row="9" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
-     <property name="qgisRelation" stdset="0">
-      <string notr="true"/>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Help</set>
      </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QGroupBox" name="gbCRS">
+     <property name="title">
+      <string>Coordinate Reference System</string>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelCoordRefSys">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Policy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>441</width>
+          <height>23</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnChangeSpatialRefSys">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Change…</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -270,8 +246,6 @@
   <tabstop>btnLoad</tabstop>
   <tabstop>btnSave</tabstop>
   <tabstop>treeView</tabstop>
-  <tabstop>cbxUseTitleLayerName</tabstop>
-  <tabstop>mHoldDialogOpen</tabstop>
   <tabstop>cbxFeatureCurrentViewExtent</tabstop>
   <tabstop>btnChangeSpatialRefSys</tabstop>
  </tabstops>

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -39,14 +39,14 @@
    <item row="1" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::StandardButton::Help</set>
      </property>
     </widget>
    </item>
    <item row="0" column="0">
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -57,7 +57,7 @@
         <x>0</x>
         <y>0</y>
         <width>744</width>
-        <height>639</height>
+        <height>647</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -142,7 +142,7 @@
                <item>
                 <spacer name="horizontalSpacer_2">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -256,7 +256,7 @@
                 <item row="2" column="0">
                  <widget class="QLabel" name="label_4">
                   <property name="text">
-                   <string>Request step size</string>
+                   <string>Re&amp;quest step size</string>
                   </property>
                   <property name="buddy">
                    <cstring>mTileWidth</cstring>
@@ -280,7 +280,7 @@
                 <item row="4" column="2">
                  <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
                   <property name="focusPolicy">
-                   <enum>Qt::StrongFocus</enum>
+                   <enum>Qt::FocusPolicy::StrongFocus</enum>
                   </property>
                  </widget>
                 </item>
@@ -303,7 +303,7 @@
                 </sizepolicy>
                </property>
                <property name="selectionMode">
-                <enum>QAbstractItemView::ExtendedSelection</enum>
+                <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
                </property>
                <property name="allColumnsShowFocus">
                 <bool>true</bool>
@@ -380,7 +380,7 @@
              <item row="0" column="2">
               <spacer>
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -462,10 +462,10 @@
                 <bool>true</bool>
                </property>
                <property name="selectionMode">
-                <enum>QAbstractItemView::SingleSelection</enum>
+                <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
                </property>
                <property name="selectionBehavior">
-                <enum>QAbstractItemView::SelectRows</enum>
+                <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
                </property>
                <property name="cornerButtonEnabled">
                 <bool>false</bool>
@@ -514,7 +514,7 @@
            <item>
             <widget class="QLabel" name="label">
              <property name="text">
-              <string>Layer name</string>
+              <string>QGIS layer name</string>
              </property>
              <property name="buddy">
               <cstring>leLayerName</cstring>


### PR DESCRIPTION
## Description

The "Layer name" field in the WMS source select dialog and "Use title for layer name" checkbox in the WFS dialog may lead to confusion as they are referring not to a WMS/WFS layer title from the GetCapabilities but to the name of the layer which will be added to QGIS.

As this option is present only in WMS, WFS and delimited text pages in Data Source Manager it makes sense to drop it completely and unify UI/UX with the rest of dialogs. So the layer is added with some sensible default name and can be renamed in the layer tree.

Fixes #28857.