### PR TITLE
use last used WMS image encoding when adding WMS layers from Browser dock (fix #57666)

### DIFF
--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -299,9 +299,10 @@ bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabiliti
   const QVector<QgsWmsLayerProperty> layers = capabilities.supportedLayers();
   mLayerProperties = layers;
 
-  QString defaultEncoding = QgsSettings().value( "qgis/WMSDefaultFormat", "" ).toString();
+  QString defaultEncoding = QgsSettings().value( QStringLiteral( "qgis/lastWmsImageEncoding" ), "image/png" ).toString();
 
   bool first = true;
+  bool found = false;
   QSet<QString> alreadyAddedLabels;
   const auto supportedImageEncodings = capabilities.supportedImageEncodings();
   for ( const QString &encoding : supportedImageEncodings )
@@ -323,7 +324,11 @@ bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabiliti
     mImageFormatGroup->button( id )->setVisible( true );
     if ( first || encoding == defaultEncoding )
     {
-      mImageFormatGroup->button( id )->setChecked( true );
+      if ( !found )
+      {
+        mImageFormatGroup->button( id )->setChecked( true );
+        found = true;
+      }
       first = false;
     }
   }
@@ -610,6 +615,8 @@ void QgsWMSSourceSelect::addButtonClicked()
   uri.setParam( QStringLiteral( "format" ), format );
   uri.setParam( QStringLiteral( "crs" ), crs );
   QgsDebugMsgLevel( QStringLiteral( "crs=%2 " ).arg( crs ), 2 );
+
+  QgsSettings().setValue( QStringLiteral( "/qgis/lastWmsImageEncoding" ), format );
 
   // Remove in case the default value from the connection settings
   // is being overridden here


### PR DESCRIPTION
## Description

When adding a WMS layer from the Data Source Manager one can choose which image encoding to use. The list of available encodings is generated from the server response and image formats supported by the provider. By default the first image encoding reported by the server is used if it is supported by the provider. Otherwise  QGIS will try to use encoding defined by setting `qgis/WMSDefaultFormat` if it is present and supported by the provider.

On the other hand, when adding a WMS layer via drag-and-drop from Browser dock, it is always added using `image/png` encoding. Both server capabilities and `qgis/WMSDefaultFormat`  setting are ignored. This happens not only because 
Browser picks the first image encoding supported by the provider which is also supported by the server, but also because drop handler in the QGIS app class overwrites it with the last used WMS imnage encoding defined by `/qgis/lastWmsImageEncoding` setting.
https://github.com/qgis/QGIS/blob/ef0dd0355ebc100b0d92fa22bb86882df7d2867d/src/app/qgisapp.cpp#L5635-L5636
The setting `/qgis/lastWmsImageEncoding` is not updated anywhere in the codebase and the `image/png` is always used.

Proposed PR unifies image encoding selection between WMS source select dialog and Browser in a following way:

- when adding a WMS layer via Data Source Manager we update `/qgis/lastWmsImageEncoding` setting with the used image encoding
- Browser and Data Source Manager will try to use as a default the first image encoding from the capabilities supported by the server and provider

Fixes #57666.