### PR TITLE
[annotations] Fix non-HTML formatted annotations losing content on settings change

### DIFF
--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -318,12 +318,12 @@ QString QgsRichTextEditor::toHtml() const
 
 void QgsRichTextEditor::editSource( bool enabled )
 {
-  if ( enabled )
+  if ( enabled && mStackedWidget->currentIndex() == 0 )
   {
     mSourceEdit->setText( mTextEdit->toHtml() );
     mStackedWidget->setCurrentIndex( 1 );
   }
-  else
+  else if ( !enabled && mStackedWidget->currentIndex() == 1 )
   {
     mTextEdit->setHtml( mSourceEdit->text() );
     mStackedWidget->setCurrentIndex( 0 );


### PR DESCRIPTION
## Description

This PR fixes #59804 whereas unchecking the [x] Allow HTML formatting text setting would result in annotation text content loss everytime a format setting was tweaked.
