### PR TITLE
Only update changed 3D entities when editing point cloud attributes

### DIFF
--- a/python/PyQt6/core/auto_additions/qgspointcloudlayer.py
+++ b/python/PyQt6/core/auto_additions/qgspointcloudlayer.py
@@ -21,7 +21,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n', 'chunkAttributeValuesChanged': 'Emitted when a node gets some attribute values of a node changed\n\n.. versionadded:: 3.42\n'}
+    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n', 'chunkAttributeValuesChanged': 'Emitted when a node gets some attribute values of some points changed\n\n.. versionadded:: 3.42\n'}
     QgsPointCloudLayer.__signal_arguments__ = {'raiseError': ['msg: str'], 'statisticsCalculationStateChanged': ['state: QgsPointCloudLayer.PointCloudStatisticsCalculationState'], 'chunkAttributeValuesChanged': ['n: QgsPointCloudNodeId']}
     QgsPointCloudLayer.__group__ = ['pointcloud']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_additions/qgspointcloudlayer.py
+++ b/python/PyQt6/core/auto_additions/qgspointcloudlayer.py
@@ -21,8 +21,8 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n'}
-    QgsPointCloudLayer.__signal_arguments__ = {'raiseError': ['msg: str'], 'statisticsCalculationStateChanged': ['state: QgsPointCloudLayer.PointCloudStatisticsCalculationState']}
+    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n', 'chunkAttributeValuesChanged': 'Emitted when a node gets some attribute values of a node changed\n\n.. versionadded:: 3.42\n'}
+    QgsPointCloudLayer.__signal_arguments__ = {'raiseError': ['msg: str'], 'statisticsCalculationStateChanged': ['state: QgsPointCloudLayer.PointCloudStatisticsCalculationState'], 'chunkAttributeValuesChanged': ['n: QgsPointCloudNodeId']}
     QgsPointCloudLayer.__group__ = ['pointcloud']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
@@ -370,6 +370,11 @@ an error message in case the call failed.
 Returns ``True`` if there are uncommitted changes, ``False`` otherwise
 %End
 
+    QList<QgsPointCloudNodeId> updatedNodes() const;
+%Docstring
+Returns a list of node IDs that have been modified
+%End
+
 };
 
 

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -309,7 +309,7 @@ Emitted when statistics calculation state has changed
 
     void chunkAttributeValuesChanged( const QgsPointCloudNodeId &n );
 %Docstring
-Emitted when a node gets some attribute values of a node changed
+Emitted when a node gets some attribute values of some points changed
 
 .. versionadded:: 3.42
 %End

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -307,6 +307,13 @@ Emitted when statistics calculation state has changed
 .. versionadded:: 3.26
 %End
 
+    void chunkAttributeValuesChanged( const QgsPointCloudNodeId &n );
+%Docstring
+Emitted when a node gets some attribute values of a node changed
+
+.. versionadded:: 3.42
+%End
+
   private:
     QgsPointCloudLayer( const QgsPointCloudLayer &rhs );
 };

--- a/python/core/auto_additions/qgspointcloudlayer.py
+++ b/python/core/auto_additions/qgspointcloudlayer.py
@@ -21,7 +21,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n', 'chunkAttributeValuesChanged': 'Emitted when a node gets some attribute values of a node changed\n\n.. versionadded:: 3.42\n'}
+    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n', 'chunkAttributeValuesChanged': 'Emitted when a node gets some attribute values of some points changed\n\n.. versionadded:: 3.42\n'}
     QgsPointCloudLayer.__signal_arguments__ = {'raiseError': ['msg: str'], 'statisticsCalculationStateChanged': ['state: QgsPointCloudLayer.PointCloudStatisticsCalculationState'], 'chunkAttributeValuesChanged': ['n: QgsPointCloudNodeId']}
     QgsPointCloudLayer.__group__ = ['pointcloud']
 except (NameError, AttributeError):

--- a/python/core/auto_additions/qgspointcloudlayer.py
+++ b/python/core/auto_additions/qgspointcloudlayer.py
@@ -21,8 +21,8 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n'}
-    QgsPointCloudLayer.__signal_arguments__ = {'raiseError': ['msg: str'], 'statisticsCalculationStateChanged': ['state: QgsPointCloudLayer.PointCloudStatisticsCalculationState']}
+    QgsPointCloudLayer.__attribute_docs__ = {'subsetStringChanged': "Emitted when the layer's subset string has changed.\n\n.. versionadded:: 3.26\n", 'raiseError': 'Signals an error related to this point cloud layer.\n\n.. versionadded:: 3.26\n', 'statisticsCalculationStateChanged': 'Emitted when statistics calculation state has changed\n\n.. versionadded:: 3.26\n', 'chunkAttributeValuesChanged': 'Emitted when a node gets some attribute values of a node changed\n\n.. versionadded:: 3.42\n'}
+    QgsPointCloudLayer.__signal_arguments__ = {'raiseError': ['msg: str'], 'statisticsCalculationStateChanged': ['state: QgsPointCloudLayer.PointCloudStatisticsCalculationState'], 'chunkAttributeValuesChanged': ['n: QgsPointCloudNodeId']}
     QgsPointCloudLayer.__group__ = ['pointcloud']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudindex.sip.in
@@ -370,6 +370,11 @@ an error message in case the call failed.
 Returns ``True`` if there are uncommitted changes, ``False`` otherwise
 %End
 
+    QList<QgsPointCloudNodeId> updatedNodes() const;
+%Docstring
+Returns a list of node IDs that have been modified
+%End
+
 };
 
 

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -309,7 +309,7 @@ Emitted when statistics calculation state has changed
 
     void chunkAttributeValuesChanged( const QgsPointCloudNodeId &n );
 %Docstring
-Emitted when a node gets some attribute values of a node changed
+Emitted when a node gets some attribute values of some points changed
 
 .. versionadded:: 3.42
 %End

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -307,6 +307,13 @@ Emitted when statistics calculation state has changed
 .. versionadded:: 3.26
 %End
 
+    void chunkAttributeValuesChanged( const QgsPointCloudNodeId &n );
+%Docstring
+Emitted when a node gets some attribute values of a node changed
+
+.. versionadded:: 3.42
+%End
+
   private:
     QgsPointCloudLayer( const QgsPointCloudLayer &rhs );
 };

--- a/src/3d/chunks/qgschunkedentity.cpp
+++ b/src/3d/chunks/qgschunkedentity.cpp
@@ -612,9 +612,10 @@ void QgsChunkedEntity::onActiveJobFinished()
 
   QgsChunkNode *node = job->chunk();
 
-  if ( QgsChunkLoader *loader = qobject_cast<QgsChunkLoader *>( job ) )
+  if ( node->state() == QgsChunkNode::Loading )
   {
-    Q_ASSERT( node->state() == QgsChunkNode::Loading );
+    QgsChunkLoader *loader = qobject_cast<QgsChunkLoader *>( job );
+    Q_ASSERT( loader );
     Q_ASSERT( node->loader() == loader );
 
     QgsEventTracing::addEvent( QgsEventTracing::AsyncEnd, QStringLiteral( "3D" ), QStringLiteral( "Load " ) + node->tileId().text(), node->tileId().text() );
@@ -653,6 +654,18 @@ void QgsChunkedEntity::onActiveJobFinished()
   else
   {
     Q_ASSERT( node->state() == QgsChunkNode::Updating );
+
+    // This is a special case when we're replacing the node's entity
+    // with QgsChunkUpdaterFactory passed to updatedNodes(). The returned
+    // updater is actually a chunk loader that will give us a completely
+    // new QEntity, so we just delete the old one and use the new one
+    if ( QgsChunkLoader* nodeUpdater = qobject_cast<QgsChunkLoader*>( node->updater() ) )
+    {
+      Qt3DCore::QEntity *newEntity = nodeUpdater->createEntity( this );
+      node->replaceEntity( newEntity );
+      emit newEntityCreated( newEntity );
+    }
+
     QgsEventTracing::addEvent( QgsEventTracing::AsyncEnd, QStringLiteral( "3D" ), QStringLiteral( "Update" ), node->tileId().text() );
     node->setUpdated();
   }

--- a/src/3d/chunks/qgschunkedentity.cpp
+++ b/src/3d/chunks/qgschunkedentity.cpp
@@ -659,7 +659,7 @@ void QgsChunkedEntity::onActiveJobFinished()
     // with QgsChunkUpdaterFactory passed to updatedNodes(). The returned
     // updater is actually a chunk loader that will give us a completely
     // new QEntity, so we just delete the old one and use the new one
-    if ( QgsChunkLoader* nodeUpdater = qobject_cast<QgsChunkLoader*>( node->updater() ) )
+    if ( QgsChunkLoader *nodeUpdater = qobject_cast<QgsChunkLoader *>( node->updater() ) )
     {
       Qt3DCore::QEntity *newEntity = nodeUpdater->createEntity( this );
       node->replaceEntity( newEntity );

--- a/src/3d/chunks/qgschunkloader.h
+++ b/src/3d/chunks/qgschunkloader.h
@@ -166,7 +166,7 @@ class QgsChunkUpdaterFactory : public QgsChunkQueueJobFactory
     }
 
   private:
-    QgsChunkLoaderFactory* mChunkLoaderFactory;
+    QgsChunkLoaderFactory *mChunkLoaderFactory;
 };
 
 /// @endcond

--- a/src/3d/chunks/qgschunkloader.h
+++ b/src/3d/chunks/qgschunkloader.h
@@ -144,6 +144,31 @@ class _3D_EXPORT QgsQuadtreeChunkLoaderFactory : public QgsChunkLoaderFactory
     int mMaxLevel = 0;
 };
 
+/**
+ * \ingroup 3d
+ * Factory that uses a chunk loader factory for in-place updates
+ * of loaded nodes. Use it with QgsChunkedEntity::updateNodes()
+ * to rebuild entity of an existing node.
+ *
+ * \since QGIS 3.42
+ */
+class QgsChunkUpdaterFactory : public QgsChunkQueueJobFactory
+{
+  public:
+    QgsChunkUpdaterFactory( QgsChunkLoaderFactory *loaderFactory )
+      : mChunkLoaderFactory( loaderFactory )
+    {
+    }
+
+    QgsChunkQueueJob *createJob( QgsChunkNode *chunk ) override
+    {
+      return mChunkLoaderFactory->createChunkLoader( chunk );
+    }
+
+  private:
+    QgsChunkLoaderFactory* mChunkLoaderFactory;
+};
+
 /// @endcond
 
 #endif // QGSCHUNKLOADER_H

--- a/src/3d/chunks/qgschunknode.cpp
+++ b/src/3d/chunks/qgschunknode.cpp
@@ -238,6 +238,17 @@ void QgsChunkNode::setUpdated()
   mState = QgsChunkNode::Loaded;
 }
 
+void QgsChunkNode::replaceEntity( Qt3DCore::QEntity *newEntity )
+{
+  Q_ASSERT( mState == QgsChunkNode::Updating );
+  Q_ASSERT( mUpdater );
+  Q_ASSERT( mEntity );
+  Q_ASSERT( newEntity );
+
+  mEntity->deleteLater();
+  mEntity = newEntity;
+}
+
 void QgsChunkNode::setExactBox3D( const QgsBox3D &box3D )
 {
   mBox3D = box3D;

--- a/src/3d/chunks/qgschunknode.h
+++ b/src/3d/chunks/qgschunknode.h
@@ -239,6 +239,9 @@ class QgsChunkNode
     //! mark node that it finished updating - back to loaded node
     void setUpdated();
 
+    //! replaces an existing entity with a newly created one (only allowed when updating the node)
+    void replaceEntity( Qt3DCore::QEntity *newEntity );
+
     //! called when the true bounding box is known so that we can use tighter bounding box
     void setExactBox3D( const QgsBox3D &box3D );
 

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -713,7 +713,6 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
     QgsPointCloudLayer *pclayer = qobject_cast<QgsPointCloudLayer *>( layer );
     connect( pclayer, &QgsPointCloudLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
     connect( pclayer, &QgsPointCloudLayer::subsetStringChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
-    connect( pclayer, &QgsPointCloudLayer::layerModified, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
 }
 

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -162,7 +162,7 @@ Qt3DCore::QEntity *QgsPointCloudLayer3DRenderer::createEntity( Qgs3DMapSettings 
   Qt3DCore::QEntity *entity = nullptr;
   if ( pcl->index() )
   {
-    entity = new QgsPointCloudLayerChunkedEntity( map, pcl->index(), coordinateTransform, dynamic_cast<QgsPointCloud3DSymbol *>( mSymbol->clone() ), static_cast<float>( maximumScreenError() ), showBoundingBoxes(), static_cast<const QgsPointCloudLayerElevationProperties *>( pcl->elevationProperties() )->zScale(), static_cast<const QgsPointCloudLayerElevationProperties *>( pcl->elevationProperties() )->zOffset(), mPointBudget );
+    entity = new QgsPointCloudLayerChunkedEntity( map, pcl, pcl->index(), coordinateTransform, dynamic_cast<QgsPointCloud3DSymbol *>( mSymbol->clone() ), static_cast<float>( maximumScreenError() ), showBoundingBoxes(), static_cast<const QgsPointCloudLayerElevationProperties *>( pcl->elevationProperties() )->zScale(), static_cast<const QgsPointCloudLayerElevationProperties *>( pcl->elevationProperties() )->zOffset(), mPointBudget );
   }
   else if ( !pcl->dataProvider()->subIndexes().isEmpty() )
   {

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -286,11 +286,11 @@ QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( Qgs3DMapSettin
 
     mChunkUpdaterFactory.reset( new QgsChunkUpdaterFactory( mChunkLoaderFactory ) );
 
-    connect( pcl, &QgsPointCloudLayer::chunkAttributeValuesChanged, this, [this]( const QgsPointCloudNodeId &n) {
-      QList<QgsChunkNode*> nodes;
+    connect( pcl, &QgsPointCloudLayer::chunkAttributeValuesChanged, this, [this]( const QgsPointCloudNodeId &n ) {
+      QList<QgsChunkNode *> nodes;
       nodes << findChunkNodeFromNodeId( mRootNode, n );
       updateNodes( nodes, mChunkUpdaterFactory.get() );
-    });
+    } );
   }
 }
 
@@ -302,7 +302,7 @@ QgsPointCloudLayerChunkedEntity::~QgsPointCloudLayerChunkedEntity()
 
 void QgsPointCloudLayerChunkedEntity::updateIndex()
 {
-  static_cast<QgsPointCloudLayerChunkLoaderFactory*>( mChunkLoaderFactory )->mPointCloudIndex = mLayer->index();
+  static_cast<QgsPointCloudLayerChunkLoaderFactory *>( mChunkLoaderFactory )->mPointCloudIndex = mLayer->index();
 }
 
 QVector<QgsRayCastingUtils::RayHit> QgsPointCloudLayerChunkedEntity::rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -238,16 +238,71 @@ QVector<QgsChunkNode *> QgsPointCloudLayerChunkLoaderFactory::createChildren( Qg
 ///////////////
 
 
-QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( Qgs3DMapSettings *map, QgsPointCloudIndex pc, const QgsCoordinateTransform &coordinateTransform, QgsPointCloud3DSymbol *symbol, float maximumScreenSpaceError, bool showBoundingBoxes, double zValueScale, double zValueOffset, int pointBudget )
-  : QgsChunkedEntity( map, maximumScreenSpaceError, new QgsPointCloudLayerChunkLoaderFactory( Qgs3DRenderContext::fromMapSettings( map ), coordinateTransform, pc, symbol, zValueScale, zValueOffset, pointBudget ), true, pointBudget )
+static QgsChunkNode *findChunkNodeFromNodeId( QgsChunkNode *rootNode, QgsPointCloudNodeId nodeId )
+{
+  // find path from the node to the root
+  QVector<QgsPointCloudNodeId> parentIds;
+  while ( nodeId.d() > 0 )
+  {
+    parentIds << nodeId;
+    nodeId = nodeId.parentNode();
+  }
+
+  // now descend from the root to the node in the QgsChunkNode hierarchy
+  QgsChunkNode *chunk = rootNode;
+  while ( !parentIds.empty() )
+  {
+    QgsPointCloudNodeId p = parentIds.takeLast();
+    QgsChunkNodeId childNodeId( p.d(), p.x(), p.y(), p.z() );
+
+    QgsChunkNode *chunkChild = nullptr;
+    QgsChunkNode *const *children = chunk->children();
+    for ( int i = 0; i < chunk->childCount(); ++i )
+    {
+      if ( children[i]->tileId() == childNodeId )
+      {
+        chunkChild = children[i];
+        break;
+      }
+    }
+    Q_ASSERT( chunkChild );
+    chunk = chunkChild;
+  }
+  return chunk;
+}
+
+
+QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( Qgs3DMapSettings *map, QgsPointCloudLayer *pcl, QgsPointCloudIndex index, const QgsCoordinateTransform &coordinateTransform, QgsPointCloud3DSymbol *symbol, float maximumScreenSpaceError, bool showBoundingBoxes, double zValueScale, double zValueOffset, int pointBudget )
+  : QgsChunkedEntity( map, maximumScreenSpaceError, new QgsPointCloudLayerChunkLoaderFactory( Qgs3DRenderContext::fromMapSettings( map ), coordinateTransform, index, symbol, zValueScale, zValueOffset, pointBudget ), true, pointBudget )
+  , mLayer( pcl )
 {
   setShowBoundingBoxes( showBoundingBoxes );
+
+  if ( pcl->supportsEditing() )
+  {
+    // when editing starts or stops, we need to update our index to use the editing index (or not)
+    connect( pcl, &QgsPointCloudLayer::editingStarted, this, &QgsPointCloudLayerChunkedEntity::updateIndex );
+    connect( pcl, &QgsPointCloudLayer::editingStopped, this, &QgsPointCloudLayerChunkedEntity::updateIndex );
+
+    mChunkUpdaterFactory.reset( new QgsChunkUpdaterFactory( mChunkLoaderFactory ) );
+
+    connect( pcl, &QgsPointCloudLayer::chunkAttributeValuesChanged, this, [this]( const QgsPointCloudNodeId &n) {
+      QList<QgsChunkNode*> nodes;
+      nodes << findChunkNodeFromNodeId( mRootNode, n );
+      updateNodes( nodes, mChunkUpdaterFactory.get() );
+    });
+  }
 }
 
 QgsPointCloudLayerChunkedEntity::~QgsPointCloudLayerChunkedEntity()
 {
   // cancel / wait for jobs
   cancelActiveJobs();
+}
+
+void QgsPointCloudLayerChunkedEntity::updateIndex()
+{
+  static_cast<QgsPointCloudLayerChunkLoaderFactory*>( mChunkLoaderFactory )->mPointCloudIndex = mLayer->index();
 }
 
 QVector<QgsRayCastingUtils::RayHit> QgsPointCloudLayerChunkedEntity::rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const

--- a/src/3d/qgspointcloudlayerchunkloader_p.h
+++ b/src/3d/qgspointcloudlayerchunkloader_p.h
@@ -127,11 +127,18 @@ class QgsPointCloudLayerChunkedEntity : public QgsChunkedEntity
 {
     Q_OBJECT
   public:
-    explicit QgsPointCloudLayerChunkedEntity( Qgs3DMapSettings *map, QgsPointCloudIndex pc, const QgsCoordinateTransform &coordinateTransform, QgsPointCloud3DSymbol *symbol, float maxScreenError, bool showBoundingBoxes, double zValueScale, double zValueOffset, int pointBudget );
+    explicit QgsPointCloudLayerChunkedEntity( Qgs3DMapSettings *map, QgsPointCloudLayer *pcl, QgsPointCloudIndex index, const QgsCoordinateTransform &coordinateTransform, QgsPointCloud3DSymbol *symbol, float maxScreenError, bool showBoundingBoxes, double zValueScale, double zValueOffset, int pointBudget );
 
     QVector<QgsRayCastingUtils::RayHit> rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const override;
 
     ~QgsPointCloudLayerChunkedEntity();
+
+  private slots:
+    void updateIndex();
+
+  private:
+    QgsPointCloudLayer *mLayer = nullptr;
+    std::unique_ptr<QgsChunkUpdaterFactory> mChunkUpdaterFactory;
 };
 
 /// @endcond

--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -61,6 +61,7 @@ QgsVirtualPointCloudEntity::QgsVirtualPointCloudEntity(
   {
     mOverviewEntity = new QgsPointCloudLayerChunkedEntity(
       mapSettings(),
+      mLayer,
       provider()->overview(),
       mCoordinateTransform,
       dynamic_cast<QgsPointCloud3DSymbol *>( mSymbol->clone() ),
@@ -106,6 +107,7 @@ void QgsVirtualPointCloudEntity::createChunkedEntityForSubIndex( int i )
 
   QgsPointCloudLayerChunkedEntity *newChunkedEntity = new QgsPointCloudLayerChunkedEntity(
     mapSettings(),
+    mLayer,
     si.index(),
     mCoordinateTransform,
     static_cast<QgsPointCloud3DSymbol *>( mSymbol->clone() ),

--- a/src/core/pointcloud/qgspointcloudeditingindex.cpp
+++ b/src/core/pointcloud/qgspointcloudeditingindex.cpp
@@ -190,6 +190,11 @@ bool QgsPointCloudEditingIndex::isModified() const
   return !mEditedNodeData.isEmpty();
 }
 
+QList<QgsPointCloudNodeId> QgsPointCloudEditingIndex::updatedNodes() const
+{
+  return mEditedNodeData.keys();
+}
+
 bool QgsPointCloudEditingIndex::updateNodeData( const QHash<QgsPointCloudNodeId, QByteArray> &data )
 {
   for ( auto it = data.constBegin(); it != data.constEnd(); ++it )

--- a/src/core/pointcloud/qgspointcloudeditingindex.h
+++ b/src/core/pointcloud/qgspointcloudeditingindex.h
@@ -66,6 +66,9 @@ class CORE_EXPORT QgsPointCloudEditingIndex : public QgsAbstractPointCloudIndex
     //! Returns TRUE if there are uncommitted changes, FALSE otherwise
     bool isModified() const;
 
+    //! Returns a list of node IDs that have been modified
+    QList<QgsPointCloudNodeId> updatedNodes() const;
+
 
   private:
     QgsPointCloudIndex mIndex;

--- a/src/core/pointcloud/qgspointcloudindex.cpp
+++ b/src/core/pointcloud/qgspointcloudindex.cpp
@@ -521,3 +521,10 @@ bool QgsPointCloudIndex::isModified() const
   return false;
 }
 
+QList<QgsPointCloudNodeId> QgsPointCloudIndex::updatedNodes() const
+{
+  if ( QgsPointCloudEditingIndex *index = dynamic_cast<QgsPointCloudEditingIndex *>( mIndex.get() ) )
+    return index->updatedNodes();
+
+  return QList<QgsPointCloudNodeId>();
+}

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -655,6 +655,9 @@ class CORE_EXPORT QgsPointCloudIndex SIP_NODEFAULTCTORS
     //! Returns TRUE if there are uncommitted changes, FALSE otherwise
     bool isModified() const;
 
+    //! Returns a list of node IDs that have been modified
+    QList<QgsPointCloudNodeId> updatedNodes() const;
+
   private:
     std::shared_ptr<QgsAbstractPointCloudIndex> mIndex;
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -1112,7 +1112,7 @@ bool QgsPointCloudLayer::changeAttributeValue( const QgsPointCloudNodeId &n, con
        sortedPoints.constLast() >= mEditIndex.getNode( n ).pointCount() )
     return false;
 
-  undoStack()->push( new QgsPointCloudLayerUndoCommandChangeAttribute( mEditIndex, n, sortedPoints, attribute, value ) );
+  undoStack()->push( new QgsPointCloudLayerUndoCommandChangeAttribute( this, n, sortedPoints, attribute, value ) );
 
   return true;
 }

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -352,7 +352,7 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer, public QgsAbstractPro
     void statisticsCalculationStateChanged( QgsPointCloudLayer::PointCloudStatisticsCalculationState state );
 
     /**
-     * Emitted when a node gets some attribute values of a node changed
+     * Emitted when a node gets some attribute values of some points changed
      *
      * \since QGIS 3.42
      */

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -351,6 +351,13 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer, public QgsAbstractPro
      */
     void statisticsCalculationStateChanged( QgsPointCloudLayer::PointCloudStatisticsCalculationState state );
 
+    /**
+     * Emitted when a node gets some attribute values of a node changed
+     *
+     * \since QGIS 3.42
+     */
+    void chunkAttributeValuesChanged( const QgsPointCloudNodeId &n );
+
   private slots:
     void onPointCloudIndexGenerationStateChanged( QgsPointCloudDataProvider::PointCloudIndexGenerationState state );
     void setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, Qgis::DataProviderReadFlags flags ) override;

--- a/src/core/pointcloud/qgspointcloudlayerundocommand.h
+++ b/src/core/pointcloud/qgspointcloudlayerundocommand.h
@@ -24,6 +24,8 @@
 
 #include <QUndoCommand>
 
+class QgsPointCloudLayer;
+
 /**
  * \ingroup core
  *
@@ -35,8 +37,8 @@ class CORE_EXPORT QgsPointCloudLayerUndoCommand : public QUndoCommand
 {
   protected:
     //! Ctor
-    QgsPointCloudLayerUndoCommand( QgsPointCloudIndex index );
-    QgsPointCloudIndex mIndex;
+    QgsPointCloudLayerUndoCommand( QgsPointCloudLayer *layer );
+    QgsPointCloudLayer *mLayer;
 };
 
 /**
@@ -52,13 +54,13 @@ class CORE_EXPORT QgsPointCloudLayerUndoCommandChangeAttribute : public QgsPoint
 
     /**
      * Constructor for QgsPointCloudLayerUndoCommandChangeAttribute
-     * \param index associated point cloud index
+     * \param layer associated point cloud layer
      * \param n the node id whose points will be modified
      * \param points the list of points to be modified
      * \param attribute the attribute whose value will be modified
      * \param value the new value for the modified attribure
      */
-    QgsPointCloudLayerUndoCommandChangeAttribute( QgsPointCloudIndex index, const QgsPointCloudNodeId &n, const QVector<int> &points, const QgsPointCloudAttribute &attribute, double value );
+    QgsPointCloudLayerUndoCommandChangeAttribute( QgsPointCloudLayer *layer, const QgsPointCloudNodeId &n, const QVector<int> &points, const QgsPointCloudAttribute &attribute, double value );
 
     void undo() override;
     void redo() override;


### PR DESCRIPTION
QgsChunkedEntity gets a capability to update an existing sub-entity for a node by loading the node again, creating a new 3D entity, and then discarding the old entity in favor of the new one.

QgsPointCloudLayer gets a new signal - emitted whenever a particular node's attribute values get changed.

These two are combined for point cloud layer's 3D chunked entity: whenever there are edits to the point cloud data, instead of doing big hard reload of the whole point cloud, we only update entities of the few nodes that were modified. This greatly improves the user experience of point cloud editing (no "flashing" of the 3D view while loading everything from scratch), and it improves how quickly the changes can be seen.