### PR TITLE
[vector layer] Fix newly-added features in the edit buffer prior to adding a new attribute will not save the new attribute's values

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -321,7 +321,7 @@ Update feature with uncommitted geometry updates
 Update feature with uncommitted attribute updates
 %End
 
-    void handleAttributeAdded( int index );
+    void handleAttributeAdded( int index, const QgsField &field );
 %Docstring
 Update added and changed features after addition of an attribute
 %End

--- a/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -321,7 +321,7 @@ Update feature with uncommitted geometry updates
 Update feature with uncommitted attribute updates
 %End
 
-    void handleAttributeAdded( int index );
+    void handleAttributeAdded( int index, const QgsField &field );
 %Docstring
 Update added and changed features after addition of an attribute
 %End

--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -294,7 +294,9 @@ bool QgsVectorLayerEditBuffer::changeAttributeValue( QgsFeatureId fid, int field
   if ( field < 0 || field >= L->fields().count() ||
        L->fields().fieldOrigin( field ) == Qgis::FieldOrigin::Join ||
        L->fields().fieldOrigin( field ) == Qgis::FieldOrigin::Expression )
+  {
     return false;
+  }
 
   L->undoStack()->push( new QgsVectorLayerUndoCommandChangeAttribute( this, fid, field, newValue, oldValue ) );
   return true;
@@ -919,6 +921,8 @@ bool QgsVectorLayerEditBuffer::commitChangesAddFeatures( bool &featuresAdded, QS
     // not be sent to the data provider. Refs #18784
     for ( int i = 0; i < featuresToAdd.count(); ++i )
     {
+      // Empty the feature's fields so the up-to-date fields from the data provider is used to match attributes
+      featuresToAdd[i].setFields( QgsFields(), false );
       QgsVectorLayerUtils::matchAttributesToFields( featuresToAdd[i], L->dataProvider()->fields() );
     }
 

--- a/src/core/vector/qgsvectorlayereditbuffer.h
+++ b/src/core/vector/qgsvectorlayereditbuffer.h
@@ -297,7 +297,7 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     void updateChangedAttributes( QgsFeature &f );
 
     //! Update added and changed features after addition of an attribute
-    void handleAttributeAdded( int index );
+    void handleAttributeAdded( int index, const QgsField &field );
 
     //! Update added and changed features after removal of an attribute
     void handleAttributeDeleted( int index );

--- a/src/core/vector/qgsvectorlayerundocommand.cpp
+++ b/src/core/vector/qgsvectorlayerundocommand.cpp
@@ -334,7 +334,7 @@ void QgsVectorLayerUndoCommandAddAttribute::undo()
 void QgsVectorLayerUndoCommandAddAttribute::redo()
 {
   mBuffer->mAddedAttributes.append( mField );
-  mBuffer->handleAttributeAdded( mFieldIndex );
+  mBuffer->handleAttributeAdded( mFieldIndex, mField );
   mBuffer->updateLayerFields();
 
   emit mBuffer->attributeAdded( mFieldIndex );
@@ -391,7 +391,7 @@ void QgsVectorLayerUndoCommandDeleteAttribute::undo()
   }
 
   mBuffer->updateLayerFields();
-  mBuffer->handleAttributeAdded( mFieldIndex ); // update changed attributes + new features
+  mBuffer->handleAttributeAdded( mFieldIndex, mOldField ); // update changed attributes + new features
 
   if ( !mOldName.isEmpty() )
   {

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -13,7 +13,7 @@ __copyright__ = "Copyright 2016, The QGIS Project"
 import os
 from osgeo import gdal
 
-from qgis.PyQt.QtCore import QTemporaryDir, QVariant
+from qgis.PyQt.QtCore import QMetaType, QTemporaryDir, QVariant
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     Qgis,
@@ -855,6 +855,29 @@ class TestQgsVectorLayerEditBuffer(QgisTestCase):
             _test(Qgis.TransactionMode.AutomaticGroups)
 
         _test(Qgis.TransactionMode.BufferedGroups)
+
+    def testAddNewFeatureAndNewAttribute(self):
+        layer = QgsVectorLayer(
+            "Point?field=fldtxt:string", "addfeat", "memory"
+        )
+        layer.startEditing()
+
+        # Add a new feature with fields information attached to it
+        f = QgsFeature(layer.fields())
+        f.setAttributes(["test"])
+        f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(100, 200)))
+        layer.addFeature(f)
+
+        # Add a new attribute to the layer
+        layer.addAttribute(QgsField("fldint", QMetaType.Type.Int))
+
+        # Change the newly-added attribute value for the new feature
+        layer.changeAttributeValue(f.id(), 1, 123)
+
+        # Commit changes
+        layer.commitChanges()
+
+        self.assertEqual(layer.getFeature(1).attributes(), ["test", 123])
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -857,9 +857,7 @@ class TestQgsVectorLayerEditBuffer(QgisTestCase):
         _test(Qgis.TransactionMode.BufferedGroups)
 
     def testAddNewFeatureAndNewAttribute(self):
-        layer = QgsVectorLayer(
-            "Point?field=fldtxt:string", "addfeat", "memory"
-        )
+        layer = QgsVectorLayer("Point?field=fldtxt:string", "addfeat", "memory")
         layer.startEditing()
 
         # Add a new feature with fields information attached to it


### PR DESCRIPTION
## Description

This PR fixes #59783 , a pretty serious data loss scenario with regards to the way the vector layer edit buffer handles newly added features followed by newly added attributes.

Basically, when adding a new feature via attribute table, the feature would come with a defined fields(), which would then become outdated when a newly-added attribute was added during the session. That meant that if a user would do the following:

1/ add a new feature
2/ add a new attribute
3/ edit the new attribute from the newly-added feature
4/ commit

The user would lose the data added in step 3.