### PR TITLE
Add prepare-commit.sh setup step in how to contribute patches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,11 @@ You can help us **by submitting bug reports or fixing bugs** in the [QGIS bug tr
 
 If you wish to contribute patches you can:
 
-1. [fork the project](https://help.github.com/forking/)
-1. make your changes
-1. commit to your repository
-1. and then [create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
+1. [Fork the project](https://help.github.com/forking/)
+2. Install the [pre-commit](https://pre-commit.com/) hook: `pre-commit install --install-hooks` (version 4.1+ required)
+3. Make your changes
+4. Commit to your repository
+5. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 
  The development team can then review your contribution and commit it upstream as appropriate.
 


### PR DESCRIPTION
Also use real step numbers so you don't need a markdown renderer to read the content
