### PR TITLE
add point cloud output to compatible output types for point cloud widget wrapper (fix #57550)

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -7980,7 +7980,7 @@ QStringList QgsProcessingPointCloudLayerWidgetWrapper::compatibleOutputTypes() c
 {
   return QStringList()
          << QgsProcessingOutputString::typeName()
-         // TODO  << QgsProcessingOutputPointCloudLayer::typeName()
+         << QgsProcessingOutputPointCloudLayer::typeName()
          << QgsProcessingOutputMapLayer::typeName()
          << QgsProcessingOutputFile::typeName()
          << QgsProcessingOutputFolder::typeName();


### PR DESCRIPTION
## Description

`QgsProcessingOutputPointCloudLayer` was not added as a compatible output type for `QgsProcessingPointCloudLayerWidgetWrapper` resulting in inability to use some point cloud algorithms in modeler context.

Fixes #57550.