### PR TITLE
fix msvc version and update cmake version.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -585,7 +585,7 @@ cmake .. -DBUILD_WITH_QT6=ON -DWITH_QTWEBKIT=OFF -DWITH_QTWEBENGINE=ON
 
 ## 4.1. Building with Microsoft Visual Studio
 
-This section describes how to build QGIS using Visual Studio (MSVC) 2019 on Windows.
+This section describes how to build QGIS using Visual Studio (MSVC) 2022 on Windows.
 The official Windows packages are built using OSGeo4W.
 
 This section describes the setup required to allow Visual Studio to be used to
@@ -593,7 +593,7 @@ build QGIS.
 
 ### 4.1.1. Visual Studio 2022 Community Edition
 
-Download and install the [free (as in free beer) Community installer](https://download.visualstudio.microsoft.com/download/pr/68d6b204-9df0-4fcc-abcc-08ee0eff9cb2/b029547488a9383b0c8d8a9c813e246feb3ec19e0fe55020d4878fde5f0983fe/vs_Community.exe)
+Download and install the [free (as in free beer) Community installer](https://c2rsetup.officeapps.live.com/c2r/downloadVS.aspx?sku=community&channel=Release&version=VS2022&source=VSLandingPage&cid=2030:7851336a02d44ba38a548acc719002df)
 
 Select "Desktop Development with C++"
 
@@ -601,7 +601,7 @@ Select "Desktop Development with C++"
 
 Download and install following packages:
 
-* [CMake](https://cmake.org/files/v3.12/cmake-3.12.3-win64-x64.msi)
+* [CMake](https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-windows-x86_64.msi)
 * GNU flex, GNU bison and GIT with [cygwin 64bit](https://cygwin.com/setup-x86_64.exe)
 * [OSGeo4W](https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe)
 * [ninja](https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip): Copy the `ninja.exe` to `C:\OSGeo4W\bin\`


### PR DESCRIPTION
I tried to build QGIS locally, and I found the build guide have some mistaked information.
1. Currently official binary and script use msvc 2022 as compiler.
2. CMake 3.12 is too old to build QGIS.

I fixed them in this PR.