### PR TITLE
improve QgsDockableWidgetHelper API

### DIFF
--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditordockwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditordockwidget.sip.in
@@ -27,7 +27,7 @@ A custom dock widget for code editors.
 #include "qgscodeeditordockwidget.h"
 %End
   public:
-    QgsCodeEditorDockWidget( const QString &windowGeometrySettingsKey = QString(), bool usePersistentWidget = false );
+    QgsCodeEditorDockWidget( const QString &dockId = QString(), bool usePersistentWidget = false );
 %Docstring
 Constructor for QgsCodeEditorDockWidget, with the specified window geometry settings key.
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditordockwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditordockwidget.sip.in
@@ -27,7 +27,7 @@ A custom dock widget for code editors.
 #include "qgscodeeditordockwidget.h"
 %End
   public:
-    QgsCodeEditorDockWidget( const QString &windowGeometrySettingsKey = QString(), bool usePersistentWidget = false );
+    QgsCodeEditorDockWidget( const QString &dockId = QString(), bool usePersistentWidget = false );
 %Docstring
 Constructor for QgsCodeEditorDockWidget, with the specified window geometry settings key.
 

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -325,7 +325,8 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
 
   onTotalPendingJobsCountChanged();
 
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( isDocked, mCanvasName, this, QgisApp::instance() );
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( mCanvasName, this, QgisApp::instance(), mCanvasName, QStringList(), isDocked ? QgsDockableWidgetHelper::OpeningMode::ForceDocked : QgsDockableWidgetHelper::OpeningMode::RespectSetting );
+
   if ( QDialog *dialog = mDockableWidgetHelper->dialog() )
   {
     QFontMetrics fm( font() );

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -457,7 +457,8 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   } );
   setLayout( layout );
 
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( true, mCanvasName, this, QgisApp::instance(), Qt::BottomDockWidgetArea, QStringList(), true );
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( mCanvasName, this, QgisApp::instance(), mCanvasName, QStringList(), QgsDockableWidgetHelper::OpeningMode::RespectSetting, false, Qt::DockWidgetArea::BottomDockWidgetArea, QgsDockableWidgetHelper::Option::RaiseTab );
+
   QToolButton *toggleButton = mDockableWidgetHelper->createDockUndockToolButton();
   toggleButton->setToolTip( tr( "Dock Elevation Profile View" ) );
   toolBar->addWidget( toggleButton );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -57,6 +57,7 @@
 #include "qgsdockwidget.h"
 #include "qgssettingsregistrycore.h"
 
+
 QgsExpressionContext QgsAttributeTableDialog::createExpressionContext() const
 {
   QgsExpressionContext expContext;
@@ -283,9 +284,11 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   // info from table to application
   connect( this, &QgsAttributeTableDialog::saveEdits, this, [=] { QgisApp::instance()->saveEdits(); } );
 
-  const bool isDocked = initiallyDocked ? *initiallyDocked : settings.value( QStringLiteral( "qgis/dockAttributeTable" ), false ).toBool();
-  toggleShortcuts( !isDocked );
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( isDocked, windowTitle(), this, QgisApp::instance(), Qt::BottomDockWidgetArea, QStringList(), !initiallyDocked, QStringLiteral( "Windows/BetterAttributeTable/geometry" ) );
+  QgsDockableWidgetHelper::OpeningMode openingMode = QgsDockableWidgetHelper::OpeningMode::RespectSetting;
+  if ( initiallyDocked )
+    openingMode = *initiallyDocked ? QgsDockableWidgetHelper::OpeningMode::ForceDocked : QgsDockableWidgetHelper::OpeningMode::ForceDialog;
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( windowTitle(), this, QgisApp::instance(), QStringLiteral( "attribute-table" ), QStringList(), openingMode, true, Qt::BottomDockWidgetArea );
+  toggleShortcuts( !mDockableWidgetHelper->isDocked() );
   connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::closed, this, [=]() {
     close();
   } );

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -243,7 +243,7 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &QgsMapCanvasDockWidget::currentMapThemeRenamed );
 
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( isDocked, mCanvasName, this, QgisApp::instance(), Qt::RightDockWidgetArea );
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( mCanvasName, this, QgisApp::instance(), mCanvasName, QStringList(), isDocked ? QgsDockableWidgetHelper::OpeningMode::ForceDocked : QgsDockableWidgetHelper::OpeningMode::RespectSetting );
   QToolButton *toggleButton = mDockableWidgetHelper->createDockUndockToolButton();
   toggleButton->setToolTip( tr( "Dock 2D Map View" ) );
   mToolbar->addWidget( toggleButton );

--- a/src/gui/codeeditors/qgscodeeditordockwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditordockwidget.cpp
@@ -17,10 +17,24 @@
 #include "moc_qgscodeeditordockwidget.cpp"
 #include "qgsdockablewidgethelper.h"
 
-QgsCodeEditorDockWidget::QgsCodeEditorDockWidget( const QString &windowGeometrySettingsKey, bool usePersistentWidget )
+QgsCodeEditorDockWidget::QgsCodeEditorDockWidget( const QString &dockId, bool usePersistentWidget )
   : QWidget( nullptr )
 {
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( true, tr( "Code Editor" ), this, QgsDockableWidgetHelper::sOwnerWindow, Qt::BottomDockWidgetArea, QStringList(), true, windowGeometrySettingsKey, usePersistentWidget );
+  QgsDockableWidgetHelper::Options options = QgsDockableWidgetHelper::Option::RaiseTab;
+  if ( usePersistentWidget )
+    options.setFlag( QgsDockableWidgetHelper::Option::PermanentWidget );
+
+  mDockableWidgetHelper = new QgsDockableWidgetHelper(
+    tr( "Code Editor" ),
+    this,
+    QgsDockableWidgetHelper::sOwnerWindow,
+    dockId,
+    QStringList(),
+    QgsDockableWidgetHelper::OpeningMode::RespectSetting,
+    true,
+    Qt::BottomDockWidgetArea,
+    options
+  );
 
   mDockToggleButton = mDockableWidgetHelper->createDockUndockToolButton();
   mDockToggleButton->setToolTip( tr( "Dock Code Editor" ) );

--- a/src/gui/codeeditors/qgscodeeditordockwidget.h
+++ b/src/gui/codeeditors/qgscodeeditordockwidget.h
@@ -41,7 +41,7 @@ class GUI_EXPORT QgsCodeEditorDockWidget : public QWidget
      *
      * If \a usePersistentWidget is TRUE then the widget (either as a dock or window) cannot be destroyed and must be hidden instead.
      */
-    QgsCodeEditorDockWidget( const QString &windowGeometrySettingsKey = QString(), bool usePersistentWidget = false );
+    QgsCodeEditorDockWidget( const QString &dockId = QString(), bool usePersistentWidget = false );
     ~QgsCodeEditorDockWidget() override;
 
     /**

--- a/src/gui/qgsdockablewidgethelper.cpp
+++ b/src/gui/qgsdockablewidgethelper.cpp
@@ -26,6 +26,9 @@
 
 ///@cond PRIVATE
 
+const QgsSettingsEntryBool *QgsDockableWidgetHelper::sSettingsIsDocked = new QgsSettingsEntryBool( QStringLiteral( "is-docked" ), QgsDockableWidgetHelper::sTtreeDockConfigs, false );
+const QgsSettingsEntryVariant *QgsDockableWidgetHelper::sSettingsWindowGeometry = new QgsSettingsEntryVariant( QStringLiteral( "geometry" ), QgsDockableWidgetHelper::sTtreeDockConfigs );
+const QgsSettingsEntryEnumFlag<Qt::DockWidgetArea> *QgsDockableWidgetHelper::sSettingsDockArea = new QgsSettingsEntryEnumFlag<Qt::DockWidgetArea>( QStringLiteral( "area" ), QgsDockableWidgetHelper::sTtreeDockConfigs, Qt::RightDockWidgetArea );
 
 std::function<void( Qt::DockWidgetArea, QDockWidget *, const QStringList &, bool )> QgsDockableWidgetHelper::sAddTabifiedDockWidgetFunction = []( Qt::DockWidgetArea, QDockWidget *, const QStringList &, bool ) {};
 std::function<QString()> QgsDockableWidgetHelper::sAppStylesheetFunction = [] { return QString(); };
@@ -40,11 +43,33 @@ QgsDockableWidgetHelper::QgsDockableWidgetHelper( bool isDocked, const QString &
   , mWindowTitle( windowTitle )
   , mOwnerWindow( ownerWindow )
   , mTabifyWith( tabifyWith )
-  , mRaiseTab( raiseTab )
   , mWindowGeometrySettingsKey( windowGeometrySettingsKey )
   , mUuid( QUuid::createUuid().toString() )
-  , mUsePersistentWidget( usePersistentWidget )
 {
+  mOptions.setFlag( Option::RaiseTab, raiseTab );
+  mOptions.setFlag( Option::PermanentWidget, usePersistentWidget );
+  toggleDockMode( isDocked );
+}
+
+QgsDockableWidgetHelper::QgsDockableWidgetHelper( const QString &windowTitle, QWidget *widget, QMainWindow *ownerWindow, const QString &dockId, const QStringList &tabifyWith, OpeningMode openingMode, bool defaultIsDocked, Qt::DockWidgetArea defaultDockArea, Options options )
+  : QObject( nullptr )
+  , mWidget( widget )
+  , mDialogGeometry( 0, 0, 0, 0 )
+  , mWindowTitle( windowTitle )
+  , mOwnerWindow( ownerWindow )
+  , mTabifyWith( tabifyWith )
+  , mOptions( options )
+  , mUuid( QUuid::createUuid().toString() )
+  , mSettingKeyDockId( dockId )
+{
+  bool isDocked = sSettingsIsDocked->valueWithDefaultOverride( defaultIsDocked, mSettingKeyDockId );
+  if ( openingMode == OpeningMode::ForceDocked )
+    isDocked = true;
+  else if ( openingMode == OpeningMode::ForceDialog )
+    isDocked = false;
+
+  mDockArea = sSettingsDockArea->valueWithDefaultOverride( defaultDockArea, mSettingKeyDockId );
+  mIsDockFloating = mDockArea == Qt::DockWidgetArea::NoDockWidgetArea;
   toggleDockMode( isDocked );
 }
 
@@ -53,6 +78,8 @@ QgsDockableWidgetHelper::~QgsDockableWidgetHelper()
   if ( mDock )
   {
     mDockGeometry = mDock->geometry();
+    if ( !mSettingKeyDockId.isEmpty() )
+      sSettingsWindowGeometry->setValue( mDock->saveGeometry(), mSettingKeyDockId );
     mIsDockFloating = mDock->isFloating();
     if ( mOwnerWindow )
       mDockArea = mOwnerWindow->dockWidgetArea( mDock );
@@ -73,6 +100,8 @@ QgsDockableWidgetHelper::~QgsDockableWidgetHelper()
     {
       QgsSettings().setValue( mWindowGeometrySettingsKey, mDialog->saveGeometry() );
     }
+    if ( !mSettingKeyDockId.isEmpty() )
+      sSettingsWindowGeometry->setValue( mDialog->saveGeometry(), mSettingKeyDockId );
 
     mDialog->layout()->removeWidget( mWidget );
     mDialog->deleteLater();
@@ -243,6 +272,8 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
   }
 
   mIsDocked = docked;
+  if ( !mSettingKeyDockId.isEmpty() )
+    sSettingsIsDocked->setValue( mIsDocked, mSettingKeyDockId );
 
   // If there is no widget set, do not create a dock or a dialog
   if ( !mWidget )
@@ -258,6 +289,13 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     mDock->setProperty( "dock_uuid", mUuid );
     setupDockWidget();
 
+    if ( !mSettingKeyDockId.isEmpty() )
+    {
+      connect( mDock, &QgsDockWidget::dockLocationChanged, this, [=]( Qt::DockWidgetArea area ) {
+        sSettingsDockArea->setValue( area, mSettingKeyDockId );
+      } );
+    }
+
     connect( mDock, &QgsDockWidget::closed, this, [=]() {
       mDockGeometry = mDock->geometry();
       mIsDockFloating = mDock->isFloating();
@@ -266,7 +304,7 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
       emit closed();
     } );
 
-    if ( mUsePersistentWidget )
+    if ( mOptions.testFlag( Option::PermanentWidget ) )
       mDock->installEventFilter( this );
 
     connect( mDock, &QgsDockWidget::visibilityChanged, this, &QgsDockableWidgetHelper::visibilityChanged );
@@ -278,7 +316,7 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     // going from dock -> window
     // note -- we explicitly DO NOT set the parent for the dialog, as we want these treated as
     // proper top level windows and have their own taskbar entries. See https://github.com/qgis/QGIS/issues/49286
-    if ( mUsePersistentWidget )
+    if ( mOptions.testFlag( Option::PermanentWidget ) )
       mDialog = new QgsNonRejectableDialog( nullptr, Qt::Window );
     else
       mDialog = new QDialog( nullptr, Qt::Window );
@@ -287,7 +325,7 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     mDialog->setWindowTitle( mWindowTitle );
     mDialog->setObjectName( mObjectName );
 
-    if ( mUsePersistentWidget )
+    if ( mOptions.testFlag( Option::PermanentWidget ) )
       mDialog->installEventFilter( this );
 
     QVBoxLayout *vl = new QVBoxLayout();
@@ -298,6 +336,10 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     {
       QgsSettings settings;
       mDialog->restoreGeometry( settings.value( mWindowGeometrySettingsKey ).toByteArray() );
+    }
+    else if ( !mSettingKeyDockId.isEmpty() )
+    {
+      mDialog->restoreGeometry( sSettingsWindowGeometry->value( mSettingKeyDockId ).toByteArray() );
     }
     else
     {
@@ -390,6 +432,7 @@ void QgsDockableWidgetHelper::setupDockWidget( const QStringList &tabSiblings )
     return;
 
   mDock->setFloating( mIsDockFloating );
+  // default dock geometry
   if ( mDockGeometry.isEmpty() && mOwnerWindow )
   {
     const QFontMetrics fm( mOwnerWindow->font() );
@@ -400,9 +443,9 @@ void QgsDockableWidgetHelper::setupDockWidget( const QStringList &tabSiblings )
   {
     sAddTabifiedDockWidgetFunction( mDockArea, mDock, tabSiblings, false );
   }
-  else if ( mRaiseTab )
+  else if ( mOptions.testFlag( Option::RaiseTab ) )
   {
-    sAddTabifiedDockWidgetFunction( mDockArea, mDock, mTabifyWith, mRaiseTab );
+    sAddTabifiedDockWidgetFunction( mDockArea, mDock, mTabifyWith, true );
   }
   else if ( mOwnerWindow )
   {
@@ -411,7 +454,11 @@ void QgsDockableWidgetHelper::setupDockWidget( const QStringList &tabSiblings )
 
   // can only resize properly and set the dock geometry after pending events have been processed,
   // so queue the geometry setting on the end of the event loop
-  QMetaObject::invokeMethod( mDock, [this] { mDock->setGeometry( mDockGeometry ); }, Qt::QueuedConnection );
+  QMetaObject::invokeMethod( mDock, [this] {
+    if (mIsDockFloating && sSettingsWindowGeometry->exists(mSettingKeyDockId))
+        mDock->restoreGeometry( sSettingsWindowGeometry->value(mSettingKeyDockId).toByteArray() );
+    else
+      mDock->setGeometry( mDockGeometry ); }, Qt::QueuedConnection );
 }
 
 QToolButton *QgsDockableWidgetHelper::createDockUndockToolButton()

--- a/src/gui/qgsdockablewidgethelper.h
+++ b/src/gui/qgsdockablewidgethelper.h
@@ -24,6 +24,10 @@
 #include <QDomElement>
 #include <QPointer>
 
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsentryenumflag.h"
+#include "qgsgui.h"
+
 #define SIP_NO_FILE
 
 class QgsDockWidget;
@@ -50,8 +54,29 @@ class GUI_EXPORT QgsNonRejectableDialog : public QDialog
  */
 class GUI_EXPORT QgsDockableWidgetHelper : public QObject
 {
+    static inline QgsSettingsTreeNode *sTtreeDockConfigs = QgsGui::sTtreeWidgetGeometry->createNamedListNode( QStringLiteral( "docks" ) ) SIP_SKIP;
+
+    static const QgsSettingsEntryBool *sSettingsIsDocked SIP_SKIP;
+    static const QgsSettingsEntryVariant *sSettingsWindowGeometry SIP_SKIP;
+    static const QgsSettingsEntryEnumFlag<Qt::DockWidgetArea> *sSettingsDockArea SIP_SKIP;
+
     Q_OBJECT
   public:
+    enum class OpeningMode : int
+    {
+      RespectSetting, //! Respect the setting used
+      ForceDocked,    //! Force the widget to be docked, despite its settings
+      ForceDialog,    //! Force the widget to be shown in a dialog, despite its settings
+    };
+
+    enum class Option : int
+    {
+      RaiseTab = 1 << 1,        //!< Raise Tab
+      PermanentWidget = 1 << 2, //!< The widget (either as a dock or window) cannot be destroyed and must be hidden instead
+    };
+    Q_ENUM( Option )
+    Q_DECLARE_FLAGS( Options, Option )
+
     /**
      * Constructs an object that is responsible of making a docked widget or a window titled \a windowTitle that holds the \a widget
      * The ownership of \a widget is returned to \a ownerWindow once the object is destroyed.
@@ -59,7 +84,34 @@ class GUI_EXPORT QgsDockableWidgetHelper : public QObject
      * If \a usePersistentWidget is TRUE then the \a widget (either as a dock or window) cannot be destroyed and must be hidden instead.
      */
     QgsDockableWidgetHelper( bool isDocked, const QString &windowTitle, QWidget *widget, QMainWindow *ownerWindow, Qt::DockWidgetArea defaultDockArea = Qt::NoDockWidgetArea, const QStringList &tabifyWith = QStringList(), bool raiseTab = false, const QString &windowGeometrySettingsKey = QString(), bool usePersistentWidget = false );
+
+    /**
+     * Constructs an object that is responsible of making a docked widget or a window titled \a windowTitle that holds the \a widget
+     * The ownership of \a widget is returned to \a ownerWindow once the object is destroyed.
+     *
+     * With a unique \a dockId, the status (docked, area and geometry) are saved in the settings and re-used on creation.
+     *
+     * If \a usePersistentWidget is TRUE then the \a widget (either as a dock or window) cannot be destroyed and must be hidden instead.
+     *
+     * \since QGIS 3.42
+     */
+    QgsDockableWidgetHelper(
+      const QString &windowTitle,
+      QWidget *widget,
+      QMainWindow *ownerWindow,
+      const QString &dockId,
+      const QStringList &tabifyWith = QStringList(),
+      OpeningMode openingMode = OpeningMode::RespectSetting,
+      bool defaultIsDocked = false,
+      Qt::DockWidgetArea defaultDockArea = Qt::DockWidgetArea::RightDockWidgetArea,
+      Options options = Options()
+    );
+
     ~QgsDockableWidgetHelper();
+
+    //! Returns if the widget is docked
+    //! \since 3.42
+    bool isDocked() const { return mIsDocked; }
 
     //! Reads the dimensions of both the dock widget and the top level window
     void writeXml( QDomElement &viewDom );
@@ -140,15 +192,19 @@ class GUI_EXPORT QgsDockableWidgetHelper : public QObject
     QMainWindow *mOwnerWindow = nullptr;
 
     QStringList mTabifyWith;
-    bool mRaiseTab = false;
+    Options mOptions;
 
     QString mWindowGeometrySettingsKey;
 
     // Unique identifier of dock
     QString mUuid;
 
-    bool mUsePersistentWidget = false;
+
+    const QString mSettingKeyDockId;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDockableWidgetHelper::Options )
+
 
 ///@endcond
 

--- a/src/gui/qgsdockablewidgethelper.h
+++ b/src/gui/qgsdockablewidgethelper.h
@@ -57,7 +57,8 @@ class GUI_EXPORT QgsDockableWidgetHelper : public QObject
     static inline QgsSettingsTreeNode *sTtreeDockConfigs = QgsGui::sTtreeWidgetGeometry->createNamedListNode( QStringLiteral( "docks" ) ) SIP_SKIP;
 
     static const QgsSettingsEntryBool *sSettingsIsDocked SIP_SKIP;
-    static const QgsSettingsEntryVariant *sSettingsWindowGeometry SIP_SKIP;
+    static const QgsSettingsEntryVariant *sSettingsDockGeometry SIP_SKIP;
+    static const QgsSettingsEntryVariant *sSettingsDialogGeometry SIP_SKIP;
     static const QgsSettingsEntryEnumFlag<Qt::DockWidgetArea> *sSettingsDockArea SIP_SKIP;
 
     Q_OBJECT
@@ -76,14 +77,6 @@ class GUI_EXPORT QgsDockableWidgetHelper : public QObject
     };
     Q_ENUM( Option )
     Q_DECLARE_FLAGS( Options, Option )
-
-    /**
-     * Constructs an object that is responsible of making a docked widget or a window titled \a windowTitle that holds the \a widget
-     * The ownership of \a widget is returned to \a ownerWindow once the object is destroyed.
-     *
-     * If \a usePersistentWidget is TRUE then the \a widget (either as a dock or window) cannot be destroyed and must be hidden instead.
-     */
-    QgsDockableWidgetHelper( bool isDocked, const QString &windowTitle, QWidget *widget, QMainWindow *ownerWindow, Qt::DockWidgetArea defaultDockArea = Qt::NoDockWidgetArea, const QStringList &tabifyWith = QStringList(), bool raiseTab = false, const QString &windowGeometrySettingsKey = QString(), bool usePersistentWidget = false );
 
     /**
      * Constructs an object that is responsible of making a docked widget or a window titled \a windowTitle that holds the \a widget
@@ -192,8 +185,6 @@ class GUI_EXPORT QgsDockableWidgetHelper : public QObject
 
     QStringList mTabifyWith;
     Options mOptions;
-
-    QString mWindowGeometrySettingsKey;
 
     // Unique identifier of dock
     QString mUuid;

--- a/src/gui/qgsdockablewidgethelper.h
+++ b/src/gui/qgsdockablewidgethelper.h
@@ -90,8 +90,7 @@ class GUI_EXPORT QgsDockableWidgetHelper : public QObject
      * The ownership of \a widget is returned to \a ownerWindow once the object is destroyed.
      *
      * With a unique \a dockId, the status (docked, area and geometry) are saved in the settings and re-used on creation.
-     *
-     * If \a usePersistentWidget is TRUE then the \a widget (either as a dock or window) cannot be destroyed and must be hidden instead.
+     * The default values of the settings can be overridden with \a defaultIsDocked and \a defaultDockArea.
      *
      * \since QGIS 3.42
      */

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -65,6 +65,7 @@ class GUI_EXPORT QgsGui : public QObject
     Q_OBJECT
 
   public:
+    static inline QgsSettingsTreeNode *sTtreeWidgetGeometry = QgsSettingsTree::sTreeApp->createChildNode( QStringLiteral( "widget-geometry" ) ) SIP_SKIP;
     static inline QgsSettingsTreeNode *sTtreeWidgetLastUsedValues = QgsSettingsTree::sTreeApp->createChildNode( QStringLiteral( "widget-last-used-values" ) ) SIP_SKIP;
 
     /**


### PR DESCRIPTION
uses dynamic settings to save the state (docked, area, geometry) 
now if the dock is floating, its geometry is also reset

No API break
I would be in favor of having this included as a bugfix for 3.42 (not 3.40).

