### PR TITLE
3D views: use the correct resolution on high DPI displays!

### DIFF
--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -99,7 +99,7 @@ void QgsWindow3DEngine::setSize( QSize s )
 
   mMapCanvas3D->setWidth( mSize.width() );
   mMapCanvas3D->setHeight( mSize.height() );
-  mFrameGraph->setSize( mSize );
+  mFrameGraph->setSize( mSize * mMapCanvas3D->devicePixelRatio() );
   camera()->setAspectRatio( float( mSize.width() ) / float( mSize.height() ) );
   emit sizeChanged();
 }


### PR DESCRIPTION
Nowadays Qt gives us size in device independent pixels, and we were using those values for the textures as well - but that means on high DPI screens where device pixel ratio is 2, we were rendering in low resolution and then upscaling the textures. This should fix that, and intermediate textures use the correct size - the rendered output is much crispier, yay!

One potential problem is that existing QGIS projects may start to look slightly different, because e.g. line width or point sizes are in pixels - so on a high DPI screen one may need to double those values to get similar looking scene. And yes, we should move towards using millimeters like in 2D maps to avoid these issues...

Some examples from my laptop below (device pixel ratio = 2). Notice the more detailed edge lines or finer details in the point cloud.

| Before | After |
:-: | :-:
![3d-edges-lowdpi](https://github.com/user-attachments/assets/bce648f2-003d-4550-a7a1-6c141c71ae26) | ![3d-edges-highpi](https://github.com/user-attachments/assets/c087154b-d42e-49ff-8557-bf8d48ce8a6a)
![3d-point-cloud-lowdpi](https://github.com/user-attachments/assets/066ee7e8-b1f5-4129-b8c7-40f5bb8e3e1d) | ![3d-point-cloud-highdpi](https://github.com/user-attachments/assets/be1bac06-1980-4dcb-b8ba-e8f50cb983c0)


