### PR TITLE
Insure the list of active python plugins in the About dialog is always up-to-date

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5439,8 +5439,8 @@ void QgisApp::about()
   if ( !sAbt )
   {
     sAbt = new QgsAbout( this );
-    sAbt->setVersion( QgisApp::getVersionString() );
   }
+  sAbt->setVersion( QgisApp::getVersionString() );
   sAbt->show();
   sAbt->raise();
   sAbt->activateWindow();


### PR DESCRIPTION
## Description

The PR fixes https://github.com/qgis/QGIS/issues/59779 whereas the list of active plugins in the about dialog was not always up-to-date. 