### PR TITLE
avoid non-standard b3dm data format problems

### DIFF
--- a/src/core/textrenderer/qgstextdocumentmetrics.cpp
+++ b/src/core/textrenderer/qgstextdocumentmetrics.cpp
@@ -185,6 +185,10 @@ void QgsTextDocumentMetrics::finalizeBlock( QgsTextDocumentMetrics &res, const Q
   else
   {
     // html vertical margins between blocks collapse and take the size of the highest margin:
+    if (documentMetrics.verticalMarginsBetweenBlocks.isEmpty()) {
+      qWarning() << "verticalMarginsBetweenBlocks is empty!";
+      documentMetrics.verticalMarginsBetweenBlocks.append(0.0);
+    }
     const double verticalMarginBeforeBlock = std::max( documentMetrics.verticalMarginsBetweenBlocks.last(), metrics.marginTop );
     documentMetrics.verticalMarginsBetweenBlocks.last() = verticalMarginBeforeBlock;
     documentMetrics.verticalMarginsBetweenBlocks.append( metrics.marginBottom );


### PR DESCRIPTION
## Description

print 3d layout bug:
![1 crash](https://github.com/user-attachments/assets/1731246e-b1bf-4250-9c41-104b4611b7d4)

![2 gdb](https://github.com/user-attachments/assets/24338a9b-eaa7-4463-9b2f-dfe718c25ae9)

Fixes #60256
