### PR TITLE
allow building with GRASS and without PostgreSQL

### DIFF
--- a/src/providers/grass/CMakeLists.txt
+++ b/src/providers/grass/CMakeLists.txt
@@ -132,7 +132,10 @@ macro(ADD_GRASSLIB GRASS_BUILD_VERSION)
       )
     endif()
 
-    target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} ${GRASS_TARGET_LINK_LIBRARIES${GRASS_BUILD_VERSION}} PostgreSQL::PostgreSQL)
+    target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} ${GRASS_TARGET_LINK_LIBRARIES${GRASS_BUILD_VERSION}})
+	if(WITH_POSTGRESQL)
+	  target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} PostgreSQL::PostgreSQL)
+	endif()
 
     if (WITH_GUI)
       target_link_libraries(qgisgrass${GRASS_BUILD_VERSION}

--- a/src/providers/grass/CMakeLists.txt
+++ b/src/providers/grass/CMakeLists.txt
@@ -133,9 +133,9 @@ macro(ADD_GRASSLIB GRASS_BUILD_VERSION)
     endif()
 
     target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} ${GRASS_TARGET_LINK_LIBRARIES${GRASS_BUILD_VERSION}})
-	if(WITH_POSTGRESQL)
-	  target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} PostgreSQL::PostgreSQL)
-	endif()
+	  if(WITH_POSTGRESQL)
+	    target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} PostgreSQL::PostgreSQL)
+	  endif()
 
     if (WITH_GUI)
       target_link_libraries(qgisgrass${GRASS_BUILD_VERSION}


### PR DESCRIPTION
Added changes suggested by @m-kuhn in https://github.com/qgis/QGIS/pull/60038#issuecomment-2605153583

in: src/providers/grass/CMakeLists.txt:135 to

```
target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} ${GRASS_TARGET_LINK_LIBRARIES${GRASS_BUILD_VERSION}})
if(WITH_POSTGRESQL)
  target_link_libraries(qgisgrass${GRASS_BUILD_VERSION} PostgreSQL::PostgreSQL)
endif()
```

This solves an issue encountered when building QGIS with GRASS but without PostgreSQL, when PostgreSQL::PostgreSQL could not be found.

Tested locally, works OK.