### PR TITLE
[elevation profile] Avoid snapping to non-rendered features when using the identify tool

### DIFF
--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -525,7 +525,10 @@ void QgsVectorLayerProfileResults::renderResultsAsIndividualFeatures( QgsProfile
       context.renderContext().expressionContext().setFeature( feature );
       QgsSymbol *rendererSymbol = renderer->symbolForFeature( feature, context.renderContext() );
       if ( !rendererSymbol )
+      {
+        features.remove( feature.id() );
         continue;
+      }
 
       marker->setColor( rendererSymbol->color() );
       marker->setOpacity( rendererSymbol->opacity() );


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/59744 whereas non-rendered features would still be snapped to when using the identify tool.

@nyalldawson , the filtering could happen earlier but I'm not sure it makes a lot of sense, esp. when considering that the feature visibility might rely on some render context that isn't available when generating the profile.