### PR TITLE
[vector layer] Fix geometry validity check preventing saving of changes after removing problematic feature(s)

### DIFF
--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -133,15 +133,16 @@ void QgsGeometryValidationService::onGeometryChanged( QgsVectorLayer *layer, Qgs
 
 void QgsGeometryValidationService::onFeatureDeleted( QgsVectorLayer *layer, QgsFeatureId fid )
 {
-  mLayerChecks[layer].singleFeatureCheckErrors.remove( fid );
+  VectorLayerCheckInformation &checkInformation = mLayerChecks[layer];
+  checkInformation.singleFeatureCheckErrors.remove( fid );
 
-  if ( !mLayerChecks[layer].topologyChecks.empty() )
+  if ( !checkInformation.topologyChecks.empty() )
   {
     invalidateTopologyChecks( layer );
   }
   else
   {
-    layer->setAllowCommit( mLayerChecks[layer].singleFeatureCheckErrors.empty() );
+    layer->setAllowCommit( checkInformation.singleFeatureCheckErrors.empty() );
   }
 
   // There should be no geometry errors on a non-existent feature, right?


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/59688 whereas logic was missing to ensure that delete feature(s) with problematic geometry would allow for the remaining valid changes to be saved during an editing session.