### PR TITLE
Improve qgsmessagelog caller information

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
@@ -34,13 +34,6 @@ window for the user.
 
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
                             const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
-%Docstring
-Adds a ``message`` to the log instance (and creates it if necessary).
-
-If ``notifyUser`` is ``True``, then the message should be brought to the user's attention by various UI hints.
-If it is ``False``, the message should appear in logs silently. Note that log viewer implementations may
-only respect notification hints for certain message levels.
-%End
 
   signals:
 

--- a/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
@@ -32,7 +32,8 @@ window for the user.
 
     QgsMessageLog();
 
-    static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true );
+    static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
+                            const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
 %Docstring
 Adds a ``message`` to the log instance (and creates it if necessary).
 

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -34,13 +34,6 @@ window for the user.
 
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
                             const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
-%Docstring
-Adds a ``message`` to the log instance (and creates it if necessary).
-
-If ``notifyUser`` is ``True``, then the message should be brought to the user's attention by various UI hints.
-If it is ``False``, the message should appear in logs silently. Note that log viewer implementations may
-only respect notification hints for certain message levels.
-%End
 
   signals:
 

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -32,7 +32,8 @@ window for the user.
 
     QgsMessageLog();
 
-    static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true );
+    static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
+                            const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
 %Docstring
 Adds a ``message`` to the log instance (and creates it if necessary).
 

--- a/src/core/qgslogger.h
+++ b/src/core/qgslogger.h
@@ -32,11 +32,15 @@ class QFile;
 #ifdef QGISDEBUG
 #define QgsDebugError(str) QgsLogger::debug(QString(str), 0, __FILE__, __FUNCTION__, __LINE__)
 #define QgsDebugMsgLevel(str, level) if ( level <= QgsLogger::debugLevel() ) { QgsLogger::debug(QString(str), (level), __FILE__, __FUNCTION__, __LINE__); }(void)(0)
+#define QgsDebugErrorLoc(str, file, func, line) QgsLogger::debug(QString(str), 0, file, func, line)
+#define QgsDebugMsgLevelLoc(str, level, file, func, line) if ( level <= QgsLogger::debugLevel() ) { QgsLogger::debug(QString(str), (level), file, func, line); }(void)(0)
 #define QgsDebugCall QgsScopeLogger _qgsScopeLogger(__FILE__, __FUNCTION__, __LINE__)
 #else
 #define QgsDebugCall do {} while(false)
 #define QgsDebugError(str) do {} while(false)
 #define QgsDebugMsgLevel(str, level) do {} while(false)
+#define QgsDebugErrorLoc(str, file, func, line) do {} while(false)
+#define QgsDebugMsgLevelLoc(str, level, file, func, line) do {} while(false)
 #endif
 
 /**

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -28,6 +28,11 @@ class QgsMessageLogConsole;
 void QgsMessageLog::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser,
                                 const char *file, const char *function, int line )
 {
+#ifndef QGISDEBUG
+  Q_UNUSED( file )
+  Q_UNUSED( function )
+  Q_UNUSED( line )
+#endif
   switch ( level )
   {
     case Qgis::MessageLevel::Info:

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -25,19 +25,22 @@
 
 class QgsMessageLogConsole;
 
-void QgsMessageLog::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser )
+void QgsMessageLog::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser,
+                                const char *file, const char *function, int line )
 {
   switch ( level )
   {
     case Qgis::MessageLevel::Info:
     case Qgis::MessageLevel::Success:
     case Qgis::MessageLevel::NoLevel:
-      QgsDebugMsgLevel( QStringLiteral( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ), 1 );
+      QgsDebugMsgLevelLoc( QStringLiteral( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ),
+                           1, file, function, line );
       break;
 
     case Qgis::MessageLevel::Warning:
     case Qgis::MessageLevel::Critical:
-      QgsDebugError( QStringLiteral( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ) );
+      QgsDebugErrorLoc( QStringLiteral( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ),
+                        file, function, line );
       break;
   }
 

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -51,7 +51,8 @@ class CORE_EXPORT QgsMessageLog : public QObject
      * If it is FALSE, the message should appear in logs silently. Note that log viewer implementations may
      * only respect notification hints for certain message levels.
      */
-    static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true );
+    static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
+                            const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
 
   signals:
 

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -51,6 +51,14 @@ class CORE_EXPORT QgsMessageLog : public QObject
      * If it is FALSE, the message should appear in logs silently. Note that log viewer implementations may
      * only respect notification hints for certain message levels.
      */
+    // TODO: Update this code to use std::source_location from C++20 when transitioning to a fully C++20-compliant codebase.
+    //       Currently, we rely on __builtin_XXX functions (e.g., __builtin_FILE(), __builtin_LINE()),
+    //       which have been successfully tested across multiple systems (Windows, macOS, Linux, FreeBSD)
+    //       and compilers (LLVM, GCC, MSVC).
+    // Note: We tested with LLVM on FreeBSD and macOS, and std::experimental::source_location is not available.
+    //       It works fine with GNU. It also seems unavailable with MSVC.
+    //       For now, we stick with __builtin_XXX because it is "portable" and functional across all tested environments.
+    //       We'll switch to std::source_location once the transition to C++20 is complete.
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
                             const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
 

--- a/src/server/services/wfs/qgswfsparameters.cpp
+++ b/src/server/services/wfs/qgswfsparameters.cpp
@@ -364,8 +364,8 @@ namespace QgsWfs
     return version;
   }
 
-  void QgsWfsParameters::log( const QString &msg ) const
+  void QgsWfsParameters::log( const QString &msg, const char *file, const char *function, int line ) const
   {
-    QgsMessageLog::logMessage( msg, "Server", Qgis::MessageLevel::Info );
+    QgsMessageLog::logMessage( msg, "Server", Qgis::MessageLevel::Info, true, file, function, line );
   }
 } // namespace QgsWfs

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -283,7 +283,7 @@ namespace QgsWfs
       bool loadParameter( const QString &key, const QString &value ) override;
       void save( const QgsWfsParameter &parameter );
 
-      void log( const QString &msg ) const;
+      void log( const QString &msg, const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() ) const;
 
       QList<QgsProjectVersion> mVersions;
       QMap<QgsWfsParameter::Name, QgsWfsParameter> mWfsParameters;

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -2056,9 +2056,9 @@ namespace QgsWms
     return mWmsParameters.value( QgsWmsParameter::WMTVER ).toString();
   }
 
-  void QgsWmsParameters::log( const QString &msg ) const
+  void QgsWmsParameters::log( const QString &msg, const char *file, const char *function, int line ) const
   {
-    QgsMessageLog::logMessage( msg, QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+    QgsMessageLog::logMessage( msg, QStringLiteral( "Server" ), Qgis::MessageLevel::Info, true, file, function, line );
   }
 
   void QgsWmsParameters::raiseError( const QString &msg ) const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -1530,7 +1530,7 @@ namespace QgsWms
       QgsWmsParameter idParameter( QgsWmsParameter::Name name, int id ) const;
 
       void raiseError( const QString &msg ) const;
-      void log( const QString &msg ) const;
+      void log( const QString &msg, const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() ) const;
 
       QgsWmsParametersExternalLayer externalLayerParameter( const QString &name ) const;
 

--- a/src/server/services/wmts/qgswmtsparameters.cpp
+++ b/src/server/services/wmts/qgswmtsparameters.cpp
@@ -292,8 +292,8 @@ namespace QgsWmts
     return version;
   }
 
-  void QgsWmtsParameters::log( const QString &msg ) const
+  void QgsWmtsParameters::log( const QString &msg, const char *file, const char *function, int line ) const
   {
-    QgsMessageLog::logMessage( msg, "Server", Qgis::MessageLevel::Info );
+    QgsMessageLog::logMessage( msg, "Server", Qgis::MessageLevel::Info, true, file, function, line );
   }
 } // namespace QgsWmts

--- a/src/server/services/wmts/qgswmtsparameters.h
+++ b/src/server/services/wmts/qgswmtsparameters.h
@@ -314,7 +314,7 @@ namespace QgsWmts
       bool loadParameter( const QString &key, const QString &value ) override;
       void save( const QgsWmtsParameter &parameter );
 
-      void log( const QString &msg ) const;
+      void log( const QString &msg, const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() ) const;
 
       QList<QgsProjectVersion> mVersions;
       QMap<QgsWmtsParameter::Name, QgsWmtsParameter> mWmtsParameters;


### PR DESCRIPTION
QgsMessageLog::log calls  `QgsDebugMsgLevel` which display caller information based on the `__FILE__`,  `__FUNCTION__` and  `__FILE__` macros. This produce outputs like below where the caller information are lost:

```raw
src/core/qgsmessagelog.cpp:35 : (logMessage) [2ms] 2025-01-22T19:34:33 Server[0] WMS Request parameters:
src/core/qgsmessagelog.cpp:35 : (logMessage) [0ms] 2025-01-22T19:34:33 Server[0]  - CRS : EPSG:3857
```

This PR makes use of  `__builtin_FILE()`, `__builtin_FUNCTION()` and `__builtin_LINE()` buildin c++ functions to retrieve the caller information to produce something like that:

```raw
src/server/services/wms/qgswmsparameters.cpp:565 : (dump) [52ms] 2025-01-24T16:13:15 Server[0] WMS Request parameters:
src/server/services/wms/qgswmsparameters.cpp:579 : (dump) [0ms] 2025-01-24T16:13:15 Server[0]  - CRS : EPSG:3857
```
