### PR TITLE
Fix QgsRasterLayer and QgsRasterBlock as_numpy methods

### DIFF
--- a/python/PyQt6/core/__init__.py.in
+++ b/python/PyQt6/core/__init__.py.in
@@ -569,11 +569,15 @@ try:
          raise ValueError(f"The raster block data type '{str(self.dataType())}' is not compatible with NumPy arrays.")
       src_array = _numpy.frombuffer(self.data(), dtype=raster_dtype)
       src_array = src_array.reshape((self.height(), self.width()))
-      if not self.hasNoDataValue() or not use_masking:
-         return src_array
-      else:
-         no_data_value = self.noDataValue() if isinstance(self.noDataValue(), raster_dtype) else 0
+      if use_masking:
+         if not self.hasNoDataValue():
+      	    # Default to 0 as noDataValue if none is set
+            no_data_value = 0
+         else:
+            no_data_value = self.noDataValue()
          return _numpy.ma.masked_equal(src_array, no_data_value)
+      else:
+         return src_array
 
    QgsRasterBlock.as_numpy = _raster_block_as_numpy
 
@@ -586,7 +590,10 @@ try:
           src_array = block.as_numpy(use_masking=use_masking)
           arrays.append(src_array)
 
-      return _numpy.array(arrays)  # This converts any maskedArrays to numpy.array
+      if use_masking:
+          return _numpy.ma.stack(arrays, axis=0)
+      else:
+          return _numpy.array(arrays)
 
    QgsRasterLayer.as_numpy = _raster_layer_as_numpy
 
@@ -646,7 +653,7 @@ try:
 
 
    QgsGeometry.as_numpy = _qgsgeometry_as_numpy
-   
+
 except ModuleNotFoundError:
    def _raster_block_as_numpy(self, use_masking:bool = True):
        raise QgsNotSupportedException('QgsRasterBlock.as_numpy is not available, numpy is not installed on the system')
@@ -657,7 +664,7 @@ except ModuleNotFoundError:
        raise QgsNotSupportedException('QgsRasterLayer.as_numpy is not available, numpy is not installed on the system')
 
    QgsRasterLayer.as_numpy = _raster_layer_as_numpy
-   
+
    def _geometry_as_numpy(self):
       raise QgsNotSupportedException('QgsGeometry.as_numpy is not available, numpy is not installed on the system')
 

--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -579,11 +579,15 @@ try:
          raise ValueError(f"The raster block data type '{str(self.dataType())}' is not compatible with NumPy arrays.")
       src_array = _numpy.frombuffer(self.data(), dtype=raster_dtype)
       src_array = src_array.reshape((self.height(), self.width()))
-      if not self.hasNoDataValue() or not use_masking:
-         return src_array
-      else:
-         no_data_value = self.noDataValue() if isinstance(self.noDataValue(), raster_dtype) else 0
+      if use_masking:
+         if not self.hasNoDataValue():
+      	    # Default to 0 as noDataValue if none is set
+            no_data_value = 0
+         else:
+            no_data_value = self.noDataValue()
          return _numpy.ma.masked_equal(src_array, no_data_value)
+      else:
+         return src_array
 
    QgsRasterBlock.as_numpy = _raster_block_as_numpy
 
@@ -596,7 +600,10 @@ try:
           src_array = block.as_numpy(use_masking=use_masking)
           arrays.append(src_array)
 
-      return _numpy.array(arrays)  # This converts any maskedArrays to numpy.array
+      if use_masking:
+          return _numpy.ma.stack(arrays, axis=0)
+      else:
+          return _numpy.array(arrays)
 
    QgsRasterLayer.as_numpy = _raster_layer_as_numpy
 

--- a/tests/src/python/test_qgsrasterblock.py
+++ b/tests/src/python/test_qgsrasterblock.py
@@ -47,10 +47,12 @@ class TestQgsRasterBlock(QgisTestCase):
         self.assertTrue((block.as_numpy() == expected_array).all())
 
         # test with noDataValue set
-        block.setNoDataValue(0)
+        block.setNoDataValue(-999)
         data = numpy.array([[numpy.nan, 2], [4, 4]])
         expected_masked_array = numpy.ma.masked_array(data, mask=numpy.isnan(data))
         self.assertTrue((block.as_numpy() == expected_masked_array).all())
+        self.assertTrue(numpy.ma.isMaskedArray(block.as_numpy()))
+        self.assertTrue(block.as_numpy().fill_value == -999)
 
         # test with noDataValue set and use_masking == False
         self.assertTrue((block.as_numpy(use_masking=False) == expected_array).all())

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -17,6 +17,7 @@ import filecmp
 import os
 from shutil import copyfile
 
+import numpy
 import numpy as np
 from osgeo import gdal
 from qgis.PyQt.QtCore import QFileInfo, QSize, QTemporaryDir
@@ -1488,20 +1489,20 @@ class TestQgsRasterLayerTransformContext(QgisTestCase):
     def test_as_numpy(self):
         layer = QgsRasterLayer(self.rpath, "raster")
         arrays = layer.as_numpy()
-        self.assertEqual(type(arrays[5]), np.ndarray)
+        self.assertTrue(numpy.ma.isMaskedArray(arrays[0]))
         self.assertEqual(arrays.shape, (9, 200, 200))
         self.assertEqual(arrays[0].dtype, np.int8)
 
         # test with bands parameter
         arrays = layer.as_numpy(bands=[1, 3])
-        self.assertEqual(type(arrays[0]), np.ndarray)
+        self.assertTrue(numpy.ma.isMaskedArray(arrays[0]))
         self.assertEqual(arrays.shape, (2, 200, 200))
         self.assertEqual(arrays[0].dtype, np.int8)
 
         path = os.path.join(unitTestDataPath("raster"), "rgb_with_mask.tif")
         layer = QgsRasterLayer(path, QFileInfo(path).baseName())
         arrays = layer.as_numpy()
-        self.assertEqual(type(arrays[0]), np.ndarray)
+        self.assertTrue(numpy.ma.isMaskedArray(arrays[0]))
         self.assertEqual(arrays.shape, (4, 150, 162))
         self.assertEqual(arrays[0].dtype, np.int8)
 
@@ -1510,9 +1511,7 @@ class TestQgsRasterLayerTransformContext(QgisTestCase):
         )
         layer = QgsRasterLayer(path, QFileInfo(path).baseName())
         arrays = layer.as_numpy()
-        self.assertEqual(
-            type(arrays[0]), np.ndarray
-        )  # All maskedArrays are converted to numpy.array
+        self.assertTrue(numpy.ma.isMaskedArray(arrays[0]))
         self.assertEqual(arrays.shape, (1, 4, 4))
         self.assertEqual(arrays[0].dtype, np.float64)
 


### PR DESCRIPTION
This PR addresses two issues:
1. `QgsRasterLayer.as_numpy(use_masking=True)` previously did not return a masked array.
2. `QgsRasterBlock.as_numpy()` did not use the correct fill value.

The updates ensure:
`QgsRasterLayer.as_numpy(use_masking=True)` now returns masked arrays using `numpy.ma.stack()`.
`QgsRasterBlock.as_numpy()` correctly applies the set `noDataValue` for filling, defaulting to 0 if no value is set.

Closes #60205.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
