### PR TITLE
[ui][diagrams] Fix drag and drop to reorder stacked diagram not working

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1010,7 +1010,8 @@ QTreeView::indicator:unchecked:disabled {
 QgsLayerTreeView::item,
 QTreeView#viewGraduated::item,
 QTreeView#viewCategories::item,
-QTreeView#viewRules::item
+QTreeView#viewRules::item,
+QTreeView#mSubDiagramsView::item
 {
     border-top: 0.5px solid rgba(108,108,108,50);
     border-bottom: 0.5px solid rgba(108,108,108,50);
@@ -1020,7 +1021,8 @@ QTreeView#viewRules::item
 QgsLayerTreeView::item:hover, QgsLayerTreeView::branch:hover,
 QTreeView#viewGraduated::item:hover, QTreeView#viewGraduated::branch:hover,
 QTreeView#viewCategories::item:hover, QTreeView#viewCategories::branch:hover,
-QTreeView#viewRules::item:hover, QTreeView#viewRules::branch:hover
+QTreeView#viewRules::item:hover, QTreeView#viewRules::branch:hover,
+QTreeView#mSubDiagramsView::item:hover, QTreeView#mSubDiagramsView::branch:hover
 {
     background-color: @hover;
     color: @itembackground;
@@ -1029,7 +1031,8 @@ QTreeView#viewRules::item:hover, QTreeView#viewRules::branch:hover
 QgsLayerTreeView::item:selected:hover, QgsLayerTreeView::branch:selected:hover,
 QTreeView#viewGraduated::item:selected:hover, QTreeView#viewGraduated::branch:selected:hover,
 QTreeView#viewCategories::item:selected:hover, QTreeView#viewCategories::branch:selected:hover,
-QTreeView#viewRules::item:selected:hover, QTreeView#viewRules::branch:selected:hover
+QTreeView#viewRules::item:selected:hover, QTreeView#viewRules::branch:selected:hover,
+QTreeView#mSubDiagramsView::item:selected:hover, QTreeView#mSubDiagramsView::branch:selected:hover
 {
     background-color: @selection;
     color: @textlight;
@@ -1038,7 +1041,8 @@ QTreeView#viewRules::item:selected:hover, QTreeView#viewRules::branch:selected:h
 QgsLayerTreeView::indicator:unchecked,
 QTreeView#viewGraduated::indicator:unchecked,
 QTreeView#viewCategories::indicator:unchecked,
-QTreeView#viewRules::indicator:unchecked 
+QTreeView#viewRules::indicator:unchecked,
+QTreeView#mSubDiagramsView::indicator:unchecked
 {
     border: none;
     background-color: transparent;
@@ -1048,7 +1052,8 @@ QTreeView#viewRules::indicator:unchecked
 QgsLayerTreeView::indicator:checked,
 QTreeView#viewGraduated::indicator:checked, 
 QTreeView#viewCategories::indicator:checked, 
-QTreeView#viewRules::indicator:checked 
+QTreeView#viewRules::indicator:checked,
+QTreeView#mSubDiagramsView::indicator:checked
 {
     border: none;
     background-color: transparent;

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -399,15 +399,13 @@ QMimeData *QgsStackedDiagramPropertiesModel::mimeData( const QModelIndexList &in
 
   QDataStream stream( &encodedData, QIODevice::WriteOnly );
 
-  const auto constIndexes = indexes;
-  for ( const QModelIndex &index : constIndexes )
+  for ( const QModelIndex &index : indexes )
   {
     // each item consists of several columns - let's add it with just first one
     if ( !index.isValid() || index.column() != 0 )
       continue;
 
-    QgsDiagramRenderer *diagram = mRenderers.at( index.row() );
-    if ( diagram )
+    if ( QgsDiagramRenderer *diagram = mRenderers.at( index.row() ) )
     {
       QDomDocument doc;
 

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -406,8 +406,6 @@ QMimeData *QgsStackedDiagramPropertiesModel::mimeData( const QModelIndexList &in
     if ( !index.isValid() || index.column() != 0 )
       continue;
 
-    // we use a clone of the existing rule because it has a new unique rule key
-    // non-unique rule keys would confuse other components using them (e.g. legend)
     QgsDiagramRenderer *diagram = mRenderers.at( index.row() );
     if ( diagram )
     {

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -62,7 +62,6 @@ QgsStackedDiagramProperties::QgsStackedDiagramProperties( QgsVectorLayer *layer,
 
   mModel = new QgsStackedDiagramPropertiesModel();
   mSubDiagramsView->setModel( mModel );
-  mSubDiagramsView->resizeColumnToContents( 0 );
 
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsStackedDiagramProperties::widgetChanged );
   connect( mModel, &QAbstractItemModel::rowsInserted, this, &QgsStackedDiagramProperties::widgetChanged );
@@ -376,7 +375,7 @@ Qt::ItemFlags QgsStackedDiagramPropertiesModel::flags( const QModelIndex &index 
   const Qt::ItemFlag checkable = ( index.column() == 0 ? Qt::ItemIsUserCheckable : Qt::NoItemFlags );
 
   // allow drop only at first column
-  const Qt::ItemFlag drop = ( index.column() < 2 ? Qt::ItemIsDropEnabled : Qt::NoItemFlags );
+  const Qt::ItemFlag drop = ( index.column() == 0 ? Qt::ItemIsDropEnabled : Qt::NoItemFlags );
 
   return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | drop | checkable;
 }
@@ -435,7 +434,7 @@ bool QgsStackedDiagramPropertiesModel::dropMimeData( const QMimeData *data, Qt::
   if ( !data->hasFormat( QStringLiteral( "application/vnd.text.list" ) ) )
     return false;
 
-  if ( parent.column() > 1 )
+  if ( parent.column() > 0 )
     return false;
 
   QByteArray encodedData = data->data( QStringLiteral( "application/vnd.text.list" ) );
@@ -499,7 +498,7 @@ QVariant QgsStackedDiagramPropertiesModel::data( const QModelIndex &index, int r
   {
     switch ( index.column() )
     {
-      case 1:
+      case 0:
         if ( dr && dr->diagram() )
         {
           if ( dr->diagram()->diagramName() == QgsPieDiagram::DIAGRAM_NAME_PIE )
@@ -531,7 +530,7 @@ QVariant QgsStackedDiagramPropertiesModel::data( const QModelIndex &index, int r
         {
           return tr( "(no diagram)" );
         }
-      case 2:
+      case 1:
         if ( !dr )
         {
           return tr( "(no renderer)" );
@@ -545,7 +544,7 @@ QVariant QgsStackedDiagramPropertiesModel::data( const QModelIndex &index, int r
           else
             return tr( "Unknown" );
         }
-      case 3:
+      case 2:
         if ( dr && dr->diagram() && !dr->diagramSettings().isEmpty() )
         {
           if ( QgsHistogramDiagram::DIAGRAM_NAME_HISTOGRAM == dr->diagram()->diagramName() || QgsStackedBarDiagram::DIAGRAM_NAME_STACKED_BAR == dr->diagram()->diagramName() )
@@ -564,14 +563,9 @@ QVariant QgsStackedDiagramPropertiesModel::data( const QModelIndex &index, int r
           }
         }
         return QVariant();
-      case 0:
       default:
         return QVariant();
     }
-  }
-  else if ( role == Qt::TextAlignmentRole )
-  {
-    return index.column() == 0 ? static_cast<Qt::Alignment::Int>( Qt::AlignCenter ) : static_cast<Qt::Alignment::Int>( Qt::AlignLeft );
   }
   else if ( role == Qt::CheckStateRole )
   {
@@ -588,10 +582,10 @@ QVariant QgsStackedDiagramPropertiesModel::data( const QModelIndex &index, int r
 
 QVariant QgsStackedDiagramPropertiesModel::headerData( int section, Qt::Orientation orientation, int role ) const
 {
-  if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 4 )
+  if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 3 )
   {
     QStringList lst;
-    lst << tr( "Enabled" ) << tr( "Diagram type" ) << tr( "Size" ) << tr( "Orientation" );
+    lst << tr( "Diagram type" ) << tr( "Size" ) << tr( "Orientation" );
     return lst[section];
   }
 
@@ -605,7 +599,7 @@ int QgsStackedDiagramPropertiesModel::rowCount( const QModelIndex & ) const
 
 int QgsStackedDiagramPropertiesModel::columnCount( const QModelIndex & ) const
 {
-  return 4;
+  return 3;
 }
 
 bool QgsStackedDiagramPropertiesModel::setData( const QModelIndex &index, const QVariant &value, int role )

--- a/src/gui/vector/qgsstackeddiagramproperties.h
+++ b/src/gui/vector/qgsstackeddiagramproperties.h
@@ -62,8 +62,13 @@ class GUI_EXPORT QgsStackedDiagramPropertiesModel : public QAbstractTableModel
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
     bool removeRows( int row, int count, const QModelIndex &parent = QModelIndex() ) override;
 
-    // new methods
+    // drag'n'drop support
+    Qt::DropActions supportedDropActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData( const QModelIndexList &indexes ) const override;
+    bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
 
+    // new methods
     //! Returns the diagram renderer at the specified index. Does not transfer ownership.
     QgsDiagramRenderer *subDiagramForIndex( const QModelIndex &index ) const;
 

--- a/src/ui/qgsstackeddiagrampropertiesbase.ui
+++ b/src/ui/qgsstackeddiagrampropertiesbase.ui
@@ -26,13 +26,25 @@
    <item>
     <widget class="QTreeView" name="mSubDiagramsView">
      <property name="selectionMode">
-      <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
+      <enum>QAbstractItemView::ExtendedSelection</enum>
      </property>
      <property name="itemsExpandable">
       <bool>false</bool>
      </property>
      <property name="expandsOnDoubleClick">
       <bool>false</bool>
+     </property>
+     <property name="acceptDrops">
+      <bool>true</bool>
+     </property>
+     <property name="dragEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="allColumnsShowFocus">
+      <bool>true</bool>
      </property>
      <attribute name="headerMinimumSectionSize">
       <number>57</number>

--- a/src/ui/qgsstackeddiagrampropertiesbase.ui
+++ b/src/ui/qgsstackeddiagrampropertiesbase.ui
@@ -47,10 +47,10 @@
       <bool>true</bool>
      </property>
      <attribute name="headerMinimumSectionSize">
-      <number>57</number>
+      <number>100</number>
      </attribute>
      <attribute name="headerDefaultSectionSize">
-      <number>110</number>
+      <number>150</number>
      </attribute>
     </widget>
    </item>


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/59505 whereas the stacked diagrams tree view was not allowing for drag and drop re-ordering of sub-diagrams. It's an important UI/UX that users would definitively expect here as we allow for drag and drop re-ordering for symbology renderers and rule-based label renderer widgets.

In addition, while fixing this, I've harmonized the tree view by removing the "Enabled" column in favor of adding a checkbox in the first column where the diagram name is located (like we do pretty much everywhere else), as well as adding a nice touch of night mapping (eye toggles!).

![Screenshot From 2025-01-27 09-43-45](https://github.com/user-attachments/assets/e54217d0-338c-487e-8267-4240ce9f009f)
