### PR TITLE
Fix qkeysequence

### DIFF
--- a/python/plugins/db_manager/sqledit.py
+++ b/python/plugins/db_manager/sqledit.py
@@ -131,7 +131,7 @@ class SqlEdit(QsciScintilla):
 
         # Use Ctrl+Space for autocompletion
         self.shortcutAutocomplete = QShortcut(
-            QKeySequence(Qt.Modifier.CTRL + Qt.Key.Key_Space), self
+            QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_Space), self
         )
         self.shortcutAutocomplete.setContext(Qt.ShortcutContext.WidgetShortcut)
         self.shortcutAutocomplete.activated.connect(self.autoComplete)

--- a/python/plugins/processing/script/ScriptEdit.py
+++ b/python/plugins/processing/script/ScriptEdit.py
@@ -49,7 +49,7 @@ class ScriptEdit(QgsCodeEditorPython):
 
         # Use Ctrl+Space for autocompletion
         self.shortcutAutocomplete = QShortcut(
-            QKeySequence(Qt.Modifier.CTRL + Qt.Key.Key_Space), self
+            QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_Space), self
         )
         self.shortcutAutocomplete.setContext(Qt.ShortcutContext.WidgetShortcut)
         self.shortcutAutocomplete.activated.connect(self.autoComplete)


### PR DESCRIPTION
## Description

The `+` operator used to create `QKeySequence` from modifier(s) and key combination throws `TypeError` when used with Qt enums. We should use `|` operator in such cases. 

Fixes #60063 and similar unreported issue in DB Manager plugin.