### PR TITLE
webconnections saving as .xml: add a xmlns:x=y attribute when the http-header: prefix is used

### DIFF
--- a/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
@@ -109,14 +109,21 @@ KEY_REFERER value will be available at key "KEY_PREFIX+KEY_REFERER" and key "KEY
 :return: ``True`` if the update succeed
 %End
 
-    bool updateDomElement( QDomElement &el ) const;
+ bool updateDomElement( QDomElement &el ) const /Deprecated="Since 3.42. Will be removed in QGIS 4.0."/;
 %Docstring
-Updates a ``map`` by adding all the HTTP headers
+Updates a DOM element by adding all the HTTP headers
 
 KEY_REFERER value will be available at attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
 
+:param el: DOM element
+
 :return: ``True`` if the update succeed
+
+.. deprecated:: 3.42
+
+   Will be removed in QGIS 4.0.
 %End
+
 
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
 %Docstring
@@ -184,6 +191,7 @@ Returns key/value pairs as strings separated by space
 
 
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -109,14 +109,21 @@ KEY_REFERER value will be available at key "KEY_PREFIX+KEY_REFERER" and key "KEY
 :return: ``True`` if the update succeed
 %End
 
-    bool updateDomElement( QDomElement &el ) const;
+ bool updateDomElement( QDomElement &el ) const /Deprecated="Since 3.42. Will be removed in QGIS 4.0."/;
 %Docstring
-Updates a ``map`` by adding all the HTTP headers
+Updates a DOM element by adding all the HTTP headers
 
 KEY_REFERER value will be available at attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
 
+:param el: DOM element
+
 :return: ``True`` if the update succeed
+
+.. deprecated:: 3.42
+
+   Will be removed in QGIS 4.0.
 %End
+
 
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
 %Docstring
@@ -184,6 +191,7 @@ Returns key/value pairs as strings separated by space
 
 
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -123,8 +123,18 @@ bool QgsHttpHeaders::updateMap( QVariantMap &map ) const
 
 bool QgsHttpHeaders::updateDomElement( QDomElement &el ) const
 {
+  QMap<QString, QString> namespaceDeclarations;
+  return updateDomElement( el, namespaceDeclarations );
+}
+
+bool QgsHttpHeaders::updateDomElement( QDomElement &el, QMap<QString, QString> &namespaceDeclarations ) const
+{
+  QString httpHeaderURIPrefix( QgsHttpHeaders::PARAM_PREFIX );
+  httpHeaderURIPrefix.chop( 1 );
+
   for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
   {
+    namespaceDeclarations.insert( httpHeaderURIPrefix, QStringLiteral( "https://qgis.org/" ) + httpHeaderURIPrefix );
     el.setAttribute( QgsHttpHeaders::PARAM_PREFIX + ite.key().toUtf8(), ite.value().toString() );
   }
 

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -126,13 +126,26 @@ class CORE_EXPORT QgsHttpHeaders
     bool updateMap( QVariantMap &map ) const;
 
     /**
-     * \brief Updates a \a map by adding all the HTTP headers
+     * \brief Updates a DOM element by adding all the HTTP headers
      *
      * KEY_REFERER value will be available at attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
      *
+     * \param el DOM element
+     * \return TRUE if the update succeed
+     * \deprecated QGIS 3.42. Will be removed in QGIS 4.0.
+     */
+    Q_DECL_DEPRECATED bool updateDomElement( QDomElement &el ) const SIP_DEPRECATED;
+
+    /**
+     * \brief Updates a DOM element by adding all the HTTP headers
+     *
+     * KEY_REFERER value will be available at attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
+     *
+     * \param el DOM element
+     * \param[out] namespaceDeclarations Map of (prefix, URI) tuples for namespaces used by el.
      * \return TRUE if the update succeed
      */
-    bool updateDomElement( QDomElement &el ) const;
+    bool updateDomElement( QDomElement &el, QMap<QString, QString> &namespaceDeclarations ) const SIP_SKIP;
 
     /**
      * \brief Loads headers from the \a settings
@@ -211,3 +224,4 @@ class CORE_EXPORT QgsHttpHeaders
 };
 
 #endif // QGSHTTPHEADERS_H
+

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -461,6 +461,14 @@ bool QgsManageConnectionsDialog::populateConnections()
   return true;
 }
 
+static void addNamespaceDeclarations( QDomElement &root, const QMap<QString, QString> &namespaceDeclarations )
+{
+  for ( auto it = namespaceDeclarations.begin(); it != namespaceDeclarations.end(); ++it )
+  {
+    root.setAttribute( QStringLiteral( "xmlns:" ) + it.key(), it.value() );
+  }
+}
+
 QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &connections, const QString &service )
 {
   QDomDocument doc( QStringLiteral( "connections" ) );
@@ -468,6 +476,7 @@ QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
   doc.appendChild( root );
 
+  QMap<QString, QString> namespaceDeclarations;
   for ( int i = 0; i < connections.count(); ++i )
   {
     QDomElement el = doc.createElement( service.toLower() );
@@ -484,13 +493,15 @@ QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &
       el.setAttribute( QStringLiteral( "dpiMode" ), static_cast<int>( QgsOwsConnection::settingsDpiMode->value( { service.toLower(), connections[i] } ) ) );
 
       QgsHttpHeaders httpHeader( QgsOwsConnection::settingsHeaders->value( { service.toLower(), connections[i] } ) );
-      httpHeader.updateDomElement( el );
+      httpHeader.updateDomElement( el, namespaceDeclarations );
     }
 
     el.setAttribute( QStringLiteral( "username" ), QgsOwsConnection::settingsUsername->value( { service.toLower(), connections[i] } ) );
     el.setAttribute( QStringLiteral( "password" ), QgsOwsConnection::settingsPassword->value( { service.toLower(), connections[i] } ) );
     root.appendChild( el );
   }
+
+  addNamespaceDeclarations( root, namespaceDeclarations );
 
   return doc;
 }
@@ -710,6 +721,7 @@ QDomDocument QgsManageConnectionsDialog::saveXyzTilesConnections( const QStringL
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
   doc.appendChild( root );
 
+  QMap<QString, QString> namespaceDeclarations;
   for ( int i = 0; i < connections.count(); ++i )
   {
     QDomElement el = doc.createElement( QStringLiteral( "xyztiles" ) );
@@ -724,10 +736,12 @@ QDomDocument QgsManageConnectionsDialog::saveXyzTilesConnections( const QStringL
     el.setAttribute( QStringLiteral( "tilePixelRatio" ), QgsXyzConnectionSettings::settingsTilePixelRatio->value( connections[i] ) );
 
     QgsHttpHeaders httpHeader( QgsXyzConnectionSettings::settingsHeaders->value( connections[i] ) );
-    httpHeader.updateDomElement( el );
+    httpHeader.updateDomElement( el, namespaceDeclarations );
 
     root.appendChild( el );
   }
+
+  addNamespaceDeclarations( root, namespaceDeclarations );
 
   return doc;
 }
@@ -739,6 +753,7 @@ QDomDocument QgsManageConnectionsDialog::saveArcgisConnections( const QStringLis
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
   doc.appendChild( root );
 
+  QMap<QString, QString> namespaceDeclarations;
   for ( const QString &connection : connections )
   {
     QDomElement el = doc.createElement( QStringLiteral( "arcgisfeatureserver" ) );
@@ -746,7 +761,7 @@ QDomDocument QgsManageConnectionsDialog::saveArcgisConnections( const QStringLis
     el.setAttribute( QStringLiteral( "url" ), QgsArcGisConnectionSettings::settingsUrl->value( connection ) );
 
     QgsHttpHeaders httpHeader( QgsArcGisConnectionSettings::settingsHeaders->value( connection ) );
-    httpHeader.updateDomElement( el );
+    httpHeader.updateDomElement( el, namespaceDeclarations );
 
     el.setAttribute( QStringLiteral( "username" ), QgsArcGisConnectionSettings::settingsUsername->value( connection ) );
     el.setAttribute( QStringLiteral( "password" ), QgsArcGisConnectionSettings::settingsPassword->value( connection ) );
@@ -754,6 +769,8 @@ QDomDocument QgsManageConnectionsDialog::saveArcgisConnections( const QStringLis
 
     root.appendChild( el );
   }
+
+  addNamespaceDeclarations( root, namespaceDeclarations );
 
   return doc;
 }
@@ -765,6 +782,7 @@ QDomDocument QgsManageConnectionsDialog::saveVectorTileConnections( const QStrin
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
   doc.appendChild( root );
 
+  QMap<QString, QString> namespaceDeclarations;
   for ( int i = 0; i < connections.count(); ++i )
   {
     QDomElement el = doc.createElement( QStringLiteral( "vectortile" ) );
@@ -780,10 +798,12 @@ QDomDocument QgsManageConnectionsDialog::saveVectorTileConnections( const QStrin
     el.setAttribute( QStringLiteral( "styleUrl" ), QgsVectorTileProviderConnection::settingsStyleUrl->value( connections[i] ) );
 
     QgsHttpHeaders httpHeader( QgsVectorTileProviderConnection::settingsHeaders->value( connections[i] ) );
-    httpHeader.updateDomElement( el );
+    httpHeader.updateDomElement( el, namespaceDeclarations );
 
     root.appendChild( el );
   }
+
+  addNamespaceDeclarations( root, namespaceDeclarations );
 
   return doc;
 }
@@ -795,6 +815,7 @@ QDomDocument QgsManageConnectionsDialog::saveTiledSceneConnections( const QStrin
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
   doc.appendChild( root );
 
+  QMap<QString, QString> namespaceDeclarations;
   for ( int i = 0; i < connections.count(); ++i )
   {
     QDomElement el = doc.createElement( QStringLiteral( "tiledscene" ) );
@@ -807,10 +828,12 @@ QDomDocument QgsManageConnectionsDialog::saveTiledSceneConnections( const QStrin
     el.setAttribute( QStringLiteral( "password" ), QgsTiledSceneProviderConnection::settingsPassword->value( connections[i] ) );
 
     QgsHttpHeaders httpHeader( QgsTiledSceneProviderConnection::settingsHeaders->value( connections[i] ) );
-    httpHeader.updateDomElement( el );
+    httpHeader.updateDomElement( el, namespaceDeclarations );
 
     root.appendChild( el );
   }
+
+  addNamespaceDeclarations( root, namespaceDeclarations );
 
   return doc;
 }
@@ -822,6 +845,7 @@ QDomDocument QgsManageConnectionsDialog::saveSensorThingsConnections( const QStr
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
   doc.appendChild( root );
 
+  QMap<QString, QString> namespaceDeclarations;
   for ( int i = 0; i < connections.count(); ++i )
   {
     QDomElement el = doc.createElement( QStringLiteral( "sensorthings" ) );
@@ -833,10 +857,12 @@ QDomDocument QgsManageConnectionsDialog::saveSensorThingsConnections( const QStr
     el.setAttribute( QStringLiteral( "password" ), QgsSensorThingsProviderConnection::settingsPassword->value( connections[i] ) );
 
     QgsHttpHeaders httpHeader( QgsTiledSceneProviderConnection::settingsHeaders->value( connections[i] ) );
-    httpHeader.updateDomElement( el );
+    httpHeader.updateDomElement( el, namespaceDeclarations );
 
     root.appendChild( el );
   }
+
+  addNamespaceDeclarations( root, namespaceDeclarations );
 
   return doc;
 }
@@ -882,6 +908,7 @@ QDomDocument QgsManageConnectionsDialog::saveStacConnections( const QStringList 
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
   doc.appendChild( root );
 
+  QMap<QString, QString> namespaceDeclarations;
   for ( int i = 0; i < connections.count(); ++i )
   {
     QDomElement el = doc.createElement( QStringLiteral( "stac" ) );
@@ -893,10 +920,12 @@ QDomDocument QgsManageConnectionsDialog::saveStacConnections( const QStringList 
     el.setAttribute( QStringLiteral( "password" ), QgsStacConnection::settingsPassword->value( connections[i] ) );
 
     QgsHttpHeaders httpHeader( QgsStacConnection::settingsHeaders->value( connections[i] ) );
-    httpHeader.updateDomElement( el );
+    httpHeader.updateDomElement( el, namespaceDeclarations );
 
     root.appendChild( el );
   }
+
+  addNamespaceDeclarations( root, namespaceDeclarations );
 
   return doc;
 }

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -272,7 +272,8 @@ void TestQgsHttpheaders::updateSetDomElement()
   QDomElement element = doc.createElement( "qgs" );
   // === update
   QgsHttpHeaders h( QVariantMap( { { QStringLiteral( "key1" ), "value1" }, { QgsHttpHeaders::KEY_REFERER, "my_ref" } } ) );
-  h.updateDomElement( element );
+  QMap<QString, QString> namespaceDeclarations;
+  h.updateDomElement( element, namespaceDeclarations );
 
   QVERIFY( element.hasAttribute( QgsHttpHeaders::PARAM_PREFIX + "key1" ) );
   QCOMPARE( element.attribute( QgsHttpHeaders::PARAM_PREFIX + "key1" ), "value1" );
@@ -283,6 +284,8 @@ void TestQgsHttpheaders::updateSetDomElement()
   // TODO mandatory or not?
   QVERIFY( element.hasAttribute( QgsHttpHeaders::KEY_REFERER ) );
   QCOMPARE( element.attribute( QgsHttpHeaders::KEY_REFERER ), "my_ref" );
+
+  QCOMPARE( namespaceDeclarations["http-header"], "https://qgis.org/http-header" );
 
   // === setFrom
   QgsHttpHeaders h2;


### PR DESCRIPTION
Fixes #60242
