### PR TITLE
Fix potential (unlikely) crash in concave hull algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmconcavehull.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehull.cpp
@@ -193,8 +193,9 @@ void QgsConcaveHullAlgorithm::concaveHullQgis( std::unique_ptr<QgsFeatureSink> &
   const QgsProcessingAlgorithm *delaunayAlg = QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "native:delaunaytriangulation" ) );
   if ( !delaunayAlg )
   {
-    feedback->reportError( QObject::tr( "Failed to compute concave hull: Delaunay triangulation algorithm not found!" ), true );
+    throw QgsProcessingException( QObject::tr( "Failed to compute concave hull: Delaunay triangulation algorithm not found!" ) );
   }
+
   std::unique_ptr<QgsProcessingAlgorithm> algorithm;
   algorithm.reset( delaunayAlg->create() );
   QVariantMap results = algorithm->run( params, context, &multiStepFeedback );


### PR DESCRIPTION
Probably can never occur in real-world situations, but should be fixed anyway.

Refs #59778