### PR TITLE
Fix placement of STAC tab in Data Source Manager

### DIFF
--- a/src/gui/stac/qgsstacsourceselectprovider.cpp
+++ b/src/gui/stac/qgsstacsourceselectprovider.cpp
@@ -49,5 +49,5 @@ QgsAbstractDataSourceWidget *QgsStacSourceSelectProvider::createDataSourceWidget
 
 int QgsStacSourceSelectProvider::ordering() const
 {
-  return OrderSearchProvider;
+  return OrderRemoteProvider + 201;
 }


### PR DESCRIPTION
The metadata search tab should be last
