### PR TITLE
Remove dedicated "show editing toolbar" action from 3d windows

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -78,6 +78,9 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 
     void updateLayerRelatedActions( QgsMapLayer *layer );
 
+    bool eventFilter( QObject *watched, QEvent *event ) override;
+
+
   private slots:
     void resetView();
     void configure();
@@ -161,6 +164,8 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QToolBar *mEditingToolBar = nullptr;
     QComboBox *mCboChangeAttribute = nullptr;
     QgsDoubleSpinBox *mSpinChangeAttributeValue = nullptr;
+
+    QMenu *mToolbarMenu = nullptr;
 };
 
 #endif // QGS3DMAPCANVASWIDGET_H


### PR DESCRIPTION
Instead add right-click menu to main 3d window toolbar to toggle optional toolbar visibilty, just like we do for the main QGIS window.

This avoids UI bloat in 3d map windows, and removes an action which will be rarely used.
