### PR TITLE
delete old tiled scene connection when renaming (fix #57570)

### DIFF
--- a/src/gui/tiledscene/qgstiledsceneconnectiondialog.cpp
+++ b/src/gui/tiledscene/qgstiledsceneconnectiondialog.cpp
@@ -17,6 +17,8 @@
 #include "moc_qgstiledsceneconnectiondialog.cpp"
 #include "qgstiledsceneconnection.h"
 #include "qgsgui.h"
+#include "qgssettings.h"
+
 #include <QMessageBox>
 #include <QPushButton>
 
@@ -37,6 +39,7 @@ QgsTiledSceneConnectionDialog::QgsTiledSceneConnectionDialog( QWidget *parent )
 void QgsTiledSceneConnectionDialog::setConnection( const QString &name, const QString &uri )
 {
   mEditName->setText( name );
+  mOriginalConnectionName = name;
 
   const QgsTiledSceneProviderConnection::Data conn = QgsTiledSceneProviderConnection::decodedUri( uri );
   mEditUrl->setText( conn.url );
@@ -73,6 +76,16 @@ void QgsTiledSceneConnectionDialog::updateOkButtonState()
 
 void QgsTiledSceneConnectionDialog::accept()
 {
+  const QString newConnectionName = mEditName->text();
+
+  // on rename delete original entry first
+  if ( !mOriginalConnectionName.isNull() && mOriginalConnectionName != newConnectionName )
+  {
+    QgsSettings settings;
+    QgsTiledSceneProviderConnection( QString() ).remove( mOriginalConnectionName );
+    settings.sync();
+  }
+
   QDialog::accept();
 }
 

--- a/src/gui/tiledscene/qgstiledsceneconnectiondialog.h
+++ b/src/gui/tiledscene/qgstiledsceneconnectiondialog.h
@@ -39,6 +39,9 @@ class QgsTiledSceneConnectionDialog : public QDialog, public Ui::QgsTiledSceneCo
 
   private slots:
     void updateOkButtonState();
+
+  private:
+    QString mOriginalConnectionName; //store initial name to delete entry in case of rename
 };
 
 ///@endcond


### PR DESCRIPTION
## Description

When editing a tiled scene connection and changing connection name don't create a new connection. Instead remove old connection and save changed one. This is how we handle all other connections.

Fixes #57570.