### PR TITLE
main annotation layer should be used as a valid option even if type hint is set to UnknownType (fix #49010)

### DIFF
--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -335,7 +335,7 @@ Normalizes a layer ``source`` string for safe comparison across different
 operating system environments.
 %End
 
-    static QString layerToStringIdentifier( const QgsMapLayer *layer ) /HoldGIL/;
+    static QString layerToStringIdentifier( const QgsMapLayer *layer, const QString &layerName = QString() ) /HoldGIL/;
 %Docstring
 Returns a string representation of the source for a ``layer``. The returned
 value is suitable for storage for subsequent executions of an algorithm

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -335,7 +335,7 @@ Normalizes a layer ``source`` string for safe comparison across different
 operating system environments.
 %End
 
-    static QString layerToStringIdentifier( const QgsMapLayer *layer ) /HoldGIL/;
+    static QString layerToStringIdentifier( const QgsMapLayer *layer, const QString &layerName = QString() ) /HoldGIL/;
 %Docstring
 Returns a string representation of the source for a ``layer``. The returned
 value is suitable for storage for subsequent executions of an algorithm

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2704,7 +2704,7 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
       p.insert( name(), value );
       if ( QgsMapLayer *layer = QgsProcessingParameters::parameterAsLayer( this, p, context ) )
       {
-        return QgsProcessingUtils::layerToStringIdentifier( layer );
+        return QgsProcessingUtils::layerToStringIdentifier( layer, value.toString() );
       }
     }
 
@@ -2882,7 +2882,7 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
     p.insert( name(), value );
     if ( QgsMapLayer *layer = QgsProcessingParameters::parameterAsLayer( this, p, context ) )
     {
-      return QgsProcessingUtils::layerToStringIdentifier( layer );
+      return QgsProcessingUtils::layerToStringIdentifier( layer, value.toString() );
     }
   }
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -748,7 +748,7 @@ QString QgsProcessingUtils::normalizeLayerSource( const QString &source )
   return normalized.trimmed();
 }
 
-QString QgsProcessingUtils::layerToStringIdentifier( const QgsMapLayer *layer )
+QString QgsProcessingUtils::layerToStringIdentifier( const QgsMapLayer *layer, const QString &layerName )
 {
   if ( !layer )
     return QString();
@@ -766,6 +766,12 @@ QString QgsProcessingUtils::layerToStringIdentifier( const QgsMapLayer *layer )
 
     return QStringLiteral( "%1://%2" ).arg( provider, source );
   }
+
+  if ( layer->dataProvider()->name() == QLatin1String( "annotation" ) && layerName.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return layerName;
+  }
+
   return layer->id();
 }
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -516,7 +516,7 @@ QgsMapLayer *QgsProcessingUtils::mapLayerFromString( const QString &string, QgsP
     return nullptr;
 
   // prefer project layers
-  if ( context.project() && typeHint == LayerHint::Annotation && string.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
+  if ( context.project() && ( typeHint == LayerHint::Annotation || typeHint == LayerHint::UnknownType ) && string.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
     return context.project()->mainAnnotationLayer();
 
   QgsMapLayer *layer = nullptr;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -767,7 +767,7 @@ QString QgsProcessingUtils::layerToStringIdentifier( const QgsMapLayer *layer, c
     return QStringLiteral( "%1://%2" ).arg( provider, source );
   }
 
-  if ( layer->dataProvider()->name() == QLatin1String( "annotation" ) && layerName.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
+  if ( layer->type() == Qgis::LayerType::Annotation && layerName.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
   {
     return layerName;
   }

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -516,7 +516,7 @@ QgsMapLayer *QgsProcessingUtils::mapLayerFromString( const QString &string, QgsP
     return nullptr;
 
   // prefer project layers
-  if ( context.project() && ( typeHint == LayerHint::Annotation || typeHint == LayerHint::UnknownType ) && string.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
+  if ( context.project() && ( typeHint == LayerHint::Annotation ) && string.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
     return context.project()->mainAnnotationLayer();
 
   QgsMapLayer *layer = nullptr;
@@ -530,6 +530,11 @@ QgsMapLayer *QgsProcessingUtils::mapLayerFromString( const QString &string, QgsP
   layer = mapLayerFromStore( string, context.temporaryLayerStore(), typeHint );
   if ( layer )
     return layer;
+
+  // check main annotation layer
+  if ( context.project() && ( typeHint == LayerHint::UnknownType ) && string.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
+    return context.project()->mainAnnotationLayer();
+
 
   if ( !allowLoadingNewLayers )
     return nullptr;

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -315,7 +315,7 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * \since QGIS 3.34
      */
-    static QString layerToStringIdentifier( const QgsMapLayer *layer ) SIP_HOLDGIL;
+    static QString layerToStringIdentifier( const QgsMapLayer *layer, const QString &layerName = QString() ) SIP_HOLDGIL;
 
     /**
      * Converts a variant to a Python literal.

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -11474,14 +11474,14 @@ void TestQgsProcessing::parameterAnnotationLayer()
   QCOMPARE( def->valueAsPythonString( QVariant::fromValue( QgsProperty::fromExpression( "\"a\"=1" ) ), context ), QStringLiteral( "QgsProperty.fromExpression('\"a\"=1')" ) );
 
   QCOMPARE( def->valueAsJsonObject( QVariant(), context ), QVariant() );
-  QCOMPARE( def->valueAsJsonObject( QStringLiteral( "main" ), context ), QVariant( context.project()->mainAnnotationLayer()->id() ) );
+  QCOMPARE( def->valueAsJsonObject( QStringLiteral( "main" ), context ), QVariant( QStringLiteral( "main" ) ) );
   QCOMPARE( def->valueAsJsonObject( al->id(), context ), QVariant( al->id() ) );
   QCOMPARE( def->valueAsJsonObject( QVariant::fromValue( al ), context ), QVariant( al->id() ) );
 
   bool ok = false;
   QCOMPARE( def->valueAsString( QVariant(), context, ok ), QString() );
   QVERIFY( ok );
-  QCOMPARE( def->valueAsString( QStringLiteral( "main" ), context, ok ), context.project()->mainAnnotationLayer()->id() );
+  QCOMPARE( def->valueAsString( QStringLiteral( "main" ), context, ok ), QStringLiteral( "main" ) );
   QVERIFY( ok );
   QCOMPARE( def->valueAsString( al->id(), context, ok ), al->id() );
   QVERIFY( ok );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -11474,14 +11474,14 @@ void TestQgsProcessing::parameterAnnotationLayer()
   QCOMPARE( def->valueAsPythonString( QVariant::fromValue( QgsProperty::fromExpression( "\"a\"=1" ) ), context ), QStringLiteral( "QgsProperty.fromExpression('\"a\"=1')" ) );
 
   QCOMPARE( def->valueAsJsonObject( QVariant(), context ), QVariant() );
-  QCOMPARE( def->valueAsJsonObject( QStringLiteral( "main" ), context ), QVariant( QStringLiteral( "main" ) ) );
+  QCOMPARE( def->valueAsJsonObject( QStringLiteral( "main" ), context ), QVariant( context.project()->mainAnnotationLayer()->id() ) );
   QCOMPARE( def->valueAsJsonObject( al->id(), context ), QVariant( al->id() ) );
   QCOMPARE( def->valueAsJsonObject( QVariant::fromValue( al ), context ), QVariant( al->id() ) );
 
   bool ok = false;
   QCOMPARE( def->valueAsString( QVariant(), context, ok ), QString() );
   QVERIFY( ok );
-  QCOMPARE( def->valueAsString( QStringLiteral( "main" ), context, ok ), QStringLiteral( "main" ) );
+  QCOMPARE( def->valueAsString( QStringLiteral( "main" ), context, ok ), context.project()->mainAnnotationLayer()->id() );
   QVERIFY( ok );
   QCOMPARE( def->valueAsString( al->id(), context, ok ), al->id() );
   QVERIFY( ok );


### PR DESCRIPTION
## Description

If Processing algorithm uses multiple layers parameter with `Qgis::ProcessingSourceType::MapLayer` type, annotation layers are should be considered as a valid choice. However, this will fail with the main annotation layer which exists in all projects by default. 

The `mapLayerFromString()` method will return `true` only if type hint is explicitly set to `Annotation`. In case of multiple layers input we check parameter value using the `UnknownType` type hint and main annotation layer won't be considered as a valid parameter value.

Fixes #49010.