### PR TITLE
QgsChunkBoundsEntity: use 3D boxes in map coordinates + QgsGeoTransform

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -375,7 +375,7 @@ Expands the bbox so that it covers both the original rectangle and the given poi
 Converts the box to a 2D rectangle.
 %End
 
-    double distanceTo( const QVector3D &point ) const /Deprecated="Since 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats)."/;
+ double distanceTo( const QVector3D &point ) const /Deprecated="Since 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats)."/;
 %Docstring
 Returns the smallest distance between the box and the point ``point``
 (returns 0 if the point is inside the box)

--- a/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -375,12 +375,24 @@ Expands the bbox so that it covers both the original rectangle and the given poi
 Converts the box to a 2D rectangle.
 %End
 
-    double distanceTo( const  QVector3D &point ) const /HoldGIL/;
+    double distanceTo( const QVector3D &point ) const /Deprecated="Since 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats)."/;
 %Docstring
 Returns the smallest distance between the box and the point ``point``
 (returns 0 if the point is inside the box)
 
 .. versionadded:: 3.18
+
+.. deprecated:: 3.42
+
+   Use :py:func:`~QgsBox3D.distanceTo` with :py:class:`QgsVector3D` instead (QVector3D uses floats).
+%End
+
+    double distanceTo( const QgsVector3D &point ) const /HoldGIL/;
+%Docstring
+Returns the smallest distance between the box and the point ``point``
+(returns 0 if the point is inside the box)
+
+.. versionadded:: 3.42
 %End
 
     bool operator==( const QgsBox3D &other ) const /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -375,7 +375,7 @@ Expands the bbox so that it covers both the original rectangle and the given poi
 Converts the box to a 2D rectangle.
 %End
 
-    double distanceTo( const QVector3D &point ) const /Deprecated="Since 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats)."/;
+ double distanceTo( const QVector3D &point ) const /Deprecated="Since 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats)."/;
 %Docstring
 Returns the smallest distance between the box and the point ``point``
 (returns 0 if the point is inside the box)

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -375,12 +375,24 @@ Expands the bbox so that it covers both the original rectangle and the given poi
 Converts the box to a 2D rectangle.
 %End
 
-    double distanceTo( const  QVector3D &point ) const /HoldGIL/;
+    double distanceTo( const QVector3D &point ) const /Deprecated="Since 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats)."/;
 %Docstring
 Returns the smallest distance between the box and the point ``point``
 (returns 0 if the point is inside the box)
 
 .. versionadded:: 3.18
+
+.. deprecated:: 3.42
+
+   Use :py:func:`~QgsBox3D.distanceTo` with :py:class:`QgsVector3D` instead (QVector3D uses floats).
+%End
+
+    double distanceTo( const QgsVector3D &point ) const /HoldGIL/;
+%Docstring
+Returns the smallest distance between the box and the point ``point``
+(returns 0 if the point is inside the box)
+
+.. versionadded:: 3.42
 %End
 
     bool operator==( const QgsBox3D &other ) const /HoldGIL/;

--- a/src/3d/chunks/qgschunkboundsentity_p.cpp
+++ b/src/3d/chunks/qgschunkboundsentity_p.cpp
@@ -20,12 +20,15 @@
 
 #include "qgsaabb.h"
 #include "qgs3dwiredmesh_p.h"
+#include "qgsbox3d.h"
+#include "qgsgeotransform.h"
 
 
 ///@cond PRIVATE
 
-QgsChunkBoundsEntity::QgsChunkBoundsEntity( Qt3DCore::QNode *parent )
+QgsChunkBoundsEntity::QgsChunkBoundsEntity( const QgsVector3D &vertexDataOrigin, Qt3DCore::QNode *parent )
   : Qt3DCore::QEntity( parent )
+  , mVertexDataOrigin( vertexDataOrigin )
 {
   mAabbMesh = new Qgs3DWiredMesh;
   addComponent( mAabbMesh );
@@ -33,11 +36,20 @@ QgsChunkBoundsEntity::QgsChunkBoundsEntity( Qt3DCore::QNode *parent )
   Qt3DExtras::QPhongMaterial *bboxesMaterial = new Qt3DExtras::QPhongMaterial;
   bboxesMaterial->setAmbient( Qt::red );
   addComponent( bboxesMaterial );
+
+  QgsGeoTransform *transform = new QgsGeoTransform;
+  transform->setGeoTranslation( mVertexDataOrigin );
+  addComponent( transform );
 }
 
-void QgsChunkBoundsEntity::setBoxes( const QList<QgsAABB> &bboxes )
+void QgsChunkBoundsEntity::setBoxes( const QList<QgsBox3D> &bboxes )
 {
-  mAabbMesh->setVertices( bboxes );
+  QList<QgsAABB> aabbBoxes;
+  for ( const QgsBox3D &box : bboxes )
+  {
+    aabbBoxes << QgsAABB::fromBox3D( box, mVertexDataOrigin );
+  }
+  mAabbMesh->setVertices( aabbBoxes );
 }
 
 /// @endcond

--- a/src/3d/chunks/qgschunkboundsentity_p.h
+++ b/src/3d/chunks/qgschunkboundsentity_p.h
@@ -29,7 +29,9 @@
 
 #include <Qt3DCore/QEntity>
 
-class QgsAABB;
+#include "qgsvector3d.h"
+
+class QgsBox3D;
 class Qgs3DWiredMesh;
 
 #define SIP_NO_FILE
@@ -46,12 +48,16 @@ class QgsChunkBoundsEntity : public Qt3DCore::QEntity
 
   public:
     //! Constructs the entity
-    QgsChunkBoundsEntity( Qt3DCore::QNode *parent = nullptr );
+    QgsChunkBoundsEntity( const QgsVector3D &vertexDataOrigin, Qt3DCore::QNode *parent = nullptr );
 
     //! Sets a list of bounding boxes to be rendered by the entity
-    void setBoxes( const QList<QgsAABB> &bboxes );
+    void setBoxes( const QList<QgsBox3D> &bboxes );
+
+    //! Returns origin of vertex data used in this entity
+    QgsVector3D vertexDataOrigin() const { return mVertexDataOrigin; }
 
   private:
+    QgsVector3D mVertexDataOrigin;
     Qgs3DWiredMesh *mAabbMesh = nullptr;
 };
 

--- a/src/3d/chunks/qgschunkedentity.cpp
+++ b/src/3d/chunks/qgschunkedentity.cpp
@@ -201,9 +201,9 @@ void QgsChunkedEntity::handleSceneUpdate( const SceneContext &sceneContext )
 
   if ( mBboxesEntity )
   {
-    QList<QgsAABB> bboxes;
+    QList<QgsBox3D> bboxes;
     for ( QgsChunkNode *n : std::as_const( mActiveNodes ) )
-      bboxes << Qgs3DUtils::mapToWorldExtent( n->box3D(), mMapSettings->origin() );
+      bboxes << n->box3D();
     mBboxesEntity->setBoxes( bboxes );
   }
 
@@ -301,7 +301,7 @@ void QgsChunkedEntity::setShowBoundingBoxes( bool enabled )
 
   if ( enabled )
   {
-    mBboxesEntity = new QgsChunkBoundsEntity( this );
+    mBboxesEntity = new QgsChunkBoundsEntity( mRootNode->box3D().center(), this );
   }
   else
   {

--- a/src/3d/qgsaabb.h
+++ b/src/3d/qgsaabb.h
@@ -22,6 +22,8 @@
 #include <QList>
 #include <QVector3D>
 
+#include "qgsbox3d.h"
+
 #define SIP_NO_FILE
 
 /**
@@ -37,6 +39,21 @@ class _3D_EXPORT QgsAABB
 
     //! Constructs bounding box
     QgsAABB( float xMin, float yMin, float zMin, float xMax, float yMax, float zMax );
+
+    /**
+     * Constructs bounding box from QgsBox3D by subtracting origin 3D vector.
+     * Note: this is potentially lossy operation as the coordinates are converted
+     * from double values to floats!
+     */
+    static QgsAABB fromBox3D( const QgsBox3D &box3D, const QgsVector3D &origin )
+    {
+      return QgsAABB( static_cast<float>( box3D.xMinimum() - origin.x() ),
+                      static_cast<float>( box3D.yMinimum() - origin.y() ),
+                      static_cast<float>( box3D.zMinimum() - origin.z() ),
+                      static_cast<float>( box3D.xMaximum() - origin.x() ),
+                      static_cast<float>( box3D.yMaximum() - origin.y() ),
+                      static_cast<float>( box3D.zMaximum() - origin.z() ) );
+    }
 
     //! Returns box width in X axis
     float xExtent() const { return xMax - xMin; }

--- a/src/3d/qgsaabb.h
+++ b/src/3d/qgsaabb.h
@@ -47,12 +47,7 @@ class _3D_EXPORT QgsAABB
      */
     static QgsAABB fromBox3D( const QgsBox3D &box3D, const QgsVector3D &origin )
     {
-      return QgsAABB( static_cast<float>( box3D.xMinimum() - origin.x() ),
-                      static_cast<float>( box3D.yMinimum() - origin.y() ),
-                      static_cast<float>( box3D.zMinimum() - origin.z() ),
-                      static_cast<float>( box3D.xMaximum() - origin.x() ),
-                      static_cast<float>( box3D.yMaximum() - origin.y() ),
-                      static_cast<float>( box3D.zMaximum() - origin.z() ) );
+      return QgsAABB( static_cast<float>( box3D.xMinimum() - origin.x() ), static_cast<float>( box3D.yMinimum() - origin.y() ), static_cast<float>( box3D.zMinimum() - origin.z() ), static_cast<float>( box3D.xMaximum() - origin.x() ), static_cast<float>( box3D.yMaximum() - origin.y() ), static_cast<float>( box3D.zMaximum() - origin.z() ) );
     }
 
     //! Returns box width in X axis

--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -135,8 +135,8 @@ void QgsVirtualPointCloudEntity::handleSceneUpdate( const SceneContext &sceneCon
 
     // magic number 256 is the common span value for a COPC root node
     constexpr int SPAN = 256;
-    const float epsilon = std::min( box3D.width(), box3D.height() ) / SPAN;
-    const float distance = box3D.distanceTo( cameraPosMapCoords );
+    const float epsilon = static_cast<float>( std::min( box3D.width(), box3D.height() ) ) / SPAN;
+    const float distance = static_cast<float>( box3D.distanceTo( cameraPosMapCoords ) );
     const float sse = Qgs3DUtils::screenSpaceError( epsilon, distance, sceneContext.screenSizePx, sceneContext.cameraFov );
     constexpr float THRESHOLD = .2;
 

--- a/src/3d/qgsvirtualpointcloudentity_p.h
+++ b/src/3d/qgsvirtualpointcloudentity_p.h
@@ -88,14 +88,11 @@ class QgsVirtualPointCloudEntity : public Qgs3DMapSceneEntity
     //! Returns a pointer to the associated layer's provider
     QgsVirtualPointCloudProvider *provider() const;
 
-    //! Returns the bounding box for sub index i
-    QgsAABB boundingBox( int i ) const;
-
     QgsPointCloudLayer *mLayer = nullptr;
     QMap<int, QgsChunkedEntity *> mChunkedEntitiesMap;
     QgsChunkBoundsEntity *mBboxesEntity = nullptr;
     QgsPointCloudLayerChunkedEntity *mOverviewEntity = nullptr;
-    QList<QgsAABB> mBboxes;
+    QList<QgsBox3D> mBboxes;
     QgsCoordinateTransform mCoordinateTransform;
     std::unique_ptr<QgsPointCloud3DSymbol> mSymbol;
     double mZValueScale = 1.0;

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -245,7 +245,7 @@ void QgsBox3D::combineWith( double x, double y, double z )
   }
 }
 
-double QgsBox3D::distanceTo( const  QVector3D &point ) const
+double QgsBox3D::distanceTo( const QgsVector3D &point ) const
 {
   const double dx = std::max( mBounds2d.xMinimum() - point.x(), std::max( 0., point.x() - mBounds2d.xMaximum() ) );
   const double dy = std::max( mBounds2d.yMinimum() - point.y(), std::max( 0., point.y() - mBounds2d.yMaximum() ) );

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -400,7 +400,7 @@ class CORE_EXPORT QgsBox3D
      * \since QGIS 3.18
      * \deprecated QGIS 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats).
      */
-    double distanceTo( const QVector3D &point ) const SIP_DEPRECATED { return distanceTo( QgsVector3D( point ) ); }
+    Q_DECL_DEPRECATED double distanceTo( const QVector3D &point ) const SIP_DEPRECATED { return distanceTo( QgsVector3D( point ) ); }
 
     /**
      * Returns the smallest distance between the box and the point \a point

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -398,8 +398,17 @@ class CORE_EXPORT QgsBox3D
      * (returns 0 if the point is inside the box)
      *
      * \since QGIS 3.18
+     * \deprecated QGIS 3.42. Use distanceTo() with QgsVector3D instead (QVector3D uses floats).
      */
-    double distanceTo( const  QVector3D &point ) const SIP_HOLDGIL;
+    double distanceTo( const QVector3D &point ) const SIP_DEPRECATED { return distanceTo( QgsVector3D( point ) ); }
+
+    /**
+     * Returns the smallest distance between the box and the point \a point
+     * (returns 0 if the point is inside the box)
+     *
+     * \since QGIS 3.42
+     */
+    double distanceTo( const QgsVector3D &point ) const SIP_HOLDGIL;
 
     bool operator==( const QgsBox3D &other ) const SIP_HOLDGIL;
 

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -175,13 +175,13 @@ void TestQgs3DUtils::testQgsBox3DDistanceTo()
 {
   {
     const QgsBox3D box( -1, -1, -1, 1, 1, 1 );
-    QCOMPARE( box.distanceTo( QVector3D( 0, 0, 0 ) ), 0.0 );
-    QCOMPARE( box.distanceTo( QVector3D( 2, 2, 2 ) ), qSqrt( 3.0 ) );
+    QCOMPARE( box.distanceTo( QgsVector3D( 0, 0, 0 ) ), 0.0 );
+    QCOMPARE( box.distanceTo( QgsVector3D( 2, 2, 2 ) ), qSqrt( 3.0 ) );
   }
   {
     const QgsBox3D box( 1, 2, 1, 4, 3, 3 );
-    QCOMPARE( box.distanceTo( QVector3D( 1, 2, 1 ) ), 0.0 );
-    QCOMPARE( box.distanceTo( QVector3D( 0, 0, 0 ) ), qSqrt( 6.0 ) );
+    QCOMPARE( box.distanceTo( QgsVector3D( 1, 2, 1 ) ), 0.0 );
+    QCOMPARE( box.distanceTo( QgsVector3D( 0, 0, 0 ) ), qSqrt( 6.0 ) );
   }
 }
 


### PR DESCRIPTION
Until now, chunk bounds entity used axis-aligned bboxes in world coordinates (floats) We are switching to bboxes in map coordinates (doubles) and we use QgsGeoTransform to react correctly when the origin vector changes.

Follow up on earlier work towards large scene support (e.g. #59174 and #59236)