### PR TITLE
Simplify authentication step during process of adding plugin repository

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -605,7 +605,7 @@ class QgsPluginInstaller(QObject):
             reposName = reposName + "(2)"
         # add to settings
         settings.setValue(reposName + "/url", reposURL)
-        settings.setValue(reposName + "/authcfg", dlg.editAuthCfg.text().strip())
+        settings.setValue(reposName + "/authcfg", dlg.configId().strip())
         settings.setValue(
             reposName + "/enabled", bool(dlg.checkBoxEnabled.checkState())
         )
@@ -622,7 +622,7 @@ class QgsPluginInstaller(QObject):
         dlg = QgsPluginInstallerRepositoryDialog(iface.mainWindow())
         dlg.editName.setText(reposName)
         dlg.editURL.setText(repositories.all()[reposName]["url"])
-        dlg.editAuthCfg.setText(repositories.all()[reposName]["authcfg"])
+        dlg.editAuthCfgWgt.setConfigId(repositories.all()[reposName]["authcfg"])
         dlg.editParams.setText(repositories.urlParams())
         dlg.checkBoxEnabled.setCheckState(
             checkState[repositories.all()[reposName]["enabled"]]
@@ -658,10 +658,15 @@ class QgsPluginInstaller(QObject):
         if newName in repositories.all() and newName != reposName:
             newName = newName + "(2)"
         settings.setValue(newName + "/url", dlg.editURL.text().strip())
-        settings.setValue(newName + "/authcfg", dlg.editAuthCfg.text().strip())
+        settings.setValue(newName + "/authcfg", dlg.configId().strip())
         settings.setValue(newName + "/enabled", bool(dlg.checkBoxEnabled.checkState()))
-        if dlg.editAuthCfg.text().strip() != repositories.all()[reposName]["authcfg"]:
-            repositories.all()[reposName]["authcfg"] = dlg.editAuthCfg.text().strip()
+        if (
+            dlg.editAuthCfgWgt.configId().strip()
+            != repositories.all()[reposName]["authcfg"]
+        ):
+            repositories.all()[reposName][
+                "authcfg"
+            ] = dlg.editAuthCfgWgt.configId().strip()
         if (
             dlg.editURL.text().strip() == repositories.all()[reposName]["url"]
             and dlg.checkBoxEnabled.checkState()

--- a/python/pyplugin_installer/qgsplugininstallerrepositorybase.ui
+++ b/python/pyplugin_installer/qgsplugininstallerrepositorybase.ui
@@ -27,29 +27,16 @@
    <string/>
   </property>
   <layout class="QGridLayout">
-   <item row="5" column="2">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="1" colspan="2">
+    <widget class="QLineEdit" name="editURL">
+     <property name="toolTip">
+      <string>Enter the repository URL, beginning with &quot;http://&quot; or &quot;file:///&quot;</string>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
+     <property name="whatsThis">
+      <string>Enter the repository URL, beginning with &quot;http://&quot; or &quot;file:///&quot;</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>351</width>
-       <height>23</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>URL</string>
-     </property>
-     <property name="buddy">
-      <cstring>editURL</cstring>
+      <string/>
      </property>
     </widget>
    </item>
@@ -60,36 +47,6 @@
      </property>
      <property name="buddy">
       <cstring>checkBoxEnabled</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QLineEdit" name="editName">
-     <property name="toolTip">
-      <string>Enter a name for the repository</string>
-     </property>
-     <property name="whatsThis">
-      <string>Enter a name for the repository</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QLineEdit" name="editParams">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>?qgis=</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -106,6 +63,80 @@
      </property>
      <property name="buddy">
       <cstring>editName</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QgsAuthConfigSelect" name="editAuthCfgWgt" native="true"/>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="checkBoxEnabled">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Enable or disable the repository (disabled repositories will be omitted)</string>
+     </property>
+     <property name="whatsThis">
+      <string>Enable or disable the repository (disabled repositories will be omitted)</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>351</width>
+       <height>23</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="editName">
+     <property name="toolTip">
+      <string>Enter a name for the repository</string>
+     </property>
+     <property name="whatsThis">
+      <string>Enter a name for the repository</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Parameters</string>
+     </property>
+     <property name="buddy">
+      <cstring>editParams</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>URL</string>
+     </property>
+     <property name="buddy">
+      <cstring>editURL</cstring>
      </property>
     </widget>
    </item>
@@ -159,7 +190,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -171,51 +201,20 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Parameters</string>
-     </property>
-     <property name="buddy">
-      <cstring>editParams</cstring>
+      <string>Authentication</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="checkBoxEnabled">
-     <property name="enabled">
-      <bool>true</bool>
+   <item row="9" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Enable or disable the repository (disabled repositories will be omitted)</string>
-     </property>
-     <property name="whatsThis">
-      <string>Enable or disable the repository (disabled repositories will be omitted)</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QLineEdit" name="editURL">
-     <property name="toolTip">
-      <string>Enter the repository URL, beginning with &quot;http://&quot; or &quot;file:///&quot;</string>
-     </property>
-     <property name="whatsThis">
-      <string>Enter the repository URL, beginning with &quot;http://&quot; or &quot;file:///&quot;</string>
-     </property>
-     <property name="text">
-      <string/>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -232,55 +231,26 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_5">
+   <item row="3" column="1" colspan="2">
+    <widget class="QLineEdit" name="editParams">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="text">
-      <string>Authentication</string>
+      <string>?qgis=</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
-    <layout class="QHBoxLayout" name="layoutAuthCfg">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="editAuthCfg">
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnClearAuthCfg">
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Clear</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnEditAuthCfg">
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Edit</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsAuthConfigSelect</class>
+   <extends>QWidget</extends>
+   <header>qgsauthconfigselect.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>editName</tabstop>
   <tabstop>editURL</tabstop>

--- a/python/pyplugin_installer/qgsplugininstallerrepositorydialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerrepositorydialog.py
@@ -46,8 +46,6 @@ class QgsPluginInstallerRepositoryDialog(
         self.editURL.setText("http://")
         self.editName.textChanged.connect(self.textChanged)
         self.editURL.textChanged.connect(self.textChanged)
-        self.btnClearAuthCfg.clicked.connect(self.editAuthCfg.clear)
-        self.btnEditAuthCfg.clicked.connect(self.editAuthCfgId)
         self.textChanged(None)
 
     # ----------------------------------------- #
@@ -55,21 +53,5 @@ class QgsPluginInstallerRepositoryDialog(
         enable = len(self.editName.text()) > 0 and len(self.editURL.text()) > 0
         self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(enable)
 
-    def editAuthCfgId(self):
-        dlg = QDialog(self)
-        dlg.setWindowModality(Qt.WindowModality.WindowModal)
-        layout = QVBoxLayout()
-        selector = QgsAuthConfigSelect(self)
-        if self.editAuthCfg.text():
-            selector.setConfigId(self.editAuthCfg.text())
-        layout.addWidget(selector)
-        buttonBox = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Close
-        )
-        buttonBox.accepted.connect(dlg.accept)
-        buttonBox.rejected.connect(dlg.reject)
-        layout.addWidget(buttonBox)
-        dlg.setLayout(layout)
-        if dlg.exec():
-            self.editAuthCfg.setText(selector.configId())
-        del dlg
+    def configId(self):
+        return self.editAuthCfgWgt.configId()


### PR DESCRIPTION
As of now, in plugin-repository-addition dialog there is a LineEdit field for authentication step, which is filled from the widget of the same one-line structure.

This PR proposes to skip this in-between step by inserting authentication widget directly in place of current LineEdit.

Screenshots with addition and editing process in new version are attached:

![image](https://github.com/user-attachments/assets/4e64a0ff-ea05-48db-aed3-a6dba8039878)

![image](https://github.com/user-attachments/assets/929952dc-3e0c-44c7-9a49-ed5f32bcc639)
