### PR TITLE
Use font button in annotation widgets instead of full text format widget

### DIFF
--- a/src/gui/annotations/qgsannotationitemwidget_impl.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.cpp
@@ -314,14 +314,9 @@ QgsAnnotationPointTextItemWidget::QgsAnnotationPointTextItemWidget( QWidget *par
 {
   setupUi( this );
 
-  mTextFormatWidget = new QgsTextFormatWidget();
-  QVBoxLayout *vLayout = new QVBoxLayout();
-  vLayout->setContentsMargins( 0, 0, 0, 0 );
-  vLayout->addWidget( mTextFormatWidget );
-  mTextFormatWidgetContainer->setLayout( vLayout );
-
   mTextEdit->setMode( QgsRichTextEditor::Mode::QgsTextRenderer );
-  mTextEdit->setMaximumHeight( mTextEdit->fontMetrics().height() * 10 );
+
+  mTextFormatButton->setMode( QgsFontButton::ModeTextRenderer );
 
   mSpinTextAngle->setClearValue( 0 );
 
@@ -330,10 +325,9 @@ QgsAnnotationPointTextItemWidget::QgsAnnotationPointTextItemWidget( QWidget *par
 
   mAlignmentComboBox->setAvailableAlignments( Qt::AlignLeft | Qt::AlignHCenter | Qt::AlignRight );
 
-  mTextFormatWidget->setDockMode( dockMode() );
-  connect( mTextFormatWidget, &QgsTextFormatWidget::widgetChanged, this, [=] {
+  connect( mTextFormatButton, &QgsFontButton::changed, this, [=] {
     mTextEdit->setMode(
-      mTextFormatWidget->format().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText
+      mTextFormatButton->textFormat().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText
     );
 
     if ( !mBlockChangedSignal )
@@ -377,8 +371,8 @@ void QgsAnnotationPointTextItemWidget::updateItem( QgsAnnotationItem *item )
   if ( QgsAnnotationPointTextItem *pointTextItem = dynamic_cast<QgsAnnotationPointTextItem *>( item ) )
   {
     mBlockChangedSignal = true;
-    pointTextItem->setFormat( mTextFormatWidget->format() );
-    pointTextItem->setText( mTextFormatWidget->format().allowHtmlFormatting() ? mTextEdit->toHtml() : mTextEdit->toPlainText() );
+    pointTextItem->setFormat( mTextFormatButton->textFormat() );
+    pointTextItem->setText( mTextFormatButton->textFormat().allowHtmlFormatting() ? mTextEdit->toHtml() : mTextEdit->toPlainText() );
     pointTextItem->setAngle( mSpinTextAngle->value() );
     pointTextItem->setRotationMode( mRotationModeCombo->currentData().value<Qgis::SymbolRotationMode>() );
     pointTextItem->setAlignment( mAlignmentComboBox->currentAlignment() );
@@ -387,18 +381,14 @@ void QgsAnnotationPointTextItemWidget::updateItem( QgsAnnotationItem *item )
   }
 }
 
-void QgsAnnotationPointTextItemWidget::setDockMode( bool dockMode )
-{
-  QgsAnnotationItemBaseWidget::setDockMode( dockMode );
-  if ( mTextFormatWidget )
-    mTextFormatWidget->setDockMode( dockMode );
-}
-
 void QgsAnnotationPointTextItemWidget::setContext( const QgsSymbolWidgetContext &context )
 {
   QgsAnnotationItemBaseWidget::setContext( context );
-  if ( mTextFormatWidget )
-    mTextFormatWidget->setContext( context );
+  if ( mTextFormatButton )
+  {
+    mTextFormatButton->setMapCanvas( context.mapCanvas() );
+    mTextFormatButton->setMessageBar( context.messageBar() );
+  }
   mPropertiesWidget->setContext( context );
 }
 
@@ -419,7 +409,7 @@ bool QgsAnnotationPointTextItemWidget::setNewItem( QgsAnnotationItem *item )
   mItem.reset( textItem->clone() );
 
   mBlockChangedSignal = true;
-  mTextFormatWidget->setFormat( mItem->format() );
+  mTextFormatButton->setTextFormat( mItem->format() );
   mTextEdit->setMode( mItem->format().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText );
   mTextEdit->setText( mItem->text() );
   mSpinTextAngle->setValue( mItem->angle() );
@@ -464,19 +454,13 @@ QgsAnnotationLineTextItemWidget::QgsAnnotationLineTextItemWidget( QWidget *paren
 {
   setupUi( this );
 
-  mTextFormatWidget = new QgsTextFormatWidget();
-  QVBoxLayout *vLayout = new QVBoxLayout();
-  vLayout->setContentsMargins( 0, 0, 0, 0 );
-  vLayout->addWidget( mTextFormatWidget );
-  mTextFormatWidgetContainer->setLayout( vLayout );
+  mTextFormatButton->setMode( QgsFontButton::ModeTextRenderer );
 
   mTextEdit->setMode( QgsRichTextEditor::Mode::QgsTextRenderer );
-  mTextEdit->setMaximumHeight( mTextEdit->fontMetrics().height() * 10 );
 
-  mTextFormatWidget->setDockMode( dockMode() );
-  connect( mTextFormatWidget, &QgsTextFormatWidget::widgetChanged, this, [=] {
+  connect( mTextFormatButton, &QgsFontButton::changed, this, [=] {
     mTextEdit->setMode(
-      mTextFormatWidget->format().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText
+      mTextFormatButton->textFormat().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText
     );
 
     if ( !mBlockChangedSignal )
@@ -519,8 +503,8 @@ void QgsAnnotationLineTextItemWidget::updateItem( QgsAnnotationItem *item )
   if ( QgsAnnotationLineTextItem *lineTextItem = dynamic_cast<QgsAnnotationLineTextItem *>( item ) )
   {
     mBlockChangedSignal = true;
-    lineTextItem->setFormat( mTextFormatWidget->format() );
-    lineTextItem->setText( mTextFormatWidget->format().allowHtmlFormatting() ? mTextEdit->toHtml() : mTextEdit->toPlainText() );
+    lineTextItem->setFormat( mTextFormatButton->textFormat() );
+    lineTextItem->setText( mTextFormatButton->textFormat().allowHtmlFormatting() ? mTextEdit->toHtml() : mTextEdit->toPlainText() );
 
     lineTextItem->setOffsetFromLine( mSpinOffset->value() );
     lineTextItem->setOffsetFromLineUnit( mOffsetUnitWidget->unit() );
@@ -531,18 +515,14 @@ void QgsAnnotationLineTextItemWidget::updateItem( QgsAnnotationItem *item )
   }
 }
 
-void QgsAnnotationLineTextItemWidget::setDockMode( bool dockMode )
-{
-  QgsAnnotationItemBaseWidget::setDockMode( dockMode );
-  if ( mTextFormatWidget )
-    mTextFormatWidget->setDockMode( dockMode );
-}
-
 void QgsAnnotationLineTextItemWidget::setContext( const QgsSymbolWidgetContext &context )
 {
   QgsAnnotationItemBaseWidget::setContext( context );
-  if ( mTextFormatWidget )
-    mTextFormatWidget->setContext( context );
+  if ( mTextFormatButton )
+  {
+    mTextFormatButton->setMapCanvas( context.mapCanvas() );
+    mTextFormatButton->setMessageBar( context.messageBar() );
+  }
   mPropertiesWidget->setContext( context );
 }
 
@@ -561,7 +541,7 @@ bool QgsAnnotationLineTextItemWidget::setNewItem( QgsAnnotationItem *item )
   mItem.reset( textItem->clone() );
 
   mBlockChangedSignal = true;
-  mTextFormatWidget->setFormat( mItem->format() );
+  mTextFormatButton->setTextFormat( mItem->format() );
   mTextEdit->setMode( mItem->format().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText );
   mTextEdit->setText( mItem->text() );
   mPropertiesWidget->setItem( mItem.get() );
@@ -628,22 +608,16 @@ QgsAnnotationRectangleTextItemWidget::QgsAnnotationRectangleTextItemWidget( QWid
   mSpinLeftMargin->setClearValue( 0 );
   mMarginUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::MetersInMapUnits << Qgis::RenderUnit::MapUnits << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches );
 
-  mTextFormatWidget = new QgsTextFormatWidget();
-  QVBoxLayout *vLayout = new QVBoxLayout();
-  vLayout->setContentsMargins( 0, 0, 0, 0 );
-  vLayout->addWidget( mTextFormatWidget );
-  mTextFormatWidgetContainer->setLayout( vLayout );
+  mTextFormatButton->setMode( QgsFontButton::ModeTextRenderer );
 
   mTextEdit->setMode( QgsRichTextEditor::Mode::QgsTextRenderer );
-  mTextEdit->setMaximumHeight( mTextEdit->fontMetrics().height() * 10 );
 
   mAlignmentComboBox->setAvailableAlignments( Qt::AlignLeft | Qt::AlignHCenter | Qt::AlignRight | Qt::AlignJustify );
   mVerticalAlignmentComboBox->setAvailableAlignments( Qt::AlignTop | Qt::AlignVCenter | Qt::AlignBottom );
 
-  mTextFormatWidget->setDockMode( dockMode() );
-  connect( mTextFormatWidget, &QgsTextFormatWidget::widgetChanged, this, [this] {
+  connect( mTextFormatButton, &QgsFontButton::changed, this, [this] {
     mTextEdit->setMode(
-      mTextFormatWidget->format().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText
+      mTextFormatButton->textFormat().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText
     );
 
     onWidgetChanged();
@@ -685,8 +659,8 @@ void QgsAnnotationRectangleTextItemWidget::updateItem( QgsAnnotationItem *item )
   if ( QgsAnnotationRectangleTextItem *rectTextItem = dynamic_cast<QgsAnnotationRectangleTextItem *>( item ) )
   {
     mBlockChangedSignal = true;
-    rectTextItem->setFormat( mTextFormatWidget->format() );
-    rectTextItem->setText( mTextFormatWidget->format().allowHtmlFormatting() ? mTextEdit->toHtml() : mTextEdit->toPlainText() );
+    rectTextItem->setFormat( mTextFormatButton->textFormat() );
+    rectTextItem->setText( mTextFormatButton->textFormat().allowHtmlFormatting() ? mTextEdit->toHtml() : mTextEdit->toPlainText() );
     rectTextItem->setAlignment( mAlignmentComboBox->currentAlignment() | mVerticalAlignmentComboBox->currentAlignment() );
 
     rectTextItem->setPlacementMode( mSizeModeCombo->currentData().value<Qgis::AnnotationPlacementMode>() );
@@ -714,18 +688,14 @@ void QgsAnnotationRectangleTextItemWidget::updateItem( QgsAnnotationItem *item )
   }
 }
 
-void QgsAnnotationRectangleTextItemWidget::setDockMode( bool dockMode )
-{
-  QgsAnnotationItemBaseWidget::setDockMode( dockMode );
-  if ( mTextFormatWidget )
-    mTextFormatWidget->setDockMode( dockMode );
-}
-
 void QgsAnnotationRectangleTextItemWidget::setContext( const QgsSymbolWidgetContext &context )
 {
   QgsAnnotationItemBaseWidget::setContext( context );
-  if ( mTextFormatWidget )
-    mTextFormatWidget->setContext( context );
+  if ( mTextFormatButton )
+  {
+    mTextFormatButton->setMapCanvas( context.mapCanvas() );
+    mTextFormatButton->setMessageBar( context.messageBar() );
+  }
   mBackgroundSymbolButton->setMapCanvas( context.mapCanvas() );
   mBackgroundSymbolButton->setMessageBar( context.messageBar() );
   mFrameSymbolButton->setMapCanvas( context.mapCanvas() );
@@ -760,7 +730,7 @@ bool QgsAnnotationRectangleTextItemWidget::setNewItem( QgsAnnotationItem *item )
   mItem.reset( textItem->clone() );
 
   mBlockChangedSignal = true;
-  mTextFormatWidget->setFormat( mItem->format() );
+  mTextFormatButton->setTextFormat( mItem->format() );
   mTextEdit->setMode( mItem->format().allowHtmlFormatting() ? QgsRichTextEditor::Mode::QgsTextRenderer : QgsRichTextEditor::Mode::PlainText );
   mTextEdit->setText( mItem->text() );
   mAlignmentComboBox->setCurrentAlignment( mItem->alignment() & Qt::AlignHorizontal_Mask );

--- a/src/gui/annotations/qgsannotationitemwidget_impl.h
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.h
@@ -121,7 +121,6 @@ class QgsAnnotationPointTextItemWidget : public QgsAnnotationItemBaseWidget, pri
     ~QgsAnnotationPointTextItemWidget() override;
     QgsAnnotationItem *createItem() override;
     void updateItem( QgsAnnotationItem *item ) override;
-    void setDockMode( bool dockMode ) override;
     void setContext( const QgsSymbolWidgetContext &context ) override;
 
   public slots:
@@ -134,7 +133,6 @@ class QgsAnnotationPointTextItemWidget : public QgsAnnotationItemBaseWidget, pri
   private:
     void mInsertExpressionButton_clicked();
 
-    QgsTextFormatWidget *mTextFormatWidget = nullptr;
     bool mBlockChangedSignal = false;
     std::unique_ptr<QgsAnnotationPointTextItem> mItem;
 };
@@ -149,7 +147,6 @@ class QgsAnnotationRectangleTextItemWidget : public QgsAnnotationItemBaseWidget,
     ~QgsAnnotationRectangleTextItemWidget() override;
     QgsAnnotationItem *createItem() override;
     void updateItem( QgsAnnotationItem *item ) override;
-    void setDockMode( bool dockMode ) override;
     void setContext( const QgsSymbolWidgetContext &context ) override;
     QgsExpressionContext createExpressionContext() const override;
 
@@ -170,7 +167,6 @@ class QgsAnnotationRectangleTextItemWidget : public QgsAnnotationItemBaseWidget,
   private:
     void mInsertExpressionButton_clicked();
 
-    QgsTextFormatWidget *mTextFormatWidget = nullptr;
     bool mBlockChangedSignal = false;
     bool mUpdateItemPosition = false;
 
@@ -186,7 +182,6 @@ class QgsAnnotationLineTextItemWidget : public QgsAnnotationItemBaseWidget, priv
     ~QgsAnnotationLineTextItemWidget() override;
     QgsAnnotationItem *createItem() override;
     void updateItem( QgsAnnotationItem *item ) override;
-    void setDockMode( bool dockMode ) override;
     void setContext( const QgsSymbolWidgetContext &context ) override;
 
   public slots:
@@ -199,7 +194,6 @@ class QgsAnnotationLineTextItemWidget : public QgsAnnotationItemBaseWidget, priv
   private:
     void mInsertExpressionButton_clicked();
 
-    QgsTextFormatWidget *mTextFormatWidget = nullptr;
     bool mBlockChangedSignal = false;
     std::unique_ptr<QgsAnnotationLineTextItem> mItem;
 };

--- a/src/ui/annotations/qgsannotationlinetextwidgetbase.ui
+++ b/src/ui/annotations/qgsannotationlinetextwidgetbase.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Point Text Annotation</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,7 +26,27 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="0">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Text format</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QgsFontButton" name="mTextFormatButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Text format</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
     <widget class="QToolButton" name="mInsertExpressionButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -38,17 +58,17 @@
       <string>Insert/Edit Expression…</string>
      </property>
      <property name="popupMode">
-      <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
+      <enum>QToolButton::MenuButtonPopup</enum>
      </property>
      <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+      <enum>Qt::ToolButtonTextOnly</enum>
      </property>
      <property name="arrowType">
-      <enum>Qt::ArrowType::DownArrow</enum>
+      <enum>Qt::DownArrow</enum>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
     <widget class="QgsRichTextEditor" name="mTextEdit" native="true">
      <property name="minimumSize">
       <size>
@@ -58,7 +78,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="3" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Properties</string>
@@ -100,7 +120,7 @@
            </size>
           </property>
           <property name="focusPolicy">
-           <enum>Qt::FocusPolicy::StrongFocus</enum>
+           <enum>Qt::StrongFocus</enum>
           </property>
          </widget>
         </item>
@@ -116,25 +136,27 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="4" column="0" colspan="2">
     <widget class="QgsAnnotationItemCommonPropertiesWidget" name="mPropertiesWidget" native="true"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QWidget" name="mTextFormatWidgetContainer" native="true"/>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsAnnotationItemCommonPropertiesWidget</class>
    <extends>QWidget</extends>
    <header>qgsannotationitemcommonpropertieswidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsRichTextEditor</class>

--- a/src/ui/annotations/qgsannotationpointtextwidgetbase.ui
+++ b/src/ui/annotations/qgsannotationpointtextwidgetbase.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Point Text Annotation</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,2">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,11 +26,14 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="6" column="0" colspan="2">
-    <widget class="QgsAnnotationItemCommonPropertiesWidget" name="mPropertiesWidget" native="true"/>
-   </item>
    <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Rotation</string>
      </property>
@@ -70,16 +73,13 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QWidget" name="mTextFormatWidgetContainer" native="true"/>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QgsRichTextEditor" name="mTextEdit" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>150</height>
-      </size>
+   <item row="6" column="0" colspan="2">
+    <widget class="QgsAnnotationItemCommonPropertiesWidget" name="mPropertiesWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>
@@ -95,23 +95,53 @@
       <string>Insert/Edit Expression…</string>
      </property>
      <property name="popupMode">
-      <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
+      <enum>QToolButton::MenuButtonPopup</enum>
      </property>
      <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+      <enum>Qt::ToolButtonTextOnly</enum>
      </property>
      <property name="arrowType">
-      <enum>Qt::ArrowType::DownArrow</enum>
+      <enum>Qt::DownArrow</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QgsAlignmentComboBox" name="mAlignmentComboBox"/>
-   </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Alignment</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QgsAlignmentComboBox" name="mAlignmentComboBox"/>
+   </item>
+   <item row="2" column="1">
+    <widget class="QgsFontButton" name="mTextFormatButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Text format</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QgsRichTextEditor" name="mTextEdit" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>2</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Text format</string>
      </property>
     </widget>
    </item>
@@ -119,20 +149,25 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsAnnotationItemCommonPropertiesWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsannotationitemcommonpropertieswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsAlignmentComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsalignmentcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsAnnotationItemCommonPropertiesWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsannotationitemcommonpropertieswidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsRichTextEditor</class>

--- a/src/ui/annotations/qgsannotationrectangulartextwidgetbase.ui
+++ b/src/ui/annotations/qgsannotationrectangulartextwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>321</width>
-    <height>716</height>
+    <height>779</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,13 +23,67 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="2" column="0" colspan="2">
-    <widget class="QgsRichTextEditor" name="mTextEdit" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>150</height>
-      </size>
+   <item row="10" column="0" colspan="2">
+    <widget class="QGroupBox" name="mFrameCheckbox">
+     <property name="title">
+      <string>Frame</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Symbol</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsSymbolButton" name="mFrameSymbolButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Change…</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QgsAlignmentComboBox" name="mAlignmentComboBox"/>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Vertical alignment</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QToolButton" name="mInsertExpressionButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Insert/Edit Expression…</string>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::MenuButtonPopup</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextOnly</enum>
+     </property>
+     <property name="arrowType">
+      <enum>Qt::DownArrow</enum>
      </property>
     </widget>
    </item>
@@ -65,18 +119,118 @@
      </layout>
     </widget>
    </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QgsAnnotationItemCommonPropertiesWidget" name="mPropertiesWidget" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
+   <item row="0" column="0" colspan="2">
+    <widget class="QComboBox" name="mSizeModeCombo"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="QgsAlignmentComboBox" name="mVerticalAlignmentComboBox"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Horizontal alignment</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QgsAlignmentComboBox" name="mVerticalAlignmentComboBox"/>
+   <item row="1" column="0" colspan="2">
+    <widget class="QWidget" name="mWidgetFixedSize" native="true">
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsDoubleSpinBox" name="mWidthSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.200000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="showClearButton" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Height</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsDoubleSpinBox" name="mHeightSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.200000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="showClearButton" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="text">
+         <string>Unit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QgsRichTextEditor" name="mTextEdit" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
+     </property>
+    </widget>
    </item>
    <item row="7" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mMarginsGroupBox">
@@ -247,170 +401,33 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Vertical alignment</string>
-     </property>
-    </widget>
-   </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>Horizontal alignment</string>
+      <string>Text format</string>
      </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QWidget" name="mTextFormatWidgetContainer" native="true"/>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QComboBox" name="mSizeModeCombo"/>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QGroupBox" name="mFrameCheckbox">
-     <property name="title">
-      <string>Frame</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Symbol</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsSymbolButton" name="mFrameSymbolButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Change…</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QWidget" name="mWidgetFixedSize" native="true">
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>Width</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsDoubleSpinBox" name="mWidthSpinBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="maximum">
-         <double>100000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="showClearButton" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_12">
-        <property name="text">
-         <string>Height</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsDoubleSpinBox" name="mHeightSpinBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="maximum">
-         <double>100000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="showClearButton" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_13">
-        <property name="text">
-         <string>Unit</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="QgsAlignmentComboBox" name="mAlignmentComboBox"/>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QToolButton" name="mInsertExpressionButton">
+    <widget class="QgsFontButton" name="mTextFormatButton">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Insert/Edit Expression…</string>
+      <string>Text format</string>
      </property>
-     <property name="popupMode">
-      <enum>QToolButton::MenuButtonPopup</enum>
-     </property>
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonTextOnly</enum>
-     </property>
-     <property name="arrowType">
-      <enum>Qt::DownArrow</enum>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="2">
+    <widget class="QgsAnnotationItemCommonPropertiesWidget" name="mPropertiesWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </widget>
    </item>
@@ -418,9 +435,30 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsAlignmentComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsalignmentcombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsAnnotationItemCommonPropertiesWidget</class>
    <extends>QWidget</extends>
    <header>qgsannotationitemcommonpropertieswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsRichTextEditor</class>
+   <extends>QWidget</extends>
+   <header>qgsrichtexteditor.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -429,25 +467,9 @@
    <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsAlignmentComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsalignmentcombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsRichTextEditor</class>
-   <extends>QWidget</extends>
-   <header>qgsrichtexteditor.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsrichtexteditorbase.ui
+++ b/src/ui/qgsrichtexteditorbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>846</width>
-    <height>312</height>
+    <height>705</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -51,7 +51,7 @@
        <item>
         <widget class="QgsImageDropTextEdit" name="mTextEdit">
          <property name="autoFormatting">
-          <set>QTextEdit::AutoFormattingFlag::AutoNone</set>
+          <set>QTextEdit::AutoNone</set>
          </property>
          <property name="tabChangesFocus">
           <bool>true</bool>


### PR DESCRIPTION
The widgets were getting very complex, this reduces the amount of controls shown in the dock
