### PR TITLE
update raster resampling widgets after loading a style (fix #56771)

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -816,6 +816,9 @@ void QgsRasterLayerProperties::sync()
     mInvertColorsCheck->setChecked( hueSaturationFilter->invertColors() );
   }
 
+  // Resampling
+  mResamplingUtils.refreshWidgetsFromLayer();
+
   mRefreshSettingsWidget->syncToLayer();
 
   QgsDebugMsgLevel( QStringLiteral( "populate general tab" ), 3 );


### PR DESCRIPTION
## Description

When raster style is loaded changes in the resampling configuration are not reflected in the UI. We need to update widgets to reflect these changes.

Fixes #56771.