### PR TITLE
Register vector tile label features first when all tiles are fetched

### DIFF
--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -224,6 +224,15 @@ bool QgsVectorTileLayerRenderer::render()
       mErrors.append( asyncLoader->error() );
   }
 
+  // Register labels features when all tiles are fetched to ensure consistent labeling
+  if ( mLabelProvider )
+  {
+    for ( const auto &tile : mTileDataMap )
+    {
+      mLabelProvider->registerTileFeatures( tile, ctx );
+    }
+  }
+
   if ( ctx.flags() & Qgis::RenderContextFlag::DrawSelection )
     mRenderer->renderSelectedFeatures( mSelectedFeatures, ctx );
 
@@ -309,8 +318,9 @@ void QgsVectorTileLayerRenderer::decodeAndDrawTile( const QgsVectorTileRawData &
     mTotalDrawTime += tDraw.elapsed();
   }
 
+  // Store tile for later use
   if ( mLabelProvider )
-    mLabelProvider->registerTileFeatures( tile, ctx );
+    mTileDataMap.insert( tile.id().toString(), tile );
 
   if ( mDrawTileBoundaries )
   {

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -71,6 +71,9 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
      */
     QgsVectorTileLabelProvider *mLabelProvider = nullptr;
 
+    // Decoded tile data
+    QMap<QString, QgsVectorTileRendererData> mTileDataMap;
+
     //! Whether to draw boundaries of tiles (useful for debugging)
     bool mDrawTileBoundaries = false;
 


### PR DESCRIPTION
This is a follow up on https://github.com/qgis/QGIS/pull/60346, where the problem is described in more detail. 

## Problem 
When rendering a map from a vector tile service, tiles are fetched asynchronously. Once a tile is fetched, its features are registered for labeling. However, the order in which the label features are registered can change depending on the order in which tiles are fetched. This results in inconsistent labeling.

## Solution 
Rather than registering label features when an individual tile is fetched, tiles are stored in a map. Once all tiles have been fetched, they are registered for labeling in order by tile id. 