### PR TITLE
[Sip] Don't use deprecated annotation with message

### DIFF
--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -65,11 +65,14 @@ MACRO(GENERATE_SIP_PYTHON_MODULE_CODE MODULE_NAME MODULE_SIP SIP_FILES CPP_FILES
     CONFIGURE_FILE(${_sip_file} ${_out_sip_file})
 
     # Deprecated annotation supports message only since version 6.9.0
-    if(${SIP_VERSION_STR} VERSION_LESS 6.9.0)
-      file(READ ${_out_sip_file} _content)
-      string(REGEX REPLACE "([/,])Deprecated=\"[^\"]*\"([/,])" "\\1Deprecated\\2" _content "${_content}")
-      file(GENERATE OUTPUT ${_out_sip_file} CONTENT "${_content}")
-    endif()
+    # if(${SIP_VERSION_STR} VERSION_LESS 6.9.0)
+
+    # For now disabling SIP deprecated because it crashes the application
+    file(READ ${_out_sip_file} _content)
+    string(REGEX REPLACE "([/,])Deprecated=\"[^\"]*\"([/,])" "\\1Deprecated\\2" _content "${_content}")
+    file(GENERATE OUTPUT ${_out_sip_file} CONTENT "${_content}")
+
+    # endif()
 
   ENDFOREACH (_sip_file)
 


### PR DESCRIPTION
It crashes in 6.9.1, I'll restore it when everything is fixed. Reason of crash for context [here](https://github.com/Python-SIP/sip/pull/53/commits/6437bd41cd99e5a72c885b81189431fc1abbd910#r1935968699)

Fixes #60286