### PR TITLE
Remove an extraneous setting of layer scope for vectors

### DIFF
--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -171,8 +171,6 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
     // set editing vertex markers style (main renderer only)
     mRenderer->setVertexMarkerAppearance( mVertexMarkerStyle, mVertexMarkerSize );
   }
-  if ( !mNoSetLayerExpressionContext )
-    renderContext()->expressionContext() << QgsExpressionContextUtils::layerScope( layer );
 
   for ( const std::unique_ptr< QgsFeatureRenderer > &renderer : mRenderers )
   {


### PR DESCRIPTION
We already have set the layer scope for ALL layer types in the map renderer job preparation, so there's no need to add another layer scope in the vector layer renderer

Refs #60112
