### PR TITLE
When a layer changes from non-spatial to spatial, update canvas layers

### DIFF
--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -203,6 +203,7 @@ void QgsLayerTreeMapCanvasBridge::layersAdded( const QList<QgsMapLayer *> &layer
           // if we are moving from zero valid layers to non-zero VALID layers, let's zoom to those data
           mCanvas->zoomToProjectExtent();
         }
+        deferredSetCanvasLayers();
       } );
     }
   }


### PR DESCRIPTION
If a layer changes data source then it may potentially change from a non-spatial layer to a spatial layer. Accordingly, listen out for this and trigger a canvas layer update whenever a layer's source changes. This ensures that ALL spatial layers are correctly visible in the canvas immediately after the source change triggers the spatial status change.

Fixes #59723
