### PR TITLE
[sensorthings] Hide proxy fields for interval fields in filter builder

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -56,9 +56,12 @@ Returns the SensorThings properties which correspond to a specified entity ``typ
 .. versionadded:: 3.38
 %End
 
-    static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
+    static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type, bool includeRangeFieldProxies = true );
 %Docstring
 Returns the fields which correspond to a specified entity ``type``.
+
+Since QGIS 3.42 the ``includeRangeFieldProxies`` argument can be used to hide the "start"/"end" fields
+which are proxies for the date time range field types which are not natively supported in QGIS.
 %End
 
     static QgsFields fieldsForExpandedEntityType( Qgis::SensorThingsEntity baseType, const QList< Qgis::SensorThingsEntity > &expandedTypes );

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -56,9 +56,12 @@ Returns the SensorThings properties which correspond to a specified entity ``typ
 .. versionadded:: 3.38
 %End
 
-    static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
+    static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type, bool includeRangeFieldProxies = true );
 %Docstring
 Returns the fields which correspond to a specified entity ``type``.
+
+Since QGIS 3.42 the ``includeRangeFieldProxies`` argument can be used to hide the "start"/"end" fields
+which are proxies for the date time range field types which are not natively supported in QGIS.
 %End
 
     static QgsFields fieldsForExpandedEntityType( Qgis::SensorThingsEntity baseType, const QList< Qgis::SensorThingsEntity > &expandedTypes );

--- a/src/core/providers/sensorthings/qgssensorthingsutils.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.cpp
@@ -478,7 +478,7 @@ QStringList QgsSensorThingsUtils::propertiesForEntityType( Qgis::SensorThingsEnt
   return {};
 }
 
-QgsFields QgsSensorThingsUtils::fieldsForEntityType( Qgis::SensorThingsEntity type )
+QgsFields QgsSensorThingsUtils::fieldsForEntityType( Qgis::SensorThingsEntity type, bool includeRangeFieldProxies )
 {
   QgsFields fields;
 
@@ -517,10 +517,13 @@ QgsFields QgsSensorThingsUtils::fieldsForEntityType( Qgis::SensorThingsEntity ty
       fields.append( QgsField( QStringLiteral( "unitOfMeasurement" ), QMetaType::Type::QVariantMap, QStringLiteral( "json" ), 0, 0, QString(), QMetaType::Type::QString ) );
       fields.append( QgsField( QStringLiteral( "observationType" ), QMetaType::Type::QString ) );
       fields.append( QgsField( QStringLiteral( "properties" ), QMetaType::Type::QVariantMap, QStringLiteral( "json" ), 0, 0, QString(), QMetaType::Type::QString ) );
-      fields.append( QgsField( QStringLiteral( "phenomenonTimeStart" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "phenomenonTimeEnd" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "resultTimeStart" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "resultTimeEnd" ), QMetaType::Type::QDateTime ) );
+      if ( includeRangeFieldProxies )
+      {
+        fields.append( QgsField( QStringLiteral( "phenomenonTimeStart" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "phenomenonTimeEnd" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "resultTimeStart" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "resultTimeEnd" ), QMetaType::Type::QDateTime ) );
+      }
       break;
 
     case Qgis::SensorThingsEntity::Sensor:
@@ -541,16 +544,22 @@ QgsFields QgsSensorThingsUtils::fieldsForEntityType( Qgis::SensorThingsEntity ty
 
     case Qgis::SensorThingsEntity::Observation:
       // https://docs.ogc.org/is/18-088/18-088.html#observation
-      fields.append( QgsField( QStringLiteral( "phenomenonTimeStart" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "phenomenonTimeEnd" ), QMetaType::Type::QDateTime ) );
+      if ( includeRangeFieldProxies )
+      {
+        fields.append( QgsField( QStringLiteral( "phenomenonTimeStart" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "phenomenonTimeEnd" ), QMetaType::Type::QDateTime ) );
+      }
 
       // TODO -- handle type correctly
       fields.append( QgsField( QStringLiteral( "result" ), QMetaType::Type::QString ) );
 
       fields.append( QgsField( QStringLiteral( "resultTime" ), QMetaType::Type::QDateTime ) );
       fields.append( QgsField( QStringLiteral( "resultQuality" ), QMetaType::Type::QStringList, QString(), 0, 0, QString(), QMetaType::Type::QString ) );
-      fields.append( QgsField( QStringLiteral( "validTimeStart" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "validTimeEnd" ), QMetaType::Type::QDateTime ) );
+      if ( includeRangeFieldProxies )
+      {
+        fields.append( QgsField( QStringLiteral( "validTimeStart" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "validTimeEnd" ), QMetaType::Type::QDateTime ) );
+      }
       fields.append( QgsField( QStringLiteral( "parameters" ), QMetaType::Type::QVariantMap, QStringLiteral( "json" ), 0, 0, QString(), QMetaType::Type::QString ) );
       break;
 
@@ -569,10 +578,13 @@ QgsFields QgsSensorThingsUtils::fieldsForEntityType( Qgis::SensorThingsEntity ty
       fields.append( QgsField( QStringLiteral( "observationType" ), QMetaType::Type::QString ) );
       fields.append( QgsField( QStringLiteral( "multiObservationDataTypes" ), QMetaType::Type::QStringList, QString(), 0, 0, QString(), QMetaType::Type::QString ) );
       fields.append( QgsField( QStringLiteral( "properties" ), QMetaType::Type::QVariantMap, QStringLiteral( "json" ), 0, 0, QString(), QMetaType::Type::QString ) );
-      fields.append( QgsField( QStringLiteral( "phenomenonTimeStart" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "phenomenonTimeEnd" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "resultTimeStart" ), QMetaType::Type::QDateTime ) );
-      fields.append( QgsField( QStringLiteral( "resultTimeEnd" ), QMetaType::Type::QDateTime ) );
+      if ( includeRangeFieldProxies )
+      {
+        fields.append( QgsField( QStringLiteral( "phenomenonTimeStart" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "phenomenonTimeEnd" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "resultTimeStart" ), QMetaType::Type::QDateTime ) );
+        fields.append( QgsField( QStringLiteral( "resultTimeEnd" ), QMetaType::Type::QDateTime ) );
+      }
       break;
   }
 

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -81,8 +81,11 @@ class CORE_EXPORT QgsSensorThingsUtils
 
     /**
      * Returns the fields which correspond to a specified entity \a type.
+     *
+     * Since QGIS 3.42 the \a includeRangeFieldProxies argument can be used to hide the "start"/"end" fields
+     * which are proxies for the date time range field types which are not natively supported in QGIS.
      */
-    static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type );
+    static QgsFields fieldsForEntityType( Qgis::SensorThingsEntity type, bool includeRangeFieldProxies = true );
 
     /**
      * Returns the fields which correspond to a specified entity \a baseType, expanded

--- a/src/gui/providers/sensorthings/qgssensorthingssourceselect.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssourceselect.cpp
@@ -282,7 +282,7 @@ void QgsSensorThingsSourceSelect::cmbConnections_currentTextChanged( const QStri
 
 void QgsSensorThingsSourceSelect::buildFilter()
 {
-  const QgsFields fields = QgsSensorThingsUtils::fieldsForEntityType( mSourceWidget->currentEntityType() );
+  const QgsFields fields = QgsSensorThingsUtils::fieldsForEntityType( mSourceWidget->currentEntityType(), false );
   QgsSensorThingsSubsetEditor subsetEditor( nullptr, fields );
   subsetEditor.setSubsetString( txtSubsetSQL->text() );
   if ( subsetEditor.exec() )

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
@@ -1007,7 +1007,7 @@ QString QgsSensorThingsFilterWidget::filter() const
 
 void QgsSensorThingsFilterWidget::setQuery()
 {
-  const QgsFields fields = QgsSensorThingsUtils::fieldsForEntityType( mEntity );
+  const QgsFields fields = QgsSensorThingsUtils::fieldsForEntityType( mEntity, false );
   QgsSensorThingsSubsetEditor editor( nullptr, fields, this );
   editor.setSubsetString( mFilter );
   if ( editor.exec() )

--- a/tests/src/python/test_provider_sensorthings.py
+++ b/tests/src/python/test_provider_sensorthings.py
@@ -567,6 +567,47 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             "$expand=Things($orderby=id;$top=3;$expand=Datastreams($orderby=description;$top=30;$expand=ObservedProperty($orderby=name)))",
         )
 
+    def test_fields_for_entity_type(self):
+        """
+        Test calculating fields for an entity type.
+        """
+        fields = QgsSensorThingsUtils.fieldsForEntityType(
+            Qgis.SensorThingsEntity.Datastream
+        )
+        self.assertEqual(
+            [field.name() for field in fields],
+            [
+                "id",
+                "selfLink",
+                "name",
+                "description",
+                "unitOfMeasurement",
+                "observationType",
+                "properties",
+                "phenomenonTimeStart",
+                "phenomenonTimeEnd",
+                "resultTimeStart",
+                "resultTimeEnd",
+            ],
+        )
+
+        # hide proxy fields for missing interval field type
+        fields = QgsSensorThingsUtils.fieldsForEntityType(
+            Qgis.SensorThingsEntity.Datastream, False
+        )
+        self.assertEqual(
+            [field.name() for field in fields],
+            [
+                "id",
+                "selfLink",
+                "name",
+                "description",
+                "unitOfMeasurement",
+                "observationType",
+                "properties",
+            ],
+        )
+
     def test_fields_for_expanded_entity(self):
         """
         Test calculating fields for an expanded entity


### PR DESCRIPTION
These don't exist on the backend, so just hide them from the builder dialog to avoid user confusion.

(Note that it's impossible to show the actual non-proxy fields here, as we can ONLY show fields with types compatible with native QGIS field types in this dialog)

Fixes #59528
