### PR TITLE
[annotations][ui] Fix fixed-size unit combo box not set when editing a rectangle text annotation

### DIFF
--- a/src/gui/annotations/qgsannotationitemwidget_impl.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.cpp
@@ -594,7 +594,6 @@ QgsAnnotationRectangleTextItemWidget::QgsAnnotationRectangleTextItemWidget( QWid
 
   mSizeUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches << Qgis::RenderUnit::Percentage );
 
-
   mBackgroundSymbolButton->setSymbolType( Qgis::SymbolType::Fill );
   mBackgroundSymbolButton->setDialogTitle( tr( "Background" ) );
   mBackgroundSymbolButton->registerExpressionContextGenerator( this );
@@ -753,6 +752,7 @@ bool QgsAnnotationRectangleTextItemWidget::setNewItem( QgsAnnotationItem *item )
 
   mWidthSpinBox->setValue( textItem->fixedSize().width() );
   mHeightSpinBox->setValue( textItem->fixedSize().height() );
+  mSizeUnitWidget->setUnit( textItem->fixedSizeUnit() );
   mSizeModeCombo->setCurrentIndex( mSizeModeCombo->findData( QVariant::fromValue( textItem->placementMode() ) ) );
 
   mBlockChangedSignal = false;


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/59188 whereas the rectangle text annotation widget wouldn't set the fixed size unit type combo box to the right value when editing a preexisting annotation.

