### PR TITLE
[ui] Fix missing @cluster_size and @cluster_color variables not visible when editing the cluster renderer's cluster symbol

### DIFF
--- a/src/gui/symbology/qgspointclusterrendererwidget.cpp
+++ b/src/gui/symbology/qgspointclusterrendererwidget.cpp
@@ -212,6 +212,7 @@ QgsExpressionContext QgsPointClusterRendererWidget::createExpressionContext() co
   {
     context << new QgsExpressionContextScope( s );
   }
+  context.setHighlightedVariables( QStringList() << QgsExpressionContext::EXPR_CLUSTER_COLOR << QgsExpressionContext::EXPR_CLUSTER_SIZE );
   return context;
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/58985 .

Proof of life:

![Screenshot From 2025-02-02 16-20-56](https://github.com/user-attachments/assets/60fc51d2-6990-42ea-8f2b-48761af76ee0)
