### PR TITLE
Revert "Remove dedicated "show editing toolbar" action from 3d windows"

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -69,9 +69,6 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
 {
   const QgsSettings setting;
 
-  mToolbarMenu = new QMenu( tr( "Toolbars" ), this );
-  mToolbarMenu->setObjectName( QStringLiteral( "mToolbarMenu" ) );
-
   QToolBar *toolBar = new QToolBar( this );
   toolBar->setIconSize( QgisApp::instance()->iconSize( isDocked ) );
 
@@ -82,7 +79,6 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
 
   // Editing toolbar
   mEditingToolBar = new QToolBar( this );
-  mEditingToolBar->setWindowTitle( tr( "Editing Toolbar" ) );
   mEditingToolBar->setVisible( false );
 
   QAction *actionPointCloudChangeAttributeTool = mEditingToolBar->addAction( QIcon( QgsApplication::iconPath( "mActionSelectPolygon.svg" ) ), tr( "Change Point Cloud Attribute" ), this, &Qgs3DMapCanvasWidget::changePointCloudAttribute );
@@ -94,6 +90,8 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   mSpinChangeAttributeValue = new QgsDoubleSpinBox();
   mEditingToolBar->addWidget( new QLabel( tr( "Value" ) ) );
   mEditingToolBar->addWidget( mSpinChangeAttributeValue );
+  QAction *actionEditingToolbar = toolBar->addAction( QIcon( QgsApplication::iconPath( "mIconPointCloudLayer.svg" ) ), tr( "Show Editing Toolbar" ), this, [this] { mEditingToolBar->setVisible( !mEditingToolBar->isVisible() ); } );
+  actionEditingToolbar->setCheckable( true );
   connect( mCboChangeAttribute, qOverload<int>( &QComboBox::currentIndexChanged ), this, [this]( int ) { onPointCloudChangeAttributeSettingsChanged(); } );
   connect( mSpinChangeAttributeValue, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, [this]( double ) { onPointCloudChangeAttributeSettingsChanged(); } );
 
@@ -344,24 +342,6 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   } );
 
   updateLayerRelatedActions( QgisApp::instance()->activeLayer() );
-
-  QList<QAction *> toolbarMenuActions;
-  // Set action names so that they can be used in customization
-  for ( QToolBar *toolBar : { mEditingToolBar } )
-  {
-    toolBar->toggleViewAction()->setObjectName( "mActionToggle" + toolBar->objectName().mid( 1 ) );
-    toolbarMenuActions << toolBar->toggleViewAction();
-  }
-
-  // sort actions in toolbar menu
-  std::sort( toolbarMenuActions.begin(), toolbarMenuActions.end(), []( QAction *a, QAction *b ) {
-    return QString::localeAwareCompare( a->text(), b->text() ) < 0;
-  } );
-
-  mToolbarMenu->addActions( toolbarMenuActions );
-
-  toolBar->installEventFilter( this );
-  mEditingToolBar->installEventFilter( this );
 }
 
 Qgs3DMapCanvasWidget::~Qgs3DMapCanvasWidget()
@@ -472,26 +452,6 @@ void Qgs3DMapCanvasWidget::updateLayerRelatedActions( QgsMapLayer *layer )
   mCboChangeAttribute->setCurrentIndex( std::max( index, 0 ) );
 
   enableEditingTools( pcLayer->isEditable() );
-}
-
-bool Qgs3DMapCanvasWidget::eventFilter( QObject *watched, QEvent *event )
-{
-  if ( qobject_cast< QToolBar * >( watched ) )
-  {
-    if ( event->type() != QEvent::MouseButtonPress )
-      return QObject::eventFilter( watched, event );
-
-    QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>( event );
-    if ( !mouseEvent )
-      return QObject::eventFilter( watched, event );
-
-    if ( mouseEvent->button() != Qt::RightButton )
-      return QObject::eventFilter( watched, event );
-
-    mToolbarMenu->exec( mouseEvent->globalPos() );
-    return false;
-  }
-  return QObject::eventFilter( watched, event );
 }
 
 void Qgs3DMapCanvasWidget::toggleNavigationWidget( bool visibility )

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -78,9 +78,6 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 
     void updateLayerRelatedActions( QgsMapLayer *layer );
 
-    bool eventFilter( QObject *watched, QEvent *event ) override;
-
-
   private slots:
     void resetView();
     void configure();
@@ -164,8 +161,6 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QToolBar *mEditingToolBar = nullptr;
     QComboBox *mCboChangeAttribute = nullptr;
     QgsDoubleSpinBox *mSpinChangeAttributeValue = nullptr;
-
-    QMenu *mToolbarMenu = nullptr;
 };
 
 #endif // QGS3DMAPCANVASWIDGET_H


### PR DESCRIPTION
Fixes #60313
I would like to open discussion on this PR as @uclaros pointed out some eloquent stuff, to which I agree. I would like to come to an agreement with both sides...

The points:

>   - I don't think the 3d view toolbar is bloated, it only has 12 buttons, which is 44 less than the main windows' default. If you think that's too many, I'd rather remove the semi-broken on-screen navigation relic button instead.
>   - Point cloud editing might be niche, but the toolbar may accommodate other layer types' editing tools in the future. Vector layer 3d editing is a much requested feature.
>   - Main window has the editing toolbar visible by default
>   -  Toolbar position and visibility persist in the main window
>   But more importantly:
>   - There is no visible clue that the toolbars are dynamic and one needs to right click. In the main window, toolbars have a handle and are movable. Users (or at least many of them) expect it to be right clickable, and even if not, there is a menu entry to manipulate the toolbars. In the secondary views however, both 2d and 3d, this is not the case.
>   - Right click does not work on the big blank space to the right of the last item of the main toolbar
