### PR TITLE
[sensorthings] Fix provider does not work with oauth2 config method

### DIFF
--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
@@ -96,8 +96,7 @@ QgsSensorThingsSharedData::QgsSensorThingsSharedData( const QString &uri )
     mGeometryType = Qgis::WkbType::NoGeometry;
   }
 
-  QgsDataSourceUri dsUri;
-  dsUri.setEncodedUri( uri );
+  const QgsDataSourceUri dsUri( uri );
   mAuthCfg = dsUri.authConfigId();
   mHeaders = dsUri.httpHeaders();
 


### PR DESCRIPTION
The provider was incorrectly retrieving the authcfg id key from the layer URI

Fixes #60407
