### PR TITLE
When changing rect text annotation to fixed size mode, use current size

### DIFF
--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -200,6 +200,10 @@ void QgsAnnotationItemPropertiesWidget::setItemId( const QString &itemId )
         mItemWidget->setItemId( itemId );
       }
     }
+    else
+    {
+      mItemWidget->setItemId( itemId );
+    }
   }
 
   if ( !setItem )


### PR DESCRIPTION
Instead of resetting the size to a default size, use the actual size of the annotation item at the current map scale as the initial fixed size.

Fixes #59189
