### PR TITLE
[Clang] Remove some deprecated warnings

### DIFF
--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -573,9 +573,9 @@ void TestQgsRasterCalculator::calcWithDataType_data()
 void TestQgsRasterCalculator::calcWithDataType()
 {
   QFETCH( int, dataType );
-  QFETCH( bool, useOpenCL );
 
 #ifdef HAVE_OPENCL
+  QFETCH( bool, useOpenCL );
   if ( QgsOpenClUtils::available() && useOpenCL )
     QgsOpenClUtils::setEnabled( useOpenCL );
   else


### PR DESCRIPTION
Because either
- non working Q_NOWARN_DEPRECATED_PUSH/POP in recent clang versions
- newly deprecated 3d classes
- Indirect used of Qt 3d deprecated classes

