### PR TITLE
restore fill brush when switching back to single and double box scalebar (fix #37413)

### DIFF
--- a/python/PyQt6/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
@@ -38,13 +38,6 @@ Double box with alternating colors.
 
     virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
 
-%Docstring
-Applies any default settings relating to the scalebar to the passed ``settings`` object.
-
-Returns ``True`` if settings were applied.
-
-.. versionadded:: 3.42
-%End
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
@@ -36,6 +36,15 @@ Double box with alternating colors.
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
 
+    virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
+
+%Docstring
+Applies any default settings relating to the scalebar to the passed ``settings`` object.
+
+Returns ``True`` if settings were applied.
+
+.. versionadded:: 3.42
+%End
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
@@ -40,7 +40,6 @@ alternating segments. AKA "South African" style.
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
     virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
 
-
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
@@ -39,13 +39,6 @@ color for the segments.
 
     virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
 
-%Docstring
-Applies any default settings relating to the scalebar to the passed ``settings`` object.
-
-Returns ``True`` if settings were applied.
-
-.. versionadded:: 3.42
-%End
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
@@ -37,6 +37,15 @@ color for the segments.
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
 
+    virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
+
+%Docstring
+Applies any default settings relating to the scalebar to the passed ``settings`` object.
+
+Returns ``True`` if settings were applied.
+
+.. versionadded:: 3.42
+%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
@@ -38,13 +38,6 @@ Double box with alternating colors.
 
     virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
 
-%Docstring
-Applies any default settings relating to the scalebar to the passed ``settings`` object.
-
-Returns ``True`` if settings were applied.
-
-.. versionadded:: 3.42
-%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip.in
@@ -36,6 +36,15 @@ Double box with alternating colors.
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
 
+    virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
+
+%Docstring
+Applies any default settings relating to the scalebar to the passed ``settings`` object.
+
+Returns ``True`` if settings were applied.
+
+.. versionadded:: 3.42
+%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgshollowscalebarrenderer.sip.in
@@ -40,7 +40,6 @@ alternating segments. AKA "South African" style.
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
     virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
 
-
 };
 
 /************************************************************************

--- a/python/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
@@ -39,13 +39,6 @@ color for the segments.
 
     virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
 
-%Docstring
-Applies any default settings relating to the scalebar to the passed ``settings`` object.
-
-Returns ``True`` if settings were applied.
-
-.. versionadded:: 3.42
-%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgssingleboxscalebarrenderer.sip.in
@@ -37,6 +37,15 @@ color for the segments.
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const;
 
+    virtual bool applyDefaultSettings( QgsScaleBarSettings &settings ) const;
+
+%Docstring
+Applies any default settings relating to the scalebar to the passed ``settings`` object.
+
+Returns ``True`` if settings were applied.
+
+.. versionadded:: 3.42
+%End
 };
 
 /************************************************************************

--- a/src/core/scalebar/qgsdoubleboxscalebarrenderer.cpp
+++ b/src/core/scalebar/qgsdoubleboxscalebarrenderer.cpp
@@ -194,7 +194,7 @@ void QgsDoubleBoxScaleBarRenderer::draw( QgsRenderContext &context, const QgsSca
 
 bool QgsDoubleBoxScaleBarRenderer::applyDefaultSettings( QgsScaleBarSettings &settings ) const
 {
-  QgsSimpleFillSymbolLayer *fill = qgis::down_cast< QgsSimpleFillSymbolLayer * >( settings.fillSymbol()->symbolLayers().at( 0 ) );
+  QgsSimpleFillSymbolLayer *fill = dynamic_cast< QgsSimpleFillSymbolLayer * >( settings.fillSymbol()->symbolLayers().at( 0 ) );
 
   // restore the fill symbols by default
   if ( fill && fill->brushStyle() == Qt::NoBrush )

--- a/src/core/scalebar/qgsdoubleboxscalebarrenderer.cpp
+++ b/src/core/scalebar/qgsdoubleboxscalebarrenderer.cpp
@@ -20,6 +20,7 @@
 #include "qgstextrenderer.h"
 #include "qgslinesymbol.h"
 #include "qgsfillsymbol.h"
+#include "qgsfillsymbollayer.h"
 #include <QList>
 #include <QPainter>
 
@@ -189,4 +190,25 @@ void QgsDoubleBoxScaleBarRenderer::draw( QgsRenderContext &context, const QgsSca
 
   //draw labels using the default method
   drawDefaultLabels( context, settings, scaleContext );
+}
+
+bool QgsDoubleBoxScaleBarRenderer::applyDefaultSettings( QgsScaleBarSettings &settings ) const
+{
+  // restore the fill symbols by default
+  std::unique_ptr< QgsFillSymbol > fillSymbol = std::make_unique< QgsFillSymbol >();
+  std::unique_ptr< QgsSimpleFillSymbolLayer > fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+  fillSymbolLayer->setColor( QColor( 0, 0, 0 ) );
+  fillSymbolLayer->setBrushStyle( Qt::SolidPattern );
+  fillSymbolLayer->setStrokeStyle( Qt::SolidLine );
+  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+  settings.setFillSymbol( fillSymbol.release() );
+
+  fillSymbol = std::make_unique< QgsFillSymbol >();
+  fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+  fillSymbolLayer->setColor( QColor( 255, 255, 255 ) );
+  fillSymbolLayer->setStrokeStyle( Qt::NoPen );
+  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+  settings.setAlternateFillSymbol( fillSymbol.release() );
+
+  return true;
 }

--- a/src/core/scalebar/qgsdoubleboxscalebarrenderer.cpp
+++ b/src/core/scalebar/qgsdoubleboxscalebarrenderer.cpp
@@ -194,21 +194,26 @@ void QgsDoubleBoxScaleBarRenderer::draw( QgsRenderContext &context, const QgsSca
 
 bool QgsDoubleBoxScaleBarRenderer::applyDefaultSettings( QgsScaleBarSettings &settings ) const
 {
-  // restore the fill symbols by default
-  std::unique_ptr< QgsFillSymbol > fillSymbol = std::make_unique< QgsFillSymbol >();
-  std::unique_ptr< QgsSimpleFillSymbolLayer > fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
-  fillSymbolLayer->setColor( QColor( 0, 0, 0 ) );
-  fillSymbolLayer->setBrushStyle( Qt::SolidPattern );
-  fillSymbolLayer->setStrokeStyle( Qt::SolidLine );
-  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
-  settings.setFillSymbol( fillSymbol.release() );
+  QgsSimpleFillSymbolLayer *fill = qgis::down_cast< QgsSimpleFillSymbolLayer * >( settings.fillSymbol()->symbolLayers().at( 0 ) );
 
-  fillSymbol = std::make_unique< QgsFillSymbol >();
-  fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
-  fillSymbolLayer->setColor( QColor( 255, 255, 255 ) );
-  fillSymbolLayer->setStrokeStyle( Qt::NoPen );
-  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
-  settings.setAlternateFillSymbol( fillSymbol.release() );
+  // restore the fill symbols by default
+  if ( fill && fill->brushStyle() == Qt::NoBrush )
+  {
+    std::unique_ptr< QgsFillSymbol > fillSymbol = std::make_unique< QgsFillSymbol >();
+    std::unique_ptr< QgsSimpleFillSymbolLayer > fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+    fillSymbolLayer->setColor( QColor( 0, 0, 0 ) );
+    fillSymbolLayer->setBrushStyle( Qt::SolidPattern );
+    fillSymbolLayer->setStrokeStyle( Qt::SolidLine );
+    fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+    settings.setFillSymbol( fillSymbol.release() );
+
+    fillSymbol = std::make_unique< QgsFillSymbol >();
+    fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+    fillSymbolLayer->setColor( QColor( 255, 255, 255 ) );
+    fillSymbolLayer->setStrokeStyle( Qt::NoPen );
+    fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+    settings.setAlternateFillSymbol( fillSymbol.release() );
+  }
 
   return true;
 }

--- a/src/core/scalebar/qgsdoubleboxscalebarrenderer.h
+++ b/src/core/scalebar/qgsdoubleboxscalebarrenderer.h
@@ -42,6 +42,14 @@ class CORE_EXPORT QgsDoubleBoxScaleBarRenderer: public QgsScaleBarRenderer
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const override;
 
+    /**
+     * Applies any default settings relating to the scalebar to the passed \a settings object.
+     *
+     * Returns TRUE if settings were applied.
+     *
+     * \since QGIS 3.42
+     */
+    bool applyDefaultSettings( QgsScaleBarSettings &settings ) const override;
 };
 
 #endif // QGSDOUBLEBOXSCALEBARRENDERER_H

--- a/src/core/scalebar/qgsdoubleboxscalebarrenderer.h
+++ b/src/core/scalebar/qgsdoubleboxscalebarrenderer.h
@@ -42,13 +42,6 @@ class CORE_EXPORT QgsDoubleBoxScaleBarRenderer: public QgsScaleBarRenderer
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const override;
 
-    /**
-     * Applies any default settings relating to the scalebar to the passed \a settings object.
-     *
-     * Returns TRUE if settings were applied.
-     *
-     * \since QGIS 3.42
-     */
     bool applyDefaultSettings( QgsScaleBarSettings &settings ) const override;
 };
 

--- a/src/core/scalebar/qgshollowscalebarrenderer.cpp
+++ b/src/core/scalebar/qgshollowscalebarrenderer.cpp
@@ -193,6 +193,3 @@ bool QgsHollowScaleBarRenderer::applyDefaultSettings( QgsScaleBarSettings &setti
 
   return true;
 }
-
-
-

--- a/src/core/scalebar/qgshollowscalebarrenderer.h
+++ b/src/core/scalebar/qgshollowscalebarrenderer.h
@@ -44,7 +44,6 @@ class CORE_EXPORT QgsHollowScaleBarRenderer: public QgsScaleBarRenderer
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const override;
     bool applyDefaultSettings( QgsScaleBarSettings &settings ) const override;
-
 };
 
 #endif // QGSHOLLOWSCALEBARRENDERER_H

--- a/src/core/scalebar/qgssingleboxscalebarrenderer.cpp
+++ b/src/core/scalebar/qgssingleboxscalebarrenderer.cpp
@@ -160,21 +160,26 @@ void QgsSingleBoxScaleBarRenderer::draw( QgsRenderContext &context, const QgsSca
 
 bool QgsSingleBoxScaleBarRenderer::applyDefaultSettings( QgsScaleBarSettings &settings ) const
 {
-  // restore the fill symbols by default
-  std::unique_ptr< QgsFillSymbol > fillSymbol = std::make_unique< QgsFillSymbol >();
-  std::unique_ptr< QgsSimpleFillSymbolLayer > fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
-  fillSymbolLayer->setColor( QColor( 0, 0, 0 ) );
-  fillSymbolLayer->setBrushStyle( Qt::SolidPattern );
-  fillSymbolLayer->setStrokeStyle( Qt::SolidLine );
-  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
-  settings.setFillSymbol( fillSymbol.release() );
+  QgsSimpleFillSymbolLayer *fill = qgis::down_cast< QgsSimpleFillSymbolLayer * >( settings.fillSymbol()->symbolLayers().at( 0 ) );
 
-  fillSymbol = std::make_unique< QgsFillSymbol >();
-  fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
-  fillSymbolLayer->setColor( QColor( 255, 255, 255 ) );
-  fillSymbolLayer->setStrokeStyle( Qt::NoPen );
-  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
-  settings.setAlternateFillSymbol( fillSymbol.release() );
+  // restore the fill symbols by default
+  if ( fill && fill->brushStyle() == Qt::NoBrush )
+  {
+    std::unique_ptr< QgsFillSymbol > fillSymbol = std::make_unique< QgsFillSymbol >();
+    std::unique_ptr< QgsSimpleFillSymbolLayer > fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+    fillSymbolLayer->setColor( QColor( 0, 0, 0 ) );
+    fillSymbolLayer->setBrushStyle( Qt::SolidPattern );
+    fillSymbolLayer->setStrokeStyle( Qt::SolidLine );
+    fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+    settings.setFillSymbol( fillSymbol.release() );
+
+    fillSymbol = std::make_unique< QgsFillSymbol >();
+    fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+    fillSymbolLayer->setColor( QColor( 255, 255, 255 ) );
+    fillSymbolLayer->setStrokeStyle( Qt::NoPen );
+    fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+    settings.setAlternateFillSymbol( fillSymbol.release() );
+  }
 
   return true;
 }

--- a/src/core/scalebar/qgssingleboxscalebarrenderer.cpp
+++ b/src/core/scalebar/qgssingleboxscalebarrenderer.cpp
@@ -160,7 +160,7 @@ void QgsSingleBoxScaleBarRenderer::draw( QgsRenderContext &context, const QgsSca
 
 bool QgsSingleBoxScaleBarRenderer::applyDefaultSettings( QgsScaleBarSettings &settings ) const
 {
-  QgsSimpleFillSymbolLayer *fill = qgis::down_cast< QgsSimpleFillSymbolLayer * >( settings.fillSymbol()->symbolLayers().at( 0 ) );
+  QgsSimpleFillSymbolLayer *fill = dynamic_cast< QgsSimpleFillSymbolLayer * >( settings.fillSymbol()->symbolLayers().at( 0 ) );
 
   // restore the fill symbols by default
   if ( fill && fill->brushStyle() == Qt::NoBrush )

--- a/src/core/scalebar/qgssingleboxscalebarrenderer.cpp
+++ b/src/core/scalebar/qgssingleboxscalebarrenderer.cpp
@@ -20,6 +20,7 @@
 #include "qgstextrenderer.h"
 #include "qgslinesymbol.h"
 #include "qgsfillsymbol.h"
+#include "qgsfillsymbollayer.h"
 #include <QList>
 #include <QPainter>
 
@@ -157,5 +158,23 @@ void QgsSingleBoxScaleBarRenderer::draw( QgsRenderContext &context, const QgsSca
   drawDefaultLabels( context, settings, scaleContext );
 }
 
+bool QgsSingleBoxScaleBarRenderer::applyDefaultSettings( QgsScaleBarSettings &settings ) const
+{
+  // restore the fill symbols by default
+  std::unique_ptr< QgsFillSymbol > fillSymbol = std::make_unique< QgsFillSymbol >();
+  std::unique_ptr< QgsSimpleFillSymbolLayer > fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+  fillSymbolLayer->setColor( QColor( 0, 0, 0 ) );
+  fillSymbolLayer->setBrushStyle( Qt::SolidPattern );
+  fillSymbolLayer->setStrokeStyle( Qt::SolidLine );
+  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+  settings.setFillSymbol( fillSymbol.release() );
 
+  fillSymbol = std::make_unique< QgsFillSymbol >();
+  fillSymbolLayer = std::make_unique< QgsSimpleFillSymbolLayer >();
+  fillSymbolLayer->setColor( QColor( 255, 255, 255 ) );
+  fillSymbolLayer->setStrokeStyle( Qt::NoPen );
+  fillSymbol->changeSymbolLayer( 0, fillSymbolLayer.release() );
+  settings.setAlternateFillSymbol( fillSymbol.release() );
 
+  return true;
+}

--- a/src/core/scalebar/qgssingleboxscalebarrenderer.h
+++ b/src/core/scalebar/qgssingleboxscalebarrenderer.h
@@ -43,13 +43,6 @@ class CORE_EXPORT QgsSingleBoxScaleBarRenderer: public QgsScaleBarRenderer
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const override;
 
-    /**
-     * Applies any default settings relating to the scalebar to the passed \a settings object.
-     *
-     * Returns TRUE if settings were applied.
-     *
-     * \since QGIS 3.42
-     */
     bool applyDefaultSettings( QgsScaleBarSettings &settings ) const override;
 };
 

--- a/src/core/scalebar/qgssingleboxscalebarrenderer.h
+++ b/src/core/scalebar/qgssingleboxscalebarrenderer.h
@@ -43,6 +43,14 @@ class CORE_EXPORT QgsSingleBoxScaleBarRenderer: public QgsScaleBarRenderer
                const QgsScaleBarSettings &settings,
                const QgsScaleBarRenderer::ScaleBarContext &scaleContext ) const override;
 
+    /**
+     * Applies any default settings relating to the scalebar to the passed \a settings object.
+     *
+     * Returns TRUE if settings were applied.
+     *
+     * \since QGIS 3.42
+     */
+    bool applyDefaultSettings( QgsScaleBarSettings &settings ) const override;
 };
 
 #endif // QGSSINGLEBOXSCALEBARRENDERER_H


### PR DESCRIPTION
## Description

When a Hollow style of scalebar is selected, scalebar settings are updated and brush style is set to `Qt::NoBrush` and stroke is set to `Qt::NoPen`. When switching back to Single or Double box style of scalebar brush and pen are not restored as these two renderers do not override `applyDefaultSettings()` method.

Fixes #37413.
