### PR TITLE
qgsvectorlayer: Properly invalidate extent cache on feature addition or deletion

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -3817,14 +3817,7 @@ bool QgsVectorLayer::deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteCont
   if ( !mEditBuffer )
     return false;
 
-  bool res = deleteFeatureCascade( fid, context );
-
-  if ( res )
-  {
-    updateExtents();
-  }
-
-  return res;
+  return deleteFeatureCascade( fid, context );
 }
 
 bool QgsVectorLayer::deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context )
@@ -5975,6 +5968,8 @@ void QgsVectorLayer::onFeatureAdded( QgsFeatureId fid )
 void QgsVectorLayer::onFeatureDeleted( QgsFeatureId fid )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  updateExtents();
 
   if ( mEditCommandActive  || mCommitChangesActive )
   {

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2797,6 +2797,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onFeatureCounterCompleted();
     void onFeatureCounterTerminated();
     void onJoinedFieldsChanged();
+    void onFeatureAdded( QgsFeatureId fid );
     void onFeatureDeleted( QgsFeatureId fid );
     void onRelationsLoaded();
     void onSymbolsCounted();

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -76,6 +76,7 @@ class TestQgsVectorLayer : public QgsTest
     void testCopyPasteFieldConfiguration_data();
     void testFieldExpression();
     void testFieldAggregateExpression();
+    void testAddFeatureExtentUpdated();
 };
 
 void TestQgsVectorLayer::initTestCase()
@@ -493,6 +494,33 @@ void TestQgsVectorLayer::testFieldAggregateExpression()
   QVERIFY( feature2.isValid() );
   QCOMPARE( feature2.attribute( 0 ).toInt(), 2 );
   QVERIFY( qgsDoubleNear( feature2.attribute( vfIndex ).toDouble(), 359065580.0, 1 ) );
+}
+
+void TestQgsVectorLayer::testAddFeatureExtentUpdated()
+{
+  QgsVectorLayer *layerLine = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:27700" ), QStringLiteral( "layer line" ), QStringLiteral( "memory" ) );
+  QVERIFY( layerLine->isValid() );
+  QCOMPARE( layerLine->featureCount(), static_cast<long>( 0 ) );
+  QCOMPARE( layerLine->extent(), QgsRectangle() );
+
+  const QSignalSpy spyAdded( layerLine, &QgsVectorLayer::featureAdded );
+
+  QgsFeature lineF1;
+  lineF1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "LineString (2 1, 1 1, 1 5, 7 12)" ) ) );
+
+  connect( layerLine, &QgsVectorLayer::featureAdded, this, [&layerLine, &lineF1]( const QgsFeatureId &fid ) {
+    QCOMPARE( fid, lineF1.id() );
+    QCOMPARE( layerLine->extent(), QgsRectangle( 1, 1, 7, 12 ) );
+    QCOMPARE( layerLine->extent3D(), QgsBox3D( 1, 1, std::numeric_limits<double>::quiet_NaN(), 7, 12, std::numeric_limits<double>::quiet_NaN() ) );
+  } );
+
+  layerLine->startEditing();
+  layerLine->addFeature( lineF1 );
+  QCOMPARE( spyAdded.count(), 1 );
+  QCOMPARE( layerLine->featureCount(), static_cast<long>( 1 ) );
+  QCOMPARE( spyAdded.at( 0 ).at( 0 ), QVariant( lineF1.id() ) );
+
+  delete layerLine;
 }
 
 

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -701,6 +701,7 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
 
         def checkAfter():
             self.assertEqual(layer.featureCount(), 1)
+            self.assertEqual(layer.extent(), QgsRectangle(1, 2, 1, 2))
 
             # check select+nextFeature
             f = next(layer.getFeatures())
@@ -712,6 +713,7 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
 
         def checkBefore():
             self.assertEqual(layer.featureCount(), 0)
+            self.assertEqual(layer.extent(), QgsRectangle())
 
             # check select+nextFeature
             with self.assertRaises(StopIteration):
@@ -721,10 +723,15 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
 
         spy = QSignalSpy(layer.layerModified)
         repaint_spy = QSignalSpy(layer.repaintRequested)
+        feature_added_spy = QSignalSpy(layer.featureAdded)
+        feature_deleted_spy = QSignalSpy(layer.featureDeleted)
 
         # try to add feature without editing mode
         self.assertFalse(layer.addFeature(feat))
         self.assertEqual(len(repaint_spy), 0)
+        self.assertEqual(len(feature_added_spy), 0)
+        self.assertEqual(len(feature_deleted_spy), 0)
+        self.assertEqual(layer.extent(), QgsRectangle())
 
         # add feature
         layer.startEditing()
@@ -733,6 +740,9 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
         bad_feature = QgsFeature()
         self.assertFalse(layer.addFeature(bad_feature))
         self.assertEqual(len(repaint_spy), 0)
+        self.assertEqual(len(feature_added_spy), 0)
+        self.assertEqual(len(feature_deleted_spy), 0)
+        self.assertEqual(layer.extent(), QgsRectangle())
 
         self.assertEqual(len(spy), 0)
 
@@ -741,12 +751,16 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
 
         self.assertEqual(len(spy), 1)
         self.assertEqual(len(repaint_spy), 1)
+        self.assertEqual(len(feature_added_spy), 1)
+        self.assertEqual(len(feature_deleted_spy), 0)
 
         checkAfter()
         self.assertEqual(layer.dataProvider().featureCount(), 0)
 
         # now try undo/redo
         layer.undoStack().undo()
+        self.assertEqual(len(feature_added_spy), 1)
+        self.assertEqual(len(feature_deleted_spy), 1)
         checkBefore()
         self.assertEqual(len(spy), 2)
         self.assertEqual(len(repaint_spy), 2)
@@ -756,6 +770,8 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
 
         self.assertEqual(len(spy), 3)
         self.assertEqual(len(repaint_spy), 3)
+        self.assertEqual(len(feature_added_spy), 2)
+        self.assertEqual(len(feature_deleted_spy), 1)
 
         self.assertTrue(layer.commitChanges())
 


### PR DESCRIPTION
## Description

When a new feature is added to a `QgsVectorLayer`
`QgsVectorLayer::addFeature` is called. This function makes mostly 2 things in case of a successful operation:
1. it calls `QgsVectorLayerEditBuffer::addFeature` which itself will emit the `QgsVectorLayerEditBuffer::featureAdded` signal. Finally, `QgsVectorLayer` listend to this signal to directly emit the `QgsVectorLayer::featureAdded` signal
2. Call `QgsVectorLayer::updateExtents()` to invalidate the cache of the extent

In practice, this means that the `QgsVectorLayer::featureAdded` signal may be emitted before the cache of the extent is invalidated. This can cause some issues.

For example, in the elevation profile tool,
`QgsElevationProfileCanvas` listens to the
`QgsVectorLayer::featureAdded` signal in order to regenerate the profile of a vector layer when a feature is added. This causes the creation of a new `QgsVectorLayerProfileGenerator` which needs to copy the extent of the vector layer. However,
`QgsVectorLayer::updateExtents()` has not been called yet. Thus, it will use an outdated version of the extent.

This issue is solved by calling `updateExtents()` before emitting the `featureAdded` signal.


cc @Djedouas 
