### PR TITLE
fix(OpenCL): Fix unused variable 'useOpenCL'

### DIFF
--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -573,9 +573,9 @@ void TestQgsRasterCalculator::calcWithDataType_data()
 void TestQgsRasterCalculator::calcWithDataType()
 {
   QFETCH( int, dataType );
-  QFETCH( bool, useOpenCL );
 
 #ifdef HAVE_OPENCL
+  QFETCH( bool, useOpenCL );
   if ( QgsOpenClUtils::available() && useOpenCL )
     QgsOpenClUtils::setEnabled( useOpenCL );
   else


### PR DESCRIPTION
## Description

Move `QFETCH( bool, useOpenCL );` inside the `ifdef ` to avoid a warning.
