### PR TITLE
Add a CMAKE option to completely disable Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # don't relink it only the shared object changes
 set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
 
-option (WITH_PYTHON "Determines whether Python should be built" ON)
+option (WITH_PYTHON "Determines whether Python support should be built (disabling it will in particular disable processing)" ON)
 if(NOT WITH_PYTHON)
     set(WITH_BINDINGS OFF CACHE BOOL "Determines whether Python bindings should be built")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,8 @@ endif()
 set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
 
 option (WITH_PYTHON "Determines whether Python support should be built (disabling it will in particular disable processing)" ON)
-if(NOT WITH_PYTHON)
-    set(WITH_BINDINGS OFF CACHE BOOL "Determines whether Python bindings should be built")
-else()
-  set(WITH_BINDINGS ON CACHE BOOL "Determines whether Python bindings should be built")
-endif()
+set(WITH_BINDINGS ${WITH_PYTHON} CACHE BOOL "Determines whether Python bindings should be built")
+
 set (WITH_3D TRUE CACHE BOOL "Determines whether QGIS 3D library should be built")
 set (WITH_QGIS_PROCESS TRUE CACHE BOOL "Determines whether the standalone \"qgis_process\" tool should be built")
 set (WITH_DESKTOP TRUE CACHE BOOL "Determines whether QGIS desktop should be built")
@@ -321,14 +318,11 @@ if(WITH_CORE)
   if ( WITH_DESKTOP )
     # The qgis_desktop target is meant to build a minimal but complete running QGIS during development
     # This should help to reduce compile time while still having a "complete enough" QGIS for most of the development
+    add_custom_target(qgis_desktop
+      DEPENDS qgis provider_postgres staged-plugins resources svg doc icons
+    )
     if ( WITH_PYTHON )
-      add_custom_target(qgis_desktop
-        DEPENDS qgis qgispython pycore pygui pyanalysis provider_postgres staged-plugins pyplugin-installer resources svg doc icons
-      )
-    else()
-      add_custom_target(qgis_desktop
-        DEPENDS qgis provider_postgres staged-plugins resources svg doc icons
-      )
+      add_dependencies(qgis_desktop qgispython pycore pygui pyanalysis staged-plugins pyplugin-installer )
     endif()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,12 @@ endif()
 # don't relink it only the shared object changes
 set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
 
-set (WITH_BINDINGS TRUE CACHE BOOL "Determines whether Python bindings should be built")
+option (WITH_PYTHON "Determines whether Python should be built" ON)
+if(NOT WITH_PYTHON)
+    set(WITH_BINDINGS OFF CACHE BOOL "Determines whether Python bindings should be built")
+else()
+  set(WITH_BINDINGS ON CACHE BOOL "Determines whether Python bindings should be built")
+endif()
 set (WITH_3D TRUE CACHE BOOL "Determines whether QGIS 3D library should be built")
 set (WITH_QGIS_PROCESS TRUE CACHE BOOL "Determines whether the standalone \"qgis_process\" tool should be built")
 set (WITH_DESKTOP TRUE CACHE BOOL "Determines whether QGIS desktop should be built")
@@ -316,9 +321,15 @@ if(WITH_CORE)
   if ( WITH_DESKTOP )
     # The qgis_desktop target is meant to build a minimal but complete running QGIS during development
     # This should help to reduce compile time while still having a "complete enough" QGIS for most of the development
-    add_custom_target(qgis_desktop
-      DEPENDS qgis qgispython pycore pygui pyanalysis provider_postgres staged-plugins pyplugin-installer resources svg doc icons
-    )
+    if ( WITH_PYTHON )
+      add_custom_target(qgis_desktop
+        DEPENDS qgis qgispython pycore pygui pyanalysis provider_postgres staged-plugins pyplugin-installer resources svg doc icons
+      )
+    else()
+      add_custom_target(qgis_desktop
+        DEPENDS qgis provider_postgres staged-plugins resources svg doc icons
+      )
+    endif()
   endif()
 
   # try to configure and build MDAL support
@@ -1180,7 +1191,6 @@ if (WITH_CORE AND WITH_BINDINGS)
     set(PYUIC_WIDGET_PLUGIN_DIRECTORY ${PYQT_MOD_DIR}/uic/widget-plugins/)
   endif()
 endif()
-
 
 #############################################################
 # create qgsconfig.h

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -361,7 +361,7 @@ QGIS build is tunable according to your needs. Many flags are available to activ
 * `WITH_ORACLE`: Determines whether Oracle support should be built
 * `WITH_PDAL`: Determines whether PDAL support should be built
 * `WITH_POSTGRESQL`: Determines whether POSTGRESQL support should be built
-* `WITH_PYTHON`: Determines whether Python should be built
+* `WITH_PYTHON`: Determines whether Python support should be built (disabling it will in particular disable processing)
 * `WITH_QGIS_PROCESS`: Determines whether the standalone \"qgis_process\" tool should be built
 * `WITH_QSPATIALITE`: Determines whether QSPATIALITE sql driver should be built
 * `WITH_SERVER`: Determines whether QGIS server should be built

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -361,6 +361,7 @@ QGIS build is tunable according to your needs. Many flags are available to activ
 * `WITH_ORACLE`: Determines whether Oracle support should be built
 * `WITH_PDAL`: Determines whether PDAL support should be built
 * `WITH_POSTGRESQL`: Determines whether POSTGRESQL support should be built
+* `WITH_PYTHON`: Determines whether Python should be built
 * `WITH_QGIS_PROCESS`: Determines whether the standalone \"qgis_process\" tool should be built
 * `WITH_QSPATIALITE`: Determines whether QSPATIALITE sql driver should be built
 * `WITH_SERVER`: Determines whether QGIS server should be built

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -567,11 +567,16 @@ target_include_directories(qgis_app PUBLIC
   ${CMAKE_SOURCE_DIR}/src/app/tiledscene
   ${CMAKE_SOURCE_DIR}/src/app/vectortile
   ${CMAKE_SOURCE_DIR}/src/plugins
-  ${CMAKE_SOURCE_DIR}/src/python
   ${CMAKE_SOURCE_DIR}/src/native
 
   ${CMAKE_BINARY_DIR}/src/app
 )
+
+if (WITH_PYTHON)
+  target_include_directories(qgis_app PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/python
+  )
+endif()
 
 if (WITH_3D)
   target_include_directories(qgis_app PUBLIC


### PR DESCRIPTION
## Description

I'm opening this PR to discuss whether we should introduce an additional layer of restriction when disabling Python in QGIS. Is the `WITH_BINDINGS` flag sufficient to completely disable Python or should be enforced?

While `WITH_BINDINGS` disables PyQGIS support, if the goal is to entirely remove Python—especially for security reasons—is that enough? For example, I'm thinking about the `pyplugin-installer`, which is used with `QGIS_DESTKTOP`. Moreover, the CMakeLists file adds dependencies for `pycore`, `pygui`, and `pyanalysis`, yet I can't seem to locate them.

Is it necessary to include the `src/python` directory when `WITH_BINDINGS` is set to false?

Any thoughts?