### PR TITLE
Check conformance classes to avoid duplicate collection/item entries

### DIFF
--- a/src/core/stac/qgsstaccatalog.cpp
+++ b/src/core/stac/qgsstaccatalog.cpp
@@ -33,7 +33,7 @@ QString QgsStacCatalog::toHtml() const
 {
   QString html = QStringLiteral( "<html><head></head>\n<body>\n" );
 
-  html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Catalog") );
+  html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Catalog" ) );
   html += QLatin1String( "<table class=\"list-view\">\n" );
   html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "id" ), id() );
   html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "stac_version" ), stacVersion() );
@@ -43,7 +43,7 @@ QString QgsStacCatalog::toHtml() const
 
   if ( !mStacExtensions.isEmpty() )
   {
-    html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Extensions") );
+    html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Extensions" ) );
     html += QLatin1String( "<ul>\n" );
     for ( const QString &extension : mStacExtensions )
     {
@@ -54,7 +54,7 @@ QString QgsStacCatalog::toHtml() const
 
   if ( ! mConformanceClasses.isEmpty() )
   {
-    html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Conformance Classes") );
+    html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Conformance Classes" ) );
     html += QLatin1String( "<ul>\n" );
     for ( const QString &cc : mConformanceClasses )
     {
@@ -63,7 +63,7 @@ QString QgsStacCatalog::toHtml() const
     html += QLatin1String( "</ul>\n" );
   }
 
-  html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Links") );
+  html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Links" ) );
   for ( const QgsStacLink &link : mLinks )
   {
     html += QLatin1String( "<table class=\"list-view\">\n" );
@@ -111,9 +111,4 @@ void QgsStacCatalog::setConformanceClasses( const QStringList &conformanceClasse
 void QgsStacCatalog::addConformanceClass( const QString &conformanceClass )
 {
   mConformanceClasses.insert( conformanceClass );
-}
-
-bool QgsStacCatalog::supportsStacApi() const
-{
-  return conformsTo( QStringLiteral( "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30" ) );
 }

--- a/src/core/stac/qgsstaccatalog.h
+++ b/src/core/stac/qgsstaccatalog.h
@@ -80,9 +80,6 @@ class CORE_EXPORT QgsStacCatalog : public QgsStacObject
     //! Checks if the catalog is a STAC API conforming to the specified \a conformanceClass
     bool conformsTo( const QString &conformanceClass ) const;
 
-    //! Checks if the catalog is a STAC API endpoint
-    bool supportsStacApi() const;
-
   protected:
     QString mTitle;
     QString mDescription;

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -314,8 +314,6 @@ void QgsStacCatalogItem::onControllerFinished( int requestId, const QString &err
 
 QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
 {
-  QgsStacCatalog *root = rootCatalog();
-  const bool supportsApi = root ? root->supportsStacApi() : false;
 
   QgsStacController *controller = stacController();
   QString error;
@@ -326,27 +324,33 @@ QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
   if ( !mStacCatalog )
     return { new QgsErrorItem( this, error, path() + QStringLiteral( "/error" ) ) };
 
+  QgsStacCatalog *root = rootCatalog();
+
+  const bool supportsCollections = root && root->conformsTo( QStringLiteral( "https://api.stacspec.org/v1.0.0/collections" ) );
+  const bool supportsItems = root && root->conformsTo( QStringLiteral( "https://api.stacspec.org/v1.0.0/ogcapi-features" ) );
+
   int itemsCount = 0;
   QVector<QgsDataItem *> contents;
   const QVector< QgsStacLink > links = mStacCatalog->links();
 
   // treat catalog/collection as static if it does not have a /items endpoint
-  bool hasItemsEndpoint = false;
-  bool hasCollectionsEndpoint = false;
-  if ( supportsApi )
+  bool useItemsEndpoint = false;
+  bool useCollectionsEndpoint = false;
+  if ( supportsCollections || supportsItems )
   {
     for ( const auto &link : links )
     {
       if ( link.relation() == QLatin1String( "items" ) )
       {
-        hasItemsEndpoint = true;
+        useItemsEndpoint = true;
       }
       else if ( link.relation() == QLatin1String( "data" ) &&
                 link.href().endsWith( QLatin1String( "/collections" ) ) )
       {
-        hasCollectionsEndpoint = true;
+        useCollectionsEndpoint = true;
       }
-      if ( hasItemsEndpoint && hasCollectionsEndpoint )
+      // if we found what we need we can stop looking
+      if ( supportsItems == useItemsEndpoint && supportsCollections == useCollectionsEndpoint )
         break;
     }
   }
@@ -361,7 +365,7 @@ QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
       continue;
 
     if ( link.relation() == QLatin1String( "child" ) &&
-         !hasCollectionsEndpoint )
+         !useCollectionsEndpoint )
     {
       // may be either catalog or collection
       QgsStacCatalogItem *c = new QgsStacCatalogItem( this, link.title(), link.href() );
@@ -385,7 +389,7 @@ QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
       }
     }
     else if ( link.relation() == QLatin1String( "item" ) &&
-              !hasItemsEndpoint )
+              !useItemsEndpoint )
     {
       itemsCount++;
 
@@ -395,7 +399,8 @@ QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
       QgsStacItemItem *i = new QgsStacItemItem( this, link.title(), link.href() );
       contents.append( i );
     }
-    else if ( link.relation() == QLatin1String( "items" ) )
+    else if ( link.relation() == QLatin1String( "items" ) &&
+              useItemsEndpoint )
     {
       // stac api items (ogcapi features)
       QString error;

--- a/src/gui/stac/qgsstacsourceselect.cpp
+++ b/src/gui/stac/qgsstacsourceselect.cpp
@@ -284,16 +284,25 @@ void QgsStacSourceSelect::onStacObjectRequestFinished( int requestId, QString er
     mStatusLabel->setText( error );
     return;
   }
-  QgsDebugMsgLevel( QStringLiteral( "STAC catalog supports API: %1" ).arg( cat->supportsStacApi() ), 2 );
 
-  for ( auto &l : cat->links() )
+  const bool supportsCollections = cat->conformsTo( QStringLiteral( "https://api.stacspec.org/v1.0.0/collections" ) );
+  const bool supportsSearch = cat->conformsTo( QStringLiteral( "https://api.stacspec.org/v1.0.0/item-search" ) );
+  QgsDebugMsgLevel( QStringLiteral( "STAC catalog supports API: %1" ).arg( supportsCollections && supportsSearch ), 2 );
+
+  if ( supportsCollections && supportsSearch )
   {
-    // collections endpoint should have a "data" relation according to spec but some servers don't
-    // so let's be less strict and only check the href
-    if ( l.href().endsWith( "/collections" ) )
-      mCollectionsUrl = l.href();
-    else if ( l.relation() == "search" )
-      mSearchUrl = l.href();
+    for ( auto &l : cat->links() )
+    {
+      // collections endpoint should have a "data" relation according to spec but some servers don't
+      // so let's be less strict and only check the href
+      if ( l.href().endsWith( "/collections" ) )
+        mCollectionsUrl = l.href();
+      else if ( l.relation() == "search" )
+        mSearchUrl = l.href();
+
+      if ( !mCollectionsUrl.isEmpty() && !mSearchUrl.isEmpty() )
+        break;
+    }
   }
 
   if ( mCollectionsUrl.isEmpty() || mSearchUrl.isEmpty() )


### PR DESCRIPTION
## Description
Removed the `QgsStacCatalog::supportsStacApi()` method as different conformance classes need to be checked for different cases.

Now `/items` endpoint is used when catalog conforms to `https://api.stacspec.org/v1.0.0/ogcapi-features` and `/collections` is used when it conforms to `https://api.stacspec.org/v1.0.0/collections`.

Also for the data source manager search functionality conformance classes `https://api.stacspec.org/v1.0.0/collections` and `https://api.stacspec.org/v1.0.0/item-search` are checked.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
