### PR TITLE
Silence deprecation warnings for QgsMaskPaintEngine

### DIFF
--- a/src/core/painting/qgsmaskpaintdevice.h
+++ b/src/core/painting/qgsmaskpaintdevice.h
@@ -31,7 +31,7 @@ class QgsMaskPaintEngine: public QPaintEngine
 
   public:
 
-    Q_DECL_DEPRECATED QgsMaskPaintEngine( bool usePathStroker = false );
+    QgsMaskPaintEngine( bool usePathStroker = false );
 
     bool begin( QPaintDevice * ) override { return true; };
     bool end() override { return true; };


### PR DESCRIPTION
We can't silence the constructor deprecation warning when used with make_unique, so just remove the constructor deprecated flag.

This is a private class, not exposed to Python, and only used from within QGIS by a class which is itself completely deprecated (and marked accordingly).

Alternative to https://github.com/qgis/QGIS/pull/60428 which doesn't complicate cmake files