### PR TITLE
More descriptive expression parsing errors when a function is not found

### DIFF
--- a/tests/testdata/qgis_server/wfs_getFeature_1_0_0_EXP_FILTER_invalid_expression_1_0_0.txt
+++ b/tests/testdata/qgis_server/wfs_getFeature_1_0_0_EXP_FILTER_invalid_expression_1_0_0.txt
@@ -4,5 +4,5 @@ Content-Type: text/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <ServiceExceptionReport xmlns="http://www.opengis.net/ogc" version="1.2.0">
  <ServiceException code="RequestNotWellFormed">The EXP_FILTER expression has errors: 
-Function is not known</ServiceException>
+Function invalid_expression is not known</ServiceException>
 </ServiceExceptionReport>


### PR DESCRIPTION
Include the name of the missing function in the error, so that it's easier to debug.

Also fix a leak when a function is missing
