### PR TITLE
Fix pasting unsaved changes as temporary scratch layers

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2256,13 +2256,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Sets project properties, including map untis
     void projectProperties( const QString &currentPage = QString() );
 
-    /**
-     * Paste features from clipboard into a new memory layer.
-     * If no features are in clipboard an empty layer is returned.
-     * Returns a new memory layer or NULLPTR if the operation failed.
-     */
-    std::unique_ptr<QgsVectorLayer> pasteToNewMemoryVector();
-
     //! Returns all annotation items in the canvas
     QList<QgsMapCanvasAnnotationItem *> annotationItems();
 

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -43,6 +43,8 @@
 #include "qgsapplication.h"
 #include "qgsvectortilelayer.h"
 #include "qgsvectorlayerutils.h"
+#include "qgsmemoryproviderutils.h"
+#include "qgsmessagebar.h"
 
 #include <nlohmann/json.hpp>
 
@@ -563,6 +565,117 @@ QgsMapLayer *QgsClipboard::layer() const
     return mFeatureLayer.data();
   else
     return nullptr;
+}
+
+std::unique_ptr<QgsVectorLayer> QgsClipboard::pasteToNewMemoryVector( QgsMessageBar *messageBar )
+{
+  const QgsFields fields = QgsClipboard::fields();
+
+  // Decide geometry type from features, switch to multi type if at least one multi is found
+  QMap<Qgis::WkbType, int> typeCounts;
+  const QgsFeatureList features = copyOf( fields );
+  for ( const QgsFeature &feature : features )
+  {
+    if ( !feature.hasGeometry() )
+      continue;
+
+    const Qgis::WkbType type = feature.geometry().wkbType();
+
+    if ( type == Qgis::WkbType::Unknown || type == Qgis::WkbType::NoGeometry )
+      continue;
+
+    if ( QgsWkbTypes::isSingleType( type ) )
+    {
+      if ( typeCounts.contains( QgsWkbTypes::multiType( type ) ) )
+      {
+        typeCounts[QgsWkbTypes::multiType( type )] = typeCounts[QgsWkbTypes::multiType( type )] + 1;
+      }
+      else
+      {
+        typeCounts[type] = typeCounts[type] + 1;
+      }
+    }
+    else if ( QgsWkbTypes::isMultiType( type ) )
+    {
+      if ( typeCounts.contains( QgsWkbTypes::singleType( type ) ) )
+      {
+        // switch to multi type
+        typeCounts[type] = typeCounts[QgsWkbTypes::singleType( type )];
+        typeCounts.remove( QgsWkbTypes::singleType( type ) );
+      }
+      typeCounts[type] = typeCounts[type] + 1;
+    }
+  }
+
+  const Qgis::WkbType wkbType = !typeCounts.isEmpty() ? typeCounts.constBegin().key() : Qgis::WkbType::NoGeometry;
+
+  if ( features.isEmpty() )
+  {
+    // should not happen
+    if ( messageBar )
+      messageBar->pushMessage( tr( "Paste features" ), tr( "No features in clipboard." ), Qgis::MessageLevel::Info );
+    return nullptr;
+  }
+  else if ( typeCounts.size() > 1 )
+  {
+    QString typeName = wkbType != Qgis::WkbType::NoGeometry ? QgsWkbTypes::displayString( wkbType ) : QStringLiteral( "none" );
+    if ( messageBar )
+      messageBar->pushMessage( tr( "Paste features" ), tr( "Multiple geometry types found, features with geometry different from %1 will be created without geometry." ).arg( typeName ), Qgis::MessageLevel::Info );
+  }
+
+  std::unique_ptr<QgsVectorLayer> layer( QgsMemoryProviderUtils::createMemoryLayer( QStringLiteral( "pasted_features" ), QgsFields(), wkbType, crs() ) );
+
+  if ( !layer->isValid() || !layer->dataProvider() )
+  {
+    if ( messageBar )
+      messageBar->pushMessage( tr( "Paste features" ), tr( "Cannot create new layer." ), Qgis::MessageLevel::Warning );
+    return nullptr;
+  }
+
+  layer->startEditing();
+  for ( const QgsField &f : QgsClipboard::fields() )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "field %1 (%2)" ).arg( f.name(), QVariant::typeToName( f.type() ) ), 2 );
+    if ( !layer->addAttribute( f ) )
+    {
+      if ( messageBar )
+        messageBar->pushMessage( tr( "Paste features" ), tr( "Cannot create field %1 (%2,%3), falling back to string type" ).arg( f.name(), f.typeName(), QVariant::typeToName( f.type() ) ), Qgis::MessageLevel::Warning );
+
+      // Fallback to string
+      QgsField strField { f };
+      strField.setType( QMetaType::Type::QString );
+      if ( !layer->addAttribute( strField ) )
+      {
+        if ( messageBar )
+          messageBar->pushMessage( tr( "Paste features" ), tr( "Cannot create field %1 (%2,%3)" ).arg( strField.name(), strField.typeName(), QVariant::typeToName( strField.type() ) ), Qgis::MessageLevel::Critical );
+        return nullptr;
+      }
+    }
+  }
+
+  QgsFeatureList convertedFeatures { QgsVectorLayerUtils::makeFeaturesCompatible( features, layer.get() ) };
+
+  // Convert attributes
+  for ( auto it = convertedFeatures.begin(); it != convertedFeatures.end(); ++it )
+  {
+    for ( int idx = 0; idx < layer->fields().count() && idx < it->attributeCount(); ++idx )
+    {
+      QVariant attr = it->attribute( idx );
+      //if convertCompatible fails, it will replace attr with an appropriate null QVariant
+      //so we're calling setAttribute regardless, covering cases like 'Autogenerate' or 'nextVal()' on int fields.
+      layer->fields().at( idx ).convertCompatible( attr );
+      it->setAttribute( idx, attr );
+    }
+  }
+
+  if ( !layer->addFeatures( convertedFeatures ) || !layer->commitChanges() )
+  {
+    QgsDebugError( QStringLiteral( "Cannot add features or commit changes" ) );
+    return nullptr;
+  }
+
+  QgsDebugMsgLevel( QStringLiteral( "%1 features pasted to temporary scratch layer" ).arg( layer->featureCount() ), 2 );
+  return layer;
 }
 
 void QgsClipboard::systemClipboardChanged()

--- a/src/app/qgsclipboard.h
+++ b/src/app/qgsclipboard.h
@@ -32,6 +32,7 @@
 class QgsVectorLayer;
 class QgsVectorTileLayer;
 class QgsFeatureStore;
+class QgsMessageBar;
 
 /**
  * \brief QGIS internal clipboard for features.
@@ -142,6 +143,15 @@ class APP_EXPORT QgsClipboard : public QObject
     QgsFields fields() const;
 
     QgsMapLayer *layer() const;
+
+    /**
+     * Pastes clipboard features to a new memory layer.
+     *
+     * If no features are in clipboard an empty layer is returned.
+     *
+     * Returns a new memory layer or NULLPTR if the operation failed.
+     */
+    std::unique_ptr<QgsVectorLayer> pasteToNewMemoryVector( QgsMessageBar *messageBar );
 
   private slots:
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -576,7 +576,7 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
         QString providerDefault = layer->dataProvider()->defaultValueClause( providerIndex );
         if ( !providerDefault.isEmpty() )
         {
-          v = providerDefault;
+          v = QgsUnsetAttributeValue( providerDefault );
           checkUnique = false;
         }
       }

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -74,7 +74,7 @@ QVariant QgsTextEditWrapper::value() const
 
   if ( !QgsVariantUtils::isNull( defaultValue() ) && v == defaultValue().toString() )
   {
-    return defaultValue();
+    return QVariant::fromValue( QgsUnsetAttributeValue( defaultValue().toString() ) );
   }
 
   QVariant res( v );
@@ -301,6 +301,10 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
   else if ( val.userType() == QMetaType::Type::Double && std::isnan( val.toDouble() ) )
   {
     v = QgsApplication::nullRepresentation();
+  }
+  else if ( val.userType() == qMetaTypeId<QgsUnsetAttributeValue>() )
+  {
+    v = defaultValue().toString();
   }
   else
   {

--- a/tests/src/python/test_qgsvectorlayerutils_postgres.py
+++ b/tests/src/python/test_qgsvectorlayerutils_postgres.py
@@ -17,6 +17,7 @@ from qgis.core import (
     QgsDefaultValue,
     QgsVectorLayer,
     QgsVectorLayerUtils,
+    QgsUnsetAttributeValue,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -53,7 +54,9 @@ class TestQgsVectorLayerUtilsPostgres(QgisTestCase):
         f = QgsVectorLayerUtils.createFeature(pg_layer)
         self.assertEqual(f.attributes(), [default_clause, NULL])
         self.assertTrue(pg_layer.addFeatures([f]))
-        self.assertTrue(QgsVectorLayerUtils.valueExists(pg_layer, 0, default_clause))
+        self.assertTrue(
+            QgsVectorLayerUtils.valueExists(pg_layer, 0, QgsUnsetAttributeValue())
+        )
         f = QgsVectorLayerUtils.createFeature(pg_layer)
         self.assertEqual(f.attributes(), [default_clause, NULL])
         self.assertTrue(pg_layer.addFeatures([f]))


### PR DESCRIPTION
Alternative fix to https://github.com/qgis/QGIS/pull/57985, which fixes the underlying issue.

I think these changes are too risky to merge for 3.42.0, so I propose holding them off till 3.44 (and temporarily including https://github.com/qgis/QGIS/pull/57985 as a fix in the meantime)