### PR TITLE
add missed import and fix getThemeIcon() call (follow-up #60261)

### DIFF
--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -27,6 +27,7 @@ import warnings
 
 from qgis.PyQt import uic, sip
 from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QPalette
 from qgis.PyQt.QtWidgets import QMessageBox, QFileDialog, QVBoxLayout
 
 from qgis.gui import QgsGui, QgsErrorDialog, QgsCodeEditorWidget
@@ -116,8 +117,10 @@ class ScriptEditorDialog(BASE, WIDGET):
             QgsApplication.getThemeIcon("/mActionDecreaseFont.svg")
         )
         self.actionToggleComment.setIcon(
-            QgsApplication.getThemeIcon("console/iconCommentEditorConsole.svg"),
-            self.palette().color(QPalette.ColorRole.WindowText),
+            QgsApplication.getThemeIcon(
+                "console/iconCommentEditorConsole.svg",
+                self.palette().color(QPalette.ColorRole.WindowText),
+            )
         )
 
         # Connect signals and slots


### PR DESCRIPTION
## Description

Adds missed import and fixes typo in the `getThemeIcon()` call.

Follow up #60261.