### PR TITLE
Use reply content as an error string if it is plain text

### DIFF
--- a/src/core/stac/qgsstaccontroller.cpp
+++ b/src/core/stac/qgsstaccontroller.cpp
@@ -109,7 +109,10 @@ void QgsStacController::handleStacObjectReply()
 
   if ( reply->error() != QNetworkReply::NoError )
   {
-    emit finishedStacObjectRequest( requestId, reply->errorString() );
+    const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
+    const QString errorMessage = contentType.startsWith( QLatin1String( "text/plain" ) ) ? reply->readAll() : reply->errorString();
+
+    emit finishedStacObjectRequest( requestId, errorMessage );
     reply->deleteLater();
     mReplies.removeOne( reply );
     return;
@@ -155,7 +158,10 @@ void QgsStacController::handleItemCollectionReply()
 
   if ( reply->error() != QNetworkReply::NoError )
   {
-    emit finishedItemCollectionRequest( requestId, reply->errorString() );
+    const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
+    const QString errorMessage = contentType.startsWith( QLatin1String( "text/plain" ) ) ? reply->readAll() : reply->errorString();
+
+    emit finishedItemCollectionRequest( requestId, errorMessage );
     reply->deleteLater();
     mReplies.removeOne( reply );
     return;
@@ -184,7 +190,10 @@ void QgsStacController::handleCollectionsReply()
 
   if ( reply->error() != QNetworkReply::NoError )
   {
-    emit finishedCollectionsRequest( requestId, reply->errorString() );
+    const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
+    const QString errorMessage = contentType.startsWith( QLatin1String( "text/plain" ) ) ? reply->readAll() : reply->errorString();
+
+    emit finishedCollectionsRequest( requestId, errorMessage );
     reply->deleteLater();
     mReplies.removeOne( reply );
     return;


### PR DESCRIPTION
## Description
For example, a search with empty collections on the planetary computer will now show:
`collection is required` instead of the more cryptic `Unprocessable Content`, the human readable for http 422.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
