### PR TITLE
[symbology][gui] Fix symbol selector dialog not passing on its context to its widget

### DIFF
--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -417,9 +417,13 @@ void QgsSymbolSelectorWidget::setContext( const QgsSymbolWidgetContext &context 
 
   QWidget *widget = stackedWidget->currentWidget();
   if ( QgsLayerPropertiesWidget *layerProp = qobject_cast<QgsLayerPropertiesWidget *>( widget ) )
+  {
     layerProp->setContext( context );
+  }
   else if ( QgsSymbolsListWidget *listWidget = qobject_cast<QgsSymbolsListWidget *>( widget ) )
+  {
     listWidget->setContext( context );
+  }
 
   layerChanged();
   updatePreview();
@@ -872,12 +876,12 @@ QMenu *QgsSymbolSelectorDialog::advancedMenu()
 
 void QgsSymbolSelectorDialog::setContext( const QgsSymbolWidgetContext &context )
 {
-  mContext = context;
+  mSelectorWidget->setContext( context );
 }
 
 QgsSymbolWidgetContext QgsSymbolSelectorDialog::context() const
 {
-  return mContext;
+  return mSelectorWidget->context();
 }
 
 QgsSymbol *QgsSymbolSelectorDialog::symbol()

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -398,7 +398,6 @@ class GUI_EXPORT QgsSymbolSelectorDialog : public QDialog
 
     QgsSymbolSelectorWidget *mSelectorWidget = nullptr;
     QDialogButtonBox *mButtonBox = nullptr;
-    QgsSymbolWidgetContext mContext;
 };
 
 #endif


### PR DESCRIPTION
## Description

This fix (https://github.com/qgis/QGIS/pull/60394) revealed an issue with QGIS' symbol selector *dialog* whereas the symbol context is never actually passed onto the dialog's symbol selector widget.

It meant that the behavior of the symbol selector could vary depending on whether it was created as a dialog (vector layer properties for e.g.) or as a widget (styling panel). 

@alexbruy , good catch -- that being said, styling panel > vector layer properties dialog :wink: 