### PR TITLE
Fix QgsError.isEmpty() documentation

### DIFF
--- a/src/core/qgserror.h
+++ b/src/core/qgserror.h
@@ -104,8 +104,8 @@ class CORE_EXPORT QgsError
     void append( const QgsErrorMessage &message );
 
     /**
-     * Test if any error is set.
-     *  \returns TRUE if contains error
+     * Test if no error is set.
+     *  \returns FALSE if contains error
      */
     bool isEmpty() const { return mMessageList.isEmpty(); }
 


### PR DESCRIPTION
The method checks if there is an empty message list. It will actually return `TRUE` if there is *no* error message and `FALSE` if there *is* an error.

-----

I was surprised when reading the documentation, stating that `isEmpty()` returning `TRUE` would indicate an error while intuition says "empty error = no error". Checking the code, it is indeed checking for error messages and if there are none, returns `TRUE`.

So the documentation was falsely inverted.

This PR simply fixes the documentation. I am certain that the behaviour must be kept to avoid lots of breakage everywhere.