### PR TITLE
fix(systemMemorySizeMb): Improve system memory detection on BSD systems

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsapplication.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsapplication.sip.in
@@ -427,7 +427,7 @@ Returns a string name of the operating system QGIS is running on.
 .. seealso:: :py:func:`platform`
 %End
 
-    static int systemMemorySizeMb();
+    static unsigned long systemMemorySizeMb();
 %Docstring
 Returns the size of the system memory (RAM) in megabytes.
 

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -427,7 +427,7 @@ Returns a string name of the operating system QGIS is running on.
 .. seealso:: :py:func:`platform`
 %End
 
-    static int systemMemorySizeMb();
+    static unsigned long systemMemorySizeMb();
 %Docstring
 Returns the size of the system memory (RAM) in megabytes.
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -475,7 +475,7 @@ class CORE_EXPORT QgsApplication : public QApplication
      *
      * \since QGIS 3.26
      */
-    static int systemMemorySizeMb();
+    static unsigned long systemMemorySizeMb();
 
     /**
      * Returns the QGIS platform name, e.g., "desktop", "server", "qgis_process" or "external" (for external CLI scripts).

--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -102,7 +102,7 @@ QgsImageCache::QgsImageCache( QObject *parent )
   }
   else
   {
-    const int sysMemory = QgsApplication::systemMemorySizeMb();
+    const unsigned long sysMemory = QgsApplication::systemMemorySizeMb();
     if ( sysMemory > 0 )
     {
       if ( sysMemory >= 32000 ) // 32 gb RAM (or more) = 500mb cache size


### PR DESCRIPTION
## Description

- Added support for detecting total system memory on FreeBSD, OpenBSD, and NetBSD using `sysctl`.
- Updated `systemMemorySizeMb()` to use `unsigned long` instead of `int` for better accuracy, especially on systems with large amounts of RAM.
- Introduced a `constexpr unsigned long megabyte` to improve readability and avoid redundant calculations.
- Unified memory detection logic for BSD systems, using `HW_PHYSMEM64` when available for better precision.

Fixes incorrect memory reporting on BSD platforms where it previously returned `-1`.


cc @landryb @gdt 