### PR TITLE
chore(architecture): Disable non 64-bit architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ set(COMPLETE_VERSION ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINO
 set(RELEASE_NAME "Master")
 project(qgis VERSION ${COMPLETE_VERSION})
 
+if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(FATAL_ERROR "Only 64-bit architectures are supported.")
+endif()
+
 if (APPLE)
   set(QGIS_APP_NAME "QGIS")
 else()


### PR DESCRIPTION
## Description

Support for 32-bit architectures is becoming increasingly obsolete. For QGIS:

- As stated on the official download page: "Since QGIS 3.20 we only ship 64-bit Windows executables."
- macOS is exclusively 64-bit
- Support for 32-bit systems is gradually deprecating on major distributions such as [Debian](https://lists.debian.org/debian-devel-announce/2024/12/msg00002.html), [Fedora](https://fedoraproject.org/wiki/Architectures), and [FreeBSD](https://www.freebsd.org/platforms/).
- 32-bit ARM, RISC-V, Power architectures are rarely used and tested, while newer versions of these architectures run on 64-bit (and also rarely used and tested except arm64, maybe).
- In the past, we also made patches for i386—I still remember the painful `-mllvm -inline-threshold=128` ... This will be a good opportunity to start cleaning things up.

To my knowledge, there is no official statement from QGIS explicitly dropping 32-bit support, apart from the information mentioned on the download page. But if there has been an official announcement that I missed, at least this formalizes it. 😄 

