### PR TITLE
Fix QgsError.isEmpty() documentation

### DIFF
--- a/python/PyQt6/core/auto_generated/qgserror.sip.in
+++ b/python/PyQt6/core/auto_generated/qgserror.sip.in
@@ -88,9 +88,9 @@ Append new error message.
 
     bool isEmpty() const;
 %Docstring
-Test if any error is set.
+Test if no error is set.
 
-:return: ``True`` if contains error
+:return: ``False`` if contains error
 %End
 
     QString message( QgsErrorMessage::Format format = QgsErrorMessage::Html ) const;

--- a/python/core/auto_generated/qgserror.sip.in
+++ b/python/core/auto_generated/qgserror.sip.in
@@ -88,9 +88,9 @@ Append new error message.
 
     bool isEmpty() const;
 %Docstring
-Test if any error is set.
+Test if no error is set.
 
-:return: ``True`` if contains error
+:return: ``False`` if contains error
 %End
 
     QString message( QgsErrorMessage::Format format = QgsErrorMessage::Html ) const;

--- a/src/core/qgserror.h
+++ b/src/core/qgserror.h
@@ -104,8 +104,8 @@ class CORE_EXPORT QgsError
     void append( const QgsErrorMessage &message );
 
     /**
-     * Test if any error is set.
-     *  \returns TRUE if contains error
+     * Test if no error is set.
+     *  \returns FALSE if contains error
      */
     bool isEmpty() const { return mMessageList.isEmpty(); }
 


### PR DESCRIPTION
The method checks if there is an empty message list. It will actually return `TRUE` if there is *no* error message and `FALSE` if there *is* an error.
