### PR TITLE
do not overwrite ignore reported extents settting with the default value (fix #60496)

### DIFF
--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -95,6 +95,8 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
   cmbFeaturePaging->addItem( tr( "Disabled" ) );
   connect( cmbFeaturePaging, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewHttpConnection::wfsFeaturePagingCurrentIndexChanged );
 
+  cbxWmsIgnoreReportedLayerExtents->setChecked( settingsIgnoreReportedLayerExtentsDefault->value() );
+
   if ( !connectionName.isEmpty() )
   {
     // populate the dialog with the information stored for the connection
@@ -155,8 +157,6 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
       mGroupBox->layout()->removeWidget( lblTilePixelRatio );
     }
   }
-
-  cbxWmsIgnoreReportedLayerExtents->setChecked( settingsIgnoreReportedLayerExtentsDefault->value() );
 
   if ( !( flags & FlagShowTestConnection ) )
   {


### PR DESCRIPTION
## Description

Do not overwrite "Ignore reported extents" setting configured for the connection with the default value used to initialise checkbox.

Fixes #60496.