### PR TITLE
Update link to ninja in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -639,7 +639,7 @@ Download and install following packages:
 * [CMake](https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-windows-x86_64.msi)
 * GNU flex, GNU bison and GIT with [cygwin 64bit](https://cygwin.com/setup-x86_64.exe)
 * [OSGeo4W](https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe)
-* [ninja](https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip): Copy the `ninja.exe` to `C:\OSGeo4W\bin\`
+* [ninja](https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip) (Version >= 1.10): Copy the `ninja.exe` to `C:\OSGeo4W\bin\`
 
 For the QGIS build you need to install following packages from cygwin:
 


### PR DESCRIPTION
Updated windows build instructions in INSTALL.md.

## Description

Previous link of ninja release was of version 1.7.2, this caused a build error on Windows (raises `multiple outputs aren't (yet?) supported by depslog;` which according to - [Support multiple outputs in gcc depfile](https://github.com/ninja-build/ninja/issues/1184) should be fixed in ninja version >=1.10.

Changed the link to current latest which is 1.12.1 and added a note.



