### PR TITLE
Point cloud editing, show human readable values

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -106,8 +106,10 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   mCboChangeAttribute = new QComboBox();
   mPointCloudEditingToolbar->addWidget( mCboChangeAttribute );
   mSpinChangeAttributeValue = new QgsDoubleSpinBox();
+  mSpinChangeAttributeValue->setShowClearButton( false );
   mPointCloudEditingToolbar->addWidget( new QLabel( tr( "Value" ) ) );
   mPointCloudEditingToolbar->addWidget( mSpinChangeAttributeValue );
+
   QAction *actionEditingToolbar = toolBar->addAction( QIcon( QgsApplication::iconPath( "mIconPointCloudLayer.svg" ) ), tr( "Show Editing Toolbar" ), this, [this] { mEditingToolBar->setVisible( !mEditingToolBar->isVisible() ); } );
   actionEditingToolbar->setCheckable( true );
   connect( mCboChangeAttribute, qOverload<int>( &QComboBox::currentIndexChanged ), this, [this]( int ) { onPointCloudChangeAttributeSettingsChanged(); } );
@@ -875,47 +877,26 @@ void Qgs3DMapCanvasWidget::onPointCloudChangeAttributeSettingsChanged()
 {
   const QString attributeName = mCboChangeAttribute->currentText();
 
-  if ( attributeName == QLatin1String( "Intensity" ) )
+  mSpinChangeAttributeValue->setSuffix( QString() );
+
+  if ( attributeName == QLatin1String( "Intensity" ) || attributeName == QLatin1String( "PointSourceId" ) || attributeName == QLatin1String( "Red" ) || attributeName == QLatin1String( "Green" ) || attributeName == QLatin1String( "Blue" ) || attributeName == QLatin1String( "Infrared" ) )
   {
     mSpinChangeAttributeValue->setMinimum( 0 );
     mSpinChangeAttributeValue->setMaximum( 65535 );
     mSpinChangeAttributeValue->setDecimals( 0 );
   }
-  else if ( attributeName == QLatin1String( "ReturnNumber" ) )
+  else if ( attributeName == QLatin1String( "ReturnNumber" ) || attributeName == QLatin1String( "NumberOfReturns" ) )
   {
     mSpinChangeAttributeValue->setMinimum( 0 );
     mSpinChangeAttributeValue->setMaximum( 15 );
     mSpinChangeAttributeValue->setDecimals( 0 );
   }
-  else if ( attributeName == QLatin1String( "NumberOfReturns" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 15 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "Synthetic" ) )
+  else if ( attributeName == QLatin1String( "Synthetic" ) || attributeName == QLatin1String( "KeyPoint" ) || attributeName == QLatin1String( "Withheld" ) || attributeName == QLatin1String( "Overlap" ) || attributeName == QLatin1String( "ScanDirectionFlag" ) || attributeName == QLatin1String( "EdgeOfFlightLine" ) )
   {
     mSpinChangeAttributeValue->setMinimum( 0 );
     mSpinChangeAttributeValue->setMaximum( 1 );
     mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "KeyPoint" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 1 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "Withheld" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 1 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "Overlap" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 1 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
+    mSpinChangeAttributeValue->setSuffix( QStringLiteral( " (%1)" ).arg( mSpinChangeAttributeValue->value() ? tr( "True" ) : tr( "False" ) ) );
   }
   else if ( attributeName == QLatin1String( "ScannerChannel" ) )
   {
@@ -923,23 +904,13 @@ void Qgs3DMapCanvasWidget::onPointCloudChangeAttributeSettingsChanged()
     mSpinChangeAttributeValue->setMaximum( 3 );
     mSpinChangeAttributeValue->setDecimals( 0 );
   }
-  else if ( attributeName == QLatin1String( "ScanDirectionFlag" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 1 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "EdgeOfFlightLine" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 1 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
   else if ( attributeName == QLatin1String( "Classification" ) )
   {
     mSpinChangeAttributeValue->setMinimum( 0 );
     mSpinChangeAttributeValue->setMaximum( 255 );
     mSpinChangeAttributeValue->setDecimals( 0 );
+    const QMap<int, QString> codes = QgsPointCloudDataProvider::translatedLasClassificationCodes();
+    mSpinChangeAttributeValue->setSuffix( QStringLiteral( " (%1)" ).arg( codes.value( mSpinChangeAttributeValue->value() ) ) );
   }
   else if ( attributeName == QLatin1String( "UserData" ) )
   {
@@ -952,11 +923,6 @@ void Qgs3DMapCanvasWidget::onPointCloudChangeAttributeSettingsChanged()
     mSpinChangeAttributeValue->setMinimum( -30'000 );
     mSpinChangeAttributeValue->setMaximum( 30'000 );
     mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "PointSourceId" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 65535 );
     mSpinChangeAttributeValue->setDecimals( 0 );
   }
   else if ( attributeName == QLatin1String( "GpsTime" ) )
@@ -964,30 +930,6 @@ void Qgs3DMapCanvasWidget::onPointCloudChangeAttributeSettingsChanged()
     mSpinChangeAttributeValue->setMinimum( 0 );
     mSpinChangeAttributeValue->setMaximum( std::numeric_limits<double>::max() );
     mSpinChangeAttributeValue->setDecimals( 42 );
-  }
-  else if ( attributeName == QLatin1String( "Red" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 65535 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "Green" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 65535 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "Blue" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 65535 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-  }
-  else if ( attributeName == QLatin1String( "Infrared" ) )
-  {
-    mSpinChangeAttributeValue->setMinimum( 0 );
-    mSpinChangeAttributeValue->setMaximum( 65535 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
   }
 
   mMapToolPointCloudChangeAttribute->setAttribute( attributeName );

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1094,7 +1094,8 @@ QValidator::State ClassValidator::validate( QString &input, int &pos ) const
   if ( mClasses.contains( n ) )
   {
     input = QStringLiteral( "%1 (%2)" ).arg( n ).arg( mClasses[n] );
-    pos = std::min( pos, number.size() );
+    if ( pos > number.size() )
+      pos = number.size();
     return QValidator::State::Acceptable;
   }
   return QValidator::State::Intermediate;

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -896,7 +896,7 @@ void Qgs3DMapCanvasWidget::onPointCloudChangeAttributeSettingsChanged()
     mSpinChangeAttributeValue->setMinimum( 0 );
     mSpinChangeAttributeValue->setMaximum( 1 );
     mSpinChangeAttributeValue->setDecimals( 0 );
-    mSpinChangeAttributeValue->setSuffix( QStringLiteral( " (%1)" ).arg( mSpinChangeAttributeValue->value() ? tr( "True" ) : tr( "False" ) ) );
+    mSpinChangeAttributeValue->setSuffix( QStringLiteral( " (%1)" ).arg( mSpinChangeAttributeValue->value() == 0. ? tr( "False" ) : tr( "True" ) ) );
   }
   else if ( attributeName == QLatin1String( "ScannerChannel" ) )
   {

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -920,10 +920,10 @@ void Qgs3DMapCanvasWidget::onPointCloudChangeAttributeSettingsChanged()
   }
   else if ( attributeName == QLatin1String( "ScanAngleRank" ) )
   {
-    mSpinChangeAttributeValue->setMinimum( -30'000 );
-    mSpinChangeAttributeValue->setMaximum( 30'000 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
-    mSpinChangeAttributeValue->setDecimals( 0 );
+    mSpinChangeAttributeValue->setMinimum( -180 );
+    mSpinChangeAttributeValue->setMaximum( 180 );
+    mSpinChangeAttributeValue->setDecimals( 3 );
+    mSpinChangeAttributeValue->setSuffix( QStringLiteral( " (%1)" ).arg( tr( "degrees" ) ) );
   }
   else if ( attributeName == QLatin1String( "GpsTime" ) )
   {

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -165,7 +165,10 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 
     QToolBar *mEditingToolBar = nullptr;
     QComboBox *mCboChangeAttribute = nullptr;
+    QComboBox *mCboChangeAttributeValue = nullptr;
     QgsDoubleSpinBox *mSpinChangeAttributeValue = nullptr;
+    QAction *mCboChangeAttributeValueAction = nullptr;
+    QAction *mSpinChangeAttributeValueAction = nullptr;
 
     QMenu *mToolbarMenu = nullptr;
 };

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -49,9 +49,24 @@ class QgsMessageBar;
 class QgsRubberBand;
 class QgsDoubleSpinBox;
 
+//! Helper validator for classification classes
+class ClassValidator : public QValidator
+{
+  public:
+    ClassValidator( QWidget *parent );
+    QValidator::State validate( QString &input, int &pos ) const override;
+    void fixup( QString &input ) const override;
+    void setClasses( const QMap<int, QString> &classes ) { mClasses = classes; }
+
+  private:
+    QMap<int, QString> mClasses;
+    QRegularExpression mRx;
+};
+
 class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 {
     Q_OBJECT
+
   public:
     Qgs3DMapCanvasWidget( const QString &name, bool isDocked );
     ~Qgs3DMapCanvasWidget();
@@ -166,6 +181,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QToolBar *mEditingToolBar = nullptr;
     QComboBox *mCboChangeAttribute = nullptr;
     QComboBox *mCboChangeAttributeValue = nullptr;
+    ClassValidator *mClassValidator = nullptr;
     QgsDoubleSpinBox *mSpinChangeAttributeValue = nullptr;
     QAction *mCboChangeAttributeValueAction = nullptr;
     QAction *mSpinChangeAttributeValueAction = nullptr;

--- a/src/core/pointcloud/qgspointcloudlayereditutils.cpp
+++ b/src/core/pointcloud/qgspointcloudlayereditutils.cpp
@@ -83,7 +83,7 @@ static void updatePoint( char *pointBuffer, int pointFormat, const QString &attr
   }
   else if ( attributeName == QLatin1String( "ScanAngleRank" ) )  // short
   {
-    qint16 newValueShort = static_cast<qint16>( newValue );
+    qint16 newValueShort = static_cast<qint16>( std::round( newValue / 0.006 ) );  // copc stores angle in 0.006deg increments
     memcpy( pointBuffer + 18, &newValueShort, sizeof( qint16 ) );
   }
   else if ( attributeName == QLatin1String( "PointSourceId" ) )  // unsigned short
@@ -182,7 +182,7 @@ bool QgsPointCloudLayerEditUtils::isAttributeValueValid( const QgsPointCloudAttr
   if ( name == QLatin1String( "USERDATA" ) )
     return value >= 0 && value <= 255;
   if ( name == QLatin1String( "SCANANGLERANK" ) )
-    return value >= -30'000 && value <= 30'000;
+    return value >= -180 && value <= 180;
   if ( name == QLatin1String( "POINTSOURCEID" ) )
     return value >= 0 && value <= 65535;
   if ( name == QLatin1String( "GPSTIME" ) )


### PR DESCRIPTION
## Description
Use the spinbox's suffix to display human readable representation of current value.
Applies for Classification and boolean attributes.

![image](https://github.com/user-attachments/assets/ce24e356-63b6-4548-a830-a030c30b22ca)

Also fixes the ScanAngleRank editing range to be between -180 and 180 degrees, which is the values we return when identifying the points.
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
