### PR TITLE
Start on a compliance test suite for raster data providers, cleanups

### DIFF
--- a/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
@@ -170,6 +170,9 @@ Returns a cleansed ``key``
     QVariant &operator[]( const QString &key );
 
 
+    bool operator==( const QgsHttpHeaders &other ) const;
+    bool operator!=( const QgsHttpHeaders &other ) const;
+
     void insert( const QString &key, const QVariant &value );
 %Docstring
 insert a ``key`` with the specific ``value``

--- a/python/PyQt6/core/auto_generated/qgsdatasourceuri.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdatasourceuri.sip.in
@@ -252,17 +252,41 @@ form of a SQL "where" clause (e.g. "VALUE > 5", "CAT IN (1,2,3)").
 .. seealso:: :py:func:`sql`
 %End
 
+    void setHost( const QString &host );
+%Docstring
+Sets the ``host`` name stored in the URI.
+
+.. seealso:: :py:func:`host`
+
+.. versionadded:: 3.42
+%End
+
     QString host() const;
 %Docstring
 Returns the host name stored in the URI.
+
+.. seealso:: :py:func:`setHost`
 %End
+
     QString database() const;
 %Docstring
 Returns the database name stored in the URI.
 %End
+
+    void setPort( const QString &port );
+%Docstring
+Sets the ``port`` stored in the URI.
+
+.. seealso:: :py:func:`port`
+
+.. versionadded:: 3.42
+%End
+
     QString port() const;
 %Docstring
 Returns the port stored in the URI.
+
+.. seealso:: :py:func:`setPort`
 %End
 
     QString driver() const;
@@ -280,14 +304,36 @@ Sets the ``driver`` name stored in the URI.
 Returns the password stored in the URI.
 %End
 
+    void setSslMode( SslMode mode );
+%Docstring
+Sets the SSL ``mode`` associated with the URI.
+
+.. seealso:: :py:func:`sslMode`
+
+.. versionadded:: 3.42
+%End
+
     SslMode sslMode() const;
 %Docstring
 Returns the SSL mode associated with the URI.
+
+.. seealso:: :py:func:`setSslMode`
+%End
+
+    void setService( const QString &service );
+%Docstring
+Sets the ``service`` name associated with the URI.
+
+.. seealso:: :py:func:`service`
+
+.. versionadded:: 3.42
 %End
 
     QString service() const;
 %Docstring
 Returns the service name associated with the URI.
+
+.. seealso:: :py:func:`setService`
 %End
 
     QString keyColumn() const;
@@ -382,6 +428,9 @@ Sets headers to ``headers``
     QString str = QStringLiteral( "<QgsDataSourceUri: %1>" ).arg( sipCpp->uri( false ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
+
+    bool operator==( const QgsDataSourceUri &other ) const;
+    bool operator!=( const QgsDataSourceUri &other ) const;
 
 };
 

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -170,6 +170,9 @@ Returns a cleansed ``key``
     QVariant &operator[]( const QString &key );
 
 
+    bool operator==( const QgsHttpHeaders &other ) const;
+    bool operator!=( const QgsHttpHeaders &other ) const;
+
     void insert( const QString &key, const QVariant &value );
 %Docstring
 insert a ``key`` with the specific ``value``

--- a/python/core/auto_generated/qgsdatasourceuri.sip.in
+++ b/python/core/auto_generated/qgsdatasourceuri.sip.in
@@ -252,17 +252,41 @@ form of a SQL "where" clause (e.g. "VALUE > 5", "CAT IN (1,2,3)").
 .. seealso:: :py:func:`sql`
 %End
 
+    void setHost( const QString &host );
+%Docstring
+Sets the ``host`` name stored in the URI.
+
+.. seealso:: :py:func:`host`
+
+.. versionadded:: 3.42
+%End
+
     QString host() const;
 %Docstring
 Returns the host name stored in the URI.
+
+.. seealso:: :py:func:`setHost`
 %End
+
     QString database() const;
 %Docstring
 Returns the database name stored in the URI.
 %End
+
+    void setPort( const QString &port );
+%Docstring
+Sets the ``port`` stored in the URI.
+
+.. seealso:: :py:func:`port`
+
+.. versionadded:: 3.42
+%End
+
     QString port() const;
 %Docstring
 Returns the port stored in the URI.
+
+.. seealso:: :py:func:`setPort`
 %End
 
     QString driver() const;
@@ -280,14 +304,36 @@ Sets the ``driver`` name stored in the URI.
 Returns the password stored in the URI.
 %End
 
+    void setSslMode( SslMode mode );
+%Docstring
+Sets the SSL ``mode`` associated with the URI.
+
+.. seealso:: :py:func:`sslMode`
+
+.. versionadded:: 3.42
+%End
+
     SslMode sslMode() const;
 %Docstring
 Returns the SSL mode associated with the URI.
+
+.. seealso:: :py:func:`setSslMode`
+%End
+
+    void setService( const QString &service );
+%Docstring
+Sets the ``service`` name associated with the URI.
+
+.. seealso:: :py:func:`service`
+
+.. versionadded:: 3.42
 %End
 
     QString service() const;
 %Docstring
 Returns the service name associated with the URI.
+
+.. seealso:: :py:func:`setService`
 %End
 
     QString keyColumn() const;
@@ -382,6 +428,9 @@ Sets headers to ``headers``
     QString str = QStringLiteral( "<QgsDataSourceUri: %1>" ).arg( sipCpp->uri( false ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
+
+    bool operator==( const QgsDataSourceUri &other ) const;
+    bool operator!=( const QgsDataSourceUri &other ) const;
 
 };
 

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -298,3 +298,13 @@ void QgsHttpHeaders::insert( const QString &key, const QVariant &val )
   }
   mHeaders.insert( k2, val );
 }
+
+bool QgsHttpHeaders::operator==( const QgsHttpHeaders &other ) const
+{
+  return mHeaders == other.mHeaders;
+}
+
+bool QgsHttpHeaders::operator!=( const QgsHttpHeaders &other ) const
+{
+  return !( *this == other );
+}

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -195,6 +195,9 @@ class CORE_EXPORT QgsHttpHeaders
 
     QgsHttpHeaders &operator = ( const QMap<QString, QVariant> &headers ) SIP_SKIP;
 
+    bool operator==( const QgsHttpHeaders &other ) const;
+    bool operator!=( const QgsHttpHeaders &other ) const;
+
     /**
      * \brief insert a \a key with the specific \a value
      * \param key a key to add

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -347,9 +347,24 @@ QString QgsDataSourceUri::database() const
   return mDatabase;
 }
 
+void QgsDataSourceUri::setPort( const QString &port )
+{
+  mPort = port;
+}
+
 QString QgsDataSourceUri::password() const
 {
   return mPassword;
+}
+
+void QgsDataSourceUri::setSslMode( SslMode mode )
+{
+  mSSLmode = mode;
+}
+
+void QgsDataSourceUri::setService( const QString &service )
+{
+  mService = service;
 }
 
 void QgsDataSourceUri::setPassword( const QString &password )
@@ -434,6 +449,11 @@ bool QgsDataSourceUri::selectAtIdDisabled() const
 void QgsDataSourceUri::setSql( const QString &sql )
 {
   mSql = sql;
+}
+
+void QgsDataSourceUri::setHost( const QString &host )
+{
+  mHost = host;
 }
 
 void QgsDataSourceUri::clearSchema()
@@ -979,4 +999,44 @@ QSet<QString> QgsDataSourceUri::parameterKeys() const
   if ( !mSrid.isEmpty() )
     paramKeys.insert( QLatin1String( "srid" ) );
   return paramKeys;
+}
+
+bool QgsDataSourceUri::operator==( const QgsDataSourceUri &other ) const
+{
+  // cheap comparisons first:
+  if ( mUseEstimatedMetadata != other.mUseEstimatedMetadata ||
+       mSelectAtIdDisabled != other.mSelectAtIdDisabled ||
+       mSelectAtIdDisabledSet != other.mSelectAtIdDisabledSet ||
+       mSSLmode != other.mSSLmode ||
+       mWkbType != other.mWkbType )
+  {
+    return false;
+  }
+
+  if ( mHost != other.mHost ||
+       mPort != other.mPort ||
+       mDriver != other.mDriver ||
+       mService != other.mService ||
+       mDatabase != other.mDatabase ||
+       mSchema != other.mSchema ||
+       mTable != other.mTable ||
+       mGeometryColumn != other.mGeometryColumn ||
+       mSql != other.mSql ||
+       mAuthConfigId != other.mAuthConfigId ||
+       mUsername != other.mUsername ||
+       mPassword != other.mPassword ||
+       mKeyColumn != other.mKeyColumn ||
+       mSrid != other.mSrid ||
+       mParams != other.mParams ||
+       mHttpHeaders != other.mHttpHeaders )
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool QgsDataSourceUri::operator!=( const QgsDataSourceUri &other ) const
+{
+  return !( *this == other );
 }

--- a/src/core/qgsdatasourceuri.h
+++ b/src/core/qgsdatasourceuri.h
@@ -252,11 +252,37 @@ class CORE_EXPORT QgsDataSourceUri
      */
     void setSql( const QString &sql );
 
-    //! Returns the host name stored in the URI.
+    /**
+     * Sets the \a host name stored in the URI.
+     *
+     * \see host()
+     * \since QGIS 3.42
+     */
+    void setHost( const QString &host );
+
+    /**
+     * Returns the host name stored in the URI.
+     *
+     * \see setHost()
+     */
     QString host() const;
+
     //! Returns the database name stored in the URI.
     QString database() const;
-    //! Returns the port stored in the URI.
+
+    /**
+     * Sets the \a port stored in the URI.
+     *
+     * \see port()
+     * \since QGIS 3.42
+     */
+    void setPort( const QString &port );
+
+    /**
+     * Returns the port stored in the URI.
+     *
+     * \see setPort()
+     */
     QString port() const;
 
     /**
@@ -272,10 +298,34 @@ class CORE_EXPORT QgsDataSourceUri
     //! Returns the password stored in the URI.
     QString password() const;
 
-    //! Returns the SSL mode associated with the URI.
+    /**
+     * Sets the SSL \a mode associated with the URI.
+     *
+     * \see sslMode()
+     * \since QGIS 3.42
+     */
+    void setSslMode( SslMode mode );
+
+    /**
+     * Returns the SSL mode associated with the URI.
+     *
+     * \see setSslMode()
+     */
     SslMode sslMode() const;
 
-    //! Returns the service name associated with the URI.
+    /**
+     * Sets the \a service name associated with the URI.
+     *
+     * \see service()
+     * \since QGIS 3.42
+     */
+    void setService( const QString &service );
+
+    /**
+     * Returns the service name associated with the URI.
+     *
+     * \see setService()
+     */
     QString service() const;
 
     //! Returns the name of the (primary) key column for the referenced table.
@@ -358,6 +408,9 @@ class CORE_EXPORT QgsDataSourceUri
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
+
+    bool operator==( const QgsDataSourceUri &other ) const;
+    bool operator!=( const QgsDataSourceUri &other ) const;
 
   private:
     void skipBlanks( const QString &uri, int &i );

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -25,6 +25,7 @@ class TestQgsDataSourceUri : public QObject
 {
     Q_OBJECT
   private slots:
+    void equality();
     void checkparser();
     void checkparser_data();
     void checkSetConnection();
@@ -269,6 +270,216 @@ void TestQgsDataSourceUri::checkparser_data()
     << ""                          // myparam
     << "public"                    // schema
     ;
+}
+
+void TestQgsDataSourceUri::equality()
+{
+  QgsDataSourceUri uri1;
+  QgsDataSourceUri uri2;
+
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setHost( QStringLiteral( "localhost" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setHost( QStringLiteral( "remote" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setHost( QStringLiteral( "localhost" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setPort( QStringLiteral( "5432" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setPort( QStringLiteral( "5433" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setPort( QStringLiteral( "5432" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setDriver( QStringLiteral( "QPSQL" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setDriver( QStringLiteral( "mssql" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setDriver( QStringLiteral( "QPSQL" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setService( QStringLiteral( "service" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setService( QStringLiteral( "service2" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setService( QStringLiteral( "service" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setDatabase( QStringLiteral( "mydb" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setDatabase( QStringLiteral( "mydb2" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setDatabase( QStringLiteral( "mydb" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setUsername( QStringLiteral( "user" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setUsername( QStringLiteral( "user2" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setUsername( QStringLiteral( "user" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setPassword( QStringLiteral( "pass" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setPassword( QStringLiteral( "pass2" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setPassword( QStringLiteral( "pass" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setSchema( QStringLiteral( "public" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setSchema( QStringLiteral( "other" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setSchema( QStringLiteral( "public" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setTable( QStringLiteral( "mytable" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setTable( QStringLiteral( "othertable" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setTable( QStringLiteral( "mytable" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setGeometryColumn( QStringLiteral( "geom" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setGeometryColumn( QStringLiteral( "geometry" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setGeometryColumn( QStringLiteral( "geom" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setKeyColumn( QStringLiteral( "id" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setKeyColumn( QStringLiteral( "id" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setSql( QStringLiteral( "WHERE id > 10" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setSql( QStringLiteral( "WHERE id < 10" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setSql( QStringLiteral( "WHERE id > 10" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setAuthConfigId( QStringLiteral( "abc123" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setAuthConfigId( QStringLiteral( "def123" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setAuthConfigId( QStringLiteral( "abc123" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setSslMode( QgsDataSourceUri::SslAllow );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setSslMode( QgsDataSourceUri::SslAllow );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setKeyColumn( QStringLiteral( "pk" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setKeyColumn( QStringLiteral( "id" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setKeyColumn( QStringLiteral( "pk" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setUseEstimatedMetadata( true );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setUseEstimatedMetadata( true );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.disableSelectAtId( true );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.disableSelectAtId( true );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setWkbType( Qgis::WkbType::Point );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setWkbType( Qgis::WkbType::Point );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setSrid( QStringLiteral( "4326" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setSrid( QStringLiteral( "3111" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setSrid( QStringLiteral( "4326" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  uri1.setParam( QStringLiteral( "param1" ), QStringLiteral( "value1" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.setParam( QStringLiteral( "param1" ), QStringLiteral( "value2" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  // params are a multi-map!
+  uri2.setParam( QStringLiteral( "param1" ), QStringLiteral( "value1" ) );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  uri2.removeParam( QStringLiteral( "param1" ) );
+  uri2.setParam( QStringLiteral( "param1" ), QStringLiteral( "value1" ) );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
+
+  QgsHttpHeaders headers1;
+  headers1.insert( QStringLiteral( "Authorization" ), QStringLiteral( "Bearer token123" ) );
+  uri1.setHttpHeaders( headers1 );
+  QVERIFY( uri1 != uri2 );
+  QVERIFY( !( uri1 == uri2 ) );
+  QgsHttpHeaders headers2;
+  headers2.insert( QStringLiteral( "Authorization" ), QStringLiteral( "Bearer token123" ) );
+  uri2.setHttpHeaders( headers2 );
+  QVERIFY( uri1 == uri2 );
+  QVERIFY( !( uri1 != uri2 ) );
 }
 
 void TestQgsDataSourceUri::checkparser()

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -39,6 +39,8 @@ class TestQgsHttpheaders : public QObject
     void init() {}            // will be called before each testfunction is executed.
     void cleanup() {}         // will be called after every testfunction.
 
+    void equality();
+
     void sanitize();
 
     void setFromSettingsGoodKey();
@@ -56,6 +58,44 @@ class TestQgsHttpheaders : public QObject
 
 void TestQgsHttpheaders::initTestCase()
 {
+}
+
+void TestQgsHttpheaders::equality()
+{
+  QgsHttpHeaders headers1;
+  QgsHttpHeaders headers2;
+  QVERIFY( headers1 == headers2 );
+  QVERIFY( !( headers1 != headers2 ) );
+
+  headers1.insert( QStringLiteral( "Content-Type" ), QStringLiteral( "application/json" ) );
+  QVERIFY( !( headers1 == headers2 ) );
+  QVERIFY( headers1 != headers2 );
+  headers2.insert( QStringLiteral( "Content-Type" ), QStringLiteral( "application/json" ) );
+  QVERIFY( headers1 == headers2 );
+  QVERIFY( !( headers1 != headers2 ) );
+
+  headers1.insert( QStringLiteral( "Accept" ), QStringLiteral( "text/html" ) );
+  QVERIFY( !( headers1 == headers2 ) );
+  QVERIFY( headers1 != headers2 );
+  headers2.insert( QStringLiteral( "Accept" ), QStringLiteral( "text/html" ) );
+  QVERIFY( headers1 == headers2 );
+  QVERIFY( !( headers1 != headers2 ) );
+
+  // different header values
+  headers1.insert( QStringLiteral( "Content-Type" ), QStringLiteral( "text/plain" ) );
+  QVERIFY( !( headers1 == headers2 ) );
+  QVERIFY( headers1 != headers2 );
+
+  // empty value
+  QgsHttpHeaders headers3;
+  headers3.insert( QStringLiteral( "Content-Type" ), QString( "" ) );
+  QgsHttpHeaders headers4;
+  QVERIFY( !( headers3 == headers4 ) );
+  QVERIFY( headers3 != headers4 );
+
+  headers4.insert( QStringLiteral( "Content-Type" ), "xxx" );
+  QVERIFY( !( headers3 == headers4 ) );
+  QVERIFY( headers3 != headers4 );
 }
 
 void TestQgsHttpheaders::sanitize()

--- a/tests/src/python/raster_provider_test_base.py
+++ b/tests/src/python/raster_provider_test_base.py
@@ -22,7 +22,7 @@ class RasterProviderTestCase:
         Test property values for a provider which does not have the
         fixed size capability
         """
-        l = self.get_layer("fixed_size")
+        l = self.get_layer("not_fixed_size")
         if l.dataProvider().capabilities() & Qgis.RasterInterfaceCapability.Size:
             return
 
@@ -32,6 +32,23 @@ class RasterProviderTestCase:
         # and 1 for raster units per pixel
         self.assertEqual(l.rasterUnitsPerPixelX(), 1)
         self.assertEqual(l.rasterUnitsPerPixelY(), 1)
+
+    def test_fixed_size_provider(self):
+        """
+        Test property values for a provider which does has the
+        fixed size capability
+        """
+        l = self.get_layer("fixed_size")
+        if not l.dataProvider().capabilities() & Qgis.RasterInterfaceCapability.Size:
+            return
+
+        # TODO -- adjust these values after we've got a generic "reference" fixed size
+        # raster which is appropriate for these tests
+        self.assertEqual(l.width(), 3)
+        self.assertEqual(l.height(), 4)
+        # and 1 for raster units per pixel
+        self.assertAlmostEqual(l.rasterUnitsPerPixelX(), 0.000642531091049392, 8)
+        self.assertAlmostEqual(l.rasterUnitsPerPixelY(), 0.00048366498497820487, 8)
 
     def test_provider_clone(self):
         """

--- a/tests/src/python/raster_provider_test_base.py
+++ b/tests/src/python/raster_provider_test_base.py
@@ -1,0 +1,49 @@
+"""QGIS Unit test utils for raster provider tests.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+
+from qgis.core import Qgis
+
+
+class RasterProviderTestCase:
+    """
+    This is a collection of tests for raster data providers and kept generic.
+    To make use of it, subclass it and implement
+    self.get_layer(test_id: str) -> QgsRasterLayer
+    to a provider you want to test.
+    """
+
+    def test_no_fixed_size_provider(self):
+        """
+        Test property values for a provider which does not have the
+        fixed size capability
+        """
+        l = self.get_layer("fixed_size")
+        if l.dataProvider().capabilities() & Qgis.RasterInterfaceCapability.Size:
+            return
+
+        # non-fixed size raster providers should return 0 for size
+        self.assertEqual(l.width(), 0)
+        self.assertEqual(l.height(), 0)
+        # and 1 for raster units per pixel
+        self.assertEqual(l.rasterUnitsPerPixelX(), 1)
+        self.assertEqual(l.rasterUnitsPerPixelY(), 1)
+
+    def test_provider_clone(self):
+        """
+        Test that cloning layer works
+        """
+        l = self.get_layer("clone")
+        self.assertTrue(l.isValid())
+
+        l2 = l.clone()
+        # expect a new instance of the data provider
+        self.assertNotEqual(l.dataProvider(), l2.dataProvider())
+        # but should be same provider class
+        self.assertEqual(l.dataProvider().name(), l2.dataProvider().name())
+        # and same provider URI
+        self.assertEqual(l.dataProvider().uri(), l2.dataProvider().uri())

--- a/tests/src/python/test_provider_ams.py
+++ b/tests/src/python/test_provider_ams.py
@@ -12,43 +12,19 @@ __author__ = "Nyall Dawson"
 __date__ = "2025-02-10"
 __copyright__ = "Copyright 2025, Nyall Dawson"
 
-import hashlib
 import shutil
 import tempfile
 import unittest
 
-from qgis.PyQt.QtCore import (
-    QCoreApplication,
-    QObject,
-)
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,
-    QgsApplication,
     QgsSettings,
     QgsRasterLayer,
 )
 from qgis.testing import start_app, QgisTestCase
 from raster_provider_test_base import RasterProviderTestCase
-
-
-def sanitize(endpoint, x):
-    if x.startswith("/query"):
-        x = x[len("/query") :]
-        endpoint = endpoint + "_query"
-
-    if len(endpoint + x) > 150:
-        ret = endpoint + hashlib.md5(x.encode()).hexdigest()
-        # print('Before: ' + endpoint + x)
-        # print('After:  ' + ret)
-        return ret
-    return endpoint + x.replace("?", "_").replace("&", "_").replace("<", "_").replace(
-        ">", "_"
-    ).replace('"', "_").replace("'", "_").replace(" ", "_").replace(":", "_").replace(
-        "/", "_"
-    ).replace(
-        "\n", "_"
-    )
 
 
 class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
@@ -80,7 +56,7 @@ class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
 
     def get_layer(self, test_id: str) -> QgsRasterLayer:
         endpoint = self.basetestpath + f"/{test_id}_fake_qgis_http_endpoint"
-        with open(sanitize(endpoint, "?f=json"), "wb") as f:
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
             f.write(
                 b"""
                 {
@@ -219,7 +195,7 @@ class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
         Test basic provider capabilities
         """
         endpoint = self.basetestpath + "/basic_test_fake_qgis_http_endpoint"
-        with open(sanitize(endpoint, "?f=json"), "wb") as f:
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
             f.write(
                 b"""
                 {
@@ -382,7 +358,7 @@ class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
         Test basic provider capabilities
         """
         endpoint = self.basetestpath + "/basic_layer_1_fake_qgis_http_endpoint"
-        with open(sanitize(endpoint, "?f=json"), "wb") as f:
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
             f.write(
                 b"""
                 {
@@ -510,7 +486,7 @@ class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
  "supportedExtensions": "WMSServer"
 }"""
             )
-        with open(sanitize(endpoint, "/1?f=json"), "wb") as f:
+        with open(self.sanitize_local_url(endpoint, "/1?f=json"), "wb") as f:
             f.write(
                 b"""
                 {
@@ -658,7 +634,7 @@ class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
         Test non-consecutive layer IDs
         """
         endpoint = self.basetestpath + "/basic_test_fake_qgis_http_endpoint"
-        with open(sanitize(endpoint, "?f=json"), "wb") as f:
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
             f.write(
                 b"""
                 {

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -27,6 +27,7 @@ import unittest
 from qgis.testing import start_app, QgisTestCase
 
 from utilities import unitTestDataPath
+from raster_provider_test_base import RasterProviderTestCase
 
 start_app()
 TEST_DATA_DIR = unitTestDataPath()
@@ -36,7 +37,12 @@ def GDAL_COMPUTE_VERSION(maj, min, rev):
     return (maj) * 1000000 + (min) * 10000 + (rev) * 100
 
 
-class PyQgsGdalProvider(QgisTestCase):
+class PyQgsGdalProvider(QgisTestCase, RasterProviderTestCase):
+
+    def get_layer(self, test_id: str) -> QgsRasterLayer:
+        return QgsRasterLayer(
+            self.get_test_data_path("landsat_4326.tif").as_posix(), test_id
+        )
 
     def checkBlockContents(self, block, expected):
         res = []

--- a/tests/src/python/test_qgsarcgisportalutils.py
+++ b/tests/src/python/test_qgsarcgisportalutils.py
@@ -12,57 +12,12 @@ __author__ = "Nyall Dawson"
 __date__ = "2018-02-16"
 __copyright__ = "Copyright 2018, Nyall Dawson"
 
-import hashlib
-import os
 import tempfile
 
 from qgis.PyQt.QtCore import QCoreApplication, QObject
 from qgis.core import QgsApplication, QgsArcGisPortalUtils, QgsSettings
 import unittest
 from qgis.testing import start_app, QgisTestCase
-
-
-def sanitize(endpoint, x):
-    if not os.path.exists(endpoint):
-        os.makedirs(endpoint)
-    if x.startswith("/query"):
-        x = x[len("/query") :]
-        endpoint = endpoint + "_query"
-
-    if len(endpoint + x) > 150:
-        ret = endpoint + hashlib.md5(x.encode()).hexdigest()
-        # print('Before: ' + endpoint + x)
-        # print('After:  ' + ret)
-        return ret
-    return endpoint + x.replace("?", "_").replace("&", "_").replace("<", "_").replace(
-        ">", "_"
-    ).replace('"', "_").replace("'", "_").replace(" ", "_").replace(":", "_").replace(
-        "/", "_"
-    ).replace(
-        "\n", "_"
-    )
-
-
-class MessageLogger(QObject):
-
-    def __init__(self, tag=None):
-        QObject.__init__(self)
-        self.log = []
-        self.tag = tag
-
-    def __enter__(self):
-        QgsApplication.messageLog().messageReceived.connect(self.logMessage)
-        return self
-
-    def __exit__(self, type, value, traceback):
-        QgsApplication.messageLog().messageReceived.disconnect(self.logMessage)
-
-    def logMessage(self, msg, tag, level):
-        if tag == self.tag or not self.tag:
-            self.log.append(msg.encode("UTF-8"))
-
-    def messages(self):
-        return self.log
 
 
 class TestPyQgsArcGisPortalUtils(QgisTestCase):
@@ -95,7 +50,7 @@ class TestPyQgsArcGisPortalUtils(QgisTestCase):
         """
         print(self.basetestpath)
         endpoint = self.basetestpath + "/user_fake_qgis_http_endpoint"
-        with open(sanitize(endpoint, "/self?f=json"), "wb") as f:
+        with open(self.sanitize_local_url(endpoint, "/self?f=json"), "wb") as f:
             f.write(
                 b"""{
   "username": "me",
@@ -136,7 +91,9 @@ class TestPyQgsArcGisPortalUtils(QgisTestCase):
         print(self.basetestpath)
         endpoint = self.basetestpath + "/user_fake_qgis_http_endpoint"
 
-        with open(sanitize(endpoint + "_users/", "some_user?f=json"), "wb") as f:
+        with open(
+            self.sanitize_local_url(endpoint + "_users/", "some_user?f=json"), "wb"
+        ) as f:
             f.write(
                 b"""{
   "username": "some_user",
@@ -180,7 +137,9 @@ class TestPyQgsArcGisPortalUtils(QgisTestCase):
         print(self.basetestpath)
         endpoint = self.basetestpath + "/group_fake_qgis_http_endpoint"
 
-        with open(sanitize(endpoint + "_users/", "some_user?f=json"), "wb") as f:
+        with open(
+            self.sanitize_local_url(endpoint + "_users/", "some_user?f=json"), "wb"
+        ) as f:
             f.write(
                 b"""{
           "username": "some_user",
@@ -217,7 +176,8 @@ class TestPyQgsArcGisPortalUtils(QgisTestCase):
         endpoint = self.basetestpath + "/group_items_fake_qgis_http_endpoint"
 
         with open(
-            sanitize(endpoint + "_groups/", "ab1?f=json&start=1&num=2"), "wb"
+            self.sanitize_local_url(endpoint + "_groups/", "ab1?f=json&start=1&num=2"),
+            "wb",
         ) as f:
             f.write(
                 b"""{
@@ -239,7 +199,10 @@ class TestPyQgsArcGisPortalUtils(QgisTestCase):
             )
 
             with open(
-                sanitize(endpoint + "_groups/", "ab1?f=json&start=3&num=2"), "wb"
+                self.sanitize_local_url(
+                    endpoint + "_groups/", "ab1?f=json&start=3&num=2"
+                ),
+                "wb",
             ) as f:
                 f.write(
                     b"""{
@@ -278,7 +241,8 @@ class TestPyQgsArcGisPortalUtils(QgisTestCase):
         endpoint = self.basetestpath + "/groupf_items_fake_qgis_http_endpoint"
 
         with open(
-            sanitize(endpoint + "_groups/", "ab1?f=json&start=1&num=2"), "wb"
+            self.sanitize_local_url(endpoint + "_groups/", "ab1?f=json&start=1&num=2"),
+            "wb",
         ) as f:
             f.write(
                 b"""{
@@ -302,7 +266,10 @@ class TestPyQgsArcGisPortalUtils(QgisTestCase):
             )
 
             with open(
-                sanitize(endpoint + "_groups/", "ab1?f=json&start=3&num=2"), "wb"
+                self.sanitize_local_url(
+                    endpoint + "_groups/", "ab1?f=json&start=3&num=2"
+                ),
+                "wb",
             ) as f:
                 f.write(
                     b"""{


### PR DESCRIPTION
Followup https://github.com/qgis/QGIS/pull/60520. This sets in place a starting point for a raster data provider compliance suite, like our current vector data provider one.

It's neither comprehensive nor testing all providers (only the arcgismapserver and gdal ones), but it's a starting point!