### PR TITLE
[oracle] Fix adding features with null attributes

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1394,9 +1394,15 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
         QVariant value = attributevec.value( fieldId[i], QVariant() );
 
         QgsField fld = field( fieldId[i] );
-        if ( ( value.isNull() && mPrimaryKeyAttrs.contains( i ) && !defaultValues.at( i ).isEmpty() ) || ( value.toString() == defaultValues[i] ) )
+        if ( ( QgsVariantUtils::isNull( value ) && mPrimaryKeyAttrs.contains( i ) && !defaultValues.at( i ).isEmpty() ) || ( value.toString() == defaultValues[i] ) )
         {
           value = evaluateDefaultExpression( defaultValues[i], fld.type() );
+        }
+        else if ( QgsVariantUtils::isNull( value ) )
+        {
+          // don't use typed null variants, always use invalid variants. Otherwise the connection
+          // may incorrectly try to coerce a null value to the variant type
+          value = QVariant();
         }
         features->setAttribute( fieldId[i], value );
 

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -1139,6 +1139,44 @@ class ProviderTestCase(FeatureSourceTestCase):
             ],
         )
 
+    def testAddFeatureAllNull(self):
+        if not getattr(self, "getEditableLayer", None):
+            return
+
+        l = self.getEditableLayer()
+        self.assertTrue(l.isValid())
+
+        f1 = QgsFeature()
+        f1.setAttributes([NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL])
+        f1.setGeometry(QgsGeometry.fromWkt("Point (-72.345 71.987)"))
+
+        if (
+            l.dataProvider().capabilities()
+            & QgsVectorDataProvider.Capability.AddFeatures
+        ):
+            # expect success
+            result, added = l.dataProvider().addFeatures([f1])
+            self.assertTrue(
+                result,
+                "Provider reported AddFeatures capability, but returned False to addFeatures",
+            )
+
+            # check result
+            f_new = next(
+                l.dataProvider().getFeatures(
+                    QgsFeatureRequest().setFilterFid(added[0].id())
+                )
+            )
+            self.assertEqual(
+                f_new.attributes()[1:], [NULL, NULL, NULL, NULL, NULL, NULL, NULL]
+            )
+        else:
+            # expect fail
+            self.assertFalse(
+                l.dataProvider().addFeatures([f1]),
+                "Provider reported no AddFeatures capability, but returned true to addFeatures",
+            )
+
     def testAddFeatureWrongGeomType(self):
         if not getattr(self, "getEditableLayer", None):
             return

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -4960,6 +4960,46 @@ class TestPyQgsPostgresProviderBigintSinglePk(QgisTestCase, ProviderTestCase):
         f2.setAttributes([7, 330, "qgis", "qgis", NULL])
         self.testGetFeatures(l.dataProvider(), [f1, f2])
 
+    def testAddFeatureAllNull(self):
+        # overridden from base test because of extra attributes in layer
+        if not getattr(self, "getEditableLayer", None):
+            return
+
+        l = self.getEditableLayer()
+        self.assertTrue(l.isValid())
+
+        f1 = QgsFeature()
+        f1.setAttributes([8, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL])
+        f1.setGeometry(QgsGeometry.fromWkt("Point (-72.345 71.987)"))
+
+        if (
+            l.dataProvider().capabilities()
+            & QgsVectorDataProvider.Capability.AddFeatures
+        ):
+            # expect success
+            result, added = l.dataProvider().addFeatures([f1])
+            self.assertTrue(
+                result,
+                "Provider reported AddFeatures capability, but returned False to addFeatures",
+            )
+
+            # check result
+            f_new = next(
+                l.dataProvider().getFeatures(
+                    QgsFeatureRequest().setFilterFid(added[0].id())
+                )
+            )
+            self.assertEqual(
+                f_new.attributes(),
+                [8, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL],
+            )
+        else:
+            # expect fail
+            self.assertFalse(
+                l.dataProvider().addFeatures([f1]),
+                "Provider reported no AddFeatures capability, but returned true to addFeatures",
+            )
+
     def testAddFeature(self):
         if not getattr(self, "getEditableLayer", None):
             return


### PR DESCRIPTION
...as I suspect https://github.com/qgis/QGIS/pull/60474 has revealed an unrelated issue in null handling for Oracle provider