### PR TITLE
docs(qgsprocessingcontext): fix typo

### DIFF
--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -515,7 +515,7 @@ function will be used when creating these outputs.
 
     QString preferredRasterFormat() const /HoldGIL/;
 %Docstring
-Returns the preferred raster format to use for vector outputs.
+Returns the preferred raster format to use for raster outputs.
 
 This method returns a file extension to use when creating raster outputs (e.g. "tif"). Generally,
 it is preferable to use the extension associated with a particular parameter, which can be retrieved through
@@ -536,7 +536,7 @@ and to provide an appropriate fallback when the returned format is not usable.
 
     void setPreferredRasterFormat( const QString &format ) /HoldGIL/;
 %Docstring
-Sets the preferred raster ``format`` to use for vector outputs.
+Sets the preferred raster ``format`` to use for raster outputs.
 
 This method sets a file extension to use when creating raster outputs (e.g. "tif"). Generally,
 it is preferable to use the extension associated with a particular parameter, which can be retrieved through

--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -515,7 +515,7 @@ function will be used when creating these outputs.
 
     QString preferredRasterFormat() const /HoldGIL/;
 %Docstring
-Returns the preferred raster format to use for vector outputs.
+Returns the preferred raster format to use for raster outputs.
 
 This method returns a file extension to use when creating raster outputs (e.g. "tif"). Generally,
 it is preferable to use the extension associated with a particular parameter, which can be retrieved through
@@ -536,7 +536,7 @@ and to provide an appropriate fallback when the returned format is not usable.
 
     void setPreferredRasterFormat( const QString &format ) /HoldGIL/;
 %Docstring
-Sets the preferred raster ``format`` to use for vector outputs.
+Sets the preferred raster ``format`` to use for raster outputs.
 
 This method sets a file extension to use when creating raster outputs (e.g. "tif"). Generally,
 it is preferable to use the extension associated with a particular parameter, which can be retrieved through

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -601,7 +601,7 @@ class CORE_EXPORT QgsProcessingContext
     void setPreferredVectorFormat( const QString &format ) SIP_HOLDGIL { mPreferredVectorFormat = format; }
 
     /**
-     * Returns the preferred raster format to use for vector outputs.
+     * Returns the preferred raster format to use for raster outputs.
      *
      * This method returns a file extension to use when creating raster outputs (e.g. "tif"). Generally,
      * it is preferable to use the extension associated with a particular parameter, which can be retrieved through
@@ -621,7 +621,7 @@ class CORE_EXPORT QgsProcessingContext
     QString preferredRasterFormat() const SIP_HOLDGIL { return mPreferredRasterFormat; }
 
     /**
-     * Sets the preferred raster \a format to use for vector outputs.
+     * Sets the preferred raster \a format to use for raster outputs.
      *
      * This method sets a file extension to use when creating raster outputs (e.g. "tif"). Generally,
      * it is preferable to use the extension associated with a particular parameter, which can be retrieved through


### PR DESCRIPTION
## Description
The raster format should be specified for **raster** outputs.

I don't know whether the `\a` is a typo as well, could add a commit to remove it if it is.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
