### PR TITLE
preserve field alias when exporting formatted values in Export to spreadsheet algorithm (fix #59403)

### DIFF
--- a/src/analysis/processing/qgsalgorithmexporttospreadsheet.cpp
+++ b/src/analysis/processing/qgsalgorithmexporttospreadsheet.cpp
@@ -53,7 +53,9 @@ class FieldValueConverter : public QgsVectorFileWriter::FieldValueConverter
       const int idx = mLayer->fields().indexFromName( field.name() );
       if ( mFormatters.contains( idx ) )
       {
-        return QgsField( field.name(), QMetaType::Type::QString );
+        QgsField newField( field.name(), QMetaType::Type::QString );
+        newField.setAlias( field.alias() );
+        return newField;
       }
       return field;
     }

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -547,6 +547,7 @@ void TestQgsProcessingAlgsPt1::exportToSpreadsheetOptions()
   bool ok = false;
 
   mPointsLayer->setFieldAlias( 1, QStringLiteral( "my heading" ) );
+  mPointsLayer->setFieldAlias( 2, QStringLiteral( "my importance" ) );
 
   const QgsProcessingAlgorithm *alg( QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "native:exporttospreadsheet" ) ) );
 
@@ -572,7 +573,6 @@ void TestQgsProcessingAlgsPt1::exportToSpreadsheetOptions()
 
   pointLayer.reset();
 
-
   mPointsLayer->setEditorWidgetSetup( 2, QgsEditorWidgetSetup( QStringLiteral( "ValueMap" ), QVariantMap { { "map", QVariantMap { { "High", "1" }, { "Medium", "10" }, { "Low", "20" }, { "VLow", "3" }, { "VHigh", "4" } } } } ) );
 
   parameters.insert( QStringLiteral( "USE_ALIAS" ), true );
@@ -584,7 +584,7 @@ void TestQgsProcessingAlgsPt1::exportToSpreadsheetOptions()
   pointLayer = std::make_unique<QgsVectorLayer>( outputPath + "|layername=points", "points", "ogr" );
   QCOMPARE( pointLayer->fields().at( 0 ).name(), QStringLiteral( "Class" ) );
   QCOMPARE( pointLayer->fields().at( 1 ).name(), QStringLiteral( "my heading" ) );
-  QCOMPARE( pointLayer->fields().at( 2 ).name(), QStringLiteral( "Importance" ) );
+  QCOMPARE( pointLayer->fields().at( 2 ).name(), QStringLiteral( "my importance" ) );
   QCOMPARE( pointLayer->fields().at( 3 ).name(), QStringLiteral( "Pilots" ) );
   QCOMPARE( pointLayer->fields().at( 4 ).name(), QStringLiteral( "Cabin Crew" ) );
 
@@ -592,7 +592,7 @@ void TestQgsProcessingAlgsPt1::exportToSpreadsheetOptions()
   QgsFeature f;
   QgsFeatureIterator it = pointLayer->getFeatures();
   while ( it.nextFeature( f ) )
-    values.insert( f.attribute( QStringLiteral( "Importance" ) ).toString() );
+    values.insert( f.attribute( QStringLiteral( "my importance" ) ).toString() );
 
   QCOMPARE( values.size(), 5 );
   QVERIFY( values.contains( "1" ) );
@@ -607,10 +607,16 @@ void TestQgsProcessingAlgsPt1::exportToSpreadsheetOptions()
 
   QVERIFY( !results.value( QStringLiteral( "OUTPUT" ) ).toString().isEmpty() );
   pointLayer = std::make_unique<QgsVectorLayer>( outputPath + "|layername=points", "points", "ogr" );
+  QCOMPARE( pointLayer->fields().at( 0 ).name(), QStringLiteral( "Class" ) );
+  QCOMPARE( pointLayer->fields().at( 1 ).name(), QStringLiteral( "my heading" ) );
+  QCOMPARE( pointLayer->fields().at( 2 ).name(), QStringLiteral( "my importance" ) );
+  QCOMPARE( pointLayer->fields().at( 3 ).name(), QStringLiteral( "Pilots" ) );
+  QCOMPARE( pointLayer->fields().at( 4 ).name(), QStringLiteral( "Cabin Crew" ) );
+
   values.clear();
   it = pointLayer->getFeatures();
   while ( it.nextFeature( f ) )
-    values.insert( f.attribute( QStringLiteral( "Importance" ) ).toString() );
+    values.insert( f.attribute( QStringLiteral( "my importance" ) ).toString() );
 
   QCOMPARE( values.size(), 5 );
   QVERIFY( values.contains( "High" ) );


### PR DESCRIPTION
## Description

When "Export formatted values" option in "Export to spreadsheet" algorithm is checked field alias is ignored even if "Use field alias" checkbox is also checked. This happens because FieldValueConverter does not preserve field alias.

Fixes #59403.