### PR TITLE
Fix file downloader algo duplicating file's extension 

### DIFF
--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -141,7 +141,7 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   url = downloadedUrl.toDisplayString();
   feedback->pushInfo( QObject::tr( "Successfully downloaded %1" ).arg( url ) );
 
-  if ( outputFile.startsWith( QgsProcessingUtils::tempFolder( &context ) ) )
+  if ( parameters.value( QStringLiteral( "OUTPUT" ) ) == QgsProcessing::TEMPORARY_OUTPUT )
   {
     // the output is temporary and its file name automatically generated, try to add a file extension
     const int length = url.size();

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -1144,6 +1144,14 @@ void TestQgsProcessingAlgsPt2::fileDownloader()
   QVERIFY( ok );
   // verify that temporary outputs have the URL file extension appended
   QVERIFY( results.value( QStringLiteral( "OUTPUT" ) ).toString().endsWith( QLatin1String( ".txt" ) ) );
+
+  const QString outputFileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "qgis_version.txt" ), *context );
+  parameters.insert( QStringLiteral( "OUTPUT" ), outputFileName );
+
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+  // compare result filename is the same as provided
+  QCOMPARE( outputFileName, results.value( QStringLiteral( "OUTPUT" ) ).toString() );
 }
 
 void TestQgsProcessingAlgsPt2::rasterize()

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -1145,7 +1145,7 @@ void TestQgsProcessingAlgsPt2::fileDownloader()
   // verify that temporary outputs have the URL file extension appended
   QVERIFY( results.value( QStringLiteral( "OUTPUT" ) ).toString().endsWith( QLatin1String( ".txt" ) ) );
 
-  const QString outputFileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "qgis_version.txt" ), &context );
+  const QString outputFileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "qgis_version.txt" ) );
   parameters.insert( QStringLiteral( "OUTPUT" ), outputFileName );
 
   results = alg->run( parameters, *context, &feedback, &ok );

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -1145,7 +1145,7 @@ void TestQgsProcessingAlgsPt2::fileDownloader()
   // verify that temporary outputs have the URL file extension appended
   QVERIFY( results.value( QStringLiteral( "OUTPUT" ) ).toString().endsWith( QLatin1String( ".txt" ) ) );
 
-  const QString outputFileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "qgis_version.txt" ), *context );
+  const QString outputFileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "qgis_version.txt" ), &context );
   parameters.insert( QStringLiteral( "OUTPUT" ), outputFileName );
 
   results = alg->run( parameters, *context, &feedback, &ok );


### PR DESCRIPTION
Fixes #60528

User can provide a properly named temporary filepath (filename + extension) and the logic applied in current alg is not necessary and can create issues if this alg is called in a larger process: the output specified miss match the filename created on disk