### PR TITLE
[ux] Fix and harmonize drag and drop in Graduated, Categorized and Point Cloud classification symbol lists

### DIFF
--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
@@ -78,6 +78,7 @@ QgsPointCloudCategory QgsPointCloudClassifiedRendererModel::category( const QMod
 
 Qt::ItemFlags QgsPointCloudClassifiedRendererModel::flags( const QModelIndex &index ) const
 {
+  // Flat list, to ease drop handling valid indexes are not dropEnabled
   if ( !index.isValid() || mCategories.empty() )
   {
     return Qt::ItemIsDropEnabled;
@@ -293,7 +294,7 @@ QMimeData *QgsPointCloudClassifiedRendererModel::mimeData( const QModelIndexList
 bool QgsPointCloudClassifiedRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
   Q_UNUSED( column )
-  Q_UNUSED( parent ) // Unused because only valid indexes have Qt::ItemIsDropEnabled
+  Q_UNUSED( parent ) // Unused because only invalid indexes have Qt::ItemIsDropEnabled
   if ( action != Qt::MoveAction )
     return true;
 
@@ -342,6 +343,7 @@ bool QgsPointCloudClassifiedRendererModel::dropMimeData( const QMimeData *data, 
   }
   emit dataChanged( createIndex( 0, 0 ), createIndex( mCategories.size(), 0 ) );
   emit categoriesChanged();
+  emit rowsMoved();
   return false;
 }
 
@@ -428,6 +430,7 @@ QgsPointCloudClassifiedRendererWidget::QgsPointCloudClassifiedRendererWidget( Qg
 
   connect( mAttributeComboBox, &QgsPointCloudAttributeComboBox::attributeChanged, this, &QgsPointCloudClassifiedRendererWidget::attributeChanged );
   connect( mModel, &QgsPointCloudClassifiedRendererModel::categoriesChanged, this, &QgsPointCloudClassifiedRendererWidget::emitWidgetChanged );
+  connect( mModel, &QgsPointCloudClassifiedRendererModel::rowsMoved, this, &QgsPointCloudClassifiedRendererWidget::rowsMoved );
 
   connect( viewCategories, &QAbstractItemView::doubleClicked, this, &QgsPointCloudClassifiedRendererWidget::categoriesDoubleClicked );
   connect( btnAddCategories, &QAbstractButton::clicked, this, &QgsPointCloudClassifiedRendererWidget::addCategories );
@@ -707,6 +710,11 @@ void QgsPointCloudClassifiedRendererWidget::changeCategoryPointSize()
       mModel->setCategoryPointSize( row, size );
     }
   }
+}
+
+void QgsPointCloudClassifiedRendererWidget::rowsMoved()
+{
+  viewCategories->selectionModel()->clear();
 }
 
 QList<int> QgsPointCloudClassifiedRendererWidget::selectedCategories()

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
@@ -311,6 +311,9 @@ bool QgsPointCloudClassifiedRendererModel::dropMimeData( const QMimeData *data, 
     rows.append( r );
   }
 
+  // Items may come unsorted depending on selecion order
+  std::sort( rows.begin(), rows.end() );
+
   int to = row;
   // to is -1 if dragged outside items, i.e. below any item,
   // then move to the last position

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
@@ -83,7 +83,7 @@ Qt::ItemFlags QgsPointCloudClassifiedRendererModel::flags( const QModelIndex &in
     return Qt::ItemIsDropEnabled;
   }
 
-  Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | Qt::ItemIsUserCheckable;
+  Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsUserCheckable;
   if ( index.column() == 1 || index.column() == 2 || index.column() == 3 )
   {
     flags |= Qt::ItemIsEditable;
@@ -292,8 +292,8 @@ QMimeData *QgsPointCloudClassifiedRendererModel::mimeData( const QModelIndexList
 
 bool QgsPointCloudClassifiedRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
-  Q_UNUSED( row )
   Q_UNUSED( column )
+  Q_UNUSED( parent ) // Unused because only valid indexes have Qt::ItemIsDropEnabled
   if ( action != Qt::MoveAction )
     return true;
 
@@ -311,7 +311,7 @@ bool QgsPointCloudClassifiedRendererModel::dropMimeData( const QMimeData *data, 
     rows.append( r );
   }
 
-  int to = parent.row();
+  int to = row;
   // to is -1 if dragged outside items, i.e. below any item,
   // then move to the last position
   if ( to == -1 )

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
@@ -70,6 +70,9 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererModel : public QAbstractItemMode
   signals:
     void categoriesChanged();
 
+    //! Informs views that categories were moved (e.g., via mCategories.move()) in the model.
+    void rowsMoved();
+
   private:
     QgsPointCloudCategoryList mCategories;
     QMap<int, float> mPercentages;
@@ -126,6 +129,7 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererWidget : public QgsPointCloudRen
     void changeCategoryColor();
     void changeCategoryOpacity();
     void changeCategoryPointSize();
+    void rowsMoved();
 
   private:
     //! Sets default category and available classes

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -108,6 +108,7 @@ QgsRendererCategory QgsCategorizedSymbolRendererModel::category( const QModelInd
 
 Qt::ItemFlags QgsCategorizedSymbolRendererModel::flags( const QModelIndex &index ) const
 {
+  // Flat list, to ease drop handling valid indexes are not dropEnabled
   if ( !index.isValid() || !mRenderer )
   {
     return Qt::ItemIsDropEnabled;
@@ -399,7 +400,7 @@ QMimeData *QgsCategorizedSymbolRendererModel::mimeData( const QModelIndexList &i
 bool QgsCategorizedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
   Q_UNUSED( column )
-  Q_UNUSED( parent ) // Unused because only valid indexes have Qt::ItemIsDropEnabled
+  Q_UNUSED( parent ) // Unused because only invalid indexes have Qt::ItemIsDropEnabled
   if ( action != Qt::MoveAction )
     return true;
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -113,7 +113,7 @@ Qt::ItemFlags QgsCategorizedSymbolRendererModel::flags( const QModelIndex &index
     return Qt::ItemIsDropEnabled;
   }
 
-  Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | Qt::ItemIsUserCheckable;
+  Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsUserCheckable;
   if ( index.column() == 1 )
   {
     const QgsRendererCategory category = mRenderer->categories().value( index.row() );
@@ -398,8 +398,8 @@ QMimeData *QgsCategorizedSymbolRendererModel::mimeData( const QModelIndexList &i
 
 bool QgsCategorizedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
-  Q_UNUSED( row )
   Q_UNUSED( column )
+  Q_UNUSED( parent )
   if ( action != Qt::MoveAction )
     return true;
 
@@ -417,7 +417,8 @@ bool QgsCategorizedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt:
     rows.append( r );
   }
 
-  int to = parent.row();
+  int to = row;
+
   // to is -1 if dragged outside items, i.e. below any item,
   // then move to the last position
   if ( to == -1 )

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -417,6 +417,9 @@ bool QgsCategorizedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt:
     rows.append( r );
   }
 
+  // Items may come unsorted depending on selecion order
+  std::sort( rows.begin(), rows.end() );
+
   int to = row;
 
   // to is -1 if dragged outside items, i.e. below any item,

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -399,7 +399,7 @@ QMimeData *QgsCategorizedSymbolRendererModel::mimeData( const QModelIndexList &i
 bool QgsCategorizedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
   Q_UNUSED( column )
-  Q_UNUSED( parent )
+  Q_UNUSED( parent ) // Unused because only valid indexes have Qt::ItemIsDropEnabled
   if ( action != Qt::MoveAction )
     return true;
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -139,7 +139,7 @@ Qt::ItemFlags QgsGraduatedSymbolRendererModel::flags( const QModelIndex &index )
     return Qt::ItemIsDropEnabled;
   }
 
-  Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | Qt::ItemIsUserCheckable;
+  Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsUserCheckable;
 
   if ( index.column() == 2 )
   {
@@ -306,8 +306,8 @@ QMimeData *QgsGraduatedSymbolRendererModel::mimeData( const QModelIndexList &ind
 
 bool QgsGraduatedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
-  Q_UNUSED( row )
   Q_UNUSED( column )
+  Q_UNUSED( parent )
   if ( action != Qt::MoveAction )
     return true;
 
@@ -325,7 +325,8 @@ bool QgsGraduatedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::D
     rows.append( r );
   }
 
-  int to = parent.row();
+  int to = row;
+
   // to is -1 if dragged outside items, i.e. below any item,
   // then move to the last position
   if ( to == -1 )

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -307,7 +307,7 @@ QMimeData *QgsGraduatedSymbolRendererModel::mimeData( const QModelIndexList &ind
 bool QgsGraduatedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
   Q_UNUSED( column )
-  Q_UNUSED( parent )
+  Q_UNUSED( parent ) // Unused because only valid indexes have Qt::ItemIsDropEnabled
   if ( action != Qt::MoveAction )
     return true;
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -134,6 +134,7 @@ QgsRendererRange QgsGraduatedSymbolRendererModel::rendererRange( const QModelInd
 
 Qt::ItemFlags QgsGraduatedSymbolRendererModel::flags( const QModelIndex &index ) const
 {
+  // Flat list, to ease drop handling valid indexes are not dropEnabled
   if ( !index.isValid() )
   {
     return Qt::ItemIsDropEnabled;
@@ -307,7 +308,7 @@ QMimeData *QgsGraduatedSymbolRendererModel::mimeData( const QModelIndexList &ind
 bool QgsGraduatedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
   Q_UNUSED( column )
-  Q_UNUSED( parent ) // Unused because only valid indexes have Qt::ItemIsDropEnabled
+  Q_UNUSED( parent ) // Unused because only invalid indexes have Qt::ItemIsDropEnabled
   if ( action != Qt::MoveAction )
     return true;
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -325,6 +325,9 @@ bool QgsGraduatedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::D
     rows.append( r );
   }
 
+  // Items may come unsorted depending on selecion order
+  std::sort( rows.begin(), rows.end() );
+
   int to = row;
 
   // to is -1 if dragged outside items, i.e. below any item,


### PR DESCRIPTION
This PR fixes an annoying and longstanding issue with drag and drop in Graduated and Categorized symbol lists.
Namely, when attempting to move an item and realizing it would end up in the last position (i.e., being appended).

BEFORE:

https://github.com/user-attachments/assets/c0ec9a68-56aa-4173-8ae8-3f82c8f7848d


AFTER:

https://github.com/user-attachments/assets/936a81f1-0d5b-462c-bf57-5d307da13cec


BONUS:
It also happens in Point Clouds --> Layer Styling --> Classification. This PR also fixes that one.

Fix #50823
Fix #55267 
Fix #60559 

EXTRA BONUS:
 + Harmonize drag and drop of multiple items: sort them because they may come unsorted due to selection order, which then makes it lose the order after the drop. (Unreported so far).
 + Harmonize selection after drag and drop: Clear selection in Point Clouds classification list.


