### PR TITLE
Fix misbehaving virtual point cloud chunks in 3D views

### DIFF
--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -72,6 +72,7 @@ QgsVirtualPointCloudEntity::QgsVirtualPointCloudEntity(
     );
     mOverviewEntity->setParent( this );
     connect( mOverviewEntity, &QgsChunkedEntity::pendingJobsCountChanged, this, &Qgs3DMapSceneEntity::pendingJobsCountChanged );
+    connect( mOverviewEntity, &QgsChunkedEntity::newEntityCreated, this, &Qgs3DMapSceneEntity::newEntityCreated );
     emit newEntityCreated( mOverviewEntity );
   }
 
@@ -119,6 +120,7 @@ void QgsVirtualPointCloudEntity::createChunkedEntityForSubIndex( int i )
   mChunkedEntitiesMap.insert( i, newChunkedEntity );
   newChunkedEntity->setParent( this );
   connect( newChunkedEntity, &QgsChunkedEntity::pendingJobsCountChanged, this, &Qgs3DMapSceneEntity::pendingJobsCountChanged );
+  connect( newChunkedEntity, &QgsChunkedEntity::newEntityCreated, this, &Qgs3DMapSceneEntity::newEntityCreated );
   emit newEntityCreated( newChunkedEntity );
 }
 


### PR DESCRIPTION
This is a follow up of #59468. In case of VPCs, the 3D entity was not proxying newEntityCreated() signals from the sub-entities. Previously this was less of an issue, but after #59468 the newly created entities were not getting correctly set origin point and thus were not showing up properly.
