### PR TITLE
[processing] Use matrix editor panel value if open

### DIFF
--- a/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
+++ b/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
@@ -179,6 +179,15 @@ QgsProcessingMatrixParameterPanel::QgsProcessingMatrixParameterPanel( QWidget *p
   connect( mToolButton, &QToolButton::clicked, this, &QgsProcessingMatrixParameterPanel::showDialog );
 }
 
+QVariantList QgsProcessingMatrixParameterPanel::value() const
+{
+  // if editing widget is still open, use the value currently shown in that widget
+  if ( mPanelWidget )
+    return mPanelWidget->table();
+
+  return mTable;
+}
+
 void QgsProcessingMatrixParameterPanel::setValue( const QVariantList &value )
 {
   mTable = value;
@@ -190,14 +199,14 @@ void QgsProcessingMatrixParameterPanel::showDialog()
 {
   if ( QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this ) )
   {
-    QgsProcessingMatrixParameterPanelWidget *widget = new QgsProcessingMatrixParameterPanelWidget( this, mParam, mTable );
+    mPanelWidget = new QgsProcessingMatrixParameterPanelWidget( this, mParam, mTable );
 
-    widget->setPanelTitle( mParam->description() );
+    mPanelWidget->setPanelTitle( mParam->description() );
 
-    panel->openPanel( widget );
+    panel->openPanel( mPanelWidget );
 
-    connect( widget, &QgsPanelWidget::widgetChanged, this, [=] {
-      setValue( widget->table() );
+    connect( mPanelWidget, &QgsPanelWidget::widgetChanged, this, [=] {
+      setValue( mPanelWidget->table() );
     } );
   }
 }

--- a/src/gui/processing/qgsprocessingmatrixparameterdialog.h
+++ b/src/gui/processing/qgsprocessingmatrixparameterdialog.h
@@ -82,7 +82,7 @@ class GUI_EXPORT QgsProcessingMatrixParameterPanel : public QWidget
   public:
     QgsProcessingMatrixParameterPanel( QWidget *parent = nullptr, const QgsProcessingParameterMatrix *param = nullptr );
 
-    QVariantList value() const { return mTable; }
+    QVariantList value() const;
 
     void setValue( const QVariantList &value );
 
@@ -102,6 +102,7 @@ class GUI_EXPORT QgsProcessingMatrixParameterPanel : public QWidget
     QToolButton *mToolButton = nullptr;
 
     QVariantList mTable;
+    QPointer< QgsProcessingMatrixParameterPanelWidget > mPanelWidget;
 
     friend class TestProcessingGui;
 };


### PR DESCRIPTION
When an algorithm is run and the editor panel is still open for a matrix parameter, use the table defined in that panel as for the parameter.

Fixes #60442
