### PR TITLE
[Snapping] Remove and delete locator when layer is destroyed

### DIFF
--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -43,6 +43,11 @@ QgsPointLocator *QgsSnappingUtils::locatorForLayer( QgsVectorLayer *vl )
   {
     QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), nullptr );
     connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
+    connect( vl, &QObject::destroyed, this, [this, vl]()
+    {
+      mLocators.remove( vl );
+    } );
+
     mLocators.insert( vl, vlpl );
   }
   return mLocators.value( vl );

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -45,7 +45,7 @@ QgsPointLocator *QgsSnappingUtils::locatorForLayer( QgsVectorLayer *vl )
     connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
     connect( vl, &QObject::destroyed, this, [this, vl]()
     {
-      mLocators.remove( vl );
+      delete mLocators.take( vl );
     } );
 
     mLocators.insert( vl, vlpl );

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -321,6 +321,8 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     //! Disable or not the snapping on all features. By default is always TRUE except for non visible features on map canvas.
     bool mEnableSnappingForInvisibleFeature = true;
+
+    friend class TestQgsSnappingUtils;
 };
 
 


### PR DESCRIPTION
Fixes #59530 and very likely #59308 and avoid also memory leaks

The issue were happening because a previously created locator were assigned to a new layer having the same address than a now deleted layer.

**Funded by GISPO**

