### PR TITLE
Implement click-move-click & snapping behavior for the georeferencer's move GCP point tool

### DIFF
--- a/src/app/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/app/georeferencer/qgsgcpcanvasitem.cpp
@@ -48,7 +48,7 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   p->setRenderHint( QPainter::Antialiasing );
 
   bool enabled = true;
-  double scale = 1.0;
+  int scale = 1;
   QgsPointXY worldCoords;
   int id = -1;
   const QgsCoordinateReferenceSystem mapCrs = mMapCanvas->mapSettings().destinationCrs();
@@ -56,7 +56,7 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   if ( mDataPoint )
   {
     enabled = mDataPoint->isEnabled();
-    scale = mDataPoint->isHovered() ? 2.0 : 1.0;
+    scale = mDataPoint->isHovered() ? 2 : 1;
     worldCoords = mDataPoint->destinationPoint();
     id = mDataPoint->id();
   }

--- a/src/app/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/app/georeferencer/qgsgcpcanvasitem.cpp
@@ -65,7 +65,7 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   // draw the point
   p->setPen( Qt::black );
   p->setBrush( mPointBrush );
-  p->drawEllipse( -3 * scale, -3 * scale, 6 * scale, 6 * scale );
+  p->drawEllipse( -2 * scale, -2 * scale, 5 * scale, 5 * scale );
 
   // Don't draw point tip for temporary points
   if ( id < 0 )
@@ -142,7 +142,7 @@ QRectF QgsGCPCanvasItem::boundingRect() const
   }
 
   const QRectF residualArrowRect( QPointF( residualLeft, residualTop ), QPointF( residualRight, residualBottom ) );
-  const QRectF markerRect( -6, -6, mTextBounds.width() + 12, mTextBounds.height() + 12 );
+  const QRectF markerRect( -4, -4, mTextBounds.width() + 10, mTextBounds.height() + 10 );
   QRectF boundingRect = residualArrowRect.united( markerRect );
   if ( !mTextBoxRect.isNull() )
   {
@@ -154,7 +154,7 @@ QRectF QgsGCPCanvasItem::boundingRect() const
 QPainterPath QgsGCPCanvasItem::shape() const
 {
   QPainterPath p;
-  p.addEllipse( -3, -3, 6, 6 );
+  p.addEllipse( -2, -2, 5, 5 );
   p.addRect( 6, 6, mTextBounds.width(), mTextBounds.height() );
 
   return p;

--- a/src/app/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/app/georeferencer/qgsgcpcanvasitem.cpp
@@ -48,6 +48,7 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   p->setRenderHint( QPainter::Antialiasing );
 
   bool enabled = true;
+  double scale = 1.0;
   QgsPointXY worldCoords;
   int id = -1;
   const QgsCoordinateReferenceSystem mapCrs = mMapCanvas->mapSettings().destinationCrs();
@@ -55,6 +56,7 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   if ( mDataPoint )
   {
     enabled = mDataPoint->isEnabled();
+    scale = mDataPoint->isHovered() ? 2.0 : 1.0;
     worldCoords = mDataPoint->destinationPoint();
     id = mDataPoint->id();
   }
@@ -63,7 +65,7 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   // draw the point
   p->setPen( Qt::black );
   p->setBrush( mPointBrush );
-  p->drawEllipse( -2, -2, 5, 5 );
+  p->drawEllipse( -3 * scale, -3 * scale, 6 * scale, 6 * scale );
 
   // Don't draw point tip for temporary points
   if ( id < 0 )
@@ -140,7 +142,7 @@ QRectF QgsGCPCanvasItem::boundingRect() const
   }
 
   const QRectF residualArrowRect( QPointF( residualLeft, residualTop ), QPointF( residualRight, residualBottom ) );
-  const QRectF markerRect( -2, -2, mTextBounds.width() + 6, mTextBounds.height() + 6 );
+  const QRectF markerRect( -6, -6, mTextBounds.width() + 12, mTextBounds.height() + 12 );
   QRectF boundingRect = residualArrowRect.united( markerRect );
   if ( !mTextBoxRect.isNull() )
   {
@@ -152,7 +154,7 @@ QRectF QgsGCPCanvasItem::boundingRect() const
 QPainterPath QgsGCPCanvasItem::shape() const
 {
   QPainterPath p;
-  p.addEllipse( -2, -2, 5, 5 );
+  p.addEllipse( -3, -3, 6, 6 );
   p.addRect( 6, 6, mTextBounds.width(), mTextBounds.height() );
 
   return p;

--- a/src/app/georeferencer/qgsgeorefdatapoint.cpp
+++ b/src/app/georeferencer/qgsgeorefdatapoint.cpp
@@ -130,47 +130,49 @@ void QgsGeorefDataPoint::updateCoords()
   }
 }
 
-bool QgsGeorefDataPoint::contains( QPoint p, QgsGcpPoint::PointType type, double &distance )
+bool QgsGeorefDataPoint::contains( QgsPointXY p, QgsGcpPoint::PointType type, double &distance )
 {
   const double searchRadiusMM = QgsMapTool::searchRadiusMM();
   const double pixelsPerMM = mGCPSourceItem->canvas()->logicalDpiX() / 25.4;
   const double searchRadiusPx = searchRadiusMM * pixelsPerMM;
 
+  QPointF pPos;
   QPointF itemPos;
   switch ( type )
   {
     case QgsGcpPoint::PointType::Source:
     {
+      pPos = mGCPSourceItem->toCanvasCoordinates( p );
       itemPos = mGCPSourceItem->pos();
       break;
     }
 
     case QgsGcpPoint::PointType::Destination:
     {
+      pPos = mGCPDestinationItem->toCanvasCoordinates( p );
       itemPos = mGCPDestinationItem->pos();
       break;
     }
   }
 
-  const double dx = p.x() - itemPos.x();
-  const double dy = p.y() - itemPos.y();
+  const double dx = pPos.x() - itemPos.x();
+  const double dy = pPos.y() - itemPos.y();
   distance = std::sqrt( dx * dx + dy * dy );
   return distance <= searchRadiusPx;
 }
 
-void QgsGeorefDataPoint::moveTo( QPoint canvasPixels, QgsGcpPoint::PointType type )
+void QgsGeorefDataPoint::moveTo( QgsPointXY p, QgsGcpPoint::PointType type )
 {
   switch ( type )
   {
     case QgsGcpPoint::PointType::Source:
     {
-      const QgsPointXY pnt = mGCPSourceItem->toMapCoordinates( canvasPixels );
-      mGcpPoint.setSourcePoint( pnt );
+      mGcpPoint.setSourcePoint( p );
       break;
     }
     case QgsGcpPoint::PointType::Destination:
     {
-      mGcpPoint.setDestinationPoint( mGCPDestinationItem->toMapCoordinates( canvasPixels ) );
+      mGcpPoint.setDestinationPoint( p );
       if ( mSrcCanvas && mSrcCanvas->mapSettings().destinationCrs().isValid() )
         mGcpPoint.setDestinationPointCrs( mSrcCanvas->mapSettings().destinationCrs() );
       else

--- a/src/app/georeferencer/qgsgeorefdatapoint.cpp
+++ b/src/app/georeferencer/qgsgeorefdatapoint.cpp
@@ -45,6 +45,7 @@ QgsGeorefDataPoint::QgsGeorefDataPoint( const QgsGeorefDataPoint &p )
   , mDstCanvas( p.mDstCanvas )
   , mGCPSourceItem( nullptr )
   , mGCPDestinationItem( nullptr )
+  , mHovered( p.mHovered )
   , mGcpPoint( p.mGcpPoint )
   , mId( p.id() )
   , mResidual( p.residual() )
@@ -144,7 +145,7 @@ void QgsGeorefDataPoint::setHovered( bool hovered )
   }
 }
 
-bool QgsGeorefDataPoint::contains( QgsPointXY p, QgsGcpPoint::PointType type, double &distance )
+bool QgsGeorefDataPoint::contains( const QgsPointXY &p, QgsGcpPoint::PointType type, double &distance )
 {
   const double searchRadiusMM = QgsMapTool::searchRadiusMM();
   const double pixelsPerMM = mGCPSourceItem->canvas()->logicalDpiX() / 25.4;

--- a/src/app/georeferencer/qgsgeorefdatapoint.cpp
+++ b/src/app/georeferencer/qgsgeorefdatapoint.cpp
@@ -130,6 +130,20 @@ void QgsGeorefDataPoint::updateCoords()
   }
 }
 
+void QgsGeorefDataPoint::setHovered( bool hovered )
+{
+  mHovered = hovered;
+
+  if ( mGCPSourceItem )
+  {
+    mGCPSourceItem->update();
+  }
+  if ( mGCPDestinationItem )
+  {
+    mGCPDestinationItem->update();
+  }
+}
+
 bool QgsGeorefDataPoint::contains( QgsPointXY p, QgsGcpPoint::PointType type, double &distance )
 {
   const double searchRadiusMM = QgsMapTool::searchRadiusMM();

--- a/src/app/georeferencer/qgsgeorefdatapoint.h
+++ b/src/app/georeferencer/qgsgeorefdatapoint.h
@@ -110,7 +110,7 @@ class APP_EXPORT QgsGeorefDataPoint : public QObject
     int id() const { return mId; }
     void setId( int id );
 
-    bool contains( QgsPointXY p, QgsGcpPoint::PointType type, double &distance );
+    bool contains( const QgsPointXY &p, QgsGcpPoint::PointType type, double &distance );
 
     QgsMapCanvas *srcCanvas() const { return mSrcCanvas; }
     QgsMapCanvas *dstCanvas() const { return mDstCanvas; }

--- a/src/app/georeferencer/qgsgeorefdatapoint.h
+++ b/src/app/georeferencer/qgsgeorefdatapoint.h
@@ -106,7 +106,7 @@ class APP_EXPORT QgsGeorefDataPoint : public QObject
     int id() const { return mId; }
     void setId( int id );
 
-    bool contains( QPoint p, QgsGcpPoint::PointType type, double &distance );
+    bool contains( QgsPointXY p, QgsGcpPoint::PointType type, double &distance );
 
     QgsMapCanvas *srcCanvas() const { return mSrcCanvas; }
     QgsMapCanvas *dstCanvas() const { return mDstCanvas; }
@@ -124,7 +124,7 @@ class APP_EXPORT QgsGeorefDataPoint : public QObject
     QgsGcpPoint point() const { return mGcpPoint; }
 
   public slots:
-    void moveTo( QPoint canvasPixels, QgsGcpPoint::PointType type );
+    void moveTo( QgsPointXY p, QgsGcpPoint::PointType type );
     void updateCoords();
 
   private:

--- a/src/app/georeferencer/qgsgeorefdatapoint.h
+++ b/src/app/georeferencer/qgsgeorefdatapoint.h
@@ -103,6 +103,10 @@ class APP_EXPORT QgsGeorefDataPoint : public QObject
      */
     void setEnabled( bool enabled );
 
+    bool isHovered() const { return mHovered; }
+
+    void setHovered( bool hovered );
+
     int id() const { return mId; }
     void setId( int id );
 
@@ -132,6 +136,7 @@ class APP_EXPORT QgsGeorefDataPoint : public QObject
     QgsMapCanvas *mDstCanvas = nullptr;
     QgsGCPCanvasItem *mGCPSourceItem = nullptr;
     QgsGCPCanvasItem *mGCPDestinationItem = nullptr;
+    bool mHovered = false;
 
     QgsGcpPoint mGcpPoint;
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -728,7 +728,7 @@ void QgsGeoreferencerMainWindow::deleteDataPoint( int theGCPIndex )
   updateGeorefTransform();
 }
 
-void QgsGeoreferencerMainWindow::selectPoint( QPoint p )
+void QgsGeoreferencerMainWindow::selectPoint( QgsPointXY p )
 {
   const QgsGcpPoint::PointType pointType = sender() == mToolMovePoint ? QgsGcpPoint::PointType::Source : QgsGcpPoint::PointType::Destination;
   QgsGeorefDataPoint *&mvPoint = pointType == QgsGcpPoint::PointType::Source ? mMovingPoint : mMovingPointQgis;
@@ -748,19 +748,19 @@ void QgsGeoreferencerMainWindow::selectPoint( QPoint p )
   }
 }
 
-void QgsGeoreferencerMainWindow::movePoint( QPoint canvasPixels )
+void QgsGeoreferencerMainWindow::movePoint( QgsPointXY p )
 {
   const QgsGcpPoint::PointType pointType = sender() == mToolMovePoint ? QgsGcpPoint::PointType::Source : QgsGcpPoint::PointType::Destination;
   QgsGeorefDataPoint *&mvPoint = pointType == QgsGcpPoint::PointType::Source ? mMovingPoint : mMovingPointQgis;
 
   if ( mvPoint )
   {
-    mvPoint->moveTo( canvasPixels, pointType );
+    mvPoint->moveTo( p, pointType );
     mGCPListWidget->updateResiduals();
   }
 }
 
-void QgsGeoreferencerMainWindow::releasePoint( QPoint p )
+void QgsGeoreferencerMainWindow::releasePoint( QgsPointXY p )
 {
   Q_UNUSED( p )
   mGCPListWidget->updateResiduals();

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1154,7 +1154,7 @@ void QgsGeoreferencerMainWindow::createActions()
   connect( mActionFullHistogramStretch, &QAction::triggered, this, &QgsGeoreferencerMainWindow::fullHistogramStretch );
   mActionFullHistogramStretch->setEnabled( false );
 
-  mActionQuit->setShortcuts( QList<QKeySequence>() << QKeySequence( QStringLiteral( "CTRL+Q" ) ) << QKeySequence( Qt::Key_Escape ) );
+  mActionQuit->setShortcuts( QList<QKeySequence>() << QKeySequence( QStringLiteral( "CTRL+Q" ) ) );
   connect( mActionQuit, &QAction::triggered, this, &QWidget::close );
 }
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -744,6 +744,12 @@ void QgsGeoreferencerMainWindow::selectPoint( const QgsPointXY &p )
   mvPoint = findPoint( p, pointType );
   if ( mvPoint )
   {
+    if ( mHoveredPoint )
+    {
+      mHoveredPoint->setHovered( false );
+      mHoveredPoint = nullptr;
+    }
+
     if ( pointType == QgsGcpPoint::PointType::Source )
     {
       mToolMovePoint->setStartPoint( mvPoint->sourcePoint() );
@@ -794,7 +800,7 @@ void QgsGeoreferencerMainWindow::movePoint( const QgsPointXY &p )
   }
 }
 
-void QgsGeoreferencerMainWindow::releasePoint( const QgsPointXY & )
+void QgsGeoreferencerMainWindow::releasePoint( const QgsPointXY &p )
 {
   const QgsGcpPoint::PointType pointType = sender() == mToolMovePoint ? QgsGcpPoint::PointType::Source : QgsGcpPoint::PointType::Destination;
   if ( pointType == QgsGcpPoint::PointType::Source )
@@ -807,6 +813,17 @@ void QgsGeoreferencerMainWindow::releasePoint( const QgsPointXY & )
     mToolMovePointQgis->setStartPoint( QgsPointXY() );
     mMovingPointQgis = nullptr;
   }
+
+  QgsGeorefDataPoint *point = findPoint( p, pointType );
+  if ( point )
+  {
+    point->setHovered( true );
+  }
+  if ( mHoveredPoint && point != mHoveredPoint )
+  {
+    mHoveredPoint->setHovered( false );
+  }
+  mHoveredPoint = point;
 }
 
 void QgsGeoreferencerMainWindow::cancelPoint( const QgsPointXY &p )

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -691,28 +691,16 @@ void QgsGeoreferencerMainWindow::addPoint( const QgsPointXY &sourceCoords, const
   }
 }
 
-void QgsGeoreferencerMainWindow::deleteDataPoint( QPoint coords )
+void QgsGeoreferencerMainWindow::deletePoint( const QgsPointXY &p )
 {
-  QgsGeorefDataPoint *dataPoint = nullptr;
-  double lastPickedDistance = -1.0;
-  for ( QgsGCPList::iterator it = mPoints.begin(); it != mPoints.end(); ++it )
+  QgsGeorefDataPoint *point = findPoint( p, QgsGcpPoint::PointType::Source );
+  if ( point )
   {
-    QgsGeorefDataPoint *pt = *it;
-    double distance = 0.0;
-    if ( pt->contains( coords, QgsGcpPoint::PointType::Source, distance ) ) // first operand for removing from GCP table
-    {
-      if ( lastPickedDistance < 0 || lastPickedDistance > distance )
-      {
-        dataPoint = *it;
-        lastPickedDistance = distance;
-      }
-    }
-  }
+    // At this stage, the hovered point will be the one being deleted
+    mHoveredPoint = nullptr;
 
-  if ( dataPoint )
-  {
-    mPoints.removeAll( dataPoint );
-    delete dataPoint;
+    mPoints.removeAll( point );
+    delete point;
     mGCPListWidget->setGCPList( &mPoints );
     mCanvas->refresh();
     updateGeorefTransform();
@@ -765,6 +753,20 @@ void QgsGeoreferencerMainWindow::selectPoint( const QgsPointXY &p )
       mToolMovePointQgis->setStartPoint( mvPoint->destinationPoint() );
     }
   }
+}
+
+void QgsGeoreferencerMainWindow::hoverPoint( const QgsPointXY &p )
+{
+  QgsGeorefDataPoint *point = findPoint( p, QgsGcpPoint::PointType::Source );
+  if ( point )
+  {
+    point->setHovered( true );
+  }
+  if ( mHoveredPoint && point != mHoveredPoint )
+  {
+    mHoveredPoint->setHovered( false );
+  }
+  mHoveredPoint = point;
 }
 
 void QgsGeoreferencerMainWindow::movePoint( const QgsPointXY &p )
@@ -1264,7 +1266,15 @@ void QgsGeoreferencerMainWindow::createMapCanvas()
 
   mToolDeletePoint = new QgsGeorefToolDeletePoint( mCanvas );
   mToolDeletePoint->setAction( mActionDeletePoint );
-  connect( mToolDeletePoint, &QgsGeorefToolDeletePoint::deleteDataPoint, this, static_cast<void ( QgsGeoreferencerMainWindow::* )( QPoint )>( &QgsGeoreferencerMainWindow::deleteDataPoint ) );
+  connect( mToolDeletePoint, &QgsGeorefToolDeletePoint::hoverPoint, this, &QgsGeoreferencerMainWindow::hoverPoint );
+  connect( mToolDeletePoint, &QgsGeorefToolDeletePoint::deletePoint, this, &QgsGeoreferencerMainWindow::deletePoint );
+  connect( mToolDeletePoint, &QgsMapTool::deactivated, this, [=] {
+    if ( mHoveredPoint )
+    {
+      mHoveredPoint->setHovered( false );
+      mHoveredPoint = nullptr;
+    }
+  } );
 
   mToolMovePoint = new QgsGeorefToolMovePoint( mCanvas );
   mToolMovePoint->setAction( mActionMoveGCPPoint );
@@ -1354,7 +1364,7 @@ void QgsGeoreferencerMainWindow::createDockWidgets()
   dockWidgetGCPpoints->setWidget( mGCPListWidget );
 
   connect( mGCPListWidget, &QgsGCPListWidget::jumpToGCP, this, &QgsGeoreferencerMainWindow::recenterOnPoint );
-  connect( mGCPListWidget, static_cast<void ( QgsGCPListWidget::* )( int )>( &QgsGCPListWidget::deleteDataPoint ), this, static_cast<void ( QgsGeoreferencerMainWindow::* )( int )>( &QgsGeoreferencerMainWindow::deleteDataPoint ) );
+  connect( mGCPListWidget, static_cast<void ( QgsGCPListWidget::* )( int )>( &QgsGCPListWidget::deleteDataPoint ), this, &QgsGeoreferencerMainWindow::deleteDataPoint );
   connect( mGCPListWidget, &QgsGCPListWidget::pointEnabled, this, &QgsGeoreferencerMainWindow::updateGeorefTransform );
 }
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -130,9 +130,9 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     void deleteDataPoint( int index );
     void showCoordDialog( const QgsPointXY &sourceCoordinates );
 
-    void selectPoint( QPoint );
-    void movePoint( QPoint canvasPixels );
-    void releasePoint( QPoint );
+    void selectPoint( QgsPointXY p );
+    void movePoint( QgsPointXY p );
+    void releasePoint( QgsPointXY p );
 
     void loadGCPsDialog();
     void saveGCPsDialog();

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -134,6 +134,7 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     void selectPoint( QgsPointXY p );
     void movePoint( QgsPointXY p );
     void releasePoint( QgsPointXY p );
+    void cancelPoint( QgsPointXY p );
 
     void loadGCPsDialog();
     void saveGCPsDialog();
@@ -298,6 +299,8 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
 
     QgsGeorefDataPoint *mMovingPoint = nullptr;
     QgsGeorefDataPoint *mMovingPointQgis = nullptr;
+    QgsPointXY mMovingPointLastPosition;
+
     QgsGeorefDataPoint *mNewlyAddedPoint = nullptr;
     QgsGeorefDataPoint *mHoveredPoint = nullptr;
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -131,10 +131,10 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     void deleteDataPoint( int index );
     void showCoordDialog( const QgsPointXY &sourceCoordinates );
 
-    void selectPoint( QgsPointXY p );
-    void movePoint( QgsPointXY p );
-    void releasePoint( QgsPointXY p );
-    void cancelPoint( QgsPointXY p );
+    void selectPoint( const QgsPointXY &p );
+    void movePoint( const QgsPointXY &p );
+    void releasePoint( const QgsPointXY &p );
+    void cancelPoint( const QgsPointXY &p );
 
     void loadGCPsDialog();
     void saveGCPsDialog();
@@ -189,7 +189,7 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     // gcp points
     bool loadGCPs( QString &error );
     void saveGCPs();
-    QgsGeorefDataPoint *findPoint( QgsPointXY &p, QgsGcpPoint::PointType pointType );
+    QgsGeorefDataPoint *findPoint( const QgsPointXY &p, QgsGcpPoint::PointType pointType );
 
     QgsGeoreferencerMainWindow::SaveGCPs checkNeedGCPSave();
 
@@ -299,8 +299,6 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
 
     QgsGeorefDataPoint *mMovingPoint = nullptr;
     QgsGeorefDataPoint *mMovingPointQgis = nullptr;
-    QgsPointXY mMovingPointLastPosition;
-
     QgsGeorefDataPoint *mNewlyAddedPoint = nullptr;
     QgsGeorefDataPoint *mHoveredPoint = nullptr;
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -15,6 +15,7 @@
 #include "qgsgeoreftransform.h"
 
 #include "qgsgcplist.h"
+#include "qgsgcppoint.h"
 #include "qgsmapcoordsdialog.h"
 #include "qgsimagewarper.h"
 #include "qgscoordinatereferencesystem.h"
@@ -187,6 +188,8 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     // gcp points
     bool loadGCPs( QString &error );
     void saveGCPs();
+    QgsGeorefDataPoint *findPoint( QgsPointXY &p, QgsGcpPoint::PointType pointType );
+
     QgsGeoreferencerMainWindow::SaveGCPs checkNeedGCPSave();
 
     // georeference
@@ -296,6 +299,8 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
     QgsGeorefDataPoint *mMovingPoint = nullptr;
     QgsGeorefDataPoint *mMovingPointQgis = nullptr;
     QgsGeorefDataPoint *mNewlyAddedPoint = nullptr;
+    QgsGeorefDataPoint *mHoveredPoint = nullptr;
+
     QPointer<QgsMapCoordsDialog> mMapCoordsDialog;
 
     bool mUseZeroForTrans = false;

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -126,10 +126,11 @@ class APP_EXPORT QgsGeoreferencerMainWindow : public QMainWindow, private Ui::Qg
      * \param finalize
      */
     void addPoint( const QgsPointXY &sourceCoords, const QgsPointXY &destinationMapCoords, const QgsCoordinateReferenceSystem &destinationCrs, bool enable = true, bool finalize = true );
-
-    void deleteDataPoint( QPoint pixelCoords );
     void deleteDataPoint( int index );
     void showCoordDialog( const QgsPointXY &sourceCoordinates );
+
+    void deletePoint( const QgsPointXY &p );
+    void hoverPoint( const QgsPointXY &p );
 
     void selectPoint( const QgsPointXY &p );
     void movePoint( const QgsPointXY &p );

--- a/src/app/georeferencer/qgsgeoreftooldeletepoint.cpp
+++ b/src/app/georeferencer/qgsgeoreftooldeletepoint.cpp
@@ -19,16 +19,19 @@
 #include "qgsmapmouseevent.h"
 
 QgsGeorefToolDeletePoint::QgsGeorefToolDeletePoint( QgsMapCanvas *canvas )
-  : QgsMapToolEmitPoint( canvas )
+  : QgsMapTool( canvas )
 {
 }
 
-// Mouse press event for overriding
+void QgsGeorefToolDeletePoint::canvasMoveEvent( QgsMapMouseEvent *e )
+{
+  emit hoverPoint( toMapCoordinates( e->pos() ) );
+}
+
 void QgsGeorefToolDeletePoint::canvasPressEvent( QgsMapMouseEvent *e )
 {
-  // Only add point on Qt:LeftButton
   if ( Qt::LeftButton == e->button() )
   {
-    emit deleteDataPoint( e->pos() );
+    emit deletePoint( toMapCoordinates( e->pos() ) );
   }
 }

--- a/src/app/georeferencer/qgsgeoreftooldeletepoint.h
+++ b/src/app/georeferencer/qgsgeoreftooldeletepoint.h
@@ -21,18 +21,19 @@
 class QgsPointXY;
 class QgsMapCanvas;
 
-class QgsGeorefToolDeletePoint : public QgsMapToolEmitPoint
+class QgsGeorefToolDeletePoint : public QgsMapTool
 {
     Q_OBJECT
 
   public:
     explicit QgsGeorefToolDeletePoint( QgsMapCanvas *canvas );
 
-    // Mouse events for overriding
+    void canvasMoveEvent( QgsMapMouseEvent *e ) override;
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
 
   signals:
-    void deleteDataPoint( QPoint );
+    void hoverPoint( const QgsPointXY &p );
+    void deletePoint( const QgsPointXY &p );
 };
 
 #endif // QGSGEOREFTOOLDELETEPOINT_H

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
@@ -39,6 +39,10 @@ void QgsGeorefToolMovePoint::canvasPressEvent( QgsMapMouseEvent *e )
       mStartPointMapCoords = QgsPointXY();
     }
   }
+  else if ( e->button() & Qt::RightButton )
+  {
+    mStartPointMapCoords = QgsPointXY();
+  }
 }
 
 bool QgsGeorefToolMovePoint::isCanvas( QgsMapCanvas *canvas )
@@ -62,7 +66,14 @@ void QgsGeorefToolMovePoint::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
   if ( mStartPointMapCoords.isEmpty() )
   {
-    mSnapIndicator->setMatch( QgsPointLocator::Match() );
-    emit pointReleased( toMapCoordinates( e->pos() ) );
+    if ( e->button() & Qt::LeftButton )
+    {
+      mSnapIndicator->setMatch( QgsPointLocator::Match() );
+      emit pointReleased( toMapCoordinates( e->pos() ) );
+    }
+    else if ( e->button() & Qt::RightButton )
+    {
+      emit pointCanceled( toMapCoordinates( e->pos() ) );
+    }
   }
 }

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
@@ -48,13 +48,14 @@ bool QgsGeorefToolMovePoint::isCanvas( QgsMapCanvas *canvas )
 
 void QgsGeorefToolMovePoint::canvasMoveEvent( QgsMapMouseEvent *e )
 {
+  QgsPointLocator::Match match;
   if ( !mStartPointMapCoords.isEmpty() )
   {
     const QgsPointXY pnt = toMapCoordinates( e->pos() );
-    QgsPointLocator::Match match = canvas()->snappingUtils()->snapToMap( pnt );
+    match = canvas()->snappingUtils()->snapToMap( pnt );
     mSnapIndicator->setMatch( match );
-    emit pointMoved( match.isValid() ? match.point() : toMapCoordinates( e->pos() ) );
   }
+  emit pointMoved( match.isValid() ? match.point() : toMapCoordinates( e->pos() ) );
 }
 
 void QgsGeorefToolMovePoint::canvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
@@ -48,7 +48,7 @@ void QgsGeorefToolMovePoint::canvasReleaseEvent( QgsMapMouseEvent *e )
   {
     if ( mStartPointMapCoords.isEmpty() )
     {
-      emit pointBeginMove( mStartPointMapCoords );
+      emit pointBeginMove( toMapCoordinates( e->pos() ) );
     }
     else
     {

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.cpp
@@ -65,3 +65,15 @@ void QgsGeorefToolMovePoint::canvasReleaseEvent( QgsMapMouseEvent *e )
     }
   }
 }
+
+void QgsGeorefToolMovePoint::keyPressEvent( QKeyEvent *event )
+{
+  if ( event->key() == Qt::Key_Escape )
+  {
+    if ( !mStartPointMapCoords.isEmpty() )
+    {
+      mSnapIndicator->setMatch( QgsPointLocator::Match() );
+      emit pointCancelMove( QgsPointXY() );
+    }
+  }
+}

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.h
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.h
@@ -37,6 +37,7 @@ class QgsGeorefToolMovePoint : public QgsMapTool
     void pointPressed( QgsPointXY p );
     void pointMoved( QgsPointXY p );
     void pointReleased( QgsPointXY p );
+    void pointCanceled( QgsPointXY p );
 
   private:
     //! Start point of the move in map coordinates

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.h
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.h
@@ -27,22 +27,23 @@ class QgsGeorefToolMovePoint : public QgsMapTool
   public:
     explicit QgsGeorefToolMovePoint( QgsMapCanvas *canvas );
 
-    void canvasPressEvent( QgsMapMouseEvent *e ) override;
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
 
     bool isCanvas( QgsMapCanvas * );
 
+    QgsPointXY startPoint() const { return mStartPointMapCoords; }
+    void setStartPoint( const QgsPointXY &startPoint ) { mStartPointMapCoords = startPoint; }
+
   signals:
-    void pointPressed( QgsPointXY p );
-    void pointMoved( QgsPointXY p );
-    void pointReleased( QgsPointXY p );
-    void pointCanceled( QgsPointXY p );
+    void pointBeginMove( const QgsPointXY &p );
+    void pointMoving( const QgsPointXY &p );
+    void pointEndMove( const QgsPointXY &p );
+    void pointCancelMove( const QgsPointXY &p );
 
   private:
     //! Start point of the move in map coordinates
     QgsPointXY mStartPointMapCoords;
-
     std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 };
 

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.h
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.h
@@ -29,6 +29,7 @@ class QgsGeorefToolMovePoint : public QgsMapTool
 
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
 
     bool isCanvas( QgsMapCanvas * );
 

--- a/src/app/georeferencer/qgsgeoreftoolmovepoint.h
+++ b/src/app/georeferencer/qgsgeoreftoolmovepoint.h
@@ -18,6 +18,7 @@
 
 #include "qgsmaptool.h"
 #include "qgsrubberband.h"
+#include "qgssnapindicator.h"
 
 class QgsGeorefToolMovePoint : public QgsMapTool
 {
@@ -33,13 +34,15 @@ class QgsGeorefToolMovePoint : public QgsMapTool
     bool isCanvas( QgsMapCanvas * );
 
   signals:
-    void pointPressed( QPoint p );
-    void pointMoved( QPoint p );
-    void pointReleased( QPoint p );
+    void pointPressed( QgsPointXY p );
+    void pointMoved( QgsPointXY p );
+    void pointReleased( QgsPointXY p );
 
   private:
     //! Start point of the move in map coordinates
-    QPoint mStartPointMapCoords;
+    QgsPointXY mStartPointMapCoords;
+
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 };
 
 #endif // QGSGEOREFTOOLMOVEPOINT_H


### PR DESCRIPTION
## Description

This PR upgrades the georeferencer's move GCP point tool to rely on a click-move-click behavior. On top of harmonizing the behavior with other QGIS tools (such as the vertex editor tool, annotation node manipulation tool, etc.), it allows us to implement snapping when moving the GCP points. 

Having moved to the click-move-click behavior also made it possible to implement a right-click cancel functionality when users realize they are moving the wrong GCP point.

Finally, GCP points now react to being hovered, with a larger symbol being drawn when that's the case. It makes for a much nicer experience trying to pick the right point to move.