### PR TITLE
[Backport release-3_40] ensures that "gdal:rasterize" uses integer numbers as input to -ts parameter

### DIFF
--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -250,8 +250,8 @@ class rasterize(GdalAlgorithm):
         units = self.parameterAsEnum(parameters, self.UNITS, context)
         if units == 0:
             arguments.append("-ts")
-            arguments.append(self.parameterAsInt(parameters, self.WIDTH, context))
-            arguments.append(self.parameterAsInt(parameters, self.HEIGHT, context))
+            arguments.append(int(self.parameterAsDouble(parameters, self.WIDTH, context)))
+            arguments.append(int(self.parameterAsDouble(parameters, self.HEIGHT, context)))
         else:
             arguments.append("-tr")
             arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -250,8 +250,12 @@ class rasterize(GdalAlgorithm):
         units = self.parameterAsEnum(parameters, self.UNITS, context)
         if units == 0:
             arguments.append("-ts")
-            arguments.append(int(self.parameterAsDouble(parameters, self.WIDTH, context)))
-            arguments.append(int(self.parameterAsDouble(parameters, self.HEIGHT, context)))
+            arguments.append(
+                int(self.parameterAsDouble(parameters, self.WIDTH, context))
+            )
+            arguments.append(
+                int(self.parameterAsDouble(parameters, self.HEIGHT, context))
+            )
         else:
             arguments.append("-tr")
             arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -250,10 +250,12 @@ class rasterize(GdalAlgorithm):
         units = self.parameterAsEnum(parameters, self.UNITS, context)
         if units == 0:
             arguments.append("-ts")
+            arguments.append(self.parameterAsInt(parameters, self.WIDTH, context))
+            arguments.append(self.parameterAsInt(parameters, self.HEIGHT, context))
         else:
             arguments.append("-tr")
-        arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))
-        arguments.append(self.parameterAsDouble(parameters, self.HEIGHT, context))
+            arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))
+            arguments.append(self.parameterAsDouble(parameters, self.HEIGHT, context))
 
         if self.INIT in parameters and parameters[self.INIT] is not None:
             initValue = self.parameterAsDouble(parameters, self.INIT, context)

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -3506,6 +3506,30 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ],
             )
 
+            # truncate HEIGHT and WIDTH floats
+            self.assertEqual(
+                alg.getConsoleCommands(
+                    {
+                        "INPUT": source,
+                        "FIELD": "id",
+                        "UNITS": 0,
+                        "WIDTH": 100.4,
+                        "HEIGHT": 200.6,
+                        "OUTPUT": outdir + "/check.jpg",
+                    },
+                    context,
+                    feedback,
+                ),
+                [
+                    "gdal_rasterize",
+                    "-l polys2 -a id -ts 100 200 -ot Float32 -of JPEG "
+                    + source
+                    + " "
+                    + outdir
+                    + "/check.jpg",
+                ],
+            )
+
             if GdalUtils.version() >= 3070000:
                 self.assertEqual(
                     alg.getConsoleCommands(

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -3332,7 +3332,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -ot Float32 -of JPEG "
+                    "-l polys2 -a id -ts 0 0 -ot Float32 -of JPEG "
                     + source
                     + " "
                     + outdir
@@ -3353,7 +3353,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -a_nodata 9999.0 -ot Float32 -of JPEG "
+                    "-l polys2 -a id -ts 0 0 -a_nodata 9999.0 -ot Float32 -of JPEG "
                     + source
                     + " "
                     + outdir
@@ -3374,7 +3374,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -init 0.0 -ot Float32 -of JPEG "
+                    "-l polys2 -a id -ts 0 0 -init 0.0 -ot Float32 -of JPEG "
                     + source
                     + " "
                     + outdir
@@ -3395,7 +3395,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -a_nodata 0.0 -ot Float32 -of JPEG "
+                    "-l polys2 -a id -ts 0 0 -a_nodata 0.0 -ot Float32 -of JPEG "
                     + source
                     + " "
                     + outdir
@@ -3416,7 +3416,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -ot Float32 -of JPEG -at -add "
+                    "-l polys2 -a id -ts 0 0 -ot Float32 -of JPEG -at -add "
                     + source
                     + " "
                     + outdir
@@ -3433,7 +3433,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG "
+                    "-l pointsz -3d -ts 0 0 -ot Float32 -of JPEG "
                     + sourceZ
                     + " "
                     + outdir
@@ -3455,7 +3455,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG "
+                    "-l pointsz -3d -ts 0 0 -ot Float32 -of JPEG "
                     + sourceZ
                     + " "
                     + outdir
@@ -3477,7 +3477,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -te -1.0 -3.0 10.0 6.0 -ot Float32 -of JPEG "
+                    "-l polys2 -a id -ts 0 0 -te -1.0 -3.0 10.0 6.0 -ot Float32 -of JPEG "
                     + source
                     + " "
                     + outdir
@@ -3498,7 +3498,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -te -1.000000001857055 -2.9999999963940835 10.000000000604246 5.999999999604708 -ot Float32 -of JPEG "
+                    "-l polys2 -a id -ts 0 0 -te -1.000000001857055 -2.9999999963940835 10.000000000604246 5.999999999604708 -ot Float32 -of JPEG "
                     + source
                     + " "
                     + outdir
@@ -3520,7 +3520,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                     ),
                     [
                         "gdal_rasterize",
-                        "-l polys2 -a id -ts 0.0 0.0 -ot Float32 -of JPEG -oo X_POSSIBLE_NAMES=geom_x -oo Y_POSSIBLE_NAMES=geom_y "
+                        "-l polys2 -a id -ts 0 0 -ot Float32 -of JPEG -oo X_POSSIBLE_NAMES=geom_x -oo Y_POSSIBLE_NAMES=geom_y "
                         + source
                         + " "
                         + outdir
@@ -3540,7 +3540,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ),
                 [
                     "gdal_rasterize",
-                    "-l polys2 -a id -ts 0.0 0.0 -ot Float32 -of JPEG --config X Y --config Z A "
+                    "-l polys2 -a id -ts 0 0 -ot Float32 -of JPEG --config X Y --config Z A "
                     + source
                     + " "
                     + outdir


### PR DESCRIPTION
## Description

Manual backport of https://github.com/qgis/QGIS/pull/60533 to `release-3_40` branch.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
