### PR TITLE
Remove unused clone() method from QgsAbstractPointCloudIndex

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -53,14 +53,6 @@ QgsCopcPointCloudIndex::QgsCopcPointCloudIndex() = default;
 
 QgsCopcPointCloudIndex::~QgsCopcPointCloudIndex() = default;
 
-std::unique_ptr<QgsAbstractPointCloudIndex> QgsCopcPointCloudIndex::clone() const
-{
-  QgsCopcPointCloudIndex *clone = new QgsCopcPointCloudIndex;
-  QMutexLocker locker( &mHierarchyMutex );
-  copyCommonProperties( clone );
-  return std::unique_ptr<QgsAbstractPointCloudIndex>( clone );
-}
-
 void QgsCopcPointCloudIndex::load( const QString &urlString )
 {
   QUrl url = urlString;
@@ -430,22 +422,6 @@ QgsPointCloudNode QgsCopcPointCloudIndex::getNode( const QgsPointCloudNodeId &id
 
   QgsBox3D bounds = QgsPointCloudNode::bounds( mRootBounds, id );
   return QgsPointCloudNode( id, pointCount, children, bounds.width() / mSpan, bounds );
-}
-
-void QgsCopcPointCloudIndex::copyCommonProperties( QgsCopcPointCloudIndex *destination ) const
-{
-  QgsAbstractPointCloudIndex::copyCommonProperties( destination );
-
-  // QgsCopcPointCloudIndex specific fields
-  destination->mIsValid = mIsValid;
-  destination->mAccessType = mAccessType;
-  destination->mUri = mUri;
-  if ( mAccessType == Qgis::PointCloudAccessType::Local )
-    destination->mCopcFile.open( QgsLazDecoder::toNativePath( mUri ), std::ios::binary );
-  destination->mCopcInfoVlr = mCopcInfoVlr;
-  destination->mHierarchyNodePos = mHierarchyNodePos;
-  destination->mOriginalMetadata = mOriginalMetadata;
-  destination->mLazInfo.reset( new QgsLazInfo( *mLazInfo ) );
 }
 
 QByteArray QgsCopcPointCloudIndex::readRange( uint64_t offset, uint64_t length ) const

--- a/src/core/pointcloud/qgscopcpointcloudindex.h
+++ b/src/core/pointcloud/qgscopcpointcloudindex.h
@@ -46,8 +46,6 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsAbstractPointCloudIndex
     explicit QgsCopcPointCloudIndex();
     ~QgsCopcPointCloudIndex();
 
-    std::unique_ptr<QgsAbstractPointCloudIndex> clone() const override;
-
     void load( const QString &fileName ) override;
 
     bool hasNode( const QgsPointCloudNodeId &n ) const override;
@@ -76,12 +74,6 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsAbstractPointCloudIndex
      * \since QGIS 3.42
      */
     QgsPointCloudStatistics metadataStatistics() const override;
-
-    /**
-     * Copies common properties to the \a destination index
-     * \since QGIS 3.26
-     */
-    void copyCommonProperties( QgsCopcPointCloudIndex *destination ) const;
 
     /**
      * Returns one datapoint, "CopcGpsTimeFlag": The gps time flag from global_encoding field in LAS header,

--- a/src/core/pointcloud/qgseptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgseptpointcloudindex.cpp
@@ -55,14 +55,6 @@ QgsEptPointCloudIndex::QgsEptPointCloudIndex()
 
 QgsEptPointCloudIndex::~QgsEptPointCloudIndex() = default;
 
-std::unique_ptr<QgsAbstractPointCloudIndex> QgsEptPointCloudIndex::clone() const
-{
-  QgsEptPointCloudIndex *clone = new QgsEptPointCloudIndex;
-  QMutexLocker locker( &mHierarchyMutex );
-  copyCommonProperties( clone );
-  return std::unique_ptr<QgsAbstractPointCloudIndex>( clone );
-}
-
 void QgsEptPointCloudIndex::load( const QString &urlString )
 {
   QUrl url = urlString;
@@ -649,23 +641,6 @@ bool QgsEptPointCloudIndex::isValid() const
 Qgis::PointCloudAccessType QgsEptPointCloudIndex::accessType() const
 {
   return mAccessType;
-}
-
-void QgsEptPointCloudIndex::copyCommonProperties( QgsEptPointCloudIndex *destination ) const
-{
-  QgsAbstractPointCloudIndex::copyCommonProperties( destination );
-
-  // QgsEptPointCloudIndex specific fields
-  destination->mIsValid = mIsValid;
-  destination->mAccessType = mAccessType;
-  destination->mDataType = mDataType;
-  destination->mUrlDirectoryPart = mUrlDirectoryPart;
-  destination->mWkt = mWkt;
-  destination->mHierarchyNodes = mHierarchyNodes;
-  destination->mPointCount = mPointCount;
-  destination->mMetadataStats = mMetadataStats;
-  destination->mAttributeClasses = mAttributeClasses;
-  destination->mOriginalMetadata = mOriginalMetadata;
 }
 
 #undef PROVIDER_KEY

--- a/src/core/pointcloud/qgseptpointcloudindex.h
+++ b/src/core/pointcloud/qgseptpointcloudindex.h
@@ -41,8 +41,6 @@ class CORE_EXPORT QgsEptPointCloudIndex: public QgsAbstractPointCloudIndex
     explicit QgsEptPointCloudIndex();
     ~QgsEptPointCloudIndex();
 
-    std::unique_ptr<QgsAbstractPointCloudIndex> clone() const override;
-
     void load( const QString &fileName ) override;
 
     std::unique_ptr<QgsPointCloudBlock> nodeData( const QgsPointCloudNodeId &n, const QgsPointCloudRequest &request ) override;
@@ -57,12 +55,6 @@ class CORE_EXPORT QgsEptPointCloudIndex: public QgsAbstractPointCloudIndex
 
     bool isValid() const override;
     Qgis::PointCloudAccessType accessType() const override;
-
-    /**
-     * Copies common properties to the \a destination index
-     * \since QGIS 3.26
-     */
-    void copyCommonProperties( QgsEptPointCloudIndex *destination ) const;
 
   protected:
     bool loadSchema( const QByteArray &dataJson );

--- a/src/core/pointcloud/qgspointcloudeditingindex.cpp
+++ b/src/core/pointcloud/qgspointcloudeditingindex.cpp
@@ -47,11 +47,6 @@ QgsPointCloudEditingIndex::QgsPointCloudEditingIndex( QgsPointCloudLayer *layer 
   mIsValid = true;
 }
 
-std::unique_ptr<QgsAbstractPointCloudIndex> QgsPointCloudEditingIndex::clone() const
-{
-  return nullptr;
-}
-
 void QgsPointCloudEditingIndex::load( const QString & )
 {
   return;

--- a/src/core/pointcloud/qgspointcloudeditingindex.h
+++ b/src/core/pointcloud/qgspointcloudeditingindex.h
@@ -39,7 +39,6 @@ class CORE_EXPORT QgsPointCloudEditingIndex : public QgsAbstractPointCloudIndex
     //! Ctor
     explicit QgsPointCloudEditingIndex( QgsPointCloudLayer *layer );
 
-    std::unique_ptr<QgsAbstractPointCloudIndex> clone() const override;
     void load( const QString &fileName ) override;
     bool isValid() const override;
     Qgis::PointCloudAccessType accessType() const override;

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -218,13 +218,6 @@ class CORE_EXPORT QgsAbstractPointCloudIndex
     explicit QgsAbstractPointCloudIndex();
     virtual ~QgsAbstractPointCloudIndex();
 
-    /**
-     * Returns a clone of the current point cloud index object
-     * \note It is the responsibility of the caller to handle the ownership and delete the object.
-     * \since QGIS 3.26
-     */
-    virtual std::unique_ptr<QgsAbstractPointCloudIndex> clone() const = 0;
-
     //! Loads the index from the file
     virtual void load( const QString &fileName ) = 0;
 


### PR DESCRIPTION
## Description

Since my last point cloud refactoring (#59939), `clone()` is no longer used (and shouldn't be used). This PR removes it, since it's now just clutter.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
