### PR TITLE
[Backport release-3_40] [gui] Insure modified attribute form properties are stored when switching from one field to another

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -618,8 +618,13 @@ void QgsAttributesFormProperties::loadAttributeSpecificEditor( QgsAttributesDnDT
   const Qgis::AttributeFormLayout layout = mEditorLayoutComboBox->currentData().value<Qgis::AttributeFormLayout>();
 
   if ( layout == Qgis::AttributeFormLayout::DragAndDrop )
+  {
     storeAttributeWidgetEdit();
-
+  }
+  if ( mAttributeTypeDialog )
+  {
+    storeAttributeTypeDialog();
+  }
   clearAttributeTypeFrame();
 
   if ( emitter->selectedItems().count() != 1 )
@@ -648,7 +653,9 @@ void QgsAttributesFormProperties::loadAttributeSpecificEditor( QgsAttributesDnDT
       {
         receiver->selectFirstMatchingItem( itemData );
         if ( layout == Qgis::AttributeFormLayout::DragAndDrop )
+        {
           loadAttributeWidgetEdit();
+        }
         loadAttributeTypeDialog();
         break;
       }

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -422,6 +422,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QString mInitFilePath;
     QString mInitCode;
     int mBlockUpdates = 0;
+
+    friend class TestQgsAttributesFormProperties;
 };
 
 

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TESTS
   testqgsdoublespinbox.cpp
   testqgsdualview.cpp
   testqgsattributeform.cpp
+  testqgsattributesformproperties.cpp
   testqgsdatetimeedit.cpp
   testqgsdockwidget.cpp
   testqgsfieldexpressionwidget.cpp

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+    testqgsattributesformproperties.cpp
+     --------------------------------------
+    Date                 : 2025-01-21
+    Copyright            : (C) 2025 Mathieu Pellerin
+    Email                : paul dot blottiere at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+ #include "qgstest.h"
+
+ #include "qgsattributesformproperties.h"
+ #include "qgsattributetypedialog.h"
+ #include "qgsvectorlayer.h"
+ #include "qgsvectordataprovider.h"
+ #include "qgsgui.h"
+ 
+ class TestQgsAttributesFormProperties : public QObject
+ {
+     Q_OBJECT
+   public:
+     TestQgsAttributesFormProperties() = default;
+ 
+   private slots:
+     void initTestCase();    // will be called before the first testfunction is executed.
+     void cleanupTestCase(); // will be called after the last testfunction was executed.
+     void init();            // will be called before each testfunction is executed.
+     void cleanup();         // will be called after every testfunction.
+ 
+     void testConfigStored();
+ };
+ 
+ void TestQgsAttributesFormProperties::initTestCase()
+ {
+   QgsApplication::init();
+   QgsApplication::initQgis();
+ }
+ 
+ void TestQgsAttributesFormProperties::cleanupTestCase()
+ {
+   QgsApplication::exitQgis();
+ }
+ 
+ void TestQgsAttributesFormProperties::init()
+ {
+ }
+ 
+ void TestQgsAttributesFormProperties::cleanup()
+ {
+ }
+ 
+ void TestQgsAttributesFormProperties::testConfigStored()
+ {
+   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=col0:integer&field=col1:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+   QgsAttributesFormProperties attributeFormProperties( layer );
+   attributeFormProperties.init();
+ 
+   // Get the fields
+   QVERIFY( attributeFormProperties.mAvailableWidgetsTree );
+   QTreeWidgetItem *fieldsItem = attributeFormProperties.mAvailableWidgetsTree->topLevelItem( 0 );
+   QVERIFY( fieldsItem );
+   QCOMPARE( fieldsItem->text( 0 ), QStringLiteral( "Fields" ) );
+   QCOMPARE( fieldsItem->childCount(), 2 );
+ 
+   // Insure that the configuration was stored when switching from one available widgets tree item to another
+   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
+   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+   attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias0" ) );
+   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
+   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+   attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias1" ) );
+ 
+   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
+   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+   QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias0" ) );
+   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
+   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+   QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias1" ) );
+ }
+ 
+ QGSTEST_MAIN( TestQgsAttributesFormProperties )
+ #include "testqgsattributesformproperties.moc"
+ 

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -14,77 +14,76 @@
  ***************************************************************************/
 
 
- #include "qgstest.h"
+#include "qgstest.h"
 
- #include "qgsattributesformproperties.h"
- #include "qgsattributetypedialog.h"
- #include "qgsvectorlayer.h"
- #include "qgsvectordataprovider.h"
- #include "qgsgui.h"
- 
- class TestQgsAttributesFormProperties : public QObject
- {
-     Q_OBJECT
-   public:
-     TestQgsAttributesFormProperties() = default;
- 
-   private slots:
-     void initTestCase();    // will be called before the first testfunction is executed.
-     void cleanupTestCase(); // will be called after the last testfunction was executed.
-     void init();            // will be called before each testfunction is executed.
-     void cleanup();         // will be called after every testfunction.
- 
-     void testConfigStored();
- };
- 
- void TestQgsAttributesFormProperties::initTestCase()
- {
-   QgsApplication::init();
-   QgsApplication::initQgis();
- }
- 
- void TestQgsAttributesFormProperties::cleanupTestCase()
- {
-   QgsApplication::exitQgis();
- }
- 
- void TestQgsAttributesFormProperties::init()
- {
- }
- 
- void TestQgsAttributesFormProperties::cleanup()
- {
- }
- 
- void TestQgsAttributesFormProperties::testConfigStored()
- {
-   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=col0:integer&field=col1:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
-   QgsAttributesFormProperties attributeFormProperties( layer );
-   attributeFormProperties.init();
- 
-   // Get the fields
-   QVERIFY( attributeFormProperties.mAvailableWidgetsTree );
-   QTreeWidgetItem *fieldsItem = attributeFormProperties.mAvailableWidgetsTree->topLevelItem( 0 );
-   QVERIFY( fieldsItem );
-   QCOMPARE( fieldsItem->text( 0 ), QStringLiteral( "Fields" ) );
-   QCOMPARE( fieldsItem->childCount(), 2 );
- 
-   // Insure that the configuration was stored when switching from one available widgets tree item to another
-   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
-   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
-   attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias0" ) );
-   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
-   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
-   attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias1" ) );
- 
-   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
-   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
-   QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias0" ) );
-   attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
-   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
-   QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias1" ) );
- }
- 
- QGSTEST_MAIN( TestQgsAttributesFormProperties )
- #include "testqgsattributesformproperties.moc"
- 
+#include "qgsattributesformproperties.h"
+#include "qgsattributetypedialog.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataprovider.h"
+#include "qgsgui.h"
+
+class TestQgsAttributesFormProperties : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsAttributesFormProperties() = default;
+
+  private slots:
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init();            // will be called before each testfunction is executed.
+    void cleanup();         // will be called after every testfunction.
+
+    void testConfigStored();
+};
+
+void TestQgsAttributesFormProperties::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsAttributesFormProperties::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsAttributesFormProperties::init()
+{
+}
+
+void TestQgsAttributesFormProperties::cleanup()
+{
+}
+
+void TestQgsAttributesFormProperties::testConfigStored()
+{
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=col0:integer&field=col1:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  QgsAttributesFormProperties attributeFormProperties( layer );
+  attributeFormProperties.init();
+
+  // Get the fields
+  QVERIFY( attributeFormProperties.mAvailableWidgetsTree );
+  QTreeWidgetItem *fieldsItem = attributeFormProperties.mAvailableWidgetsTree->topLevelItem( 0 );
+  QVERIFY( fieldsItem );
+  QCOMPARE( fieldsItem->text( 0 ), QStringLiteral( "Fields" ) );
+  QCOMPARE( fieldsItem->childCount(), 2 );
+
+  // Insure that the configuration was stored when switching from one available widgets tree item to another
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias0" ) );
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  attributeFormProperties.mAttributeTypeDialog->setAlias( QStringLiteral( "alias1" ) );
+
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 0 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias0" ) );
+  attributeFormProperties.mAvailableWidgetsTree->setCurrentItem( fieldsItem->child( 1 ) );
+  QVERIFY( attributeFormProperties.mAttributeTypeDialog );
+  QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), QStringLiteral( "alias1" ) );
+}
+
+QGSTEST_MAIN( TestQgsAttributesFormProperties )
+#include "testqgsattributesformproperties.moc"


### PR DESCRIPTION
## Description

Manual backport of #60192 

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
