### PR TITLE
[Clang-Tidy] Fix clang-tidy because of unity build

### DIFF
--- a/.docker/docker-qgis-clangtidy.sh
+++ b/.docker/docker-qgis-clangtidy.sh
@@ -34,6 +34,9 @@ echo "::group::Download clang-tidy-diff"
 curl -XGET https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-14.0.6/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o clang-tidy-diff.py
 echo "::endgroup::"
 
+echo "${bold}Disable unity build...${endbold}"
+cmake . -B build -DENABLE_UNITY_BUILDS=OFF
+
 echo "${bold}Run clang-tidy on modifications...${endbold}"
 
 # We need to add build/src/test dir as extra include directories because when clang-tidy tries to process qgstest.h


### PR DESCRIPTION
"Unity builds" build everything into a unique cpp file. That's problematic for clang-tidy which rely on  compile_command.json to figure out how to build each file. Without these informations, clang-tidy displayed false errors (missing include file for instance)

This PR include temporary #60536 (where the issue was initially spotted)  in order to check that the proposed modification actually fix the issue. **EDIT** not anymore, it does fix the issue, I removed the commit