### PR TITLE
Handle polar CRS with NE axis order

### DIFF
--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -95,6 +95,12 @@ void TestQgsProjUtils::axisOrderIsSwapped()
   QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
   crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::3903" ) );
   QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::32761" ) );
+  QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::5482" ) );
+  QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::32661" ) );
+  QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
 }
 
 void TestQgsProjUtils::searchPath()


### PR DESCRIPTION
This PR addresses an issue in QGIS Server where the axis order was not being correctly flipped when handling WMS 1.3.0 requests for the projection `EPSG:32661` (WGS 84 / UPS North), which resulted in inverted responses.

I updated `QgsProjUtils::axisOrderIsSwapped` to handle polar projections by looking in the axis name for 'easting' and 'northing' to determine the order. 

The logic is from the GDAL function [OGRSpatialReference::isNorthEastAxisOrder](https://github.com/OSGeo/gdal/blob/release/3.10/ogr/ogrspatialreference.cpp#L419)
