### PR TITLE
Fix drag and drop for stacked diagrams (follow-up)

### DIFF
--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -88,7 +88,7 @@ void QgsStackedDiagramProperties::addSubDiagramRenderer()
     const QModelIndex currentIndex = mSubDiagramsView->selectionModel()->currentIndex();
     mModel->insertSubDiagram( currentIndex.row() + 1, renderer.release() );
     const QModelIndex newIndex = mModel->index( currentIndex.row() + 1, 0 );
-    mSubDiagramsView->selectionModel()->setCurrentIndex( newIndex, QItemSelectionModel::ClearAndSelect );
+    mSubDiagramsView->selectionModel()->setCurrentIndex( newIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
   }
   else
   {
@@ -103,7 +103,7 @@ void QgsStackedDiagramProperties::appendSubDiagramRenderer( QgsDiagramRenderer *
   const int rows = mModel->rowCount();
   mModel->insertSubDiagram( rows, dr ); // Transfers ownership
   const QModelIndex newIndex = mModel->index( rows, 0 );
-  mSubDiagramsView->selectionModel()->setCurrentIndex( newIndex, QItemSelectionModel::ClearAndSelect );
+  mSubDiagramsView->selectionModel()->setCurrentIndex( newIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
 }
 
 void QgsStackedDiagramProperties::editSubDiagramRenderer()
@@ -199,6 +199,8 @@ void QgsStackedDiagramProperties::syncToLayer()
 
     const QgsDiagramLayerSettings *dls = mLayer->diagramLayerSettings();
     mModel->updateDiagramLayerSettings( *dls );
+
+    mSubDiagramsView->selectionModel()->clear();
   }
 }
 

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -407,7 +407,11 @@ QMimeData *QgsStackedDiagramPropertiesModel::mimeData( const QModelIndexList &in
 
   QDataStream stream( &encodedData, QIODevice::WriteOnly );
 
-  for ( const QModelIndex &index : indexes )
+  // Sort indexes since their order reflects selection order
+  QModelIndexList sortedIndexes = indexes;
+  std::sort( sortedIndexes.begin(), sortedIndexes.end() );
+
+  for ( const QModelIndex &index : std::as_const( sortedIndexes ) )
   {
     // each item consists of several columns - let's add it with just first one
     if ( !index.isValid() || index.column() != 0 )

--- a/src/gui/vector/qgsstackeddiagramproperties.cpp
+++ b/src/gui/vector/qgsstackeddiagramproperties.cpp
@@ -69,6 +69,8 @@ QgsStackedDiagramProperties::QgsStackedDiagramProperties( QgsVectorLayer *layer,
   connect( mModel, &QAbstractItemModel::rowsInserted, this, &QgsStackedDiagramProperties::widgetChanged );
   connect( mModel, &QAbstractItemModel::rowsRemoved, this, &QgsStackedDiagramProperties::widgetChanged );
 
+  connect( mModel, &QgsStackedDiagramPropertiesModel::subDiagramsMoved, this, &QgsStackedDiagramProperties::clearCurrentIndex );
+
   syncToLayer();
 }
 
@@ -169,6 +171,11 @@ void QgsStackedDiagramProperties::removeSubDiagramRenderer()
   }
   // make sure that the selection is gone
   mSubDiagramsView->selectionModel()->clear();
+}
+
+void QgsStackedDiagramProperties::clearCurrentIndex()
+{
+  mSubDiagramsView->selectionModel()->clearCurrentIndex();
 }
 
 void QgsStackedDiagramProperties::syncToLayer()
@@ -490,6 +497,7 @@ bool QgsStackedDiagramPropertiesModel::dropMimeData( const QMimeData *data, Qt::
     }
   }
 
+  emit subDiagramsMoved(); // Let views know they can clean some things up
   return true;
 }
 

--- a/src/gui/vector/qgsstackeddiagramproperties.h
+++ b/src/gui/vector/qgsstackeddiagramproperties.h
@@ -24,6 +24,7 @@
 #include "qgis_gui.h"
 #include "qgsdiagramrenderer.h"
 #include "ui_qgsstackeddiagrampropertiesbase.h"
+#include "qgsproxystyle.h"
 
 #include <QWidget>
 #include <QDialog>
@@ -93,6 +94,25 @@ class GUI_EXPORT QgsStackedDiagramPropertiesModel : public QAbstractTableModel
     QgsDiagramLayerSettings mDiagramLayerSettings;
 };
 
+/**
+ * \ingroup gui
+ * \brief View style which shows drop indicator line between items
+ *
+ * \since QGIS 3.40.6
+ */
+class QgsStackedDiagramsViewStyle : public QgsProxyStyle
+{
+    Q_OBJECT
+
+  public:
+    /**
+    * Constructor for QgsStackedDiagramsViewStyle
+    * \param parent parent object
+    */
+    explicit QgsStackedDiagramsViewStyle( QWidget *parent );
+
+    void drawPrimitive( PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr ) const override;
+};
 
 /**
  * \ingroup gui

--- a/src/gui/vector/qgsstackeddiagramproperties.h
+++ b/src/gui/vector/qgsstackeddiagramproperties.h
@@ -89,6 +89,10 @@ class GUI_EXPORT QgsStackedDiagramPropertiesModel : public QAbstractTableModel
      */
     void updateDiagramLayerSettings( QgsDiagramLayerSettings dls );
 
+  signals:
+    //! Informs views that subdiagrams were moved in the model.
+    void subDiagramsMoved();
+
   protected:
     QList<QgsDiagramRenderer *> mRenderers;
     QgsDiagramLayerSettings mDiagramLayerSettings;
@@ -137,6 +141,13 @@ class GUI_EXPORT QgsStackedDiagramProperties : public QgsPanelWidget, private Ui
 
   public slots:
     void apply();
+
+    /**
+     * Clears current item from the view.
+     *
+     * \since QGIS 3.40.6
+     */
+    void clearCurrentIndex();
 
   private slots:
 


### PR DESCRIPTION
Follow-up #60278.

This PR adjusts issues and improves consistency with drag and drop behavior in other parts of QGIS. See #60596 for screencasts of the buggy behavior in the current master.

Namely, this PR:

1. **Replaces the drop indicator**, switching from a box to a horizontal line (which expands to the whole row). The rationale is that stacked diagrams don't handle (yet) a parent-child hierarchy (i.e., one cannot have nested stacked diagrams in the GUI), but act instead as a flat list. This is consistent with drag and drop for other flat lists in QGIS (e.g., classification symbol lists or graduated symbol lists).

2. Fixes an issue that moves the dropped item to the end of the list (i.e., an **append** operation), even if the desired position was, e.g., between other items.

3. Fixes an issue that makes it possible to obtain **copies** of the dragged object.

4. Enables **moving multiple items** and positioning them in the expected way (e.g., if a diagram A is below a diagram B before the drag, it should continue being below B once dropped).

5. Minor fixes: Allow dropping items **below all other items** (i.e., in the blank area), as well as in the whole row span (i.e., also for columns > 0). 

6. **Clear leftover current index** in the view after the drag'n'drop. This is how other flat lists behave, e.g., Graduated and Classification symbology for vector layers.

Screencast of the result:

https://github.com/user-attachments/assets/e32e2180-344f-4cf7-8906-1707677eaf40

Fix #60596 