### PR TITLE
Fix slow performance of raster image marker

### DIFF
--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3116,7 +3116,7 @@ bool QgsRasterMarkerSymbolLayer::setPreservedAspectRatio( bool par )
 
 double QgsRasterMarkerSymbolLayer::updateDefaultAspectRatio()
 {
-  if ( mDefaultAspectRatio == 0.0 )
+  if ( mDefaultAspectRatio == 0.0 && !mPath.isEmpty() )
   {
     const QSize size = QgsApplication::imageCache()->originalSize( mPath );
     mDefaultAspectRatio = ( !size.isNull() && size.isValid() && size.width() > 0 ) ? static_cast< double >( size.height() ) / static_cast< double >( size.width() ) : 0.0;
@@ -3365,7 +3365,12 @@ QVariantMap QgsRasterMarkerSymbolLayer::properties() const
 
 QgsRasterMarkerSymbolLayer *QgsRasterMarkerSymbolLayer::clone() const
 {
-  auto m = std::make_unique< QgsRasterMarkerSymbolLayer >( mPath, mSize, mAngle );
+  auto m = std::make_unique< QgsRasterMarkerSymbolLayer >();
+  m->mPath = mPath;
+  m->mDefaultAspectRatio = mDefaultAspectRatio;
+  m->mSize = mSize;
+  m->mAngle = mAngle;
+  // other members are copied by:
   copyCommonProperties( m.get() );
   return m.release();
 }


### PR DESCRIPTION
- More efficient cloning of QgsRasterMarkerSymbolLayer, which doesn't require a re-open of the image file
- Cache original image sizes

Fixes https://github.com/qgis/QGIS/issues/51273