### PR TITLE
Add help to GDAL raster Slope and Proximity algs parameters

### DIFF
--- a/python/plugins/processing/algs/gdal/proximity.py
+++ b/python/plugins/processing/algs/gdal/proximity.py
@@ -93,15 +93,16 @@ class proximity(GdalAlgorithm):
                 parentLayerParameterName=self.INPUT,
             )
         )
-        self.addParameter(
-            QgsProcessingParameterString(
-                self.VALUES,
-                self.tr(
-                    "A list of pixel values in the source image to be considered target pixels"
-                ),
-                optional=True,
-            )
+        values_param = QgsProcessingParameterString(
+            self.VALUES,
+            self.tr(
+                "List of target pixels"
+            ),
+            optional=True,
         )
+        values_param.setHelp(self.tr("Comma-separated list of pixel values in the source image to consider as target pixels. If not specified, all non-zero pixels will be considered target pixels."))
+        self.addParameter(values_param)
+
         self.addParameter(
             QgsProcessingParameterEnum(
                 self.UNITS,
@@ -114,33 +115,36 @@ class proximity(GdalAlgorithm):
         self.addParameter(
             QgsProcessingParameterNumber(
                 self.MAX_DISTANCE,
-                self.tr("The maximum distance to be generated"),
+                self.tr("The maximum distance to generate"),
                 type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0.0,
                 defaultValue=0.0,
                 optional=True,
             )
         )
-        self.addParameter(
-            QgsProcessingParameterNumber(
-                self.REPLACE,
-                self.tr(
-                    "Value to be applied to all pixels that are within the -maxdist of target pixels"
-                ),
-                type=QgsProcessingParameterNumber.Type.Double,
-                defaultValue=0.0,
-                optional=True,
-            )
+
+        replace_param = QgsProcessingParameterNumber(
+            self.REPLACE,
+            self.tr(
+                "Value to apply to pixels within the maximum distance of target pixels"
+            ),
+            type=QgsProcessingParameterNumber.Type.Double,
+            defaultValue=0.0,
+            optional=True,
         )
-        self.addParameter(
-            QgsProcessingParameterNumber(
-                self.NODATA,
-                self.tr("Nodata value to use for the destination proximity raster"),
-                type=QgsProcessingParameterNumber.Type.Double,
-                defaultValue=0.0,
-                optional=True,
-            )
+        replace_param.setHelp(self.tr("Value to apply to all pixels within the maximum distance of target pixels (including the target pixels) instead of a distance value"))
+        self.addParameter(replace_param)
+
+        nodata_param = QgsProcessingParameterNumber(
+            self.NODATA,
+            self.tr("Nodata value to use for the destination proximity raster"),
+            type=QgsProcessingParameterNumber.Type.Double,
+            defaultValue=0.0,
+            optional=True,
         )
+        nodata_param.setHelp(self.tr("NoData value to use for the pixels beyond the maximum distance. "
+            "If not provided, it will be set to the one from the output band, or ultimately to 65535."))
+        self.addParameter(nodata_param)
 
         options_param = QgsProcessingParameterString(
             self.OPTIONS,

--- a/python/plugins/processing/algs/gdal/proximity.py
+++ b/python/plugins/processing/algs/gdal/proximity.py
@@ -95,12 +95,14 @@ class proximity(GdalAlgorithm):
         )
         values_param = QgsProcessingParameterString(
             self.VALUES,
-            self.tr(
-                "List of target pixels"
-            ),
+            self.tr("List of target pixels"),
             optional=True,
         )
-        values_param.setHelp(self.tr("Comma-separated list of pixel values in the source image to consider as target pixels. If not specified, all non-zero pixels will be considered target pixels."))
+        values_param.setHelp(
+            self.tr(
+                "Comma-separated list of pixel values in the source image to consider as target pixels. If not specified, all non-zero pixels will be considered target pixels."
+            )
+        )
         self.addParameter(values_param)
 
         self.addParameter(
@@ -132,7 +134,11 @@ class proximity(GdalAlgorithm):
             defaultValue=0.0,
             optional=True,
         )
-        replace_param.setHelp(self.tr("Value to apply to all pixels within the maximum distance of target pixels (including the target pixels) instead of a distance value"))
+        replace_param.setHelp(
+            self.tr(
+                "Value to apply to all pixels within the maximum distance of target pixels (including the target pixels) instead of a distance value"
+            )
+        )
         self.addParameter(replace_param)
 
         nodata_param = QgsProcessingParameterNumber(
@@ -142,8 +148,12 @@ class proximity(GdalAlgorithm):
             defaultValue=0.0,
             optional=True,
         )
-        nodata_param.setHelp(self.tr("NoData value to use for the pixels beyond the maximum distance. "
-            "If not provided, it will be set to the one from the output band, or ultimately to 65535."))
+        nodata_param.setHelp(
+            self.tr(
+                "NoData value to use for the pixels beyond the maximum distance. "
+                "If not provided, it will be set to the one from the output band, or ultimately to 65535."
+            )
+        )
         self.addParameter(nodata_param)
 
         options_param = QgsProcessingParameterString(

--- a/python/plugins/processing/algs/gdal/slope.py
+++ b/python/plugins/processing/algs/gdal/slope.py
@@ -76,7 +76,7 @@ class slope(GdalAlgorithm):
         self.addParameter(
             QgsProcessingParameterBoolean(
                 self.AS_PERCENT,
-                self.tr("Slope expressed as percent instead of degrees"),
+                self.tr("Express slope as percent instead of degrees"),
                 defaultValue=False,
             )
         )


### PR DESCRIPTION
and remove passive form text on labels.
Most (if not all) of our parameters are labeled using active form, excepted these ones (taken fro GDAL). While on my way to adjust and simplify the labels, I took the opportunity to add help text (mostly taken from GDAL docs) to the proximity alg params.

Before
![image](https://github.com/user-attachments/assets/4625d391-053a-46d4-8053-e9f3e17291fd)

After
![Peek 14-02-2025 06-09](https://github.com/user-attachments/assets/62c13db5-a695-419f-bf5d-d7ed79b8f4d5)
