### PR TITLE
Misc changes

### DIFF
--- a/resources/function_help/json/bearing
+++ b/resources/function_help/json/bearing
@@ -13,12 +13,10 @@
     "arg": "source_crs",
     "optional": true,
     "description": "an optional string or CRS object representing the source CRS of the points. By default the current layer's CRS is used."
-
   }, {
     "arg": "ellipsoid",
     "optional": true,
-    "description": "an optional string representing the acronym or the authority:ID (eg 'EPSG:7030') of the ellipsoid on which the bearing should be measured. By default the current project's ellipsoid setting is used."  
-
+    "description": "an optional string representing the acronym or the authority ID (e.g., 'EPSG:7030') of the ellipsoid on which the bearing should be measured. By default the current project's ellipsoid setting is used."
   }],
   "examples": [{
     "expression": "degrees( bearing( make_point(16198544, -4534850), make_point(18736872, -1877769), 'EPSG:3857', 'EPSG:7030') )",

--- a/resources/function_help/json/crs_from_text
+++ b/resources/function_help/json/crs_from_text
@@ -2,7 +2,7 @@
   "name": "crs_from_text",
   "type": "function",
   "groups": ["CRS"],
-  "description": "Creates a coordinate reference system from a string definition. The string can represent an auth:id code, a WKT definition, or a PROJ string definition of the CRS.",
+  "description": "Creates a coordinate reference system from a string definition. The string can represent an authority ID, a WKT definition, or a PROJ string definition of the CRS.",
   "arguments": [{
     "arg": "definition",
     "description": "CRS definition"

--- a/resources/function_help/json/crs_to_authid
+++ b/resources/function_help/json/crs_to_authid
@@ -2,7 +2,7 @@
   "name": "crs_to_authid",
   "type": "function",
   "groups": ["CRS"],
-  "description": "Returns the authority:id identifier string for a coordinate reference system.",
+  "description": "Returns the authority ID string for a coordinate reference system.",
   "arguments": [{
     "arg": "crs",
     "description": "crs value"

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -256,7 +256,7 @@
                 <item row="2" column="0">
                  <widget class="QLabel" name="label_4">
                   <property name="text">
-                   <string>Re&amp;quest step size</string>
+                   <string>Request step size</string>
                   </property>
                   <property name="buddy">
                    <cstring>mTileWidth</cstring>
@@ -510,23 +510,6 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout">
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>QGIS layer name</string>
-             </property>
-             <property name="buddy">
-              <cstring>leLayerName</cstring>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leLayerName"/>
-           </item>
-          </layout>
-         </item>
-         <item>
           <widget class="QCheckBox" name="mLoadLayersIndividuallyCheckBox">
            <property name="toolTip">
             <string>Load each selected layer as an individual layer</string>
@@ -606,7 +589,6 @@
   <tabstop>mFeatureCount</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mContextualLegendCheckbox</tabstop>
-  <tabstop>leLayerName</tabstop>
   <tabstop>mLayerUpButton</tabstop>
   <tabstop>mLayerDownButton</tabstop>
   <tabstop>mLayerOrderTreeWidget</tabstop>


### PR DESCRIPTION
- Remove option to define layer name from WMS source select dialogs - follow-up #60215
- Use a more user-friendly "authority ID" string in crs function help text - refs https://github.com/qgis/QGIS/pull/60485#pullrequestreview-2617818032