### PR TITLE
clang-tidy: Ignore the external directory

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,2 @@
 Checks: 'bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-virtual-near-miss,-bugprone-suspicious-include'
+HeaderFilterRegex: ''

--- a/external/.clang-tidy
+++ b/external/.clang-tidy
@@ -1,0 +1,4 @@
+# clang-tidy does not allow easy deactivation of a directory.
+# Use a dummy .clang-tidy file that disables all clang-tidy checks except one that will never match.
+# This one check is necessary; clang-tidy reports an error when no checks are enabled.
+Checks: '-*,llvm-twine-local'


### PR DESCRIPTION
## Description

The external directory contains code for external librairies. It
should not be inspected by clang-tidy.

The regex syntax does not allow to directly ignore a directory. Solve
this issue by adding a `clang-tidy` config file in the external
directory which disables all the checks.

See:
https://stackoverflow.com/questions/74349432/clang-tidy-exclude-specific-dir-from-analysis
See:
https://stackoverflow.com/questions/58338202/cmake-clang-tidy-disable-checking-in-directory
See: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/777/diffs

cc @troopa81 @benoitdm-oslandia 