### PR TITLE
Add an option to delete unused categories in the categorized symbol renderer widget

### DIFF
--- a/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -126,9 +126,9 @@ Changes the selected symbols alone for the change button, if there is a selectio
 Applies current symbol to selected categories, or to all categories if none is selected
 %End
 
-    QList<QVariant> layerUniqueValues( QString attrName );
+    QList<QVariant> layerUniqueValues( const QString attrName );
 %Docstring
-Returns the list of unique values in the widget's layer.
+Returns the list of unique values in the current widget's layer for attribute name ``attrName``.
 
 Called by :py:func:`~QgsCategorizedSymbolRendererWidget.addCategories` and :py:func:`~QgsCategorizedSymbolRendererWidget.deleteUnusedCategories`
 %End

--- a/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -65,6 +65,7 @@ Applies the color ramp passed on by the color ramp button
 
     void deleteCategories();
     void deleteAllCategories();
+    void deleteUnusedCategories();
 
     void showSymbolLevels();
 
@@ -123,6 +124,13 @@ Changes the selected symbols alone for the change button, if there is a selectio
     void applyChangeToSymbol();
 %Docstring
 Applies current symbol to selected categories, or to all categories if none is selected
+%End
+
+    QList<QVariant> layerUniqueValues( QString attrName );
+%Docstring
+Returns the list of unique values in the widget's layer.
+
+Called by :py:func:`~QgsCategorizedSymbolRendererWidget.addCategories` and :py:func:`~QgsCategorizedSymbolRendererWidget.deleteUnusedCategories`
 %End
 
     virtual QList<QgsSymbol *> selectedSymbols();

--- a/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -65,7 +65,11 @@ Applies the color ramp passed on by the color ramp button
 
     void deleteCategories();
     void deleteAllCategories();
+
     void deleteUnusedCategories();
+%Docstring
+Deletes unused categories from the widget which are not used by the layer renderer.
+%End
 
     void showSymbolLevels();
 
@@ -126,7 +130,7 @@ Changes the selected symbols alone for the change button, if there is a selectio
 Applies current symbol to selected categories, or to all categories if none is selected
 %End
 
-    QList<QVariant> layerUniqueValues( const QString attrName );
+    QList<QVariant> layerUniqueValues( const QString &attrName );
 %Docstring
 Returns the list of unique values in the current widget's layer for attribute name ``attrName``.
 

--- a/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -126,9 +126,9 @@ Changes the selected symbols alone for the change button, if there is a selectio
 Applies current symbol to selected categories, or to all categories if none is selected
 %End
 
-    QList<QVariant> layerUniqueValues( QString attrName );
+    QList<QVariant> layerUniqueValues( const QString attrName );
 %Docstring
-Returns the list of unique values in the widget's layer.
+Returns the list of unique values in the current widget's layer for attribute name ``attrName``.
 
 Called by :py:func:`~QgsCategorizedSymbolRendererWidget.addCategories` and :py:func:`~QgsCategorizedSymbolRendererWidget.deleteUnusedCategories`
 %End

--- a/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -65,6 +65,7 @@ Applies the color ramp passed on by the color ramp button
 
     void deleteCategories();
     void deleteAllCategories();
+    void deleteUnusedCategories();
 
     void showSymbolLevels();
 
@@ -123,6 +124,13 @@ Changes the selected symbols alone for the change button, if there is a selectio
     void applyChangeToSymbol();
 %Docstring
 Applies current symbol to selected categories, or to all categories if none is selected
+%End
+
+    QList<QVariant> layerUniqueValues( QString attrName );
+%Docstring
+Returns the list of unique values in the widget's layer.
+
+Called by :py:func:`~QgsCategorizedSymbolRendererWidget.addCategories` and :py:func:`~QgsCategorizedSymbolRendererWidget.deleteUnusedCategories`
 %End
 
     virtual QList<QgsSymbol *> selectedSymbols();

--- a/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -65,7 +65,11 @@ Applies the color ramp passed on by the color ramp button
 
     void deleteCategories();
     void deleteAllCategories();
+
     void deleteUnusedCategories();
+%Docstring
+Deletes unused categories from the widget which are not used by the layer renderer.
+%End
 
     void showSymbolLevels();
 
@@ -126,7 +130,7 @@ Changes the selected symbols alone for the change button, if there is a selectio
 Applies current symbol to selected categories, or to all categories if none is selected
 %End
 
-    QList<QVariant> layerUniqueValues( const QString attrName );
+    QList<QVariant> layerUniqueValues( const QString &attrName );
 %Docstring
 Returns the list of unique values in the current widget's layer for attribute name ``attrName``.
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -1090,7 +1090,7 @@ void QgsCategorizedSymbolRendererWidget::deleteUnusedCategories()
   emit widgetChanged();
 }
 
-QList<QVariant> QgsCategorizedSymbolRendererWidget::layerUniqueValues( const QString attrName )
+QList<QVariant> QgsCategorizedSymbolRendererWidget::layerUniqueValues( const QString &attrName )
 {
   const int idx = mLayer->fields().lookupField( attrName );
   QList<QVariant> uniqueValues;

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -900,8 +900,8 @@ void QgsCategorizedSymbolRendererWidget::changeCategorySymbol()
 
 void QgsCategorizedSymbolRendererWidget::addCategories()
 {
-  QString attrName = mExpressionWidget->currentField();
-  QList<QVariant> uniqueValues = layerUniqueValues( attrName );
+  const QString attrName = mExpressionWidget->currentField();
+  const QList<QVariant> uniqueValues = layerUniqueValues( attrName );
 
   // ask to abort if too many classes
   if ( uniqueValues.size() >= 1000 )
@@ -1071,8 +1071,8 @@ void QgsCategorizedSymbolRendererWidget::deleteUnusedCategories()
 {
   if ( !mRenderer )
     return;
-  QString attrName = mExpressionWidget->currentField();
-  QList<QVariant> uniqueValues = layerUniqueValues( attrName );
+  const QString attrName = mExpressionWidget->currentField();
+  const QList<QVariant> uniqueValues = layerUniqueValues( attrName );
 
   const QgsCategoryList catList = mRenderer->categories();
 
@@ -1080,7 +1080,7 @@ void QgsCategorizedSymbolRendererWidget::deleteUnusedCategories()
 
   for ( int i = 0; i < catList.size(); ++i )
   {
-    QgsRendererCategory cat = catList.at( i );
+    const QgsRendererCategory cat = catList.at( i );
     if ( !uniqueValues.contains( cat.value() ) )
     {
       unusedIndexes.append( i );
@@ -1090,7 +1090,7 @@ void QgsCategorizedSymbolRendererWidget::deleteUnusedCategories()
   emit widgetChanged();
 }
 
-QList<QVariant> QgsCategorizedSymbolRendererWidget::layerUniqueValues( QString attrName )
+QList<QVariant> QgsCategorizedSymbolRendererWidget::layerUniqueValues( const QString attrName )
 {
   const int idx = mLayer->fields().lookupField( attrName );
   QList<QVariant> uniqueValues;

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -708,6 +708,7 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
   connect( btnAddCategories, &QAbstractButton::clicked, this, &QgsCategorizedSymbolRendererWidget::addCategories );
   connect( btnDeleteCategories, &QAbstractButton::clicked, this, &QgsCategorizedSymbolRendererWidget::deleteCategories );
   connect( btnDeleteAllCategories, &QAbstractButton::clicked, this, &QgsCategorizedSymbolRendererWidget::deleteAllCategories );
+  connect( btnDeleteUnusedCategories, &QAbstractButton::clicked, this, &QgsCategorizedSymbolRendererWidget::deleteUnusedCategories );
   connect( btnAddCategory, &QAbstractButton::clicked, this, &QgsCategorizedSymbolRendererWidget::addCategory );
 
   connect( btnColorRamp, &QgsColorRampButton::colorRampChanged, this, &QgsCategorizedSymbolRendererWidget::applyColorRamp );
@@ -899,35 +900,8 @@ void QgsCategorizedSymbolRendererWidget::changeCategorySymbol()
 
 void QgsCategorizedSymbolRendererWidget::addCategories()
 {
-  const QString attrName = mExpressionWidget->currentField();
-  const int idx = mLayer->fields().lookupField( attrName );
-  QList<QVariant> uniqueValues;
-  if ( idx == -1 )
-  {
-    // Lets assume it's an expression
-    QgsExpression *expression = new QgsExpression( attrName );
-    QgsExpressionContext context;
-    context << QgsExpressionContextUtils::globalScope()
-            << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
-            << QgsExpressionContextUtils::atlasScope( nullptr )
-            << QgsExpressionContextUtils::layerScope( mLayer );
-
-    expression->prepare( &context );
-    QgsFeatureIterator fit = mLayer->getFeatures();
-    QgsFeature feature;
-    while ( fit.nextFeature( feature ) )
-    {
-      context.setFeature( feature );
-      const QVariant value = expression->evaluate( &context );
-      if ( uniqueValues.contains( value ) )
-        continue;
-      uniqueValues << value;
-    }
-  }
-  else
-  {
-    uniqueValues = qgis::setToList( mLayer->uniqueValues( idx ) );
-  }
+  QString attrName = mExpressionWidget->currentField();
+  QList<QVariant> uniqueValues = layerUniqueValues( attrName );
 
   // ask to abort if too many classes
   if ( uniqueValues.size() >= 1000 )
@@ -1091,6 +1065,62 @@ void QgsCategorizedSymbolRendererWidget::deleteAllCategories()
 {
   mModel->removeAllRows();
   emit widgetChanged();
+}
+
+void QgsCategorizedSymbolRendererWidget::deleteUnusedCategories()
+{
+  if ( !mRenderer )
+    return;
+  QString attrName = mExpressionWidget->currentField();
+  QList<QVariant> uniqueValues = layerUniqueValues( attrName );
+
+  const QgsCategoryList catList = mRenderer->categories();
+
+  QList<int> unusedIndexes;
+
+  for ( int i = 0; i < catList.size(); ++i )
+  {
+    QgsRendererCategory cat = catList.at( i );
+    if ( !uniqueValues.contains( cat.value() ) )
+    {
+      unusedIndexes.append( i );
+    }
+  }
+  mModel->deleteRows( unusedIndexes );
+  emit widgetChanged();
+}
+
+QList<QVariant> QgsCategorizedSymbolRendererWidget::layerUniqueValues( QString attrName )
+{
+  const int idx = mLayer->fields().lookupField( attrName );
+  QList<QVariant> uniqueValues;
+  if ( idx == -1 )
+  {
+    // Lets assume it's an expression
+    QgsExpression *expression = new QgsExpression( attrName );
+    QgsExpressionContext context;
+    context << QgsExpressionContextUtils::globalScope()
+            << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+            << QgsExpressionContextUtils::atlasScope( nullptr )
+            << QgsExpressionContextUtils::layerScope( mLayer );
+
+    expression->prepare( &context );
+    QgsFeatureIterator fit = mLayer->getFeatures();
+    QgsFeature feature;
+    while ( fit.nextFeature( feature ) )
+    {
+      context.setFeature( feature );
+      const QVariant value = expression->evaluate( &context );
+      if ( uniqueValues.contains( value ) )
+        continue;
+      uniqueValues << value;
+    }
+  }
+  else
+  {
+    uniqueValues = qgis::setToList( mLayer->uniqueValues( idx ) );
+  }
+  return uniqueValues;
 }
 
 void QgsCategorizedSymbolRendererWidget::addCategory()

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -1097,20 +1097,20 @@ QList<QVariant> QgsCategorizedSymbolRendererWidget::layerUniqueValues( const QSt
   if ( idx == -1 )
   {
     // Lets assume it's an expression
-    QgsExpression *expression = new QgsExpression( attrName );
+    QgsExpression expression = QgsExpression( attrName );
     QgsExpressionContext context;
     context << QgsExpressionContextUtils::globalScope()
             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
             << QgsExpressionContextUtils::atlasScope( nullptr )
             << QgsExpressionContextUtils::layerScope( mLayer );
 
-    expression->prepare( &context );
+    expression.prepare( &context );
     QgsFeatureIterator fit = mLayer->getFeatures();
     QgsFeature feature;
     while ( fit.nextFeature( feature ) )
     {
       context.setFeature( feature );
-      const QVariant value = expression->evaluate( &context );
+      const QVariant value = expression.evaluate( &context );
       if ( uniqueValues.contains( value ) )
         continue;
       uniqueValues << value;

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -164,6 +164,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
 
     void deleteCategories();
     void deleteAllCategories();
+    void deleteUnusedCategories();
 
     void showSymbolLevels();
 
@@ -234,6 +235,13 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void changeCategorySymbol();
     //! Applies current symbol to selected categories, or to all categories if none is selected
     void applyChangeToSymbol();
+
+    /**
+     * Returns the list of unique values in the widget's layer.
+     *
+     * Called by addCategories() and deleteUnusedCategories()
+     */
+    QList<QVariant> layerUniqueValues( QString attrName );
 
     QList<QgsSymbol *> selectedSymbols() override;
     QgsCategoryList selectedCategoryList();

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -237,11 +237,11 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void applyChangeToSymbol();
 
     /**
-     * Returns the list of unique values in the widget's layer.
+     * Returns the list of unique values in the current widget's layer for attribute name \a attrName.
      *
      * Called by addCategories() and deleteUnusedCategories()
      */
-    QList<QVariant> layerUniqueValues( QString attrName );
+    QList<QVariant> layerUniqueValues( const QString attrName );
 
     QList<QgsSymbol *> selectedSymbols() override;
     QgsCategoryList selectedCategoryList();

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -164,6 +164,10 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
 
     void deleteCategories();
     void deleteAllCategories();
+
+    /**
+     * Deletes unused categories from the widget which are not used by the layer renderer.
+     */
     void deleteUnusedCategories();
 
     void showSymbolLevels();
@@ -241,7 +245,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
      *
      * Called by addCategories() and deleteUnusedCategories()
      */
-    QList<QVariant> layerUniqueValues( const QString attrName );
+    QList<QVariant> layerUniqueValues( const QString &attrName );
 
     QList<QgsSymbol *> selectedSymbols() override;
     QgsCategoryList selectedCategoryList();

--- a/src/ui/qgscategorizedsymbolrendererwidget.ui
+++ b/src/ui/qgscategorizedsymbolrendererwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>424</width>
+    <width>471</width>
     <height>368</height>
    </rect>
   </property>
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
      </property>
@@ -156,6 +156,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="btnDeleteUnusedCategories">
+       <property name="text">
+        <string>Delete Unused</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -202,19 +209,19 @@
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
-   <header location="global">qgsfieldexpressionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorRampButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorrampbutton.h</header>
+   <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
    <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorRampButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorrampbutton.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -229,6 +236,7 @@
   <tabstop>btnAdvanced</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgscategorizedsymbolrendererwidget.ui
+++ b/src/ui/qgscategorizedsymbolrendererwidget.ui
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
      </property>
@@ -209,19 +209,19 @@
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
-   <header>qgsfieldexpressionwidget.h</header>
+   <header location="global">qgsfieldexpressionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -236,7 +236,6 @@
   <tabstop>btnAdvanced</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgscategorizedsymbolrendererwidget.ui
+++ b/src/ui/qgscategorizedsymbolrendererwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>471</width>
+    <width>424</width>
     <height>368</height>
    </rect>
   </property>


### PR DESCRIPTION
## Description
This Feature adds an option via a button in the categorized symbol renderer widget to delete unused categories from the model/view. I.e. any categories which are not matched in the attribute field or expression used to categorize the layer.

An example use case is using a style file for a large layer with many categories to style a smaller layer clipped from the large layer who's features now only represent a subset of the categories in the style file. With this feature the user can load or copy/paste the original style file then quickly and easily remove the 'orphaned' categories which are not used in the smaller subset layer:

![remove-unused-categories](https://github.com/user-attachments/assets/75900b6f-d6bd-4e77-8b6a-50ee34f49c3e)



<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
