### PR TITLE
clear highlight from selected widgets when cancelling customization dialog (fix #23199)

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -278,7 +278,7 @@ void QgsCustomizationDialog::cancel()
   {
     for ( int i = 0; i < mSelectedWidgets.size(); i++ )
     {
-      if ( QWidget* widget = mSelectedWidgets.at( i ) )
+      if ( QWidget *widget = mSelectedWidgets.at( i ) )
         widget->setStyleSheet( mSelectedWidgets.at( i )->property( "originalStylesheet" ).toString() );
     }
     mSelectedWidgets.clear();

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -282,6 +282,7 @@ void QgsCustomizationDialog::cancel()
     }
     mSelectedWidgets.clear();
   }
+  reset();
   hide();
 }
 

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -278,7 +278,8 @@ void QgsCustomizationDialog::cancel()
   {
     for ( int i = 0; i < mSelectedWidgets.size(); i++ )
     {
-      mSelectedWidgets.at( i )->setStyleSheet( mSelectedWidgets.at( i )->property( "originalStylesheet" ).toString() );
+      if ( QWidget* widget = mSelectedWidgets.at( i ) )
+        widget->setStyleSheet( mSelectedWidgets.at( i )->property( "originalStylesheet" ).toString() );
     }
     mSelectedWidgets.clear();
   }

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -278,7 +278,7 @@ void QgsCustomizationDialog::cancel()
   {
     for ( int i = 0; i < mSelectedWidgets.size(); i++ )
     {
-      mSelectedWidgets.at( i )->setStyleSheet( "" );
+      mSelectedWidgets.at( i )->setStyleSheet( mSelectedWidgets.at( i )->property( "originalStylesheet" ).toString() );
     }
     mSelectedWidgets.clear();
   }
@@ -525,8 +525,9 @@ bool QgsCustomizationDialog::switchWidget( QWidget *widget, QMouseEvent *e )
     {
       mSelectedWidgets.append( widget );
       style = QStringLiteral( "background-color: #FFCCCC;" );
+      widget->setProperty( "originalStylesheet", widget->styleSheet() );
     }
-    widget->setStyleSheet( style );
+    widget->setStyleSheet( !style.isEmpty() ? style : widget->property( "originalStylesheet" ).toString() );
   }
 
   return true;

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -268,6 +268,8 @@ void QgsCustomizationDialog::apply()
 
   QSettings settings;
   settings.setValue( QStringLiteral( "UI/Customization/enabled" ), mCustomizationEnabledCheckBox->isChecked() );
+
+  mSelectedWidgets.clear();
 }
 
 void QgsCustomizationDialog::cancel()

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -272,6 +272,14 @@ void QgsCustomizationDialog::apply()
 
 void QgsCustomizationDialog::cancel()
 {
+  if ( mSelectedWidgets.size() > 0 )
+  {
+    for ( int i = 0; i < mSelectedWidgets.size(); i++ )
+    {
+      mSelectedWidgets.at( i )->setStyleSheet( "" );
+    }
+    mSelectedWidgets.clear();
+  }
   hide();
 }
 
@@ -513,6 +521,7 @@ bool QgsCustomizationDialog::switchWidget( QWidget *widget, QMouseEvent *e )
     QString style;
     if ( !on )
     {
+      mSelectedWidgets.append( widget );
       style = QStringLiteral( "background-color: #FFCCCC;" );
     }
     widget->setStyleSheet( style );

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -104,7 +104,7 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
 
     QString mLastDirSettingsName;
     QSettings *mSettings = nullptr;
-    QList<QWidget *> mSelectedWidgets;
+    QList<QPointer< QWidget > > mSelectedWidgets;
 
   protected:
     QMap<QTreeWidgetItem *, bool> mTreeInitialExpand;

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -104,6 +104,7 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
 
     QString mLastDirSettingsName;
     QSettings *mSettings = nullptr;
+    QList<QWidget *> mSelectedWidgets;
 
   protected:
     QMap<QTreeWidgetItem *, bool> mTreeInitialExpand;


### PR DESCRIPTION
## Description

Clear highlight created by the widget catcher tool in UI Customization dialog when closing dialog with Cancel button.

Fixes #23199.