### PR TITLE
qgs3dmapsettings: Fix terrain generation on 3d view creation

### DIFF
--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -680,7 +680,8 @@ void Qgs3DMapSettings::setTerrainSettings( QgsAbstractTerrainSettings *settings 
   }
   else
   {
-    hasChanged = !settings->equals( mTerrainSettings.get() );
+    // ensure to generate the terrain if the settings have changed or if the terrain has never been generated.
+    hasChanged = !settings->equals( mTerrainSettings.get() ) || !mTerrainGenerator;
     mTerrainSettings.reset( settings );
   }
 

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -31,6 +31,7 @@
 #include "qgs3dmapsettings.h"
 #include "qgs3dutils.h"
 #include "qgscameracontroller.h"
+#include "qgsflatterrainsettings.h"
 #include "qgsdemterrainsettings.h"
 #include "qgsflatterraingenerator.h"
 #include "qgsline3dsymbol.h"
@@ -282,9 +283,12 @@ void TestQgs3DRendering::testFlatTerrain()
   map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayerRgb );
 
-  QgsFlatTerrainGenerator *flatTerrain = new QgsFlatTerrainGenerator;
-  flatTerrain->setCrs( map->crs(), map->transformContext() );
-  map->setTerrainGenerator( flatTerrain );
+  QgsFlatTerrainSettings *flatTerrainSettings = new QgsFlatTerrainSettings;
+  map->setTerrainSettings( flatTerrainSettings );
+
+  std::unique_ptr<QgsTerrainGenerator> generator = flatTerrainSettings->createTerrainGenerator( Qgs3DRenderContext::fromMapSettings( map ) );
+  QVERIFY( dynamic_cast<QgsFlatTerrainGenerator *>( generator.get() )->isValid() );
+  QCOMPARE( dynamic_cast<QgsFlatTerrainGenerator *>( generator.get() )->crs(), map->crs() );
 
   QgsOffscreen3DEngine engine;
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );


### PR DESCRIPTION
## Description

When a new 3d is created `Qgs3DMapSettings::configureTerrainFromProject` is called to configure the
terrain. This method calls `Qgs3DMapSettings::setTerrainSettings` which sets the terrain settings
and creates the terrain generator if necessary. This generator is not updated if the settings have not changed.

However, on a new 3d view, the terrain settings (`mTerrainSettings`)
have already been created with the default values and the `QgsAbstractTerrainSettings` parameter of
`Qgs3DMapSettings::setTerrainSettings` also contains the default settings. Therefore, this call does nothing and the terrain generator is not created. This results in a 3d view which does not contain any terrain. 

This issue is fixed by also checking if the terrain generator has
already been created. If that's not the case, the terrain generator is
now created.

The flatTerrain test is updated to test this workflow.

Fixes: 8af23b10024be91a8e97a81832907393544a7fd5