### PR TITLE
Fix QgsDateTimeEdit paste when fully selected

### DIFF
--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -109,6 +109,22 @@ bool QgsDateTimeEdit::event( QEvent *event )
     mClearAction->setVisible( !isReadOnly() && mAllowNull && ( !mIsNull || mIsEmpty ) );
   }
 
+  // Fix wrong internal logic of Qt when pasting text with selected text
+  // when the selection starts in a different position than the stored cursor
+  // position (which selects the currently active section of the date widget)
+  // See: https://github.com/qgis/QGIS/issues/53149
+  if ( event->type() == QEvent::KeyPress )
+  {
+    QKeyEvent *keyEvent = static_cast<QKeyEvent *>( event );
+    if ( keyEvent->matches( QKeySequence::Paste ) && lineEdit()->hasSelectedText() )
+    {
+      const int selectionStart { lineEdit()->selectionStart() };
+      const int selectionEnd { lineEdit()->selectionEnd() };
+      lineEdit()->setCursorPosition( selectionStart );
+      lineEdit()->setSelection( selectionStart, selectionEnd );
+    }
+  }
+
   return QDateTimeEdit::event( event );
 }
 

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -121,7 +121,7 @@ bool QgsDateTimeEdit::event( QEvent *event )
       const int selectionStart { lineEdit()->selectionStart() };
       const int selectionEnd { lineEdit()->selectionEnd() };
       lineEdit()->setCursorPosition( selectionStart );
-      lineEdit()->setSelection( selectionStart, selectionEnd );
+      lineEdit()->setSelection( selectionStart, selectionEnd - selectionStart );
     }
   }
 


### PR DESCRIPTION
Fix #53149
...and possibly #60625

The issue is deep into QT internals: the abstract spinbox has a line edit wich holds the different datetime components divided into "Sections", when the user selects all (e.g. with CTRL+A) and then pastes a datetime string from the clipboard, it may get pasted in the wrong position (i.e. not at the beginning of the selection) because the internal position of the cursor wasn't updated.

I tried hard to write a test (even tried QTest::click* and injection of forged events) but I couldn't find a way to reproduce the issue programmatically using the QT public API).
