### PR TITLE
do not enable default Duplicate Feature and Digitize action for geometryless layers (refs #57916)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7806,6 +7806,7 @@ Qgis.MapLayerActionTargets.baseClass = Qgis
 MapLayerActionTargets = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 Qgis.MapLayerActionFlag.EnabledOnlyWhenEditable.__doc__ = "Action should be shown only for editable layers"
+Qgis.MapLayerActionFlag.EnableOnlyWhenHasGeometry.__doc__ = "Action should be shown only for layers with geometry, \n.. versionadded:: 3.42"
 Qgis.MapLayerActionFlag.__doc__ = """Map layer action flags.
 
 Prior to QGIS 3.30 this was available as :py:class:`QgsMapLayerAction`.Flag
@@ -7813,6 +7814,10 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsMapLayerAction`.Flag
 .. versionadded:: 3.30
 
 * ``EnabledOnlyWhenEditable``: Action should be shown only for editable layers
+* ``EnableOnlyWhenHasGeometry``: Action should be shown only for layers with geometry,
+
+  .. versionadded:: 3.42
+
 
 """
 # --

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2461,6 +2461,7 @@ The development version
     enum class MapLayerActionFlag /BaseType=IntFlag/
     {
       EnabledOnlyWhenEditable,
+      EnableOnlyWhenHasGeometry,
     };
 
     typedef QFlags<Qgis::MapLayerActionFlag> MapLayerActionFlags;

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -7730,6 +7730,7 @@ Qgis.MapLayerActionTargets.baseClass = Qgis
 MapLayerActionTargets = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 Qgis.MapLayerActionFlag.EnabledOnlyWhenEditable.__doc__ = "Action should be shown only for editable layers"
+Qgis.MapLayerActionFlag.EnableOnlyWhenHasGeometry.__doc__ = "Action should be shown only for layers with geometry, \n.. versionadded:: 3.42"
 Qgis.MapLayerActionFlag.__doc__ = """Map layer action flags.
 
 Prior to QGIS 3.30 this was available as :py:class:`QgsMapLayerAction`.Flag
@@ -7737,6 +7738,10 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsMapLayerAction`.Flag
 .. versionadded:: 3.30
 
 * ``EnabledOnlyWhenEditable``: Action should be shown only for editable layers
+* ``EnableOnlyWhenHasGeometry``: Action should be shown only for layers with geometry,
+
+  .. versionadded:: 3.42
+
 
 """
 # --

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2461,6 +2461,7 @@ The development version
     enum class MapLayerActionFlag
     {
       EnabledOnlyWhenEditable,
+      EnableOnlyWhenHasGeometry,
     };
 
     typedef QFlags<Qgis::MapLayerActionFlag> MapLayerActionFlags;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9153,7 +9153,7 @@ void QgisApp::setupDuplicateFeaturesAction()
     duplicateFeatures( layer, feat );
   } );
 
-  mDuplicateFeatureDigitizeAction.reset( new QgsMapLayerAction( tr( "Duplicate Feature and Digitize" ), nullptr, Qgis::MapLayerActionTarget::SingleFeature, QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeatureDigitized.svg" ) ), Qgis::MapLayerActionFlag::EnabledOnlyWhenEditable ) );
+  mDuplicateFeatureDigitizeAction.reset( new QgsMapLayerAction( tr( "Duplicate Feature and Digitize" ), nullptr, Qgis::MapLayerActionTarget::SingleFeature, QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeatureDigitized.svg" ) ), Qgis::MapLayerActionFlag::EnabledOnlyWhenEditable | Qgis::MapLayerActionFlag::EnableOnlyWhenHasGeometry ) );
 
   QgsGui::mapLayerActionRegistry()->addMapLayerAction( mDuplicateFeatureDigitizeAction.get() );
   connect( mDuplicateFeatureDigitizeAction.get(), &QgsMapLayerAction::triggeredForFeatureV2, this, [this]( QgsMapLayer *layer, const QgsFeature &feat, const QgsMapLayerActionContext & ) {

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4398,6 +4398,7 @@ class CORE_EXPORT Qgis
     enum class MapLayerActionFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
       EnabledOnlyWhenEditable = 1 << 1, //!< Action should be shown only for editable layers
+      EnableOnlyWhenHasGeometry = 1 << 2, //!< Action should be shown only for layers with geometry, \since QGIS 3.42
     };
     Q_ENUM( MapLayerActionFlag )
 

--- a/src/gui/actions/qgsmaplayeraction.cpp
+++ b/src/gui/actions/qgsmaplayeraction.cpp
@@ -75,6 +75,17 @@ bool QgsMapLayerAction::canRunUsingLayer( QgsMapLayer *layer, const QgsMapLayerA
       return false;
   }
 
+  if ( mFlags & Qgis::MapLayerActionFlag::EnableOnlyWhenHasGeometry )
+  {
+    // action is only enabled for layers with geometry
+    if ( !layer )
+      return false;
+    if ( layer->type() != Qgis::LayerType::Vector )
+      return false;
+    if ( qobject_cast<QgsVectorLayer *>( layer )->wkbType() == Qgis::WkbType::NoGeometry )
+      return false;
+  }
+
   //check layer details
   if ( !mSingleLayer && !mSpecificLayerType )
   {


### PR DESCRIPTION
## Description

Disable default Duplicate Feature and Digitize action for geometry-less layers, as it makes no sense for geeometry-less layer. The Duplicate feature will still be enabled as it is usable and make sense when called from attribute table.

This PR introduces new flag `MapLayerActionFlag::EnableOnlyIfHasGeometry` which indicates that action should be shown/enabled only for layers with geometry.

Partial fix for #57916.