### PR TITLE
fetch feature with geometry when opening a feature context menu in attribute table (fix #48964)

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayercache.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayercache.sip.in
@@ -181,18 +181,18 @@ Returns the set of feature IDs for features which are cached.
 .. seealso:: :py:func:`isFidCached`
 %End
 
-    bool featureAtId( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool featureAtId( QgsFeatureId featureId, QgsFeature &feature /Out/, bool skipCache = false );
 %Docstring
 Gets the feature at the given feature id. Considers the changed, added, deleted and permanent features
 
 :param featureId: The id of the feature to query
-:param feature: The result of the operation will be written to this feature
 :param skipCache: Will query the layer regardless if the feature is in the cache already
 
-:return: ``True`` in case of success
+:return: - ``True`` in case of success
+         - feature: The result of the operation will be written to this feature
 %End
 
-    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature /Out/, bool skipCache = false );
 %Docstring
 Gets the feature at the given feature id with all attributes, if the cached feature
 already contains all attributes, calling this function has the same effect as calling
@@ -201,17 +201,17 @@ already contains all attributes, calling this function has the same effect as ca
 Considers the changed, added, deleted and permanent features
 
 :param featureId: The id of the feature to query
-:param feature: The result of the operation will be written to this feature
 :param skipCache: Will query the layer regardless if the feature is in the cache already
 
-:return: ``True`` in case of success
+:return: - ``True`` in case of success
+         - feature: The result of the operation will be written to this feature
 
 .. seealso:: :py:func:`featureAtId`
 
 .. versionadded:: 3.32
 %End
 
-    bool featureAtIdWithAllAttributesAndGeometry( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool completeFeatureAtId( QgsFeatureId featureId, QgsFeature &feature /Out/, bool skipCache = false );
 %Docstring
 Gets the feature at the given feature id with all attributes and geometry, if the cached feature
 already contains all attributes and geometry, calling this function has the same effect as calling
@@ -220,14 +220,14 @@ already contains all attributes and geometry, calling this function has the same
 Considers the changed, added, deleted and permanent features
 
 :param featureId: The id of the feature to query
-:param feature: The result of the operation will be written to this feature
 :param skipCache: Will query the layer regardless if the feature is in the cache already
 
-:return: ``True`` in case of success
+:return: - ``True`` in case of success
+         - feature: The result of the operation will be written to this feature
 
 .. seealso:: :py:func:`featureAtId`
 
-.. versionadded:: 3.42
+.. versionadded:: 3.44
 %End
 
     bool removeCachedFeature( QgsFeatureId fid );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayercache.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayercache.sip.in
@@ -211,6 +211,25 @@ Considers the changed, added, deleted and permanent features
 .. versionadded:: 3.32
 %End
 
+    bool featureAtIdWithAllAttributesAndGeometry( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+%Docstring
+Gets the feature at the given feature id with all attributes and geometry, if the cached feature
+already contains all attributes and geometry, calling this function has the same effect as calling
+:py:func:`~QgsVectorLayerCache.featureAtId`.
+
+Considers the changed, added, deleted and permanent features
+
+:param featureId: The id of the feature to query
+:param feature: The result of the operation will be written to this feature
+:param skipCache: Will query the layer regardless if the feature is in the cache already
+
+:return: ``True`` in case of success
+
+.. seealso:: :py:func:`featureAtId`
+
+.. versionadded:: 3.42
+%End
+
     bool removeCachedFeature( QgsFeatureId fid );
 %Docstring
 Removes the feature identified by fid from the cache if present.

--- a/python/PyQt6/gui/auto_additions/qgsfeaturelistmodel.py
+++ b/python/PyQt6/gui/auto_additions/qgsfeaturelistmodel.py
@@ -1,6 +1,7 @@
 # The following has been generated automatically from src/gui/attributetable/qgsfeaturelistmodel.h
 QgsFeatureListModel.FeatureInfoRole = QgsFeatureListModel.Role.FeatureInfoRole
 QgsFeatureListModel.FeatureRole = QgsFeatureListModel.Role.FeatureRole
+QgsFeatureListModel.FeatureWithGeometryRole = QgsFeatureListModel.Role.FeatureWithGeometryRole
 try:
     QgsFeatureListModel.FeatureInfo.__attribute_docs__ = {'isNew': 'True if feature is a newly added feature.', 'isEdited': 'True if feature has been edited.'}
     QgsFeatureListModel.FeatureInfo.__group__ = ['attributetable']

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -30,7 +30,8 @@ class QgsFeatureListModel : QSortFilterProxyModel, QgsFeatureModel
     enum Role /BaseType=IntEnum/
     {
       FeatureInfoRole,
-      FeatureRole
+      FeatureRole,
+      FeatureWithGeometryRole,
     };
 
   public:

--- a/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
@@ -181,18 +181,18 @@ Returns the set of feature IDs for features which are cached.
 .. seealso:: :py:func:`isFidCached`
 %End
 
-    bool featureAtId( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool featureAtId( QgsFeatureId featureId, QgsFeature &feature /Out/, bool skipCache = false );
 %Docstring
 Gets the feature at the given feature id. Considers the changed, added, deleted and permanent features
 
 :param featureId: The id of the feature to query
-:param feature: The result of the operation will be written to this feature
 :param skipCache: Will query the layer regardless if the feature is in the cache already
 
-:return: ``True`` in case of success
+:return: - ``True`` in case of success
+         - feature: The result of the operation will be written to this feature
 %End
 
-    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature /Out/, bool skipCache = false );
 %Docstring
 Gets the feature at the given feature id with all attributes, if the cached feature
 already contains all attributes, calling this function has the same effect as calling
@@ -201,17 +201,17 @@ already contains all attributes, calling this function has the same effect as ca
 Considers the changed, added, deleted and permanent features
 
 :param featureId: The id of the feature to query
-:param feature: The result of the operation will be written to this feature
 :param skipCache: Will query the layer regardless if the feature is in the cache already
 
-:return: ``True`` in case of success
+:return: - ``True`` in case of success
+         - feature: The result of the operation will be written to this feature
 
 .. seealso:: :py:func:`featureAtId`
 
 .. versionadded:: 3.32
 %End
 
-    bool featureAtIdWithAllAttributesAndGeometry( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool completeFeatureAtId( QgsFeatureId featureId, QgsFeature &feature /Out/, bool skipCache = false );
 %Docstring
 Gets the feature at the given feature id with all attributes and geometry, if the cached feature
 already contains all attributes and geometry, calling this function has the same effect as calling
@@ -220,14 +220,14 @@ already contains all attributes and geometry, calling this function has the same
 Considers the changed, added, deleted and permanent features
 
 :param featureId: The id of the feature to query
-:param feature: The result of the operation will be written to this feature
 :param skipCache: Will query the layer regardless if the feature is in the cache already
 
-:return: ``True`` in case of success
+:return: - ``True`` in case of success
+         - feature: The result of the operation will be written to this feature
 
 .. seealso:: :py:func:`featureAtId`
 
-.. versionadded:: 3.42
+.. versionadded:: 3.44
 %End
 
     bool removeCachedFeature( QgsFeatureId fid );

--- a/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
@@ -211,6 +211,25 @@ Considers the changed, added, deleted and permanent features
 .. versionadded:: 3.32
 %End
 
+    bool featureAtIdWithAllAttributesAndGeometry( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+%Docstring
+Gets the feature at the given feature id with all attributes and geometry, if the cached feature
+already contains all attributes and geometry, calling this function has the same effect as calling
+:py:func:`~QgsVectorLayerCache.featureAtId`.
+
+Considers the changed, added, deleted and permanent features
+
+:param featureId: The id of the feature to query
+:param feature: The result of the operation will be written to this feature
+:param skipCache: Will query the layer regardless if the feature is in the cache already
+
+:return: ``True`` in case of success
+
+.. seealso:: :py:func:`featureAtId`
+
+.. versionadded:: 3.42
+%End
+
     bool removeCachedFeature( QgsFeatureId fid );
 %Docstring
 Removes the feature identified by fid from the cache if present.

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -30,7 +30,8 @@ class QgsFeatureListModel : QSortFilterProxyModel, QgsFeatureModel
     enum Role
     {
       FeatureInfoRole,
-      FeatureRole
+      FeatureRole,
+      FeatureWithGeometryRole,
     };
 
   public:

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -220,6 +220,33 @@ bool QgsVectorLayerCache::featureAtIdWithAllAttributes( QgsFeatureId featureId, 
   return featureFound;
 }
 
+bool QgsVectorLayerCache::featureAtIdWithAllAttributesAndGeometry( QgsFeatureId featureId, QgsFeature &feature, bool skipCache )
+{
+  bool featureFound = false;
+
+  QgsCachedFeature *cachedFeature = nullptr;
+
+  if ( !skipCache )
+  {
+    cachedFeature = mCache[ featureId ];
+  }
+
+  if ( cachedFeature && cachedFeature->allAttributesFetched() && cachedFeature->geometryFetched() )
+  {
+    feature = QgsFeature( *cachedFeature->feature() );
+    featureFound = true;
+  }
+  else if ( mLayer->getFeatures( QgsFeatureRequest()
+                                 .setFilterFid( featureId ) )
+            .nextFeature( feature ) )
+  {
+    cacheFeature( feature, true, true );
+    featureFound = true;
+  }
+
+  return featureFound;
+}
+
 bool QgsVectorLayerCache::removeCachedFeature( QgsFeatureId fid )
 {
   bool removed = mCache.remove( fid );
@@ -561,3 +588,7 @@ bool QgsVectorLayerCache::QgsCachedFeature::allAttributesFetched() const
   return mAllAttributesFetched;
 }
 
+bool QgsVectorLayerCache::QgsCachedFeature::geometryFetched() const
+{
+  return mGeometryFetched;
+}

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -220,7 +220,7 @@ bool QgsVectorLayerCache::featureAtIdWithAllAttributes( QgsFeatureId featureId, 
   return featureFound;
 }
 
-bool QgsVectorLayerCache::featureAtIdWithAllAttributesAndGeometry( QgsFeatureId featureId, QgsFeature &feature, bool skipCache )
+bool QgsVectorLayerCache::completeFeatureAtId( QgsFeatureId featureId, QgsFeature &feature, bool skipCache )
 {
   bool featureFound = false;
 

--- a/src/core/vector/qgsvectorlayercache.h
+++ b/src/core/vector/qgsvectorlayercache.h
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
          * \param feat     The feature to cache. A copy will be made.
          * \param vlCache  The cache to inform when the feature has been removed from the cache.
          * \param allAttributesFetched TRUE if the feature was fetched with all attributes (and not a subset)
-         * \param geometryFetched TRUE if the feature was fetched with geometry, \since QGIS 3.42
+         * \param geometryFetched TRUE if the feature was fetched with geometry, \since QGIS 3.44
          */
         QgsCachedFeature( const QgsFeature &feat, QgsVectorLayerCache *vlCache, bool allAttributesFetched, bool geometryFetched )
           : mCache( vlCache )
@@ -258,7 +258,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * \param skipCache Will query the layer regardless if the feature is in the cache already
      * \returns TRUE in case of success
      */
-    bool featureAtId( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool featureAtId( QgsFeatureId featureId, QgsFeature &feature SIP_OUT, bool skipCache = false );
 
     /**
      * Gets the feature at the given feature id with all attributes, if the cached feature
@@ -273,7 +273,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * \see featureAtId()
      * \since QGIS 3.32
      */
-    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature SIP_OUT, bool skipCache = false );
 
     /**
      * Gets the feature at the given feature id with all attributes and geometry, if the cached feature
@@ -286,9 +286,9 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * \param skipCache Will query the layer regardless if the feature is in the cache already
      * \returns TRUE in case of success
      * \see featureAtId()
-     * \since QGIS 3.42
+     * \since QGIS 3.44
      */
-    bool featureAtIdWithAllAttributesAndGeometry( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+    bool completeFeatureAtId( QgsFeatureId featureId, QgsFeature &feature SIP_OUT, bool skipCache = false );
 
     /**
      * Removes the feature identified by fid from the cache if present.
@@ -439,7 +439,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
 
     inline void cacheFeature( QgsFeature &feat, bool allAttributesFetched, bool geometryFetched = false )
     {
-      QgsCachedFeature *cachedFeature = new QgsCachedFeature( feat, this, allAttributesFetched, geometryFetched );
+      QgsCachedFeature *cachedFeature = new QgsCachedFeature( feat, this, allAttributesFetched, geometryFetched || mCacheGeometry );
       mCache.insert( feat.id(), cachedFeature );
       if ( mCacheUnorderedKeys.find( feat.id() ) == mCacheUnorderedKeys.end() )
       {

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -119,7 +119,7 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
   {
     QgsFeature feat;
 
-    mFilterModel->layerCache()->featureAtIdWithAllAttributesAndGeometry( idxToFid( index ), feat );
+    mFilterModel->layerCache()->completeFeatureAtId( idxToFid( index ), feat );
 
     return QVariant::fromValue( feat );
   }

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -115,6 +115,14 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
 
     return QVariant::fromValue( feat );
   }
+  else if ( role == FeatureWithGeometryRole )
+  {
+    QgsFeature feat;
+
+    mFilterModel->layerCache()->featureAtIdWithAllAttributesAndGeometry( idxToFid( index ), feat );
+
+    return QVariant::fromValue( feat );
+  }
   else if ( role == Qt::TextAlignmentRole )
   {
     return static_cast<Qt::Alignment::Int>( Qt::AlignLeft );

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -56,7 +56,8 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
     enum Role
     {
       FeatureInfoRole = 0x1000, // Make sure no collisions with roles on QgsAttributeTableModel
-      FeatureRole
+      FeatureRole,              //!< Feature with all attributes and no geometry
+      FeatureWithGeometryRole,  //!< Feature with all attributes and geometry, \since QGIS 3.42
     };
 
   public:

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -389,7 +389,7 @@ void QgsFeatureListView::contextMenuEvent( QContextMenuEvent *event )
 
   if ( index.isValid() )
   {
-    const QgsFeature feature = mModel->data( index, QgsFeatureListModel::FeatureRole ).value<QgsFeature>();
+    const QgsFeature feature = mModel->data( index, QgsFeatureListModel::FeatureWithGeometryRole ).value<QgsFeature>();
 
     QgsActionMenu *menu = new QgsActionMenu( mModel->layerCache()->layer(), feature, QStringLiteral( "Feature" ), this );
 


### PR DESCRIPTION
## Description

The "Duplicate Feature" action executed from the feature context menu in attribute table form mode creates a feature without geometry. This happens because feature to use with action is constructed from the layer cache and by default we do not cache feature geometries when populating attribute table.

Proposed PR fetches feature with geometry whenever feature context menu is opened and caches it.

Fixes #48964.