### PR TITLE
Fix clang-tidy ci

### DIFF
--- a/.docker/docker-qgis-clangtidy.sh
+++ b/.docker/docker-qgis-clangtidy.sh
@@ -32,10 +32,6 @@ echo "::endgroup::"
 
 cd ${SRCDIR}
 
-echo "::group::Download clang-tidy-diff"
-curl -XGET https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-15.0.7/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o clang-tidy-diff.py
-echo "::endgroup::"
-
 echo "${bold}Disable unity build...${endbold}"
 cmake . -B build -DENABLE_UNITY_BUILDS=OFF
 
@@ -44,7 +40,7 @@ echo "${bold}Run clang-tidy on modifications...${endbold}"
 # We need to add build/src/test dir as extra include directories because when clang-tidy tries to process qgstest.h
 # it has no compile_commands.json instructions to know what are include directories
 # It manages to figure out for other headers though, I don't get how...
-git diff -U0 HEAD^ | python3 clang-tidy-diff.py -p1 -path=${CTEST_BUILD_DIR} -use-color -extra-arg=-I${CTEST_BUILD_DIR}/src/test/ -clang-tidy-binary /usr/bin/clang-tidy-15 | tee clang-tidy.log
+git diff -U0 HEAD^ | python3 /usr/bin/clang-tidy-diff-15.py -p1 -path=${CTEST_BUILD_DIR} -use-color -extra-arg=-I${CTEST_BUILD_DIR}/src/test/ -clang-tidy-binary /usr/bin/clang-tidy-15 | tee clang-tidy.log
 
 echo -e "\e[1;34mTo reproduce locally:"
 echo -e "\e[1;34m - launch cmake with option -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"

--- a/.docker/docker-qgis-clangtidy.sh
+++ b/.docker/docker-qgis-clangtidy.sh
@@ -23,15 +23,17 @@ cd ${SRCDIR}
 # https://github.com/qgis/QGIS/runs/6733585841?check_suite_focus=true#step:13:89
 git config --global --add safe.directory ${SRCDIR}
 
+# The clang-tidy version installed needs to match the one used to compile QGIS.
+# Otherwise, it will not be able to inspect the modified files.
 echo "::group::Install clang tidy"
 apt install -y \
-    clang-tidy
+    clang-tidy-15
 echo "::endgroup::"
 
 cd ${SRCDIR}
 
 echo "::group::Download clang-tidy-diff"
-curl -XGET https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-14.0.6/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o clang-tidy-diff.py
+curl -XGET https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-15.0.7/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o clang-tidy-diff.py
 echo "::endgroup::"
 
 echo "${bold}Disable unity build...${endbold}"
@@ -42,7 +44,7 @@ echo "${bold}Run clang-tidy on modifications...${endbold}"
 # We need to add build/src/test dir as extra include directories because when clang-tidy tries to process qgstest.h
 # it has no compile_commands.json instructions to know what are include directories
 # It manages to figure out for other headers though, I don't get how...
-git diff -U0 HEAD^ | python3 clang-tidy-diff.py -p1 -path=${CTEST_BUILD_DIR} -use-color -extra-arg=-I${CTEST_BUILD_DIR}/src/test/ | tee clang-tidy.log
+git diff -U0 HEAD^ | python3 clang-tidy-diff.py -p1 -path=${CTEST_BUILD_DIR} -use-color -extra-arg=-I${CTEST_BUILD_DIR}/src/test/ -clang-tidy-binary /usr/bin/clang-tidy-15 | tee clang-tidy.log
 
 echo -e "\e[1;34mTo reproduce locally:"
 echo -e "\e[1;34m - launch cmake with option -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"


### PR DESCRIPTION
## Description

At the moment the clang-tidy CI fails on each file with the following
message:

```
error: PCH file uses an older PCH format that is no longer supported
[clang-diagnostic-error]
```

This is because clang-tidy version 18 is used while QGIS
compilation is achieved with clang 15. Indeed, QGIS is built with
clazy support which relies on clang 15.

This issue is fixed by using clang version 15 instead of version 18 in
`docker-qgis-clangtidy.sh`.

The 3rd commit should be removed before merge. It is only present to check that the CI detects errors correctly.
