### PR TITLE
HANA: Make regular expression for schemas more accurate

### DIFF
--- a/src/providers/hana/qgshanaconnection.cpp
+++ b/src/providers/hana/qgshanaconnection.cpp
@@ -582,7 +582,7 @@ QVector<QgsHanaLayerProperty> QgsHanaConnection::getLayers(
     "SELECT DISTINCT(SCHEMA_NAME) FROM SYS.EFFECTIVE_PRIVILEGES WHERE "
     "OBJECT_TYPE IN ('SCHEMA', 'TABLE', 'VIEW') AND "
     "SCHEMA_NAME LIKE ? AND "
-    "SCHEMA_NAME NOT LIKE_REGEXPR 'SYS|_SYS.*|UIS|SAP_XS|SAP_REST|HANA_XS' AND "
+    "SCHEMA_NAME NOT LIKE_REGEXPR '^(SYS|_SYS.*|UIS|SAP_XS|SAP_REST|HANA_XS|XSSQLCC_)$' AND "
     "PRIVILEGE IN ('SELECT', 'CREATE ANY') AND "
     "USER_NAME = CURRENT_USER AND IS_VALID = 'TRUE'"
   );
@@ -862,7 +862,7 @@ QVector<QgsHanaSchemaProperty> QgsHanaConnection::getSchemas( const QString &own
 {
   QString sql = QStringLiteral( "SELECT SCHEMA_NAME, SCHEMA_OWNER FROM SYS.SCHEMAS WHERE "
                                 "HAS_PRIVILEGES = 'TRUE' AND %1 AND "
-                                "SCHEMA_NAME NOT LIKE_REGEXPR 'SYS|_SYS.*|UIS|SAP_XS|SAP_REST|HANA_XS|XSSQLCC_'" )
+                                "SCHEMA_NAME NOT LIKE_REGEXPR '^(SYS|_SYS.*|UIS|SAP_XS|SAP_REST|HANA_XS|XSSQLCC_)$'" )
                   .arg( !ownerName.isEmpty() ? QStringLiteral( "SCHEMA_OWNER = ?" ) : QStringLiteral( "SCHEMA_OWNER IS NOT NULL" ) );
 
   QVector<QgsHanaSchemaProperty> list;

--- a/tests/src/python/test_hana_utils.py
+++ b/tests/src/python/test_hana_utils.py
@@ -212,7 +212,9 @@ class QgsHanaProviderUtils:
             cursor.close()
 
             for row in rows:
-                QgsHanaProviderUtils.executeSQL(conn, f'DROP SCHEMA "{row["SCHEMA_NAME"]}" CASCADE')
+                QgsHanaProviderUtils.executeSQL(
+                    conn, f'DROP SCHEMA "{row["SCHEMA_NAME"]}" CASCADE'
+                )
         except Exception as ex:
             print(f"Unable to drop old test schemas. Error: {ex}")
             pass

--- a/tests/src/python/test_hana_utils.py
+++ b/tests/src/python/test_hana_utils.py
@@ -11,6 +11,7 @@ __author__ = "Maxim Rylov"
 __date__ = "2019-11-21"
 __copyright__ = "Copyright 2019, The QGIS Project"
 
+from datetime import datetime, timedelta
 from hdbcli import dbapi
 from qgis.core import QgsDataSourceUri, QgsVectorLayer
 
@@ -198,8 +199,23 @@ class QgsHanaProviderUtils:
         )
 
     @staticmethod
-    def cleanUp(conn, schema_name):
-        QgsHanaProviderUtils.dropSchemaIfExists(conn, schema_name)
+    def dropOldTestSchemas(conn, schema_prefix):
+        try:
+            assert conn
+            cursor = conn.cursor()
+            assert cursor
+            sql = f"""SELECT SCHEMA_NAME FROM SYS.SCHEMAS WHERE SCHEMA_NAME
+                      LIKE '{schema_prefix.replace('_', '__')}__%' ESCAPE '_' AND
+                      LOCALTOUTC(CREATE_TIME) < ?"""
+            cursor.execute(sql, datetime.now() - timedelta(days=1))
+            rows = cursor.fetchall()
+            cursor.close()
+
+            for row in rows:
+                QgsHanaProviderUtils.executeSQL(conn, f'DROP SCHEMA "{row["SCHEMA_NAME"]}" CASCADE')
+        except Exception as ex:
+            print(f"Unable to drop old test schemas. Error: {ex}")
+            pass
 
     @staticmethod
     def generateSchemaName(conn, prefix):

--- a/tests/src/python/test_provider_hana.py
+++ b/tests/src/python/test_provider_hana.py
@@ -65,7 +65,11 @@ class TestPyQgsHanaProvider(QgisTestCase, ProviderTestCase):
         if "QGIS_HANA_TEST_DB" in os.environ:
             cls.uri = os.environ["QGIS_HANA_TEST_DB"]
         cls.conn = QgsHanaProviderUtils.createConnection(cls.uri)
-        cls.schemaName = QgsHanaProviderUtils.generateSchemaName(cls.conn, "qgis_test")
+
+        schemaPrefix = "qgis_test"
+        QgsHanaProviderUtils.dropOldTestSchemas(cls.conn, schemaPrefix)
+
+        cls.schemaName = QgsHanaProviderUtils.generateSchemaName(cls.conn, schemaPrefix)
 
         QgsHanaProviderUtils.createAndFillDefaultTables(cls.conn, cls.schemaName)
 
@@ -87,7 +91,7 @@ class TestPyQgsHanaProvider(QgisTestCase, ProviderTestCase):
     def tearDownClass(cls):
         """Run after all tests"""
 
-        QgsHanaProviderUtils.cleanUp(cls.conn, cls.schemaName)
+        QgsHanaProviderUtils.dropSchemaIfExists(cls.conn, cls.schemaName)
         cls.conn.close()
         super().tearDownClass()
 

--- a/tests/src/python/test_qgsproviderconnection_hana.py
+++ b/tests/src/python/test_qgsproviderconnection_hana.py
@@ -49,9 +49,11 @@ class TestPyQgsProviderConnectionHana(
         if "QGIS_HANA_TEST_DB" in os.environ:
             cls.uri = os.environ["QGIS_HANA_TEST_DB"]
         cls.conn = QgsHanaProviderUtils.createConnection(cls.uri)
-        cls.schemaName = QgsHanaProviderUtils.generateSchemaName(
-            cls.conn, "qgis_test_provider_conn"
-        )
+
+        schemaPrefix = "qgis_test_providerconn"
+        QgsHanaProviderUtils.dropOldTestSchemas(cls.conn, schemaPrefix)
+
+        cls.schemaName = QgsHanaProviderUtils.generateSchemaName(cls.conn, schemaPrefix)
 
         QgsHanaProviderUtils.createAndFillDefaultTables(cls.conn, cls.schemaName)
         # Create test layers
@@ -65,12 +67,12 @@ class TestPyQgsProviderConnectionHana(
     def tearDownClass(cls):
         """Run after all tests"""
 
-        QgsHanaProviderUtils.cleanUp(cls.conn, cls.schemaName)
+        QgsHanaProviderUtils.dropSchemaIfExists(cls.conn, cls.schemaName)
         cls.conn.close()
         super().tearDownClass()
 
     def getUniqueSchemaName(self, name):
-        return "qgis_test_" + QgsHanaProviderUtils.generateSchemaName(self.conn, name)
+        return "qgis_test_providerconn_" + QgsHanaProviderUtils.generateSchemaName(self.conn, name)
 
     def createProviderMetadata(self):
         return QgsProviderRegistry.instance().providerMetadata(self.providerKey)

--- a/tests/src/python/test_qgsproviderconnection_hana.py
+++ b/tests/src/python/test_qgsproviderconnection_hana.py
@@ -72,7 +72,9 @@ class TestPyQgsProviderConnectionHana(
         super().tearDownClass()
 
     def getUniqueSchemaName(self, name):
-        return "qgis_test_providerconn_" + QgsHanaProviderUtils.generateSchemaName(self.conn, name)
+        return "qgis_test_providerconn_" + QgsHanaProviderUtils.generateSchemaName(
+            self.conn, name
+        )
 
     def createProviderMetadata(self):
         return QgsProviderRegistry.instance().providerMetadata(self.providerKey)


### PR DESCRIPTION
This PR contains the following changes:
 - Fixes an issue when some schemas are not listed due to an incorrect regular expression filter
 - Adds a code that cleans up old schemas created by previous test runs
