### PR TITLE
Further improve 3D Map View performance

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -344,7 +344,7 @@ void Qgs3DMapScene::updateScene( bool forceUpdate )
   float fovRadians = ( camera->fieldOfView() / 2.0f ) * static_cast<float>( M_PI ) / 180.0f;
   float fovCotan = std::cos( fovRadians ) / std::sin( fovRadians );
   QMatrix4x4 projMatrix(
-    fovCotan / camera->fieldOfView(), 0, 0, 0,
+    fovCotan / camera->aspectRatio(), 0, 0, 0,
     0, fovCotan, 0, 0,
     0, 0, -1, -2,
     0, 0, -1, 0

--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -140,7 +140,7 @@ void QgsVirtualPointCloudEntity::handleSceneUpdate( const SceneContext &sceneCon
     if ( !needsUpdate && box3D.isEmpty() )
       continue;
 
-    QgsAABB aabb = QgsAABB::fromBox3D( box3D, mBboxesEntity->vertexDataOrigin() );
+    QgsAABB aabb = QgsAABB::fromBox3D( box3D, mMapSettings->origin() );
     if ( !needsUpdate && Qgs3DUtils::isCullable( aabb, sceneContext.viewProjectionMatrix ) )
       continue;
 
@@ -190,7 +190,7 @@ QgsRange<float> QgsVirtualPointCloudEntity::getNearFarPlaneRange( const QMatrix4
   {
     for ( const QgsBox3D &box : mBboxes )
     {
-      QgsAABB aabb = QgsAABB::fromBox3D( box, mBboxesEntity->vertexDataOrigin() );
+      QgsAABB aabb = QgsAABB::fromBox3D( box, mMapSettings->origin() );
       float bboxfnear;
       float bboxffar;
       Qgs3DUtils::computeBoundingBoxNearFarPlanes( aabb, viewMatrix, bboxfnear, bboxffar );


### PR DESCRIPTION
## Description

This PR comprises two changes to the 3D view:

- *Decoupling entity visibility from the currently set near/far planes*: Currently, which entities are visible depends on the near/far planes. However, adding/removing entities will likely change the near/far planes that are used as input. Currently, we just re-run the scene update once, but to do this properly we'd need to loop until the planes stabilise.
  
  I instead propose not caring about the planes when selecting entities (by just choosing small/large enough constants), which is where the current process would converge to after enough frames anyway. This way, we get rid of the second (expensive) `updateScene()` call per frame, almost doubling frame rate, and reduce complexity as a bonus.

- *Early culling in QgsVirtualPointCloudEntity*: On each scene update, the VPC entity iterates over its constituent point clouds and calls their `handleSceneUpdate()` method. That will eventually do frustum culling somewhere in `QgsChunkedEntity`, but we can get a significant speedup if we do the frustum culling on whole point clouds already in the VPC entity.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
