### PR TITLE
Show GDAL release nickname in about screen

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -15,7 +15,6 @@
 
 
 
-
 class QgsCoordinateReferenceSystem
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -15,7 +15,6 @@
 
 
 
-
 class QgsCoordinateReferenceSystem
 {
 %Docstring(signature="appended")

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5505,10 +5505,20 @@ QString QgisApp::getVersionString()
   // GDAL version
   const QString gdalVersionCompiled { GDAL_RELEASE_NAME };
   const QString gdalVersionRunning { GDALVersionInfo( "RELEASE_NAME" ) };
-  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "GDAL/OGR version" ), gdalVersionCompiled );
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION( 3, 11, 0 )
+  const QString gdalReleaseNickName { GDAL_RELEASE_NICKNAME };
+#else
+  const QString gdalReleaseNickName;
+#endif
+
+  versionString += QStringLiteral( "<td>%1</td><td>%2" ).arg( tr( "GDAL version" ), gdalVersionCompiled );
   if ( gdalVersionCompiled != gdalVersionRunning )
   {
     versionString += QStringLiteral( " (%1)<br/>%2 (%3)" ).arg( compLabel, gdalVersionRunning, runLabel );
+  }
+  if ( !gdalReleaseNickName.isEmpty() )
+  {
+    versionString += QStringLiteral( " — <i>%1</i>" ).arg( gdalReleaseNickName );
   }
   versionString += QLatin1String( "</td></tr><tr>" );
 

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -55,12 +55,6 @@ typedef struct pj_ctx PJ_CONTEXT;
 // forward declaration for sqlite3
 typedef struct sqlite3 sqlite3 SIP_SKIP;
 
-#ifdef DEBUG
-typedef struct OGRSpatialReferenceHS *OGRSpatialReferenceH SIP_SKIP;
-#else
-typedef void *OGRSpatialReferenceH SIP_SKIP;
-#endif
-
 class QgsCoordinateReferenceSystem;
 typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SKIP;
 

--- a/src/core/proj/qgscoordinatereferencesystem_p.h
+++ b/src/core/proj/qgscoordinatereferencesystem_p.h
@@ -35,12 +35,6 @@
 #include "qgsprojutils.h"
 #include "qgsreadwritelocker.h"
 
-#ifdef DEBUG
-typedef struct OGRSpatialReferenceHS *OGRSpatialReferenceH;
-#else
-typedef void *OGRSpatialReferenceH;
-#endif
-
 class QgsCoordinateReferenceSystemPrivate : public QSharedData
 {
   public:


### PR DESCRIPTION
For GDAL >= 3.11, show the GDAL release nickname in the about screen. It makes the world a better place :+1: 
