### PR TITLE
improve locator titles and groups visibility

### DIFF
--- a/src/core/locator/qgslocatormodel.cpp
+++ b/src/core/locator/qgslocatormodel.cpp
@@ -115,10 +115,11 @@ QVariant QgsLocatorModel::data( const QModelIndex &index, int role ) const
     }
 
     case Qt::FontRole:
-      if ( index.column() == Name && !entry.groupTitle.isEmpty() )
+      if ( index.column() == Name )
       {
         QFont font;
-        font.setItalic( true );
+        font.setItalic( entry.type == EntryType::Group );
+        font.setBold( entry.type != EntryType::Result );
         return font;
       }
       else

--- a/src/core/locator/qgslocatormodel.cpp
+++ b/src/core/locator/qgslocatormodel.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include <QFont>
+#include <QPalette>
 
 #include "qgslocatormodel.h"
 #include "moc_qgslocatormodel.cpp"
@@ -115,11 +116,12 @@ QVariant QgsLocatorModel::data( const QModelIndex &index, int role ) const
     }
 
     case Qt::FontRole:
+    {
       if ( index.column() == Name )
       {
         QFont font;
+        font.setBold( entry.type == EntryType::Filter );
         font.setItalic( entry.type == EntryType::Group );
-        font.setBold( entry.type != EntryType::Result );
         return font;
       }
       else
@@ -127,6 +129,18 @@ QVariant QgsLocatorModel::data( const QModelIndex &index, int role ) const
         return QVariant();
       }
       break;
+    }
+
+    case Qt::BackgroundRole:
+    {
+      return entry.type == EntryType::Result ? QPalette().base() : QPalette().alternateBase();
+    }
+
+    case Qt::ForegroundRole:
+    {
+      return QPalette().text();
+    }
+
 
     case Qt::DecorationRole:
       switch ( static_cast<Column>( index.column() ) )


### PR DESCRIPTION
improve locator titles and groups visibility by using bold text

before:
![image](https://github.com/user-attachments/assets/c3cb40e5-7a09-4a59-971b-c76a5b090f27)

now:
![image](https://github.com/user-attachments/assets/408f6145-3570-47c5-a3da-a632f3f5e133)


former version of this PR:
![image](https://github.com/user-attachments/assets/7a43a5b4-7831-4fe7-9463-4fd5c7ecad15)
