### PR TITLE
don't treat all geometry collections as points/lines when noding

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -1457,7 +1457,7 @@ geos::unique_ptr QgsGeos::nodeGeometries( const GEOSGeometry *splitLine, const G
 
   geos::unique_ptr geometryBoundary;
   GEOSContextHandle_t context = QgsGeosContext::get();
-  if ( GEOSGeomTypeId_r( context, geom ) == GEOS_POLYGON || GEOSGeomTypeId_r( context, geom ) == GEOS_MULTIPOLYGON )
+  if ( GEOSGeom_getDimensions_r( context, geom ) == 2 )
     geometryBoundary.reset( GEOSBoundary_r( context, geom ) );
   else
     geometryBoundary.reset( GEOSGeom_clone_r( context, geom ) );


### PR DESCRIPTION
## Description
When a `GEOMETRYCOLLECTION` is passed into `QgsGeos::nodeGeometries()` it was treated as a point or line geometry, potentially causing a crash later when splitting.
Now it will trigger a geos exception with an error message `IllegalArgumentException: Operation not supported by GeometryCollection\n` which is caught.
We should probably not allow splitting of geometry collections in the first place and inform the users about their messed up data, but at first let's avoid crashing.

Fixes #58379

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
