### PR TITLE
add support for checkPrimaryKeyUnicity parameter in decodeUri() for PostgreSQL dataprovider

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -5688,10 +5688,8 @@ QVariantMap QgsPostgresProviderMetadata::decodeUri( const QString &uri ) const
     uriParts[QStringLiteral( "authcfg" )] = dsUri.authConfigId();
   if ( dsUri.wkbType() != Qgis::WkbType::Unknown )
     uriParts[QStringLiteral( "type" )] = static_cast<quint32>( dsUri.wkbType() );
-
   if ( uri.contains( QStringLiteral( "selectatid=" ), Qt::CaseSensitivity::CaseInsensitive ) )
     uriParts[QStringLiteral( "selectatid" )] = !dsUri.selectAtIdDisabled();
-
   if ( !dsUri.table().isEmpty() )
     uriParts[QStringLiteral( "table" )] = dsUri.table();
   if ( !dsUri.schema().isEmpty() )
@@ -5700,15 +5698,14 @@ QVariantMap QgsPostgresProviderMetadata::decodeUri( const QString &uri ) const
     uriParts[QStringLiteral( "key" )] = dsUri.keyColumn();
   if ( !dsUri.srid().isEmpty() )
     uriParts[QStringLiteral( "srid" )] = dsUri.srid();
-
   if ( uri.contains( QStringLiteral( "estimatedmetadata=" ), Qt::CaseSensitivity::CaseInsensitive ) )
     uriParts[QStringLiteral( "estimatedmetadata" )] = dsUri.useEstimatedMetadata();
-
   if ( uri.contains( QStringLiteral( "sslmode=" ), Qt::CaseSensitivity::CaseInsensitive ) )
     uriParts[QStringLiteral( "sslmode" )] = dsUri.sslMode();
-
   if ( !dsUri.sql().isEmpty() )
     uriParts[QStringLiteral( "sql" )] = dsUri.sql();
+  if ( !dsUri.param( QStringLiteral( "checkPrimaryKeyUnicity" ) ).isEmpty() )
+    uriParts[QStringLiteral( "checkPrimaryKeyUnicity" )] = dsUri.param( QStringLiteral( "checkPrimaryKeyUnicity" ) );
   if ( !dsUri.geometryColumn().isEmpty() )
     uriParts[QStringLiteral( "geometrycolumn" )] = dsUri.geometryColumn();
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -3535,6 +3535,7 @@ class TestPyQgsPostgresProvider(QgisTestCase, ProviderTestCase):
                 "table": "copas1",
                 "type": 6,
                 "username": "myuser",
+                "checkPrimaryKeyUnicity": "1",
             },
         )
 
@@ -3556,6 +3557,27 @@ class TestPyQgsPostgresProvider(QgisTestCase, ProviderTestCase):
                 }
             ),
             "dbname='qgis_tests' user='myuser' srid=3763 estimatedmetadata='true' host='localhost' key='id' port='5432' sslmode='disable' type='MultiPolygon' table=\"public\".\"copas1\" (geom)",
+        )
+
+        self.assertEqual(
+            md.encodeUri(
+                {
+                    "dbname": "qgis_tests",
+                    "estimatedmetadata": True,
+                    "geometrycolumn": "geom",
+                    "host": "localhost",
+                    "key": "id",
+                    "port": "5432",
+                    "schema": "public",
+                    "srid": "3763",
+                    "sslmode": 1,
+                    "table": "copas1",
+                    "type": 6,
+                    "username": "myuser",
+                    "checkPrimaryKeyUnicity": "1",
+                }
+            ),
+            "dbname='qgis_tests' user='myuser' srid=3763 estimatedmetadata='true' host='localhost' key='id' port='5432' sslmode='disable' type='MultiPolygon' checkPrimaryKeyUnicity='1' table=\"public\".\"copas1\" (geom)",
         )
 
         self.assertEqual(

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -3577,7 +3577,7 @@ class TestPyQgsPostgresProvider(QgisTestCase, ProviderTestCase):
                     "checkPrimaryKeyUnicity": "1",
                 }
             ),
-            "dbname='qgis_tests' user='myuser' srid=3763 estimatedmetadata='true' host='localhost' key='id' port='5432' sslmode='disable' type='MultiPolygon' checkPrimaryKeyUnicity='1' table=\"public\".\"copas1\" (geom)",
+            "dbname='qgis_tests' user='myuser' srid=3763 checkPrimaryKeyUnicity='1' estimatedmetadata='true' host='localhost' key='id' port='5432' sslmode='disable' type='MultiPolygon' table=\"public\".\"copas1\" (geom)",
         )
 
         self.assertEqual(


### PR DESCRIPTION
## Description

`decodeUri()` method of PostgreSQL data provider does not handle `checkPrimaryKeyUnicity` parameter leading to silent data loss when parsing datasource string.