### PR TITLE
Fix point cloud editing asserts

### DIFF
--- a/src/3d/chunks/qgschunkedentity.cpp
+++ b/src/3d/chunks/qgschunkedentity.cpp
@@ -323,6 +323,18 @@ void QgsChunkedEntity::updateNodes( const QList<QgsChunkNode *> &nodes, QgsChunk
     {
       cancelActiveJob( node->updater() );
     }
+    else if ( node->state() == QgsChunkNode::Skeleton || node->state() == QgsChunkNode::QueuedForLoad )
+    {
+      // there is not much to update yet
+      continue;
+    }
+    else if ( node->state() == QgsChunkNode::Loading )
+    {
+      // let's cancel the current loading job and queue for loading again
+      cancelActiveJob( node->loader() );
+      requestResidency( node );
+      continue;
+    }
 
     Q_ASSERT( node->state() == QgsChunkNode::Loaded );
 

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -255,6 +255,9 @@ static QgsChunkNode *findChunkNodeFromNodeId( QgsChunkNode *rootNode, QgsPointCl
     QgsPointCloudNodeId p = parentIds.takeLast();
     QgsChunkNodeId childNodeId( p.d(), p.x(), p.y(), p.z() );
 
+    if ( !chunk->hasChildrenPopulated() )
+      return nullptr;
+
     QgsChunkNode *chunkChild = nullptr;
     QgsChunkNode *const *children = chunk->children();
     for ( int i = 0; i < chunk->childCount(); ++i )
@@ -287,9 +290,11 @@ QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( Qgs3DMapSettin
     mChunkUpdaterFactory.reset( new QgsChunkUpdaterFactory( mChunkLoaderFactory ) );
 
     connect( pcl, &QgsPointCloudLayer::chunkAttributeValuesChanged, this, [this]( const QgsPointCloudNodeId &n ) {
-      QList<QgsChunkNode *> nodes;
-      nodes << findChunkNodeFromNodeId( mRootNode, n );
-      updateNodes( nodes, mChunkUpdaterFactory.get() );
+      QgsChunkNode *node = findChunkNodeFromNodeId( mRootNode, n );
+      if ( node )
+      {
+        updateNodes( QList<QgsChunkNode *>() << node, mChunkUpdaterFactory.get() );
+      }
     } );
   }
 }


### PR DESCRIPTION
Fix two cases when asserts can be triggered when editing point clouds and we are requesting updates of nodes that are not active in the 3D view (e.g. when we are zoomed out)