### PR TITLE
Add merge policies

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6928,6 +6928,7 @@ Qgis.FieldDomainSplitPolicy.baseClass = Qgis
 Qgis.FieldDomainMergePolicy.DefaultValue.__doc__ = "Use default field value"
 Qgis.FieldDomainMergePolicy.Sum.__doc__ = "Sum of values"
 Qgis.FieldDomainMergePolicy.GeometryWeighted.__doc__ = "New values are computed as the weighted average of the source values"
+Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6938,6 +6939,10 @@ attributes following the domain are computed.
 * ``DefaultValue``: Use default field value
 * ``Sum``: Sum of values
 * ``GeometryWeighted``: New values are computed as the weighted average of the source values
+* ``UnsetField``: Clears the field value so that the data provider backend will populate using any backend triggers or similar logic
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6929,6 +6929,7 @@ Qgis.FieldDomainMergePolicy.DefaultValue.__doc__ = "Use default field value"
 Qgis.FieldDomainMergePolicy.Sum.__doc__ = "Sum of values"
 Qgis.FieldDomainMergePolicy.GeometryWeighted.__doc__ = "New values are computed as the weighted average of the source values"
 Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.LargestGeometry.__doc__ = "Use value from the feature with the largest geometry \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6940,6 +6941,10 @@ attributes following the domain are computed.
 * ``Sum``: Sum of values
 * ``GeometryWeighted``: New values are computed as the weighted average of the source values
 * ``UnsetField``: Clears the field value so that the data provider backend will populate using any backend triggers or similar logic
+
+  .. versionadded:: 3.44
+
+* ``LargestGeometry``: Use value from the feature with the largest geometry
 
   .. versionadded:: 3.44
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6930,6 +6930,9 @@ Qgis.FieldDomainMergePolicy.Sum.__doc__ = "Sum of values"
 Qgis.FieldDomainMergePolicy.GeometryWeighted.__doc__ = "New values are computed as the weighted average of the source values"
 Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.LargestGeometry.__doc__ = "Use value from the feature with the largest geometry \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.MinimumValue.__doc__ = "Use the minimum value from the features-to-be-merged \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.MaximumValue.__doc__ = "Use the maximum value from the features-to-be-merged \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.SkipAttribute.__doc__ = "Use a null value \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6945,6 +6948,18 @@ attributes following the domain are computed.
   .. versionadded:: 3.44
 
 * ``LargestGeometry``: Use value from the feature with the largest geometry
+
+  .. versionadded:: 3.44
+
+* ``MinimumValue``: Use the minimum value from the features-to-be-merged
+
+  .. versionadded:: 3.44
+
+* ``MaximumValue``: Use the maximum value from the features-to-be-merged
+
+  .. versionadded:: 3.44
+
+* ``SkipAttribute``: Use a null value
 
   .. versionadded:: 3.44
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6932,7 +6932,7 @@ Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that
 Qgis.FieldDomainMergePolicy.LargestGeometry.__doc__ = "Use value from the feature with the largest geometry \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.MinimumValue.__doc__ = "Use the minimum value from the features-to-be-merged \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.MaximumValue.__doc__ = "Use the maximum value from the features-to-be-merged \n.. versionadded:: 3.44"
-Qgis.FieldDomainMergePolicy.SkipAttribute.__doc__ = "Use a null value \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.SetToNull.__doc__ = "Use a null value \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6959,7 +6959,7 @@ attributes following the domain are computed.
 
   .. versionadded:: 3.44
 
-* ``SkipAttribute``: Use a null value
+* ``SetToNull``: Use a null value
 
   .. versionadded:: 3.44
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2116,7 +2116,7 @@ The development version
       LargestGeometry,
       MinimumValue,
       MaximumValue,
-      SkipAttribute,
+      SetToNull,
     };
 
     enum class FieldDuplicatePolicy /BaseType=IntEnum/

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2112,6 +2112,7 @@ The development version
       DefaultValue,
       Sum,
       GeometryWeighted,
+      UnsetField,
     };
 
     enum class FieldDuplicatePolicy /BaseType=IntEnum/

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2114,6 +2114,9 @@ The development version
       GeometryWeighted,
       UnsetField,
       LargestGeometry,
+      MinimumValue,
+      MaximumValue,
+      SkipAttribute,
     };
 
     enum class FieldDuplicatePolicy /BaseType=IntEnum/

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2113,6 +2113,7 @@ The development version
       Sum,
       GeometryWeighted,
       UnsetField,
+      LargestGeometry,
     };
 
     enum class FieldDuplicatePolicy /BaseType=IntEnum/

--- a/python/PyQt6/core/auto_generated/qgsfield.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfield.sip.in
@@ -533,6 +533,26 @@ be handled during a duplicate operation.
 .. versionadded:: 3.38
 %End
 
+    Qgis::FieldDomainMergePolicy mergePolicy() const /HoldGIL/;
+%Docstring
+Returns the field's merge policy, which indicates how field values should
+be handled during a merge operation.
+
+.. seealso:: :py:func:`setMergePolicy`
+
+.. versionadded:: 3.44
+%End
+
+    void setMergePolicy( Qgis::FieldDomainMergePolicy policy ) /HoldGIL/;
+%Docstring
+Sets the field's merge ``policy``, which indicates how field values should
+be handled during a merge operation.
+
+.. seealso:: :py:func:`mergePolicy`
+
+.. versionadded:: 3.44
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsField: %1 (%2)>" ).arg( sipCpp->name() ).arg( sipCpp->typeName() );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1953,6 +1953,27 @@ Sets a duplicate ``policy`` for the field with the specified index.
     }
 %End
 
+    void setFieldMergePolicy( int index, Qgis::FieldDomainMergePolicy policy );
+%Docstring
+Sets a merge ``policy`` for the field with the specified index.
+
+:raises KeyError: if no field with the specified index exists
+
+.. versionadded:: 3.44
+%End
+
+%MethodCode
+    if ( a0 < 0 || a0 >= sipCpp->fields().count() )
+    {
+      PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipCpp->setFieldMergePolicy( a0, a1 );
+    }
+%End
+
  QSet<QString> excludeAttributesWms() const /Deprecated="Since 3.16. Use fields().configurationFlags() instead."/;
 %Docstring
 A set of attributes that are not advertised in WMS requests with QGIS server.

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6863,6 +6863,7 @@ Qgis.FieldDomainMergePolicy.DefaultValue.__doc__ = "Use default field value"
 Qgis.FieldDomainMergePolicy.Sum.__doc__ = "Sum of values"
 Qgis.FieldDomainMergePolicy.GeometryWeighted.__doc__ = "New values are computed as the weighted average of the source values"
 Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.LargestGeometry.__doc__ = "Use value from the feature with the largest geometry \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6874,6 +6875,10 @@ attributes following the domain are computed.
 * ``Sum``: Sum of values
 * ``GeometryWeighted``: New values are computed as the weighted average of the source values
 * ``UnsetField``: Clears the field value so that the data provider backend will populate using any backend triggers or similar logic
+
+  .. versionadded:: 3.44
+
+* ``LargestGeometry``: Use value from the feature with the largest geometry
 
   .. versionadded:: 3.44
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6862,6 +6862,7 @@ Qgis.FieldDomainSplitPolicy.baseClass = Qgis
 Qgis.FieldDomainMergePolicy.DefaultValue.__doc__ = "Use default field value"
 Qgis.FieldDomainMergePolicy.Sum.__doc__ = "Sum of values"
 Qgis.FieldDomainMergePolicy.GeometryWeighted.__doc__ = "New values are computed as the weighted average of the source values"
+Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6872,6 +6873,10 @@ attributes following the domain are computed.
 * ``DefaultValue``: Use default field value
 * ``Sum``: Sum of values
 * ``GeometryWeighted``: New values are computed as the weighted average of the source values
+* ``UnsetField``: Clears the field value so that the data provider backend will populate using any backend triggers or similar logic
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6864,6 +6864,9 @@ Qgis.FieldDomainMergePolicy.Sum.__doc__ = "Sum of values"
 Qgis.FieldDomainMergePolicy.GeometryWeighted.__doc__ = "New values are computed as the weighted average of the source values"
 Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.LargestGeometry.__doc__ = "Use value from the feature with the largest geometry \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.MinimumValue.__doc__ = "Use the minimum value from the features-to-be-merged \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.MaximumValue.__doc__ = "Use the maximum value from the features-to-be-merged \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.SkipAttribute.__doc__ = "Use a null value \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6879,6 +6882,18 @@ attributes following the domain are computed.
   .. versionadded:: 3.44
 
 * ``LargestGeometry``: Use value from the feature with the largest geometry
+
+  .. versionadded:: 3.44
+
+* ``MinimumValue``: Use the minimum value from the features-to-be-merged
+
+  .. versionadded:: 3.44
+
+* ``MaximumValue``: Use the maximum value from the features-to-be-merged
+
+  .. versionadded:: 3.44
+
+* ``SkipAttribute``: Use a null value
 
   .. versionadded:: 3.44
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6866,7 +6866,7 @@ Qgis.FieldDomainMergePolicy.UnsetField.__doc__ = "Clears the field value so that
 Qgis.FieldDomainMergePolicy.LargestGeometry.__doc__ = "Use value from the feature with the largest geometry \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.MinimumValue.__doc__ = "Use the minimum value from the features-to-be-merged \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.MaximumValue.__doc__ = "Use the maximum value from the features-to-be-merged \n.. versionadded:: 3.44"
-Qgis.FieldDomainMergePolicy.SkipAttribute.__doc__ = "Use a null value \n.. versionadded:: 3.44"
+Qgis.FieldDomainMergePolicy.SetToNull.__doc__ = "Use a null value \n.. versionadded:: 3.44"
 Qgis.FieldDomainMergePolicy.__doc__ = """Merge policy for field domains.
 
 When a feature is built by merging multiple features, defines how the value of
@@ -6893,7 +6893,7 @@ attributes following the domain are computed.
 
   .. versionadded:: 3.44
 
-* ``SkipAttribute``: Use a null value
+* ``SetToNull``: Use a null value
 
   .. versionadded:: 3.44
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2114,6 +2114,9 @@ The development version
       GeometryWeighted,
       UnsetField,
       LargestGeometry,
+      MinimumValue,
+      MaximumValue,
+      SkipAttribute,
     };
 
     enum class FieldDuplicatePolicy

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2116,7 +2116,7 @@ The development version
       LargestGeometry,
       MinimumValue,
       MaximumValue,
-      SkipAttribute,
+      SetToNull,
     };
 
     enum class FieldDuplicatePolicy

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2112,6 +2112,7 @@ The development version
       DefaultValue,
       Sum,
       GeometryWeighted,
+      UnsetField,
     };
 
     enum class FieldDuplicatePolicy

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2113,6 +2113,7 @@ The development version
       Sum,
       GeometryWeighted,
       UnsetField,
+      LargestGeometry,
     };
 
     enum class FieldDuplicatePolicy

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -533,6 +533,26 @@ be handled during a duplicate operation.
 .. versionadded:: 3.38
 %End
 
+    Qgis::FieldDomainMergePolicy mergePolicy() const /HoldGIL/;
+%Docstring
+Returns the field's merge policy, which indicates how field values should
+be handled during a merge operation.
+
+.. seealso:: :py:func:`setMergePolicy`
+
+.. versionadded:: 3.44
+%End
+
+    void setMergePolicy( Qgis::FieldDomainMergePolicy policy ) /HoldGIL/;
+%Docstring
+Sets the field's merge ``policy``, which indicates how field values should
+be handled during a merge operation.
+
+.. seealso:: :py:func:`mergePolicy`
+
+.. versionadded:: 3.44
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsField: %1 (%2)>" ).arg( sipCpp->name() ).arg( sipCpp->typeName() );

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1953,6 +1953,27 @@ Sets a duplicate ``policy`` for the field with the specified index.
     }
 %End
 
+    void setFieldMergePolicy( int index, Qgis::FieldDomainMergePolicy policy );
+%Docstring
+Sets a merge ``policy`` for the field with the specified index.
+
+:raises KeyError: if no field with the specified index exists
+
+.. versionadded:: 3.44
+%End
+
+%MethodCode
+    if ( a0 < 0 || a0 >= sipCpp->fields().count() )
+    {
+      PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipCpp->setFieldMergePolicy( a0, a1 );
+    }
+%End
+
  QSet<QString> excludeAttributesWms() const /Deprecated="Since 3.16. Use fields().configurationFlags() instead."/;
 %Docstring
 A set of attributes that are not advertised in WMS requests with QGIS server.

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2257,7 +2257,7 @@ QString QgsFieldDomainDetailsWidget::htmlMetadata( QgsFieldDomain *domain, const
       metadata += tr( "Minimum value" );
       break;
     case Qgis::FieldDomainMergePolicy::SetToNull:
-      metadata += tr( "Skip attribute" );
+      metadata += tr( "Set attribute to NULL." );
       break;
   }
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2256,7 +2256,7 @@ QString QgsFieldDomainDetailsWidget::htmlMetadata( QgsFieldDomain *domain, const
     case Qgis::FieldDomainMergePolicy::MinimumValue:
       metadata += tr( "Minimum value" );
       break;
-    case Qgis::FieldDomainMergePolicy::SkipAttribute:
+    case Qgis::FieldDomainMergePolicy::SetToNull:
       metadata += tr( "Skip attribute" );
       break;
   }

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2247,6 +2247,9 @@ QString QgsFieldDomainDetailsWidget::htmlMetadata( QgsFieldDomain *domain, const
     case Qgis::FieldDomainMergePolicy::UnsetField:
       metadata += tr( "Unset field" );
       break;
+    case Qgis::FieldDomainMergePolicy::LargestGeometry:
+      metadata += tr( "Largest geometry" );
+      break;
   }
 
   metadata += QLatin1String( "</table>\n<br><br>" );

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2250,6 +2250,15 @@ QString QgsFieldDomainDetailsWidget::htmlMetadata( QgsFieldDomain *domain, const
     case Qgis::FieldDomainMergePolicy::LargestGeometry:
       metadata += tr( "Largest geometry" );
       break;
+    case Qgis::FieldDomainMergePolicy::MaximumValue:
+      metadata += tr( "Maximum value" );
+      break;
+    case Qgis::FieldDomainMergePolicy::MinimumValue:
+      metadata += tr( "Minimum value" );
+      break;
+    case Qgis::FieldDomainMergePolicy::SkipAttribute:
+      metadata += tr( "Skip attribute" );
+      break;
   }
 
   metadata += QLatin1String( "</table>\n<br><br>" );

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2244,6 +2244,9 @@ QString QgsFieldDomainDetailsWidget::htmlMetadata( QgsFieldDomain *domain, const
     case Qgis::FieldDomainMergePolicy::GeometryWeighted:
       metadata += tr( "Use geometry weighted value" );
       break;
+    case Qgis::FieldDomainMergePolicy::UnsetField:
+      metadata += tr( "Unset field" );
+      break;
   }
 
   metadata += QLatin1String( "</table>\n<br><br>" );

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2257,7 +2257,7 @@ QString QgsFieldDomainDetailsWidget::htmlMetadata( QgsFieldDomain *domain, const
       metadata += tr( "Minimum value" );
       break;
     case Qgis::FieldDomainMergePolicy::SetToNull:
-      metadata += tr( "Set attribute to NULL." );
+      metadata += tr( "Set attribute to NULL" );
       break;
   }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9451,9 +9451,8 @@ void QgisApp::mergeAttributesOfSelectedFeatures()
   QgsFeatureList featureList = vl->selectedFeatures();
 
   //merge the attributes together
-  QgsMergeAttributesDialog d( featureList, vl, mapCanvas() );
-  //initialize dialog with all columns set to skip
-  d.setAllToSkip();
+  QgsMergeAttributesDialog d( featureList, vl, mapCanvas(), true );
+
   if ( d.exec() == QDialog::Rejected )
   {
     return;

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -390,7 +390,7 @@ void QgsMergeAttributesDialog::createTableWidgetContents( bool skipAll )
       case Qgis::FieldDomainMergePolicy::SetToNull:
       {
         if ( currentComboBox )
-          currentComboBox->setCurrentIndex( currentComboBox->findData( QStringLiteral( "skip" ) ) );
+          currentComboBox->setCurrentIndex( currentComboBox->findData( QStringLiteral( "null" ) ) );
 
         break;
       }
@@ -453,6 +453,7 @@ QComboBox *QgsMergeAttributesDialog::createMergeComboBox( QMetaType::Type column
 
   newComboBox->addItem( tr( "Skip Attribute" ), QStringLiteral( "skip" ) );
   newComboBox->addItem( tr( "Manual Value" ), QStringLiteral( "manual" ) );
+  newComboBox->addItem( tr( "Set to NULL" ), QStringLiteral( "null" ) );
 
   connect( newComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [=]() {
     bool isManual = newComboBox->currentData() == QLatin1String( "manual" );
@@ -542,6 +543,10 @@ void QgsMergeAttributesDialog::refreshMergedValue( int col )
     {
       mergeResult = tr( "Skipped" );
     }
+    else if ( mergeBehaviorString == QLatin1String( "null" ) )
+    {
+      mergeResult = tr( "NULL" );
+    }
     else if ( mergeBehaviorString.startsWith( 'f' ) )
     {
       //an existing feature value
@@ -560,7 +565,7 @@ void QgsMergeAttributesDialog::refreshMergedValue( int col )
 
     // Result formatting
     QString stringVal;
-    if ( mergeBehaviorString != QLatin1String( "skip" ) && mergeBehaviorString != QLatin1String( "manual" ) )
+    if ( mergeBehaviorString != QLatin1String( "skip" ) && mergeBehaviorString != QLatin1String( "manual" ) && mergeBehaviorString != QLatin1String( "null" ) )
     {
       const QgsEditorWidgetSetup setup = mFields.at( fieldIdx ).editorWidgetSetup();
       const QgsFieldFormatter *formatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
@@ -921,6 +926,14 @@ QgsAttributes QgsMergeAttributesDialog::mergedAttributes() const
       continue;
 
     QVariant value;
+
+    if ( comboBox->currentData().toString() == QLatin1String( "null" ) )
+    {
+      results[fieldIdx] = value;
+      widgetIndex++;
+      continue;
+    }
+
     QWidget *w = mTableWidget->cellWidget( mFeatureList.size() + 1, widgetIndex );
     QgsEditorWidgetWrapper *eww = QgsEditorWidgetWrapper::fromWidget( w );
     if ( eww )

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -387,7 +387,7 @@ void QgsMergeAttributesDialog::createTableWidgetContents( bool skipAll )
         break;
       }
 
-      case Qgis::FieldDomainMergePolicy::SkipAttribute:
+      case Qgis::FieldDomainMergePolicy::SetToNull:
       {
         if ( currentComboBox )
           currentComboBox->setCurrentIndex( currentComboBox->findData( QStringLiteral( "skip" ) ) );

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -50,7 +50,7 @@ const QList<Qgis::Statistic> QgsMergeAttributesDialog::DISPLAY_STATS = QList<Qgi
                                                                                                 << Qgis::Statistic::ThirdQuartile
                                                                                                 << Qgis::Statistic::InterQuartileRange;
 
-QgsMergeAttributesDialog::QgsMergeAttributesDialog( const QgsFeatureList &features, QgsVectorLayer *vl, QgsMapCanvas *canvas, QWidget *parent, Qt::WindowFlags f )
+QgsMergeAttributesDialog::QgsMergeAttributesDialog( const QgsFeatureList &features, QgsVectorLayer *vl, QgsMapCanvas *canvas, bool skipAll, QWidget *parent, Qt::WindowFlags f )
   : QDialog( parent, f )
   , mFeatureList( features )
   , mVectorLayer( vl )
@@ -63,7 +63,11 @@ QgsMergeAttributesDialog::QgsMergeAttributesDialog( const QgsFeatureList &featur
   connect( mFromSelectedPushButton, &QPushButton::clicked, this, &QgsMergeAttributesDialog::mFromSelectedPushButton_clicked );
   connect( mFromLargestPushButton, &QPushButton::clicked, this, &QgsMergeAttributesDialog::mFromLargestPushButton_clicked );
   connect( mRemoveFeatureFromSelectionButton, &QPushButton::clicked, this, &QgsMergeAttributesDialog::mRemoveFeatureFromSelectionButton_clicked );
-  createTableWidgetContents();
+
+  createTableWidgetContents( skipAll );
+
+  if ( skipAll )
+    setAllToSkip();
 
   QHeaderView *verticalHeader = mTableWidget->verticalHeader();
   if ( verticalHeader )
@@ -149,7 +153,7 @@ void QgsMergeAttributesDialog::setAttributeTableConfig( const QgsAttributeTableC
   }
 }
 
-void QgsMergeAttributesDialog::createTableWidgetContents()
+void QgsMergeAttributesDialog::createTableWidgetContents( bool skipAll )
 {
   //get information about attributes from vector layer
   if ( !mVectorLayer )
@@ -238,26 +242,106 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
   //initially set any fields with default values/default value clauses to that value
   for ( int j = 0; j < mTableWidget->columnCount(); j++ )
   {
+    if ( skipAll )
+      break;
+
     int idx = mTableWidget->horizontalHeaderItem( j )->data( FieldIndex ).toInt();
     bool setToManual = false;
 
-    if ( !mVectorLayer->dataProvider()->defaultValueClause( idx ).isEmpty() )
+    const QgsField field = mVectorLayer->fields().at( idx );
+
+    switch ( field.mergePolicy() )
     {
-      QVariant v = mVectorLayer->dataProvider()->defaultValueClause( idx );
-      mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, v );
-      mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, v );
-      setToManual = true;
-    }
-    else
-    {
-      QVariant v = mVectorLayer->dataProvider()->defaultValue( idx );
-      if ( v.isValid() )
+      case Qgis::FieldDomainMergePolicy::Sum:
       {
+        if ( !field.isNumeric() )
+          break;
+
+        const double sum = std::accumulate( mFeatureList.constBegin(), mFeatureList.constEnd(), 0.0, [idx]( double sum, const QgsFeature &f ) {
+          return sum + f.attribute( idx ).toDouble();
+        } );
+
+        mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, sum );
+        mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, sum );
+        setToManual = true;
+
+        break;
+      }
+
+      case Qgis::FieldDomainMergePolicy::DefaultValue:
+      {
+        // create a dummy feature with the combined geometry in case the default value expression uses the geometry.
+        // however populating the feature's fields is problematic because the values haven't been set yet and
+        // generating them at this point isn't possible since the expression might refer to another field
+        // with a default value expression leading to conflicts
+        QgsFeature f;
+
+        QVector<QgsGeometry> geoms;
+        for ( const QgsFeature &f : mFeatureList )
+          geoms << f.geometry();
+
+        const QgsGeometry mergedGeom = QgsGeometry::unaryUnion( geoms );
+        f.setGeometry( mergedGeom );
+
+        const QVariant v = mVectorLayer->defaultValue( idx, f );
+
+        if ( !v.isValid() )
+          break;
+
         mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, v );
         mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, v );
         setToManual = true;
+        break;
+      }
+
+      case Qgis::FieldDomainMergePolicy::GeometryWeighted:
+      {
+        if ( !field.isNumeric() || mVectorLayer->geometryType() == Qgis::GeometryType::Point )
+          break;
+
+        QVector<QgsGeometry> geoms;
+        for ( const QgsFeature &f : mFeatureList )
+          geoms << f.geometry();
+
+        const QgsGeometry mergedGeom = QgsGeometry::unaryUnion( geoms );
+        const double mergedSize = mVectorLayer->geometryType() == Qgis::GeometryType::Polygon ? mergedGeom.area() : mergedGeom.length();
+
+        const double value = std::accumulate( mFeatureList.constBegin(), mFeatureList.constEnd(), 0.0, [&, idx]( double sum, const QgsFeature &f ) {
+          const double geomSize = mVectorLayer->geometryType() == Qgis::GeometryType::Polygon ? f.geometry().area() : f.geometry().length();
+          const double weightMultiplier = geomSize / mergedSize;
+          return sum + ( f.attribute( idx ).toDouble() * weightMultiplier );
+        } );
+
+        mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, value );
+        mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, value );
+        setToManual = true;
+
+        break;
+      }
+
+      case Qgis::FieldDomainMergePolicy::UnsetField:
+      {
+        if ( !mVectorLayer->dataProvider()->defaultValueClause( idx ).isEmpty() )
+        {
+          QVariant v = mVectorLayer->dataProvider()->defaultValueClause( idx );
+          mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, v );
+          mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, v );
+          setToManual = true;
+        }
+        else
+        {
+          QVariant v = mVectorLayer->dataProvider()->defaultValue( idx );
+          if ( v.isValid() )
+          {
+            mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, v );
+            mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, v );
+            setToManual = true;
+          }
+        }
       }
     }
+
+
     if ( setToManual )
     {
       QComboBox *currentComboBox = qobject_cast<QComboBox *>( mTableWidget->cellWidget( 0, j ) );

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -338,7 +338,25 @@ void QgsMergeAttributesDialog::createTableWidgetContents( bool skipAll )
             setToManual = true;
           }
         }
+        break;
       }
+
+      case Qgis::FieldDomainMergePolicy::LargestGeometry:
+      {
+        if ( mVectorLayer->geometryType() == Qgis::GeometryType::Unknown || mVectorLayer->geometryType() == Qgis::GeometryType::Null || mVectorLayer->geometryType() == Qgis::GeometryType::Point )
+          break;
+
+        std::function<double( const QgsGeometry & )> getSize = mVectorLayer->geometryType() == Qgis::GeometryType::Polygon ? &QgsGeometry::area : &QgsGeometry::length;
+
+        QList<QgsFeature>::iterator largestSelectedFeature = std::max_element( mFeatureList.begin(), mFeatureList.end(), [&getSize]( const QgsFeature &a, const QgsFeature &b ) -> bool {
+          return getSize( a.geometry() ) < getSize( b.geometry() );
+        } );
+
+        mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, largestSelectedFeature->attribute( idx ) );
+        mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, largestSelectedFeature->attribute( idx ) );
+        setToManual = true;
+      }
+      break;
     }
 
 

--- a/src/app/qgsmergeattributesdialog.h
+++ b/src/app/qgsmergeattributesdialog.h
@@ -42,7 +42,7 @@ class APP_EXPORT QgsMergeAttributesDialog : public QDialog, private Ui::QgsMerge
     };
 
 
-    QgsMergeAttributesDialog( const QgsFeatureList &features, QgsVectorLayer *vl, QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
+    QgsMergeAttributesDialog( const QgsFeatureList &features, QgsVectorLayer *vl, QgsMapCanvas *canvas, bool skipAll = false, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
     ~QgsMergeAttributesDialog() override;
 
     QgsAttributes mergedAttributes() const;
@@ -82,7 +82,7 @@ class APP_EXPORT QgsMergeAttributesDialog : public QDialog, private Ui::QgsMerge
 
   private:
     QgsMergeAttributesDialog(); //default constructor forbidden
-    void createTableWidgetContents();
+    void createTableWidgetContents( bool skipAll );
     void setAttributeTableConfig( const QgsAttributeTableConfig &config );
 
     //! Create new combo box with the options for featureXX / mean / min / max

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3730,6 +3730,7 @@ class CORE_EXPORT Qgis
       Sum, //!< Sum of values
       GeometryWeighted, //!< New values are computed as the weighted average of the source values
       UnsetField, //!< Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \since QGIS 3.44
+      LargestGeometry, //!< Use value from the feature with the largest geometry \since QGIS 3.44
     };
     Q_ENUM( FieldDomainMergePolicy )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3733,7 +3733,7 @@ class CORE_EXPORT Qgis
       LargestGeometry, //!< Use value from the feature with the largest geometry \since QGIS 3.44
       MinimumValue, //!< Use the minimum value from the features-to-be-merged \since QGIS 3.44
       MaximumValue, //!< Use the maximum value from the features-to-be-merged \since QGIS 3.44
-      SkipAttribute, //!< Use a null value \since QGIS 3.44
+      SetToNull, //!< Use a null value \since QGIS 3.44
     };
     Q_ENUM( FieldDomainMergePolicy )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3731,6 +3731,9 @@ class CORE_EXPORT Qgis
       GeometryWeighted, //!< New values are computed as the weighted average of the source values
       UnsetField, //!< Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \since QGIS 3.44
       LargestGeometry, //!< Use value from the feature with the largest geometry \since QGIS 3.44
+      MinimumValue, //!< Use the minimum value from the features-to-be-merged \since QGIS 3.44
+      MaximumValue, //!< Use the maximum value from the features-to-be-merged \since QGIS 3.44
+      SkipAttribute, //!< Use a null value \since QGIS 3.44
     };
     Q_ENUM( FieldDomainMergePolicy )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3729,6 +3729,7 @@ class CORE_EXPORT Qgis
       DefaultValue, //!< Use default field value
       Sum, //!< Sum of values
       GeometryWeighted, //!< New values are computed as the weighted average of the source values
+      UnsetField, //!< Clears the field value so that the data provider backend will populate using any backend triggers or similar logic \since QGIS 3.44
     };
     Q_ENUM( FieldDomainMergePolicy )
 

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -772,6 +772,16 @@ void QgsField::setDuplicatePolicy( Qgis::FieldDuplicatePolicy policy )
   d->duplicatePolicy = policy;
 }
 
+Qgis::FieldDomainMergePolicy QgsField::mergePolicy() const
+{
+  return d->mergePolicy;
+}
+
+void QgsField::setMergePolicy( Qgis::FieldDomainMergePolicy policy )
+{
+  d->mergePolicy = policy;
+}
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests in testqgsfield.cpp.

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -545,6 +545,26 @@ class CORE_EXPORT QgsField
      */
     void setDuplicatePolicy( Qgis::FieldDuplicatePolicy policy ) SIP_HOLDGIL;
 
+    /**
+     * Returns the field's merge policy, which indicates how field values should
+     * be handled during a merge operation.
+     *
+     * \see setMergePolicy()
+     *
+     * \since QGIS 3.44
+     */
+    Qgis::FieldDomainMergePolicy mergePolicy() const SIP_HOLDGIL;
+
+    /**
+     * Sets the field's merge \a policy, which indicates how field values should
+     * be handled during a merge operation.
+     *
+     * \see mergePolicy()
+     *
+     * \since QGIS 3.44
+     */
+    void setMergePolicy( Qgis::FieldDomainMergePolicy policy ) SIP_HOLDGIL;
+
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -85,6 +85,7 @@ class QgsFieldPrivate : public QSharedData
       , editorWidgetSetup( other.editorWidgetSetup )
       , splitPolicy( other.splitPolicy )
       , duplicatePolicy( other.duplicatePolicy )
+      , mergePolicy( other.mergePolicy )
       , isReadOnly( other.isReadOnly )
     {
     }
@@ -101,6 +102,7 @@ class QgsFieldPrivate : public QSharedData
                && ( constraints == other.constraints )  && ( flags == other.flags )
                && ( splitPolicy == other.splitPolicy )
                && ( duplicatePolicy == other.duplicatePolicy )
+               && ( mergePolicy == other.mergePolicy )
                && ( isReadOnly == other.isReadOnly )
                && ( editorWidgetSetup == other.editorWidgetSetup ) );
     }
@@ -148,6 +150,9 @@ class QgsFieldPrivate : public QSharedData
 
     //! Duplicate policy
     Qgis::FieldDuplicatePolicy duplicatePolicy = Qgis::FieldDuplicatePolicy::Duplicate;
+
+    //! Merge policy
+    Qgis::FieldDomainMergePolicy mergePolicy = Qgis::FieldDomainMergePolicy::UnsetField;
 
     //! Read-only
     bool isReadOnly = false;

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -2301,6 +2301,9 @@ OGRFieldDomainH QgsOgrUtils::convertFieldDomain( const QgsFieldDomain *domain )
 
     case Qgis::FieldDomainMergePolicy::UnsetField:
     case Qgis::FieldDomainMergePolicy::LargestGeometry:
+    case Qgis::FieldDomainMergePolicy::MinimumValue:
+    case Qgis::FieldDomainMergePolicy::MaximumValue:
+    case Qgis::FieldDomainMergePolicy::SkipAttribute:
       // not supported
       break;
   }

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -2298,6 +2298,10 @@ OGRFieldDomainH QgsOgrUtils::convertFieldDomain( const QgsFieldDomain *domain )
     case Qgis::FieldDomainMergePolicy::Sum:
       OGR_FldDomain_SetMergePolicy( res, OFDMP_SUM );
       break;
+
+    case Qgis::FieldDomainMergePolicy::UnsetField:
+      // not supported
+      break;
   }
 
   switch ( domain->splitPolicy() )

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -2300,6 +2300,7 @@ OGRFieldDomainH QgsOgrUtils::convertFieldDomain( const QgsFieldDomain *domain )
       break;
 
     case Qgis::FieldDomainMergePolicy::UnsetField:
+    case Qgis::FieldDomainMergePolicy::LargestGeometry:
       // not supported
       break;
   }

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -2303,7 +2303,7 @@ OGRFieldDomainH QgsOgrUtils::convertFieldDomain( const QgsFieldDomain *domain )
     case Qgis::FieldDomainMergePolicy::LargestGeometry:
     case Qgis::FieldDomainMergePolicy::MinimumValue:
     case Qgis::FieldDomainMergePolicy::MaximumValue:
-    case Qgis::FieldDomainMergePolicy::SkipAttribute:
+    case Qgis::FieldDomainMergePolicy::SetToNull:
       // not supported
       break;
   }

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1851,6 +1851,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \since QGIS 3.38
      */
     void setFieldDuplicatePolicy( int index, Qgis::FieldDuplicatePolicy policy );
+
+    /**
+     * Sets a merge \a policy for the field with the specified index.
+     *
+     * \since QGIS 3.44
+     */
+    void setFieldMergePolicy( int index, Qgis::FieldDomainMergePolicy policy );
 #else
 
     /**
@@ -1890,6 +1897,26 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     else
     {
       sipCpp->setFieldDuplicatePolicy( a0, a1 );
+    }
+    % End
+
+    /**
+     * Sets a merge \a policy for the field with the specified index.
+     *
+     * \throws KeyError if no field with the specified index exists
+     * \since QGIS 3.44
+     */
+    void setFieldMergePolicy( int index, Qgis::FieldDomainMergePolicy policy );
+
+    % MethodCode
+    if ( a0 < 0 || a0 >= sipCpp->fields().count() )
+    {
+      PyErr_SetString( PyExc_KeyError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipCpp->setFieldMergePolicy( a0, a1 );
     }
     % End
 #endif
@@ -2908,6 +2935,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     //! Map that stores the duplicate policy for attributes
     QMap< QString, Qgis::FieldDuplicatePolicy > mAttributeDuplicatePolicy;
+
+    //! Map that stores the merge policy for attributes
+    QMap< QString, Qgis::FieldDomainMergePolicy > mAttributeMergePolicy;
 
     //! An internal structure to keep track of fields that have a defaultValueOnUpdate
     QSet<int> mDefaultValueOnUpdateFields;

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -137,18 +137,13 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
       mMergePolicyComboBox->addItem( tr( "Use Sum" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::Sum ) );
       mMergePolicyComboBox->addItem( tr( "Use Maximum Value" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::MaximumValue ) );
       mMergePolicyComboBox->addItem( tr( "Use Minimum Value" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::MinimumValue ) );
-      mMergePolicyComboBox->addItem( tr( "Skip Attribute" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::SkipAttribute ) );
 
       if ( mLayer->geometryType() != Qgis::GeometryType::Point )
-      {
         mMergePolicyComboBox->addItem( tr( "Use Average Weighted by Geometry" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::GeometryWeighted ) );
-      }
     }
 
-    if ( mLayer->geometryType() != Qgis::GeometryType::Point )
-    {
-      mMergePolicyComboBox->addItem( tr( "Use Largest Feature" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::LargestGeometry ) );
-    }
+    mMergePolicyComboBox->addItem( tr( "Use Largest Feature" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::LargestGeometry ) );
+    mMergePolicyComboBox->addItem( tr( "Skip Attribute" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::SkipAttribute ) );
   }
   else
   {

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -137,7 +137,14 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
       mMergePolicyComboBox->addItem( tr( "Use Sum" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::Sum ) );
 
       if ( mLayer->geometryType() != Qgis::GeometryType::Point )
+      {
         mMergePolicyComboBox->addItem( tr( "Use Average Weighted by Geometry" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::GeometryWeighted ) );
+      }
+    }
+
+    if ( mLayer->geometryType() != Qgis::GeometryType::Point )
+    {
+      mMergePolicyComboBox->addItem( tr( "Use Largest Feature" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::LargestGeometry ) );
     }
   }
   else
@@ -590,6 +597,10 @@ void QgsAttributeTypeDialog::updateMergePolicyLabel()
 
     case Qgis::FieldDomainMergePolicy::UnsetField:
       helperText = tr( "Clears the field to an unset state." );
+      break;
+
+    case Qgis::FieldDomainMergePolicy::LargestGeometry:
+      helperText = tr( "Use value from feature with the largest geometry." );
       break;
   }
   mMergePolicyDescriptionLabel->setText( QStringLiteral( "<i>%1</i>" ).arg( helperText ) );

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -143,7 +143,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
     }
 
     mMergePolicyComboBox->addItem( tr( "Use Largest Feature" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::LargestGeometry ) );
-    mMergePolicyComboBox->addItem( tr( "Skip Attribute" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::SkipAttribute ) );
+    mMergePolicyComboBox->addItem( tr( "Skip Attribute" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::SetToNull ) );
   }
   else
   {
@@ -609,7 +609,7 @@ void QgsAttributeTypeDialog::updateMergePolicyLabel()
       helperText = tr( "Use the highest value from the selected features." );
       break;
 
-    case Qgis::FieldDomainMergePolicy::SkipAttribute:
+    case Qgis::FieldDomainMergePolicy::SetToNull:
       helperText = tr( "Skip attribute." );
       break;
   }

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -135,6 +135,9 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
     if ( mLayer->fields().at( mFieldIdx ).isNumeric() )
     {
       mMergePolicyComboBox->addItem( tr( "Use Sum" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::Sum ) );
+      mMergePolicyComboBox->addItem( tr( "Use Maximum Value" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::MaximumValue ) );
+      mMergePolicyComboBox->addItem( tr( "Use Minimum Value" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::MinimumValue ) );
+      mMergePolicyComboBox->addItem( tr( "Skip Attribute" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::SkipAttribute ) );
 
       if ( mLayer->geometryType() != Qgis::GeometryType::Point )
       {
@@ -601,6 +604,18 @@ void QgsAttributeTypeDialog::updateMergePolicyLabel()
 
     case Qgis::FieldDomainMergePolicy::LargestGeometry:
       helperText = tr( "Use value from feature with the largest geometry." );
+      break;
+
+    case Qgis::FieldDomainMergePolicy::MinimumValue:
+      helperText = tr( "Use the lowest value from the selected features." );
+      break;
+
+    case Qgis::FieldDomainMergePolicy::MaximumValue:
+      helperText = tr( "Use the highest value from the selected features." );
+      break;
+
+    case Qgis::FieldDomainMergePolicy::SkipAttribute:
+      helperText = tr( "Skip attribute." );
       break;
   }
   mMergePolicyDescriptionLabel->setText( QStringLiteral( "<i>%1</i>" ).arg( helperText ) );

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -143,7 +143,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
     }
 
     mMergePolicyComboBox->addItem( tr( "Use Largest Feature" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::LargestGeometry ) );
-    mMergePolicyComboBox->addItem( tr( "Skip Attribute" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::SetToNull ) );
+    mMergePolicyComboBox->addItem( tr( "Set to NULL" ), QVariant::fromValue( Qgis::FieldDomainMergePolicy::SetToNull ) );
   }
   else
   {
@@ -610,7 +610,7 @@ void QgsAttributeTypeDialog::updateMergePolicyLabel()
       break;
 
     case Qgis::FieldDomainMergePolicy::SetToNull:
-      helperText = tr( "Skip attribute." );
+      helperText = tr( "Set attribute to NULL." );
       break;
   }
   mMergePolicyDescriptionLabel->setText( QStringLiteral( "<i>%1</i>" ).arg( helperText ) );

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -276,7 +276,7 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
      *
      * \see setMergePolicy()
      *
-     * \since QGIS 3.42
+     * \since QGIS 3.44
      */
     Qgis::FieldDomainMergePolicy mergePolicy() const;
 
@@ -285,7 +285,7 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
      *
      * \see mergePolicy()
      *
-     * \since QGIS 3.42
+     * \since QGIS 3.44
      */
     void setMergePolicy( Qgis::FieldDomainMergePolicy policy );
 

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -271,6 +271,24 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
      */
     void setDuplicatePolicy( Qgis::FieldDuplicatePolicy policy );
 
+    /**
+     * Returns the field's merge policy.
+     *
+     * \see setMergePolicy()
+     *
+     * \since QGIS 3.42
+     */
+    Qgis::FieldDomainMergePolicy mergePolicy() const;
+
+    /**
+     * Sets the field's merge policy.
+     *
+     * \see mergePolicy()
+     *
+     * \since QGIS 3.42
+     */
+    void setMergePolicy( Qgis::FieldDomainMergePolicy policy );
+
   private slots:
 
     /**
@@ -284,6 +302,8 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
     void updateSplitPolicyLabel();
 
     void updateDuplicatePolicyLabel();
+
+    void updateMergePolicyLabel();
 
   private:
     QgsVectorLayer *mLayer = nullptr;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -374,6 +374,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         QString mComment;
         Qgis::FieldDomainSplitPolicy mSplitPolicy = Qgis::FieldDomainSplitPolicy::Duplicate;
         Qgis::FieldDuplicatePolicy mDuplicatePolicy = Qgis::FieldDuplicatePolicy::Duplicate;
+        Qgis::FieldDomainMergePolicy mMergePolicy = Qgis::FieldDomainMergePolicy::DefaultValue;
 
         operator QVariant();
     };

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -284,25 +284,15 @@
       <string>Policies</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="1" colspan="3">
-       <widget class="QComboBox" name="mSplitPolicyComboBox"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="mDuplicatePolicyLabel">
-        <property name="text">
-         <string>When duplicating features</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" colspan="3">
-       <widget class="QComboBox" name="mDuplicatePolicyComboBox"/>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="mSplitPolicyLabel">
         <property name="text">
          <string>When splitting features</string>
         </property>
        </widget>
+      </item>
+      <item row="4" column="1" colspan="3">
+       <widget class="QComboBox" name="mDuplicatePolicyComboBox"/>
       </item>
       <item row="5" column="0" colspan="4">
        <widget class="QLabel" name="mDuplicatePolicyDescriptionLabel">
@@ -314,6 +304,26 @@
         </property>
        </widget>
       </item>
+      <item row="6" column="1" colspan="3">
+       <widget class="QComboBox" name="mMergePolicyComboBox"/>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="mMergePolicyLabel">
+        <property name="text">
+         <string>When merging features</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="mDuplicatePolicyLabel">
+        <property name="text">
+         <string>When duplicating features</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="3">
+       <widget class="QComboBox" name="mSplitPolicyComboBox"/>
+      </item>
       <item row="1" column="0" colspan="4">
        <widget class="QLabel" name="mSplitPolicyDescriptionLabel">
         <property name="text">
@@ -321,6 +331,13 @@
         </property>
         <property name="wordWrap">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="4">
+       <widget class="QLabel" name="mMergePolicyDescriptionLabel">
+        <property name="text">
+         <string>TextLabel</string>
         </property>
        </widget>
       </item>

--- a/tests/src/app/testqgsmergeattributesdialog.cpp
+++ b/tests/src/app/testqgsmergeattributesdialog.cpp
@@ -235,7 +235,9 @@ class TestQgsMergeattributesDialog : public QgsTest
       QgsField minimumValueField( QStringLiteral( "minimumValue" ), QMetaType::Type::Int );
       QgsField maximumValueField( QStringLiteral( "maximumValue" ), QMetaType::Type::Int );
       QgsField skipAttributeField( QStringLiteral( "skipAttribute" ), QMetaType::Type::Int );
-      QVERIFY( ml.dataProvider()->addAttributes( { defaultValueField, sumField, geometryWeightedField, largestGeometryField, minimumValueField, maximumValueField, skipAttributeField } ) );
+      QgsField unsetField( QStringLiteral( "unsetField" ), QMetaType::Type::Int );
+
+      QVERIFY( ml.dataProvider()->addAttributes( { defaultValueField, sumField, geometryWeightedField, largestGeometryField, minimumValueField, maximumValueField, skipAttributeField, unsetField } ) );
       ml.updateFields();
 
       // set policies
@@ -246,6 +248,7 @@ class TestQgsMergeattributesDialog : public QgsTest
       ml.setFieldMergePolicy( 4, Qgis::FieldDomainMergePolicy::MinimumValue );
       ml.setFieldMergePolicy( 5, Qgis::FieldDomainMergePolicy::MaximumValue );
       ml.setFieldMergePolicy( 6, Qgis::FieldDomainMergePolicy::SkipAttribute );
+      ml.setFieldMergePolicy( 7, Qgis::FieldDomainMergePolicy::UnsetField );
 
       // verify that policies have been correctly set
 
@@ -256,31 +259,31 @@ class TestQgsMergeattributesDialog : public QgsTest
       QCOMPARE( ml.fields().field( 4 ).mergePolicy(), Qgis::FieldDomainMergePolicy::MinimumValue );
       QCOMPARE( ml.fields().field( 5 ).mergePolicy(), Qgis::FieldDomainMergePolicy::MaximumValue );
       QCOMPARE( ml.fields().field( 6 ).mergePolicy(), Qgis::FieldDomainMergePolicy::SkipAttribute );
+      QCOMPARE( ml.fields().field( 7 ).mergePolicy(), Qgis::FieldDomainMergePolicy::UnsetField );
 
       // Create features
       QgsFeature f1( ml.fields(), 1 );
-      f1.setAttributes( QVector<QVariant>() << 10 << 200 << 7.5 << QStringLiteral( "smaller" ) << 10 << -10 << 0 );
+      f1.setAttributes( QVector<QVariant>() << 10 << 200 << 7.5 << QStringLiteral( "smaller" ) << 10 << -10 << 0 << 20 );
       f1.setGeometry( QgsGeometry::fromWkt( "LINESTRING(10 0, 15 0)" ) );
       QVERIFY( ml.dataProvider()->addFeature( f1 ) );
       QCOMPARE( ml.featureCount(), 1 );
 
       QgsFeature f2( ml.fields(), 2 );
-      f2.setAttributes( QVector<QVariant>() << 15 << 100 << 5 << QStringLiteral( "bigger" ) << -10 << 10 << 5 );
+      f2.setAttributes( QVector<QVariant>() << 15 << 100 << 5 << QStringLiteral( "bigger" ) << -10 << 10 << 5 << 12 );
       f2.setGeometry( QgsGeometry::fromWkt( "LINESTRING(0 0, 10 0)" ) );
       QVERIFY( ml.dataProvider()->addFeature( f2 ) );
       QCOMPARE( ml.featureCount(), 2 );
 
       QgsMergeAttributesDialog dialog1( QgsFeatureList() << f1 << f2, &ml, mQgisApp->mapCanvas() );
 
-      qDebug() << dialog1.mergedAttributes().at( 2 ).toDouble();
-
       QCOMPARE( dialog1.mergedAttributes().at( 0 ).toInt(), 10 );
       QCOMPARE( dialog1.mergedAttributes().at( 1 ).toInt(), 300 );
       QVERIFY( qgsDoubleNear( dialog1.mergedAttributes().at( 2 ).toDouble(), 5.83333, 0.00001 ) );
       QCOMPARE( dialog1.mergedAttributes().at( 3 ).toString(), QStringLiteral( "bigger" ) );
-      QCOMPARE( dialog1.mergedAttributes().at( 4 ).toInt(), 10 );
-      QCOMPARE( dialog1.mergedAttributes().at( 5 ).toInt(), -10 );
-      QCOMPARE( dialog1.mergedAttributes().at( 6 ).toString(), QStringLiteral( "Skipped" ) );
+      QCOMPARE( dialog1.mergedAttributes().at( 4 ).toInt(), -10 );
+      QCOMPARE( dialog1.mergedAttributes().at( 5 ).toInt(), 10 );
+      QVERIFY( !dialog1.mergedAttributes().at( 6 ).isValid() );
+      QCOMPARE( dialog1.mergedAttributes().at( 7 ).toInt(), 20 );
     }
 };
 

--- a/tests/src/app/testqgsmergeattributesdialog.cpp
+++ b/tests/src/app/testqgsmergeattributesdialog.cpp
@@ -247,7 +247,7 @@ class TestQgsMergeattributesDialog : public QgsTest
       ml.setFieldMergePolicy( 3, Qgis::FieldDomainMergePolicy::LargestGeometry );
       ml.setFieldMergePolicy( 4, Qgis::FieldDomainMergePolicy::MinimumValue );
       ml.setFieldMergePolicy( 5, Qgis::FieldDomainMergePolicy::MaximumValue );
-      ml.setFieldMergePolicy( 6, Qgis::FieldDomainMergePolicy::SkipAttribute );
+      ml.setFieldMergePolicy( 6, Qgis::FieldDomainMergePolicy::SetToNull );
       ml.setFieldMergePolicy( 7, Qgis::FieldDomainMergePolicy::UnsetField );
 
       // verify that policies have been correctly set
@@ -258,7 +258,7 @@ class TestQgsMergeattributesDialog : public QgsTest
       QCOMPARE( ml.fields().field( 3 ).mergePolicy(), Qgis::FieldDomainMergePolicy::LargestGeometry );
       QCOMPARE( ml.fields().field( 4 ).mergePolicy(), Qgis::FieldDomainMergePolicy::MinimumValue );
       QCOMPARE( ml.fields().field( 5 ).mergePolicy(), Qgis::FieldDomainMergePolicy::MaximumValue );
-      QCOMPARE( ml.fields().field( 6 ).mergePolicy(), Qgis::FieldDomainMergePolicy::SkipAttribute );
+      QCOMPARE( ml.fields().field( 6 ).mergePolicy(), Qgis::FieldDomainMergePolicy::SetToNull );
       QCOMPARE( ml.fields().field( 7 ).mergePolicy(), Qgis::FieldDomainMergePolicy::UnsetField );
 
       // Create features

--- a/tests/src/app/testqgsmergeattributesdialog.cpp
+++ b/tests/src/app/testqgsmergeattributesdialog.cpp
@@ -232,7 +232,10 @@ class TestQgsMergeattributesDialog : public QgsTest
       QgsField sumField( QStringLiteral( "sum" ), QMetaType::Type::Int );
       QgsField geometryWeightedField( QStringLiteral( "geometryWeighted" ), QMetaType::Type::Double );
       QgsField largestGeometryField( QStringLiteral( "largestGeometry" ), QMetaType::Type::QString );
-      QVERIFY( ml.dataProvider()->addAttributes( { defaultValueField, sumField, geometryWeightedField, largestGeometryField } ) );
+      QgsField minimumValueField( QStringLiteral( "minimumValue" ), QMetaType::Type::Int );
+      QgsField maximumValueField( QStringLiteral( "maximumValue" ), QMetaType::Type::Int );
+      QgsField skipAttributeField( QStringLiteral( "skipAttribute" ), QMetaType::Type::Int );
+      QVERIFY( ml.dataProvider()->addAttributes( { defaultValueField, sumField, geometryWeightedField, largestGeometryField, minimumValueField, maximumValueField, skipAttributeField } ) );
       ml.updateFields();
 
       // set policies
@@ -240,6 +243,9 @@ class TestQgsMergeattributesDialog : public QgsTest
       ml.setFieldMergePolicy( 1, Qgis::FieldDomainMergePolicy::Sum );
       ml.setFieldMergePolicy( 2, Qgis::FieldDomainMergePolicy::GeometryWeighted );
       ml.setFieldMergePolicy( 3, Qgis::FieldDomainMergePolicy::LargestGeometry );
+      ml.setFieldMergePolicy( 4, Qgis::FieldDomainMergePolicy::MinimumValue );
+      ml.setFieldMergePolicy( 5, Qgis::FieldDomainMergePolicy::MaximumValue );
+      ml.setFieldMergePolicy( 6, Qgis::FieldDomainMergePolicy::SkipAttribute );
 
       // verify that policies have been correctly set
 
@@ -247,16 +253,19 @@ class TestQgsMergeattributesDialog : public QgsTest
       QCOMPARE( ml.fields().field( 1 ).mergePolicy(), Qgis::FieldDomainMergePolicy::Sum );
       QCOMPARE( ml.fields().field( 2 ).mergePolicy(), Qgis::FieldDomainMergePolicy::GeometryWeighted );
       QCOMPARE( ml.fields().field( 3 ).mergePolicy(), Qgis::FieldDomainMergePolicy::LargestGeometry );
+      QCOMPARE( ml.fields().field( 4 ).mergePolicy(), Qgis::FieldDomainMergePolicy::MinimumValue );
+      QCOMPARE( ml.fields().field( 5 ).mergePolicy(), Qgis::FieldDomainMergePolicy::MaximumValue );
+      QCOMPARE( ml.fields().field( 6 ).mergePolicy(), Qgis::FieldDomainMergePolicy::SkipAttribute );
 
       // Create features
       QgsFeature f1( ml.fields(), 1 );
-      f1.setAttributes( QVector<QVariant>() << 10 << 200 << 7.5 << QStringLiteral( "smaller" ) );
+      f1.setAttributes( QVector<QVariant>() << 10 << 200 << 7.5 << QStringLiteral( "smaller" ) << 10 << -10 << 0 );
       f1.setGeometry( QgsGeometry::fromWkt( "LINESTRING(10 0, 15 0)" ) );
       QVERIFY( ml.dataProvider()->addFeature( f1 ) );
       QCOMPARE( ml.featureCount(), 1 );
 
       QgsFeature f2( ml.fields(), 2 );
-      f2.setAttributes( QVector<QVariant>() << 15 << 100 << 5 << QStringLiteral( "bigger" ) );
+      f2.setAttributes( QVector<QVariant>() << 15 << 100 << 5 << QStringLiteral( "bigger" ) << -10 << 10 << 5 );
       f2.setGeometry( QgsGeometry::fromWkt( "LINESTRING(0 0, 10 0)" ) );
       QVERIFY( ml.dataProvider()->addFeature( f2 ) );
       QCOMPARE( ml.featureCount(), 2 );
@@ -269,6 +278,9 @@ class TestQgsMergeattributesDialog : public QgsTest
       QCOMPARE( dialog1.mergedAttributes().at( 1 ).toInt(), 300 );
       QVERIFY( qgsDoubleNear( dialog1.mergedAttributes().at( 2 ).toDouble(), 5.83333, 0.00001 ) );
       QCOMPARE( dialog1.mergedAttributes().at( 3 ).toString(), QStringLiteral( "bigger" ) );
+      QCOMPARE( dialog1.mergedAttributes().at( 4 ).toInt(), 10 );
+      QCOMPARE( dialog1.mergedAttributes().at( 5 ).toInt(), -10 );
+      QCOMPARE( dialog1.mergedAttributes().at( 6 ).toString(), QStringLiteral( "Skipped" ) );
     }
 };
 

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -208,6 +208,9 @@ void TestQgsField::gettersSetters()
   field.setDuplicatePolicy( Qgis::FieldDuplicatePolicy::UnsetField );
   QCOMPARE( field.duplicatePolicy(), Qgis::FieldDuplicatePolicy::UnsetField );
 
+  field.setMergePolicy( Qgis::FieldDomainMergePolicy::GeometryWeighted );
+  QCOMPARE( field.mergePolicy(), Qgis::FieldDomainMergePolicy::GeometryWeighted );
+
   field.setMetadata( { { static_cast<int>( Qgis::FieldMetadataProperty::GeometryCrs ), QStringLiteral( "abc" ) }, { 2, 5 } } );
   QMap<int, QVariant> expected { { static_cast<int>( Qgis::FieldMetadataProperty::GeometryCrs ), QStringLiteral( "abc" ) }, { 2, 5 } };
   QCOMPARE( field.metadata(), expected );


### PR DESCRIPTION
Fixes #59494.

Similarly to already existing Split and Duplicate "policies" this PR implements Merge Policies, which determine the initial values in the Merge Features dialog. The PR includes the following merge policies:

From the existing `Qgis::FieldDomainMergePolicy` enum:
* Sum: numeric fields only
* Geometry Weighted: numeric fields only, uses weighted average by geometry
* Default Value: uses the default value set in QGIS (expressions use a dummy feature with the merged geometry, but referring to other fields won't work)

New policies:
* Unset Field: similarly to Split & Duplicate policies clears the field and lets the data provider populate any default value if one exists. If it doesn't the first feature is used (this is the behavior which is currently implemented)
* Largest Geometry: use the value from the feature with the biggest geometry (length/area/number of parts for multipoints)
* Minimum Value: numeric fields only
* Maximum Value: numeric fields only
* Set to Null: sets the value of the field for the feature to NULL

Initial merge dialog before PR:
![MERGEPOLICY_BEFORE](https://github.com/user-attachments/assets/551387b6-a491-4346-9783-9ab74bbfcb88)

Initial merge dialog after PR:
![MERGEPOLICY_AFTER](https://github.com/user-attachments/assets/0d1efbc7-ad85-481b-abc0-0ac962cc08c1)

Configuring the policies:
![image](https://github.com/user-attachments/assets/388adab1-1603-42cb-80b6-cf501416205c)

Funded by the National Land Survey of Finland.