### PR TITLE
[mssql] Allow SQL queries as layer sources 

### DIFF
--- a/src/providers/mssql/CMakeLists.txt
+++ b/src/providers/mssql/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MSSQL_SRCS
   qgsmssqlsqlquerybuilder.cpp
   qgsmssqltransaction.cpp
   qgsmssqldatabase.cpp
+  qgsmssqlutils.cpp
 )
 
 if (WITH_GUI)

--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -18,6 +18,7 @@
 #include "qgsmssqlconnection.h"
 #include "qgsmssqlprovider.h"
 #include "qgsmssqldatabase.h"
+#include "qgsmssqlutils.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgsdatasourceuri.h"
@@ -422,7 +423,7 @@ QString QgsMssqlConnection::buildQueryForTables( bool allowTablesWithNoGeometry,
   {
     QStringList quotedSchemas;
     for ( const QString &sch : excludedSchemaList )
-      quotedSchemas.append( QgsMssqlProvider::quotedValue( sch ) );
+      quotedSchemas.append( QgsMssqlUtils::quotedValue( sch ) );
     notSelectedSchemas = quotedSchemas.join( ',' );
     notSelectedSchemas.prepend( QStringLiteral( "( " ) );
     notSelectedSchemas.append( QStringLiteral( " )" ) );

--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -20,6 +20,7 @@
 #include "qgsvariantutils.h"
 #include "qgsmssqlprovider.h"
 #include "qgsdbquerylog.h"
+#include "qgsmssqlutils.h"
 
 #include <QCoreApplication>
 #include <QtDebug>
@@ -251,7 +252,7 @@ bool QgsMssqlDatabase::loadFields( FieldDetails &details, const QString &schema,
     const QString sql2 { QStringLiteral( "SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS TC"
                                          " INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE CC ON TC.CONSTRAINT_NAME = CC.CONSTRAINT_NAME"
                                          " WHERE TC.CONSTRAINT_SCHEMA = %1 AND TC.TABLE_NAME = %2 AND TC.CONSTRAINT_TYPE = 'unique'" )
-                           .arg( QgsMssqlProvider::quotedValue( schema ), QgsMssqlProvider::quotedValue( tableName ) ) };
+                           .arg( QgsMssqlUtils::quotedValue( schema ), QgsMssqlUtils::quotedValue( tableName ) ) };
     if ( !LoggedExec( query, sql2 ) )
     {
       error = query.lastError().text();
@@ -264,7 +265,7 @@ bool QgsMssqlDatabase::loadFields( FieldDetails &details, const QString &schema,
     }
   }
 
-  const QString sql3 { QStringLiteral( "exec sp_columns @table_name = %1, @table_owner = %2" ).arg( QgsMssqlProvider::quotedValue( tableName ), QgsMssqlProvider::quotedValue( schema ) ) };
+  const QString sql3 { QStringLiteral( "exec sp_columns @table_name = %1, @table_owner = %2" ).arg( QgsMssqlUtils::quotedValue( tableName ), QgsMssqlUtils::quotedValue( schema ) ) };
   if ( !LoggedExec( query, sql3 ) )
   {
     error = query.lastError().text();
@@ -367,7 +368,7 @@ bool QgsMssqlDatabase::loadFields( FieldDetails &details, const QString &schema,
   {
     query.clear();
     query.setForwardOnly( true );
-    const QString sql4 { QStringLiteral( "exec sp_pkeys @table_name = %1, @table_owner = %2 " ).arg( QgsMssqlProvider::quotedValue( tableName ), QgsMssqlProvider::quotedValue( schema ) ) };
+    const QString sql4 { QStringLiteral( "exec sp_pkeys @table_name = %1, @table_owner = %2 " ).arg( QgsMssqlUtils::quotedValue( tableName ), QgsMssqlUtils::quotedValue( schema ) ) };
     if ( !LoggedExec( query, sql4 ) )
     {
       QgsDebugError( QStringLiteral( "SQL:%1\n  Error:%2" ).arg( query.lastQuery(), query.lastError().text() ) );

--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -166,59 +166,6 @@ QSqlQuery QgsMssqlDatabase::createQuery()
   return QSqlQuery( d );
 }
 
-QMetaType::Type QgsMssqlDatabase::decodeSqlType( const QString &sqlTypeName )
-{
-  QMetaType::Type type = QMetaType::Type::UnknownType;
-  // cloned branches are intentional here for improved readability
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if ( sqlTypeName.startsWith( QLatin1String( "decimal" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "numeric" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "real" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "float" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::Double;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "char" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "nchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "varchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "nvarchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "text" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "ntext" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "uniqueidentifier" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::QString;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "smallint" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "int" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "bit" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "tinyint" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::Int;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "bigint" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::LongLong;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "binary" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "varbinary" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "image" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::QByteArray;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "datetime" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "smalldatetime" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "datetime2" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::QDateTime;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "date" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::QDate;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "timestamp" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::QString;
-  }
-  else if ( sqlTypeName.startsWith( QLatin1String( "time" ), Qt::CaseInsensitive ) )
-  {
-    type = QMetaType::Type::QTime;
-  }
-  else
-  {
-    QgsDebugError( QStringLiteral( "Unknown field type: %1" ).arg( sqlTypeName ) );
-    // Everything else just dumped as a string.
-    type = QMetaType::Type::QString;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-
-  return type;
-}
-
-
 bool QgsMssqlDatabase::loadFields( FieldDetails &details, const QString &schema, const QString &tableName, QString &error )
 {
   error.clear();
@@ -291,7 +238,7 @@ bool QgsMssqlDatabase::loadFields( FieldDetails &details, const QString &schema,
     }
     else
     {
-      const QMetaType::Type sqlType = decodeSqlType( sqlTypeName );
+      const QMetaType::Type sqlType = QgsMssqlUtils::convertSqlFieldType( sqlTypeName );
       if ( sqlTypeName == QLatin1String( "int identity" ) || sqlTypeName == QLatin1String( "bigint identity" ) )
       {
         details.primaryKeyType = PrimaryKeyType::Int;

--- a/src/providers/mssql/qgsmssqldatabase.h
+++ b/src/providers/mssql/qgsmssqldatabase.h
@@ -81,8 +81,6 @@ class QgsMssqlDatabase
 
     QSqlQuery createQuery();
 
-    static QMetaType::Type decodeSqlType( const QString &sqlTypeName );
-
     struct FieldDetails
     {
         QgsFields attributeFields;

--- a/src/providers/mssql/qgsmssqldatabase.h
+++ b/src/providers/mssql/qgsmssqldatabase.h
@@ -93,7 +93,15 @@ class QgsMssqlDatabase
         QList<int> primaryKeyAttrs;
     };
 
+    /**
+     * Loads the field details  corresponding to the specified \a schema and \a tableName.
+     */
     bool loadFields( FieldDetails &details, const QString &schema, const QString &tableName, QString &error );
+
+    /**
+     * Loads the field details corresponding to the specified SQL \a query.
+     */
+    bool loadQueryFields( FieldDetails &details, const QString &query, QString &error );
 
   private:
     QgsMssqlDatabase( const QSqlDatabase &db, const QgsDataSourceUri &uri, bool transaction );

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -19,7 +19,7 @@
 #include "moc_qgsmssqldataitems.cpp"
 #include "qgsmssqlconnection.h"
 #include "qgsmssqldatabase.h"
-
+#include "qgsmssqlutils.h"
 #include "qgsmssqlgeomcolumntypethread.h"
 #include "qgslogger.h"
 #include "qgsmimedatautils.h"
@@ -357,7 +357,7 @@ void QgsMssqlConnectionItem::setLayerType( QgsMssqlLayerProperty layerProperty )
 
   for ( int i = 0; i < typeList.size(); i++ )
   {
-    Qgis::WkbType wkbType = QgsMssqlTableModel::wkbTypeFromMssql( typeList[i] );
+    Qgis::WkbType wkbType = QgsMssqlUtils::wkbTypeFromGeometryType( typeList[i] );
     if ( wkbType == Qgis::WkbType::Unknown )
     {
       QgsDebugError( QStringLiteral( "unsupported geometry type:%1" ).arg( typeList[i] ) );
@@ -512,7 +512,7 @@ QString QgsMssqlLayerItem::createUri()
   QgsDataSourceUri uri = QgsDataSourceUri( connItem->connInfo() );
   uri.setDataSource( mLayerProperty.schemaName, mLayerProperty.tableName, mLayerProperty.geometryColName, mLayerProperty.sql, pkColName );
   uri.setSrid( mLayerProperty.srid );
-  uri.setWkbType( QgsMssqlTableModel::wkbTypeFromMssql( mLayerProperty.type ) );
+  uri.setWkbType( QgsMssqlUtils::wkbTypeFromGeometryType( mLayerProperty.type ) );
   uri.setUseEstimatedMetadata( QgsMssqlConnection::useEstimatedMetadata( connItem->name() ) );
   mDisableInvalidGeometryHandling = QgsMssqlConnection::isInvalidGeometryHandlingDisabled( connItem->name() );
   uri.setParam( QStringLiteral( "disableInvalidGeometryHandling" ), mDisableInvalidGeometryHandling ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
@@ -560,7 +560,7 @@ void QgsMssqlSchemaItem::addLayers( QgsDataItem *newLayers )
 
 QgsMssqlLayerItem *QgsMssqlSchemaItem::addLayer( const QgsMssqlLayerProperty &layerProperty, bool refresh )
 {
-  Qgis::WkbType wkbType = QgsMssqlTableModel::wkbTypeFromMssql( layerProperty.type );
+  Qgis::WkbType wkbType = QgsMssqlUtils::wkbTypeFromGeometryType( layerProperty.type );
   QString tip = tr( "%1 as %2 in %3" ).arg( layerProperty.geometryColName, QgsWkbTypes::displayString( wkbType ), layerProperty.srid );
 
   Qgis::BrowserLayerType layerType;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -209,7 +209,14 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
 
   mStatement = selectColumns.join( ',' );
 
-  mStatement += QStringLiteral( " FROM [%1].[%2]" ).arg( mSource->mSchemaName, mSource->mTableName );
+  if ( !mSource->mQuery.isEmpty() )
+  {
+    mStatement += QStringLiteral( " FROM (%1) _subquery" ).arg( mSource->mQuery );
+  }
+  else
+  {
+    mStatement += QStringLiteral( " FROM [%1].[%2]" ).arg( mSource->mSchemaName, mSource->mTableName );
+  }
 
   bool filterAdded = false;
   // set spatial filter
@@ -702,6 +709,7 @@ QgsMssqlFeatureSource::QgsMssqlFeatureSource( const QgsMssqlProvider *p )
   , mGeometryColType( p->mGeometryColType )
   , mSchemaName( p->mSchemaName )
   , mTableName( p->mTableName )
+  , mQuery( p->mQuery )
   , mUserName( p->mUserName )
   , mPassword( p->mPassword )
   , mService( p->mService )

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -19,6 +19,7 @@
 #include "qgsmssqlexpressioncompiler.h"
 #include "qgsmssqlprovider.h"
 #include "qgsmssqltransaction.h"
+#include "qgsmssqlutils.h"
 #include "qgslogger.h"
 #include "qgsdbquerylog.h"
 #include "qgsdbquerylog_p.h"
@@ -35,8 +36,6 @@ QgsMssqlFeatureIterator::QgsMssqlFeatureIterator( QgsMssqlFeatureSource *source,
   : QgsAbstractFeatureIteratorFromSource<QgsMssqlFeatureSource>( source, ownSource, request )
   , mDisableInvalidGeometryHandling( source->mDisableInvalidGeometryHandling )
 {
-  mClosed = false;
-
   mParser.mIsGeography = mSource->mIsGeography;
 
   mTransform = mRequest.calculateTransform( mSource->mCrs );
@@ -124,7 +123,7 @@ QString QgsMssqlFeatureIterator::whereClauseFid( QgsFeatureId featureId )
         for ( int i = 0; i < mSource->mPrimaryKeyAttrs.size(); ++i )
         {
           const QgsField &fld = mSource->mFields.at( mSource->mPrimaryKeyAttrs[i] );
-          whereClause += QStringLiteral( "%1[%2]=%3" ).arg( delim, fld.name(), QgsMssqlProvider::quotedValue( pkVals[i] ) );
+          whereClause += QStringLiteral( "%1[%2]=%3" ).arg( delim, fld.name(), QgsMssqlUtils::quotedValue( pkVals[i] ) );
           delim = QStringLiteral( " AND " );
         }
 
@@ -277,7 +276,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
           if ( QgsVariantUtils::isNull( key[i] ) )
             expr = QString( "[%1] IS NULL" ).arg( colName );
           else
-            expr = QString( "[%1]=%2" ).arg( colName, QgsMssqlProvider::quotedValue( key[i] ) );
+            expr = QString( "[%1]=%2" ).arg( colName, QgsMssqlUtils::quotedValue( key[i] ) );
 
           mStatement += QStringLiteral( "%1%2" ).arg( delim, expr );
           delim = " AND ";

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -56,6 +56,7 @@ class QgsMssqlFeatureSource final : public QgsAbstractFeatureSource
     // current layer name
     QString mSchemaName;
     QString mTableName;
+    QString mQuery;
 
     // login
     QString mUserName;

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -67,6 +67,7 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
     void updateExtents() override;
     QString storageType() const override;
     QStringList subLayers() const override;
+    Qgis::VectorLayerTypeFlags vectorLayerTypeFlags() const override;
     QVariant minimumValue( int index ) const override;
     QVariant maximumValue( int index ) const override;
     QSet<QVariant> uniqueValues( int index, int limit = -1 ) const override;
@@ -176,6 +177,9 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
     mutable QgsRectangle mExtent;
 
     bool mValid = false;
+
+    bool mIsQuery = false;
+    QString mQuery;
 
     bool mUseWkb = false;
     bool mUseEstimatedMetadata = false;

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -128,10 +128,6 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
     // Parse type name and num coordinates as stored in geometry_columns table and returns normalized (M, Z or ZM) type name
     static QString typeFromMetadata( const QString &typeName, int numCoords );
 
-    //! Convert values to quoted values for database work
-    static QString quotedValue( const QVariant &value );
-    static QString quotedIdentifier( const QString &value );
-
     QString defaultValueClause( int fieldId ) const override;
     QVariant defaultValue( int fieldId ) const override;
 

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -683,7 +683,6 @@ QgsVectorLayer *QgsMssqlProviderConnection::createSqlVectorLayer( const SqlVecto
   {
     tUri.setGeometryColumn( options.geometryColumn );
 
-    const QString limit { QgsDataSourceUri( uri() ).useEstimatedMetadata() ? QStringLiteral( "AND ROWNUM < 100" ) : QString() };
     const QString sql = QStringLiteral( "SELECT %3"
                                         " UPPER(%1.STGeometryType()),"
                                         " %1.STSrid,"

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -68,6 +68,8 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
     QIcon icon() const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
     QgsProviderSqlQueryBuilder *queryBuilder() const override;
+    QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
+    SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
 
   private:
     QgsAbstractDatabaseProviderConnection::QueryResult executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr ) const;

--- a/src/providers/mssql/qgsmssqlsqlquerybuilder.cpp
+++ b/src/providers/mssql/qgsmssqlsqlquerybuilder.cpp
@@ -15,17 +15,17 @@ email                : nyall dot dawson at gmail dot com
  ***************************************************************************/
 
 #include "qgsmssqlsqlquerybuilder.h"
-#include "qgsmssqlprovider.h"
+#include "qgsmssqlutils.h"
 
 QString QgsMsSqlSqlQueryBuilder::createLimitQueryForTable( const QString &schema, const QString &name, int limit ) const
 {
   if ( schema.isEmpty() )
-    return QStringLiteral( "SELECT TOP %1 * FROM %2" ).arg( limit ).arg( quoteIdentifier( name ) );
+    return QStringLiteral( "SELECT TOP %1 * FROM %2" ).arg( limit ).arg( QgsMssqlUtils::quotedIdentifier( name ) );
   else
-    return QStringLiteral( "SELECT TOP %1 * FROM %2.%3" ).arg( limit ).arg( quoteIdentifier( schema ), quoteIdentifier( name ) );
+    return QStringLiteral( "SELECT TOP %1 * FROM %2.%3" ).arg( limit ).arg( QgsMssqlUtils::quotedIdentifier( schema ), QgsMssqlUtils::quotedIdentifier( name ) );
 }
 
 QString QgsMsSqlSqlQueryBuilder::quoteIdentifier( const QString &identifier ) const
 {
-  return QgsMssqlProvider::quotedIdentifier( identifier );
+  return QgsMssqlUtils::quotedIdentifier( identifier );
 }

--- a/src/providers/mssql/qgsmssqltablemodel.cpp
+++ b/src/providers/mssql/qgsmssqltablemodel.cpp
@@ -21,6 +21,7 @@
 #include "qgslogger.h"
 #include "qgsdatasourceuri.h"
 #include "qgsiconutils.h"
+#include "qgsmssqlutils.h"
 
 QgsMssqlTableModel::QgsMssqlTableModel( QObject *parent )
   : QgsAbstractDbTableModel( parent )
@@ -90,7 +91,7 @@ void QgsMssqlTableModel::addTableEntry( const QgsMssqlLayerProperty &layerProper
     invisibleRootItem()->setChild( invisibleRootItem()->rowCount(), schemaItem );
   }
 
-  Qgis::WkbType wkbType = QgsMssqlTableModel::wkbTypeFromMssql( layerProperty.type );
+  Qgis::WkbType wkbType = QgsMssqlUtils::wkbTypeFromGeometryType( layerProperty.type );
   if ( wkbType == Qgis::WkbType::Unknown && layerProperty.geometryColName.isEmpty() )
   {
     wkbType = Qgis::WkbType::NoGeometry;
@@ -298,7 +299,7 @@ void QgsMssqlTableModel::setGeometryTypesForTable( QgsMssqlLayerProperty layerPr
       else
       {
         // update existing row
-        Qgis::WkbType wkbType = QgsMssqlTableModel::wkbTypeFromMssql( typeList.at( 0 ) );
+        Qgis::WkbType wkbType = QgsMssqlUtils::wkbTypeFromGeometryType( typeList.at( 0 ) );
 
         row[DbtmType]->setIcon( QgsIconUtils::iconForWkbType( wkbType ) );
         row[DbtmType]->setText( QgsWkbTypes::translatedDisplayString( wkbType ) );
@@ -414,12 +415,6 @@ QString QgsMssqlTableModel::layerURI( const QModelIndex &index, const QString &c
     uri.setParam( QStringLiteral( "primaryKeyInGeometryColumns" ), QgsMssqlConnection::primaryKeyInGeometryColumns( mConnectionName ) ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
   return uri.uri();
-}
-
-Qgis::WkbType QgsMssqlTableModel::wkbTypeFromMssql( QString type )
-{
-  type = type.toUpper();
-  return QgsWkbTypes::parseType( type );
 }
 
 void QgsMssqlTableModel::setConnectionName( const QString &connectionName )

--- a/src/providers/mssql/qgsmssqltablemodel.h
+++ b/src/providers/mssql/qgsmssqltablemodel.h
@@ -87,8 +87,6 @@ class QgsMssqlTableModel : public QgsAbstractDbTableModel
 
     QString layerURI( const QModelIndex &index, const QString &connInfo, bool useEstimatedMetadata, bool disableInvalidGeometryHandling );
 
-    static Qgis::WkbType wkbTypeFromMssql( QString dbType );
-
     void setConnectionName( const QString &connectionName );
 
   private:

--- a/src/providers/mssql/qgsmssqlutils.cpp
+++ b/src/providers/mssql/qgsmssqlutils.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsmssqlutils.h"
 #include "qgsvariantutils.h"
+#include "qgslogger.h"
 
 QString QgsMssqlUtils::quotedValue( const QVariant &value )
 {
@@ -45,4 +46,56 @@ QString QgsMssqlUtils::quotedValue( const QVariant &value )
 QString QgsMssqlUtils::quotedIdentifier( const QString &value )
 {
   return QStringLiteral( "[%1]" ).arg( value );
+}
+
+QMetaType::Type QgsMssqlUtils::convertSqlFieldType( const QString &sqlTypeName )
+{
+  QMetaType::Type type = QMetaType::Type::UnknownType;
+  // cloned branches are intentional here for improved readability
+  // NOLINTBEGIN(bugprone-branch-clone)
+  if ( sqlTypeName.startsWith( QLatin1String( "decimal" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "numeric" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "real" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "float" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::Double;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "char" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "nchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "varchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "nvarchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "text" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "ntext" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "uniqueidentifier" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::QString;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "smallint" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "int" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "bit" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "tinyint" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::Int;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "bigint" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::LongLong;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "binary" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "varbinary" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "image" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::QByteArray;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "datetime" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "smalldatetime" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "datetime2" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::QDateTime;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "date" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::QDate;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "timestamp" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::QString;
+  }
+  else if ( sqlTypeName.startsWith( QLatin1String( "time" ), Qt::CaseInsensitive ) )
+  {
+    type = QMetaType::Type::QTime;
+  }
+  else
+  {
+    QgsDebugError( QStringLiteral( "Unknown field type: %1" ).arg( sqlTypeName ) );
+    // Everything else just dumped as a string.
+    type = QMetaType::Type::QString;
+  }
+  // NOLINTEND(bugprone-branch-clone)
+
+  return type;
 }

--- a/src/providers/mssql/qgsmssqlutils.cpp
+++ b/src/providers/mssql/qgsmssqlutils.cpp
@@ -17,6 +17,7 @@
 #include "qgsvariantutils.h"
 #include "qgslogger.h"
 #include "qgsfield.h"
+#include "qgswkbtypes.h"
 
 QString QgsMssqlUtils::quotedValue( const QVariant &value )
 {
@@ -154,4 +155,9 @@ QgsField QgsMssqlUtils::createField( const QString &name, const QString &systemT
     field.setReadOnly( true );
   }
   return field;
+}
+
+Qgis::WkbType QgsMssqlUtils::wkbTypeFromGeometryType( const QString &type )
+{
+  return QgsWkbTypes::parseType( type.toUpper() );
 }

--- a/src/providers/mssql/qgsmssqlutils.cpp
+++ b/src/providers/mssql/qgsmssqlutils.cpp
@@ -16,6 +16,7 @@
 #include "qgsmssqlutils.h"
 #include "qgsvariantutils.h"
 #include "qgslogger.h"
+#include "qgsfield.h"
 
 QString QgsMssqlUtils::quotedValue( const QVariant &value )
 {
@@ -48,54 +49,109 @@ QString QgsMssqlUtils::quotedIdentifier( const QString &value )
   return QStringLiteral( "[%1]" ).arg( value );
 }
 
-QMetaType::Type QgsMssqlUtils::convertSqlFieldType( const QString &sqlTypeName )
+QMetaType::Type QgsMssqlUtils::convertSqlFieldType( const QString &systemTypeName )
 {
   QMetaType::Type type = QMetaType::Type::UnknownType;
   // cloned branches are intentional here for improved readability
   // NOLINTBEGIN(bugprone-branch-clone)
-  if ( sqlTypeName.startsWith( QLatin1String( "decimal" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "numeric" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "real" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "float" ), Qt::CaseInsensitive ) )
+  if ( systemTypeName.startsWith( QLatin1String( "decimal" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "numeric" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "real" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "float" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::Double;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "char" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "nchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "varchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "nvarchar" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "text" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "ntext" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "uniqueidentifier" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "char" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "nchar" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "varchar" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "nvarchar" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "text" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "ntext" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "uniqueidentifier" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::QString;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "smallint" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "int" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "bit" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "tinyint" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "smallint" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "int" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "bit" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "tinyint" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::Int;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "bigint" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "bigint" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::LongLong;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "binary" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "varbinary" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "image" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "binary" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "varbinary" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "image" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::QByteArray;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "datetime" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "smalldatetime" ), Qt::CaseInsensitive ) || sqlTypeName.startsWith( QLatin1String( "datetime2" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "datetime" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "smalldatetime" ), Qt::CaseInsensitive ) || systemTypeName.startsWith( QLatin1String( "datetime2" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::QDateTime;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "date" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "date" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::QDate;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "timestamp" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "timestamp" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::QString;
   }
-  else if ( sqlTypeName.startsWith( QLatin1String( "time" ), Qt::CaseInsensitive ) )
+  else if ( systemTypeName.startsWith( QLatin1String( "time" ), Qt::CaseInsensitive ) )
   {
     type = QMetaType::Type::QTime;
   }
   else
   {
-    QgsDebugError( QStringLiteral( "Unknown field type: %1" ).arg( sqlTypeName ) );
+    QgsDebugError( QStringLiteral( "Unknown field type: %1" ).arg( systemTypeName ) );
     // Everything else just dumped as a string.
     type = QMetaType::Type::QString;
   }
   // NOLINTEND(bugprone-branch-clone)
 
   return type;
+}
+
+QgsField QgsMssqlUtils::createField( const QString &name, const QString &systemTypeName, int length, int precision, int scale, bool nullable, bool unique, bool readOnly )
+{
+  QgsField field;
+  const QMetaType::Type sqlType = convertSqlFieldType( systemTypeName );
+  switch ( sqlType )
+  {
+    case QMetaType::Type::QString:
+    {
+      // Field length in chars is "Length" of the sp_columns output,
+      // except for uniqueidentifiers which must use "Precision".
+      int stringLength = systemTypeName.startsWith( QStringLiteral( "uniqueidentifier" ), Qt::CaseInsensitive ) ? precision : length;
+      if ( systemTypeName.startsWith( QLatin1Char( 'n' ) ) )
+      {
+        stringLength = stringLength / 2;
+      }
+      field = QgsField( name, sqlType, systemTypeName, stringLength );
+      break;
+    }
+
+    case QMetaType::Type::Double:
+    {
+      field = QgsField( name, sqlType, systemTypeName, precision, systemTypeName == QLatin1String( "decimal" ) || systemTypeName == QLatin1String( "numeric" ) ? scale : -1 );
+      break;
+    }
+
+    case QMetaType::Type::QDate:
+    case QMetaType::Type::QDateTime:
+    case QMetaType::Type::QTime:
+    {
+      field = QgsField( name, sqlType, systemTypeName, -1, -1 );
+      break;
+    }
+
+    default:
+    {
+      field = QgsField( name, sqlType, systemTypeName );
+      break;
+    }
+  }
+
+  // Set constraints
+  QgsFieldConstraints constraints;
+  if ( !nullable )
+    constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
+  if ( unique )
+    constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
+  field.setConstraints( constraints );
+
+  if ( readOnly )
+  {
+    field.setReadOnly( true );
+  }
+  return field;
 }

--- a/src/providers/mssql/qgsmssqlutils.cpp
+++ b/src/providers/mssql/qgsmssqlutils.cpp
@@ -1,0 +1,48 @@
+/***************************************************************************
+  qgsmssqlutils.cpp
+  --------------------------------------
+  Date                 : February 2025
+  Copyright            : (C) 2025 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmssqlutils.h"
+#include "qgsvariantutils.h"
+
+QString QgsMssqlUtils::quotedValue( const QVariant &value )
+{
+  if ( QgsVariantUtils::isNull( value ) )
+    return QStringLiteral( "NULL" );
+
+  switch ( value.userType() )
+  {
+    case QMetaType::Type::Int:
+    case QMetaType::Type::LongLong:
+    case QMetaType::Type::Double:
+      return value.toString();
+
+    case QMetaType::Type::Bool:
+      return QString( value.toBool() ? '1' : '0' );
+
+    default:
+    case QMetaType::Type::QString:
+      QString v = value.toString();
+      v.replace( '\'', QLatin1String( "''" ) );
+      if ( v.contains( '\\' ) )
+        return v.replace( '\\', QLatin1String( "\\\\" ) ).prepend( "N'" ).append( '\'' );
+      else
+        return v.prepend( "N'" ).append( '\'' );
+  }
+}
+
+QString QgsMssqlUtils::quotedIdentifier( const QString &value )
+{
+  return QStringLiteral( "[%1]" ).arg( value );
+}

--- a/src/providers/mssql/qgsmssqlutils.h
+++ b/src/providers/mssql/qgsmssqlutils.h
@@ -19,6 +19,8 @@
 #include <QString>
 #include <QVariant>
 
+class QgsField;
+
 /**
  * Contains utility functions for working with Microsoft SQL Server databases.
  */
@@ -36,9 +38,14 @@ class QgsMssqlUtils
     static QString quotedIdentifier( const QString &identifier );
 
     /**
-     * Converts a SQL Server field type name string to the equivalent QVariant type.
+     * Converts a SQL Server field system type string to the equivalent QVariant type.
      */
-    static QMetaType::Type convertSqlFieldType( const QString &sqlTypeName );
+    static QMetaType::Type convertSqlFieldType( const QString &systemTypeName );
+
+    /**
+     * Creates the equivalent QgsField corresponding to the properties of a SQL Server field.
+     */
+    static QgsField createField( const QString &name, const QString &systemTypeName, int length, int precision, int scale, bool nullable, bool unique, bool readOnly );
 };
 
 

--- a/src/providers/mssql/qgsmssqlutils.h
+++ b/src/providers/mssql/qgsmssqlutils.h
@@ -34,6 +34,11 @@ class QgsMssqlUtils
      * Returns a quoted string version of a database \a identifier, for safe use in a SQL query.
      */
     static QString quotedIdentifier( const QString &identifier );
+
+    /**
+     * Converts a SQL Server field type name string to the equivalent QVariant type.
+     */
+    static QMetaType::Type convertSqlFieldType( const QString &sqlTypeName );
 };
 
 

--- a/src/providers/mssql/qgsmssqlutils.h
+++ b/src/providers/mssql/qgsmssqlutils.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+  qgsmssqlutils.h
+  --------------------------------------
+  Date                 : February 2025
+  Copyright            : (C) 2025 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMSSQLUTILS_H
+#define QGSMSSQLUTILS_H
+
+#include <QString>
+#include <QVariant>
+
+/**
+ * Contains utility functions for working with Microsoft SQL Server databases.
+ */
+class QgsMssqlUtils
+{
+  public:
+    /**
+     * Returns a quoted string version of \a value, for safe use in a SQL query.
+     */
+    static QString quotedValue( const QVariant &value );
+
+    /**
+     * Returns a quoted string version of a database \a identifier, for safe use in a SQL query.
+     */
+    static QString quotedIdentifier( const QString &identifier );
+};
+
+
+#endif // QGSMSSQLUTILS_H

--- a/src/providers/mssql/qgsmssqlutils.h
+++ b/src/providers/mssql/qgsmssqlutils.h
@@ -18,6 +18,7 @@
 
 #include <QString>
 #include <QVariant>
+#include "qgis.h"
 
 class QgsField;
 
@@ -46,6 +47,11 @@ class QgsMssqlUtils
      * Creates the equivalent QgsField corresponding to the properties of a SQL Server field.
      */
     static QgsField createField( const QString &name, const QString &systemTypeName, int length, int precision, int scale, bool nullable, bool unique, bool readOnly );
+
+    /**
+     * Converts the string values from .STGeometryType() to a QGIS WKB type.
+     */
+    static Qgis::WkbType wkbTypeFromGeometryType( const QString &type );
 };
 
 

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -55,6 +55,7 @@ class TestQgsMssqlProvider : public QObject
     void testGeomTypeResolutionInvalid();
     void testGeomTypeResolutionInvalidNoWorkaround();
     void testFieldsForTable();
+    void testFieldsForQuery();
 
   private:
     QString mDbConn;
@@ -439,6 +440,58 @@ void TestQgsMssqlProvider::testFieldsForTable()
   QCOMPARE( details.attributeFields.at( 7 ).name(), QStringLiteral( "time" ) );
   QCOMPARE( details.attributeFields.at( 7 ).type(), QVariant::Time );
   QCOMPARE( details.attributeFields.at( 7 ).typeName(), QStringLiteral( "time" ) );
+}
+
+void TestQgsMssqlProvider::testFieldsForQuery()
+{
+  QgsDataSourceUri uri( mDbConn );
+
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( uri );
+
+  QgsMssqlDatabase::FieldDetails details;
+  QString error;
+  QVERIFY( db->loadQueryFields( details, QStringLiteral( "SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) AS _uid1_, concat('a', cnt ) as b, cast(cnt as numeric)/100 as c, * FROM [qgis_test].[someData]" ), error ) );
+  QCOMPARE( error, QString() );
+  QCOMPARE( details.attributeFields.size(), 11 );
+
+  QCOMPARE( details.attributeFields.at( 0 ).name(), QStringLiteral( "_uid1_" ) );
+  QCOMPARE( details.attributeFields.at( 0 ).type(), QVariant::LongLong );
+  QCOMPARE( details.attributeFields.at( 0 ).typeName(), QStringLiteral( "bigint" ) );
+  QCOMPARE( details.attributeFields.at( 1 ).name(), QStringLiteral( "b" ) );
+  QCOMPARE( details.attributeFields.at( 1 ).type(), QVariant::String );
+  QCOMPARE( details.attributeFields.at( 1 ).typeName(), QStringLiteral( "varchar(13)" ) );
+  QCOMPARE( details.attributeFields.at( 2 ).name(), QStringLiteral( "c" ) );
+  QCOMPARE( details.attributeFields.at( 2 ).type(), QVariant::Double );
+  QCOMPARE( details.attributeFields.at( 2 ).typeName(), QStringLiteral( "numeric(24,6)" ) );
+  QCOMPARE( details.attributeFields.at( 2 ).length(), 24 );
+  QCOMPARE( details.attributeFields.at( 3 ).name(), QStringLiteral( "pk" ) );
+  QCOMPARE( details.attributeFields.at( 3 ).type(), QVariant::Int );
+  QCOMPARE( details.attributeFields.at( 3 ).typeName(), QStringLiteral( "int" ) );
+  QCOMPARE( details.attributeFields.at( 4 ).name(), QStringLiteral( "cnt" ) );
+  QCOMPARE( details.attributeFields.at( 4 ).type(), QVariant::Int );
+  QCOMPARE( details.attributeFields.at( 4 ).typeName(), QStringLiteral( "int" ) );
+  QCOMPARE( details.attributeFields.at( 5 ).name(), QStringLiteral( "name" ) );
+  QCOMPARE( details.attributeFields.at( 5 ).type(), QVariant::String );
+  QCOMPARE( details.attributeFields.at( 5 ).typeName(), QStringLiteral( "nvarchar(max)" ) );
+  QCOMPARE( details.attributeFields.at( 6 ).name(), QStringLiteral( "name2" ) );
+  QCOMPARE( details.attributeFields.at( 6 ).type(), QVariant::String );
+  QCOMPARE( details.attributeFields.at( 6 ).typeName(), QStringLiteral( "nvarchar(max)" ) );
+  QCOMPARE( details.attributeFields.at( 7 ).name(), QStringLiteral( "num_char" ) );
+  QCOMPARE( details.attributeFields.at( 7 ).type(), QVariant::String );
+  QCOMPARE( details.attributeFields.at( 7 ).typeName(), QStringLiteral( "nvarchar(max)" ) );
+  QCOMPARE( details.attributeFields.at( 8 ).name(), QStringLiteral( "dt" ) );
+  QCOMPARE( details.attributeFields.at( 8 ).type(), QVariant::DateTime );
+  QCOMPARE( details.attributeFields.at( 8 ).typeName(), QStringLiteral( "datetime" ) );
+  QCOMPARE( details.attributeFields.at( 9 ).name(), QStringLiteral( "date" ) );
+  QCOMPARE( details.attributeFields.at( 9 ).type(), QVariant::Date );
+  QCOMPARE( details.attributeFields.at( 9 ).typeName(), QStringLiteral( "date" ) );
+  QCOMPARE( details.attributeFields.at( 10 ).name(), QStringLiteral( "time" ) );
+  QCOMPARE( details.attributeFields.at( 10 ).type(), QVariant::Time );
+  QCOMPARE( details.attributeFields.at( 10 ).typeName(), QStringLiteral( "time(7)" ) );
+
+  QCOMPARE( details.geometryColumnName, QStringLiteral( "geom" ) );
+  QCOMPARE( details.geometryColumnType, QStringLiteral( "geometry" ) );
+  QVERIFY( !details.isGeography );
 }
 
 QGSTEST_MAIN( TestQgsMssqlProvider )

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -28,6 +28,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
 #include "qgsmssqlgeomcolumntypethread.h"
+#include "qgsmssqldatabase.h"
 
 /**
  * \ingroup UnitTests
@@ -53,6 +54,7 @@ class TestQgsMssqlProvider : public QObject
     void testGeomTypeResolutionValidNoWorkaround();
     void testGeomTypeResolutionInvalid();
     void testGeomTypeResolutionInvalidNoWorkaround();
+    void testFieldsForTable();
 
   private:
     QString mDbConn;
@@ -400,6 +402,43 @@ void TestQgsMssqlProvider::testGeomTypeResolutionInvalidNoWorkaround()
   QCOMPARE( result.isGeography, false );
   QCOMPARE( result.sql, QString() );
   QCOMPARE( result.isView, false );
+}
+
+void TestQgsMssqlProvider::testFieldsForTable()
+{
+  QgsDataSourceUri uri( mDbConn );
+
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( uri );
+
+  QgsMssqlDatabase::FieldDetails details;
+  QString error;
+  QVERIFY( db->loadFields( details, QStringLiteral( "qgis_test" ), QStringLiteral( "someData" ), error ) );
+  QCOMPARE( error, QString() );
+  QCOMPARE( details.attributeFields.size(), 8 );
+  QCOMPARE( details.attributeFields.at( 0 ).name(), QStringLiteral( "pk" ) );
+  QCOMPARE( details.attributeFields.at( 0 ).type(), QVariant::Int );
+  QCOMPARE( details.attributeFields.at( 0 ).typeName(), QStringLiteral( "int" ) );
+  QCOMPARE( details.attributeFields.at( 1 ).name(), QStringLiteral( "cnt" ) );
+  QCOMPARE( details.attributeFields.at( 1 ).type(), QVariant::Int );
+  QCOMPARE( details.attributeFields.at( 1 ).typeName(), QStringLiteral( "int" ) );
+  QCOMPARE( details.attributeFields.at( 2 ).name(), QStringLiteral( "name" ) );
+  QCOMPARE( details.attributeFields.at( 2 ).type(), QVariant::String );
+  QCOMPARE( details.attributeFields.at( 2 ).typeName(), QStringLiteral( "ntext" ) );
+  QCOMPARE( details.attributeFields.at( 3 ).name(), QStringLiteral( "name2" ) );
+  QCOMPARE( details.attributeFields.at( 3 ).type(), QVariant::String );
+  QCOMPARE( details.attributeFields.at( 3 ).typeName(), QStringLiteral( "ntext" ) );
+  QCOMPARE( details.attributeFields.at( 4 ).name(), QStringLiteral( "num_char" ) );
+  QCOMPARE( details.attributeFields.at( 4 ).type(), QVariant::String );
+  QCOMPARE( details.attributeFields.at( 4 ).typeName(), QStringLiteral( "ntext" ) );
+  QCOMPARE( details.attributeFields.at( 5 ).name(), QStringLiteral( "dt" ) );
+  QCOMPARE( details.attributeFields.at( 5 ).type(), QVariant::DateTime );
+  QCOMPARE( details.attributeFields.at( 5 ).typeName(), QStringLiteral( "datetime" ) );
+  QCOMPARE( details.attributeFields.at( 6 ).name(), QStringLiteral( "date" ) );
+  QCOMPARE( details.attributeFields.at( 6 ).type(), QVariant::Date );
+  QCOMPARE( details.attributeFields.at( 6 ).typeName(), QStringLiteral( "date" ) );
+  QCOMPARE( details.attributeFields.at( 7 ).name(), QStringLiteral( "time" ) );
+  QCOMPARE( details.attributeFields.at( 7 ).type(), QVariant::Time );
+  QCOMPARE( details.attributeFields.at( 7 ).typeName(), QStringLiteral( "time" ) );
 }
 
 QGSTEST_MAIN( TestQgsMssqlProvider )

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -62,7 +62,9 @@ class FeatureSourceTestCase:
     def testFields(self):
         fields = self.source.fields()
         for f in ("pk", "cnt", "name", "name2", "num_char"):
-            self.assertGreaterEqual(fields.lookupField(f), 0)
+            self.assertGreaterEqual(
+                fields.lookupField(f), 0, f"Could not find field {f}"
+            )
 
     def testGetFeatures(
         self,

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -44,93 +44,19 @@ start_app()
 TEST_DATA_DIR = unitTestDataPath()
 
 
-class TestPyQgsMssqlProvider(QgisTestCase, ProviderTestCase):
+class MssqlProviderTestBase(ProviderTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        """Run before all tests"""
-        super().setUpClass()
-        # These are the connection details for the SQL Server instance running on Travis
-        cls.dbconn = "service='testsqlserver' user=sa password='QGIStestSQLServer1234' "
-        if "QGIS_MSSQLTEST_DB" in os.environ:
-            cls.dbconn = os.environ["QGIS_MSSQLTEST_DB"]
-        # Create test layers
-        cls.vl = QgsVectorLayer(
-            cls.dbconn
-            + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=',
-            "test",
-            "mssql",
-        )
-        assert (
-            cls.vl.dataProvider() is not None
-        ), f"No data provider for {cls.vl.source()}"
-        assert cls.vl.isValid(), cls.vl.dataProvider().error().message()
-        cls.source = cls.vl.dataProvider()
-        cls.poly_vl = QgsVectorLayer(
-            cls.dbconn
-            + ' sslmode=disable key=\'pk\' srid=4326 type=POLYGON table="qgis_test"."some_poly_data" (geom) sql=',
-            "test",
-            "mssql",
-        )
-        assert cls.poly_vl.isValid(), cls.poly_vl.dataProvider().error().message()
-        cls.poly_provider = cls.poly_vl.dataProvider()
+    def getSubsetString(self):
+        return "[cnt] > 100 and [cnt] < 410"
 
-        # Use connections API
-        md = QgsProviderRegistry.instance().providerMetadata("mssql")
-        cls.conn_api = md.createConnection(cls.dbconn, {})
+    def getSubsetString2(self):
+        return "[cnt] > 100 and [cnt] < 400"
 
-    def setUp(self):
-        for t in ["new_table", "new_table_multipoint", "new_table_multipolygon"]:
-            self.execSQLCommand(f"DROP TABLE IF EXISTS qgis_test.[{t}]")
+    def getSubsetString3(self):
+        return "[name]='Apple'"
 
-    def execSQLCommand(self, sql):
-        self.assertTrue(self.conn_api)
-        self.conn_api.executeSql(sql)
-
-    def getSource(self):
-        # create temporary table for edit tests
-        self.execSQLCommand("DROP TABLE IF EXISTS qgis_test.edit_data")
-        self.execSQLCommand(
-            """CREATE TABLE qgis_test.edit_data (pk INTEGER PRIMARY KEY,cnt integer, name nvarchar(max), name2 nvarchar(max), num_char nvarchar(max), dt datetime, [date] date, [time] time, geom geometry)"""
-        )
-        self.execSQLCommand(
-            "INSERT INTO [qgis_test].[edit_data] (pk, cnt, name, name2, num_char, dt, [date], [time], geom) VALUES "
-            "(5, -200, NULL, 'NuLl', '5', '2020-05-04T12:13:14', '2020-05-02', '12:13:01', geometry::STGeomFromText('POINT(-71.123 78.23)', 4326)),"
-            "(3, 300, 'Pear', 'PEaR', '3', NULL, NULL, NULL, NULL),"
-            "(1, 100, 'Orange', 'oranGe', '1', '2020-05-03T12:13:14', '2020-05-03', '12:13:14', geometry::STGeomFromText('POINT(-70.332 66.33)', 4326)),"
-            "(2, 200, 'Apple', 'Apple', '2', '2020-05-04T12:14:14', '2020-05-04', '12:14:14', geometry::STGeomFromText('POINT(-68.2 70.8)', 4326)),"
-            "(4, 400, 'Honey', 'Honey', '4', '2021-05-04T13:13:14', '2021-05-04', '13:13:14', geometry::STGeomFromText('POINT(-65.32 78.3)', 4326))"
-        )
-
-        vl = QgsVectorLayer(
-            self.dbconn
-            + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."edit_data" (geom) sql=',
-            "test",
-            "mssql",
-        )
-        return vl
-
-    def testDeleteFeaturesPktInt(self):
-        vl = self.getSource()
-        dp = vl.dataProvider()
-
-        self.assertEqual(dp.featureCount(), 5)
-
-        self.assertTrue(dp.deleteFeatures([1, 3, 4]))
-        self.assertEqual(dp.featureCount(), 2)
-
-        self.assertFalse(dp.deleteFeatures([3]))
-        self.assertFalse(dp.deleteFeatures([10]))
-        self.assertFalse(dp.deleteFeatures([3, 10]))
-
-        self.assertTrue(dp.deleteFeatures([5]))
-        self.assertEqual(dp.featureCount(), 1)
-
-        self.assertTrue(dp.deleteFeatures([2]))
-        self.assertEqual(dp.featureCount(), 0)
-
-    def getEditableLayer(self):
-        return self.getSource()
+    def getSubsetStringNoMatching(self):
+        return "[name]='AppleBearOrangePear'"
 
     def enableCompiler(self):
         QgsSettings().setValue("/qgis/compileExpressions", True)
@@ -224,6 +150,95 @@ class TestPyQgsMssqlProvider(QgisTestCase, ProviderTestCase):
             "\"time\" = to_time('000www14ww13ww12www','zzzwwwsswwmmwwhhwww')",
         }
         return filters
+
+
+class TestPyQgsMssqlProvider(QgisTestCase, MssqlProviderTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        super().setUpClass()
+        # These are the connection details for the SQL Server instance running on Travis
+        cls.dbconn = "service='testsqlserver' user=sa password='QGIStestSQLServer1234' "
+        if "QGIS_MSSQLTEST_DB" in os.environ:
+            cls.dbconn = os.environ["QGIS_MSSQLTEST_DB"]
+        # Create test layers
+        cls.vl = QgsVectorLayer(
+            cls.dbconn
+            + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=',
+            "test",
+            "mssql",
+        )
+        assert (
+            cls.vl.dataProvider() is not None
+        ), f"No data provider for {cls.vl.source()}"
+        assert cls.vl.isValid(), cls.vl.dataProvider().error().message()
+        cls.source = cls.vl.dataProvider()
+        cls.poly_vl = QgsVectorLayer(
+            cls.dbconn
+            + ' sslmode=disable key=\'pk\' srid=4326 type=POLYGON table="qgis_test"."some_poly_data" (geom) sql=',
+            "test",
+            "mssql",
+        )
+        assert cls.poly_vl.isValid(), cls.poly_vl.dataProvider().error().message()
+        cls.poly_provider = cls.poly_vl.dataProvider()
+
+        # Use connections API
+        md = QgsProviderRegistry.instance().providerMetadata("mssql")
+        cls.conn_api = md.createConnection(cls.dbconn, {})
+
+    def setUp(self):
+        for t in ["new_table", "new_table_multipoint", "new_table_multipolygon"]:
+            self.execSQLCommand(f"DROP TABLE IF EXISTS qgis_test.[{t}]")
+
+    def execSQLCommand(self, sql):
+        self.assertTrue(self.conn_api)
+        self.conn_api.executeSql(sql)
+
+    def getSource(self):
+        # create temporary table for edit tests
+        self.execSQLCommand("DROP TABLE IF EXISTS qgis_test.edit_data")
+        self.execSQLCommand(
+            """CREATE TABLE qgis_test.edit_data (pk INTEGER PRIMARY KEY,cnt integer, name nvarchar(max), name2 nvarchar(max), num_char nvarchar(max), dt datetime, [date] date, [time] time, geom geometry)"""
+        )
+        self.execSQLCommand(
+            "INSERT INTO [qgis_test].[edit_data] (pk, cnt, name, name2, num_char, dt, [date], [time], geom) VALUES "
+            "(5, -200, NULL, 'NuLl', '5', '2020-05-04T12:13:14', '2020-05-02', '12:13:01', geometry::STGeomFromText('POINT(-71.123 78.23)', 4326)),"
+            "(3, 300, 'Pear', 'PEaR', '3', NULL, NULL, NULL, NULL),"
+            "(1, 100, 'Orange', 'oranGe', '1', '2020-05-03T12:13:14', '2020-05-03', '12:13:14', geometry::STGeomFromText('POINT(-70.332 66.33)', 4326)),"
+            "(2, 200, 'Apple', 'Apple', '2', '2020-05-04T12:14:14', '2020-05-04', '12:14:14', geometry::STGeomFromText('POINT(-68.2 70.8)', 4326)),"
+            "(4, 400, 'Honey', 'Honey', '4', '2021-05-04T13:13:14', '2021-05-04', '13:13:14', geometry::STGeomFromText('POINT(-65.32 78.3)', 4326))"
+        )
+
+        vl = QgsVectorLayer(
+            self.dbconn
+            + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."edit_data" (geom) sql=',
+            "test",
+            "mssql",
+        )
+        return vl
+
+    def testDeleteFeaturesPktInt(self):
+        vl = self.getSource()
+        dp = vl.dataProvider()
+
+        self.assertEqual(dp.featureCount(), 5)
+
+        self.assertTrue(dp.deleteFeatures([1, 3, 4]))
+        self.assertEqual(dp.featureCount(), 2)
+
+        self.assertFalse(dp.deleteFeatures([3]))
+        self.assertFalse(dp.deleteFeatures([10]))
+        self.assertFalse(dp.deleteFeatures([3, 10]))
+
+        self.assertTrue(dp.deleteFeatures([5]))
+        self.assertEqual(dp.featureCount(), 1)
+
+        self.assertTrue(dp.deleteFeatures([2]))
+        self.assertEqual(dp.featureCount(), 0)
+
+    def getEditableLayer(self):
+        return self.getSource()
 
     def testAddFeatureAllNull(self):
         # overridden from base test because of non-null primary key, with no default clause
@@ -1166,18 +1181,6 @@ class TestPyQgsMssqlProvider(QgisTestCase, ProviderTestCase):
         )
         self.assertTrue(identity_field.isReadOnly())
 
-    def getSubsetString(self):
-        return "[cnt] > 100 and [cnt] < 410"
-
-    def getSubsetString2(self):
-        return "[cnt] > 100 and [cnt] < 400"
-
-    def getSubsetString3(self):
-        return "[name]='Apple'"
-
-    def getSubsetStringNoMatching(self):
-        return "[name]='AppleBearOrangePear'"
-
     def testExtentFromGeometryTable(self):
         """
         Check if the behavior of the mssql provider if extent is defined in the geometry_column table
@@ -1322,6 +1325,273 @@ class TestPyQgsMssqlProvider(QgisTestCase, ProviderTestCase):
             )
         )
         self.assertEqual(vl.dataProvider().fields().at(1).length(), 12)
+
+    def test_query(self):
+
+        uri = f"{self.dbconn} key='_uid1_' table=\"(SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) AS _uid1_, concat('a', cnt ) as b, cast(cnt as numeric)/100 as c, * FROM [qgis_test].[someData])\""
+        vl = QgsVectorLayer(uri, "", "mssql")
+        self.assertTrue(vl.isValid())
+        self.assertEqual(
+            [f.name() for f in vl.dataProvider().fields()],
+            [
+                "_uid1_",
+                "b",
+                "c",
+                "pk",
+                "cnt",
+                "name",
+                "name2",
+                "num_char",
+                "dt",
+                "date",
+                "time",
+            ],
+        )
+        self.assertEqual(
+            [f.type() for f in vl.dataProvider().fields()],
+            [
+                QVariant.LongLong,
+                QVariant.String,
+                QVariant.Double,
+                QVariant.Int,
+                QVariant.Int,
+                QVariant.String,
+                QVariant.String,
+                QVariant.String,
+                QVariant.DateTime,
+                QVariant.Date,
+                QVariant.Time,
+            ],
+        )
+        self.assertEqual(
+            [f.typeName() for f in vl.dataProvider().fields()],
+            [
+                "bigint",
+                "varchar(13)",
+                "numeric(24,6)",
+                "int",
+                "int",
+                "nvarchar(max)",
+                "nvarchar(max)",
+                "nvarchar(max)",
+                "datetime",
+                "date",
+                "time(7)",
+            ],
+        )
+        self.assertEqual(
+            [f.length() for f in vl.dataProvider().fields()],
+            [0, 13, 24, 0, 0, 0, 0, 0, -1, -1, -1],
+        )
+        self.assertEqual(
+            [f.precision() for f in vl.dataProvider().fields()],
+            [0, 0, -1, 0, 0, 0, 0, 0, -1, -1, -1],
+        )
+
+        self.assertEqual(vl.dataProvider().featureCount(), 5)
+
+        features = [f for f in vl.dataProvider().getFeatures()]
+        self.assertEqual(
+            [f.attributes() for f in features],
+            [
+                [
+                    1,
+                    "a100",
+                    1.0,
+                    1,
+                    100,
+                    "Orange",
+                    "oranGe",
+                    "1",
+                    QDateTime(2020, 5, 3, 12, 13, 14),
+                    QDate(2020, 5, 3),
+                    QTime(12, 13, 14),
+                ],
+                [
+                    2,
+                    "a200",
+                    2.0,
+                    2,
+                    200,
+                    "Apple",
+                    "Apple",
+                    "2",
+                    QDateTime(2020, 5, 4, 12, 14, 14),
+                    QDate(2020, 5, 4),
+                    QTime(12, 14, 14),
+                ],
+                [3, "a300", 3.0, 3, 300, "Pear", "PEaR", "3", NULL, NULL, NULL],
+                [
+                    4,
+                    "a400",
+                    4.0,
+                    4,
+                    400,
+                    "Honey",
+                    "Honey",
+                    "4",
+                    QDateTime(2021, 5, 4, 13, 13, 14),
+                    QDate(2021, 5, 4),
+                    QTime(13, 13, 14),
+                ],
+                [
+                    5,
+                    "a-200",
+                    -2.0,
+                    5,
+                    -200,
+                    NULL,
+                    "NuLl",
+                    "5",
+                    QDateTime(2020, 5, 4, 12, 13, 14),
+                    QDate(2020, 5, 2),
+                    QTime(12, 13, 1),
+                ],
+            ],
+        )
+
+    def test_query_without_row_number(self):
+
+        uri = f"{self.dbconn} table=\"(SELECT concat('a', cnt ) as b, cast(cnt as numeric)/100 as c, * FROM [qgis_test].[someData])\" key='pk'"
+        vl = QgsVectorLayer(uri, "", "mssql")
+        self.assertTrue(vl.isValid())
+        self.assertEqual(len(vl.dataProvider().fields()), 10)
+        self.assertEqual(
+            [f.name() for f in vl.dataProvider().fields()],
+            ["b", "c", "pk", "cnt", "name", "name2", "num_char", "dt", "date", "time"],
+        )
+        self.assertEqual(
+            [f.type() for f in vl.dataProvider().fields()],
+            [
+                QVariant.String,
+                QVariant.Double,
+                QVariant.Int,
+                QVariant.Int,
+                QVariant.String,
+                QVariant.String,
+                QVariant.String,
+                QVariant.DateTime,
+                QVariant.Date,
+                QVariant.Time,
+            ],
+        )
+        self.assertEqual(
+            [f.typeName() for f in vl.dataProvider().fields()],
+            [
+                "varchar(13)",
+                "numeric(24,6)",
+                "int",
+                "int",
+                "nvarchar(max)",
+                "nvarchar(max)",
+                "nvarchar(max)",
+                "datetime",
+                "date",
+                "time(7)",
+            ],
+        )
+        self.assertEqual(
+            [f.length() for f in vl.dataProvider().fields()],
+            [13, 24, 0, 0, 0, 0, 0, -1, -1, -1],
+        )
+        self.assertEqual(
+            [f.precision() for f in vl.dataProvider().fields()],
+            [0, -1, 0, 0, 0, 0, 0, -1, -1, -1],
+        )
+
+        self.assertEqual(vl.dataProvider().featureCount(), 5)
+
+        features = [f for f in vl.dataProvider().getFeatures()]
+        self.assertEqual(
+            [f.attributes() for f in features],
+            [
+                [
+                    "a100",
+                    1.0,
+                    1,
+                    100,
+                    "Orange",
+                    "oranGe",
+                    "1",
+                    QDateTime(2020, 5, 3, 12, 13, 14),
+                    QDate(2020, 5, 3),
+                    QTime(12, 13, 14),
+                ],
+                [
+                    "a200",
+                    2.0,
+                    2,
+                    200,
+                    "Apple",
+                    "Apple",
+                    "2",
+                    QDateTime(2020, 5, 4, 12, 14, 14),
+                    QDate(2020, 5, 4),
+                    QTime(12, 14, 14),
+                ],
+                ["a300", 3.0, 3, 300, "Pear", "PEaR", "3", NULL, NULL, NULL],
+                [
+                    "a400",
+                    4.0,
+                    4,
+                    400,
+                    "Honey",
+                    "Honey",
+                    "4",
+                    QDateTime(2021, 5, 4, 13, 13, 14),
+                    QDate(2021, 5, 4),
+                    QTime(13, 13, 14),
+                ],
+                [
+                    "a-200",
+                    -2.0,
+                    5,
+                    -200,
+                    NULL,
+                    "NuLl",
+                    "5",
+                    QDateTime(2020, 5, 4, 12, 13, 14),
+                    QDate(2020, 5, 2),
+                    QTime(12, 13, 1),
+                ],
+            ],
+        )
+
+
+class TestPyQgsMssqlProviderQuery(QgisTestCase, MssqlProviderTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        super().setUpClass()
+        # These are the connection details for the SQL Server instance running on Travis
+        cls.dbconn = "service='testsqlserver' user=sa password='QGIStestSQLServer1234' "
+        if "QGIS_MSSQLTEST_DB" in os.environ:
+            cls.dbconn = os.environ["QGIS_MSSQLTEST_DB"]
+        # Create test layers
+        cls.vl = QgsVectorLayer(
+            cls.dbconn
+            + " sslmode=disable srid=4326 type=POINT key='pk' table=\"(SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) AS pk, cnt as cnt, name as name, name2 as name2, num_char as num_char, dt as dt, date as date, time as time, geom as geom FROM [qgis_test].[someData])\" (geom) sql=",
+            "test",
+            "mssql",
+        )
+        assert (
+            cls.vl.dataProvider() is not None
+        ), f"No data provider for {cls.vl.source()}"
+        assert cls.vl.isValid(), cls.vl.dataProvider().error().message()
+        cls.source = cls.vl.dataProvider()
+        cls.poly_vl = QgsVectorLayer(
+            cls.dbconn
+            + " sslmode=disable srid=4326 type=POINT key='pk' table=\"(SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) AS pk, geom as geometry FROM [qgis_test].[some_poly_data])\" (geometry) sql=",
+            "test",
+            "mssql",
+        )
+        assert cls.poly_vl.isValid(), cls.poly_vl.dataProvider().error().message()
+        cls.poly_provider = cls.poly_vl.dataProvider()
+
+        # Use connections API
+        md = QgsProviderRegistry.instance().providerMetadata("mssql")
+        cls.conn_api = md.createConnection(cls.dbconn, {})
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsproviderconnection_mssql.py
+++ b/tests/src/python/test_qgsproviderconnection_mssql.py
@@ -20,6 +20,7 @@ from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,
     QgsFields,
+    QgsAbstractDatabaseProviderConnection,
 )
 from qgis.testing import unittest
 
@@ -241,6 +242,82 @@ class TestPyQgsProviderConnectionMssql(
         # we can't retrieve this, as SQL server will have raised an exception
         # due to the invalid geometries in this table
         self.assertEqual(len(tb.geometryColumnTypes()), 0)
+
+    def test_create_vector_layer(self):
+        """Test query layers"""
+
+        md = QgsProviderRegistry.instance().providerMetadata("mssql")
+        conn = md.createConnection(self.uri, {})
+
+        options = QgsAbstractDatabaseProviderConnection.SqlVectorLayerOptions()
+        options.sql = "SELECT pk as pk, name as my_name, geom as geometry FROM qgis_test.someData WHERE pk < 3"
+        options.primaryKeyColumns = ["pk"]
+        options.geometryColumn = "geometry"
+        vl = conn.createSqlVectorLayer(options)
+        self.assertTrue(vl.isValid())
+        self.assertTrue(vl.isSqlQuery())
+        # Test flags
+        self.assertTrue(vl.vectorLayerTypeFlags() & Qgis.VectorLayerTypeFlag.SqlQuery)
+        self.assertEqual(vl.geometryType(), Qgis.GeometryType.Point)
+        features = [f for f in vl.getFeatures()]
+        self.assertEqual(len(features), 2)
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "geometry")
+        self.assertEqual(
+            vl.dataProvider().crs(), QgsCoordinateReferenceSystem("EPSG:4326")
+        )
+
+        # Wrong calls
+        options.primaryKeyColumns = ["DOES_NOT_EXIST"]
+        vl = conn.createSqlVectorLayer(options)
+        self.assertFalse(vl.isValid())
+        self.assertFalse(vl.vectorLayerTypeFlags() & Qgis.VectorLayerTypeFlag.SqlQuery)
+        self.assertFalse(vl.isSqlQuery())
+
+        options.primaryKeyColumns = ["id"]
+        options.geometryColumn = "DOES_NOT_EXIST"
+        vl = conn.createSqlVectorLayer(options)
+        self.assertFalse(vl.isValid())
+        self.assertFalse(vl.isSqlQuery())
+
+        # No geometry and no PK
+        options.sql = "SELECT pk as pk, geom as geometry FROM qgis_test.someData"
+        options.primaryKeyColumns = []
+        options.geometryColumn = ""
+        vl = conn.createSqlVectorLayer(options)
+        self.assertTrue(vl.isValid())
+        self.assertTrue(vl.isSqlQuery())
+        self.assertEqual(vl.geometryType(), Qgis.GeometryType.Unknown)
+        self.assertEqual(vl.dataProvider().pkAttributeIndexes(), [0])
+        features = [f for f in vl.getFeatures()]
+        self.assertEqual(len(features), 5)
+
+        # No PKs
+        options.primaryKeyColumns = []
+        options.geometryColumn = "geometry"
+        vl = conn.createSqlVectorLayer(options)
+        self.assertTrue(vl.isSqlQuery())
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.geometryType(), Qgis.GeometryType.Point)
+        self.assertEqual(vl.dataProvider().pkAttributeIndexes(), [0])
+        features = [f for f in vl.getFeatures()]
+        self.assertEqual(len(features), 5)
+
+        # changing geometry type
+        options.sql = (
+            "SELECT pk as pk, geom.STBuffer(1) as geometry FROM qgis_test.someData"
+        )
+        options.primaryKeyColumns = ["pk"]
+        options.geometryColumn = "geometry"
+        vl = conn.createSqlVectorLayer(options)
+        self.assertTrue(vl.isSqlQuery())
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.geometryType(), Qgis.GeometryType.Polygon)
+        self.assertEqual(vl.dataProvider().pkAttributeIndexes(), [0])
+        features = [f for f in vl.getFeatures()]
+        self.assertEqual(len(features), 5)
+        self.assertEqual(
+            vl.dataProvider().crs(), QgsCoordinateReferenceSystem("EPSG:4326")
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows loading SQL Server queries as map layers from the browser, and updating the SQL for existing query layers

Sponsored by City of Canning

Fixes https://github.com/qgis/QGIS/issues/19301
