### PR TITLE
Saving/loading SQL queries from Execute SQL/Update SQL dialogs

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsqueryresultwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsqueryresultwidget.sip.in
@@ -35,6 +35,7 @@ be used in different contexts like when updating the SQL of an existing query la
 #include "qgsqueryresultwidget.h"
 %End
   public:
+
     enum class QueryWidgetMode /BaseType=IntFlag/
     {
       SqlQueryMode,
@@ -67,6 +68,7 @@ Sets the connection to ``connection``, ownership is transferred to the widget.
 %Docstring
 Convenience method to set the SQL editor text to ``sql``.
 %End
+
 
   public slots:
 
@@ -124,6 +126,79 @@ Emitted when the first batch of results has been fetched.
 
    If the query returns no results this signal is not emitted.
 %End
+
+
+};
+
+class QgsQueryResultDialog : QDialog
+{
+%Docstring(signature="appended")
+A dialog which allows users to enter and run an SQL query on a
+DB connection (an instance of :py:class:`QgsAbstractDatabaseProviderConnection`).
+
+.. note::
+
+   the ownership of the connection is transferred to the dialog.
+
+.. seealso:: :py:class:`QgsQueryResultWidget`
+
+.. versionadded:: 3.44
+%End
+
+%TypeHeaderCode
+#include "qgsqueryresultwidget.h"
+%End
+  public:
+    QgsQueryResultDialog( QgsAbstractDatabaseProviderConnection *connection /Transfer/ = 0, QWidget *parent = 0 );
+%Docstring
+Constructor for QgsQueryResultDialog.
+
+Ownership of the ``connection`` is transferred to the dialog.
+%End
+
+    QgsQueryResultWidget *resultWidget();
+%Docstring
+Returns the :py:class:`QgsQueryResultWidget` shown in the dialog.
+%End
+
+    virtual void closeEvent( QCloseEvent *event );
+
+
+};
+
+class QgsQueryResultMainWindow : QMainWindow
+{
+%Docstring(signature="appended")
+A main window which allows users to enter and run an SQL query on a
+DB connection (an instance of :py:class:`QgsAbstractDatabaseProviderConnection`).
+
+.. note::
+
+   the ownership of the connection is transferred to the window.
+
+.. seealso:: :py:class:`QgsQueryResultWidget`
+
+.. versionadded:: 3.44
+%End
+
+%TypeHeaderCode
+#include "qgsqueryresultwidget.h"
+%End
+  public:
+    QgsQueryResultMainWindow( QgsAbstractDatabaseProviderConnection *connection /Transfer/ = 0, const QString &identifierName = QString() );
+%Docstring
+Constructor for QgsQueryResultMainWindow.
+
+Ownership of the ``connection`` is transferred to the window.
+%End
+
+    QgsQueryResultWidget *resultWidget();
+%Docstring
+Returns the :py:class:`QgsQueryResultWidget` shown in the window.
+%End
+
+    virtual void closeEvent( QCloseEvent *event );
+
 
 };
 

--- a/python/PyQt6/gui/auto_generated/qgsqueryresultwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsqueryresultwidget.sip.in
@@ -68,7 +68,6 @@ Sets the connection to ``connection``, ownership is transferred to the widget.
 Convenience method to set the SQL editor text to ``sql``.
 %End
 
-
   public slots:
 
     void notify( const QString &title, const QString &text, Qgis::MessageLevel level = Qgis::MessageLevel::Info );

--- a/python/gui/auto_generated/qgsqueryresultwidget.sip.in
+++ b/python/gui/auto_generated/qgsqueryresultwidget.sip.in
@@ -68,7 +68,6 @@ Sets the connection to ``connection``, ownership is transferred to the widget.
 Convenience method to set the SQL editor text to ``sql``.
 %End
 
-
   public slots:
 
     void notify( const QString &title, const QString &text, Qgis::MessageLevel level = Qgis::MessageLevel::Info );

--- a/python/gui/auto_generated/qgsqueryresultwidget.sip.in
+++ b/python/gui/auto_generated/qgsqueryresultwidget.sip.in
@@ -35,6 +35,7 @@ be used in different contexts like when updating the SQL of an existing query la
 #include "qgsqueryresultwidget.h"
 %End
   public:
+
     enum class QueryWidgetMode
     {
       SqlQueryMode,
@@ -67,6 +68,7 @@ Sets the connection to ``connection``, ownership is transferred to the widget.
 %Docstring
 Convenience method to set the SQL editor text to ``sql``.
 %End
+
 
   public slots:
 
@@ -124,6 +126,79 @@ Emitted when the first batch of results has been fetched.
 
    If the query returns no results this signal is not emitted.
 %End
+
+
+};
+
+class QgsQueryResultDialog : QDialog
+{
+%Docstring(signature="appended")
+A dialog which allows users to enter and run an SQL query on a
+DB connection (an instance of :py:class:`QgsAbstractDatabaseProviderConnection`).
+
+.. note::
+
+   the ownership of the connection is transferred to the dialog.
+
+.. seealso:: :py:class:`QgsQueryResultWidget`
+
+.. versionadded:: 3.44
+%End
+
+%TypeHeaderCode
+#include "qgsqueryresultwidget.h"
+%End
+  public:
+    QgsQueryResultDialog( QgsAbstractDatabaseProviderConnection *connection /Transfer/ = 0, QWidget *parent = 0 );
+%Docstring
+Constructor for QgsQueryResultDialog.
+
+Ownership of the ``connection`` is transferred to the dialog.
+%End
+
+    QgsQueryResultWidget *resultWidget();
+%Docstring
+Returns the :py:class:`QgsQueryResultWidget` shown in the dialog.
+%End
+
+    virtual void closeEvent( QCloseEvent *event );
+
+
+};
+
+class QgsQueryResultMainWindow : QMainWindow
+{
+%Docstring(signature="appended")
+A main window which allows users to enter and run an SQL query on a
+DB connection (an instance of :py:class:`QgsAbstractDatabaseProviderConnection`).
+
+.. note::
+
+   the ownership of the connection is transferred to the window.
+
+.. seealso:: :py:class:`QgsQueryResultWidget`
+
+.. versionadded:: 3.44
+%End
+
+%TypeHeaderCode
+#include "qgsqueryresultwidget.h"
+%End
+  public:
+    QgsQueryResultMainWindow( QgsAbstractDatabaseProviderConnection *connection /Transfer/ = 0, const QString &identifierName = QString() );
+%Docstring
+Constructor for QgsQueryResultMainWindow.
+
+Ownership of the ``connection`` is transferred to the window.
+%End
+
+    QgsQueryResultWidget *resultWidget();
+%Docstring
+Returns the :py:class:`QgsQueryResultWidget` shown in the window.
+%End
+
+    virtual void closeEvent( QCloseEvent *event );
+
 
 };
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2010,25 +2010,13 @@ void QgsDatabaseItemGuiProvider::openSqlDialog( const QString &connectionUri, co
 
   std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( qgis::down_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, QVariantMap() ) ) );
 
-  // Create the SQL dialog: this might become an independent class dialog in the future, for now
-  // we are still prototyping the features that this dialog will have.
-
-  QMainWindow *dialog = new QMainWindow();
-  dialog->setObjectName( QStringLiteral( "SQLCommandsDialog" ) );
-  if ( !identifierName.isEmpty() )
-    dialog->setWindowTitle( tr( "%1 — Execute SQL" ).arg( identifierName ) );
-  else
-    dialog->setWindowTitle( tr( "Execute SQL" ) );
-
-  QgsGui::enableAutoGeometryRestore( dialog );
+  QgsQueryResultMainWindow *dialog = new QgsQueryResultMainWindow( conn.release(), identifierName );
   dialog->setAttribute( Qt::WA_DeleteOnClose );
   dialog->setStyleSheet( QgisApp::instance()->styleSheet() );
 
-  QgsQueryResultWidget *widget { new QgsQueryResultWidget( nullptr, conn.release() ) };
-  widget->setQuery( query );
-  dialog->setCentralWidget( widget );
+  dialog->resultWidget()->setQuery( query );
 
-  connect( widget, &QgsQueryResultWidget::createSqlVectorLayer, widget, [provider, connectionUri, context]( const QString &, const QString &, const QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions &options ) {
+  connect( dialog->resultWidget(), &QgsQueryResultWidget::createSqlVectorLayer, dialog, [provider, connectionUri, context]( const QString &, const QString &, const QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions &options ) {
     QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( provider ) };
     if ( !md )
       return;

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2022,6 +2022,7 @@ void QgsDatabaseItemGuiProvider::openSqlDialog( const QString &connectionUri, co
 
   QgsGui::enableAutoGeometryRestore( dialog );
   dialog->setAttribute( Qt::WA_DeleteOnClose );
+  dialog->setStyleSheet( QgisApp::instance()->styleSheet() );
 
   QgsQueryResultWidget *widget { new QgsQueryResultWidget( nullptr, conn.release() ) };
   widget->setQuery( query );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -316,6 +316,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
                 queryResultWidget->executeQuery();
                 queryResultWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
                 dialog.layout()->addWidget( queryResultWidget );
+                dialog.setStyleSheet( QgisApp::instance()->styleSheet() );
 
                 connect( queryResultWidget, &QgsQueryResultWidget::createSqlVectorLayer, queryResultWidget, [queryResultWidget, layer, this]( const QString &, const QString &, const QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions &options ) {
                   ( void ) this;

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -48,6 +48,9 @@ QgsQueryResultWidget::QgsQueryResultWidget( QWidget *parent, QgsAbstractDatabase
   // mSqlEditor->setLineNumbersVisible( true );
 
   mToolBar->setIconSize( QgsGuiUtils::iconSize( false ) );
+  // explicitly needed for some reason (Qt 5.15)
+  mainLayout->setSpacing( 6 );
+  progressLayout->setSpacing( 6 );
 
   mQueryResultsTableView->hide();
   mQueryResultsTableView->setItemDelegate( new QgsQueryResultItemDelegate( mQueryResultsTableView ) );

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -28,9 +28,16 @@
 #include "qgsproviderregistry.h"
 #include "qgsprovidermetadata.h"
 #include "qgscodeeditorwidget.h"
+#include "qgsfileutils.h"
 
 #include <QClipboard>
 #include <QShortcut>
+#include <QFileDialog>
+#include <QMessageBox>
+
+///@cond PRIVATE
+const QgsSettingsEntryString *QgsQueryResultWidget::settingLastSourceFolder = new QgsSettingsEntryString( QStringLiteral( "last-source-folder" ), sTreeSqlQueries, QString(), QStringLiteral( "Last used folder for SQL source files" ) );
+///@endcond PRIVATE
 
 QgsQueryResultWidget::QgsQueryResultWidget( QWidget *parent, QgsAbstractDatabaseProviderConnection *connection )
   : QWidget( parent )
@@ -56,6 +63,10 @@ QgsQueryResultWidget::QgsQueryResultWidget( QWidget *parent, QgsAbstractDatabase
   vl->addWidget( mCodeEditorWidget );
   mSqlEditorContainer->setLayout( vl );
 
+  connect( mActionOpenQuery, &QAction::triggered, this, &QgsQueryResultWidget::openQuery );
+  connect( mActionSaveQuery, &QAction::triggered, this, [this] { saveQuery( false ); } );
+  connect( mActionSaveQueryAs, &QAction::triggered, this, [this] { saveQuery( true ); } );
+
   connect( mActionCut, &QAction::triggered, mSqlEditor, &QgsCodeEditor::cut );
   connect( mActionCopy, &QAction::triggered, mSqlEditor, &QgsCodeEditor::copy );
   connect( mActionPaste, &QAction::triggered, mSqlEditor, &QgsCodeEditor::paste );
@@ -66,6 +77,7 @@ QgsQueryResultWidget::QgsQueryResultWidget( QWidget *parent, QgsAbstractDatabase
 
   connect( mActionFindReplace, &QAction::toggled, mCodeEditorWidget, &QgsCodeEditorWidget::setSearchBarVisible );
   connect( mCodeEditorWidget, &QgsCodeEditorWidget::searchBarToggled, mActionFindReplace, &QAction::setChecked );
+  connect( mSqlEditor, &QgsCodeEditor::modificationChanged, this, &QgsQueryResultWidget::setHasChanged );
 
   connect( mExecuteButton, &QPushButton::pressed, this, &QgsQueryResultWidget::executeQuery );
 
@@ -139,6 +151,7 @@ QgsQueryResultWidget::QgsQueryResultWidget( QWidget *parent, QgsAbstractDatabase
   connect( copySelection, &QShortcut::activated, this, &QgsQueryResultWidget::copySelection );
 
   setConnection( connection );
+  setHasChanged( false );
 }
 
 QgsQueryResultWidget::~QgsQueryResultWidget()
@@ -517,9 +530,72 @@ void QgsQueryResultWidget::copyResults( int fromRow, int toRow, int fromColumn, 
   }
 }
 
+void QgsQueryResultWidget::openQuery()
+{
+  if ( !mCodeEditorWidget->filePath().isEmpty() && mHasChangedFileContents )
+  {
+    if ( QMessageBox::warning( this, tr( "Unsaved Changes" ), tr( "There are unsaved changes in the query. Continue?" ), QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::No ) == QMessageBox::StandardButton::No )
+      return;
+  }
+
+  QString initialDir = settingLastSourceFolder->value();
+  if ( initialDir.isEmpty() )
+    initialDir = QDir::homePath();
+
+  const QString fileName = QFileDialog::getOpenFileName( this, tr( "Open Query" ), initialDir, tr( "SQL queries (*.sql *.SQL)" ) + QStringLiteral( ";;" ) + QObject::tr( "All files" ) + QStringLiteral( " (*.*)" ) );
+
+  if ( fileName.isEmpty() )
+    return;
+
+  QFileInfo fi( fileName );
+  settingLastSourceFolder->setValue( fi.path() );
+
+  QgsTemporaryCursorOverride cursor( Qt::CursorShape::WaitCursor );
+
+  mCodeEditorWidget->loadFile( fileName );
+  setHasChanged( false );
+}
+
+void QgsQueryResultWidget::saveQuery( bool saveAs )
+{
+  if ( mCodeEditorWidget->filePath().isEmpty() || saveAs )
+  {
+    QString selectedFilter;
+
+    QString initialDir = settingLastSourceFolder->value();
+    if ( initialDir.isEmpty() )
+      initialDir = QDir::homePath();
+
+    QString newPath = QFileDialog::getSaveFileName(
+      this,
+      tr( "Save Query" ),
+      initialDir,
+      tr( "SQL queries (*.sql *.SQL)" ) + QStringLiteral( ";;" ) + QObject::tr( "All files" ) + QStringLiteral( " (*.*)" ),
+      &selectedFilter
+    );
+
+    if ( !newPath.isEmpty() )
+    {
+      QFileInfo fi( newPath );
+      settingLastSourceFolder->setValue( fi.path() );
+
+      if ( !selectedFilter.contains( QStringLiteral( "*.*)" ) ) )
+        newPath = QgsFileUtils::ensureFileNameHasExtension( newPath, { QStringLiteral( "sql" ) } );
+      mCodeEditorWidget->save( newPath );
+      setHasChanged( false );
+    }
+  }
+  else if ( !mCodeEditorWidget->filePath().isEmpty() )
+  {
+    mCodeEditorWidget->save();
+    setHasChanged( false );
+  }
+}
+
 QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions QgsQueryResultWidget::sqlVectorLayerOptions() const
 {
-  mSqlVectorLayerOptions.sql = mSqlEditor->text().replace( QRegularExpression( ";\\s*$" ), QString() );
+  const thread_local QRegularExpression rx( QStringLiteral( ";\\s*$" ) );
+  mSqlVectorLayerOptions.sql = mSqlEditor->text().replace( rx, QString() );
   mSqlVectorLayerOptions.filter = mFilterLineEdit->text();
   mSqlVectorLayerOptions.primaryKeyColumns = mPkColumnsComboBox->checkedItems();
   mSqlVectorLayerOptions.geometryColumn = mGeometryColumnComboBox->currentText();
@@ -586,11 +662,72 @@ void QgsQueryResultWidget::setQuery( const QString &sql )
   mActionRedo->setEnabled( false );
 }
 
+
+bool QgsQueryResultWidget::promptUnsavedChanges()
+{
+  if ( !mCodeEditorWidget->filePath().isEmpty() && mHasChangedFileContents )
+  {
+    const QMessageBox::StandardButton ret = QMessageBox::question(
+      this,
+      tr( "Save Query?" ),
+      tr(
+        "There are unsaved changes in this query. Do you want to save those?"
+      ),
+      QMessageBox::StandardButton::Save
+        | QMessageBox::StandardButton::Cancel
+        | QMessageBox::StandardButton::Discard,
+      QMessageBox::StandardButton::Cancel
+    );
+
+    if ( ret == QMessageBox::StandardButton::Save )
+    {
+      saveQuery( false );
+      return true;
+    }
+    else if ( ret == QMessageBox::StandardButton::Discard )
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  else
+  {
+    return true;
+  }
+}
+
+
 void QgsQueryResultWidget::notify( const QString &title, const QString &text, Qgis::MessageLevel level )
 {
   mMessageBar->pushMessage( title, text, level );
 }
 
+
+void QgsQueryResultWidget::setHasChanged( bool hasChanged )
+{
+  mHasChangedFileContents = hasChanged;
+  mActionSaveQuery->setEnabled( hasChanged );
+  updateDialogTitle();
+}
+
+void QgsQueryResultWidget::updateDialogTitle()
+{
+  QString fileName;
+  if ( !mCodeEditorWidget->filePath().isEmpty() )
+  {
+    const QFileInfo fi( mCodeEditorWidget->filePath() );
+    fileName = fi.fileName();
+    if ( mHasChangedFileContents )
+    {
+      fileName.prepend( '*' );
+    }
+  }
+
+  emit requestDialogTitleUpdate( fileName );
+}
 
 ///@cond private
 
@@ -732,3 +869,81 @@ QString QgsQueryResultItemDelegate::displayText( const QVariant &value, const QL
 }
 
 ///@endcond private
+
+//
+// QgsQueryResultDialog
+//
+
+QgsQueryResultDialog::QgsQueryResultDialog( QgsAbstractDatabaseProviderConnection *connection, QWidget *parent )
+  : QDialog( parent )
+{
+  setObjectName( QStringLiteral( "QgsQueryResultDialog" ) );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mWidget = new QgsQueryResultWidget( this, connection );
+  QVBoxLayout *l = new QVBoxLayout();
+  l->setContentsMargins( 0, 0, 0, 0 );
+  l->addWidget( mWidget );
+  setLayout( l );
+}
+
+void QgsQueryResultDialog::closeEvent( QCloseEvent *event )
+{
+  if ( !mWidget->promptUnsavedChanges() )
+  {
+    event->ignore();
+  }
+  else
+  {
+    event->accept();
+  }
+}
+
+//
+// QgsQueryResultMainWindow
+//
+
+QgsQueryResultMainWindow::QgsQueryResultMainWindow( QgsAbstractDatabaseProviderConnection *connection, const QString &identifierName )
+  : mIdentifierName( identifierName )
+{
+  setObjectName( QStringLiteral( "SQLCommandsDialog" ) );
+
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mWidget = new QgsQueryResultWidget( nullptr, connection );
+  setCentralWidget( mWidget );
+
+  connect( mWidget, &QgsQueryResultWidget::requestDialogTitleUpdate, this, &QgsQueryResultMainWindow::updateWindowTitle );
+
+  updateWindowTitle( QString() );
+}
+
+void QgsQueryResultMainWindow::closeEvent( QCloseEvent *event )
+{
+  if ( !mWidget->promptUnsavedChanges() )
+  {
+    event->ignore();
+  }
+  else
+  {
+    event->accept();
+  }
+}
+
+void QgsQueryResultMainWindow::updateWindowTitle( const QString &fileName )
+{
+  if ( fileName.isEmpty() )
+  {
+    if ( !mIdentifierName.isEmpty() )
+      setWindowTitle( tr( "%1 — Execute SQL" ).arg( mIdentifierName ) );
+    else
+      setWindowTitle( tr( "Execute SQL" ) );
+  }
+  else
+  {
+    if ( !mIdentifierName.isEmpty() )
+      setWindowTitle( tr( "%1 — %2 — Execute SQL" ).arg( fileName, mIdentifierName ) );
+    else
+      setWindowTitle( tr( "%1 — Execute SQL" ).arg( fileName ) );
+  }
+}

--- a/src/gui/qgsqueryresultwidget.h
+++ b/src/gui/qgsqueryresultwidget.h
@@ -145,7 +145,6 @@ class GUI_EXPORT QgsQueryResultWidget : public QWidget, private Ui::QgsQueryResu
      */
     void setQuery( const QString &sql );
 
-
   public slots:
 
     /**

--- a/src/ui/qgsqueryresultwidgetbase.ui
+++ b/src/ui/qgsqueryresultwidgetbase.ui
@@ -14,205 +14,342 @@
    <string notr="true">Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="QgsMessageBar" name="mMessageBar" native="true"/>
-   </item>
-   <item>
-    <widget class="QWidget" name="mSqlEditorContainer" native="true"/>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,1,0,0">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
      <item>
-      <widget class="QPushButton" name="mExecuteButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Execute</string>
-       </property>
+      <widget class="QToolBar" name="mToolBar">
+       <addaction name="mActionCut"/>
+       <addaction name="mActionCopy"/>
+       <addaction name="mActionPaste"/>
+       <addaction name="separator"/>
+       <addaction name="mActionUndo"/>
+       <addaction name="mActionRedo"/>
+       <addaction name="separator"/>
+       <addaction name="mActionFindReplace"/>
+       <addaction name="separator"/>
+       <addaction name="mActionClear"/>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="mStopButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Stop</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="mStatusLabel">
-       <property name="text">
-        <string>Status and errors goes here.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QProgressBar" name="mProgressBar">
-       <property name="value">
-        <number>24</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mClearButton">
-       <property name="toolTip">
-        <string>Clear</string>
-       </property>
-       <property name="text">
-        <string>Clear</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/console/iconClearConsole.svg</normaloff>:/images/themes/default/console/iconClearConsole.svg</iconset>
-       </property>
-       <property name="autoRaise">
-        <bool>false</bool>
-       </property>
-      </widget>
+      <widget class="QgsMessageBar" name="mMessageBar" native="true"/>
      </item>
     </layout>
    </item>
    <item>
-    <widget class="QTableView" name="mQueryResultsTableView"/>
-   </item>
-   <item>
-    <widget class="QgsCodeEditorSQL" name="mSqlErrorText" native="true"/>
-   </item>
-   <item>
-    <widget class="QgsCollapsibleGroupBox" name="mLoadAsNewLayerGroupBox">
-     <property name="title">
-      <string>Load as new layer</string>
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <property name="leftMargin">
+      <number>6</number>
      </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="mPkColumnsCheckBox">
-        <property name="toolTip">
-         <string>Column(s) that can be used as an index to uniquely identify features, they are usually part of a primary key.</string>
-        </property>
-        <property name="text">
-         <string>Column(s) with unique values</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsCheckableComboBox" name="mPkColumnsComboBox"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="mGeometryColumnCheckBox">
-        <property name="toolTip">
-         <string>Column that contains the geometry.</string>
-        </property>
-        <property name="text">
-         <string>Geometry column</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="mGeometryColumnComboBox"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="mFilterLabel">
-        <property name="toolTip">
-         <string>SQL filter to restrict the features available in the layer</string>
-        </property>
-        <property name="text">
-         <string>Subset filter</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLineEdit" name="mFilterLineEdit">
-          <property name="text">
-           <string/>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>6</number>
+     </property>
+     <property name="bottomMargin">
+      <number>6</number>
+     </property>
+     <item>
+      <widget class="QWidget" name="mSqlEditorContainer" native="true"/>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,1,0">
+       <item>
+        <widget class="QPushButton" name="mExecuteButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Execute</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="mStopButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Stop</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="mStatusLabel">
+         <property name="text">
+          <string>Status and errors goes here.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QProgressBar" name="mProgressBar">
+         <property name="value">
+          <number>24</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QTableView" name="mQueryResultsTableView"/>
+     </item>
+     <item>
+      <widget class="QgsCodeEditorSQL" name="mSqlErrorText" native="true"/>
+     </item>
+     <item>
+      <widget class="QgsCollapsibleGroupBox" name="mLoadAsNewLayerGroupBox">
+       <property name="title">
+        <string>Load as new layer</string>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="mPkColumnsCheckBox">
+          <property name="toolTip">
+           <string>Column(s) that can be used as an index to uniquely identify features, they are usually part of a primary key.</string>
           </property>
-          <property name="placeholderText">
-           <string>Enter the optional SQL filter or click on the button to open the query builder tool</string>
+          <property name="text">
+           <string>Column(s) with unique values</string>
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QToolButton" name="mFilterToolButton">
+        <item row="0" column="1">
+         <widget class="QgsCheckableComboBox" name="mPkColumnsComboBox"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="mGeometryColumnCheckBox">
+          <property name="toolTip">
+           <string>Column that contains the geometry.</string>
+          </property>
           <property name="text">
-           <string>...</string>
+           <string>Geometry column</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="mGeometryColumnComboBox"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="mFilterLabel">
+          <property name="toolTip">
+           <string>SQL filter to restrict the features available in the layer</string>
+          </property>
+          <property name="text">
+           <string>Subset filter</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QLineEdit" name="mFilterLineEdit">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="placeholderText">
+             <string>Enter the optional SQL filter or click on the button to open the query builder tool</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="mFilterToolButton">
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="4" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLineEdit" name="mLayerNameLineEdit">
+            <property name="text">
+             <string>QueryLayer</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="6" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="mLoadLayerPushButton">
+            <property name="text">
+             <string>Load Layer</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="mAvoidSelectingAsFeatureIdCheckBox">
+          <property name="toolTip">
+           <string>Disable 'Fast Access to Features at ID' capability to force keeping the attribute table in memory (e.g. in case of expensive views)</string>
+          </property>
+          <property name="text">
+           <string>Avoid selecting by feature ID</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="mLayerNameLabel">
+          <property name="text">
+           <string>Layer name</string>
           </property>
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="4" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLineEdit" name="mLayerNameLineEdit">
-          <property name="text">
-           <string>QueryLayer</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="6" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="mLoadLayerPushButton">
-          <property name="text">
-           <string>Load Layer</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="mAvoidSelectingAsFeatureIdCheckBox">
-        <property name="toolTip">
-         <string>Disable 'Fast Access to Features at ID' capability to force keeping the attribute table in memory (e.g. in case of expensive views)</string>
-        </property>
-        <property name="text">
-         <string>Avoid selecting by feature ID</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="mLayerNameLabel">
-        <property name="text">
-         <string>Layer name</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
+  <action name="mActionCut">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditCut.svg</normaloff>:/images/themes/default/mActionEditCut.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Cut</string>
+   </property>
+   <property name="toolTip">
+    <string>Cut</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+X</string>
+   </property>
+  </action>
+  <action name="mActionCopy">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Copy</string>
+   </property>
+   <property name="toolTip">
+    <string>Copy</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+C</string>
+   </property>
+  </action>
+  <action name="mActionPaste">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditPaste.svg</normaloff>:/images/themes/default/mActionEditPaste.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Paste</string>
+   </property>
+   <property name="toolTip">
+    <string>Paste</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V</string>
+   </property>
+  </action>
+  <action name="mActionUndo">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Undo</string>
+   </property>
+   <property name="toolTip">
+    <string>Undo</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Z</string>
+   </property>
+  </action>
+  <action name="mActionRedo">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionRedo.svg</normaloff>:/images/themes/default/mActionRedo.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Redo</string>
+   </property>
+   <property name="toolTip">
+    <string>Redo</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Z</string>
+   </property>
+  </action>
+  <action name="mActionFindReplace">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFindReplace.svg</normaloff>:/images/themes/default/mActionFindReplace.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Find &amp;&amp; &amp;Replace</string>
+   </property>
+  </action>
+  <action name="mActionClear">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/console/iconClearConsole.svg</normaloff>:/images/themes/default/console/iconClearConsole.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Clear</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::NoRole</enum>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -240,10 +377,8 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mClearButton</tabstop>
   <tabstop>mExecuteButton</tabstop>
   <tabstop>mStopButton</tabstop>
-  <tabstop>mQueryResultsTableView</tabstop>
   <tabstop>mPkColumnsCheckBox</tabstop>
   <tabstop>mPkColumnsComboBox</tabstop>
   <tabstop>mGeometryColumnCheckBox</tabstop>

--- a/src/ui/qgsqueryresultwidgetbase.ui
+++ b/src/ui/qgsqueryresultwidgetbase.ui
@@ -61,7 +61,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_3">
+    <layout class="QVBoxLayout" name="mainLayout">
      <property name="leftMargin">
       <number>6</number>
      </property>
@@ -78,7 +78,7 @@
       <widget class="QWidget" name="mSqlEditorContainer" native="true"/>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,1,0">
+      <layout class="QHBoxLayout" name="progressLayout" stretch="0,0,0,1,0">
        <item>
         <widget class="QPushButton" name="mExecuteButton">
          <property name="enabled">

--- a/src/ui/qgsqueryresultwidgetbase.ui
+++ b/src/ui/qgsqueryresultwidgetbase.ui
@@ -39,6 +39,10 @@
      </property>
      <item>
       <widget class="QToolBar" name="mToolBar">
+       <addaction name="mActionOpenQuery"/>
+       <addaction name="mActionSaveQuery"/>
+       <addaction name="mActionSaveQueryAs"/>
+       <addaction name="separator"/>
        <addaction name="mActionCut"/>
        <addaction name="mActionCopy"/>
        <addaction name="mActionPaste"/>
@@ -348,6 +352,51 @@
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
+   </property>
+  </action>
+  <action name="mActionOpenQuery">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Open Query…</string>
+   </property>
+   <property name="toolTip">
+    <string>Open Query</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
+  </action>
+  <action name="mActionSaveQuery">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Save Query…</string>
+   </property>
+   <property name="toolTip">
+    <string>Save Query</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="mActionSaveQueryAs">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileSaveAs.svg</normaloff>:/images/themes/default/mActionFileSaveAs.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Save Query as…</string>
+   </property>
+   <property name="toolTip">
+    <string>Save Query as</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This adds support for saving and loading SQL queries to a .sql text file to the Execute SQL dialog and Update SQL dialogs.
    
Effectively, it ports this functionality from the DB Manager plugin over to the core browser-based database connection facilities.
    
The UX has been designed to mimic the same functionality from other standard parts of QGIS, eg the Processing Script Editor. Toolbar actions are used accordingly, instead of the old text button approach used in DB Manager. To accompany the new toolbar I've also added standard actions for operations like copy/paste/undo/redo, again mimicing the Processing Script Editor dialog UI
    
Sponsored by City of Canning

![image](https://github.com/user-attachments/assets/1c43cd1a-1b28-4190-a4ba-845af08f3d6c)


