### PR TITLE
explicitly set UTF-8 encoding when reading/writing color palettes (fix #60740)

### DIFF
--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -3826,6 +3826,10 @@ bool QgsSymbolLayerUtils::saveColorsToGpl( QFile &file, const QString &paletteNa
   }
 
   QTextStream stream( &file );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  stream.setCodec( "UTF-8" );
+#endif
+
   stream << "GIMP Palette" << Qt::endl;
   if ( paletteName.isEmpty() )
   {
@@ -3864,6 +3868,9 @@ QgsNamedColorList QgsSymbolLayerUtils::importColorsFromGpl( QFile &file, bool &o
   }
 
   QTextStream in( &file );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  in.setCodec( "UTF-8" );
+#endif
 
   QString line = in.readLine();
   if ( !line.startsWith( QLatin1String( "GIMP Palette" ) ) )


### PR DESCRIPTION
## Description

Explicitly set UTF-8 encoding when writing and reading color palletes to/from file.

Fixes #60740.