### PR TITLE
Add missing clone method to QgsNominatimLocatorFilter

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsgeocoderlocatorfilter.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgeocoderlocatorfilter.sip.in
@@ -49,6 +49,8 @@ filter.
     virtual QgsLocatorFilter *clone() const /Factory/;
 
 
+  protected:
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsgeocoderlocatorfilter.sip.in
+++ b/python/gui/auto_generated/qgsgeocoderlocatorfilter.sip.in
@@ -49,6 +49,8 @@ filter.
     virtual QgsLocatorFilter *clone() const /Factory/;
 
 
+  protected:
+
 };
 
 /************************************************************************

--- a/src/app/locator/qgsnominatimlocatorfilter.cpp
+++ b/src/app/locator/qgsnominatimlocatorfilter.cpp
@@ -33,6 +33,13 @@ QgsNominatimLocatorFilter::QgsNominatimLocatorFilter( QgsGeocoderInterface *geoc
   setUseWithoutPrefix( false );
 }
 
+QgsNominatimLocatorFilter *QgsNominatimLocatorFilter::clone() const
+{
+  auto filter = std::make_unique< QgsNominatimLocatorFilter >( geocoder(), mCanvas );
+  filter->setFetchResultsDelay( fetchResultsDelay() );
+  return filter.release();
+}
+
 void QgsNominatimLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
   QgsSettings settings;

--- a/src/app/locator/qgsnominatimlocatorfilter.h
+++ b/src/app/locator/qgsnominatimlocatorfilter.h
@@ -28,6 +28,7 @@ class APP_EXPORT QgsNominatimLocatorFilter : public QgsGeocoderLocatorFilter
 
   public:
     QgsNominatimLocatorFilter( QgsGeocoderInterface *geocoder, QgsMapCanvas *canvas );
+    QgsNominatimLocatorFilter *clone() const override SIP_FACTORY;
 
     void triggerResult( const QgsLocatorResult &result ) override;
 };

--- a/src/gui/qgsgeocoderlocatorfilter.h
+++ b/src/gui/qgsgeocoderlocatorfilter.h
@@ -59,10 +59,14 @@ class GUI_EXPORT QgsGeocoderLocatorFilter : public QgsAbstractGeocoderLocatorFil
 
     QgsLocatorFilter *clone() const override SIP_FACTORY;
 
+  protected:
+    /**
+     * Associated map canvas
+     */
+    QgsMapCanvas *mCanvas = nullptr;
+
   private:
     void handleGeocodeResult( const QgsGeocoderResult &result ) override;
-
-    QgsMapCanvas *mCanvas = nullptr;
 };
 
 #endif // QGSGEOCODERLOCATORFILTER_H


### PR DESCRIPTION
Fixes missing accreditation message when triggering results
