### PR TITLE
[DXF] Fix writing the codec name and set the correct DXF version (Fix #60802)

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -2354,20 +2354,17 @@ QString QgsDxfExport::layerName( const QString &id, const QgsFeature &f ) const
 
 QString QgsDxfExport::dxfEncoding( const QString &name )
 {
-  const QList< QByteArray > codecs = QTextCodec::availableCodecs();
-  for ( const QByteArray &codec : codecs )
+  const QByteArray codec = name.toLocal8Bit();
+  if ( QTextCodec::codecForName( codec ) )
   {
-    if ( name != codec )
-      continue;
-
     int i;
     for ( i = 0; i < static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) && strcasecmp( codec.data(), DXF_ENCODINGS[i][1] ) != 0; ++i )
       ;
 
-    if ( i == static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) )
-      continue;
-
-    return DXF_ENCODINGS[i][0];
+    if ( i != static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) )
+    {
+      return DXF_ENCODINGS[i][0];
+    }
   }
 
   return QString();

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -2361,7 +2361,7 @@ QString QgsDxfExport::dxfEncoding( const QString &name )
       continue;
 
     int i;
-    for ( i = 0; i < static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) && name != DXF_ENCODINGS[i][1]; ++i )
+    for ( i = 0; i < static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) && strcasecmp( codec.data(), DXF_ENCODINGS[i][1] ) != 0; ++i )
       ;
 
     if ( i == static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) )

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -319,7 +319,7 @@ void QgsDxfExport::writeHeader( const QString &codepage )
 
   // ACADVER
   writeGroup( 9, QStringLiteral( "$ACADVER" ) );
-  writeGroup( 1, QStringLiteral( "AC1015" ) );
+  writeGroup( 1, QStringLiteral( "AC1018" ) );
 
   // EXTMIN
   writeGroup( 9, QStringLiteral( "$EXTMIN" ) );


### PR DESCRIPTION
## Description

This PR
- ensures the codec name is written in the exported DXF file (on some systems, like Windows / OSGeo4W, some codecs' names were not written due to case mismatch)
- sets $ACADVER to AC1018 (AutoCAD 2004) because codes 420 and 440 (which are written in the DXF file by QgsDxfEport) are listed in DXF specs only since AutoCAD 2004

Fixes #60802.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
