### PR TITLE
Rework layer "Execute SQL" action to use non-modal dialog

### DIFF
--- a/src/core/qgsmaplayerutils.cpp
+++ b/src/core/qgsmaplayerutils.cpp
@@ -91,14 +91,14 @@ QgsRectangle QgsMapLayerUtils::combinedExtent( const QList<QgsMapLayer *> &layer
 
 QgsAbstractDatabaseProviderConnection *QgsMapLayerUtils::databaseConnection( const QgsMapLayer *layer )
 {
-  if ( ! layer || ! layer->dataProvider() )
+  if ( !layer )
   {
     return nullptr;
   }
 
   try
   {
-    QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( layer->dataProvider()->name() );
+    QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( layer->providerType() );
     if ( ! providerMetadata )
     {
       return nullptr;


### PR DESCRIPTION
If the "Execute SQL" command is executed through the browser, then the window is opened as a non-modal QMainWindow. If however the same command was used via the layer right-click menu, the dialog would open as a blocking modal dialog.

Rework the layer right-click version to also use a non-modal QMainWindow, and ensure that no references to the layer instance are required in the connected slots
