### PR TITLE
Validate SQL for new layer before attempting to create

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -592,11 +592,34 @@ Executes raw ``sql`` and returns the (possibly empty) list of results in a multi
 
     virtual QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const  /Factory/;
 %Docstring
-Creates and returns a (possibly invalid) vector layer based on the ``sql`` statement and optional ``options``.
+Creates and returns a (possibly invalid) vector layer based on a SQL statement and ``options``.
+
+The :py:func:`~QgsAbstractDatabaseProviderConnection.validateSqlVectorLayer` method can be used in advance to test whether the options are valid
+for the provider, and retrieve a user-friendly explanation if not.
 
 :raises QgsProviderConnectionException: if any errors are encountered or if SQL layer creation is not supported.
 
+.. seealso:: :py:func:`validateSqlVectorLayer`
+
 .. versionadded:: 3.22
+%End
+
+    virtual bool validateSqlVectorLayer( const SqlVectorLayerOptions &options, QString &message /Out/ ) const;
+%Docstring
+Validates the SQL query ``options`` to determine if it is possible to create a vector layer based on a SQL statement and ``options``.
+
+The base class method returns ``True`` and does not do any checks.
+
+:param options: SQL statement and options
+
+:return: - ``True`` if the SQL is valid for the provider.
+         - message: a translated, user-friendly explanation if the SQL is not valid for the provider.
+
+:raises QgsProviderConnectionException: if any errors are encountered or if SQL layer creation is not supported.
+
+.. seealso:: :py:func:`createSqlVectorLayer`
+
+.. versionadded:: 3.44
 %End
 
     virtual SqlVectorLayerOptions sqlOptions( const QString &layerSource );

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -592,11 +592,34 @@ Executes raw ``sql`` and returns the (possibly empty) list of results in a multi
 
     virtual QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const throw( QgsProviderConnectionException ) /Factory/;
 %Docstring
-Creates and returns a (possibly invalid) vector layer based on the ``sql`` statement and optional ``options``.
+Creates and returns a (possibly invalid) vector layer based on a SQL statement and ``options``.
+
+The :py:func:`~QgsAbstractDatabaseProviderConnection.validateSqlVectorLayer` method can be used in advance to test whether the options are valid
+for the provider, and retrieve a user-friendly explanation if not.
 
 :raises QgsProviderConnectionException: if any errors are encountered or if SQL layer creation is not supported.
 
+.. seealso:: :py:func:`validateSqlVectorLayer`
+
 .. versionadded:: 3.22
+%End
+
+    virtual bool validateSqlVectorLayer( const SqlVectorLayerOptions &options, QString &message /Out/ ) const throw( QgsProviderConnectionException );
+%Docstring
+Validates the SQL query ``options`` to determine if it is possible to create a vector layer based on a SQL statement and ``options``.
+
+The base class method returns ``True`` and does not do any checks.
+
+:param options: SQL statement and options
+
+:return: - ``True`` if the SQL is valid for the provider.
+         - message: a translated, user-friendly explanation if the SQL is not valid for the provider.
+
+:raises QgsProviderConnectionException: if any errors are encountered or if SQL layer creation is not supported.
+
+.. seealso:: :py:func:`createSqlVectorLayer`
+
+.. versionadded:: 3.44
 %End
 
     virtual SqlVectorLayerOptions sqlOptions( const QString &layerSource ) throw( QgsProviderConnectionException );

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1188,6 +1188,12 @@ QgsVectorLayer *QgsAbstractDatabaseProviderConnection::createSqlVectorLayer( con
   return nullptr;
 }
 
+bool QgsAbstractDatabaseProviderConnection::validateSqlVectorLayer( const SqlVectorLayerOptions &, QString & ) const
+{
+  checkCapability( Capability::SqlLayers );
+  return true;
+}
+
 void QgsAbstractDatabaseProviderConnection::deleteSpatialIndex( const QString &, const QString &, const QString & ) const
 {
   checkCapability( Capability::DeleteSpatialIndex );

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -717,11 +717,34 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual QList<QList<QVariant>> executeSql( const QString &sql, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
-     * Creates and returns a (possibly invalid) vector layer based on the \a sql statement and optional \a options.
+     * Creates and returns a (possibly invalid) vector layer based on a SQL statement and \a options.
+     *
+     * The validateSqlVectorLayer() method can be used in advance to test whether the options are valid
+     * for the provider, and retrieve a user-friendly explanation if not.
+     *
      * \throws QgsProviderConnectionException if any errors are encountered or if SQL layer creation is not supported.
+     * \see validateSqlVectorLayer()
+     *
      * \since QGIS 3.22
      */
     virtual QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const SIP_THROW( QgsProviderConnectionException ) SIP_FACTORY;
+
+    /**
+     * Validates the SQL query \a options to determine if it is possible to create a vector layer based on a SQL statement and \a options.
+     *
+     * The base class method returns TRUE and does not do any checks.
+     *
+     * \param options SQL statement and options
+     * \param message will be set to a translated, user-friendly explanation if the SQL is not valid for the provider.
+     *
+     * \returns TRUE if the SQL is valid for the provider.
+     *
+     * \throws QgsProviderConnectionException if any errors are encountered or if SQL layer creation is not supported.
+     * \see createSqlVectorLayer()
+     *
+     * \since QGIS 3.44
+     */
+    virtual bool validateSqlVectorLayer( const SqlVectorLayerOptions &options, QString &message SIP_OUT ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
      * Returns the SQL layer options from a \a layerSource.

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -105,7 +105,25 @@ QgsQueryResultWidget::QgsQueryResultWidget( QWidget *parent, QgsAbstractDatabase
   connect( mLoadLayerPushButton, &QPushButton::pressed, this, [=] {
     if ( mConnection )
     {
-      emit createSqlVectorLayer( mConnection->providerKey(), mConnection->uri(), sqlVectorLayerOptions() );
+      const QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions options = sqlVectorLayerOptions();
+
+      try
+      {
+        QString message;
+        const bool res = mConnection->validateSqlVectorLayer( options, message );
+        if ( !res )
+        {
+          mMessageBar->pushCritical( QString(), message );
+        }
+        else
+        {
+          emit createSqlVectorLayer( mConnection->providerKey(), mConnection->uri(), options );
+        }
+      }
+      catch ( QgsProviderConnectionException &e )
+      {
+        mMessageBar->pushCritical( tr( "Error validating query" ), e.what() );
+      }
     }
   } );
   connect( mSqlEditor, &QgsCodeEditorSQL::textChanged, this, &QgsQueryResultWidget::updateButtons );

--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -389,19 +389,17 @@ bool QgsMssqlDatabase::loadQueryFields( FieldDetails &details, const QString &qu
 
     QString name = dbQuery.value( 2 ).toString();
     if ( name.isEmpty() )
-      name = QStringLiteral( "col%1" ).arg( fieldIndex );
-
+      name = QStringLiteral( "__unnamed__%1" ).arg( fieldIndex );
     const bool isNullable = dbQuery.value( 3 ).toInt();
     const QString systemTypeName = dbQuery.value( 5 ).toString();
     const int maxLength = dbQuery.value( 6 ).toInt();
     const int precision = dbQuery.value( 7 ).toInt();
     const int scale = dbQuery.value( 8 ).toInt();
 
-
     // if we don't have an explicitly set geometry column name, and this is a geometry column, then use it
     // but if we DO have an explicitly set geometry column name, then load the other information if this is that column
     if ( ( details.geometryColumnName.isEmpty() && ( systemTypeName == QLatin1String( "geometry" ) || systemTypeName == QLatin1String( "geography" ) ) )
-         || name == details.geometryColumnName )
+         || ( !name.isEmpty() && name == details.geometryColumnName ) )
     {
       details.geometryColumnName = name;
       details.geometryColumnType = systemTypeName;

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -69,6 +69,7 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
     QgsProviderSqlQueryBuilder *queryBuilder() const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
+    bool validateSqlVectorLayer( const SqlVectorLayerOptions &options, QString &message ) const override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
 
   private:


### PR DESCRIPTION
Pre-validate the SQL before trying to create the layer, and show a user-friendly descriptive message if the query isn't valid for a QGIS layer.

Implemented here for SQL Server connections, showing a descriptive message if the user attempts to create a query layer with unnamed computed columns. These cannot be used in QGIS query layers, as SQL Server cannot use them in the sub-queries (eg we cannot do a SELECT COUNT(*) on them)