### PR TITLE
[LegendUrl] Make legend url part of server properties

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -1446,24 +1446,40 @@ Returns pointer to layer's undo stack
 Returns pointer to layer's style undo stack
 %End
 
-    void setLegendUrl( const QString &legendUrl );
+ void setLegendUrl( const QString &legendUrl ) /Deprecated="Since 3.44. Use serverProperties()->setLegendUrl() instead."/;
 %Docstring
 Sets the URL for the layer's legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setLegendUrl` instead.
 %End
 
-    QString legendUrl() const;
+ QString legendUrl() const /Deprecated="Since 3.44. Use serverProperties()->legendUrl() instead."/;
 %Docstring
 Returns the URL for the layer's legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.legendUrl` instead.
 %End
 
-    void setLegendUrlFormat( const QString &legendUrlFormat );
+ void setLegendUrlFormat( const QString &legendUrlFormat ) /Deprecated="Since 3.44. Use serverProperties()->setLegendUrlFormat() instead."/;
 %Docstring
 Sets the format for a URL based layer legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setLegendUrlFormat` instead.
 %End
 
-    QString legendUrlFormat() const;
+ QString legendUrlFormat() const /Deprecated="Since 3.44. Use serverProperties()->legendUrlFormat() instead."/;
 %Docstring
 Returns the format for a URL based layer legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.legendUrlFormat` instead.
 %End
 
     void setLegend( QgsMapLayerLegend *legend /Transfer/ );
@@ -2318,7 +2334,6 @@ happens.
 
 .. versionadded:: 3.20
 %End
-
 
 
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -422,6 +422,34 @@ Attribution indicates the provider of a layer or collection of layers.
 .. versionadded:: 3.38
 %End
 
+    void setLegendUrl( const QString &legendUrl );
+%Docstring
+Sets the URL for the layer's legend.
+
+.. versionadded:: 3.44
+%End
+
+    QString legendUrl() const;
+%Docstring
+Returns the URL for the layer's legend.
+
+.. versionadded:: 3.44
+%End
+
+    void setLegendUrlFormat( const QString &legendUrlFormat );
+%Docstring
+Sets the format for a URL based layer legend.
+
+.. versionadded:: 3.44
+%End
+
+    QString legendUrlFormat() const;
+%Docstring
+Returns the format for a URL based layer legend.
+
+.. versionadded:: 3.44
+%End
+
     virtual const QgsMapLayer *layer() const;
 %Docstring
 Gets the parent layer
@@ -438,7 +466,6 @@ class QgsVectorLayerServerProperties: QgsMapLayerServerProperties
     static const QMetaObject staticMetaObject;
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1446,24 +1446,40 @@ Returns pointer to layer's undo stack
 Returns pointer to layer's style undo stack
 %End
 
-    void setLegendUrl( const QString &legendUrl );
+ void setLegendUrl( const QString &legendUrl ) /Deprecated="Since 3.44. Use serverProperties()->setLegendUrl() instead."/;
 %Docstring
 Sets the URL for the layer's legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setLegendUrl` instead.
 %End
 
-    QString legendUrl() const;
+ QString legendUrl() const /Deprecated="Since 3.44. Use serverProperties()->legendUrl() instead."/;
 %Docstring
 Returns the URL for the layer's legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.legendUrl` instead.
 %End
 
-    void setLegendUrlFormat( const QString &legendUrlFormat );
+ void setLegendUrlFormat( const QString &legendUrlFormat ) /Deprecated="Since 3.44. Use serverProperties()->setLegendUrlFormat() instead."/;
 %Docstring
 Sets the format for a URL based layer legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.setLegendUrlFormat` instead.
 %End
 
-    QString legendUrlFormat() const;
+ QString legendUrlFormat() const /Deprecated="Since 3.44. Use serverProperties()->legendUrlFormat() instead."/;
 %Docstring
 Returns the format for a URL based layer legend.
+
+.. deprecated:: 3.44
+
+   Use :py:func:`~QgsMapLayer.serverProperties`->:py:func:`~QgsMapLayer.legendUrlFormat` instead.
 %End
 
     void setLegend( QgsMapLayerLegend *legend /Transfer/ );
@@ -2318,7 +2334,6 @@ happens.
 
 .. versionadded:: 3.20
 %End
-
 
 
 

--- a/python/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -422,6 +422,34 @@ Attribution indicates the provider of a layer or collection of layers.
 .. versionadded:: 3.38
 %End
 
+    void setLegendUrl( const QString &legendUrl );
+%Docstring
+Sets the URL for the layer's legend.
+
+.. versionadded:: 3.44
+%End
+
+    QString legendUrl() const;
+%Docstring
+Returns the URL for the layer's legend.
+
+.. versionadded:: 3.44
+%End
+
+    void setLegendUrlFormat( const QString &legendUrlFormat );
+%Docstring
+Sets the format for a URL based layer legend.
+
+.. versionadded:: 3.44
+%End
+
+    QString legendUrlFormat() const;
+%Docstring
+Returns the format for a URL based layer legend.
+
+.. versionadded:: 3.44
+%End
+
     virtual const QgsMapLayer *layer() const;
 %Docstring
 Gets the parent layer
@@ -438,7 +466,6 @@ class QgsVectorLayerServerProperties: QgsMapLayerServerProperties
     static const QMetaObject staticMetaObject;
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -152,8 +152,6 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   layer->setMaximumScale( maximumScale() );
   layer->setMinimumScale( minimumScale() );
   layer->setScaleBasedVisibility( hasScaleBasedVisibility() );
-  layer->setLegendUrl( legendUrl() );
-  layer->setLegendUrlFormat( legendUrlFormat() );
   layer->setDependencies( dependencies() );
   layer->mShouldValidateCrs = mShouldValidateCrs;
   layer->setCrs( crs() );
@@ -371,7 +369,34 @@ QString QgsMapLayer::attributionUrl() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
 
   return mServerProperties->attributionUrl();
+}
 
+void QgsMapLayer::setLegendUrl( const QString &legendUrl )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  mServerProperties->setLegendUrl( legendUrl );
+}
+
+QString QgsMapLayer::legendUrl() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->legendUrl();
+}
+
+void QgsMapLayer::setLegendUrlFormat( const QString &legendUrlFormat )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  mServerProperties->setLegendUrlFormat( legendUrlFormat );
+}
+
+QString QgsMapLayer::legendUrlFormat() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+
+  return mServerProperties->legendUrlFormat();
 }
 
 void QgsMapLayer::setMetadataUrl( const QString &metaUrl )
@@ -661,8 +686,8 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   const QDomElement legendUrlElem = layerElement.firstChildElement( QStringLiteral( "legendUrl" ) );
   if ( !legendUrlElem.isNull() )
   {
-    mLegendUrl = legendUrlElem.text();
-    mLegendUrlFormat = legendUrlElem.attribute( QStringLiteral( "format" ), QString() );
+    mServerProperties->setLegendUrl( legendUrlElem.text() );
+    mServerProperties->setLegendUrlFormat( legendUrlElem.attribute( QStringLiteral( "format" ), QString() ) );
   }
 
   serverProperties()->readXml( layerElement );
@@ -856,13 +881,13 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   }
 
   // layer legendUrl
-  const QString aLegendUrl = legendUrl();
+  const QString aLegendUrl = mServerProperties->legendUrl();
   if ( !aLegendUrl.isEmpty() )
   {
     QDomElement layerLegendUrl = document.createElement( QStringLiteral( "legendUrl" ) );
     const QDomText layerLegendUrlText = document.createTextNode( aLegendUrl );
     layerLegendUrl.appendChild( layerLegendUrlText );
-    layerLegendUrl.setAttribute( QStringLiteral( "format" ), legendUrlFormat() );
+    layerLegendUrl.setAttribute( QStringLiteral( "format" ), mServerProperties->legendUrlFormat() );
     layerElement.appendChild( layerLegendUrl );
   }
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -373,7 +373,7 @@ QString QgsMapLayer::attributionUrl() const
 
 void QgsMapLayer::setLegendUrl( const QString &legendUrl )
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   mServerProperties->setLegendUrl( legendUrl );
 }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -380,21 +380,21 @@ void QgsMapLayer::setLegendUrl( const QString &legendUrl )
 
 QString QgsMapLayer::legendUrl() const
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return mServerProperties->legendUrl();
 }
 
 void QgsMapLayer::setLegendUrlFormat( const QString &legendUrlFormat )
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   mServerProperties->setLegendUrlFormat( legendUrlFormat );
 }
 
 QString QgsMapLayer::legendUrlFormat() const
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS_NON_FATAL
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return mServerProperties->legendUrlFormat();
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1504,23 +1504,31 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Sets the URL for the layer's legend.
-    */
-    void setLegendUrl( const QString &legendUrl ) { mLegendUrl = legendUrl; }
+     *
+     * \deprecated QGIS 3.44. Use serverProperties()->setLegendUrl() instead.
+     */
+    Q_DECL_DEPRECATED void setLegendUrl( const QString &legendUrl ) SIP_DEPRECATED;
 
     /**
      * Returns the URL for the layer's legend.
+     *
+     * \deprecated QGIS 3.44. Use serverProperties()->legendUrl() instead.
      */
-    QString legendUrl() const { return mLegendUrl; }
+    Q_DECL_DEPRECATED QString legendUrl() const SIP_DEPRECATED;
 
     /**
      * Sets the format for a URL based layer legend.
+     *
+     * \deprecated QGIS 3.44. Use serverProperties()->setLegendUrlFormat() instead.
      */
-    void setLegendUrlFormat( const QString &legendUrlFormat ) { mLegendUrlFormat = legendUrlFormat; }
+    Q_DECL_DEPRECATED void setLegendUrlFormat( const QString &legendUrlFormat ) SIP_DEPRECATED;
 
     /**
      * Returns the format for a URL based layer legend.
+     *
+     * \deprecated QGIS 3.44. Use serverProperties()->legendUrlFormat() instead.
      */
-    QString legendUrlFormat() const { return mLegendUrlFormat; }
+    Q_DECL_DEPRECATED QString legendUrlFormat() const SIP_DEPRECATED;
 
     /**
      * Assign a legend controller to the map layer. The object will be responsible for providing legend items.
@@ -2277,10 +2285,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! Name of the layer - used for display
     QString mLayerName;
-
-    //! WMS legend
-    QString mLegendUrl;
-    QString mLegendUrlFormat;
 
     //! \brief Error
     QgsError mError;

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -227,6 +227,8 @@ void QgsMapLayerServerProperties::copyTo( QgsMapLayerServerProperties *propertie
   properties->setDataUrlFormat( mDataUrlFormat );
   properties->setAttribution( mAttribution );
   properties->setAttributionUrl( mAttributionUrl );
+  properties->setLegendUrl( mLegendUrl );
+  properties->setLegendUrlFormat( mLegendUrlFormat );
 }
 
 void QgsMapLayerServerProperties::reset() // cppcheck-suppress duplInheritedMember
@@ -300,4 +302,3 @@ void QgsMapLayerServerProperties::writeXml( QDomNode &layer_node, QDomDocument &
   // only called for SOME map layer subclasses!
   // Accordingly that logic is currently left in QgsMapLayer::writeLayerXml
 }
-

--- a/src/core/qgsmaplayerserverproperties.h
+++ b/src/core/qgsmaplayerserverproperties.h
@@ -486,6 +486,34 @@ class CORE_EXPORT QgsMapLayerServerProperties: public QgsServerMetadataUrlProper
      */
     QString attributionUrl() const { return mAttributionUrl; }
 
+    /**
+     * Sets the URL for the layer's legend.
+     *
+     * \since QGIS 3.44
+     */
+    void setLegendUrl( const QString &legendUrl ) { mLegendUrl = legendUrl; }
+
+    /**
+     * Returns the URL for the layer's legend.
+     *
+     * \since QGIS 3.44
+     */
+    QString legendUrl() const { return mLegendUrl; }
+
+    /**
+     * Sets the format for a URL based layer legend.
+     *
+     * \since QGIS 3.44
+     */
+    void setLegendUrlFormat( const QString &legendUrlFormat ) { mLegendUrlFormat = legendUrlFormat; }
+
+    /**
+     * Returns the format for a URL based layer legend.
+     *
+     * \since QGIS 3.44
+     */
+    QString legendUrlFormat() const { return mLegendUrlFormat; }
+
     //! Gets the parent layer
     const QgsMapLayer *layer() const override { return mLayer; };
 
@@ -505,6 +533,9 @@ class CORE_EXPORT QgsMapLayerServerProperties: public QgsServerMetadataUrlProper
     QString mAbstract;
     QString mKeywordList;
 
+    //! WMS legend
+    QString mLegendUrl;
+    QString mLegendUrlFormat;
 };
 
 /**
@@ -521,4 +552,3 @@ class CORE_EXPORT QgsVectorLayerServerProperties: public QgsMapLayerServerProper
 };
 
 #endif // QGSMAPLAYERSERVERPROPERTIES_H
-

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -867,8 +867,8 @@ void QgsRasterLayerProperties::sync()
   }
 
   // layer legend url
-  mLayerLegendUrlLineEdit->setText( mRasterLayer->legendUrl() );
-  mLayerLegendUrlFormatComboBox->setCurrentIndex( mLayerLegendUrlFormatComboBox->findText( mRasterLayer->legendUrlFormat() ) );
+  mLayerLegendUrlLineEdit->setText( mRasterLayer->serverProperties()->legendUrl() );
+  mLayerLegendUrlFormatComboBox->setCurrentIndex( mLayerLegendUrlFormatComboBox->findText( mRasterLayer->serverProperties()->legendUrlFormat() ) );
 
   mEnableMapTips->setChecked( mRasterLayer->mapTipsEnabled() );
   mMapTipWidget->setText( mRasterLayer->mapTipTemplate() );
@@ -1059,13 +1059,13 @@ void QgsRasterLayerProperties::apply()
   }
   mRasterLayer->serverProperties()->setMetadataUrls( metaUrls );
 
-  if ( mRasterLayer->legendUrl() != mLayerLegendUrlLineEdit->text() )
+  if ( mRasterLayer->serverProperties()->legendUrl() != mLayerLegendUrlLineEdit->text() )
     mMetadataFilled = false;
-  mRasterLayer->setLegendUrl( mLayerLegendUrlLineEdit->text() );
+  mRasterLayer->serverProperties()->setLegendUrl( mLayerLegendUrlLineEdit->text() );
 
-  if ( mRasterLayer->legendUrlFormat() != mLayerLegendUrlFormatComboBox->currentText() )
+  if ( mRasterLayer->serverProperties()->legendUrlFormat() != mLayerLegendUrlFormatComboBox->currentText() )
     mMetadataFilled = false;
-  mRasterLayer->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
+  mRasterLayer->serverProperties()->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
 
   if ( !mWMSPrintLayerLineEdit->text().isEmpty() )
   {

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -401,10 +401,10 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   }
 
   // layer legend url
-  mLayerLegendUrlLineEdit->setText( mLayer->legendUrl() );
+  mLayerLegendUrlLineEdit->setText( mLayer->serverProperties()->legendUrl() );
   mLayerLegendUrlFormatComboBox->setCurrentIndex(
     mLayerLegendUrlFormatComboBox->findText(
-      mLayer->legendUrlFormat()
+      mLayer->serverProperties()->legendUrlFormat()
     )
   );
 
@@ -890,13 +890,13 @@ void QgsVectorLayerProperties::apply()
   mLayer->serverProperties()->setMetadataUrls( metaUrls );
 
   // LegendURL
-  if ( mLayer->legendUrl() != mLayerLegendUrlLineEdit->text() )
+  if ( mLayer->serverProperties()->legendUrl() != mLayerLegendUrlLineEdit->text() )
     mMetadataFilled = false;
-  mLayer->setLegendUrl( mLayerLegendUrlLineEdit->text() );
+  mLayer->serverProperties()->setLegendUrl( mLayerLegendUrlLineEdit->text() );
 
-  if ( mLayer->legendUrlFormat() != mLayerLegendUrlFormatComboBox->currentText() )
+  if ( mLayer->serverProperties()->legendUrlFormat() != mLayerLegendUrlFormatComboBox->currentText() )
     mMetadataFilled = false;
-  mLayer->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
+  mLayer->serverProperties()->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
 
   //layer simplify drawing configuration
   Qgis::VectorRenderingSimplificationFlags simplifyHints = Qgis::VectorRenderingSimplificationFlag::NoSimplification;

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -167,8 +167,8 @@ void QgsVectorTileLayerProperties::apply()
   mLayer->serverProperties()->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
 
   // LegendURL
-  mLayer->setLegendUrl( mLayerLegendUrlLineEdit->text() );
-  mLayer->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
+  mLayer->serverProperties()->setLegendUrl( mLayerLegendUrlLineEdit->text() );
+  mLayer->serverProperties()->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
 }
 
 void QgsVectorTileLayerProperties::syncToLayer()
@@ -248,10 +248,10 @@ void QgsVectorTileLayerProperties::syncToLayer()
   mLayerAttributionUrlLineEdit->setText( mLayer->serverProperties()->attributionUrl() );
 
   // layer legend url
-  mLayerLegendUrlLineEdit->setText( mLayer->legendUrl() );
+  mLayerLegendUrlLineEdit->setText( mLayer->serverProperties()->legendUrl() );
   mLayerLegendUrlFormatComboBox->setCurrentIndex(
     mLayerLegendUrlFormatComboBox->findText(
-      mLayer->legendUrlFormat()
+      mLayer->serverProperties()->legendUrlFormat()
     )
   );
 }

--- a/src/server/services/wms/qgswmslayerinfos.cpp
+++ b/src/server/services/wms/qgswmslayerinfos.cpp
@@ -218,9 +218,9 @@ QMap<QString, QgsWmsLayerInfos> QgsWmsLayerInfos::buildWmsLayerInfos(
     // layer styles
     pLayer.styles = ml->styleManager()->styles();
     // layer legend URL
-    pLayer.legendUrl = ml->legendUrl();
+    pLayer.legendUrl = ml->serverProperties()->legendUrl();
     // layer legend URL format
-    pLayer.legendUrlFormat = ml->legendUrlFormat();
+    pLayer.legendUrlFormat = ml->serverProperties()->legendUrlFormat();
     // layer min/max scales
     if ( ml->hasScaleBasedVisibility() )
     {


### PR DESCRIPTION
Legend Url and legend Url format should be part of server properties. There are edited whitin QGIS Server tab parameters and are only used in WMS GetCapabilities.

I'm planning to refactor then those settings editing to remove duplicate code.

**Funded by Ifremer**