### PR TITLE
[3d] Large scene support: shift scene's origin if the camera got too far

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -133,6 +133,33 @@ it may be useful to temporarily disable scene updates.
 .. versionadded:: 3.40
 %End
 
+    bool hasSceneOriginShiftEnabled() const;
+%Docstring
+Returns whether the 3D scene is allowed to automatically move the scene's
+origin. This is necessary in large scenes (e.g. more than 50km across)
+to avoid issues with numerical precision (due to the use of 32-bit floats
+in rendering), that may cause jitter in camera position or object location.
+When 3D scene moves the origin (because the camera is far from it), user
+should not see any change - transforms of 3D entities should be updated
+accordingly.
+
+Normally, origin shifts are enabled. But for debugging purposes,
+it may be useful to temporarily disable origin shifts.
+
+.. versionadded:: 3.44
+%End
+
+    void setSceneOriginShiftEnabled( bool enabled );
+%Docstring
+Returns whether the 3D scene is allowed to automatically move the scene's
+origin. See :py:func:`~Qgs3DMapScene.hasSceneOriginShiftEnabled` for more details.
+
+Normally, origin shifts are enabled. But for debugging purposes,
+it may be useful to temporarily disable origin shifts.
+
+.. versionadded:: 3.44
+%End
+
  static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated="Since 3.36. Use QgisAppInterface.mapCanvases3D() instead."/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -89,6 +89,20 @@ yaw angle in degrees.
 .. versionadded:: 3.4
 %End
 
+    QgsVector3D lookingAtMapPoint() const;
+%Docstring
+Returns the point in the map coordinates towards which the camera is looking
+
+.. versionadded:: 3.44
+%End
+
+    void setLookingAtMapPoint( const QgsVector3D &point, float distance, float pitch, float yaw );
+%Docstring
+Sets camera configuration like :py:func:`~QgsCameraController.setLookingAtPoint`, but the point is given in map coordinates
+
+.. versionadded:: 3.44
+%End
+
     void setCameraPose( const QgsCameraPose &camPose, bool force = false );
 %Docstring
 Sets camera pose

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -133,6 +133,33 @@ it may be useful to temporarily disable scene updates.
 .. versionadded:: 3.40
 %End
 
+    bool hasSceneOriginShiftEnabled() const;
+%Docstring
+Returns whether the 3D scene is allowed to automatically move the scene's
+origin. This is necessary in large scenes (e.g. more than 50km across)
+to avoid issues with numerical precision (due to the use of 32-bit floats
+in rendering), that may cause jitter in camera position or object location.
+When 3D scene moves the origin (because the camera is far from it), user
+should not see any change - transforms of 3D entities should be updated
+accordingly.
+
+Normally, origin shifts are enabled. But for debugging purposes,
+it may be useful to temporarily disable origin shifts.
+
+.. versionadded:: 3.44
+%End
+
+    void setSceneOriginShiftEnabled( bool enabled );
+%Docstring
+Returns whether the 3D scene is allowed to automatically move the scene's
+origin. See :py:func:`~Qgs3DMapScene.hasSceneOriginShiftEnabled` for more details.
+
+Normally, origin shifts are enabled. But for debugging purposes,
+it may be useful to temporarily disable origin shifts.
+
+.. versionadded:: 3.44
+%End
+
  static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated="Since 3.36. Use QgisAppInterface.mapCanvases3D() instead."/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -89,6 +89,20 @@ yaw angle in degrees.
 .. versionadded:: 3.4
 %End
 
+    QgsVector3D lookingAtMapPoint() const;
+%Docstring
+Returns the point in the map coordinates towards which the camera is looking
+
+.. versionadded:: 3.44
+%End
+
+    void setLookingAtMapPoint( const QgsVector3D &point, float distance, float pitch, float yaw );
+%Docstring
+Sets camera configuration like :py:func:`~QgsCameraController.setLookingAtPoint`, but the point is given in map coordinates
+
+.. versionadded:: 3.44
+%End
+
     void setCameraPose( const QgsCameraPose &camPose, bool force = false );
 %Docstring
 Sets camera pose

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -326,8 +326,7 @@ void Qgs3DMapScene::onCameraChanged()
   if ( mSceneOriginShiftEnabled && mEngine->camera()->position().length() > originShiftThreshold )
   {
     const QgsVector3D newOrigin = mMap.origin() + QgsVector3D( mEngine->camera()->position() );
-    QgsDebugMsgLevel( QStringLiteral( "Rebasing scene origin from %1 to %2" ).arg(
-                        mMap.origin().toString( 1 ), newOrigin.toString( 1 ) ), 2 );
+    QgsDebugMsgLevel( QStringLiteral( "Rebasing scene origin from %1 to %2" ).arg( mMap.origin().toString( 1 ), newOrigin.toString( 1 ) ), 2 );
     mMap.setOrigin( newOrigin );
   }
 }

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -322,9 +322,10 @@ void Qgs3DMapScene::onCameraChanged()
   // with large coordinates in 32-bit floats (and if we do have large coordinates,
   // because the scene is far from the camera, we don't care, because those errors
   // end up being tiny when viewed from far away).
-  if ( mSceneOriginShiftEnabled && mEngine->camera()->position().length() > 10000 )
+  const float originShiftThreshold = 10'000;
+  if ( mSceneOriginShiftEnabled && mEngine->camera()->position().length() > originShiftThreshold )
   {
-    QgsVector3D newOrigin = mMap.origin() + QgsVector3D( mEngine->camera()->position() );
+    const QgsVector3D newOrigin = mMap.origin() + QgsVector3D( mEngine->camera()->position() );
     QgsDebugMsgLevel( QStringLiteral( "Rebasing scene origin from %1 to %2" ).arg(
                         mMap.origin().toString( 1 ), newOrigin.toString( 1 ) ), 2 );
     mMap.setOrigin( newOrigin );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -322,8 +322,8 @@ void Qgs3DMapScene::onCameraChanged()
   // with large coordinates in 32-bit floats (and if we do have large coordinates,
   // because the scene is far from the camera, we don't care, because those errors
   // end up being tiny when viewed from far away).
-  const float originShiftThreshold = 10'000;
-  if ( mSceneOriginShiftEnabled && mEngine->camera()->position().length() > originShiftThreshold )
+  constexpr float ORIGIN_SHIFT_THRESHOLD = 10'000;
+  if ( mSceneOriginShiftEnabled && mEngine->camera()->position().length() > ORIGIN_SHIFT_THRESHOLD )
   {
     const QgsVector3D newOrigin = mMap.origin() + QgsVector3D( mEngine->camera()->position() );
     QgsDebugMsgLevel( QStringLiteral( "Rebasing scene origin from %1 to %2" ).arg( mMap.origin().toString( 1 ), newOrigin.toString( 1 ) ), 2 );

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -210,6 +210,33 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     void setSceneUpdatesEnabled( bool enabled ) { mSceneUpdatesEnabled = enabled; }
 
     /**
+     * Returns whether the 3D scene is allowed to automatically move the scene's
+     * origin. This is necessary in large scenes (e.g. more than 50km across)
+     * to avoid issues with numerical precision (due to the use of 32-bit floats
+     * in rendering), that may cause jitter in camera position or object location.
+     * When 3D scene moves the origin (because the camera is far from it), user
+     * should not see any change - transforms of 3D entities should be updated
+     * accordingly.
+     *
+     * Normally, origin shifts are enabled. But for debugging purposes,
+     * it may be useful to temporarily disable origin shifts.
+     *
+     * \since QGIS 3.44
+     */
+    bool hasSceneOriginShiftEnabled() const { return mSceneOriginShiftEnabled; }
+
+    /**
+     * Returns whether the 3D scene is allowed to automatically move the scene's
+     * origin. See hasSceneOriginShiftEnabled() for more details.
+     *
+     * Normally, origin shifts are enabled. But for debugging purposes,
+     * it may be useful to temporarily disable origin shifts.
+     *
+     * \since QGIS 3.44
+     */
+    void setSceneOriginShiftEnabled( bool enabled ) { mSceneOriginShiftEnabled = enabled; }
+
+    /**
      * Returns a map of 3D map scenes (by name) open in the QGIS application.
      *
      * \note Only available from the QGIS desktop application.
@@ -360,6 +387,7 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     Qgs3DAxis *m3DAxis = nullptr;
 
     bool mSceneUpdatesEnabled = true;
+    bool mSceneOriginShiftEnabled = true;
 
     QList<QVector4D> mClipPlanesEquations;
     int mMaxClipPlanes = 6;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -173,17 +173,17 @@ void QgsCameraController::frameTriggered( float dt )
 
 void QgsCameraController::resetView( float distance )
 {
-  setViewFromTop( 0, 0, distance );
+  QgsPointXY extentCenter = mScene->mapSettings()->extent().center();
+  QgsVector3D origin = mScene->mapSettings()->origin();
+  setViewFromTop( extentCenter.x() - origin.x(), extentCenter.y() - origin.y(), distance );
 }
 
 void QgsCameraController::setViewFromTop( float worldX, float worldY, float distance, float yaw )
 {
   QgsCameraPose camPose;
   QgsTerrainEntity *terrain = mScene->terrainEntity();
-  if ( terrain )
-    camPose.setCenterPoint( QgsVector3D( worldX, worldY, terrain->terrainElevationOffset() ) );
-  else
-    camPose.setCenterPoint( QgsVector3D( worldX, worldY, 0.0f ) );
+  const float terrainElevationOffset = terrain ? terrain->terrainElevationOffset() : 0.0f;
+  camPose.setCenterPoint( QgsVector3D( worldX, worldY, terrainElevationOffset - mScene->mapSettings()->origin().z() ) );
   camPose.setDistanceFromCenterPoint( distance );
   camPose.setHeadingAngle( yaw );
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -209,6 +209,16 @@ void QgsCameraController::setLookingAtPoint( const QgsVector3D &point, float dis
   setCameraPose( camPose );
 }
 
+QgsVector3D QgsCameraController::lookingAtMapPoint() const
+{
+  return lookingAtPoint() + mOrigin;
+}
+
+void QgsCameraController::setLookingAtMapPoint( const QgsVector3D &point, float distance, float pitch, float yaw )
+{
+  setLookingAtPoint( point - mOrigin, distance, pitch, yaw );
+}
+
 void QgsCameraController::setCameraPose( const QgsCameraPose &camPose, bool force )
 {
   if ( camPose == mCameraPose && !force )

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -126,6 +126,18 @@ class _3D_EXPORT QgsCameraController : public QObject
     void setLookingAtPoint( const QgsVector3D &point, float distance, float pitch, float yaw );
 
     /**
+     * Returns the point in the map coordinates towards which the camera is looking
+     * \since QGIS 3.44
+     */
+    QgsVector3D lookingAtMapPoint() const;
+
+    /**
+     * Sets camera configuration like setLookingAtPoint(), but the point is given in map coordinates
+     * \since QGIS 3.44
+     */
+    void setLookingAtMapPoint( const QgsVector3D &point, float distance, float pitch, float yaw );
+
+    /**
      * Sets camera pose
      * \since QGIS 3.4
      */

--- a/src/app/3d/qgs3ddebugwidget.cpp
+++ b/src/app/3d/qgs3ddebugwidget.cpp
@@ -19,6 +19,7 @@
 #include "qgs3ddebugwidget.h"
 #include "qgs3dmapcanvas.h"
 #include "qgscameracontroller.h"
+#include "qgs3dmapscene.h"
 
 Qgs3DDebugWidget::Qgs3DDebugWidget( Qgs3DMapCanvas *canvas, QWidget *parent )
   : QWidget( parent )
@@ -72,6 +73,7 @@ void Qgs3DDebugWidget::setMapSettings( Qgs3DMapSettings *mapSettings )
   whileBlocking( chkShowCameraRotationCenter )->setChecked( mMap->showCameraRotationCenter() );
   whileBlocking( chkShowLightSourceOrigins )->setChecked( mMap->showLightSourceOrigins() );
   whileBlocking( chkStopUpdates )->setChecked( mMap->stopUpdates() );
+  whileBlocking( chkStopOriginShifts )->setChecked( !m3DMapCanvas->scene()->hasSceneOriginShiftEnabled() );
   whileBlocking( chkDebugOverlay )->setChecked( mMap->isDebugOverlayEnabled() );
   connect( chkShowTileInfo, &QCheckBox::toggled, this, [=]( const bool enabled ) { mMap->setShowTerrainTilesInfo( enabled ); } );
   connect( chkShowBoundingBoxes, &QCheckBox::toggled, this, [=]( const bool enabled ) { mMap->setShowTerrainBoundingBoxes( enabled ); } );
@@ -79,6 +81,9 @@ void Qgs3DDebugWidget::setMapSettings( Qgs3DMapSettings *mapSettings )
   connect( chkShowCameraRotationCenter, &QCheckBox::toggled, this, [=]( const bool enabled ) { mMap->setShowCameraRotationCenter( enabled ); } );
   connect( chkShowLightSourceOrigins, &QCheckBox::toggled, this, [=]( const bool enabled ) { mMap->setShowLightSourceOrigins( enabled ); } );
   connect( chkStopUpdates, &QCheckBox::toggled, this, [=]( const bool enabled ) { mMap->setStopUpdates( enabled ); } );
+  connect( chkStopOriginShifts, &QCheckBox::toggled, this, [=]( const bool enabled ) {
+    m3DMapCanvas->scene()->setSceneOriginShiftEnabled( !enabled );
+  } );
   connect( chkDebugOverlay, &QCheckBox::toggled, this, [=]( const bool enabled ) { mMap->setIsDebugOverlayEnabled( enabled ); } );
 
   // set up the shadow map block

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13209,7 +13209,6 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name )
 
     const QgsReferencedRectangle projectExtent = prj->viewSettings()->fullExtent();
     const QgsRectangle fullExtent = Qgs3DUtils::tryReprojectExtent2D( projectExtent, projectExtent.crs(), map->crs(), prj->transformContext() );
-    map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
     map->setSelectionColor( mMapCanvas->selectionColor() );
     map->setBackgroundColor( mMapCanvas->canvasColor() );
     map->setLayers( mMapCanvas->layers( true ) );

--- a/src/ui/3d/3ddebugwidget.ui
+++ b/src/ui/3d/3ddebugwidget.ui
@@ -61,7 +61,7 @@
         <x>0</x>
         <y>0</y>
         <width>501</width>
-        <height>742</height>
+        <height>795</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -127,6 +127,13 @@
           <widget class="QCheckBox" name="chkStopUpdates">
            <property name="text">
             <string>Stop scene updates</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="chkStopOriginShifts">
+           <property name="text">
+            <string>Stop automatic origin shifts</string>
            </property>
           </widget>
          </item>

--- a/tests/src/3d/CMakeLists.txt
+++ b/tests/src/3d/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(sandbox)
 
 set(TESTS
   testqgs3dcameracontroller.cpp
+  testqgs3dmapscene.cpp
   testqgs3dmaterial.cpp
   testqgs3drendering.cpp
   testqgs3dsymbolregistry.cpp

--- a/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
+++ b/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
@@ -62,7 +62,6 @@ void initCanvas3D( Qgs3DMapCanvas *canvas )
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( QgsProject::instance()->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
   map->setLayers( visibleLayers );
 
   map->setExtent( fullExtent );

--- a/tests/src/3d/testqgs3dmapscene.cpp
+++ b/tests/src/3d/testqgs3dmapscene.cpp
@@ -77,7 +77,6 @@ void TestQgs3DMapScene::testOriginShift()
   map.setCrs( mProject->crs() );
   map.setExtent( mProject->viewSettings()->fullExtent() );
   map.setLayers( QList<QgsMapLayer *>() << mLayerCountries );
-  map.setOrigin( QgsVector3D( 0, 0, 0 ) );
 
   QgsFlatTerrainGenerator *flatTerrain = new QgsFlatTerrainGenerator;
   flatTerrain->setCrs( map.crs(), map.transformContext() );
@@ -85,10 +84,12 @@ void TestQgs3DMapScene::testOriginShift()
 
   QgsOffscreen3DEngine engine;
   Qgs3DMapScene *scene = new Qgs3DMapScene( map, &engine );
-  scene->setSceneOriginShiftEnabled( false );
   engine.setRootEntity( scene );
 
   QgsVector3D webMercatorRome( 1'390'000, 5'146'000, 0 );
+
+  map.setOrigin( QgsVector3D( 0, 0, 0 ) );
+  scene->setSceneOriginShiftEnabled( false );
 
   // start with the initial view far from Rome...
   // origin should be unchanged because shifting is disabled

--- a/tests/src/3d/testqgs3dmapscene.cpp
+++ b/tests/src/3d/testqgs3dmapscene.cpp
@@ -40,7 +40,6 @@ class TestQgs3DMapScene : public QgsTest
     void testOriginShift();
 
   private:
-
     std::unique_ptr<QgsProject> mProject;
     QgsVectorLayer *mLayerCountries = nullptr;
 };

--- a/tests/src/3d/testqgs3dmapscene.cpp
+++ b/tests/src/3d/testqgs3dmapscene.cpp
@@ -1,0 +1,138 @@
+/***************************************************************************
+  testqgs3dmapscene.cpp
+  --------------------------------------
+  Date                 : March 2025
+  Copyright            : (C) 2025 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgs3d.h"
+#include "qgs3dmapscene.h"
+#include "qgs3dmapsettings.h"
+#include "qgs3dutils.h"
+#include "qgsflatterraingenerator.h"
+#include "qgsoffscreen3dengine.h"
+#include "qgsprojectviewsettings.h"
+#include "qgsvectorlayer.h"
+
+
+class TestQgs3DMapScene : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+    TestQgs3DMapScene()
+      : QgsTest( QStringLiteral( "3D Map Scene Tests" ), QStringLiteral( "3d" ) )
+    {}
+
+  private slots:
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void testOriginShift();
+
+  private:
+
+    std::unique_ptr<QgsProject> mProject;
+    QgsVectorLayer *mLayerCountries = nullptr;
+};
+
+// runs before all tests
+void TestQgs3DMapScene::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  Qgs3D::initialize();
+
+  mProject.reset( new QgsProject );
+
+  const QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.gpkg|layername=countries" );
+
+  mLayerCountries = new QgsVectorLayer( fileName, QStringLiteral( "world" ), QStringLiteral( "ogr" ) );
+  QVERIFY( mLayerCountries->isValid() );
+
+  mProject->addMapLayer( mLayerCountries );
+
+  mProject->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
+}
+
+//runs after all tests
+void TestQgs3DMapScene::cleanupTestCase()
+{
+  mProject.reset();
+  QgsApplication::exitQgis();
+}
+
+
+void TestQgs3DMapScene::testOriginShift()
+{
+  Qgs3DMapSettings map;
+  map.setCrs( mProject->crs() );
+  map.setExtent( mProject->viewSettings()->fullExtent() );
+  map.setLayers( QList<QgsMapLayer *>() << mLayerCountries );
+  map.setOrigin( QgsVector3D( 0, 0, 0 ) );
+
+  QgsFlatTerrainGenerator *flatTerrain = new QgsFlatTerrainGenerator;
+  flatTerrain->setCrs( map.crs(), map.transformContext() );
+  map.setTerrainGenerator( flatTerrain );
+
+  QgsOffscreen3DEngine engine;
+  Qgs3DMapScene *scene = new Qgs3DMapScene( map, &engine );
+  scene->setSceneOriginShiftEnabled( false );
+  engine.setRootEntity( scene );
+
+  QgsVector3D webMercatorRome( 1'390'000, 5'146'000, 0 );
+
+  // start with the initial view far from Rome...
+  // origin should be unchanged because shifting is disabled
+  scene->cameraController()->setLookingAtMapPoint( webMercatorRome, 250'000, 0, 0 );
+  Qgs3DUtils::waitForFrame( engine, scene );
+
+  QCOMPARE( scene->cameraController()->lookingAtMapPoint(), webMercatorRome );
+  QCOMPARE( scene->mapSettings()->origin(), QgsVector3D( 0, 0, 0 ) );
+  QCOMPARE( scene->cameraController()->camera()->position(), QVector3D( 1'390'000, 5'146'000, 250'000 ) );
+
+  // now let's get automatic origin shifts enabled
+  scene->setSceneOriginShiftEnabled( true );
+
+  // we're moving closer to Rome, but still quite far - origin should be moved
+  // and camera will be at the placed at the origin
+  scene->cameraController()->setLookingAtMapPoint( webMercatorRome, 100'000, 0, 0 );
+  Qgs3DUtils::waitForFrame( engine, scene );
+
+  QCOMPARE( scene->cameraController()->lookingAtMapPoint(), webMercatorRome );
+  QCOMPARE( scene->mapSettings()->origin(), QgsVector3D( 1'390'000, 5'146'000, 100'000 ) );
+  QCOMPARE( scene->cameraController()->camera()->position(), QVector3D( 0, 0, 0 ) );
+
+  // we're moving even closer to Rome, but the move is still quite big
+  // so we're expecting another origin shift
+  scene->cameraController()->setLookingAtMapPoint( webMercatorRome, 1'000, 0, 0 );
+  Qgs3DUtils::waitForFrame( engine, scene );
+
+  QCOMPARE( scene->cameraController()->lookingAtMapPoint(), webMercatorRome );
+  QCOMPARE( scene->mapSettings()->origin(), QgsVector3D( 1'390'000, 5'146'000, 1'000 ) );
+  QCOMPARE( scene->cameraController()->camera()->position(), QVector3D( 0, 0, 0 ) );
+
+  // move even closer to the map. The move is relatively small,
+  // so we are not experiencing any shift of the origin
+  scene->cameraController()->setLookingAtMapPoint( webMercatorRome, 500, 0, 0 );
+  Qgs3DUtils::waitForFrame( engine, scene );
+
+  QCOMPARE( scene->cameraController()->lookingAtMapPoint(), webMercatorRome );
+  QCOMPARE( scene->mapSettings()->origin(), QgsVector3D( 1'390'000, 5'146'000, 1'000 ) );
+  QCOMPARE( scene->cameraController()->camera()->position(), QVector3D( 0, 0, -500 ) );
+
+  delete scene;
+}
+
+
+QGSTEST_MAIN( TestQgs3DMapScene )
+#include "testqgs3dmapscene.moc"

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -1816,6 +1816,8 @@ void TestQgs3DRendering::testEpsg4978LineRendering()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
+  scene->setSceneOriginShiftEnabled( false );
+
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 1.5e7, 0, 0 );
 

--- a/tests/src/3d/testqgspointcloud3drendering.cpp
+++ b/tests/src/3d/testqgspointcloud3drendering.cpp
@@ -251,7 +251,7 @@ void TestQgsPointCloud3DRendering::testPointCloudSingleColor()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -286,7 +286,7 @@ void TestQgsPointCloud3DRendering::testPointCloudSingleColorClipping()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -338,7 +338,7 @@ void TestQgsPointCloud3DRendering::testPointCloudAttributeByRamp()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -377,7 +377,7 @@ void TestQgsPointCloud3DRendering::testPointCloudClassification()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -414,7 +414,7 @@ void TestQgsPointCloud3DRendering::testPointCloudClassificationOverridePointSize
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -454,7 +454,7 @@ void TestQgsPointCloud3DRendering::testPointCloudFilteredClassification()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -494,7 +494,6 @@ void TestQgsPointCloud3DRendering::testPointCloudFilteredSceneExtent()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( filteredExtent.center().x(), filteredExtent.center().y(), 0 ) );
   map->setExtent( filteredExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;

--- a/tests/src/3d/testqgsrubberband3drendering.cpp
+++ b/tests/src/3d/testqgsrubberband3drendering.cpp
@@ -88,7 +88,7 @@ void TestQgsRubberBand3DRendering::testRubberBandPoint()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -121,7 +121,7 @@ void TestQgsRubberBand3DRendering::testRubberBandLine()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -151,7 +151,7 @@ void TestQgsRubberBand3DRendering::testRubberBandPolygon()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -181,7 +181,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenMarker()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -214,7 +214,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenLastMarker()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -245,7 +245,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenEdges()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );
@@ -278,7 +278,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenPolygonFill()
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
   map->setCrs( mProject->crs() );
-  map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
+  map->setExtent( fullExtent );
   map->setLayers( QList<QgsMapLayer *>() << mLayer );
   QgsPointLightSettings defaultLight;
   defaultLight.setIntensity( 0.5 );


### PR DESCRIPTION
This "origin rebasing" or "origin shifting" technique is commonly used in various 3D engines when dealing with large scenes (where objects need double precision coordinates). It should greatly improve our capability to handle large scenes (e.g. more than 50km across)

For now, I have used a simple rule that when camera gets 10 km away from the world's origin, the origin is shifted (and camera is placed at the origin). The origin shift has a bit of a cost (we're updating 4x4 transform matrices of all active nodes), so we prefer not to do it on every camera change, but only when necessary. That said, I have not seen slowdowns when origin gets shifted.

Also add a checkbox to the debug panel to allow devs temporarily turn it off.

A related philosophical question from Futurama:

![image](https://github.com/user-attachments/assets/333a3f70-91c4-4eeb-8dec-25d0124570cf)


Before:

https://github.com/user-attachments/assets/ec4fea53-08a7-490b-8993-52769320e345


After:


https://github.com/user-attachments/assets/2f030fd1-ad64-4316-b349-32cebe2f598d

