### PR TITLE
Show dialog when importing tables via browser, give users options to control import

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10120,6 +10120,20 @@ Qgis.DatabaseProviderConnectionCapabilities2 = lambda flags=0: Qgis.DatabaseProv
 Qgis.DatabaseProviderConnectionCapabilities2.baseClass = Qgis
 DatabaseProviderConnectionCapabilities2 = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
+Qgis.DatabaseProviderTableImportCapability.SetGeometryColumnName.__doc__ = "Can set the name of the geometry column"
+Qgis.DatabaseProviderTableImportCapability.__doc__ = """Represents capabilities of a database provider connection when importing table data.
+
+.. versionadded:: 3.44
+
+* ``SetGeometryColumnName``: Can set the name of the geometry column
+
+"""
+# --
+Qgis.DatabaseProviderTableImportCapability.baseClass = Qgis
+Qgis.DatabaseProviderTableImportCapabilities = lambda flags=0: Qgis.DatabaseProviderTableImportCapability(flags)
+Qgis.DatabaseProviderTableImportCapabilities.baseClass = Qgis
+DatabaseProviderTableImportCapabilities = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.ProviderStyleStorageCapability.SaveToDatabase.__doc__ = ""
 Qgis.ProviderStyleStorageCapability.LoadFromDatabase.__doc__ = ""
 Qgis.ProviderStyleStorageCapability.DeleteFromDatabase.__doc__ = ""

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10106,12 +10106,17 @@ Qgis.PostgresRelKind.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.DatabaseProviderConnectionCapability2.SetFieldComment.__doc__ = "Can set comments for fields via setFieldComment()"
 Qgis.DatabaseProviderConnectionCapability2.SetFieldAlias.__doc__ = "Can set aliases for fields via setFieldAlias()"
+Qgis.DatabaseProviderConnectionCapability2.SetTableComment.__doc__ = "Can set comments for tables via setTableComment() \n.. versionadded:: 3.44"
 Qgis.DatabaseProviderConnectionCapability2.__doc__ = """The Capability enum represents the extended operations supported by the connection.
 
 .. versionadded:: 3.32
 
 * ``SetFieldComment``: Can set comments for fields via setFieldComment()
 * ``SetFieldAlias``: Can set aliases for fields via setFieldAlias()
+* ``SetTableComment``: Can set comments for tables via setTableComment()
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -10121,11 +10121,13 @@ Qgis.DatabaseProviderConnectionCapabilities2.baseClass = Qgis
 DatabaseProviderConnectionCapabilities2 = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 Qgis.DatabaseProviderTableImportCapability.SetGeometryColumnName.__doc__ = "Can set the name of the geometry column"
+Qgis.DatabaseProviderTableImportCapability.SetPrimaryKeyName.__doc__ = "Can set the name of the primary key column"
 Qgis.DatabaseProviderTableImportCapability.__doc__ = """Represents capabilities of a database provider connection when importing table data.
 
 .. versionadded:: 3.44
 
 * ``SetGeometryColumnName``: Can set the name of the geometry column
+* ``SetPrimaryKeyName``: Can set the name of the primary key column
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgsabstractdatabaseproviderconnection.py
+++ b/python/PyQt6/core/auto_additions/qgsabstractdatabaseproviderconnection.py
@@ -118,6 +118,16 @@ try:
 except (NameError, AttributeError):
     pass
 try:
+    QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions.__attribute_docs__ = {'layerName': 'Name for the new layer', 'schema': 'Optional schema for the new layer. May not be supported by all providers.', 'wkbType': 'WKB type for destination layer geometry', 'primaryKeyColumns': 'List of primary key column names. Note that some providers may ignore this if not supported.', 'geometryColumn': 'Preferred name for the geometry column, if required. Note that some providers may ignore this if a specific geometry column name is required.'}
+    QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions.__doc__ = """Stores all information required to create a :py:class:`QgsVectorLayerExporter` for the backend.
+
+.. seealso:: :py:func:`createVectorLayerExporterDestinationUri`
+
+.. versionadded:: 3.44"""
+    QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions.__group__ = ['providers']
+except (NameError, AttributeError):
+    pass
+try:
     QgsAbstractDatabaseProviderConnection.QueryResult.__doc__ = """The QueryResult class represents the result of a query executed by :py:func:`~QgsAbstractDatabaseProviderConnection.execSql`
 
 It encapsulates an iterator over the result rows and a list of the column names.

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -902,6 +902,19 @@ Sets the ``alias`` for the existing field with the specified name.
 .. versionadded:: 3.32
 %End
 
+    virtual void setTableComment( const QString &schema, const QString &tableName, const QString &comment ) const;
+%Docstring
+Sets the ``comment`` for the existing table with the specified name.
+
+:param schema: name of the schema (schema is ignored if not supported by the backend).
+:param tableName: name of the table
+:param comment: comment to set for the table. Set to an empty string to remove a previously set comment.
+
+:raises QgsProviderConnectionException: if any errors are encountered.
+
+.. versionadded:: 3.44
+%End
+
     virtual void setFieldComment( const QString &fieldName, const QString &schema, const QString &tableName, const QString &comment ) const;
 %Docstring
 Sets the ``comment`` for the existing field with the specified name.

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -805,6 +805,17 @@ should not be used when creating or altering fields.
 .. versionadded:: 3.30
 %End
 
+    virtual QString defaultPrimaryKeyColumnName() const;
+%Docstring
+Returns the default name to use for a primary key column for the connection.
+
+The returned name will match common practice for the database backend.
+
+The base class method returns "pk".
+
+.. versionadded:: 3.44
+%End
+
     virtual QString defaultGeometryColumnName() const;
 %Docstring
 Returns the default name to use for a geometry column for the connection.

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -420,6 +420,13 @@ Returns connection geometry column capabilities (Z, M, SinglePart, Curves).
 .. versionadded:: 3.16
 %End
 
+    virtual Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const = 0;
+%Docstring
+Represents capabilities of the database provider connection when importing table data.
+
+.. versionadded:: 3.44
+%End
+
     virtual Qgis::SqlLayerDefinitionCapabilities sqlLayerDefinitionCapabilities();
 %Docstring
 Returns SQL layer definition capabilities (Filters, GeometryColumn, PrimaryKeys).
@@ -796,6 +803,17 @@ Returns a list of field names which are considered illegal by the connection and
 should not be used when creating or altering fields.
 
 .. versionadded:: 3.30
+%End
+
+    virtual QString defaultGeometryColumnName() const;
+%Docstring
+Returns the default name to use for a geometry column for the connection.
+
+The returned name will match common practice for the database backend.
+
+The base class method returns "geom".
+
+.. versionadded:: 3.44
 %End
 
     virtual QStringList fieldDomainNames() const;

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -444,6 +444,13 @@ Creates an empty table with ``name`` in the given ``schema`` (schema is ignored 
 :raises QgsProviderConnectionException: if any errors are encountered.
 %End
 
+    virtual QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const;
+%Docstring
+Creates a URI for use with :py:class:`QgsVectorLayerExporter` corresponding to given destination table parameters for the backend.
+
+:raises QgsProviderConnectionException: if any errors are encountered.
+%End
+
     virtual bool tableExists( const QString &schema, const QString &name ) const;
 %Docstring
 Checks whether a table ``name`` exists in the given ``schema``.

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -444,9 +444,28 @@ Creates an empty table with ``name`` in the given ``schema`` (schema is ignored 
 :raises QgsProviderConnectionException: if any errors are encountered.
 %End
 
-    virtual QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const;
+    struct VectorLayerExporterOptions
+    {
+      QString layerName;
+
+      QString schema;
+
+      Qgis::WkbType wkbType;
+
+      QStringList primaryKeyColumns;
+
+      QString geometryColumn;
+
+    };
+
+    virtual QString createVectorLayerExporterDestinationUri( const QgsAbstractDatabaseProviderConnection::VectorLayerExporterOptions &options, QVariantMap &providerOptions /Out/ ) const;
 %Docstring
-Creates a URI for use with :py:class:`QgsVectorLayerExporter` corresponding to given destination table parameters for the backend.
+Creates a URI for use with :py:class:`QgsVectorLayerExporter` corresponding to given destination table ``options`` for the backend.
+
+:param options: defines the desired destination table details
+
+:return: - destination URI for use with :py:class:`QgsVectorLayerExporter`
+         - providerOptions: a map of options to pass to :py:func:`~QgsAbstractDatabaseProviderConnection.createVectorTable` or the provider's createEmptyTable method.
 
 :raises QgsProviderConnectionException: if any errors are encountered.
 %End

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2911,6 +2911,7 @@ The development version
     enum class DatabaseProviderTableImportCapability /BaseType=IntFlag/
     {
       SetGeometryColumnName,
+      SetPrimaryKeyName,
     };
     typedef QFlags<Qgis::DatabaseProviderTableImportCapability> DatabaseProviderTableImportCapabilities;
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2908,6 +2908,13 @@ The development version
     typedef QFlags<Qgis::DatabaseProviderConnectionCapability2> DatabaseProviderConnectionCapabilities2;
 
 
+    enum class DatabaseProviderTableImportCapability /BaseType=IntFlag/
+    {
+      SetGeometryColumnName,
+    };
+    typedef QFlags<Qgis::DatabaseProviderTableImportCapability> DatabaseProviderTableImportCapabilities;
+
+
     enum class ProviderStyleStorageCapability /BaseType=IntFlag/
     {
       SaveToDatabase,
@@ -3377,6 +3384,8 @@ QFlags<Qgis::BrowserItemCapability> operator|(Qgis::BrowserItemCapability f1, QF
 QFlags<Qgis::CoordinateTransformationFlag> operator|(Qgis::CoordinateTransformationFlag f1, QFlags<Qgis::CoordinateTransformationFlag> f2);
 
 QFlags<Qgis::DatabaseProviderConnectionCapability2> operator|(Qgis::DatabaseProviderConnectionCapability2 f1, QFlags<Qgis::DatabaseProviderConnectionCapability2> f2);
+
+QFlags<Qgis::DatabaseProviderTableImportCapability> operator|(Qgis::DatabaseProviderTableImportCapability f1, QFlags<Qgis::DatabaseProviderTableImportCapability> f2);
 
 QFlags<Qgis::DataProviderFlag> operator|(Qgis::DataProviderFlag f1, QFlags<Qgis::DataProviderFlag> f2);
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2904,6 +2904,7 @@ The development version
     {
       SetFieldComment,
       SetFieldAlias,
+      SetTableComment,
     };
     typedef QFlags<Qgis::DatabaseProviderConnectionCapability2> DatabaseProviderConnectionCapabilities2;
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10027,12 +10027,17 @@ Qgis.PostgresRelKind.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.DatabaseProviderConnectionCapability2.SetFieldComment.__doc__ = "Can set comments for fields via setFieldComment()"
 Qgis.DatabaseProviderConnectionCapability2.SetFieldAlias.__doc__ = "Can set aliases for fields via setFieldAlias()"
+Qgis.DatabaseProviderConnectionCapability2.SetTableComment.__doc__ = "Can set comments for tables via setTableComment() \n.. versionadded:: 3.44"
 Qgis.DatabaseProviderConnectionCapability2.__doc__ = """The Capability enum represents the extended operations supported by the connection.
 
 .. versionadded:: 3.32
 
 * ``SetFieldComment``: Can set comments for fields via setFieldComment()
 * ``SetFieldAlias``: Can set aliases for fields via setFieldAlias()
+* ``SetTableComment``: Can set comments for tables via setTableComment()
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10040,6 +10040,19 @@ Qgis.DatabaseProviderConnectionCapability2.baseClass = Qgis
 Qgis.DatabaseProviderConnectionCapabilities2.baseClass = Qgis
 DatabaseProviderConnectionCapabilities2 = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
+Qgis.DatabaseProviderTableImportCapability.SetGeometryColumnName.__doc__ = "Can set the name of the geometry column"
+Qgis.DatabaseProviderTableImportCapability.__doc__ = """Represents capabilities of a database provider connection when importing table data.
+
+.. versionadded:: 3.44
+
+* ``SetGeometryColumnName``: Can set the name of the geometry column
+
+"""
+# --
+Qgis.DatabaseProviderTableImportCapability.baseClass = Qgis
+Qgis.DatabaseProviderTableImportCapabilities.baseClass = Qgis
+DatabaseProviderTableImportCapabilities = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.ProviderStyleStorageCapability.SaveToDatabase.__doc__ = ""
 Qgis.ProviderStyleStorageCapability.LoadFromDatabase.__doc__ = ""
 Qgis.ProviderStyleStorageCapability.DeleteFromDatabase.__doc__ = ""

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -10041,11 +10041,13 @@ Qgis.DatabaseProviderConnectionCapabilities2.baseClass = Qgis
 DatabaseProviderConnectionCapabilities2 = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 Qgis.DatabaseProviderTableImportCapability.SetGeometryColumnName.__doc__ = "Can set the name of the geometry column"
+Qgis.DatabaseProviderTableImportCapability.SetPrimaryKeyName.__doc__ = "Can set the name of the primary key column"
 Qgis.DatabaseProviderTableImportCapability.__doc__ = """Represents capabilities of a database provider connection when importing table data.
 
 .. versionadded:: 3.44
 
 * ``SetGeometryColumnName``: Can set the name of the geometry column
+* ``SetPrimaryKeyName``: Can set the name of the primary key column
 
 """
 # --

--- a/python/core/auto_additions/qgsabstractdatabaseproviderconnection.py
+++ b/python/core/auto_additions/qgsabstractdatabaseproviderconnection.py
@@ -67,6 +67,16 @@ try:
 except (NameError, AttributeError):
     pass
 try:
+    QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions.__attribute_docs__ = {'layerName': 'Name for the new layer', 'schema': 'Optional schema for the new layer. May not be supported by all providers.', 'wkbType': 'WKB type for destination layer geometry', 'primaryKeyColumns': 'List of primary key column names. Note that some providers may ignore this if not supported.', 'geometryColumn': 'Preferred name for the geometry column, if required. Note that some providers may ignore this if a specific geometry column name is required.'}
+    QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions.__doc__ = """Stores all information required to create a :py:class:`QgsVectorLayerExporter` for the backend.
+
+.. seealso:: :py:func:`createVectorLayerExporterDestinationUri`
+
+.. versionadded:: 3.44"""
+    QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions.__group__ = ['providers']
+except (NameError, AttributeError):
+    pass
+try:
     QgsAbstractDatabaseProviderConnection.QueryResult.__doc__ = """The QueryResult class represents the result of a query executed by :py:func:`~QgsAbstractDatabaseProviderConnection.execSql`
 
 It encapsulates an iterator over the result rows and a list of the column names.

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -444,9 +444,28 @@ Creates an empty table with ``name`` in the given ``schema`` (schema is ignored 
 :raises QgsProviderConnectionException: if any errors are encountered.
 %End
 
-    virtual QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const throw( QgsProviderConnectionException );
+    struct VectorLayerExporterOptions
+    {
+      QString layerName;
+
+      QString schema;
+
+      Qgis::WkbType wkbType;
+
+      QStringList primaryKeyColumns;
+
+      QString geometryColumn;
+
+    };
+
+    virtual QString createVectorLayerExporterDestinationUri( const QgsAbstractDatabaseProviderConnection::VectorLayerExporterOptions &options, QVariantMap &providerOptions /Out/ ) const throw( QgsProviderConnectionException );
 %Docstring
-Creates a URI for use with :py:class:`QgsVectorLayerExporter` corresponding to given destination table parameters for the backend.
+Creates a URI for use with :py:class:`QgsVectorLayerExporter` corresponding to given destination table ``options`` for the backend.
+
+:param options: defines the desired destination table details
+
+:return: - destination URI for use with :py:class:`QgsVectorLayerExporter`
+         - providerOptions: a map of options to pass to :py:func:`~QgsAbstractDatabaseProviderConnection.createVectorTable` or the provider's createEmptyTable method.
 
 :raises QgsProviderConnectionException: if any errors are encountered.
 %End

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -805,6 +805,17 @@ should not be used when creating or altering fields.
 .. versionadded:: 3.30
 %End
 
+    virtual QString defaultPrimaryKeyColumnName() const;
+%Docstring
+Returns the default name to use for a primary key column for the connection.
+
+The returned name will match common practice for the database backend.
+
+The base class method returns "pk".
+
+.. versionadded:: 3.44
+%End
+
     virtual QString defaultGeometryColumnName() const;
 %Docstring
 Returns the default name to use for a geometry column for the connection.

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -420,6 +420,13 @@ Returns connection geometry column capabilities (Z, M, SinglePart, Curves).
 .. versionadded:: 3.16
 %End
 
+    virtual Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const = 0;
+%Docstring
+Represents capabilities of the database provider connection when importing table data.
+
+.. versionadded:: 3.44
+%End
+
     virtual Qgis::SqlLayerDefinitionCapabilities sqlLayerDefinitionCapabilities();
 %Docstring
 Returns SQL layer definition capabilities (Filters, GeometryColumn, PrimaryKeys).
@@ -796,6 +803,17 @@ Returns a list of field names which are considered illegal by the connection and
 should not be used when creating or altering fields.
 
 .. versionadded:: 3.30
+%End
+
+    virtual QString defaultGeometryColumnName() const;
+%Docstring
+Returns the default name to use for a geometry column for the connection.
+
+The returned name will match common practice for the database backend.
+
+The base class method returns "geom".
+
+.. versionadded:: 3.44
 %End
 
     virtual QStringList fieldDomainNames() const throw( QgsProviderConnectionException );

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -902,6 +902,19 @@ Sets the ``alias`` for the existing field with the specified name.
 .. versionadded:: 3.32
 %End
 
+    virtual void setTableComment( const QString &schema, const QString &tableName, const QString &comment ) const throw( QgsProviderConnectionException );
+%Docstring
+Sets the ``comment`` for the existing table with the specified name.
+
+:param schema: name of the schema (schema is ignored if not supported by the backend).
+:param tableName: name of the table
+:param comment: comment to set for the table. Set to an empty string to remove a previously set comment.
+
+:raises QgsProviderConnectionException: if any errors are encountered.
+
+.. versionadded:: 3.44
+%End
+
     virtual void setFieldComment( const QString &fieldName, const QString &schema, const QString &tableName, const QString &comment ) const throw( QgsProviderConnectionException );
 %Docstring
 Sets the ``comment`` for the existing field with the specified name.

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -444,6 +444,13 @@ Creates an empty table with ``name`` in the given ``schema`` (schema is ignored 
 :raises QgsProviderConnectionException: if any errors are encountered.
 %End
 
+    virtual QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const throw( QgsProviderConnectionException );
+%Docstring
+Creates a URI for use with :py:class:`QgsVectorLayerExporter` corresponding to given destination table parameters for the backend.
+
+:raises QgsProviderConnectionException: if any errors are encountered.
+%End
+
     virtual bool tableExists( const QString &schema, const QString &name ) const throw( QgsProviderConnectionException );
 %Docstring
 Checks whether a table ``name`` exists in the given ``schema``.

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2911,6 +2911,7 @@ The development version
     enum class DatabaseProviderTableImportCapability
     {
       SetGeometryColumnName,
+      SetPrimaryKeyName,
     };
     typedef QFlags<Qgis::DatabaseProviderTableImportCapability> DatabaseProviderTableImportCapabilities;
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2908,6 +2908,13 @@ The development version
     typedef QFlags<Qgis::DatabaseProviderConnectionCapability2> DatabaseProviderConnectionCapabilities2;
 
 
+    enum class DatabaseProviderTableImportCapability
+    {
+      SetGeometryColumnName,
+    };
+    typedef QFlags<Qgis::DatabaseProviderTableImportCapability> DatabaseProviderTableImportCapabilities;
+
+
     enum class ProviderStyleStorageCapability
     {
       SaveToDatabase,
@@ -3377,6 +3384,8 @@ QFlags<Qgis::BrowserItemCapability> operator|(Qgis::BrowserItemCapability f1, QF
 QFlags<Qgis::CoordinateTransformationFlag> operator|(Qgis::CoordinateTransformationFlag f1, QFlags<Qgis::CoordinateTransformationFlag> f2);
 
 QFlags<Qgis::DatabaseProviderConnectionCapability2> operator|(Qgis::DatabaseProviderConnectionCapability2 f1, QFlags<Qgis::DatabaseProviderConnectionCapability2> f2);
+
+QFlags<Qgis::DatabaseProviderTableImportCapability> operator|(Qgis::DatabaseProviderTableImportCapability f1, QFlags<Qgis::DatabaseProviderTableImportCapability> f2);
 
 QFlags<Qgis::DataProviderFlag> operator|(Qgis::DataProviderFlag f1, QFlags<Qgis::DataProviderFlag> f2);
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2904,6 +2904,7 @@ The development version
     {
       SetFieldComment,
       SetFieldAlias,
+      SetTableComment,
     };
     typedef QFlags<Qgis::DatabaseProviderConnectionCapability2> DatabaseProviderConnectionCapabilities2;
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1977,8 +1977,6 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
           exporterOptions.wkbType = vectorSrcLayer->wkbType();
 
           QVariantMap providerOptions;
-          const QString destUri = databaseConnection->createVectorLayerExporterDestinationUri( exporterOptions, providerOptions );
-
           providerOptions.insert( QStringLiteral( "update" ), true );
           providerOptions.insert( QStringLiteral( "overwrite" ), true );
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1894,6 +1894,12 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
   if ( !QgsMimeDataUtils::isUriList( data ) )
     return false;
 
+  const QgsMimeDataUtils::UriList sourceUris = QgsMimeDataUtils::decodeUriList( data );
+  if ( sourceUris.size() == 1 )
+  {
+    return handleDropUri( item, sourceUris.at( 0 ), context );
+  }
+
   QString uri;
 
   QStringList importResults;
@@ -1903,8 +1909,7 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
   auto mainTask = std::make_unique<QgsTaskWithSerialSubTasks>( tr( "Layer import" ) );
   bool hasSubTasks = false;
 
-  const QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( data );
-  for ( const QgsMimeDataUtils::Uri &dropUri : lst )
+  for ( const QgsMimeDataUtils::Uri &dropUri : sourceUris )
   {
     // Check that we are not copying over self
     if ( dropUri.uri.startsWith( item->path() ) )
@@ -2000,6 +2005,14 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
     QgsApplication::taskManager()->addTask( mainTask.release() );
   }
   return true;
+}
+
+bool QgsDatabaseItemGuiProvider::handleDropUri( QgsDataItem *item, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context )
+{
+  QPointer< QgsDataItem > connectionItemPointer( item );
+  std::unique_ptr<QgsAbstractDatabaseProviderConnection> databaseConnection( item->databaseConnection() );
+  if ( !databaseConnection )
+    return false;
 }
 
 void QgsDatabaseItemGuiProvider::openSqlDialog( const QString &connectionUri, const QString &provider, const QString &query, QgsDataItemGuiContext context, const QString &identifierName )

--- a/src/app/browser/qgsinbuiltdataitemproviders.h
+++ b/src/app/browser/qgsinbuiltdataitemproviders.h
@@ -21,6 +21,7 @@
 #include "qgis_app.h"
 #include "qgsdataitemguiprovider.h"
 #include "qgsweakrelation.h"
+#include "qgsmimedatautils.h"
 #include <QObject>
 
 class QgsDirectoryItem;
@@ -252,7 +253,7 @@ class QgsDatabaseItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     void populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
     bool acceptDrop( QgsDataItem *item, QgsDataItemGuiContext context ) override;
     bool handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction action ) override;
-
+    bool handleDropUri( QgsDataItem *item, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
 
     void openSqlDialog( const QString &connectionUri, const QString &provider, const QString &query, QgsDataItemGuiContext context, const QString &identifierName = QString() );
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.h
+++ b/src/app/browser/qgsinbuiltdataitemproviders.h
@@ -254,6 +254,7 @@ class QgsDatabaseItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     bool acceptDrop( QgsDataItem *item, QgsDataItemGuiContext context ) override;
     bool handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction action ) override;
     bool handleDropUri( QgsDataItem *item, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
+    void handleImportVector( QgsDataItem *item, QgsDataItemGuiContext context );
 
     void openSqlDialog( const QString &connectionUri, const QString &provider, const QString &query, QgsDataItemGuiContext context, const QString &identifierName = QString() );
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -541,6 +541,10 @@ QList<QgsLayerMetadataProviderResult> QgsGeoPackageProviderConnection::searchLay
   return results;
 }
 
+Qgis::DatabaseProviderTableImportCapabilities QgsGeoPackageProviderConnection::tableImportCapabilities() const
+{
+  return Qgis::DatabaseProviderTableImportCapabilities();
+}
 
 QgsFields QgsGeoPackageProviderConnection::fields( const QString &schema, const QString &table, QgsFeedback * ) const
 {

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -54,6 +54,7 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     QList< Qgis::FieldDomainType > supportedFieldDomainTypes() const override;
     QList<QgsLayerMetadataProviderResult> searchLayerMetadata( const QgsMetadataSearchContext &searchContext, const QString &searchString, const QgsRectangle &geographicExtent, QgsFeedback *feedback ) const override;
+    Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
 
   protected:
 

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -1334,4 +1334,9 @@ void QgsOgrProviderConnection::deleteRelationship( const QgsWeakRelation &relati
 #endif
 }
 
+Qgis::DatabaseProviderTableImportCapabilities QgsOgrProviderConnection::tableImportCapabilities() const
+{
+  return Qgis::DatabaseProviderTableImportCapabilities();
+}
+
 ///@endcond

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -334,6 +334,20 @@ void QgsOgrProviderConnection::createVectorTable( const QString &schema,
   }
 }
 
+QString QgsOgrProviderConnection::createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const
+{
+  if ( !options.schema.isEmpty() )
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "Schema is not supported by OGR, ignoring" ), QStringLiteral( "OGR" ), Qgis::MessageLevel::Info );
+  }
+
+  // OGR provider uses "layerName" from options rather then the table name from the URI
+  providerOptions.clear();
+  providerOptions.insert( QStringLiteral( "layerName" ), options.layerName );
+
+  return uri();
+}
+
 void QgsOgrProviderConnection::dropVectorTable( const QString &schema, const QString &name ) const
 {
   checkCapability( Capability::DropVectorTable );

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -80,6 +80,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
+    QString createVectorLayerExporterDestinationUri( const QgsAbstractDatabaseProviderConnection::VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void vacuum( const QString &schema, const QString &name ) const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -101,6 +101,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void addRelationship( const QgsWeakRelation &relationship ) const override;
     void updateRelationship( const QgsWeakRelation &relationship ) const override;
     void deleteRelationship( const QgsWeakRelation &relationship ) const override;
+    Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
 
   protected:
 

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -56,6 +56,12 @@ Qgis::SqlLayerDefinitionCapabilities QgsAbstractDatabaseProviderConnection::sqlL
   return mSqlLayerDefinitionCapabilities;
 }
 
+QString QgsAbstractDatabaseProviderConnection::createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType ) const
+{
+  Q_UNUSED( schema )
+  Q_UNUSED( name )
+  throw QgsProviderConnectionException( QObject::tr( "Operation 'createVectorLayerExporterDestinationUri' is not supported" ) );
+}
 
 QString QgsAbstractDatabaseProviderConnection::tableUri( const QString &schema, const QString &name ) const
 {

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1048,6 +1048,11 @@ QSet<QString> QgsAbstractDatabaseProviderConnection::illegalFieldNames() const
   return mIllegalFieldNames;
 }
 
+QString QgsAbstractDatabaseProviderConnection::defaultGeometryColumnName() const
+{
+  return QStringLiteral( "geom" );
+}
+
 QList<Qgis::FieldDomainType> QgsAbstractDatabaseProviderConnection::supportedFieldDomainTypes() const
 {
   return {};

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -56,10 +56,8 @@ Qgis::SqlLayerDefinitionCapabilities QgsAbstractDatabaseProviderConnection::sqlL
   return mSqlLayerDefinitionCapabilities;
 }
 
-QString QgsAbstractDatabaseProviderConnection::createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType ) const
+QString QgsAbstractDatabaseProviderConnection::createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &, QVariantMap & ) const
 {
-  Q_UNUSED( schema )
-  Q_UNUSED( name )
   throw QgsProviderConnectionException( QObject::tr( "Operation 'createVectorLayerExporterDestinationUri' is not supported" ) );
 }
 

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1048,6 +1048,11 @@ QSet<QString> QgsAbstractDatabaseProviderConnection::illegalFieldNames() const
   return mIllegalFieldNames;
 }
 
+QString QgsAbstractDatabaseProviderConnection::defaultPrimaryKeyColumnName() const
+{
+  return QStringLiteral( "pk" );
+}
+
 QString QgsAbstractDatabaseProviderConnection::defaultGeometryColumnName() const
 {
   return QStringLiteral( "geom" );

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1408,6 +1408,11 @@ void QgsAbstractDatabaseProviderConnection::setFieldAlias( const QString &, cons
   checkCapability( Qgis::DatabaseProviderConnectionCapability2::SetFieldAlias );
 }
 
+void QgsAbstractDatabaseProviderConnection::setTableComment( const QString &, const QString &, const QString & ) const
+{
+  checkCapability( Qgis::DatabaseProviderConnectionCapability2::SetTableComment );
+}
+
 void QgsAbstractDatabaseProviderConnection::setFieldComment( const QString &, const QString &, const QString &, const QString & ) const
 {
   checkCapability( Qgis::DatabaseProviderConnectionCapability2::SetFieldComment );

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -932,6 +932,17 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual QSet< QString > illegalFieldNames() const;
 
     /**
+     * Returns the default name to use for a primary key column for the connection.
+     *
+     * The returned name will match common practice for the database backend.
+     *
+     * The base class method returns "pk".
+     *
+     * \since QGIS 3.44
+     */
+    virtual QString defaultPrimaryKeyColumnName() const;
+
+    /**
      * Returns the default name to use for a geometry column for the connection.
      *
      * The returned name will match common practice for the database backend.

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -605,11 +605,40 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
-     * Creates a URI for use with QgsVectorLayerExporter corresponding to given destination table parameters for the backend.
+     * \brief Stores all information required to create a QgsVectorLayerExporter for the backend.
+     * \see createVectorLayerExporterDestinationUri()
+     *
+     * \since QGIS 3.44
+     */
+    struct CORE_EXPORT VectorLayerExporterOptions
+    {
+      //! Name for the new layer
+      QString layerName;
+
+      //! Optional schema for the new layer. May not be supported by all providers.
+      QString schema;
+
+      //! WKB type for destination layer geometry
+      Qgis::WkbType wkbType = Qgis::WkbType::NoGeometry;
+
+      //! List of primary key column names. Note that some providers may ignore this if not supported.
+      QStringList primaryKeyColumns;
+
+      //! Preferred name for the geometry column, if required. Note that some providers may ignore this if a specific geometry column name is required.
+      QString geometryColumn;
+
+    };
+
+    /**
+     * Creates a URI for use with QgsVectorLayerExporter corresponding to given destination table \a options for the backend.
+     *
+     * \param options defines the desired destination table details
+     * \param providerOptions will be set to a map of options to pass to createVectorTable() or the provider's createEmptyTable method.
+     * \returns destination URI for use with QgsVectorLayerExporter
      *
      * \throws QgsProviderConnectionException if any errors are encountered.
      */
-    virtual QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const SIP_THROW( QgsProviderConnectionException );
+    virtual QString createVectorLayerExporterDestinationUri( const QgsAbstractDatabaseProviderConnection::VectorLayerExporterOptions &options, QVariantMap &providerOptions SIP_OUT ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
      * Checks whether a table \a name exists in the given \a schema.

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -605,6 +605,13 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
+     * Creates a URI for use with QgsVectorLayerExporter corresponding to given destination table parameters for the backend.
+     *
+     * \throws QgsProviderConnectionException if any errors are encountered.
+     */
+    virtual QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const SIP_THROW( QgsProviderConnectionException );
+
+    /**
      * Checks whether a table \a name exists in the given \a schema.
      *
      * \throws QgsProviderConnectionException if any errors are encountered.

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -582,6 +582,13 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual GeometryColumnCapabilities geometryColumnCapabilities();
 
     /**
+     * Represents capabilities of the database provider connection when importing table data.
+     *
+     * \since QGIS 3.44
+     */
+    virtual Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const = 0;
+
+    /**
      * Returns SQL layer definition capabilities (Filters, GeometryColumn, PrimaryKeys).
      * \since QGIS 3.22
      */
@@ -923,6 +930,17 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * \since QGIS 3.30
      */
     virtual QSet< QString > illegalFieldNames() const;
+
+    /**
+     * Returns the default name to use for a geometry column for the connection.
+     *
+     * The returned name will match common practice for the database backend.
+     *
+     * The base class method returns "geom".
+     *
+     * \since QGIS 3.44
+     */
+    virtual QString defaultGeometryColumnName() const;
 
     /**
      * Returns a list of field domain names present on the provider.

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -1024,6 +1024,18 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual void setFieldAlias( const QString &fieldName, const QString &schema, const QString &tableName, const QString &alias ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
+     * Sets the \a comment for the existing table with the specified name.
+     *
+     * \param schema name of the schema (schema is ignored if not supported by the backend).
+     * \param tableName name of the table
+     * \param comment comment to set for the table. Set to an empty string to remove a previously set comment.
+     *
+     * \throws QgsProviderConnectionException if any errors are encountered.
+     * \since QGIS 3.44
+     */
+    virtual void setTableComment( const QString &schema, const QString &tableName, const QString &comment ) const SIP_THROW( QgsProviderConnectionException );
+
+    /**
      * Sets the \a comment for the existing field with the specified name.
      *
      * \param fieldName name of the field to be modified

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5145,6 +5145,7 @@ class CORE_EXPORT Qgis
     enum class DatabaseProviderTableImportCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
       SetGeometryColumnName = 1 << 0, //!< Can set the name of the geometry column
+      SetPrimaryKeyName = 1 << 1, //!< Can set the name of the primary key column
     };
     Q_ENUM( DatabaseProviderTableImportCapability )
     Q_DECLARE_FLAGS( DatabaseProviderTableImportCapabilities, DatabaseProviderTableImportCapability )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5138,6 +5138,19 @@ class CORE_EXPORT Qgis
     Q_FLAG( DatabaseProviderConnectionCapabilities2 )
 
     /**
+     * Represents capabilities of a database provider connection when importing table data.
+     *
+     * \since QGIS 3.44
+     */
+    enum class DatabaseProviderTableImportCapability : int SIP_ENUM_BASETYPE( IntFlag )
+    {
+      SetGeometryColumnName = 1 << 0, //!< Can set the name of the geometry column
+    };
+    Q_ENUM( DatabaseProviderTableImportCapability )
+    Q_DECLARE_FLAGS( DatabaseProviderTableImportCapabilities, DatabaseProviderTableImportCapability )
+    Q_FLAG( DatabaseProviderTableImportCapabilities )
+
+    /**
      * The StorageCapability enum represents the style storage operations supported by the provider.
      *
      * \since QGIS 3.34
@@ -5927,6 +5940,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BabelFormatCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BrowserItemCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::CoordinateTransformationFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::DatabaseProviderConnectionCapabilities2 )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::DatabaseProviderTableImportCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::DataProviderFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::FileOperationFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::GeometryValidityFlags )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5132,6 +5132,7 @@ class CORE_EXPORT Qgis
     {
       SetFieldComment = 1 << 0, //!< Can set comments for fields via setFieldComment()
       SetFieldAlias = 1 << 1, //!< Can set aliases for fields via setFieldAlias()
+      SetTableComment = 1 << 2, //!< Can set comments for tables via setTableComment() \since QGIS 3.44
     };
     Q_ENUM( DatabaseProviderConnectionCapability2 )
     Q_DECLARE_FLAGS( DatabaseProviderConnectionCapabilities2, DatabaseProviderConnectionCapability2 )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -592,6 +592,7 @@ set(QGIS_GUI_SRCS
   qgsdataitemguiproviderregistry.cpp
   qgsdataitemguiproviderutils.cpp
   qgsdatasourceselectdialog.cpp
+  qgsdbimportvectorlayerdialog.cpp
   qgsdbqueryhistoryprovider.cpp
   qgsdbrelationshipwidget.cpp
   qgsdecoratedscrollbar.cpp
@@ -857,6 +858,7 @@ set(QGIS_GUI_HDRS
   qgsdataitemguiproviderutils.h
   qgsdatasourcemanagerdialog.h
   qgsdatasourceselectdialog.h
+  qgsdbimportvectorlayerdialog.h
   qgsdbqueryhistoryprovider.h
   qgsdbrelationshipwidget.h
   qgsdecoratedscrollbar.h

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -429,6 +429,12 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
   if ( !QgsMimeDataUtils::isUriList( data ) )
     return false;
 
+  const QgsMimeDataUtils::UriList sourceUris = QgsMimeDataUtils::decodeUriList( data );
+  if ( sourceUris.size() == 1 )
+  {
+    return handleDropUri( item, sourceUris.at( 0 ), context );
+  }
+
   QString uri;
 
   QStringList importResults;
@@ -438,8 +444,7 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
   auto mainTask = std::make_unique<QgsTaskWithSerialSubTasks>( tr( "GeoPackage import" ) );
   bool hasSubTasks = false;
 
-  const auto lst = QgsMimeDataUtils::decodeUriList( data );
-  for ( const QgsMimeDataUtils::Uri &dropUri : lst )
+  for ( const QgsMimeDataUtils::Uri &dropUri : sourceUris )
   {
     // Check that we are not copying over self
     if ( dropUri.uri.startsWith( item->path() ) )
@@ -582,6 +587,14 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
     QgsApplication::taskManager()->addTask( mainTask.release() );
   }
   return true;
+}
+
+bool QgsGeoPackageItemGuiProvider::handleDropUri( QgsGeoPackageCollectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context )
+{
+  QPointer< QgsGeoPackageCollectionItem > connectionItemPointer( connectionItem );
+  std::unique_ptr<QgsAbstractDatabaseProviderConnection> databaseConnection( connectionItem->databaseConnection() );
+  if ( !databaseConnection )
+    return false;
 }
 
 ///@endcond

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -43,6 +43,7 @@
 #include "qgsprovidermetadata.h"
 #include "qgsogrproviderutils.h"
 #include "qgsfileutils.h"
+#include "qgsdbimportvectorlayerdialog.h"
 
 void QgsGeoPackageItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context )
 {
@@ -595,6 +596,11 @@ bool QgsGeoPackageItemGuiProvider::handleDropUri( QgsGeoPackageCollectionItem *c
   std::unique_ptr<QgsAbstractDatabaseProviderConnection> databaseConnection( connectionItem->databaseConnection() );
   if ( !databaseConnection )
     return false;
+
+  QgsDbImportVectorLayerDialog dialog( databaseConnection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
+  dialog.setSourceUri( sourceUri );
+  dialog.exec();
+  return true;
 }
 
 ///@endcond

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
@@ -48,6 +48,7 @@ class QgsGeoPackageItemGuiProvider : public QObject, public QgsDataItemGuiProvid
   private:
     bool handleDropGeopackage( QgsGeoPackageCollectionItem *item, const QMimeData *data, QgsDataItemGuiContext context );
     bool handleDropUri( QgsGeoPackageCollectionItem *item, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
+    void handleImportVector( QgsGeoPackageCollectionItem *item, QgsDataItemGuiContext context );
 
     //! Compacts (VACUUM) a geopackage database
     void vacuumGeoPackageDbAction( const QString &path, const QString &name, QgsDataItemGuiContext context );

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
@@ -20,7 +20,7 @@
 
 #include <QObject>
 #include "qgsdataitemguiprovider.h"
-#include "qgis_sip.h"
+#include "qgsmimedatautils.h"
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
@@ -47,6 +47,8 @@ class QgsGeoPackageItemGuiProvider : public QObject, public QgsDataItemGuiProvid
 
   private:
     bool handleDropGeopackage( QgsGeoPackageCollectionItem *item, const QMimeData *data, QgsDataItemGuiContext context );
+    bool handleDropUri( QgsGeoPackageCollectionItem *item, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
+
     //! Compacts (VACUUM) a geopackage database
     void vacuumGeoPackageDbAction( const QString &path, const QString &name, QgsDataItemGuiContext context );
     void createDatabase( const QPointer<QgsGeoPackageRootItem> &item );

--- a/src/gui/qgsdataitemguiproviderutils.cpp
+++ b/src/gui/qgsdataitemguiproviderutils.cpp
@@ -23,6 +23,9 @@
 #include "qgstaskmanager.h"
 #include "qgsmessagebaritem.h"
 #include "qgsmessageoutput.h"
+#include "qgsabstractdatabaseproviderconnection.h"
+#include "qgsproviderregistry.h"
+#include "qgsprovidermetadata.h"
 
 #include <QPointer>
 #include <QMessageBox>
@@ -68,6 +71,9 @@ bool QgsDataItemGuiProviderUtils::handleDropUriForConnection( std::unique_ptr<Qg
   if ( !connection )
     return false;
 
+  const QString connectionUri = connection->uri();
+  const QString connectionProvider = connection->providerKey();
+
   QgsDbImportVectorLayerDialog dialog( connection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
   dialog.setSourceUri( sourceUri );
   dialog.setDestinationSchema( destinationSchema );
@@ -78,26 +84,59 @@ bool QgsDataItemGuiProviderUtils::handleDropUriForConnection( std::unique_ptr<Qg
   if ( !exportTask )
     return false;
 
+  const QString destSchema = dialog.schema();
+  const QString destTableName = dialog.tableName();
+  const QString tableComment = dialog.tableComment();
+
+  auto pushError = [shortTitle, longTitle, context]( const QString &error ) {
+    QgsMessageBarItem *item = new QgsMessageBarItem( shortTitle, QObject::tr( "Import failed." ), Qgis::MessageLevel::Warning, 0, nullptr );
+    QPushButton *detailsButton = new QPushButton( QObject::tr( "Details…" ) );
+    QObject::connect( detailsButton, &QPushButton::clicked, detailsButton, [=] {
+      QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+      output->setTitle( longTitle );
+      output->setMessage( error, QgsMessageOutput::MessageText );
+      output->showMessage();
+    } );
+    item->layout()->addWidget( detailsButton );
+    context.messageBar()->pushWidget( item, Qgis::MessageLevel::Warning );
+  };
+
   // when export is successful:
-  QObject::connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, connectionContext, [onSuccessfulCompletion, shortTitle, context]() {
+  QObject::connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, connectionContext, [onSuccessfulCompletion, connectionUri, longTitle, pushError, connectionProvider, destSchema, destTableName, tableComment, shortTitle, context]() {
+    if ( !tableComment.isEmpty() )
+    {
+      std::unique_ptr<QgsAbstractDatabaseProviderConnection> connection;
+      try
+      {
+        QgsProviderMetadata *md = QgsProviderRegistry::instance()->providerMetadata( connectionProvider );
+        connection.reset( static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, {} ) ) );
+      }
+      catch ( QgsProviderConnectionException &e )
+      {
+        pushError( QObject::tr( "Could not retrieve connection details:\n\n%1" ).arg( e.what() ) );
+        return;
+      }
+
+      try
+      {
+        connection->setTableComment( destSchema, destTableName, tableComment );
+      }
+      catch ( QgsProviderConnectionException &e )
+      {
+        pushError( QObject::tr( "Failed to set new table comment!\n\n" ) + e.what() );
+        return;
+      }
+    }
+
     context.messageBar()->pushSuccess( shortTitle, QObject::tr( "Import was successful." ) );
     onSuccessfulCompletion();
   } );
 
   // when an error occurs:
-  QObject::connect( exportTask.get(), &QgsVectorLayerExporterTask::errorOccurred, connectionContext, [onError, shortTitle, longTitle, context]( Qgis::VectorExportResult error, const QString &errorMessage ) {
+  QObject::connect( exportTask.get(), &QgsVectorLayerExporterTask::errorOccurred, connectionContext, [onError, shortTitle, pushError, longTitle]( Qgis::VectorExportResult error, const QString &errorMessage ) {
     if ( error != Qgis::VectorExportResult::UserCanceled )
     {
-      QgsMessageBarItem *item = new QgsMessageBarItem( shortTitle, QObject::tr( "Import failed." ), Qgis::MessageLevel::Warning, 0, nullptr );
-      QPushButton *detailsButton = new QPushButton( QObject::tr( "Details…" ) );
-      QObject::connect( detailsButton, &QPushButton::clicked, detailsButton, [=] {
-        QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
-        output->setTitle( longTitle );
-        output->setMessage( QObject::tr( "Failed to import layer!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
-        output->showMessage();
-      } );
-      item->layout()->addWidget( detailsButton );
-      context.messageBar()->pushWidget( item, Qgis::MessageLevel::Warning );
+      pushError( QObject::tr( "Failed to import layer!\n\n" ) + errorMessage );
     }
 
     onError( error, errorMessage );

--- a/src/gui/qgsdataitemguiproviderutils.h
+++ b/src/gui/qgsdataitemguiproviderutils.h
@@ -71,6 +71,25 @@ class GUI_EXPORT QgsDataItemGuiProviderUtils
      */
     static const QString uniqueName( const QString &name, const QStringList &connectionNames );
 
+
+    /**
+     * Handles dropping a vecot layer for \a connection items.
+     *
+     * \note Not available in Python bindings
+     */
+    static bool handleDropUriForConnection(
+      std::unique_ptr< QgsAbstractDatabaseProviderConnection > connection,
+      const QgsMimeDataUtils::Uri &sourceUri,
+      const QString &destinationSchema,
+      QgsDataItemGuiContext context,
+      const QString &shortTitle,
+      const QString &longTitle,
+      const QVariantMap &destinationProviderOptions,
+      const std::function<void()> &onSuccessfulCompletion,
+      const std::function<void( Qgis::VectorExportResult error, const QString &errorMessage )> &onError,
+      QObject *connectionContext
+    );
+
 #endif
 
   private:

--- a/src/gui/qgsdataitemguiproviderutils.h
+++ b/src/gui/qgsdataitemguiproviderutils.h
@@ -71,15 +71,31 @@ class GUI_EXPORT QgsDataItemGuiProviderUtils
      */
     static const QString uniqueName( const QString &name, const QStringList &connectionNames );
 
-
     /**
-     * Handles dropping a vecot layer for \a connection items.
+     * Handles dropping a vector layer for \a connection items.
      *
      * \note Not available in Python bindings
      */
     static bool handleDropUriForConnection(
       std::unique_ptr< QgsAbstractDatabaseProviderConnection > connection,
       const QgsMimeDataUtils::Uri &sourceUri,
+      const QString &destinationSchema,
+      QgsDataItemGuiContext context,
+      const QString &shortTitle,
+      const QString &longTitle,
+      const QVariantMap &destinationProviderOptions,
+      const std::function<void()> &onSuccessfulCompletion,
+      const std::function<void( Qgis::VectorExportResult error, const QString &errorMessage )> &onError,
+      QObject *connectionContext
+    );
+
+    /**
+     * Handles importing a vector layer for \a connection items.
+     *
+     * \note Not available in Python bindings
+     */
+    static void handleImportVectorLayerForConnection(
+      std::unique_ptr< QgsAbstractDatabaseProviderConnection > connection,
       const QString &destinationSchema,
       QgsDataItemGuiContext context,
       const QString &shortTitle,

--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -17,6 +17,8 @@
 #include "moc_qgsdbimportvectorlayerdialog.cpp"
 #include "qgsabstractdatabaseproviderconnection.h"
 #include "qgsgui.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayerexporter.h"
 
 QgsDbImportVectorLayerDialog::QgsDbImportVectorLayerDialog( QgsAbstractDatabaseProviderConnection *connection, QWidget *parent )
   : QDialog( parent )
@@ -25,6 +27,9 @@ QgsDbImportVectorLayerDialog::QgsDbImportVectorLayerDialog( QgsAbstractDatabaseP
   setupUi( this );
   setObjectName( "QgsDbImportVectorLayerDialog" );
   QgsGui::enableAutoGeometryRestore( this );
+
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsDbImportVectorLayerDialog::doImport );
 
   Q_ASSERT( connection );
 
@@ -51,4 +56,39 @@ void QgsDbImportVectorLayerDialog::setDestinationSchema( const QString &schema )
 void QgsDbImportVectorLayerDialog::setSourceUri( const QgsMimeDataUtils::Uri &uri )
 {
   mEditTable->setText( uri.name );
+
+  mSourceLayer.reset();
+  bool owner = false;
+  QString error;
+  QgsVectorLayer *vl = uri.vectorLayer( owner, error );
+  if ( owner )
+    mSourceLayer.reset( vl );
+  else if ( vl )
+    mSourceLayer.reset( vl->clone() );
+}
+
+void QgsDbImportVectorLayerDialog::doImport()
+{
+  // TODO -- validate
+
+  accept();
+}
+
+std::unique_ptr<QgsVectorLayerExporterTask> QgsDbImportVectorLayerDialog::createExporterTask()
+{
+  if ( !mSourceLayer )
+    return nullptr;
+
+  QString destinationUri;
+  const Qgis::WkbType destinationWkbType = mSourceLayer->wkbType();
+  try
+  {
+    destinationUri = mConnection->createVectorLayerExporterDestinationUri( mEditSchema ? mEditSchema->text() : QString(), mEditTable->text(), destinationWkbType );
+  }
+  catch ( QgsProviderConnectionException &e )
+  {
+    return nullptr;
+  }
+
+  return std::make_unique<QgsVectorLayerExporterTask>( mSourceLayer->clone(), destinationUri, mConnection->providerKey(), mSourceLayer->crs(), QVariantMap(), true );
 }

--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+  qgsdbimportvectorlayerdialog.cpp
+  --------------------------------------
+  Date                 : March 2025
+  Copyright            : (C) 2025 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdbimportvectorlayerdialog.h"
+#include "moc_qgsdbimportvectorlayerdialog.cpp"
+#include "qgsabstractdatabaseproviderconnection.h"
+#include "qgsgui.h"
+
+QgsDbImportVectorLayerDialog::QgsDbImportVectorLayerDialog( QgsAbstractDatabaseProviderConnection *connection, QWidget *parent )
+  : QDialog( parent )
+  , mConnection( connection )
+{
+  setupUi( this );
+  setObjectName( "QgsDbImportVectorLayerDialog" );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  Q_ASSERT( connection );
+
+  mEditSchema->setReadOnly( true );
+
+  const bool supportsSchemas = mConnection->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Schemas );
+  if ( !supportsSchemas )
+  {
+    delete mLabelSchemas;
+    mLabelSchemas = nullptr;
+    delete mEditSchema;
+    mEditSchema = nullptr;
+  }
+}
+
+QgsDbImportVectorLayerDialog::~QgsDbImportVectorLayerDialog() = default;
+
+void QgsDbImportVectorLayerDialog::setDestinationSchema( const QString &schema )
+{
+  if ( mEditSchema )
+    mEditSchema->setText( schema );
+}
+
+void QgsDbImportVectorLayerDialog::setSourceUri( const QgsMimeDataUtils::Uri &uri )
+{
+  mEditTable->setText( uri.name );
+}

--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -86,6 +86,18 @@ void QgsDbImportVectorLayerDialog::setSourceUri( const QgsMimeDataUtils::Uri &ur
   if ( !mSourceLayer || !mSourceLayer->dataProvider() )
     return;
 
+  if ( !mSourceLayer->isSpatial() )
+  {
+    delete mLabelGeometryColumn;
+    mLabelGeometryColumn = nullptr;
+    delete mEditGeometryColumnName;
+    mEditGeometryColumnName = nullptr;
+    delete mLabelDestinationCrs;
+    mLabelDestinationCrs = nullptr;
+    delete mCrsSelector;
+    mCrsSelector = nullptr;
+  }
+
   if ( mEditPrimaryKey )
   {
     // set initial geometry column name. We use the source layer's primary key column name if available,
@@ -121,6 +133,11 @@ void QgsDbImportVectorLayerDialog::setSourceUri( const QgsMimeDataUtils::Uri &ur
     }
 
     mEditGeometryColumnName->setText( geomColumn );
+  }
+
+  if ( mCrsSelector )
+  {
+    mCrsSelector->setCrs( mSourceLayer->crs() );
   }
 }
 
@@ -165,5 +182,11 @@ std::unique_ptr<QgsVectorLayerExporterTask> QgsDbImportVectorLayerDialog::create
     allProviderOptions.insert( it.key(), it.value() );
   }
 
-  return std::make_unique<QgsVectorLayerExporterTask>( mSourceLayer->clone(), destinationUri, mConnection->providerKey(), mSourceLayer->crs(), allProviderOptions, true );
+  QgsCoordinateReferenceSystem destinationCrs;
+  if ( mCrsSelector )
+  {
+    destinationCrs = mCrsSelector->crs();
+  }
+
+  return std::make_unique<QgsVectorLayerExporterTask>( mSourceLayer->clone(), destinationUri, mConnection->providerKey(), destinationCrs, allProviderOptions, true );
 }

--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -217,5 +217,11 @@ std::unique_ptr<QgsVectorLayerExporterTask> QgsDbImportVectorLayerDialog::create
     destinationCrs = mCrsSelector->crs();
   }
 
+  // overwrite?
+  if ( mChkDropTable->isChecked() )
+  {
+    allProviderOptions.insert( QStringLiteral( "overwrite" ), true );
+  }
+
   return std::make_unique<QgsVectorLayerExporterTask>( mSourceLayer->clone(), destinationUri, mConnection->providerKey(), destinationCrs, allProviderOptions, true );
 }

--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -60,6 +60,15 @@ QgsDbImportVectorLayerDialog::QgsDbImportVectorLayerDialog( QgsAbstractDatabaseP
     delete mEditGeometryColumnName;
     mEditGeometryColumnName = nullptr;
   }
+
+  const bool supportsTableComments = mConnection->capabilities2().testFlag( Qgis::DatabaseProviderConnectionCapability2::SetTableComment );
+  if ( !supportsTableComments )
+  {
+    delete mLabelComment;
+    mLabelComment = nullptr;
+    delete mEditComment;
+    mEditComment = nullptr;
+  }
 }
 
 QgsDbImportVectorLayerDialog::~QgsDbImportVectorLayerDialog() = default;
@@ -139,6 +148,26 @@ void QgsDbImportVectorLayerDialog::setSourceUri( const QgsMimeDataUtils::Uri &ur
   {
     mCrsSelector->setCrs( mSourceLayer->crs() );
   }
+
+  if ( mEditComment )
+  {
+    mEditComment->setPlainText( mSourceLayer->metadata().abstract() );
+  }
+}
+
+QString QgsDbImportVectorLayerDialog::schema() const
+{
+  return mEditSchema ? mEditSchema->text() : QString();
+}
+
+QString QgsDbImportVectorLayerDialog::tableName() const
+{
+  return mEditTable->text();
+}
+
+QString QgsDbImportVectorLayerDialog::tableComment() const
+{
+  return mEditComment ? mEditComment->toPlainText() : QString();
 }
 
 void QgsDbImportVectorLayerDialog::doImport()

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -22,6 +22,7 @@
 #include "ui_qgsdbimportvectorlayerdialog.h"
 
 class QgsAbstractDatabaseProviderConnection;
+class QgsVectorLayerExporterTask;
 
 /**
  * \class QgsDbImportVectorLayerDialog
@@ -43,8 +44,15 @@ class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsD
 
     void setSourceUri( const QgsMimeDataUtils::Uri &uri );
 
+    std::unique_ptr<QgsVectorLayerExporterTask> createExporterTask();
+
+  private slots:
+
+    void doImport();
 
   private:
+    std::unique_ptr< QgsVectorLayer > mSourceLayer;
+
     std::unique_ptr< QgsAbstractDatabaseProviderConnection > mConnection;
 };
 

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -44,6 +44,10 @@ class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsD
 
     void setSourceUri( const QgsMimeDataUtils::Uri &uri );
 
+    QString schema() const;
+    QString tableName() const;
+    QString tableComment() const;
+
     std::unique_ptr<QgsVectorLayerExporterTask> createExporterTask( const QVariantMap &extraProviderOptions = QVariantMap() );
 
   private slots:

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -41,23 +41,48 @@ class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsD
     Q_OBJECT
 
   public:
+    /**
+     * Constructor for QgsDbImportVectorLayerDialog.
+     *
+     * Ownership of \a connection is transferred to the dialog.
+     */
     QgsDbImportVectorLayerDialog( QgsAbstractDatabaseProviderConnection *connection SIP_TRANSFER, QWidget *parent = nullptr );
     ~QgsDbImportVectorLayerDialog() override;
 
+    /**
+     * Sets the destination \a schema for the new table.
+     */
     void setDestinationSchema( const QString &schema );
 
+    /**
+     * Sets the source table \a uri.
+     */
     void setSourceUri( const QgsMimeDataUtils::Uri &uri );
 
+    /**
+     * Returns the destination schema.
+     */
     QString schema() const;
+
+    /**
+     * Returns the destination table name.
+     */
     QString tableName() const;
+
+    /**
+     * Returns the optional comment to use for the new table.
+     */
     QString tableComment() const;
 
+    /**
+     * Creates a new exporter task to match the settings defined in the dialog.
+     */
     std::unique_ptr<QgsVectorLayerExporterTask> createExporterTask( const QVariantMap &extraProviderOptions = QVariantMap() );
 
-    void setSourceLayer( QgsVectorLayer *layer );
   private slots:
     void sourceLayerComboChanged();
     void doImport();
+    void setSourceLayer( QgsVectorLayer *layer );
 
   private:
     std::unique_ptr< QgsVectorLayer > mOwnedSource;

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -44,7 +44,7 @@ class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsD
 
     void setSourceUri( const QgsMimeDataUtils::Uri &uri );
 
-    std::unique_ptr<QgsVectorLayerExporterTask> createExporterTask();
+    std::unique_ptr<QgsVectorLayerExporterTask> createExporterTask( const QVariantMap &extraProviderOptions = QVariantMap() );
 
   private slots:
 

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -50,12 +50,16 @@ class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsD
 
     std::unique_ptr<QgsVectorLayerExporterTask> createExporterTask( const QVariantMap &extraProviderOptions = QVariantMap() );
 
+    void setSourceLayer( QgsVectorLayer *layer );
   private slots:
-
+    void sourceLayerComboChanged();
     void doImport();
 
   private:
-    std::unique_ptr< QgsVectorLayer > mSourceLayer;
+    std::unique_ptr< QgsVectorLayer > mOwnedSource;
+    QPointer< QgsVectorLayer > mSourceLayer;
+
+    int mBlockSourceLayerChanges = 0;
 
     std::unique_ptr< QgsAbstractDatabaseProviderConnection > mConnection;
 };

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+  qgsdbimportvectorlayerdialog.h
+  --------------------------------------
+  Date                 : March 2025
+  Copyright            : (C) 2025 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDBIMPORTVECTORLAYERDIALOG_H
+#define QGSDBIMPORTVECTORLAYERDIALOG_H
+
+#include "qgis_gui.h"
+#include "qgis.h"
+#include "qgsmimedatautils.h"
+#include "ui_qgsdbimportvectorlayerdialog.h"
+
+class QgsAbstractDatabaseProviderConnection;
+
+/**
+ * \class QgsDbImportVectorLayerDialog
+ * \ingroup gui
+ *
+ * \brief A generic dialog for customising vector layer import options for database connections.
+ *
+ * \since QGIS 3.44
+ */
+class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsDbImportVectorLayerDialog
+{
+    Q_OBJECT
+
+  public:
+    QgsDbImportVectorLayerDialog( QgsAbstractDatabaseProviderConnection *connection SIP_TRANSFER, QWidget *parent = nullptr );
+    ~QgsDbImportVectorLayerDialog() override;
+
+    void setDestinationSchema( const QString &schema );
+
+    void setSourceUri( const QgsMimeDataUtils::Uri &uri );
+
+
+  private:
+    std::unique_ptr< QgsAbstractDatabaseProviderConnection > mConnection;
+};
+
+#endif // QGSDBIMPORTVECTORLAYERDIALOG_H

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -24,11 +24,15 @@
 class QgsAbstractDatabaseProviderConnection;
 class QgsVectorLayerExporterTask;
 
+#define SIP_NO_FILE
+
 /**
  * \class QgsDbImportVectorLayerDialog
  * \ingroup gui
  *
  * \brief A generic dialog for customising vector layer import options for database connections.
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.44
  */

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -166,12 +166,12 @@ bool QgsHanaDataItemGuiProvider::acceptDrop( QgsDataItem *item, QgsDataItemGuiCo
 }
 
 bool QgsHanaDataItemGuiProvider::handleDrop(
-  QgsDataItem *item, QgsDataItemGuiContext, const QMimeData *data, Qt::DropAction
+  QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction
 )
 {
   if ( QgsHanaConnectionItem *connItem = qobject_cast<QgsHanaConnectionItem *>( item ) )
   {
-    return handleDrop( connItem, data, QString() );
+    return handleDrop( connItem, data, QString(), context );
   }
   else if ( QgsHanaSchemaItem *schemaItem = qobject_cast<QgsHanaSchemaItem *>( item ) )
   {
@@ -179,7 +179,7 @@ bool QgsHanaDataItemGuiProvider::handleDrop(
     if ( !connItem )
       return false;
 
-    return handleDrop( connItem, data, schemaItem->name() );
+    return handleDrop( connItem, data, schemaItem->name(), context );
   }
   return false;
 }
@@ -391,7 +391,7 @@ void QgsHanaDataItemGuiProvider::renameLayer( QgsHanaLayerItem *layerItem, QgsDa
   }
 }
 
-bool QgsHanaDataItemGuiProvider::handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema )
+bool QgsHanaDataItemGuiProvider::handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext )
 {
   if ( !QgsMimeDataUtils::isUriList( data ) || !connectionItem )
     return false;

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -29,6 +29,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerexporter.h"
 #include "qgsmessageoutput.h"
+#include "qgsdbimportvectorlayerdialog.h"
 
 #include <QInputDialog>
 #include <QMessageBox>
@@ -503,4 +504,10 @@ bool QgsHanaDataItemGuiProvider::handleDropUri( QgsHanaConnectionItem *connectio
   std::unique_ptr<QgsAbstractDatabaseProviderConnection> databaseConnection( connectionItem->databaseConnection() );
   if ( !databaseConnection )
     return false;
+
+  QgsDbImportVectorLayerDialog dialog( databaseConnection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
+  dialog.setSourceUri( sourceUri );
+  dialog.setDestinationSchema( toSchema );
+  dialog.exec();
+  return true;
 }

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -525,16 +525,14 @@ bool QgsHanaDataItemGuiProvider::handleDropUri( QgsHanaConnectionItem *connectio
   auto onSuccess = [connectionItemPointer, toSchema]() {
     if ( connectionItemPointer )
     {
-      if ( connectionItemPointer )
-        connectionItemPointer->refreshSchema( toSchema );
+      connectionItemPointer->refreshSchema( toSchema );
     }
   };
 
   auto onFailure = [connectionItemPointer, toSchema]( Qgis::VectorExportResult, const QString & ) {
     if ( connectionItemPointer )
     {
-      if ( connectionItemPointer )
-        connectionItemPointer->refreshSchema( toSchema );
+      connectionItemPointer->refreshSchema( toSchema );
     }
   };
 
@@ -554,16 +552,14 @@ void QgsHanaDataItemGuiProvider::handleImportVector( QgsHanaConnectionItem *conn
   auto onSuccess = [connectionItemPointer, toSchema]() {
     if ( connectionItemPointer )
     {
-      if ( connectionItemPointer )
-        connectionItemPointer->refreshSchema( toSchema );
+      connectionItemPointer->refreshSchema( toSchema );
     }
   };
 
   auto onFailure = [connectionItemPointer, toSchema]( Qgis::VectorExportResult, const QString & ) {
     if ( connectionItemPointer )
     {
-      if ( connectionItemPointer )
-        connectionItemPointer->refreshSchema( toSchema );
+      connectionItemPointer->refreshSchema( toSchema );
     }
   };
 

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -51,6 +51,7 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 
     bool handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
     bool handleDropUri( QgsHanaConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, const QString &toSchema, QgsDataItemGuiContext context );
+    void handleImportVector( QgsHanaConnectionItem *connectionItem, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSHANADATAITEMGUIPROVIDER_H

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -18,6 +18,7 @@
 #define QGSHANADATAITEMGUIPROVIDER_H
 
 #include "qgsdataitemguiprovider.h"
+#include "qgsmimedatautils.h"
 
 class QgsHanaSchemaItem;
 class QgsHanaLayerItem;
@@ -49,6 +50,7 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void renameLayer( QgsHanaLayerItem *layerItem, QgsDataItemGuiContext context );
 
     bool handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
+    bool handleDropUri( QgsHanaConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSHANADATAITEMGUIPROVIDER_H

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -21,6 +21,7 @@
 
 class QgsHanaSchemaItem;
 class QgsHanaLayerItem;
+class QgsHanaConnectionItem;
 
 class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 {
@@ -46,6 +47,8 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void deleteSchema( QgsHanaSchemaItem *schemaItem, QgsDataItemGuiContext context );
     static void renameSchema( QgsHanaSchemaItem *schemaItem, QgsDataItemGuiContext context );
     static void renameLayer( QgsHanaLayerItem *layerItem, QgsDataItemGuiContext context );
+
+    bool handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema );
 };
 
 #endif // QGSHANADATAITEMGUIPROVIDER_H

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -48,7 +48,7 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void renameSchema( QgsHanaSchemaItem *schemaItem, QgsDataItemGuiContext context );
     static void renameLayer( QgsHanaLayerItem *layerItem, QgsDataItemGuiContext context );
 
-    bool handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema );
+    bool handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSHANADATAITEMGUIPROVIDER_H

--- a/src/providers/hana/qgshanadataitems.h
+++ b/src/providers/hana/qgshanadataitems.h
@@ -23,6 +23,7 @@
 #include "qgsdatabaseschemaitem.h"
 #include "qgsdatacollectionitem.h"
 #include "qgslayeritem.h"
+#include "qgsdatasourceuri.h"
 
 class QgsHanaRootItem;
 class QgsHanaConnectionItem;
@@ -52,8 +53,7 @@ class QgsHanaConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
-    using QgsDataCollectionItem::handleDrop;
-    bool handleDrop( const QMimeData *data, const QString &toSchema );
+    QgsDataSourceUri connectionUri() const;
 
   private:
     void updateToolTip( const QString &userName, const QString &dbmsVersion );

--- a/src/providers/hana/qgshanaproviderconnection.cpp
+++ b/src/providers/hana/qgshanaproviderconnection.cpp
@@ -205,6 +205,28 @@ void QgsHanaProviderConnection::createVectorTable( const QString &schema, const 
   }
 }
 
+QString QgsHanaProviderConnection::createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const
+{
+  QgsDataSourceUri destUri( uri() );
+
+  destUri.setTable( options.layerName );
+  destUri.setSchema( options.schema );
+  destUri.setGeometryColumn( options.wkbType != Qgis::WkbType::NoGeometry ? ( options.geometryColumn.isEmpty() ? QStringLiteral( "geom" ) : options.geometryColumn ) : QString() );
+
+  if ( !options.primaryKeyColumns.isEmpty() )
+  {
+    if ( options.primaryKeyColumns.length() > 1 )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Multiple primary keys are not supported by HANA, ignoring" ), QString(), Qgis::MessageLevel::Info );
+    }
+    destUri.setKeyColumn( options.primaryKeyColumns.at( 0 ) );
+  }
+
+  providerOptions.clear();
+
+  return destUri.uri( false );
+}
+
 QString QgsHanaProviderConnection::tableUri( const QString &schema, const QString &name ) const
 {
   const TableProperty tableInfo { table( schema, name ) };

--- a/src/providers/hana/qgshanaproviderconnection.cpp
+++ b/src/providers/hana/qgshanaproviderconnection.cpp
@@ -2045,7 +2045,12 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsHanaProviderConnection::sqlD
 
 Qgis::DatabaseProviderTableImportCapabilities QgsHanaProviderConnection::tableImportCapabilities() const
 {
-  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName | Qgis::DatabaseProviderTableImportCapability::SetPrimaryKeyName;
+}
+
+QString QgsHanaProviderConnection::defaultPrimaryKeyColumnName() const
+{
+  return QStringLiteral( "id" );
 }
 
 QVariantList QgsHanaEmptyProviderResultIterator::nextRowPrivate()

--- a/src/providers/hana/qgshanaproviderconnection.cpp
+++ b/src/providers/hana/qgshanaproviderconnection.cpp
@@ -2043,6 +2043,11 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsHanaProviderConnection::sqlD
   );
 }
 
+Qgis::DatabaseProviderTableImportCapabilities QgsHanaProviderConnection::tableImportCapabilities() const
+{
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+}
+
 QVariantList QgsHanaEmptyProviderResultIterator::nextRowPrivate()
 {
   return QVariantList();

--- a/src/providers/hana/qgshanaproviderconnection.h
+++ b/src/providers/hana/qgshanaproviderconnection.h
@@ -58,7 +58,7 @@ class QgsHanaProviderConnection : public QgsAbstractDatabaseProviderConnection
 
   public:
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
-
+    QString createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;

--- a/src/providers/hana/qgshanaproviderconnection.h
+++ b/src/providers/hana/qgshanaproviderconnection.h
@@ -77,6 +77,7 @@ class QgsHanaProviderConnection : public QgsAbstractDatabaseProviderConnection
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
+    Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
 
   private:
     QgsHanaConnectionRef createConnection() const;

--- a/src/providers/hana/qgshanaproviderconnection.h
+++ b/src/providers/hana/qgshanaproviderconnection.h
@@ -78,6 +78,7 @@ class QgsHanaProviderConnection : public QgsAbstractDatabaseProviderConnection
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
+    QString defaultPrimaryKeyColumnName() const override;
 
   private:
     QgsHanaConnectionRef createConnection() const;

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -160,11 +160,11 @@ bool QgsMssqlDataItemGuiProvider::acceptDrop( QgsDataItem *item, QgsDataItemGuiC
   return false;
 }
 
-bool QgsMssqlDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiContext, const QMimeData *data, Qt::DropAction )
+bool QgsMssqlDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction )
 {
   if ( QgsMssqlConnectionItem *connItem = qobject_cast<QgsMssqlConnectionItem *>( item ) )
   {
-    return handleDrop( connItem, data, QString() );
+    return handleDrop( connItem, data, QString(), context );
   }
   else if ( QgsMssqlSchemaItem *schemaItem = qobject_cast<QgsMssqlSchemaItem *>( item ) )
   {
@@ -172,7 +172,7 @@ bool QgsMssqlDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiC
     if ( !connItem )
       return false;
 
-    return handleDrop( connItem, data, schemaItem->name() );
+    return handleDrop( connItem, data, schemaItem->name(), context );
   }
   return false;
 }
@@ -272,7 +272,7 @@ void QgsMssqlDataItemGuiProvider::loadConnections( QgsDataItem *item )
     item->refreshConnections();
 }
 
-bool QgsMssqlDataItemGuiProvider::handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema )
+bool QgsMssqlDataItemGuiProvider::handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext )
 {
   if ( !QgsMimeDataUtils::isUriList( data ) || !connectionItem )
     return false;

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -28,6 +28,8 @@
 #include "qgsvectorlayerexporter.h"
 #include "qgsmessageoutput.h"
 #include "qgsabstractdatabaseproviderconnection.h"
+#include "qgsdbimportvectorlayerdialog.h"
+#include "qgsbrowsertreeview.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -379,4 +381,11 @@ bool QgsMssqlDataItemGuiProvider::handleDropUri( QgsMssqlConnectionItem *connect
   std::unique_ptr<QgsAbstractDatabaseProviderConnection> databaseConnection( connectionItem->databaseConnection() );
   if ( !databaseConnection )
     return false;
+
+  QgsDbImportVectorLayerDialog dialog( databaseConnection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
+  dialog.setDestinationSchema( toSchema );
+  dialog.setSourceUri( sourceUri );
+  dialog.exec();
+
+  return true;
 }

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -293,7 +293,6 @@ bool QgsMssqlDataItemGuiProvider::handleDrop( QgsMssqlConnectionItem *connection
   }
 
   QPointer< QgsMssqlConnectionItem > connectionItemPointer( connectionItem );
-  const QString connectionUri = connectionItem->connectionUri();
 
   // TODO: when dropping multiple layers, we need a dedicated "bulk import" dialog for settings which apply to ALL layers
 

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -43,7 +43,7 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
 
-    bool handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema );
+    bool handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSMSSQLDATAITEMGUIPROVIDER_H

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -46,6 +46,7 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
 
     bool handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
     bool handleDropUri( QgsMssqlConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, const QString &toSchema, QgsDataItemGuiContext context );
+    void handleImportVector( QgsMssqlConnectionItem *connectionItem, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSMSSQLDATAITEMGUIPROVIDER_H

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -17,6 +17,7 @@
 #define QGSMSSQLDATAITEMGUIPROVIDER_H
 
 #include "qgsdataitemguiprovider.h"
+#include "qgsmimedatautils.h"
 
 class QgsMssqlConnectionItem;
 class QgsMssqlLayerItem;
@@ -44,6 +45,7 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     static void loadConnections( QgsDataItem *item );
 
     bool handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
+    bool handleDropUri( QgsMssqlConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSMSSQLDATAITEMGUIPROVIDER_H

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -43,7 +43,6 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
 
-
     bool handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema );
 };
 

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -42,6 +42,9 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     static void truncateTable( QgsMssqlLayerItem *layerItem );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
+
+
+    bool handleDrop( QgsMssqlConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema );
 };
 
 #endif // QGSMSSQLDATAITEMGUIPROVIDER_H

--- a/src/providers/mssql/qgsmssqldataitems.h
+++ b/src/providers/mssql/qgsmssqldataitems.h
@@ -64,10 +64,7 @@ class QgsMssqlConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
-    using QgsDataCollectionItem::handleDrop;
-    bool handleDrop( const QMimeData *data, const QString &toSchema );
-
-    QString connInfo() const { return mConnInfo; }
+    QString connectionUri() const { return mConnectionUri; }
     bool allowGeometrylessTables() const { return mAllowGeometrylessTables; }
 
   signals:
@@ -85,7 +82,7 @@ class QgsMssqlConnectionItem : public QgsDataCollectionItem
     void setAsPopulated();
 
   private:
-    QString mConnInfo;
+    QString mConnectionUri;
     QString mService;
     QString mHost;
     QString mDatabase;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -2028,8 +2028,6 @@ Qgis::WkbType QgsMssqlProvider::getWkbType( const QString &geometryType )
 
 Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, QMap<int, int> *oldToNewAttrIdxMap, QString &createdLayerUri, QString *errorMessage, const QMap<QString, QVariant> *options )
 {
-  Q_UNUSED( options )
-
   // populate members from the uri structure
   QgsDataSourceUri dsUri( uri );
 

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -813,6 +813,11 @@ bool QgsMssqlProviderConnection::validateSqlVectorLayer( const SqlVectorLayerOpt
   return true;
 }
 
+Qgis::DatabaseProviderTableImportCapabilities QgsMssqlProviderConnection::tableImportCapabilities() const
+{
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+}
+
 QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions QgsMssqlProviderConnection::sqlOptions( const QString &layerSource )
 {
   SqlVectorLayerOptions options;

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -178,6 +178,27 @@ void QgsMssqlProviderConnection::createVectorTable( const QString &schema, const
   }
 }
 
+QString QgsMssqlProviderConnection::createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const
+{
+  QgsDataSourceUri destUri( uri() );
+
+  destUri.setTable( options.layerName );
+  destUri.setSchema( options.schema );
+  destUri.setGeometryColumn( options.wkbType != Qgis::WkbType::NoGeometry ? ( options.geometryColumn.isEmpty() ? QStringLiteral( "geom" ) : options.geometryColumn ) : QString() );
+  if ( !options.primaryKeyColumns.isEmpty() )
+  {
+    if ( options.primaryKeyColumns.length() > 1 )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Multiple primary keys are not supported by SQL Server, ignoring" ), QString(), Qgis::MessageLevel::Info );
+    }
+    destUri.setKeyColumn( options.primaryKeyColumns.at( 0 ) );
+  }
+
+  providerOptions.clear();
+
+  return destUri.uri( false );
+}
+
 QString QgsMssqlProviderConnection::tableUri( const QString &schema, const QString &name ) const
 {
   const auto tableInfo { table( schema, name ) };

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -815,7 +815,12 @@ bool QgsMssqlProviderConnection::validateSqlVectorLayer( const SqlVectorLayerOpt
 
 Qgis::DatabaseProviderTableImportCapabilities QgsMssqlProviderConnection::tableImportCapabilities() const
 {
-  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName | Qgis::DatabaseProviderTableImportCapability::SetPrimaryKeyName;
+}
+
+QString QgsMssqlProviderConnection::defaultPrimaryKeyColumnName() const
+{
+  return QStringLiteral( "qgs_fid" );
 }
 
 QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions QgsMssqlProviderConnection::sqlOptions( const QString &layerSource )

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -71,6 +71,7 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
     bool validateSqlVectorLayer( const SqlVectorLayerOptions &options, QString &message ) const override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
+    Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
 
   private:
     QgsAbstractDatabaseProviderConnection::QueryResult executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr ) const;

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -53,7 +53,7 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
 
   public:
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
-
+    QString createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void createSchema( const QString &name ) const override;

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -72,6 +72,7 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
     bool validateSqlVectorLayer( const SqlVectorLayerOptions &options, QString &message ) const override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
+    QString defaultPrimaryKeyColumnName() const override;
 
   private:
     QgsAbstractDatabaseProviderConnection::QueryResult executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr ) const;

--- a/src/providers/oracle/qgsoracleproviderconnection.cpp
+++ b/src/providers/oracle/qgsoracleproviderconnection.cpp
@@ -292,7 +292,12 @@ QgsVectorLayer *QgsOracleProviderConnection::createSqlVectorLayer( const QgsAbst
 
 Qgis::DatabaseProviderTableImportCapabilities QgsOracleProviderConnection::tableImportCapabilities() const
 {
-  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName | Qgis::DatabaseProviderTableImportCapability::SetPrimaryKeyName;
+}
+
+QString QgsOracleProviderConnection::defaultPrimaryKeyColumnName() const
+{
+  return QStringLiteral( "id" );
 }
 
 void QgsOracleProviderConnection::store( const QString &name ) const

--- a/src/providers/oracle/qgsoracleproviderconnection.cpp
+++ b/src/providers/oracle/qgsoracleproviderconnection.cpp
@@ -290,6 +290,11 @@ QgsVectorLayer *QgsOracleProviderConnection::createSqlVectorLayer( const QgsAbst
   return vl.release();
 }
 
+Qgis::DatabaseProviderTableImportCapabilities QgsOracleProviderConnection::tableImportCapabilities() const
+{
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+}
+
 void QgsOracleProviderConnection::store( const QString &name ) const
 {
   QString baseKey = QStringLiteral( "/Oracle/connections/" );
@@ -348,6 +353,11 @@ QList<QgsVectorDataProvider::NativeType> QgsOracleProviderConnection::nativeType
     throw QgsProviderConnectionException( QObject::tr( "Error retrieving native types for connection %1" ).arg( uri() ) );
   }
   return types;
+}
+
+QString QgsOracleProviderConnection::defaultGeometryColumnName() const
+{
+  return QStringLiteral( "GEOM" );
 }
 
 QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsOracleProviderConnection::sqlDictionary()

--- a/src/providers/oracle/qgsoracleproviderconnection.h
+++ b/src/providers/oracle/qgsoracleproviderconnection.h
@@ -47,7 +47,7 @@ class QgsOracleProviderConnection : public QgsAbstractDatabaseProviderConnection
     // QgsAbstractProviderConnection interface
 
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
-
+    QString createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;

--- a/src/providers/oracle/qgsoracleproviderconnection.h
+++ b/src/providers/oracle/qgsoracleproviderconnection.h
@@ -66,6 +66,7 @@ class QgsOracleProviderConnection : public QgsAbstractDatabaseProviderConnection
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
     Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
+    QString defaultPrimaryKeyColumnName() const override;
 
   private:
     QgsAbstractDatabaseProviderConnection::QueryResult executeSqlPrivate( const QString &sql, QgsFeedback *feedback = nullptr ) const;

--- a/src/providers/oracle/qgsoracleproviderconnection.h
+++ b/src/providers/oracle/qgsoracleproviderconnection.h
@@ -62,8 +62,10 @@ class QgsOracleProviderConnection : public QgsAbstractDatabaseProviderConnection
     void remove( const QString &name ) const override;
     QIcon icon() const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
+    QString defaultGeometryColumnName() const override;
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
+    Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
 
   private:
     QgsAbstractDatabaseProviderConnection::QueryResult executeSqlPrivate( const QString &sql, QgsFeedback *feedback = nullptr ) const;

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -32,6 +32,7 @@
 #include "qgsmessageoutput.h"
 #include "qgsprovidermetadata.h"
 #include "qgsabstractdatabaseproviderconnection.h"
+#include "qgsdbimportvectorlayerdialog.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -673,4 +674,10 @@ bool QgsPostgresDataItemGuiProvider::handleDropUri( QgsPGConnectionItem *connect
   std::unique_ptr<QgsAbstractDatabaseProviderConnection> databaseConnection( connectionItem->databaseConnection() );
   if ( !databaseConnection )
     return false;
+
+  QgsDbImportVectorLayerDialog dialog( databaseConnection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
+  dialog.setDestinationSchema( toSchema );
+  dialog.setSourceUri( sourceUri );
+  dialog.exec();
+  return true;
 }

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -181,11 +181,11 @@ bool QgsPostgresDataItemGuiProvider::acceptDrop( QgsDataItem *item, QgsDataItemG
   return false;
 }
 
-bool QgsPostgresDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiContext, const QMimeData *data, Qt::DropAction )
+bool QgsPostgresDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction )
 {
   if ( QgsPGConnectionItem *connItem = qobject_cast<QgsPGConnectionItem *>( item ) )
   {
-    return handleDrop( connItem, data, QString() );
+    return handleDrop( connItem, data, QString(), context );
   }
   else if ( QgsPGSchemaItem *schemaItem = qobject_cast<QgsPGSchemaItem *>( item ) )
   {
@@ -193,7 +193,7 @@ bool QgsPostgresDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemG
     if ( !connItem )
       return false;
 
-    return handleDrop( connItem, data, schemaItem->name() );
+    return handleDrop( connItem, data, schemaItem->name(), context );
   }
   return false;
 }
@@ -572,7 +572,7 @@ void QgsPostgresDataItemGuiProvider::loadConnections( QgsDataItem *item )
     item->refreshConnections();
 }
 
-bool QgsPostgresDataItemGuiProvider::handleDrop( QgsPGConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema )
+bool QgsPostgresDataItemGuiProvider::handleDrop( QgsPGConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext )
 {
   if ( !QgsMimeDataUtils::isUriList( data ) || !connectionItem )
     return false;

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -53,7 +53,7 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     static void refreshMaterializedView( QgsPGLayerItem *layerItem, QgsDataItemGuiContext context );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
-    bool handleDrop( QgsPGConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema );
+    bool handleDrop( QgsPGConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSPOSTGRESDATAITEMGUIPROVIDER_H

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -56,6 +56,7 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     static void loadConnections( QgsDataItem *item );
     bool handleDrop( QgsPGConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
     bool handleDropUri( QgsPGConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, const QString &toSchema, QgsDataItemGuiContext context );
+    void handleImportVector( QgsPGConnectionItem *connectionItem, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSPOSTGRESDATAITEMGUIPROVIDER_H

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -17,6 +17,7 @@
 #define QGSPOSTGRESDATAITEMGUIPROVIDER_H
 
 #include "qgsdataitemguiprovider.h"
+#include "qgsmimedatautils.h"
 
 class QgsPGSchemaItem;
 class QgsPGLayerItem;
@@ -54,6 +55,7 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
     bool handleDrop( QgsPGConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
+    bool handleDropUri( QgsPGConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, const QString &toSchema, QgsDataItemGuiContext context );
 };
 
 #endif // QGSPOSTGRESDATAITEMGUIPROVIDER_H

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -20,6 +20,8 @@
 
 class QgsPGSchemaItem;
 class QgsPGLayerItem;
+class QgsPGConnectionItem;
+
 struct QgsPostgresLayerProperty;
 
 class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
@@ -51,6 +53,7 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     static void refreshMaterializedView( QgsPGLayerItem *layerItem, QgsDataItemGuiContext context );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );
+    bool handleDrop( QgsPGConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema );
 };
 
 #endif // QGSPOSTGRESDATAITEMGUIPROVIDER_H

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -54,9 +54,7 @@ class QgsPGConnectionItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
-
-    using QgsDataCollectionItem::handleDrop;
-    bool handleDrop( const QMimeData *data, const QString &toSchema );
+    QgsDataSourceUri connectionUri() const;
 
   signals:
     void addGeometryColumn( const QgsPostgresLayerProperty & );

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -184,6 +184,20 @@ void QgsPostgresProviderConnection::createVectorTable( const QString &schema, co
   }
 }
 
+QString QgsPostgresProviderConnection::createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const
+{
+  QgsDataSourceUri destUri( uri() );
+
+  destUri.setTable( options.layerName );
+  destUri.setSchema( options.schema );
+  destUri.setGeometryColumn( options.wkbType != Qgis::WkbType::NoGeometry ? ( options.geometryColumn.isEmpty() ? QStringLiteral( "geom" ) : options.geometryColumn ) : QString() );
+  if ( !options.primaryKeyColumns.isEmpty() )
+    destUri.setKeyColumn( options.primaryKeyColumns.join( ',' ) );
+
+  providerOptions.clear();
+  return destUri.uri( false );
+}
+
 QString QgsPostgresProviderConnection::tableUri( const QString &schema, const QString &name ) const
 {
   QgsDataSourceUri dsUri( uri() );

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -878,7 +878,12 @@ QList<QgsLayerMetadataProviderResult> QgsPostgresProviderConnection::searchLayer
 
 Qgis::DatabaseProviderTableImportCapabilities QgsPostgresProviderConnection::tableImportCapabilities() const
 {
-  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName | Qgis::DatabaseProviderTableImportCapability::SetPrimaryKeyName;
+}
+
+QString QgsPostgresProviderConnection::defaultPrimaryKeyColumnName() const
+{
+  return QStringLiteral( "id" );
 }
 
 QgsVectorLayer *QgsPostgresProviderConnection::createSqlVectorLayer( const SqlVectorLayerOptions &options ) const

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -876,6 +876,11 @@ QList<QgsLayerMetadataProviderResult> QgsPostgresProviderConnection::searchLayer
   return QgsPostgresProviderMetadataUtils::searchLayerMetadata( searchContext, uri(), searchString, geographicExtent, feedback );
 }
 
+Qgis::DatabaseProviderTableImportCapabilities QgsPostgresProviderConnection::tableImportCapabilities() const
+{
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+}
+
 QgsVectorLayer *QgsPostgresProviderConnection::createSqlVectorLayer( const SqlVectorLayerOptions &options ) const
 {
   // Precondition

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -132,7 +132,8 @@ void QgsPostgresProviderConnection::setDefaultCapabilities()
     Qgis::SqlLayerDefinitionCapability::UnstableFeatureIds,
   };
 
-  mCapabilities2 |= Qgis::DatabaseProviderConnectionCapability2::SetFieldComment;
+  mCapabilities2 |= Qgis::DatabaseProviderConnectionCapability2::SetFieldComment
+                    | Qgis::DatabaseProviderConnectionCapability2::SetTableComment;
 
   // see https://www.postgresql.org/docs/current/ddl-system-columns.html
   mIllegalFieldNames = {
@@ -741,6 +742,12 @@ void QgsPostgresProviderConnection::setFieldComment( const QString &fieldName, c
 {
   executeSqlPrivate( QStringLiteral( "COMMENT ON COLUMN %1.%2.%3 IS %4;" )
                        .arg( QgsPostgresConn::quotedIdentifier( schema ), QgsPostgresConn::quotedIdentifier( tableName ), QgsPostgresConn::quotedIdentifier( fieldName ), QgsPostgresConn::quotedValue( comment ) ) );
+}
+
+void QgsPostgresProviderConnection::setTableComment( const QString &schema, const QString &tableName, const QString &comment ) const
+{
+  executeSqlPrivate( QStringLiteral( "COMMENT ON TABLE %1.%2 IS %3;" )
+                       .arg( QgsPostgresConn::quotedIdentifier( schema ), QgsPostgresConn::quotedIdentifier( tableName ), QgsPostgresConn::quotedValue( comment ) ) );
 }
 
 QList<QgsPostgresProviderConnection::TableProperty> QgsPostgresProviderConnection::tables( const QString &schema, const TableFlags &flags, QgsFeedback *feedback ) const

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -74,6 +74,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     QList<QgsLayerMetadataProviderResult> searchLayerMetadata( const QgsMetadataSearchContext &searchContext, const QString &searchString, const QgsRectangle &geographicExtent, QgsFeedback *feedback ) const override;
     Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
+    QString defaultPrimaryKeyColumnName() const override;
 
     static const QStringList CONFIGURATION_PARAMETERS;
     static const QString SETTINGS_BASE_KEY;

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -46,7 +46,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
 
   public:
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
-
+    QString createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     QgsFields fields( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -73,6 +73,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     QList<QgsLayerMetadataProviderResult> searchLayerMetadata( const QgsMetadataSearchContext &searchContext, const QString &searchString, const QgsRectangle &geographicExtent, QgsFeedback *feedback ) const override;
+    Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
 
     static const QStringList CONFIGURATION_PARAMETERS;
     static const QString SETTINGS_BASE_KEY;

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -62,6 +62,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     bool spatialIndexExists( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
     void deleteSpatialIndex( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
     void setFieldComment( const QString &fieldName, const QString &schema, const QString &tableName, const QString &comment ) const override;
+    void setTableComment( const QString &schema, const QString &tableName, const QString &comment ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema, const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     QStringList schemas() const override;

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
@@ -29,6 +29,8 @@
 #include "qgsvectorlayerexporter.h"
 #include "qgsfileutils.h"
 #include "qgsdataitemguiproviderutils.h"
+#include "qgsdbimportvectorlayerdialog.h"
+#include "qgsmessagebar.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -224,4 +226,9 @@ bool QgsSpatiaLiteDataItemGuiProvider::handleDropUri( QgsSLConnectionItem *conne
   std::unique_ptr<QgsAbstractDatabaseProviderConnection> databaseConnection( connectionItem->databaseConnection() );
   if ( !databaseConnection )
     return false;
+
+  QgsDbImportVectorLayerDialog dialog( databaseConnection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
+  dialog.setSourceUri( sourceUri );
+  dialog.exec();
+  return true;
 }

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
@@ -38,8 +38,8 @@ class QgsSpatiaLiteDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
   private:
     static void newConnection( QgsDataItem *item );
     static void createDatabase( QgsDataItem *item );
-    static bool handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction, QgsDataItemGuiContext context );
-    static bool handleDropUri( QgsSLConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
+    bool handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction, QgsDataItemGuiContext context );
+    bool handleDropUri( QgsSLConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
 };
 
 #endif // QGSSPATIALITEDATAITEMGUIPROVIDER_H

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
@@ -40,6 +40,7 @@ class QgsSpatiaLiteDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
     static void createDatabase( QgsDataItem *item );
     bool handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction, QgsDataItemGuiContext context );
     bool handleDropUri( QgsSLConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
+    void handleImportVector( QgsSLConnectionItem *connectionItem, QgsDataItemGuiContext context );
 };
 
 #endif // QGSSPATIALITEDATAITEMGUIPROVIDER_H

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
@@ -17,6 +17,7 @@
 #define QGSSPATIALITEDATAITEMGUIPROVIDER_H
 
 #include "qgsdataitemguiprovider.h"
+#include "qgsmimedatautils.h"
 
 class QgsSLConnectionItem;
 
@@ -37,7 +38,8 @@ class QgsSpatiaLiteDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
   private:
     static void newConnection( QgsDataItem *item );
     static void createDatabase( QgsDataItem *item );
-    static bool handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction );
+    static bool handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction, QgsDataItemGuiContext context );
+    static bool handleDropUri( QgsSLConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, QgsDataItemGuiContext context );
 };
 
 #endif // QGSSPATIALITEDATAITEMGUIPROVIDER_H

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -133,8 +133,6 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
 
 Qgis::VectorExportResult QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, QMap<int, int> *oldToNewAttrIdxMap, QString &createdLayerUri, QString *errorMessage, const QMap<QString, QVariant> *options )
 {
-  Q_UNUSED( options )
-
   // populate members from the uri structure
   QgsDataSourceUri dsUri( uri );
   createdLayerUri = uri;

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -146,6 +146,20 @@ QgsVectorLayer *QgsSpatiaLiteProviderConnection::createSqlVectorLayer( const Qgs
   return new QgsVectorLayer { tUri.uri( false ), options.layerName.isEmpty() ? QStringLiteral( "QueryLayer" ) : options.layerName, providerKey() };
 }
 
+QString QgsSpatiaLiteProviderConnection::createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const
+{
+  if ( !schema.isEmpty() )
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "Schema is not supported by Spatialite, ignoring" ), QStringLiteral( "OGR" ), Qgis::MessageLevel::Info );
+  }
+
+  QgsDataSourceUri destUri( uri() );
+  destUri.setTable( name );
+  destUri.setGeometryColumn( wkbType != Qgis::WkbType::NoGeometry ? QStringLiteral( "geom" ) : QString() );
+
+  return destUri.uri();
+}
+
 void QgsSpatiaLiteProviderConnection::dropVectorTable( const QString &schema, const QString &name ) const
 {
   checkCapability( Capability::DropVectorTable );

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -1128,7 +1128,12 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsSpatiaLiteProviderConnection
 
 Qgis::DatabaseProviderTableImportCapabilities QgsSpatiaLiteProviderConnection::tableImportCapabilities() const
 {
-  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName | Qgis::DatabaseProviderTableImportCapability::SetPrimaryKeyName;
+}
+
+QString QgsSpatiaLiteProviderConnection::defaultPrimaryKeyColumnName() const
+{
+  return QStringLiteral( "pk" );
 }
 
 void QgsSpatiaLiteProviderConnection::deleteField( const QString &fieldName, const QString &, const QString &tableName, bool ) const

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -1126,6 +1126,10 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsSpatiaLiteProviderConnection
   );
 }
 
+Qgis::DatabaseProviderTableImportCapabilities QgsSpatiaLiteProviderConnection::tableImportCapabilities() const
+{
+  return Qgis::DatabaseProviderTableImportCapability::SetGeometryColumnName;
+}
 
 void QgsSpatiaLiteProviderConnection::deleteField( const QString &fieldName, const QString &, const QString &tableName, bool ) const
 {

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.h
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.h
@@ -79,6 +79,7 @@ class QgsSpatiaLiteProviderConnection : public QgsAbstractDatabaseProviderConnec
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
+    Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
 
   private:
     void setDefaultCapabilities();

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.h
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.h
@@ -80,6 +80,7 @@ class QgsSpatiaLiteProviderConnection : public QgsAbstractDatabaseProviderConnec
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
+    QString defaultPrimaryKeyColumnName() const override;
 
   private:
     void setDefaultCapabilities();

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.h
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.h
@@ -66,6 +66,7 @@ class QgsSpatiaLiteProviderConnection : public QgsAbstractDatabaseProviderConnec
     QString tableUri( const QString &schema, const QString &name ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
+    QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;
     QgsAbstractDatabaseProviderConnection::QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.h
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.h
@@ -66,7 +66,7 @@ class QgsSpatiaLiteProviderConnection : public QgsAbstractDatabaseProviderConnec
     QString tableUri( const QString &schema, const QString &name ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
-    QString createVectorLayerExporterDestinationUri( const QString &schema, const QString &name, Qgis::WkbType wkbType ) const override;
+    QString createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;
     QgsAbstractDatabaseProviderConnection::QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -81,38 +81,5 @@
   <zorder>verticalSpacer</zorder>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>mButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QgsDbImportVectorLayerDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>343</x>
-     <y>617</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mButtonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>QgsDbImportVectorLayerDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>470</x>
-     <y>617</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>479</x>
-     <y>243</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>478</width>
-    <height>542</height>
+    <height>491</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Import Vector Layer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0,0">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -138,6 +138,19 @@
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -152,6 +165,7 @@
   <zorder>mButtonBox</zorder>
   <zorder>mGroupBoxOutput</zorder>
   <zorder>groupBox</zorder>
+  <zorder>verticalSpacer</zorder>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>268</height>
+    <height>387</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,8 +49,12 @@
       <string>Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="mEditGeometryColumnName"/>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mLabelPrimaryKey">
+        <property name="text">
+         <string>Primary key</string>
+        </property>
+       </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="mLabelGeometryColumn">
@@ -59,15 +63,25 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="mLabelPrimaryKey">
-        <property name="text">
-         <string>Primary key</string>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mEditPrimaryKey"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mEditGeometryColumnName"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mEditPrimaryKey"/>
+      <item row="2" column="0">
+       <widget class="QLabel" name="mLabelDestinationCrs">
+        <property name="text">
+         <string>Output CRS</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -101,6 +115,14 @@
   <zorder>mGroupBoxOutput</zorder>
   <zorder>verticalSpacer</zorder>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -6,23 +6,50 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>480</width>
-    <height>387</height>
+    <width>478</width>
+    <height>542</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Import Vector Layer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Input</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,2">
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QgsMapLayerComboBox" name="mSourceLayerComboBox">
+          <property name="toolTip">
+           <string>Allows the annotation to be associated with a map layer. If set, the annotation will only be visible when the layer is visible.</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mLabelSchemas_2">
+        <property name="text">
+         <string>Source layer</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QGroupBox" name="mGroupBoxOutput">
      <property name="title">
       <string>Output</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="mEditSchema"/>
-      </item>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,2">
       <item row="0" column="0">
        <widget class="QLabel" name="mLabelSchemas">
         <property name="text">
@@ -30,8 +57,8 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QLineEdit" name="mEditTable"/>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mEditSchema"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_3">
@@ -40,7 +67,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="3">
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mEditTable"/>
+      </item>
+      <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="mChkDropTable">
         <property name="text">
          <string>Replace destination table (if exists)</string>
@@ -55,11 +85,11 @@
      <property name="title">
       <string>Options</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="mLabelPrimaryKey">
+     <layout class="QGridLayout" name="gridLayout" columnstretch="1,2">
+      <item row="3" column="0">
+       <widget class="QLabel" name="mLabelComment">
         <property name="text">
-         <string>Primary key</string>
+         <string>Comment</string>
         </property>
        </widget>
       </item>
@@ -70,15 +100,25 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mEditPrimaryKey"/>
-      </item>
-      <item row="2" column="1">
-       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
+      <item row="3" column="1">
+       <widget class="QTextEdit" name="mEditComment">
+        <property name="enabled">
+         <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mLabelPrimaryKey">
+        <property name="text">
+         <string>Primary key</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mEditGeometryColumnName"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mEditPrimaryKey"/>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="mLabelDestinationCrs">
@@ -87,38 +127,15 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="mEditGeometryColumnName"/>
-      </item>
-      <item row="3" column="1">
-       <widget class="QTextEdit" name="mEditComment">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="mLabelComment">
-        <property name="text">
-         <string>Comment</string>
+      <item row="2" column="1">
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="mButtonBox">
@@ -134,7 +151,7 @@
   <zorder>mGroupBoxSettings</zorder>
   <zorder>mButtonBox</zorder>
   <zorder>mGroupBoxOutput</zorder>
-  <zorder>verticalSpacer</zorder>
+  <zorder>groupBox</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -143,7 +160,22 @@
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">qgsmaplayercombobox.h</header>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mSourceLayerComboBox</tabstop>
+  <tabstop>mEditSchema</tabstop>
+  <tabstop>mEditTable</tabstop>
+  <tabstop>mChkDropTable</tabstop>
+  <tabstop>mEditPrimaryKey</tabstop>
+  <tabstop>mEditGeometryColumnName</tabstop>
+  <tabstop>mCrsSelector</tabstop>
+  <tabstop>mEditComment</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -20,12 +20,18 @@
       <string>Output</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="mEditSchema"/>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="mLabelSchemas">
         <property name="text">
          <string>Schema</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QLineEdit" name="mEditTable"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_3">
@@ -34,11 +40,12 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QLineEdit" name="mEditTable"/>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="mEditSchema"/>
+      <item row="2" column="0" colspan="3">
+       <widget class="QCheckBox" name="mChkDropTable">
+        <property name="text">
+         <string>Replace destination table (if exists)</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>227</height>
+    <height>268</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -48,7 +48,28 @@
      <property name="title">
       <string>Options</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout"/>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mEditGeometryColumnName"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mLabelGeometryColumn">
+        <property name="text">
+         <string>Geometry column</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mLabelPrimaryKey">
+        <property name="text">
+         <string>Primary key</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mEditPrimaryKey"/>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDbImportVectorLayerDialog</class>
+ <widget class="QDialog" name="QgsDbImportVectorLayerDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>227</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Import Vector Layer</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="mGroupBoxOutput">
+     <property name="title">
+      <string>Output</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="mLabelSchemas">
+        <property name="text">
+         <string>Schema</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Table name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QLineEdit" name="mEditTable"/>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="mEditSchema"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="mGroupBoxSettings">
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout"/>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+  <zorder>mGroupBoxSettings</zorder>
+  <zorder>mButtonBox</zorder>
+  <zorder>mGroupBoxOutput</zorder>
+  <zorder>verticalSpacer</zorder>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsDbImportVectorLayerDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>343</x>
+     <y>617</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsDbImportVectorLayerDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>470</x>
+     <y>617</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>479</x>
+     <y>243</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -66,9 +66,6 @@
       <item row="0" column="1">
        <widget class="QLineEdit" name="mEditPrimaryKey"/>
       </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="mEditGeometryColumnName"/>
-      </item>
       <item row="2" column="1">
        <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
         <property name="focusPolicy">
@@ -80,6 +77,23 @@
        <widget class="QLabel" name="mLabelDestinationCrs">
         <property name="text">
          <string>Output CRS</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mEditGeometryColumnName"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="QTextEdit" name="mEditComment">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="mLabelComment">
+        <property name="text">
+         <string>Comment</string>
         </property>
        </widget>
       </item>

--- a/tests/src/python/test_qgsproviderconnection_hana.py
+++ b/tests/src/python/test_qgsproviderconnection_hana.py
@@ -16,6 +16,8 @@ import os
 from qgis.core import (
     QgsAbstractDatabaseProviderConnection,
     QgsProviderRegistry,
+    QgsDataSourceUri,
+    Qgis,
 )
 from qgis.testing import unittest
 
@@ -182,6 +184,93 @@ class TestPyQgsProviderConnectionHana(
         self.assertEqual(
             conn.table(self.schemaName, "some_data").primaryKeyColumns(), ["pk"]
         )
+
+    def test_createVectorLayerExporterDestinationUri(self):
+        """
+        Test createVectorLayerExporterDestinationUri
+        """
+        md = QgsProviderRegistry.instance().providerMetadata("hana")
+        conn = md.createConnection(self.uri, {})
+
+        export_options = (
+            QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions()
+        )
+        export_options.layerName = "new_layer"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.schema = "dest_schema"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.wkbType = Qgis.WkbType.Point
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geom")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.geometryColumn = "geometry"
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.primaryKeyColumns = ["pk"]
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertEqual(res_ds.keyColumn(), "pk")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsproviderconnection_mssql.py
+++ b/tests/src/python/test_qgsproviderconnection_mssql.py
@@ -359,6 +359,93 @@ class TestPyQgsProviderConnectionMssql(
         with self.assertRaises(QgsProviderConnectionException):
             conn.validateSqlVectorLayer(options)
 
+    def test_createVectorLayerExporterDestinationUri(self):
+        """
+        Test createVectorLayerExporterDestinationUri
+        """
+        md = QgsProviderRegistry.instance().providerMetadata("mssql")
+        conn = md.createConnection(self.uri, {})
+
+        export_options = (
+            QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions()
+        )
+        export_options.layerName = "new_layer"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.schema = "dest_schema"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.wkbType = Qgis.WkbType.Point
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geom")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.geometryColumn = "geometry"
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.primaryKeyColumns = ["pk"]
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertEqual(res_ds.keyColumn(), "pk")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -505,6 +505,40 @@ class TestPyQgsProviderConnectionGpkg(
         self.assertEqual(table_with_comment.tableName(), "table_with_comment")
         self.assertEqual(table_with_comment.comment(), "table_with_comment")
 
+    def test_createVectorLayerExporterDestinationUri(self):
+        """
+        Test createVectorLayerExporterDestinationUri
+        """
+        md = QgsProviderRegistry.instance().providerMetadata("ogr")
+        conn = md.createConnection(self.uri, {})
+
+        export_options = (
+            QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions()
+        )
+        export_options.layerName = "new_layer"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertEqual(options, {"layerName": "new_layer"})
+        self.assertEqual(res, self.uri)
+
+        # ignored by provider
+        export_options.wkbType = Qgis.WkbType.Point
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertEqual(options, {"layerName": "new_layer"})
+        self.assertEqual(res, self.uri)
+
+        # ignored by provider
+        export_options.geometryColumn = "geometry"
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertEqual(options, {"layerName": "new_layer"})
+        self.assertEqual(res, self.uri)
+
+        # ignored by provider
+        export_options.primaryKeyColumns = ["pk"]
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertEqual(options, {"layerName": "new_layer"})
+        self.assertEqual(res, self.uri)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_oracle.py
+++ b/tests/src/python/test_qgsproviderconnection_oracle.py
@@ -15,6 +15,7 @@ import os
 
 from qgis.PyQt.QtSql import QSqlDatabase, QSqlQuery
 from qgis.core import (
+    Qgis,
     QgsAbstractDatabaseProviderConnection,
     QgsDataSourceUri,
     QgsProviderConnectionException,
@@ -296,6 +297,93 @@ class TestPyQgsProviderConnectionOracle(
         md = QgsProviderRegistry.instance().providerMetadata("oracle")
         conn = md.createConnection(self.uri, {})
         self.assertEqual(conn.schemas(), ["QGIS"])
+
+    def test_createVectorLayerExporterDestinationUri(self):
+        """
+        Test createVectorLayerExporterDestinationUri
+        """
+        md = QgsProviderRegistry.instance().providerMetadata("oracle")
+        conn = md.createConnection(self.uri, {})
+
+        export_options = (
+            QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions()
+        )
+        export_options.layerName = "new_layer"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.schema = "dest_schema"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.wkbType = Qgis.WkbType.Point
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "GEOM")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.geometryColumn = "geometry"
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.primaryKeyColumns = ["pk"]
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertEqual(res_ds.keyColumn(), "pk")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -784,6 +784,109 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         features = [f for f in vl.getFeatures()]
         self.assertEqual(len(features), 1)
 
+    def test_createVectorLayerExporterDestinationUri(self):
+        """
+        Test createVectorLayerExporterDestinationUri
+        """
+        md = QgsProviderRegistry.instance().providerMetadata("postgres")
+        conn = md.createConnection(self.uri, {})
+
+        export_options = (
+            QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions()
+        )
+        export_options.layerName = "new_layer"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.schema = "dest_schema"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.wkbType = Qgis.WkbType.Point
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geom")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.geometryColumn = "geometry"
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.primaryKeyColumns = ["pk"]
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertEqual(res_ds.keyColumn(), "pk")
+
+        # multiple key columns
+        export_options.primaryKeyColumns = ["pk", "pk2"]
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertEqual(res_ds.schema(), "dest_schema")
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertEqual(res_ds.keyColumn(), "pk,pk2")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_spatialite.py
+++ b/tests/src/python/test_qgsproviderconnection_spatialite.py
@@ -24,6 +24,7 @@ from qgis.core import (
     QgsProviderRegistry,
     QgsVectorLayer,
     QgsWkbTypes,
+    QgsDataSourceUri,
 )
 from qgis.testing import unittest
 
@@ -244,6 +245,77 @@ class TestPyQgsProviderConnectionSpatialite(
                 "POLYGON((612694.674 5807839.658, 612668.715 5808176.815, 612547.354 5808414.452, 612509.527 5808425.73, 612522.932 5808473.02, 612407.901 5808519.082, 612505.836 5808632.763, 612463.449 5808781.115, 612433.57 5808819.061, 612422.685 5808980.281999, 612473.423 5808995.424999, 612333.856 5809647.731, 612307.316 5809781.446, 612267.099 5809852.803, 612308.221 5810040.995, 613920.397 5811079.478, 613947.16 5811129.3, 614022.726 5811154.456, 614058.436 5811260.36, 614194.037 5811331.972, 614307.176 5811360.06, 614343.842 5811323.238, 614443.449 5811363.03, 614526.199 5811059.031, 614417.83 5811057.603, 614787.296 5809648.422, 614772.062 5809583.246, 614981.93 5809245.35, 614811.885 5809138.271, 615063.452 5809100.954, 615215.476 5809029.413, 615469.441 5808883.282, 615569.846 5808829.522, 615577.239 5808806.242, 615392.964 5808736.873, 615306.34 5808662.171, 615335.445 5808290.588, 615312.192 5808290.397, 614890.582 5808077.956, 615018.854 5807799.895, 614837.326 5807688.363, 614435.698 5807646.847, 614126.351 5807661.841, 613555.813 5807814.801, 612826.66 5807964.828, 612830.113 5807856.315, 612694.674 5807839.658))",
             ],
         )
+
+    def test_createVectorLayerExporterDestinationUri(self):
+        """
+        Test createVectorLayerExporterDestinationUri
+        """
+        md = QgsProviderRegistry.instance().providerMetadata("spatialite")
+        conn = md.createConnection(self.uri, {})
+
+        export_options = (
+            QgsAbstractDatabaseProviderConnection.VectorLayerExporterOptions()
+        )
+        export_options.layerName = "new_layer"
+
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertFalse(res_ds.geometryColumn())
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.wkbType = Qgis.WkbType.Point
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertEqual(res_ds.geometryColumn(), "geom")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.geometryColumn = "geometry"
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertFalse(res_ds.keyColumn())
+
+        export_options.primaryKeyColumns = ["pk"]
+        res, options = conn.createVectorLayerExporterDestinationUri(export_options)
+        self.assertFalse(options)
+        res_ds = QgsDataSourceUri(res)
+        src_ds = QgsDataSourceUri(self.uri)
+        self.assertEqual(res_ds.host(), src_ds.host())
+        self.assertEqual(res_ds.service(), src_ds.service())
+        self.assertEqual(res_ds.database(), src_ds.database())
+        self.assertEqual(res_ds.username(), src_ds.username())
+        self.assertEqual(res_ds.password(), src_ds.password())
+        self.assertEqual(res_ds.table(), "new_layer")
+        self.assertFalse(res_ds.schema())
+        self.assertEqual(res_ds.geometryColumn(), "geometry")
+        self.assertEqual(res_ds.keyColumn(), "pk")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is a step towards porting the DB Manager "Import vector table" functionality into core/browser. I've taken extreme care here to ensure that everything is kept generic and that the GUI is all dynamically built based on the available capabilities of the destination database provider. This means that we gain native import vector table control for postgres, hana, sql server, gpkg, spatialite + the OGR database formats (eg ESRI File Geodatabase) in one shot, and that any future extensions to this dialog will automatically apply to all relevant destination providers. *

To facilitate this, I've added new API to the database connections classes. I've removed a lot of duplicate copy/paste code from the various QgsDataItemGuiProvider subclasses and moved them to generic methods in QgsDataItemGuiProviderUtils. 

Some notes:

- **Part of this work was based on efforts by @JanCaha to port the DB Manager Postgres import functionality to browser**
- The new dialog will show when dragging and dropping a SINGLE VECTOR TABLE only onto a database schema (or connection item, if the connection doesn't support schemas). You won't see it if you drag and drop multiple tables at once -- that still does an immediately import without any customisation or prompts. I've left this as I don't want to risk UI regressions for users who need to import many tables at once, where showing a dialog per table would be annoying. (At some stage we could/should make a similar import dialog designed around multiple-table import to handle this situation)
- The dialog will show when dragging and dropping a layer from the browser, OR a layer from the current project
- You can also show the dialog by right-clicking a schema item (or non-schema supporting connection item) and selecting "Import Vector Table...", giving you the choice of importing any of the layers from the current project.
- Unlike the DB Manager feature, which blocks the application and does the import in the main thread, this uses a background task to do the actual import leaving QGIS nice and responsive.
- Supported functionality is:
  - Renaming the destination table. The destination table will default to the same name as the import table/layer, but users can change this as desired
  - Replace destination table checkbox (unchecked by default)
  - Set the primary key name for the created table. Defaults to the original layer primary key name, or a default provider-specific name if the original layer does not have a primary key. Only shown if the destination supports primary key naming.
  - Set the geometry column name.  Defaults to the original layer geometry column name, or a default provider-specific name if the original layer does not have a named geometry column. Only shown if the destination supports geometry column naming and the source is a spatial layer.
  - Set the destination layer CRS. Only shown if the source layer is a spatial layer. Defaults to the original layer CRS.
  - Set the output table comment. Only shown if the destination provider supports this (which is currently only the postgres provider). Defaults to the input layer metadata description/abstract.
- Some functionality from the DB Manager Import Vector Table is NOT currently supported. This is:
  - Overriding the source layer CRS. In my view this is confusing, niche functionality which should be handled outside of this dialog, eg by setting the layer's CRS manually.
  - Similarly, the ability to override the source layer's encoding is not supported. Again, this is confusing + niche and should instead just be set for the source map layer directly when required.
  - "Do not promote to multi-part" option. I think this logic needs re-thinking to make it generic and not specific to postgres database import. In db manager it means that eg a multipolygon source layer will be imported as a (not multi)polygon layer on the database, and that the import will error out if ANY geometries are found with more than one part. It's badly named for a start, as it implies that by leaving the box unchecked that a promotion to multipart geometries will ALWAYS occur. At the very least this option should be renamed to "demote to single part" and only enabled when the source layer is a multipart geometry type, but this needs to be discussed and rethought before we do this. (It's out of scope for my current work, I will not be doing this)
  - "Convert field names to lowercase". In a follow up PR I will expose the ability to exclude source layers from the import and rename them -- after this is done we could instead have a button in the dialog which just renames all the layers to lowercase (out of scope for my current work).
  - "Create spatial index". The API for spatial index creation is messy -- we have a method in QgsVectorDataProvider to do this, but only implemented by SQL Server and Oracle providers. We have an alternative API in QgsAbstractDatabaseProviderConnection but only implemented by Oracle, Postgres, GeoPackage and Spatialite. Right now the QgsVectorLayerExporter class used by browser vector imports just ALWAYS uses the vector provider method when exporting tables, so we ALWAYS get spatial indexes for tables imported for SQL Server + Oracle providers. This is just too messy and we need to consolidate on one spatial index creation method implemented by all database providers before exposing this choice in the dialog. (This is out of scope for my current work)
  - "Import only selected features" -- I'll be sending through a follow up PR after this one with extra options for filtering the imported layer, including extent based filter + expression based filter, and I'll implement selection based filtering at this time.
  - There's no way to hit a "..." button and pick a non-project layer to import. This should be done by showing a dialog (or QgsPanelWidget) with a browser tree for picking the source layer. It's out of scope for my current work.

![image](https://github.com/user-attachments/assets/a701a251-569f-4ba1-9e10-e4694f87931e)

Sponsored by City of Canning

* Note that this functionality does not currently work for oracle databases, simple because the oracle provider is still using deprecated functionality from QgsDataItem and surprisingly does not yet implement a QgsDataItemGuiProvider! :scream_cat: There's nothing here which prevents Oracle from just working as soon as someone implements that class for oracle data items.

Fixes https://github.com/qgis/QGIS/issues/24194