### PR TITLE
Avoid crashing when a tiled scene texture is provided by an extension

### DIFF
--- a/src/3d/qgsgltf3dutils.cpp
+++ b/src/3d/qgsgltf3dutils.cpp
@@ -305,6 +305,16 @@ static QgsMaterial *parseMaterial( tinygltf::Model &model, int materialIndex, QS
   {
     tinygltf::Texture &tex = model.textures[pbr.baseColorTexture.index];
 
+    // Source can be undefined if texture is provided by an extension
+    if ( tex.source < 0 )
+    {
+      QgsMetalRoughMaterial *pbrMaterial = new QgsMetalRoughMaterial;
+      pbrMaterial->setMetalness( pbr.metallicFactor ); // [0..1] or texture
+      pbrMaterial->setRoughness( pbr.roughnessFactor );
+      pbrMaterial->setBaseColor( QColor::fromRgbF( pbr.baseColorFactor[0], pbr.baseColorFactor[1], pbr.baseColorFactor[2], pbr.baseColorFactor[3] ) );
+      return pbrMaterial;
+    }
+
     tinygltf::Image &img = model.images[tex.source];
 
     if ( !img.uri.empty() )

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -610,22 +610,26 @@ void QgsTiledSceneLayerRenderer::renderTrianglePrimitive( const tinygltf::Model 
     {
       const tinygltf::Texture &tex = model.textures[pbr.baseColorTexture.index];
 
-      switch ( QgsGltfUtils::imageResourceType( model, tex.source ) )
+      // Source can be undefined if texture is provided by an extension
+      if ( tex.source >= 0 )
       {
-        case QgsGltfUtils::ResourceType::Embedded:
-          textureImage = QgsGltfUtils::extractEmbeddedImage( model, tex.source );
-          break;
-
-        case QgsGltfUtils::ResourceType::Linked:
+        switch ( QgsGltfUtils::imageResourceType( model, tex.source ) )
         {
-          const QString linkedPath = QgsGltfUtils::linkedImagePath( model, tex.source );
-          const QString textureUri = QUrl( contentUri ).resolved( linkedPath ).toString();
-          const QByteArray rep = mIndex.retrieveContent( textureUri, feedback() );
-          if ( !rep.isEmpty() )
+          case QgsGltfUtils::ResourceType::Embedded:
+            textureImage = QgsGltfUtils::extractEmbeddedImage( model, tex.source );
+            break;
+
+          case QgsGltfUtils::ResourceType::Linked:
           {
-            textureImage = QImage::fromData( rep );
+            const QString linkedPath = QgsGltfUtils::linkedImagePath( model, tex.source );
+            const QString textureUri = QUrl( contentUri ).resolved( linkedPath ).toString();
+            const QByteArray rep = mIndex.retrieveContent( textureUri, feedback() );
+            if ( !rep.isEmpty() )
+            {
+              textureImage = QImage::fromData( rep );
+            }
+            break;
           }
-          break;
         }
       }
 


### PR DESCRIPTION
## Description
Handle the case when texture.source is undefined, because the texture is provided by an extension, eg. EXT_texture_webp

According to spec:
> When texture.source is undefined, the image SHOULD be provided by an extension or application-specific means, otherwise the texture object is undefined.

fixes: #57024

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
