### PR TITLE
CI: Run MINGW64 job on Fedora 40

### DIFF
--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -29,7 +29,7 @@ jobs:
     name: MinGW64 Windows Build
     runs-on: ubuntu-latest
     container:
-      image: fedora:39
+      image: fedora:40
       options: --security-opt seccomp=unconfined
       volumes:
         - ${{ github.workspace }}:/w


### PR DESCRIPTION
## Description

Build MINGW64 on fedora 40 to use newer versions of tools and dependencies. previous attempt to use fedora 41 was reverted because of some broken libraries.

@agiudiceandrea
