### PR TITLE
Map tool idenfify: Add support for index in mesh data

### DIFF
--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -719,6 +719,45 @@ the face The returned position is in map coordinates.
 .. versionadded:: 3.14
 %End
 
+    int closestElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint /Out/ ) const;
+%Docstring
+Returns the index of the snapped point on the mesh element closest to
+``point`` intersecting with the searching area defined by ``point`` and
+``searchRadius`` The position of the snapped point on the closest
+element is stored in ``projectedPoint``
+
+For vertex, the snapped position is the vertex position For edge, the
+snapped position is the projected point on the edge, extremity of edge
+if outside the edge For face, the snapped position is the centroid of
+the face The snapped position is in map coordinates.
+
+.. note::
+
+   It uses previously cached and indexed triangular mesh
+   and so if the layer has not been rendered previously
+   (e.g. when used in a script) it returns empty :py:class:`QgsPointXY`
+
+.. seealso:: :py:func:`updateTriangularMesh`
+
+.. note::
+
+   This is similar to the :py:func:`~QgsMeshLayer.snapOnElement` method, except it also returns the index of the snapped point
+
+.. seealso:: :py:func:`snapOnElement`
+
+:param elementType: the type of element to snap
+:param point: the center of the search area in map coordinates
+:param searchRadius: the radius of the search area in map units
+
+:return: - index of the snapped point on the closest element, -1 if no
+           element of type ``elementType``
+         - projectedPoint: the position of the snapped point on the
+           closest element, empty :py:class:`QgsPointXY` if no element
+           of type ``elementType``
+
+.. versionadded:: 3.44
+%End
+
     QList<int> selectVerticesByExpression( QgsExpression expression );
 %Docstring
 Returns a list of vertex indexes that meet the condition defined by

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -719,6 +719,45 @@ the face The returned position is in map coordinates.
 .. versionadded:: 3.14
 %End
 
+    int closestElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint /Out/ ) const;
+%Docstring
+Returns the index of the snapped point on the mesh element closest to
+``point`` intersecting with the searching area defined by ``point`` and
+``searchRadius`` The position of the snapped point on the closest
+element is stored in ``projectedPoint``
+
+For vertex, the snapped position is the vertex position For edge, the
+snapped position is the projected point on the edge, extremity of edge
+if outside the edge For face, the snapped position is the centroid of
+the face The snapped position is in map coordinates.
+
+.. note::
+
+   It uses previously cached and indexed triangular mesh
+   and so if the layer has not been rendered previously
+   (e.g. when used in a script) it returns empty :py:class:`QgsPointXY`
+
+.. seealso:: :py:func:`updateTriangularMesh`
+
+.. note::
+
+   This is similar to the :py:func:`~QgsMeshLayer.snapOnElement` method, except it also returns the index of the snapped point
+
+.. seealso:: :py:func:`snapOnElement`
+
+:param elementType: the type of element to snap
+:param point: the center of the search area in map coordinates
+:param searchRadius: the radius of the search area in map units
+
+:return: - index of the snapped point on the closest element, -1 if no
+           element of type ``elementType``
+         - projectedPoint: the position of the snapped point on the
+           closest element, empty :py:class:`QgsPointXY` if no element
+           of type ``elementType``
+
+.. versionadded:: 3.44
+%End
+
     QList<int> selectVerticesByExpression( QgsExpression expression );
 %Docstring
 Returns a list of vertex indexes that meet the condition defined by

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -926,6 +926,7 @@ int QgsMeshLayer::closestEdge( const QgsPointXY &point, double searchRadius, Qgs
   // search for the closest edge in search area from point
   const QList<int> edgeIndexes = mesh->edgeIndexesForRectangle( searchRectangle );
   int selectedIndex = -1;
+  projectedPoint = QgsPointXY();
   if ( mesh->contains( QgsMesh::Edge ) &&
        mDataProvider->isValid() )
   {

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -893,6 +893,30 @@ void QgsMeshLayer::setDatasetGroupTreeRootItem( QgsMeshDatasetGroupTreeItem *roo
   updateActiveDatasetGroups();
 }
 
+QgsMeshDatasetIndex QgsMeshLayer::staticVectorDatasetIndex( int group ) const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QgsMeshDatasetIndex( group >= 0 ? group : mRendererSettings.activeVectorDatasetGroup(), mStaticVectorDatasetIndex );
+}
+
+void QgsMeshLayer::setReferenceTime( const QDateTime &referenceTime )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  if ( auto *lDataProvider = dataProvider() )
+    mTemporalProperties->setReferenceTime( referenceTime, lDataProvider->temporalCapabilities() );
+  else
+    mTemporalProperties->setReferenceTime( referenceTime, nullptr );
+}
+
+void QgsMeshLayer::setTemporalMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  mTemporalProperties->setMatchingMethod( matchingMethod );
+}
+
 int QgsMeshLayer::closestEdge( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -923,30 +947,6 @@ int QgsMeshLayer::closestEdge( const QgsPointXY &point, double searchRadius, Qgs
   }
 
   return selectedIndex;
-}
-
-QgsMeshDatasetIndex QgsMeshLayer::staticVectorDatasetIndex( int group ) const
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  return QgsMeshDatasetIndex( group >= 0 ? group : mRendererSettings.activeVectorDatasetGroup(), mStaticVectorDatasetIndex );
-}
-
-void QgsMeshLayer::setReferenceTime( const QDateTime &referenceTime )
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  if ( auto *lDataProvider = dataProvider() )
-    mTemporalProperties->setReferenceTime( referenceTime, lDataProvider->temporalCapabilities() );
-  else
-    mTemporalProperties->setReferenceTime( referenceTime, nullptr );
-}
-
-void QgsMeshLayer::setTemporalMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod )
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  mTemporalProperties->setMatchingMethod( matchingMethod );
 }
 
 QgsPointXY QgsMeshLayer::snapOnVertex( const QgsPointXY &point, double searchRadius )

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -950,14 +950,16 @@ int QgsMeshLayer::closestEdge( const QgsPointXY &point, double searchRadius, Qgs
   return selectedIndex;
 }
 
-QgsPointXY QgsMeshLayer::snapOnVertex( const QgsPointXY &point, double searchRadius )
+int QgsMeshLayer::closestVertex( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   const QgsTriangularMesh *mesh = triangularMesh();
-  QgsPointXY exactPosition;
+  int selectedIndex = -1;
+  projectedPoint = QgsPointXY();
   if ( !mesh )
-    return exactPosition;
+    return selectedIndex;
+
   const QgsRectangle rectangle( point.x() - searchRadius, point.y() - searchRadius, point.x() + searchRadius, point.y() + searchRadius );
   double maxDistance = searchRadius;
   //attempt to snap on edges's vertices
@@ -972,12 +974,14 @@ QgsPointXY QgsMeshLayer::snapOnVertex( const QgsPointXY &point, double searchRad
     if ( dist1 < maxDistance )
     {
       maxDistance = dist1;
-      exactPosition = vertex1;
+      projectedPoint = vertex1;
+      selectedIndex = edge.first;
     }
     if ( dist2 < maxDistance )
     {
       maxDistance = dist2;
-      exactPosition = vertex2;
+      projectedPoint = vertex2;
+      selectedIndex = edge.second;
     }
   }
 
@@ -993,32 +997,25 @@ QgsPointXY QgsMeshLayer::snapOnVertex( const QgsPointXY &point, double searchRad
       if ( dist < maxDistance )
       {
         maxDistance = dist;
-        exactPosition = vertex;
+        projectedPoint = vertex;
+        selectedIndex = face.at( i );
       }
     }
   }
 
-  return exactPosition;
+  return selectedIndex;
 }
 
-QgsPointXY QgsMeshLayer::snapOnEdge( const QgsPointXY &point, double searchRadius )
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  QgsPointXY projectedPoint;
-  closestEdge( point, searchRadius, projectedPoint );
-
-  return projectedPoint;
-}
-
-QgsPointXY QgsMeshLayer::snapOnFace( const QgsPointXY &point, double searchRadius )
+int QgsMeshLayer::closestFace( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   const QgsTriangularMesh *mesh = triangularMesh();
-  QgsPointXY centroidPosition;
+  int selectedIndex = -1;
+  projectedPoint = QgsPointXY();
   if ( !mesh )
-    return centroidPosition;
+    return selectedIndex;
+
   const QgsRectangle rectangle( point.x() - searchRadius, point.y() - searchRadius, point.x() + searchRadius, point.y() + searchRadius );
   double maxDistance = std::numeric_limits<double>::max();
 
@@ -1033,11 +1030,12 @@ QgsPointXY QgsMeshLayer::snapOnFace( const QgsPointXY &point, double searchRadiu
     if ( dist < maxDistance )
     {
       maxDistance = dist;
-      centroidPosition = centroid;
+      projectedPoint = centroid;
+      selectedIndex = nativefaceIndex;
     }
   }
 
-  return centroidPosition;
+  return selectedIndex;
 }
 
 void QgsMeshLayer::resetDatasetGroupTreeItem()
@@ -1490,16 +1488,25 @@ QgsPointXY QgsMeshLayer::snapOnElement( QgsMesh::ElementType elementType, const 
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
+  QgsPointXY projectedPoint;
+  closestElement( elementType, point, searchRadius, projectedPoint );
+  return projectedPoint;
+}
+
+int QgsMeshLayer::closestElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
   switch ( elementType )
   {
     case QgsMesh::Vertex:
-      return snapOnVertex( point, searchRadius );
+      return closestVertex( point, searchRadius, projectedPoint );
     case QgsMesh::Edge:
-      return snapOnEdge( point, searchRadius );
+      return closestEdge( point, searchRadius, projectedPoint );
     case QgsMesh::Face:
-      return snapOnFace( point, searchRadius );
+      return closestFace( point, searchRadius, projectedPoint );
   }
-  return QgsPointXY(); // avoid warnings
+  return -1;
 }
 
 QList<int> QgsMeshLayer::selectVerticesByExpression( QgsExpression expression )

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -721,6 +721,34 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
     QgsPointXY snapOnElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius );
 
     /**
+      * Returns the index of the snapped point on the mesh element closest to \a point intersecting with
+      * the searching area defined by \a point and \a searchRadius
+      * The position of the snapped point on the closest element is stored in \a projectedPoint
+      *
+      * For vertex, the snapped position is the vertex position
+      * For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
+      * For face, the snapped position is the centroid of the face
+      * The snapped position is in map coordinates.
+      *
+      * \note It uses previously cached and indexed triangular mesh
+      * and so if the layer has not been rendered previously
+      * (e.g. when used in a script) it returns empty QgsPointXY
+      * \see updateTriangularMesh()
+      *
+      * \note This is similar to the snapOnElement() method, except it also returns the index of the snapped point
+      * \see snapOnElement()
+      *
+      * \param elementType the type of element to snap
+      * \param point the center of the search area in map coordinates
+      * \param searchRadius the radius of the search area in map units
+      * \param projectedPoint the position of the snapped point on the closest element, empty QgsPointXY if no element of type \a elementType
+      * \return index of the snapped point on the closest element, -1 if no element of type \a elementType
+      *
+      * \since QGIS 3.44
+      */
+    int closestElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint SIP_OUT ) const;
+
+    /**
      * Returns a list of vertex indexes that meet the condition defined by \a expression with the context \a expressionContext
      *
      * To express the relation with a vertex, the expression can be defined with function returning value
@@ -1089,16 +1117,14 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
     //! Labeling configuration
     QgsAbstractMeshLayerLabeling *mLabeling = nullptr;
 
+    //! Returns the exact position in map coordinates of the closest vertex in the search area
     int closestEdge( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const;
 
-    //! Returns the exact position in map coordinates of the closest vertex in the search area
-    QgsPointXY snapOnVertex( const QgsPointXY &point, double searchRadius );
+    //!Returns the position of the projected point on the closest edge in the search area
+    int closestVertex( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const;
 
     //!Returns the position of the projected point on the closest edge in the search area
-    QgsPointXY snapOnEdge( const QgsPointXY &point, double searchRadius );
-
-    //!Returns the position of the centroid point on the closest face in the search area
-    QgsPointXY snapOnFace( const QgsPointXY &point, double searchRadius );
+    int closestFace( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const;
 
     void updateActiveDatasetGroups();
 

--- a/src/gui/maptools/qgsmaptoolidentify.cpp
+++ b/src/gui/maptools/qgsmaptoolidentify.cpp
@@ -391,23 +391,29 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
 
   QMap<QString, QString> derivedGeometry;
 
-  QgsPointXY vertexPoint = layer->snapOnElement( QgsMesh::Vertex, point, searchRadius );
+  QgsPointXY vertexPoint;
+  const int vertexId = layer->closestElement( QgsMesh::Vertex, point, searchRadius, vertexPoint );
   if ( !vertexPoint.isEmpty() )
   {
+    derivedGeometry.insert( tr( "Snapped Vertex Index" ), QLocale().toString( vertexId ) );
     derivedGeometry.insert( tr( "Snapped Vertex Position X" ), QLocale().toString( vertexPoint.x() ) );
     derivedGeometry.insert( tr( "Snapped Vertex Position Y" ), QLocale().toString( vertexPoint.y() ) );
   }
 
-  QgsPointXY faceCentroid = layer->snapOnElement( QgsMesh::Face, point, searchRadius );
+  QgsPointXY faceCentroid;
+  const int faceId = layer->closestElement( QgsMesh::Face, point, searchRadius, faceCentroid );
   if ( !faceCentroid.isEmpty() )
   {
+    derivedGeometry.insert( tr( "Face Index" ), QLocale().toString( faceId ) );
     derivedGeometry.insert( tr( "Face Centroid X" ), QLocale().toString( faceCentroid.x() ) );
     derivedGeometry.insert( tr( "Face Centroid Y" ), QLocale().toString( faceCentroid.y() ) );
   }
 
-  QgsPointXY pointOnEdge = layer->snapOnElement( QgsMesh::Edge, point, searchRadius );
+  QgsPointXY pointOnEdge;
+  const int edgeId = layer->closestElement( QgsMesh::Edge, point, searchRadius, pointOnEdge );
   if ( !pointOnEdge.isEmpty() )
   {
+    derivedGeometry.insert( tr( "Edge Index" ), QLocale().toString( edgeId ) );
     derivedGeometry.insert( tr( "Point on Edge X" ), QLocale().toString( pointOnEdge.x() ) );
     derivedGeometry.insert( tr( "Point on Edge Y" ), QLocale().toString( pointOnEdge.y() ) );
   }


### PR DESCRIPTION
## Description

This extends the identify tool to also display the index of a vertex/face/edge of a mesh.
See, the screenshot below: 

![image](https://github.com/user-attachments/assets/12dcbc35-ab7b-434f-8011-dfee214fa074)



Funded by: EDF