### PR TITLE
When duplicating a layer copy layer tree layer's custom properties [fixes #60884]

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11766,6 +11766,12 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
     // always set duplicated layers to not visible so layer can be configured before being turned on
     nodeDupLayer->setItemVisibilityChecked( false );
 
+    // duplicate the layer tree layer's custom properties
+    for ( const QString &key : nodeSelectedLyr->customProperties() )
+    {
+        nodeDupLayer->setCustomProperty(key, nodeSelectedLyr->customProperty(key));
+    }
+
     // duplicate the layer style
     QString errMsg;
     QDomDocument style;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11769,7 +11769,7 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
     // duplicate the layer tree layer's custom properties
     for ( const QString &key : nodeSelectedLyr->customProperties() )
     {
-        nodeDupLayer->setCustomProperty(key, nodeSelectedLyr->customProperty(key));
+      nodeDupLayer->setCustomProperty( key, nodeSelectedLyr->customProperty( key ) );
     }
 
     // duplicate the layer style


### PR DESCRIPTION
## Description

When using Duplicate Layer in the Layers panel only the custom properties for the `QgsMapLayer` were being copied with any custom properties for the associated `QgsLayerTreeLayer` being omitted.

This PR fixes that issue by copying the source layer tree layer's custom properties to the new layer tree layer.

I've tested the code and it behaves as expected.  Test cases included those described in the bug report as well as with the [Layer Color Plugin](https://plugins.qgis.org/plugins/layer_color_plugin/) (which is affected by this bug).

Backporting this fix to the LTR releases would be nice.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->

Fixes #60884