### PR TITLE
[attribute form][ui] Remove the basic tab from the external storage's authentication widget

### DIFF
--- a/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
@@ -43,7 +43,7 @@ QgsExternalResourceConfigDlg::QgsExternalResourceConfigDlg( QgsVectorLayer *vl, 
   {
     mStorageType->addItem( storage->displayName(), storage->type() );
   }
-
+  mAuthSettingsProtocol->removeBasicSettings();
   mExternalStorageGroupBox->setVisible( false );
 
   initializeDataDefinedButton( mStorageUrlPropertyOverrideButton, QgsEditorWidgetWrapper::Property::StorageUrl );


### PR DESCRIPTION
## Description

The authentication configuration widget's basic tab is not used by the external resource editor widget's external storage, we can hide it and avoid users going "huh, why is it not working??".

![image](https://github.com/user-attachments/assets/f6e133a1-3421-462f-a17a-6aa5ba75503a)
