### PR TITLE
Fix crash in graduated symbol renderer widget

### DIFF
--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -203,6 +203,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
 
     QgsDoubleValidator *mSymmetryPointValidator = nullptr;
     QAction *mActionLevels = nullptr;
+
+    std::unique_ptr< QgsClassificationMethod > mClassificationMethod;
     std::vector<std::unique_ptr<QgsAbstractProcessingParameterWidgetWrapper>> mParameterWidgetWrappers;
 
     int mBlockUpdates = 0;


### PR DESCRIPTION
Caused by 75c8e3e -- the previous code was relying on the leak to reference processing parameter owned by the leaked object

Fixes #60865
