### PR TITLE
Additional documentation regarding custom properties for QgsLayerTreeNode, QgsMapLayer, QgsLayoutAtlas, and QgsLayout 

### DIFF
--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -59,6 +59,9 @@ class QgsMapLayer;
  * used by third party plugins. Custom properties are stored also in the project
  * file. The storage is not efficient for large amount of data.
  *
+ * Note that additional (and separate) custom properties may be applied to an
+ * associated QgsMapLayer (QgsVectorLayer, etc.) object.
+ *
  * Custom properties that have already been used within QGIS:
  *
  * - "loading" - whether the project is being currently loaded (root node only)
@@ -68,6 +71,56 @@ class QgsMapLayer;
  * - "embedded_project" - path to the external project (embedded root node only)
  * - "legend/..." - properties for legend appearance customization
  * - "expandedLegendNodes" - list of layer's legend nodes' rules in expanded state
+ *
+ * All custom properties used with QgsLayerTreeNode (with where they are set
+ * indicated); plugins may set additional ones:
+ *
+ * - "embedded-invisible-layers"
+ *       QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups
+ * - "embedded_project"
+ *       QgsLayerTreeRegistryBridge::layersAdded
+ *       QgsProject::loadEmbeddedNodes
+ *       QgsProject::createEmbeddedGroup
+ * - "embedded"
+ *       QgsLayerTreeRegistryBridge::layersAdded
+ *       QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups
+ *       QgsProject::createEmbeddedGroup
+ *       QgsProject::initializeEmbeddedSubtree
+ * - "expandedLegendNodes"
+ *       QgsMapThemeCollection::applyThemeToLayer
+ *       QgsLayerTreeView::updateExpandedStateToNode
+ *       QgsLayerTreeView : _expandAllLegendNodes (static function)
+ * - "legend/column-break-"*
+ *       QgsMapLayerLegendUtils::setLegendNodeColumnBreak
+ * - "legend/custom-ramp-settings-*"
+ *       QgsMapLayerLegendUtils::setLegendNodeColorRampSettings
+ * - "legend/custom-symbol-"*
+ *       QgsMapLayerLegendUtils::setLegendNodeCustomSymbol
+ * - "legend/label-"*
+ *       QgsMapLayerLegendUtils::setLegendNodeUserLabel
+ * - "legend/node-order"
+ *       QgsMapLayerLegendUtils::setLegendNodeOrder
+ * - "legend/patch-shape-"*
+ *       QgsMapLayerLegendUtils::setLegendNodePatchShape
+ * - "legend/symbol-size-"*
+ *       QgsMapLayerLegendUtils::setLegendNodeSymbolSize
+ * - "legend/title-style"
+ *       QgsLegendRenderer::setNodeLegendStyle
+ * - "overview"
+ *       QgisApp::addAllToOverview
+ *       QgisApp::removeAllFromOverview
+ *       QgsLayerTreeViewDefaultActions::showInOverview
+ * - "showFeatureCount"
+ *       QgsLayerTreeModel::connectToLayer
+ *       QgsLayerTreeViewDefaultActions::showFeatureCount
+ *       QgsWms::layerTree (top-level function, QgsWms is the namespace)
+ * - "wmsAbstract"
+ *       QgisApp::legendGroupSetWmsData
+ * - "wmsShortName"
+ *       QgisApp::legendGroupSetWmsData
+ * - "wmsTitle"
+ *       QgisApp::legendGroupSetWmsData
+ *
  *
  * \see QgsLayerTree
  * \see QgsLayerTreeLayer

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -75,6 +75,8 @@ class QgsMapLayer;
  * All custom properties used with QgsLayerTreeNode (with where they are set
  * indicated); plugins may set additional ones:
  *
+ * - "cached_name"
+ *       QgsLegendModel::data
  * - "embedded-invisible-layers"
  *       QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups
  * - "embedded_project"

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -44,6 +44,73 @@ class QgsSettingsEntryStringList;
  * preparing the layout and paint devices for correct exports, respecting various
  * user settings such as the layout context DPI.
  *
+ * Custom properties: Every layout may have custom properties assigned to it.
+ * This mechanism allows third parties store additional data with the layout.
+ * The properties are used within QGIS code, but may be also used by third party
+ * plugins. Custom properties are stored also in the project file. The storage
+ * is not efficient for large amount of data.
+ *
+ * All custom properties used by QGIS with QgsLayout (with where they are set
+ * indicated); plugins may set additional ones:
+ *
+ * - "forceVector"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "imageAntialias"
+ *       QgsLayoutDesignerDialog::getRasterExportSettings
+ * - "imageCropMarginBottom"
+ *       QgsLayoutDesignerDialog::getRasterExportSettings
+ * - "imageCropMarginLeft"
+ *       QgsLayoutDesignerDialog::getRasterExportSettings
+ * - "imageCropMarginRight"
+ *       QgsLayoutDesignerDialog::getRasterExportSettings
+ * - "imageCropMarginTop"
+ *       QgsLayoutDesignerDialog::getRasterExportSettings
+ * - "imageCropToContents"
+ *       QgsLayoutDesignerDialog::getRasterExportSettings
+ * - "pdfAppendGeoreference"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfCreateGeoPdf"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfDisableRasterTiles"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfExportThemes"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfGroupOrder"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfIncludeMetadata"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfLayerOrder"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfLosslessImages"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfSimplify"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "pdfTextFormat"
+ *       QgsLayoutDesignerDialog::getPdfExportSettings
+ * - "rasterize"
+ *       QgsLayoutDesignerDialog::showRasterizationWarning
+ * - "svgCropMarginBottom"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgCropMarginLeft"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgCropMarginRight"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgCropMarginTop"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgCropToContents"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgDisableRasterTiles"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgGroupLayers"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgIncludeMetadata"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgSimplify"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ * - "svgTextFormat"
+ *       QgsLayoutDesignerDialog::getSvgExportSettings
+ *
  */
 class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContextGenerator, public QgsLayoutUndoObjectInterface
 {

--- a/src/core/layout/qgslayoutatlas.h
+++ b/src/core/layout/qgslayoutatlas.h
@@ -36,6 +36,18 @@ class QgsLayout;
  * QgsLayoutAtlas object. Instead, the atlas attached to the print layout
  * should be used. This can be retrieved by calling QgsPrintLayout::atlas().
  *
+ * Custom properties: Every atlas may have custom properties assigned to it.
+ * This mechanism allows third parties store additional data with the atlas.
+ * The properties are used within QGIS code, but may be also used by third party
+ * plugins. Custom properties are stored also in the project file. The storage
+ * is not efficient for large amount of data.
+ *
+ * All custom properties used by QGIS with QgsLayoutAtlas (with where they are
+ * set indicated); plugins may set additional ones:
+ *
+ * - "singleFile"
+ *       QgsLayoutAtlas::QgsLayoutAtlas
+ *
  */
 class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutIterator, public QgsLayoutSerializableObject, public QgsExpressionContextGenerator
 {

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -71,6 +71,81 @@ class QgsBox3D;
  * \ingroup core
  * \brief Base class for all map layer types.
  * This is the base class for all map layer types (vector, raster).
+ *
+ * Custom properties: Every map layer may have custom properties assigned to it.
+ * This mechanism allows third parties store additional data with the nodes.
+ * The properties are used within QGIS code, but may be also used by third party
+ * plugins. Custom properties are stored also in the project file. The storage
+ * is not efficient for large amount of data.
+ *
+ * Note that additional (and separate) custom properties may be applied to an
+ * associated QgsLayerTreeLayer (QgsLayerTreeNode) object.
+ *
+ * All custom properties used by QGIS with QgsMapLayer (with where they are set
+ * indicated); plugins may set additional ones:
+ *
+ * - "dualview/previewExpressions"
+ *       QgsDualView::saveRecentDisplayExpressions
+ * - "embeddedWidgets/count"
+ *       QgsLayerTreeEmbeddedConfigWidget::applyToLayer
+ * - "embeddedWidgets/"*"/id"
+ *       QgsLayerTreeEmbeddedConfigWidget::applyToLayer
+ * - "geopdf/"*
+ *       QgsGeospatialPdfLayerTreeModel::setData
+ * - "identify/format"
+ *       QgsIdentifyResultsDialog::formatChanged
+ *       QgsRasterLayer::init
+ * - "_include_in_elevation_profiles"
+ *       QgsElevationProfileLayerTreeModel::setData
+ * - "isOfflineEditable"
+ *       QgsOfflineEditing::convertToOfflineLayer
+ * - "lastDxfOutputAttribute"
+ *       QgsVectorLayerAndAttributeModel::saveLayersOutputAttribute
+ * - "lastMaximumNumberOfBlocks"
+ *       QgsVectorLayerAndAttributeModel::saveLayersOutputAttribute
+ * - "layerNameSuffix"
+ *       QgsOfflineEditing::convertToOfflineLayer
+ * - "_layer_was_editable"
+ *       QgsProject::addLayer
+ * - "_legend_added"
+ *       QgsAppLayerHandling::addSublayers
+ * - "legend/expressionFilterEnabled"
+ *       QgsLayerTreeUtils::setLegendFilterByExpression
+ * - "legend/expressionFilter"
+ *       QgsLayerTreeUtils::setLegendFilterByExpression
+ * - "loading"
+ *       QgsProject::readProjectFile
+ * - "metadata/"*
+ *       QgsLayerMetadata::saveToLayer
+ * - "OnConvertFormatRegeneratePrimaryKey"
+ *       QgsProcessingUtils::createFeatureSink
+ * - "_prevGroupBlendMode"
+ *       QgsGroupLayer::setChildLayers
+ * - "remoteLayerId"
+ *       QgsOfflineEditing::convertToOfflineLayer
+ * - "remoteProvider"
+ *       QgsOfflineEditing::convertToOfflineLayer
+ * - "remoteSource"
+ *       QgsOfflineEditing::convertToOfflineLayer
+ * - "skipMemoryLayersCheck"
+ *       Not currently set by QGIS; if set on a memory layer will suppress on-
+ *       close unsaved data loss warning for that layer.
+ * - "sldStyleName"
+ *       QgsWms::QgsRenderer::setLayerSld (QgsWms is the namespace)
+ * - "storedSubsetString"
+ *       QgsPointCloudLayer::setSubsetString
+ *       QgsRasterLayer::setSubsetString
+ *       QgsVectorLayer::setSubsetString
+ * - "userNotes"
+ *       QgsLayerNotesUtils::setLayerNotes
+ * - "variableNames"
+ *       QgsExpressionContextUtils::setLayerVariable
+ * - "WMSBackgroundLayer"
+ *       QgsRasterLayerProperties::apply
+ * - "WMSPrintLayer"
+ *       QgsRasterLayerProperties::apply
+ * - "WMSPublishDataSourceUrl"
+ *       QgsRasterLayerProperties::apply
  */
 class CORE_EXPORT QgsMapLayer : public QObject
 {

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -73,7 +73,7 @@ class QgsBox3D;
  * This is the base class for all map layer types (vector, raster).
  *
  * Custom properties: Every map layer may have custom properties assigned to it.
- * This mechanism allows third parties store additional data with the nodes.
+ * This mechanism allows third parties store additional data with the layers.
  * The properties are used within QGIS code, but may be also used by third party
  * plugins. Custom properties are stored also in the project file. The storage
  * is not efficient for large amount of data.
@@ -117,6 +117,8 @@ class QgsBox3D;
  *       QgsProject::readProjectFile
  * - "metadata/"*
  *       QgsLayerMetadata::saveToLayer
+ * - "_noset_layer_expression_context"
+ *       QgsLayoutItemMapOverviewStack::modifyMapLayerList
  * - "OnConvertFormatRegeneratePrimaryKey"
  *       QgsProcessingUtils::createFeatureSink
  * - "_prevGroupBlendMode"


### PR DESCRIPTION
## Description

This PR expands the documentation of custom properties for the `QgsLayerTreeNode`, `QgsMapLayer`, `QgsLayoutAtlas`, and `QgsLayout` classes.  In specific it lists all custom properties currently being used by QGIS with those classes (the classes listed are all of the ones that QGIS sets custom properties on).  Additional custom properties may be [are] used by plugins; these have not been included.

Only comments are modified; there are no changes to any code.

The list of custom properties being used for `QgsLayerTreeNode` `QgsMapLayer`, `QgsLayoutAtlas`, and `QgsLayout` is current as of https://github.com/qgis/QGIS/commit/9a1d4532d129b0c4a02cf3956bd4be887d371cd1 (2025-03-06).

## Comments
The impetus for determining which custom properties currently exist (at least those set by QGIS itself) was [this comment on a recent PR](https://github.com/qgis/QGIS/pull/60897#pullrequestreview-2669172659).

Perhaps it would be useful to have a central registry of custom properties that are in use by QGIS and by plugins.  This would be intended solely for use by developers.  Such a registry could be as simple as including the property name, its function, and the class or plugin that uses it in the header file comments for `QgsLayerTreeNode` `QgsMapLayer`, `QgsLayoutAtlas`, and `QgsLayout` (as is partially done now for `QgsLayerTreeNode`).