### PR TITLE
[mssql] Add workaround for incorrect geometry system type returned by sp_describe_first_result_set

### DIFF
--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -403,6 +403,14 @@ bool QgsMssqlDatabase::loadQueryFields( FieldDetails &details, const QString &qu
     {
       details.geometryColumnName = name;
       details.geometryColumnType = systemTypeName;
+
+      // some versions/setups of SQL Server incorrectly report geometry columns as 'image' types in sp_describe_first_result_set results!
+      // let's just fix that up here...
+      if ( details.geometryColumnType == QLatin1String( "image" ) )
+      {
+        details.geometryColumnType = QStringLiteral( "geometry" );
+      }
+
       details.isGeography = systemTypeName == QLatin1String( "geography" );
     }
     else


### PR DESCRIPTION
Some (versions?) (setups?) of SQL server incorrectly report that the system type for a geometry columns is "image" in their sp_describe_first_result_set results.

Let's just automatically override this and set it back to "geometry" if we know that the column is actually the geometry column.

Fixes broken query layers on these databases

** THIS IS IMPOSSIBLE TO UNIT TEST **