### PR TITLE
Add optional extent, expression based filter when importing tables to database

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsvectorlayerexporter.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorlayerexporter.py
@@ -11,3 +11,7 @@ try:
     QgsVectorLayerExporter.__group__ = ['vector']
 except (NameError, AttributeError):
     pass
+try:
+    QgsVectorLayerExporter.ExportOptions.__group__ = ['vector']
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -116,6 +116,32 @@ Returns the destination coordinate reference system used for exported features.
 .. seealso:: :py:func:`setDestinationCrs`
 %End
 
+        void setExtent( const QgsReferencedRectangle &extent );
+%Docstring
+Sets an ``extent`` filter for the features to export.
+
+Only features with a bounding box intersecting ``extent`` will be exported.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`extent`
+%End
+
+        QgsReferencedRectangle extent() const;
+%Docstring
+Returns the extent filter for the features to export.
+
+Only features with a bounding box intersecting this extent will be exported.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`setExtent`
+%End
+
     };
 
     static Qgis::VectorExportResult exportLayer( QgsVectorLayer *layer,

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -70,6 +70,10 @@ Encapsulates options for use with QgsVectorLayerExporter.
 %Docstring
 Sets whether the export should only include selected features.
 
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.setFilterExpression`
+
 .. note::
 
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
@@ -80,6 +84,10 @@ Sets whether the export should only include selected features.
         bool selectedOnly() const;
 %Docstring
 Returns whether the export will only include selected features.
+
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.filterExpression`
 
 .. note::
 
@@ -140,6 +148,58 @@ Only features with a bounding box intersecting this extent will be exported.
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
 
 .. seealso:: :py:func:`setExtent`
+%End
+
+        void setFilterExpression( const QString &expression );
+%Docstring
+Set the filter ``expression`` for the features to export.
+
+Only features matching this expression will be exported.
+
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.setSelectedOnly`
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`setExpressionContext`
+
+.. seealso:: :py:func:`filterExpression`
+%End
+
+        QString filterExpression() const;
+%Docstring
+Returns the filter expression for features to export.
+
+Only features matching this expression will be exported.
+
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.selectedOnly`
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`expressionContext`
+
+.. seealso:: :py:func:`setFilterExpression`
+%End
+
+        void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Sets the expression ``context`` to use when a :py:func:`~ExportOptions.filterExpression` is set.
+
+.. seealso:: :py:func:`expressionContext`
+%End
+
+        const QgsExpressionContext &expressionContext() const;
+%Docstring
+Returns the expression context used when a :py:func:`~ExportOptions.filterExpression` is set.
+
+.. seealso:: :py:func:`setExpressionContext`
 %End
 
     };

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -93,7 +93,7 @@ Returns whether the export will only include selected features.
 
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
 
-\seee :py:func:`~ExportOptions.setSelectedOnly`
+.. seealso:: :py:func:`setSelectedOnly`
 %End
 
         void setTransformContext( const QgsCoordinateTransformContext &context );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -53,6 +53,94 @@ Writes the contents of vector layer to a different datasource.
          - errorMessage: if non-null, any error messages
 %End
 
+    class ExportOptions
+{
+%Docstring(signature="appended")
+Encapsulates options for use with QgsVectorLayerExporter.
+
+.. versionadded:: 3.44
+%End
+
+%TypeHeaderCode
+#include "qgsvectorlayerexporter.h"
+%End
+      public:
+
+        void setSelectedOnly( bool selected );
+%Docstring
+Sets whether the export should only include selected features.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+\seee :py:func:`~ExportOptions.selectedOnly`
+%End
+
+        bool selectedOnly() const;
+%Docstring
+Returns whether the export will only include selected features.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+\seee :py:func:`~ExportOptions.setSelectedOnly`
+%End
+
+        void setTransformContext( const QgsCoordinateTransformContext &context );
+%Docstring
+Sets the coordinate transform ``context`` to use when transforming exported features.
+
+.. seealso:: :py:func:`transformContext`
+%End
+
+        QgsCoordinateTransformContext transformContext() const;
+%Docstring
+Returns the coordinate transform context used when transforming exported features.
+
+.. seealso:: :py:func:`setTransformContext`
+%End
+
+        void setDestinationCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the destination coordinate reference system to use for exported features.
+
+.. seealso:: :py:func:`destinationCrs`
+%End
+
+        QgsCoordinateReferenceSystem destinationCrs() const;
+%Docstring
+Returns the destination coordinate reference system used for exported features.
+
+.. seealso:: :py:func:`setDestinationCrs`
+%End
+
+    };
+
+    static Qgis::VectorExportResult exportLayer( QgsVectorLayer *layer,
+        const QString &uri,
+        const QString &providerKey,
+        const QgsVectorLayerExporter::ExportOptions &exportOptions,
+        QString *errorMessage /Out/ = 0,
+        const QMap<QString, QVariant> &providerOptions = QMap<QString, QVariant>(),
+        QgsFeedback *feedback = 0 );
+%Docstring
+Writes the contents of vector layer to a different data provider.
+
+:param layer: source layer
+:param uri: URI for destination data source
+:param providerKey: string key for destination data provider
+:param exportOptions: options controlling the feature export
+:param providerOptions: optional provider dataset options
+:param feedback: optional feedback object to show progress and cancellation of export
+
+:return: - :py:class:`Qgis`.VectorExportResult.NoError for a successful export, or encountered error
+         - errorMessage: any error messages which occur during the export
+
+.. versionadded:: 3.44
+%End
+
     QgsVectorLayerExporter( const QString &uri,
                             const QString &provider,
                             const QgsFields &fields,
@@ -155,6 +243,22 @@ Constructor for QgsVectorLayerExporterTask. Takes a source ``layer``, destinatio
 and ``providerKey``, and various export related parameters such as destination CRS
 and export ``options``. ``ownsLayer`` has to be set to ``True`` if the task should take ownership
 of the layer and delete it after export.
+%End
+
+    QgsVectorLayerExporterTask( QgsVectorLayer *layer,
+                                const QString &uri,
+                                const QString &providerKey,
+                                const QgsVectorLayerExporter::ExportOptions &exportOptions,
+                                const QMap<QString, QVariant> &providerOptions = QMap<QString, QVariant>(),
+                                bool ownsLayer = false );
+%Docstring
+Constructor for QgsVectorLayerExporterTask. Takes a source ``layer``, destination ``uri``
+and ``providerKey``, and various export related parameters via the ``exportOptions`` argument.
+
+``ownsLayer`` has to be set to ``True`` if the task should take ownership
+of the layer and delete it after export.
+
+.. versionadded:: 3.44
 %End
 
     static QgsVectorLayerExporterTask *withLayerOwnership( QgsVectorLayer *layer /Transfer/,

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -78,7 +78,7 @@ Sets whether the export should only include selected features.
 
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
 
-\seee :py:func:`~ExportOptions.selectedOnly`
+.. seealso:: :py:func:`selectedOnly`
 %End
 
         bool selectedOnly() const;

--- a/python/PyQt6/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -64,6 +64,26 @@ Returns the message bar associated with the dock.
 .. versionadded:: 3.6
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets a map ``canvas`` to use alongside the dock.
+
+Setting this allows items to utilize the canvas during GUI operations.
+
+.. seealso:: :py:func:`mapCanvas`
+
+.. versionadded:: 3.44
+%End
+
+    QgsMapCanvas *mapCanvas();
+%Docstring
+Returns the map canvas associated with the dock.
+
+.. seealso:: :py:func:`setMapCanvas`
+
+.. versionadded:: 3.44
+%End
+
     void setDisabledDataItemsKeys( const QStringList &filter );
 %Docstring
 Sets the customization for data items based on item's data provider key

--- a/python/PyQt6/gui/auto_generated/qgsbrowserguimodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsbrowserguimodel.sip.in
@@ -47,6 +47,13 @@ Constructor for QgsBrowserGuiModel, with the specified ``parent`` object.
 Sets message bar that will be passed in :py:class:`QgsDataItemGuiContext` to data items
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets the associated map ``canvas`` that will be passed in :py:class:`QgsDataItemGuiContext` to data items.
+
+.. versionadded:: 3.44
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/gui/auto_generated/qgsbrowserwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsbrowserwidget.sip.in
@@ -46,6 +46,26 @@ Returns the message bar associated with the widget.
 .. seealso:: :py:func:`setMessageBar`
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets a map ``canvas`` to use alongside the widget.
+
+Setting this allows items to utilize the canvas during GUI operations.
+
+.. seealso:: :py:func:`mapCanvas`
+
+.. versionadded:: 3.44
+%End
+
+    QgsMapCanvas *mapCanvas();
+%Docstring
+Returns the map canvas associated with the widget.
+
+.. seealso:: :py:func:`setMapCanvas`
+
+.. versionadded:: 3.44
+%End
+
     void setDisabledDataItemsKeys( const QStringList &filter );
 %Docstring
 Sets the customization for data items based on item's data provider key

--- a/python/PyQt6/gui/auto_generated/qgsdataitemguiprovider.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsdataitemguiprovider.sip.in
@@ -42,6 +42,26 @@ This bar can be used to provide non-blocking feedback to users.
 .. seealso:: :py:func:`messageBar`
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets the map canvas associated with the data item.
+
+This allows the item to retrieve the current map scale and other properties from the canvas.
+
+.. seealso:: :py:func:`mapCanvas`
+
+.. versionadded:: 3.44
+%End
+
+    QgsMapCanvas *mapCanvas() const;
+%Docstring
+Returns the map canvas associated with the item.
+
+.. seealso:: :py:func:`setMapCanvas`
+
+.. versionadded:: 3.44
+%End
+
     QgsBrowserTreeView *view() const;
 %Docstring
 Returns the associated view.

--- a/python/core/auto_additions/qgsvectorlayerexporter.py
+++ b/python/core/auto_additions/qgsvectorlayerexporter.py
@@ -11,3 +11,7 @@ try:
     QgsVectorLayerExporter.__group__ = ['vector']
 except (NameError, AttributeError):
     pass
+try:
+    QgsVectorLayerExporter.ExportOptions.__group__ = ['vector']
+except (NameError, AttributeError):
+    pass

--- a/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -116,6 +116,32 @@ Returns the destination coordinate reference system used for exported features.
 .. seealso:: :py:func:`setDestinationCrs`
 %End
 
+        void setExtent( const QgsReferencedRectangle &extent );
+%Docstring
+Sets an ``extent`` filter for the features to export.
+
+Only features with a bounding box intersecting ``extent`` will be exported.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`extent`
+%End
+
+        QgsReferencedRectangle extent() const;
+%Docstring
+Returns the extent filter for the features to export.
+
+Only features with a bounding box intersecting this extent will be exported.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`setExtent`
+%End
+
     };
 
     static Qgis::VectorExportResult exportLayer( QgsVectorLayer *layer,

--- a/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -70,6 +70,10 @@ Encapsulates options for use with QgsVectorLayerExporter.
 %Docstring
 Sets whether the export should only include selected features.
 
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.setFilterExpression`
+
 .. note::
 
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
@@ -80,6 +84,10 @@ Sets whether the export should only include selected features.
         bool selectedOnly() const;
 %Docstring
 Returns whether the export will only include selected features.
+
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.filterExpression`
 
 .. note::
 
@@ -140,6 +148,58 @@ Only features with a bounding box intersecting this extent will be exported.
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
 
 .. seealso:: :py:func:`setExtent`
+%End
+
+        void setFilterExpression( const QString &expression );
+%Docstring
+Set the filter ``expression`` for the features to export.
+
+Only features matching this expression will be exported.
+
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.setSelectedOnly`
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`setExpressionContext`
+
+.. seealso:: :py:func:`filterExpression`
+%End
+
+        QString filterExpression() const;
+%Docstring
+Returns the filter expression for features to export.
+
+Only features matching this expression will be exported.
+
+.. warning::
+
+   This setting is incompatible with :py:func:`~ExportOptions.selectedOnly`
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`expressionContext`
+
+.. seealso:: :py:func:`setFilterExpression`
+%End
+
+        void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Sets the expression ``context`` to use when a :py:func:`~ExportOptions.filterExpression` is set.
+
+.. seealso:: :py:func:`expressionContext`
+%End
+
+        const QgsExpressionContext &expressionContext() const;
+%Docstring
+Returns the expression context used when a :py:func:`~ExportOptions.filterExpression` is set.
+
+.. seealso:: :py:func:`setExpressionContext`
 %End
 
     };

--- a/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -93,7 +93,7 @@ Returns whether the export will only include selected features.
 
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
 
-\seee :py:func:`~ExportOptions.setSelectedOnly`
+.. seealso:: :py:func:`setSelectedOnly`
 %End
 
         void setTransformContext( const QgsCoordinateTransformContext &context );

--- a/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -53,6 +53,94 @@ Writes the contents of vector layer to a different datasource.
          - errorMessage: if non-null, any error messages
 %End
 
+    class ExportOptions
+{
+%Docstring(signature="appended")
+Encapsulates options for use with QgsVectorLayerExporter.
+
+.. versionadded:: 3.44
+%End
+
+%TypeHeaderCode
+#include "qgsvectorlayerexporter.h"
+%End
+      public:
+
+        void setSelectedOnly( bool selected );
+%Docstring
+Sets whether the export should only include selected features.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+\seee :py:func:`~ExportOptions.selectedOnly`
+%End
+
+        bool selectedOnly() const;
+%Docstring
+Returns whether the export will only include selected features.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+\seee :py:func:`~ExportOptions.setSelectedOnly`
+%End
+
+        void setTransformContext( const QgsCoordinateTransformContext &context );
+%Docstring
+Sets the coordinate transform ``context`` to use when transforming exported features.
+
+.. seealso:: :py:func:`transformContext`
+%End
+
+        QgsCoordinateTransformContext transformContext() const;
+%Docstring
+Returns the coordinate transform context used when transforming exported features.
+
+.. seealso:: :py:func:`setTransformContext`
+%End
+
+        void setDestinationCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the destination coordinate reference system to use for exported features.
+
+.. seealso:: :py:func:`destinationCrs`
+%End
+
+        QgsCoordinateReferenceSystem destinationCrs() const;
+%Docstring
+Returns the destination coordinate reference system used for exported features.
+
+.. seealso:: :py:func:`setDestinationCrs`
+%End
+
+    };
+
+    static Qgis::VectorExportResult exportLayer( QgsVectorLayer *layer,
+        const QString &uri,
+        const QString &providerKey,
+        const QgsVectorLayerExporter::ExportOptions &exportOptions,
+        QString *errorMessage /Out/ = 0,
+        const QMap<QString, QVariant> &providerOptions = QMap<QString, QVariant>(),
+        QgsFeedback *feedback = 0 );
+%Docstring
+Writes the contents of vector layer to a different data provider.
+
+:param layer: source layer
+:param uri: URI for destination data source
+:param providerKey: string key for destination data provider
+:param exportOptions: options controlling the feature export
+:param providerOptions: optional provider dataset options
+:param feedback: optional feedback object to show progress and cancellation of export
+
+:return: - :py:class:`Qgis`.VectorExportResult.NoError for a successful export, or encountered error
+         - errorMessage: any error messages which occur during the export
+
+.. versionadded:: 3.44
+%End
+
     QgsVectorLayerExporter( const QString &uri,
                             const QString &provider,
                             const QgsFields &fields,
@@ -155,6 +243,22 @@ Constructor for QgsVectorLayerExporterTask. Takes a source ``layer``, destinatio
 and ``providerKey``, and various export related parameters such as destination CRS
 and export ``options``. ``ownsLayer`` has to be set to ``True`` if the task should take ownership
 of the layer and delete it after export.
+%End
+
+    QgsVectorLayerExporterTask( QgsVectorLayer *layer,
+                                const QString &uri,
+                                const QString &providerKey,
+                                const QgsVectorLayerExporter::ExportOptions &exportOptions,
+                                const QMap<QString, QVariant> &providerOptions = QMap<QString, QVariant>(),
+                                bool ownsLayer = false );
+%Docstring
+Constructor for QgsVectorLayerExporterTask. Takes a source ``layer``, destination ``uri``
+and ``providerKey``, and various export related parameters via the ``exportOptions`` argument.
+
+``ownsLayer`` has to be set to ``True`` if the task should take ownership
+of the layer and delete it after export.
+
+.. versionadded:: 3.44
 %End
 
     static QgsVectorLayerExporterTask *withLayerOwnership( QgsVectorLayer *layer /Transfer/,

--- a/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -78,7 +78,7 @@ Sets whether the export should only include selected features.
 
    This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
 
-\seee :py:func:`~ExportOptions.selectedOnly`
+.. seealso:: :py:func:`selectedOnly`
 %End
 
         bool selectedOnly() const;

--- a/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -64,6 +64,26 @@ Returns the message bar associated with the dock.
 .. versionadded:: 3.6
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets a map ``canvas`` to use alongside the dock.
+
+Setting this allows items to utilize the canvas during GUI operations.
+
+.. seealso:: :py:func:`mapCanvas`
+
+.. versionadded:: 3.44
+%End
+
+    QgsMapCanvas *mapCanvas();
+%Docstring
+Returns the map canvas associated with the dock.
+
+.. seealso:: :py:func:`setMapCanvas`
+
+.. versionadded:: 3.44
+%End
+
     void setDisabledDataItemsKeys( const QStringList &filter );
 %Docstring
 Sets the customization for data items based on item's data provider key

--- a/python/gui/auto_generated/qgsbrowserguimodel.sip.in
+++ b/python/gui/auto_generated/qgsbrowserguimodel.sip.in
@@ -47,6 +47,13 @@ Constructor for QgsBrowserGuiModel, with the specified ``parent`` object.
 Sets message bar that will be passed in :py:class:`QgsDataItemGuiContext` to data items
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets the associated map ``canvas`` that will be passed in :py:class:`QgsDataItemGuiContext` to data items.
+
+.. versionadded:: 3.44
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsbrowserwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserwidget.sip.in
@@ -46,6 +46,26 @@ Returns the message bar associated with the widget.
 .. seealso:: :py:func:`setMessageBar`
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets a map ``canvas`` to use alongside the widget.
+
+Setting this allows items to utilize the canvas during GUI operations.
+
+.. seealso:: :py:func:`mapCanvas`
+
+.. versionadded:: 3.44
+%End
+
+    QgsMapCanvas *mapCanvas();
+%Docstring
+Returns the map canvas associated with the widget.
+
+.. seealso:: :py:func:`setMapCanvas`
+
+.. versionadded:: 3.44
+%End
+
     void setDisabledDataItemsKeys( const QStringList &filter );
 %Docstring
 Sets the customization for data items based on item's data provider key

--- a/python/gui/auto_generated/qgsdataitemguiprovider.sip.in
+++ b/python/gui/auto_generated/qgsdataitemguiprovider.sip.in
@@ -42,6 +42,26 @@ This bar can be used to provide non-blocking feedback to users.
 .. seealso:: :py:func:`messageBar`
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets the map canvas associated with the data item.
+
+This allows the item to retrieve the current map scale and other properties from the canvas.
+
+.. seealso:: :py:func:`mapCanvas`
+
+.. versionadded:: 3.44
+%End
+
+    QgsMapCanvas *mapCanvas() const;
+%Docstring
+Returns the map canvas associated with the item.
+
+.. seealso:: :py:func:`setMapCanvas`
+
+.. versionadded:: 3.44
+%End
+
     QgsBrowserTreeView *view() const;
 %Docstring
 Returns the associated view.

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2125,6 +2125,7 @@ void QgsDatabaseItemGuiProvider::openSqlDialogGeneric( const QString &connection
 {
   QgsDataItemGuiContext context;
   context.setMessageBar( QgisApp::instance()->messageBar() );
+  context.setMapCanvas( QgisApp::instance()->mapCanvas() );
 
   openSqlDialog( connectionUri, provider, query, context );
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1409,6 +1409,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   mBrowserWidget = new QgsBrowserDockWidget( tr( "Browser" ), mBrowserModel, this );
   mBrowserWidget->setObjectName( QStringLiteral( "Browser" ) );
   mBrowserWidget->setMessageBar( mInfoBar );
+  mBrowserWidget->setMapCanvas( mMapCanvas );
 
   mTemporalControllerWidget = new QgsTemporalControllerDockWidget( tr( "Temporal Controller" ), this );
   mTemporalControllerWidget->setObjectName( QStringLiteral( "Temporal Controller" ) );

--- a/src/core/vector/qgsvectorlayerexporter.cpp
+++ b/src/core/vector/qgsvectorlayerexporter.cpp
@@ -47,6 +47,35 @@ typedef Qgis::VectorExportResult createEmptyLayer_t(
 );
 
 
+//
+// QgsVectorLayerExporter::ExportOptions
+//
+
+void QgsVectorLayerExporter::ExportOptions::setTransformContext( const QgsCoordinateTransformContext &context )
+{
+  mTransformContext = context;
+}
+
+QgsCoordinateTransformContext QgsVectorLayerExporter::ExportOptions::transformContext() const
+{
+  return mTransformContext;
+}
+
+void QgsVectorLayerExporter::ExportOptions::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  mDestinationCrs = crs;
+}
+
+QgsCoordinateReferenceSystem QgsVectorLayerExporter::ExportOptions::destinationCrs() const
+{
+  return mDestinationCrs;
+}
+
+
+//
+// QgsVectorLayerExporter
+//
+
 QgsVectorLayerExporter::QgsVectorLayerExporter( const QString &uri,
     const QString &providerKey,
     const QgsFields &fields,
@@ -292,6 +321,15 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
     const QMap<QString, QVariant> &options,
     QgsFeedback *feedback )
 {
+  ExportOptions exportOptions;
+  exportOptions.setSelectedOnly( onlySelected );
+  exportOptions.setDestinationCrs( destCRS );
+  exportOptions.setTransformContext( layer->transformContext() );
+  return exportLayer( layer, uri, providerKey, exportOptions, errorMessage, options, feedback );
+}
+
+Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer, const QString &uri, const QString &providerKey, const ExportOptions &exportOptions, QString *errorMessage, const QMap<QString, QVariant> &_providerOptions, QgsFeedback *feedback )
+{
   QgsCoordinateReferenceSystem outputCRS;
   QgsCoordinateTransform ct;
   bool shallTransform = false;
@@ -299,10 +337,10 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
   if ( !layer )
     return Qgis::VectorExportResult::ErrorInvalidLayer;
 
-  if ( destCRS.isValid() )
+  if ( exportOptions.destinationCrs().isValid() )
   {
     // This means we should transform
-    outputCRS = destCRS;
+    outputCRS = exportOptions.destinationCrs();
     shallTransform = true;
   }
   else
@@ -311,15 +349,9 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
     outputCRS = layer->crs();
   }
 
-
-  bool overwrite = false;
-  bool forceSinglePartGeom = false;
-  QMap<QString, QVariant> providerOptions = options;
-  if ( !options.isEmpty() )
-  {
-    overwrite = providerOptions.take( QStringLiteral( "overwrite" ) ).toBool();
-    forceSinglePartGeom = providerOptions.take( QStringLiteral( "forceSinglePartGeometryType" ) ).toBool();
-  }
+  QMap<QString, QVariant> providerOptions = _providerOptions;
+  const bool overwrite = providerOptions.take( QStringLiteral( "overwrite" ) ).toBool();
+  const bool forceSinglePartGeom = providerOptions.take( QStringLiteral( "forceSinglePartGeometryType" ) ).toBool();
 
   QgsFields fields = layer->fields();
 
@@ -354,15 +386,15 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
   QgsFeatureRequest req;
   if ( wkbType == Qgis::WkbType::NoGeometry )
     req.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
-  if ( onlySelected )
+  if ( exportOptions.selectedOnly() )
     req.setFilterFids( layer->selectedFeatureIds() );
 
   QgsFeatureIterator fit = layer->getFeatures( req );
 
   // Create our transform
-  if ( destCRS.isValid() )
+  if ( exportOptions.destinationCrs().isValid() )
   {
-    ct = QgsCoordinateTransform( layer->crs(), destCRS, layer->transformContext() );
+    ct = QgsCoordinateTransform( layer->crs(), exportOptions.destinationCrs(), exportOptions.transformContext() );
   }
 
   // Check for failure
@@ -370,7 +402,7 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
     shallTransform = false;
 
   long long n = 0;
-  const long long approxTotal = onlySelected ? layer->selectedFeatureCount() : layer->featureCount();
+  const long long approxTotal = exportOptions.selectedOnly() ? layer->selectedFeatureCount() : layer->featureCount();
 
   if ( errorMessage )
   {
@@ -454,7 +486,7 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
 
     if ( feedback )
     {
-      feedback->setProgress( 100.0 * static_cast< double >( n ) / approxTotal );
+      feedback->setProgress( 100.0 * static_cast< double >( n ) / static_cast< double >( approxTotal ) );
     }
 
   }
@@ -499,7 +531,6 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
   return Qgis::VectorExportResult::Success;
 }
 
-
 //
 // QgsVectorLayerExporterTask
 //
@@ -510,8 +541,24 @@ QgsVectorLayerExporterTask::QgsVectorLayerExporterTask( QgsVectorLayer *layer, c
   , mOwnsLayer( ownsLayer )
   , mDestUri( uri )
   , mDestProviderKey( providerKey )
-  , mDestCrs( destinationCrs )
   , mOptions( options )
+  , mOwnedFeedback( new QgsFeedback() )
+{
+  mExportOptions.setDestinationCrs( destinationCrs );
+  mExportOptions.setTransformContext( layer->transformContext() );
+
+  if ( mLayer )
+    setDependentLayers( QList< QgsMapLayer * >() << mLayer );
+}
+
+QgsVectorLayerExporterTask::QgsVectorLayerExporterTask( QgsVectorLayer *layer, const QString &uri, const QString &providerKey, const QgsVectorLayerExporter::ExportOptions &exportOptions, const QMap<QString, QVariant> &providerOptions, bool ownsLayer )
+  : QgsTask( tr( "Exporting %1" ).arg( layer->name() ), QgsTask::CanCancel )
+  , mLayer( layer )
+  , mOwnsLayer( ownsLayer )
+  , mDestUri( uri )
+  , mDestProviderKey( providerKey )
+  , mExportOptions( exportOptions )
+  , mOptions( providerOptions )
   , mOwnedFeedback( new QgsFeedback() )
 {
   if ( mLayer )
@@ -540,7 +587,7 @@ bool QgsVectorLayerExporterTask::run()
 
 
   mError = QgsVectorLayerExporter::exportLayer(
-             mLayer.data(), mDestUri, mDestProviderKey, mDestCrs, false, &mErrorMessage,
+             mLayer.data(), mDestUri, mDestProviderKey, mExportOptions, &mErrorMessage,
              mOptions, mOwnedFeedback.get() );
 
   return mError == Qgis::VectorExportResult::Success;

--- a/src/core/vector/qgsvectorlayerexporter.cpp
+++ b/src/core/vector/qgsvectorlayerexporter.cpp
@@ -81,6 +81,26 @@ QgsReferencedRectangle QgsVectorLayerExporter::ExportOptions::extent() const
   return mExtent;
 }
 
+void QgsVectorLayerExporter::ExportOptions::setFilterExpression( const QString &expression )
+{
+  mFilterExpression = expression;
+}
+
+QString QgsVectorLayerExporter::ExportOptions::filterExpression() const
+{
+  return mFilterExpression;
+}
+
+void QgsVectorLayerExporter::ExportOptions::setExpressionContext( const QgsExpressionContext &context )
+{
+  mExpressionContext = context;
+}
+
+const QgsExpressionContext &QgsVectorLayerExporter::ExportOptions::expressionContext() const
+{
+  return mExpressionContext;
+}
+
 
 //
 // QgsVectorLayerExporter
@@ -423,7 +443,12 @@ Qgis::VectorExportResult QgsVectorLayerExporter::exportLayer( QgsVectorLayer *la
     }
   }
 
-  if ( exportOptions.selectedOnly() )
+  if ( !exportOptions.filterExpression().isEmpty() )
+  {
+    req.setFilterExpression( exportOptions.filterExpression() );
+    req.setExpressionContext( exportOptions.expressionContext() );
+  }
+  else if ( exportOptions.selectedOnly() )
   {
     req.setFilterFids( layer->selectedFeatureIds() );
   }

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -86,6 +86,8 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
         /**
          * Sets whether the export should only include selected features.
          *
+         * \warning This setting is incompatible with setFilterExpression()
+         *
          * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
          *
          * \seee selectedOnly()
@@ -94,6 +96,8 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
 
         /**
          * Returns whether the export will only include selected features.
+         *
+         * \warning This setting is incompatible with filterExpression()
          *
          * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
          *
@@ -151,6 +155,48 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
          */
         QgsReferencedRectangle extent() const;
 
+        /**
+         * Set the filter \a expression for the features to export.
+         *
+         * Only features matching this expression will be exported.
+         *
+         * \warning This setting is incompatible with setSelectedOnly()
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \see setExpressionContext()
+         * \see filterExpression()
+         */
+        void setFilterExpression( const QString &expression );
+
+        /**
+         * Returns the filter expression for features to export.
+         *
+         * Only features matching this expression will be exported.
+         *
+         * \warning This setting is incompatible with selectedOnly()
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \see expressionContext()
+         * \see setFilterExpression()
+         */
+        QString filterExpression() const;
+
+        /**
+         * Sets the expression \a context to use when a filterExpression() is set.
+         *
+         * \see expressionContext()
+         */
+        void setExpressionContext( const QgsExpressionContext &context );
+
+        /**
+         * Returns the expression context used when a filterExpression() is set.
+         *
+         * \see setExpressionContext()
+         */
+        const QgsExpressionContext &expressionContext() const;
+
       private:
 
         bool mSelectedOnly = false;
@@ -160,6 +206,9 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
         QgsCoordinateTransformContext mTransformContext;
 
         QgsReferencedRectangle mExtent;
+
+        QString mFilterExpression;
+        QgsExpressionContext mExpressionContext;
 
     };
 

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -26,6 +26,7 @@
 #include "qgstaskmanager.h"
 #include "qgsfeedback.h"
 #include "qgsvectorlayer.h"
+#include "qgsreferencedgeometry.h"
 
 #include <QPointer>
 
@@ -128,6 +129,28 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
          */
         QgsCoordinateReferenceSystem destinationCrs() const;
 
+        /**
+         * Sets an \a extent filter for the features to export.
+         *
+         * Only features with a bounding box intersecting \a extent will be exported.
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \see extent()
+         */
+        void setExtent( const QgsReferencedRectangle &extent );
+
+        /**
+         * Returns the extent filter for the features to export.
+         *
+         * Only features with a bounding box intersecting this extent will be exported.
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \see setExtent()
+         */
+        QgsReferencedRectangle extent() const;
+
       private:
 
         bool mSelectedOnly = false;
@@ -135,6 +158,8 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
         QgsCoordinateReferenceSystem mDestinationCrs;
 
         QgsCoordinateTransformContext mTransformContext;
+
+        QgsReferencedRectangle mExtent;
 
     };
 

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -73,6 +73,94 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
         QgsFeedback *feedback = nullptr );
 
     /**
+     * \ingroup core
+     * \brief Encapsulates options for use with QgsVectorLayerExporter.
+     *
+     * \since QGIS 3.44
+     */
+    class ExportOptions
+    {
+      public:
+
+        /**
+         * Sets whether the export should only include selected features.
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \seee selectedOnly()
+         */
+        void setSelectedOnly( bool selected ) { mSelectedOnly = selected; }
+
+        /**
+         * Returns whether the export will only include selected features.
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \seee setSelectedOnly()
+         */
+        bool selectedOnly() const { return mSelectedOnly; }
+
+        /**
+         * Sets the coordinate transform \a context to use when transforming exported features.
+         *
+         * \see transformContext()
+         */
+        void setTransformContext( const QgsCoordinateTransformContext &context );
+
+        /**
+         * Returns the coordinate transform context used when transforming exported features.
+         *
+         * \see setTransformContext()
+         */
+        QgsCoordinateTransformContext transformContext() const;
+
+        /**
+         * Sets the destination coordinate reference system to use for exported features.
+         *
+         * \see destinationCrs()
+         */
+        void setDestinationCrs( const QgsCoordinateReferenceSystem &crs );
+
+        /**
+         * Returns the destination coordinate reference system used for exported features.
+         *
+         * \see setDestinationCrs()
+         */
+        QgsCoordinateReferenceSystem destinationCrs() const;
+
+      private:
+
+        bool mSelectedOnly = false;
+
+        QgsCoordinateReferenceSystem mDestinationCrs;
+
+        QgsCoordinateTransformContext mTransformContext;
+
+    };
+
+    /**
+     * Writes the contents of vector layer to a different data provider.
+     *
+     * \param layer source layer
+     * \param uri URI for destination data source
+     * \param providerKey string key for destination data provider
+     * \param exportOptions options controlling the feature export
+     * \param errorMessage will be set to any error messages which occur during the export
+     * \param providerOptions optional provider dataset options
+     * \param feedback optional feedback object to show progress and cancellation of export
+     * \returns Qgis::VectorExportResult::NoError for a successful export, or encountered error
+     *
+     * \since QGIS 3.44
+     */
+    static Qgis::VectorExportResult exportLayer( QgsVectorLayer *layer,
+        const QString &uri,
+        const QString &providerKey,
+        const QgsVectorLayerExporter::ExportOptions &exportOptions,
+        QString *errorMessage SIP_OUT = nullptr,
+        const QMap<QString, QVariant> &providerOptions = QMap<QString, QVariant>(),
+        QgsFeedback *feedback = nullptr );
+
+    /**
      * Constructor for QgsVectorLayerExporter.
      * \param uri URI for destination data source
      * \param provider string key for destination data provider
@@ -193,6 +281,22 @@ class CORE_EXPORT QgsVectorLayerExporterTask : public QgsTask
                                 bool ownsLayer = false );
 
     /**
+     * Constructor for QgsVectorLayerExporterTask. Takes a source \a layer, destination \a uri
+     * and \a providerKey, and various export related parameters via the \a exportOptions argument.
+     *
+     * \a ownsLayer has to be set to TRUE if the task should take ownership
+     * of the layer and delete it after export.
+     *
+     * \since QGIS 3.44
+    */
+    QgsVectorLayerExporterTask( QgsVectorLayer *layer,
+                                const QString &uri,
+                                const QString &providerKey,
+                                const QgsVectorLayerExporter::ExportOptions &exportOptions,
+                                const QMap<QString, QVariant> &providerOptions = QMap<QString, QVariant>(),
+                                bool ownsLayer = false );
+
+    /**
      * Creates a new QgsVectorLayerExporterTask which has ownership over a source \a layer.
      * When the export task has completed (successfully or otherwise) \a layer will be
      * deleted. The destination \a uri and \a providerKey, and various export related parameters such as destination CRS
@@ -231,7 +335,7 @@ class CORE_EXPORT QgsVectorLayerExporterTask : public QgsTask
 
     QString mDestUri;
     QString mDestProviderKey;
-    QgsCoordinateReferenceSystem mDestCrs;
+    QgsVectorLayerExporter::ExportOptions mExportOptions;
     QMap<QString, QVariant> mOptions;
 
     std::unique_ptr< QgsFeedback > mOwnedFeedback;

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -79,7 +79,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
      *
      * \since QGIS 3.44
      */
-    class ExportOptions
+    class CORE_EXPORT ExportOptions
     {
       public:
 
@@ -101,7 +101,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
          *
          * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
          *
-         * \seee setSelectedOnly()
+         * \see setSelectedOnly()
          */
         bool selectedOnly() const { return mSelectedOnly; }
 

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -90,7 +90,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
          *
          * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
          *
-         * \seee selectedOnly()
+         * \see selectedOnly()
          */
         void setSelectedOnly( bool selected ) { mSelectedOnly = selected; }
 

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -99,6 +99,16 @@ QgsMessageBar *QgsBrowserDockWidget::messageBar()
   return mWidget->messageBar();
 }
 
+void QgsBrowserDockWidget::setMapCanvas( QgsMapCanvas *canvas )
+{
+  mWidget->setMapCanvas( canvas );
+}
+
+QgsMapCanvas *QgsBrowserDockWidget::mapCanvas()
+{
+  return mWidget->mapCanvas();
+}
+
 void QgsBrowserDockWidget::setDisabledDataItemsKeys( const QStringList &filter )
 {
   mWidget->setDisabledDataItemsKeys( filter );

--- a/src/gui/qgsbrowserdockwidget.h
+++ b/src/gui/qgsbrowserdockwidget.h
@@ -22,6 +22,7 @@
 
 class QgsMessageBar;
 class QgsBrowserWidget;
+class QgsMapCanvas;
 
 /**
  * \ingroup gui
@@ -72,6 +73,24 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget
      * \since QGIS 3.6
      */
     QgsMessageBar *messageBar();
+
+    /**
+     * Sets a map \a canvas to use alongside the dock.
+     *
+     * Setting this allows items to utilize the canvas during GUI operations.
+     *
+     * \see mapCanvas()
+     * \since QGIS 3.44
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
+    /**
+     * Returns the map canvas associated with the dock.
+     *
+     * \see setMapCanvas()
+     * \since QGIS 3.44
+     */
+    QgsMapCanvas *mapCanvas();
 
     /**
      * Sets the customization for data items based on item's data provider key

--- a/src/gui/qgsbrowserguimodel.cpp
+++ b/src/gui/qgsbrowserguimodel.cpp
@@ -30,6 +30,7 @@ QgsDataItemGuiContext QgsBrowserGuiModel::createDataItemContext() const
 {
   QgsDataItemGuiContext context;
   context.setMessageBar( mMessageBar );
+  context.setMapCanvas( mMapCanvas );
   return context;
 }
 
@@ -178,4 +179,9 @@ bool QgsBrowserGuiModel::setData( const QModelIndex &index, const QVariant &valu
 void QgsBrowserGuiModel::setMessageBar( QgsMessageBar *bar )
 {
   mMessageBar = bar;
+}
+
+void QgsBrowserGuiModel::setMapCanvas( QgsMapCanvas *canvas )
+{
+  mMapCanvas = canvas;
 }

--- a/src/gui/qgsbrowserguimodel.h
+++ b/src/gui/qgsbrowserguimodel.h
@@ -20,6 +20,7 @@
 
 class QgsDataItemGuiContext;
 class QgsMessageBar;
+class QgsMapCanvas;
 
 /**
  * \ingroup gui
@@ -53,9 +54,16 @@ class GUI_EXPORT QgsBrowserGuiModel : public QgsBrowserModel
     //! Sets message bar that will be passed in QgsDataItemGuiContext to data items
     void setMessageBar( QgsMessageBar *bar );
 
+    /**
+     * Sets the associated map \a canvas that will be passed in QgsDataItemGuiContext to data items.
+     * \since QGIS 3.44
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
   private:
     QgsDataItemGuiContext createDataItemContext() const;
     QgsMessageBar *mMessageBar = nullptr;
+    QgsMapCanvas *mMapCanvas = nullptr;
 };
 
 #endif // QGSBROWSERGUIMODEL_H

--- a/src/gui/qgsbrowserwidget.cpp
+++ b/src/gui/qgsbrowserwidget.cpp
@@ -271,6 +271,17 @@ QgsMessageBar *QgsBrowserWidget::messageBar()
   return mMessageBar;
 }
 
+void QgsBrowserWidget::setMapCanvas( QgsMapCanvas *canvas )
+{
+  mMapCanvas = canvas;
+  mModel->setMapCanvas( canvas );
+}
+
+QgsMapCanvas *QgsBrowserWidget::mapCanvas()
+{
+  return mMapCanvas;
+}
+
 void QgsBrowserWidget::setDisabledDataItemsKeys( const QStringList &filter )
 {
   mDisabledDataItemsKeys = filter;
@@ -460,6 +471,7 @@ QgsDataItemGuiContext QgsBrowserWidget::createContext()
 {
   QgsDataItemGuiContext context;
   context.setMessageBar( mMessageBar );
+  context.setMapCanvas( mMapCanvas );
   context.setView( mBrowserView );
   return context;
 }

--- a/src/gui/qgsbrowserwidget.h
+++ b/src/gui/qgsbrowserwidget.h
@@ -26,6 +26,7 @@ class QgsLayerItem;
 class QgsDataItem;
 class QgsBrowserProxyModel;
 class QgsMessageBar;
+class QgsMapCanvas;
 class QgsDataItemGuiContext;
 
 class QModelIndex;
@@ -63,6 +64,24 @@ class GUI_EXPORT QgsBrowserWidget : public QgsPanelWidget, private Ui::QgsBrowse
      * \see setMessageBar()
      */
     QgsMessageBar *messageBar();
+
+    /**
+     * Sets a map \a canvas to use alongside the widget.
+     *
+     * Setting this allows items to utilize the canvas during GUI operations.
+     *
+     * \see mapCanvas()
+     * \since QGIS 3.44
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
+    /**
+     * Returns the map canvas associated with the widget.
+     *
+     * \see setMapCanvas()
+     * \since QGIS 3.44
+     */
+    QgsMapCanvas *mapCanvas();
 
     /**
      * Sets the customization for data items based on item's data provider key
@@ -167,6 +186,7 @@ class GUI_EXPORT QgsBrowserWidget : public QgsPanelWidget, private Ui::QgsBrowse
     QString mInitPath;
 
     QgsMessageBar *mMessageBar = nullptr;
+    QgsMapCanvas *mMapCanvas = nullptr;
     QStringList mDisabledDataItemsKeys;
 
     friend class QgsBrowserDockWidget;

--- a/src/gui/qgsdataitemguiprovider.cpp
+++ b/src/gui/qgsdataitemguiprovider.cpp
@@ -34,6 +34,16 @@ void QgsDataItemGuiContext::setMessageBar( QgsMessageBar *messageBar )
   mMessageBar = messageBar;
 }
 
+void QgsDataItemGuiContext::setMapCanvas( QgsMapCanvas *canvas )
+{
+  mCanvas = canvas;
+}
+
+QgsMapCanvas *QgsDataItemGuiContext::mapCanvas() const
+{
+  return mCanvas;
+}
+
 QgsBrowserTreeView *QgsDataItemGuiContext::view() const
 {
   return mView;

--- a/src/gui/qgsdataitemguiprovider.h
+++ b/src/gui/qgsdataitemguiprovider.h
@@ -29,6 +29,7 @@ class QgsDataItem;
 class QgsMessageBar;
 class QgsLayerItem;
 class QgsBrowserTreeView;
+class QgsMapCanvas;
 
 /**
  * \class QgsDataItemGuiContext
@@ -62,6 +63,24 @@ class GUI_EXPORT QgsDataItemGuiContext
     void setMessageBar( QgsMessageBar *bar );
 
     /**
+     * Sets the map canvas associated with the data item.
+     *
+     * This allows the item to retrieve the current map scale and other properties from the canvas.
+     *
+     * \see mapCanvas()
+     * \since QGIS 3.44
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
+    /**
+     * Returns the map canvas associated with the item.
+     *
+     * \see setMapCanvas()
+     * \since QGIS 3.44
+     */
+    QgsMapCanvas *mapCanvas() const;
+
+    /**
      * Returns the associated view.
      *
      * \see setView()
@@ -81,6 +100,8 @@ class GUI_EXPORT QgsDataItemGuiContext
     QgsMessageBar *mMessageBar = nullptr;
 
     QgsBrowserTreeView *mView = nullptr;
+
+    QgsMapCanvas *mCanvas = nullptr;
 };
 
 Q_DECLARE_METATYPE( QgsDataItemGuiContext );

--- a/src/gui/qgsdataitemguiproviderutils.cpp
+++ b/src/gui/qgsdataitemguiproviderutils.cpp
@@ -75,6 +75,7 @@ bool QgsDataItemGuiProviderUtils::handleDropUriForConnection( std::unique_ptr<Qg
   const QString connectionProvider = connection->providerKey();
 
   QgsDbImportVectorLayerDialog dialog( connection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
+  dialog.setMapCanvas( context.mapCanvas() );
   dialog.setSourceUri( sourceUri );
   dialog.setDestinationSchema( destinationSchema );
   if ( !dialog.exec() )
@@ -155,6 +156,7 @@ void QgsDataItemGuiProviderUtils::handleImportVectorLayerForConnection( std::uni
   const QString connectionProvider = connection->providerKey();
 
   QgsDbImportVectorLayerDialog dialog( connection.release(), context.messageBar() ? context.messageBar()->parentWidget() : nullptr );
+  dialog.setMapCanvas( context.mapCanvas() );
   dialog.setDestinationSchema( destinationSchema );
   if ( !dialog.exec() )
     return;

--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -226,19 +226,20 @@ std::unique_ptr<QgsVectorLayerExporterTask> QgsDbImportVectorLayerDialog::create
     allProviderOptions.insert( it.key(), it.value() );
   }
 
-  QgsCoordinateReferenceSystem destinationCrs;
-  if ( mCrsSelector )
-  {
-    destinationCrs = mCrsSelector->crs();
-  }
-
   // overwrite?
   if ( mChkDropTable->isChecked() )
   {
     allProviderOptions.insert( QStringLiteral( "overwrite" ), true );
   }
 
-  return std::make_unique<QgsVectorLayerExporterTask>( mSourceLayer->clone(), destinationUri, mConnection->providerKey(), destinationCrs, allProviderOptions, true );
+  QgsVectorLayerExporter::ExportOptions exportOptions;
+  if ( mCrsSelector )
+  {
+    exportOptions.setDestinationCrs( mCrsSelector->crs() );
+  }
+  exportOptions.setTransformContext( mSourceLayer->transformContext() );
+
+  return std::make_unique<QgsVectorLayerExporterTask>( mSourceLayer->clone(), destinationUri, mConnection->providerKey(), exportOptions, allProviderOptions, true );
 }
 
 void QgsDbImportVectorLayerDialog::sourceLayerComboChanged()

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -19,6 +19,7 @@
 #include "qgis_gui.h"
 #include "qgis.h"
 #include "qgsmimedatautils.h"
+#include "qgsexpressioncontextgenerator.h"
 #include "ui_qgsdbimportvectorlayerdialog.h"
 
 class QgsAbstractDatabaseProviderConnection;
@@ -36,7 +37,7 @@ class QgsVectorLayerExporterTask;
  *
  * \since QGIS 3.44
  */
-class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsDbImportVectorLayerDialog
+class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsDbImportVectorLayerDialog, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 
@@ -75,9 +76,16 @@ class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsD
     QString tableComment() const;
 
     /**
+     * Sets a map \a canvas to associate with the dialog.
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
+    /**
      * Creates a new exporter task to match the settings defined in the dialog.
      */
     std::unique_ptr<QgsVectorLayerExporterTask> createExporterTask( const QVariantMap &extraProviderOptions = QVariantMap() );
+
+    QgsExpressionContext createExpressionContext() const override;
 
   private slots:
     void sourceLayerComboChanged();

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>478</width>
-    <height>491</height>
+    <height>729</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Import Vector Layer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,1,0">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -138,6 +138,39 @@
     </widget>
    </item>
    <item>
+    <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+     <property name="title">
+      <string>Filter by Extent</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Filtering</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Feature filter</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsExpressionLineEdit" name="mFilterExpressionWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -166,6 +199,8 @@
   <zorder>mGroupBoxOutput</zorder>
   <zorder>groupBox</zorder>
   <zorder>verticalSpacer</zorder>
+  <zorder>groupBox_2</zorder>
+  <zorder>mExtentGroupBox</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -178,6 +213,24 @@
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
    <header location="global">qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExpressionLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgsexpressionlineedit.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
When a table is imported to a database via the browser, the user now has an option to filter the copied records by extent or expression:

![image](https://github.com/user-attachments/assets/7bc28d2e-c434-4a81-80ac-9bfbc627e964)


Sponsored by City of Canning