### PR TITLE
RelationReference save edits on embedded form

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -245,7 +245,6 @@ Set the limit of fetched features (0 means all features)
 .. versionadded:: 3.32
 %End
 
-
   public slots:
     void openForm();
 %Docstring
@@ -260,6 +259,13 @@ activate the map tool to select a new related feature on the map
     void deleteForeignKeys();
 %Docstring
 unset the currently related feature
+%End
+
+    bool saveReferencedAttributeForm();
+%Docstring
+Trigger save of the embedded referenced attribute form.
+
+.. versionadded:: 3.42
 %End
 
   protected:

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -264,6 +264,7 @@ unset the currently related feature
     bool saveReferencedAttributeForm();
 %Docstring
 Trigger save of the embedded referenced attribute form.
+Returns ``True`` on success or if no embedded form is present.
 
 .. versionadded:: 3.42
 %End

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -245,7 +245,6 @@ Set the limit of fetched features (0 means all features)
 .. versionadded:: 3.32
 %End
 
-
   public slots:
     void openForm();
 %Docstring
@@ -260,6 +259,13 @@ activate the map tool to select a new related feature on the map
     void deleteForeignKeys();
 %Docstring
 unset the currently related feature
+%End
+
+    bool saveReferencedAttributeForm();
+%Docstring
+Trigger save of the embedded referenced attribute form.
+
+.. versionadded:: 3.42
 %End
 
   protected:

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -264,6 +264,7 @@ unset the currently related feature
     bool saveReferencedAttributeForm();
 %Docstring
 Trigger save of the embedded referenced attribute form.
+Returns ``True`` on success or if no embedded form is present.
 
 .. versionadded:: 3.42
 %End

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -293,6 +293,15 @@ void QgsRelationReferenceWidget::deleteForeignKeys()
   emitForeignKeysChanged( foreignKeys() );
 }
 
+bool QgsRelationReferenceWidget::saveReferencedAttributeForm()
+{
+  if ( !mEmbedForm )
+    // if there is no embedded form, everything is fine anyway
+    return true;
+
+  return mReferencedAttributeForm->save();
+}
+
 QgsFeature QgsRelationReferenceWidget::referencedFeature() const
 {
   QgsFeature f;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -270,6 +270,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
 
     /**
       * Trigger save of the embedded referenced attribute form.
+      * Returns TRUE on success or if no embedded form is present.
       *
       * \since QGIS 3.42
       */

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -258,7 +258,6 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
      */
     void setFetchLimit( int fetchLimit ) { mFetchLimit = fetchLimit; }
 
-
   public slots:
     //! open the form of the related feature in a new dialog
     void openForm();
@@ -268,6 +267,13 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
 
     //! unset the currently related feature
     void deleteForeignKeys();
+
+    /**
+      * Trigger save of the embedded referenced attribute form.
+      *
+      * \since QGIS 3.42
+      */
+    bool saveReferencedAttributeForm();
 
   protected:
     void showEvent( QShowEvent *e ) override;

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -119,6 +119,12 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   connect( mWidget, &QgsRelationReferenceWidget::foreignKeysChanged, this, &QgsRelationReferenceWidgetWrapper::foreignKeysChanged );
 }
 
+void QgsRelationReferenceWidgetWrapper::aboutToSave()
+{
+  // Save changes in the embedded form
+  mWidget->saveReferencedAttributeForm();
+}
+
 QVariant QgsRelationReferenceWidgetWrapper::value() const
 {
   if ( !mWidget )

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -63,6 +63,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
     void updateConstraintWidgetStatus() override;
 
   private:
+    void aboutToSave() override;
     void updateValues( const QVariant &val, const QVariantList &additionalValues = QVariantList() ) override;
 
     QString mExpression;


### PR DESCRIPTION
You have been able to change values in the embedded form of the relation reference widget, but they were not stored. Only when changing something in the main form the save has been triggered (via vector layer modified).

Now it triggers the save of the embedded form whenever the "OK" button of t he main form is pressed or the index in the attribute table form view is changed.

This fixes #60806
