### PR TITLE
Allow field customisation when importing db tables 

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsvectorlayerexporter.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorlayerexporter.py
@@ -1,5 +1,13 @@
 # The following has been generated automatically from src/core/vector/qgsvectorlayerexporter.h
 try:
+    QgsVectorLayerExporter.OutputField.__attribute_docs__ = {'field': 'Destination field definition', 'expression': 'The expression for the exported field from the source fields'}
+    QgsVectorLayerExporter.OutputField.__doc__ = """Encapsulates output field definition.
+
+.. versionadded:: 3.44"""
+    QgsVectorLayerExporter.OutputField.__group__ = ['vector']
+except (NameError, AttributeError):
+    pass
+try:
     QgsVectorLayerExporterTask.__attribute_docs__ = {'exportComplete': 'Emitted when exporting the layer is successfully completed.\n', 'errorOccurred': 'Emitted when an error occurs which prevented the layer being exported (or if\nthe task is canceled). The export ``error`` and ``errorMessage`` will be reported.\n'}
     QgsVectorLayerExporterTask.withLayerOwnership = staticmethod(QgsVectorLayerExporterTask.withLayerOwnership)
     QgsVectorLayerExporterTask.__signal_arguments__ = {'errorOccurred': ['error: Qgis.VectorExportResult', 'errorMessage: str']}

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -53,6 +53,19 @@ Writes the contents of vector layer to a different datasource.
          - errorMessage: if non-null, any error messages
 %End
 
+
+    struct OutputField
+    {
+
+      OutputField( const QgsField &field, const QString &expression );
+%Docstring
+Constructor for OutputField, with the specified ``field`` definition and source ``expression``.
+%End
+
+      QgsField field;
+      QString expression;
+    };
+
     class ExportOptions
 {
 %Docstring(signature="appended")
@@ -200,6 +213,32 @@ Sets the expression ``context`` to use when a :py:func:`~ExportOptions.filterExp
 Returns the expression context used when a :py:func:`~ExportOptions.filterExpression` is set.
 
 .. seealso:: :py:func:`setExpressionContext`
+%End
+
+        QList<QgsVectorLayerExporter::OutputField> outputFields() const;
+%Docstring
+Returns the output field definitions for the destination table.
+
+If empty, all input fields will be copied directly.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`setOutputFields`
+%End
+
+        void setOutputFields( const QList<QgsVectorLayerExporter::OutputField> &fields );
+%Docstring
+Sets the output field definitions for the destination table.
+
+If empty, all input fields will be copied directly.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`outputFields`
 %End
 
     };

--- a/python/PyQt6/gui/auto_generated/qgsfieldmappingmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfieldmappingmodel.sip.in
@@ -54,6 +54,17 @@ field name to the corresponding expression. A ``parent`` object
 can be also specified.
 %End
 
+    void setNativeTypes( const QList< QgsVectorDataProvider::NativeType > &nativeTypes );
+%Docstring
+Sets the list of ``nativeTypes`` supported by a data provider.
+
+If this list is non-empty, then the destination field types will be populated
+accordingly. If the list is empty, then a set of default native types will be
+used instead.
+
+.. versionadded:: 3.44
+%End
+
     bool destinationEditable() const;
 %Docstring
 Returns ``True`` if the destination fields are editable

--- a/python/PyQt6/gui/auto_generated/qgsfieldmappingwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfieldmappingwidget.sip.in
@@ -23,13 +23,24 @@ for each set of "destination" fields an expression defines how to obtain the val
 #include "qgsfieldmappingwidget.h"
 %End
   public:
-    explicit QgsFieldMappingWidget( QWidget *parent = 0, const QgsFields &sourceFields = QgsFields(), const QgsFields &destinationFields = QgsFields(), const QMap<QString, QString> &expressions = QMap<QString, QString>() );
+    explicit QgsFieldMappingWidget(
+      QWidget *parent = 0,
+      const QgsFields &sourceFields = QgsFields(),
+      const QgsFields &destinationFields = QgsFields(),
+      const QMap<QString, QString> &expressions = QMap<QString, QString>(),
+      const QList< QgsVectorDataProvider::NativeType > &nativeTypes = QList< QgsVectorDataProvider::NativeType >()
+    );
 %Docstring
 Constructs a QgsFieldMappingWidget from a set of ``sourceFields``
 and ``destinationFields``, initial values for the expressions can be
 optionally specified through ``expressions`` which is a map from the original
 field name to the corresponding expression. A ``parent`` object
 can also be specified.
+
+Since QGIS 3.44, the ``nativeTypes`` argument can be used to specify the list of
+field types natively supported by a data provider. If this list is non-empty, then
+the destination field types will be populated accordingly. If the list is empty,
+then a set of default native types will be used instead.
 %End
 
     void setDestinationEditable( bool editable );
@@ -99,6 +110,17 @@ Set destination fields to ``destinationFields`` in the underlying model,
 initial values for the expressions can be optionally specified through
 ``expressions`` which is a map from the original field name to the
 corresponding expression.
+%End
+
+    void setNativeTypes( const QList< QgsVectorDataProvider::NativeType > &nativeTypes );
+%Docstring
+Sets the list of ``nativeTypes`` supported by a data provider.
+
+If this list is non-empty, then the destination field types will be populated
+accordingly. If the list is empty, then a set of default native types will be
+used instead.
+
+.. versionadded:: 3.44
 %End
 
     void scrollTo( const QModelIndex &index ) const;

--- a/python/core/auto_additions/qgsvectorlayerexporter.py
+++ b/python/core/auto_additions/qgsvectorlayerexporter.py
@@ -1,5 +1,13 @@
 # The following has been generated automatically from src/core/vector/qgsvectorlayerexporter.h
 try:
+    QgsVectorLayerExporter.OutputField.__attribute_docs__ = {'field': 'Destination field definition', 'expression': 'The expression for the exported field from the source fields'}
+    QgsVectorLayerExporter.OutputField.__doc__ = """Encapsulates output field definition.
+
+.. versionadded:: 3.44"""
+    QgsVectorLayerExporter.OutputField.__group__ = ['vector']
+except (NameError, AttributeError):
+    pass
+try:
     QgsVectorLayerExporterTask.__attribute_docs__ = {'exportComplete': 'Emitted when exporting the layer is successfully completed.\n', 'errorOccurred': 'Emitted when an error occurs which prevented the layer being exported (or if\nthe task is canceled). The export ``error`` and ``errorMessage`` will be reported.\n'}
     QgsVectorLayerExporterTask.withLayerOwnership = staticmethod(QgsVectorLayerExporterTask.withLayerOwnership)
     QgsVectorLayerExporterTask.__signal_arguments__ = {'errorOccurred': ['error: Qgis.VectorExportResult', 'errorMessage: str']}

--- a/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -53,6 +53,19 @@ Writes the contents of vector layer to a different datasource.
          - errorMessage: if non-null, any error messages
 %End
 
+
+    struct OutputField
+    {
+
+      OutputField( const QgsField &field, const QString &expression );
+%Docstring
+Constructor for OutputField, with the specified ``field`` definition and source ``expression``.
+%End
+
+      QgsField field;
+      QString expression;
+    };
+
     class ExportOptions
 {
 %Docstring(signature="appended")
@@ -200,6 +213,32 @@ Sets the expression ``context`` to use when a :py:func:`~ExportOptions.filterExp
 Returns the expression context used when a :py:func:`~ExportOptions.filterExpression` is set.
 
 .. seealso:: :py:func:`setExpressionContext`
+%End
+
+        QList<QgsVectorLayerExporter::OutputField> outputFields() const;
+%Docstring
+Returns the output field definitions for the destination table.
+
+If empty, all input fields will be copied directly.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`setOutputFields`
+%End
+
+        void setOutputFields( const QList<QgsVectorLayerExporter::OutputField> &fields );
+%Docstring
+Sets the output field definitions for the destination table.
+
+If empty, all input fields will be copied directly.
+
+.. note::
+
+   This option only applies when the :py:func:`QgsVectorLayerExporter.exportLayer()` method is used.
+
+.. seealso:: :py:func:`outputFields`
 %End
 
     };

--- a/python/gui/auto_generated/qgsfieldmappingmodel.sip.in
+++ b/python/gui/auto_generated/qgsfieldmappingmodel.sip.in
@@ -54,6 +54,17 @@ field name to the corresponding expression. A ``parent`` object
 can be also specified.
 %End
 
+    void setNativeTypes( const QList< QgsVectorDataProvider::NativeType > &nativeTypes );
+%Docstring
+Sets the list of ``nativeTypes`` supported by a data provider.
+
+If this list is non-empty, then the destination field types will be populated
+accordingly. If the list is empty, then a set of default native types will be
+used instead.
+
+.. versionadded:: 3.44
+%End
+
     bool destinationEditable() const;
 %Docstring
 Returns ``True`` if the destination fields are editable

--- a/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
@@ -23,13 +23,24 @@ for each set of "destination" fields an expression defines how to obtain the val
 #include "qgsfieldmappingwidget.h"
 %End
   public:
-    explicit QgsFieldMappingWidget( QWidget *parent = 0, const QgsFields &sourceFields = QgsFields(), const QgsFields &destinationFields = QgsFields(), const QMap<QString, QString> &expressions = QMap<QString, QString>() );
+    explicit QgsFieldMappingWidget(
+      QWidget *parent = 0,
+      const QgsFields &sourceFields = QgsFields(),
+      const QgsFields &destinationFields = QgsFields(),
+      const QMap<QString, QString> &expressions = QMap<QString, QString>(),
+      const QList< QgsVectorDataProvider::NativeType > &nativeTypes = QList< QgsVectorDataProvider::NativeType >()
+    );
 %Docstring
 Constructs a QgsFieldMappingWidget from a set of ``sourceFields``
 and ``destinationFields``, initial values for the expressions can be
 optionally specified through ``expressions`` which is a map from the original
 field name to the corresponding expression. A ``parent`` object
 can also be specified.
+
+Since QGIS 3.44, the ``nativeTypes`` argument can be used to specify the list of
+field types natively supported by a data provider. If this list is non-empty, then
+the destination field types will be populated accordingly. If the list is empty,
+then a set of default native types will be used instead.
 %End
 
     void setDestinationEditable( bool editable );
@@ -99,6 +110,17 @@ Set destination fields to ``destinationFields`` in the underlying model,
 initial values for the expressions can be optionally specified through
 ``expressions`` which is a map from the original field name to the
 corresponding expression.
+%End
+
+    void setNativeTypes( const QList< QgsVectorDataProvider::NativeType > &nativeTypes );
+%Docstring
+Sets the list of ``nativeTypes`` supported by a data provider.
+
+If this list is non-empty, then the destination field types will be populated
+accordingly. If the list is empty, then a set of default native types will be
+used instead.
+
+.. versionadded:: 3.44
 %End
 
     void scrollTo( const QModelIndex &index ) const;

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -73,6 +73,30 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
         const QMap<QString, QVariant> &options = QMap<QString, QVariant>(),
         QgsFeedback *feedback = nullptr );
 
+
+    /**
+     * \ingroup core
+     * \brief Encapsulates output field definition.
+     *
+     * \since QGIS 3.44
+     */
+    struct CORE_EXPORT OutputField
+    {
+
+      /**
+       * Constructor for OutputField, with the specified \a field definition and source \a expression.
+       */
+      OutputField( const QgsField &field, const QString &expression )
+        : field( field )
+        , expression( expression )
+      {}
+
+      //! Destination field definition
+      QgsField field;
+      //! The expression for the exported field from the source fields
+      QString expression;
+    };
+
     /**
      * \ingroup core
      * \brief Encapsulates options for use with QgsVectorLayerExporter.
@@ -197,6 +221,28 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
          */
         const QgsExpressionContext &expressionContext() const;
 
+        /**
+         * Returns the output field definitions for the destination table.
+         *
+         * If empty, all input fields will be copied directly.
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \see setOutputFields()
+         */
+        QList<QgsVectorLayerExporter::OutputField> outputFields() const;
+
+        /**
+         * Sets the output field definitions for the destination table.
+         *
+         * If empty, all input fields will be copied directly.
+         *
+         * \note This option only applies when the QgsVectorLayerExporter::exportLayer() method is used.
+         *
+         * \see outputFields()
+         */
+        void setOutputFields( const QList<QgsVectorLayerExporter::OutputField> &fields );
+
       private:
 
         bool mSelectedOnly = false;
@@ -209,6 +255,8 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
 
         QString mFilterExpression;
         QgsExpressionContext mExpressionContext;
+
+        QList< QgsVectorLayerExporter::OutputField > mOutputFields;
 
     };
 

--- a/src/gui/processing/qgsprocessingaggregatewidgets.cpp
+++ b/src/gui/processing/qgsprocessingaggregatewidgets.cpp
@@ -200,7 +200,7 @@ bool QgsAggregateMappingModel::setData( const QModelIndex &index, const QVariant
         }
         case ColumnDataIndex::DestinationType:
         {
-          QgsFieldMappingModel::setFieldTypeFromName( f.field, value.toString() );
+          setFieldTypeFromName( f.field, value.toString() );
           break;
         }
         case ColumnDataIndex::DestinationLength:
@@ -249,6 +249,34 @@ bool QgsAggregateMappingModel::moveUpOrDown( const QModelIndex &index, bool up )
   return true;
 }
 
+QString QgsAggregateMappingModel::qgsFieldToTypeName( const QgsField &field )
+{
+  const QList<QgsVectorDataProvider::NativeType> types = QgsFieldMappingModel::supportedDataTypes();
+  for ( const QgsVectorDataProvider::NativeType &type : types )
+  {
+    if ( type.mType == field.type() && type.mSubType == field.subType() )
+    {
+      return type.mTypeName;
+    }
+  }
+  return QString();
+}
+
+void QgsAggregateMappingModel::setFieldTypeFromName( QgsField &field, const QString &name )
+{
+  const QList<QgsVectorDataProvider::NativeType> types = QgsFieldMappingModel::supportedDataTypes();
+  for ( const QgsVectorDataProvider::NativeType &type : types )
+  {
+    if ( type.mTypeName == name )
+    {
+      field.setType( type.mType );
+      field.setTypeName( type.mTypeName );
+      field.setSubType( type.mSubType );
+      return;
+    }
+  }
+}
+
 void QgsAggregateMappingModel::setSourceFields( const QgsFields &sourceFields )
 {
   mSourceFields = sourceFields;
@@ -262,7 +290,7 @@ void QgsAggregateMappingModel::setSourceFields( const QgsFields &sourceFields )
   {
     Aggregate aggregate;
     aggregate.field = f;
-    aggregate.field.setTypeName( QgsFieldMappingModel::qgsFieldToTypeName( f ) );
+    aggregate.field.setTypeName( qgsFieldToTypeName( f ) );
     aggregate.source = QgsExpression::quotedColumnRef( f.name() );
 
     if ( f.isNumeric() )
@@ -298,7 +326,7 @@ void QgsAggregateMappingModel::setMapping( const QList<QgsAggregateMappingModel:
   mMapping = mapping;
   for ( auto &agg : mMapping )
   {
-    agg.field.setTypeName( QgsFieldMappingModel::qgsFieldToTypeName( agg.field ) );
+    agg.field.setTypeName( qgsFieldToTypeName( agg.field ) );
   }
   endResetModel();
 }
@@ -309,7 +337,7 @@ void QgsAggregateMappingModel::appendField( const QgsField &field, const QString
   beginInsertRows( QModelIndex(), lastRow, lastRow );
   Aggregate agg;
   agg.field = field;
-  agg.field.setTypeName( QgsFieldMappingModel::qgsFieldToTypeName( field ) );
+  agg.field.setTypeName( qgsFieldToTypeName( field ) );
   agg.source = source;
   agg.aggregate = aggregate;
   agg.delimiter = ',';

--- a/src/gui/processing/qgsprocessingaggregatewidgets.cpp
+++ b/src/gui/processing/qgsprocessingaggregatewidgets.cpp
@@ -388,7 +388,7 @@ QgsAggregateMappingWidget::QgsAggregateMappingWidget( QWidget *parent, const Qgs
   mTableView->setModel( mModel );
   mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::SourceExpression ), new QgsFieldMappingExpressionDelegate( this ) );
   mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::Aggregate ), new QgsAggregateMappingDelegate( mTableView ) );
-  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::DestinationType ), new QgsFieldMappingTypeDelegate( mTableView ) );
+  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::DestinationType ), new QgsFieldMappingTypeDelegate( {}, mTableView ) );
   updateColumns();
   // Make sure columns are updated when rows are added
   connect( mModel, &QgsAggregateMappingModel::rowsInserted, this, [=] { updateColumns(); } );

--- a/src/gui/processing/qgsprocessingaggregatewidgets.h
+++ b/src/gui/processing/qgsprocessingaggregatewidgets.h
@@ -128,6 +128,8 @@ class GUI_EXPORT QgsAggregateMappingModel : public QAbstractTableModel
 
   private:
     bool moveUpOrDown( const QModelIndex &index, bool up = true );
+    static QString qgsFieldToTypeName( const QgsField &field );
+    static void setFieldTypeFromName( QgsField &field, const QString &name );
 
     QList<Aggregate> mMapping;
     QgsFields mSourceFields;

--- a/src/gui/qgsdbimportvectorlayerdialog.h
+++ b/src/gui/qgsdbimportvectorlayerdialog.h
@@ -91,6 +91,8 @@ class GUI_EXPORT QgsDbImportVectorLayerDialog : public QDialog, private Ui::QgsD
     void sourceLayerComboChanged();
     void doImport();
     void setSourceLayer( QgsVectorLayer *layer );
+    void loadFieldsFromLayer();
+    void addField();
 
   private:
     std::unique_ptr< QgsVectorLayer > mOwnedSource;

--- a/src/gui/qgsfieldmappingmodel.cpp
+++ b/src/gui/qgsfieldmappingmodel.cpp
@@ -452,6 +452,71 @@ QString QgsFieldMappingModel::qgsFieldToTypeName( const QgsField &field ) const
       return type.mTypeName;
     }
   }
+
+  // no exact type name matches, try to match metatype as a fallback
+  for ( const QgsVectorDataProvider::NativeType &type : mNativeTypes )
+  {
+    if ( type.mType == field.type() && type.mSubType == field.subType() )
+    {
+      return type.mTypeName;
+    }
+  }
+
+  // next chance -- try promoting numeric types
+
+  // promote int -> long long
+  if ( field.type() == QMetaType::Type::Int )
+  {
+    for ( const QgsVectorDataProvider::NativeType &type : mNativeTypes )
+    {
+      if ( type.mType == QMetaType::Type::LongLong )
+      {
+        return type.mTypeName;
+      }
+    }
+  }
+  // promote uint -> unsigned long long or long long
+  if ( field.type() == QMetaType::Type::UInt )
+  {
+    for ( const QgsVectorDataProvider::NativeType &type : mNativeTypes )
+    {
+      if ( type.mType == QMetaType::Type::ULongLong || type.mType == QMetaType::Type::LongLong )
+      {
+        return type.mTypeName;
+      }
+    }
+  }
+  // promote float or int -> double
+  if ( field.type() == QMetaType::Type::Float || field.type() == QMetaType::Type::Int )
+  {
+    for ( const QgsVectorDataProvider::NativeType &type : mNativeTypes )
+    {
+      if ( type.mType == QMetaType::Type::Double )
+      {
+        return type.mTypeName;
+      }
+    }
+  }
+  // last resort -- promote certain types to string
+  if ( field.type() == QMetaType::Type::Float
+       || field.type() == QMetaType::Type::Double
+       || field.type() == QMetaType::Type::Int
+       || field.type() == QMetaType::Type::UInt
+       || field.type() == QMetaType::Type::LongLong
+       || field.type() == QMetaType::Type::ULongLong
+       || field.type() == QMetaType::Type::QDate
+       || field.type() == QMetaType::Type::QTime
+       || field.type() == QMetaType::Type::QDateTime )
+  {
+    for ( const QgsVectorDataProvider::NativeType &type : mNativeTypes )
+    {
+      if ( type.mType == QMetaType::Type::QString )
+      {
+        return type.mTypeName;
+      }
+    }
+  }
+
   return QString();
 }
 

--- a/src/gui/qgsfieldmappingmodel.h
+++ b/src/gui/qgsfieldmappingmodel.h
@@ -81,6 +81,17 @@ class GUI_EXPORT QgsFieldMappingModel : public QAbstractTableModel
      */
     QgsFieldMappingModel( const QgsFields &sourceFields = QgsFields(), const QgsFields &destinationFields = QgsFields(), const QMap<QString, QString> &expressions = QMap<QString, QString>(), QObject *parent = nullptr );
 
+    /**
+     * Sets the list of \a nativeTypes supported by a data provider.
+     *
+     * If this list is non-empty, then the destination field types will be populated
+     * accordingly. If the list is empty, then a set of default native types will be
+     * used instead.
+     *
+     * \since QGIS 3.44
+     */
+    void setNativeTypes( const QList< QgsVectorDataProvider::NativeType > &nativeTypes );
+
     //! Returns TRUE if the destination fields are editable
     bool destinationEditable() const;
 
@@ -184,13 +195,13 @@ class GUI_EXPORT QgsFieldMappingModel : public QAbstractTableModel
      * Returns the field type name matching the \a field settings.
      * \since QGIS 3.24
      */
-    static const QString qgsFieldToTypeName( const QgsField &field );
+    QString qgsFieldToTypeName( const QgsField &field ) const;
 
     /**
      * Sets the \a field type and subtype based on the type \a name provided.
      * \since QGIS 3.24
      */
-    static void setFieldTypeFromName( QgsField &field, const QString &name );
+    void setFieldTypeFromName( QgsField &field, const QString &name ) const;
 
     bool moveUpOrDown( const QModelIndex &index, bool up = true );
 
@@ -204,6 +215,8 @@ class GUI_EXPORT QgsFieldMappingModel : public QAbstractTableModel
      * Returns an expression containing a reference to the field that matches first.
      */
     QString findExpressionForDestinationField( const QgsFieldMappingModel::Field &field, QStringList &excludedFieldNames );
+
+    QList< QgsVectorDataProvider::NativeType > mNativeTypes;
 
     QList<Field> mMapping;
     bool mDestinationEditable = false;

--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -331,7 +331,6 @@ QWidget *QgsFieldMappingTypeDelegate::createEditor( QWidget *parent, const QStyl
   Q_UNUSED( option )
   QComboBox *editor = new QComboBox( parent );
 
-  const QList<QgsVectorDataProvider::NativeType> typeList = QgsFieldMappingModel::supportedDataTypes();
   int i = 0;
   for ( const QgsVectorDataProvider::NativeType &type : mNativeTypes )
   {

--- a/src/gui/qgsfieldmappingwidget.h
+++ b/src/gui/qgsfieldmappingwidget.h
@@ -28,6 +28,7 @@
 class QTableView;
 class QItemSelectionModel;
 class QgsVectorLayer;
+class QgsFieldMappingTypeDelegate;
 
 /**
  * \ingroup gui
@@ -47,8 +48,19 @@ class GUI_EXPORT QgsFieldMappingWidget : public QgsPanelWidget
      * optionally specified through \a expressions which is a map from the original
      * field name to the corresponding expression. A \a parent object
      * can also be specified.
+     *
+     * Since QGIS 3.44, the \a nativeTypes argument can be used to specify the list of
+     * field types natively supported by a data provider. If this list is non-empty, then
+     * the destination field types will be populated accordingly. If the list is empty,
+     * then a set of default native types will be used instead.
      */
-    explicit QgsFieldMappingWidget( QWidget *parent = nullptr, const QgsFields &sourceFields = QgsFields(), const QgsFields &destinationFields = QgsFields(), const QMap<QString, QString> &expressions = QMap<QString, QString>() );
+    explicit QgsFieldMappingWidget(
+      QWidget *parent = nullptr,
+      const QgsFields &sourceFields = QgsFields(),
+      const QgsFields &destinationFields = QgsFields(),
+      const QMap<QString, QString> &expressions = QMap<QString, QString>(),
+      const QList< QgsVectorDataProvider::NativeType > &nativeTypes = QList< QgsVectorDataProvider::NativeType >()
+    );
 
     //! Sets the destination fields editable state to \a editable
     void setDestinationEditable( bool editable );
@@ -108,6 +120,17 @@ class GUI_EXPORT QgsFieldMappingWidget : public QgsPanelWidget
     void setDestinationFields( const QgsFields &destinationFields, const QMap<QString, QString> &expressions = QMap<QString, QString>() );
 
     /**
+     * Sets the list of \a nativeTypes supported by a data provider.
+     *
+     * If this list is non-empty, then the destination field types will be populated
+     * accordingly. If the list is empty, then a set of default native types will be
+     * used instead.
+     *
+     * \since QGIS 3.44
+     */
+    void setNativeTypes( const QList< QgsVectorDataProvider::NativeType > &nativeTypes );
+
+    /**
      * Scroll the fields view to \a index
      */
     void scrollTo( const QModelIndex &index ) const;
@@ -148,7 +171,9 @@ class GUI_EXPORT QgsFieldMappingWidget : public QgsPanelWidget
 
   private:
     QTableView *mTableView = nullptr;
-    QAbstractTableModel *mModel = nullptr;
+    QgsFieldMappingModel *mModel = nullptr;
+
+    QgsFieldMappingTypeDelegate *mTypeDelegate = nullptr;
 
     QPointer<QgsVectorLayer> mSourceLayer;
     void updateColumns();
@@ -180,12 +205,26 @@ class QgsFieldMappingTypeDelegate : public QStyledItemDelegate
     Q_OBJECT
 
   public:
-    QgsFieldMappingTypeDelegate( QObject *parent = nullptr );
+    QgsFieldMappingTypeDelegate( const QList< QgsVectorDataProvider::NativeType > &nativeTypes, QObject *parent = nullptr );
 
     // QAbstractItemDelegate interface
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
     void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
     void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+
+    /**
+     * Sets the list of \a nativeTypes supported by a data provider.
+     *
+     * If this list is non-empty, then the destination field types will be populated
+     * accordingly. If the list is empty, then a set of default native types will be
+     * used instead.
+     *
+     * \since QGIS 3.44
+     */
+    void setNativeTypes( const QList< QgsVectorDataProvider::NativeType > &nativeTypes );
+
+  private:
+    QList< QgsVectorDataProvider::NativeType > mNativeTypes;
 };
 
 #endif

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>478</width>
-    <height>729</height>
+    <width>922</width>
+    <height>891</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Import Vector Layer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1,0,0,0,0">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -138,6 +138,112 @@
     </widget>
    </item>
    <item>
+    <widget class="QgsCollapsibleGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Attributes</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="1" rowspan="2" colspan="2">
+       <layout class="QVBoxLayout" name="buttonLayout">
+        <item>
+         <widget class="QToolButton" name="mAddButton">
+          <property name="toolTip">
+           <string>Add new field</string>
+          </property>
+          <property name="text">
+           <string>add</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionNewAttribute.svg</normaloff>:/images/themes/default/mActionNewAttribute.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mDeleteButton">
+          <property name="toolTip">
+           <string>Delete selected field</string>
+          </property>
+          <property name="text">
+           <string>delete</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionDeleteAttribute.svg</normaloff>:/images/themes/default/mActionDeleteAttribute.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mUpButton">
+          <property name="toolTip">
+           <string>Move selected field up</string>
+          </property>
+          <property name="text">
+           <string>up</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionArrowUp.svg</normaloff>:/images/themes/default/mActionArrowUp.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mDownButton">
+          <property name="toolTip">
+           <string>Move selected field down</string>
+          </property>
+          <property name="text">
+           <string>down</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionArrowDown.svg</normaloff>:/images/themes/default/mActionArrowDown.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mResetButton">
+          <property name="toolTip">
+           <string>Reset all fields</string>
+          </property>
+          <property name="text">
+           <string>reset</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mIconClearText.svg</normaloff>:/images/themes/default/mIconClearText.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QgsFieldMappingWidget" name="mFieldsView" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
      <property name="title">
       <string>Filter by Extent</string>
@@ -201,18 +307,26 @@
   <zorder>verticalSpacer</zorder>
   <zorder>groupBox_2</zorder>
   <zorder>mExtentGroupBox</zorder>
+  <zorder>groupBox_3</zorder>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldMappingWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldmappingwidget.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header location="global">qgsmaplayercombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
@@ -243,6 +357,8 @@
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mEditComment</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/tests/src/python/test_qgsfieldmappingwidget.py
+++ b/tests/src/python/test_qgsfieldmappingwidget.py
@@ -17,9 +17,17 @@ from qgis.PyQt.QtCore import (
     QModelIndex,
     QVariant,
     Qt,
+    QMetaType,
 )
 from qgis.PyQt.QtGui import QColor
-from qgis.core import QgsField, QgsFieldConstraints, QgsFields, QgsProperty, NULL
+from qgis.core import (
+    QgsField,
+    QgsFieldConstraints,
+    QgsFields,
+    QgsProperty,
+    NULL,
+    QgsVectorDataProvider,
+)
 from qgis.gui import QgsFieldMappingModel, QgsFieldMappingWidget
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -281,6 +289,281 @@ class TestPyQgsFieldMappingModel(QgisTestCase):
                 "destination_field2": QgsProperty.fromExpression("55*6"),
                 "destination_field3": QgsProperty.fromExpression("6"),
             },
+        )
+
+    def test_set_destination_fields(self):
+        """
+        Test setting destination fields
+        """
+        source_fields = QgsFields()
+        source_fields.append(
+            QgsField("a_string", QMetaType.Type.QString, "input_string_type")
+        )
+        source_fields.append(
+            QgsField("short_string", QMetaType.Type.QString, "input_short_string")
+        )
+        source_fields.append(QgsField("a_int", QMetaType.Type.Int, "input_int_type"))
+        source_fields.append(
+            QgsField("a_double", QMetaType.Type.Double, "input_double_type")
+        )
+        source_fields.append(
+            QgsField("a_date", QMetaType.Type.QDate, "input_date_type")
+        )
+        source_fields.append(
+            QgsField("a_datetime", QMetaType.Type.QDateTime, "input_datetime_type")
+        )
+        source_fields.append(
+            QgsField("a_time", QMetaType.Type.QTime, "input_time_type")
+        )
+
+        model = QgsFieldMappingModel(source_fields)
+
+        # with exact type name matches:
+        model.setNativeTypes(
+            [
+                QgsVectorDataProvider.NativeType(
+                    "input string", "input_string_type", QMetaType.Type.QString
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "input short string", "input_short_string", QMetaType.Type.QString
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "input int", "input_int_type", QMetaType.Type.Int
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "input double", "input_double_type", QMetaType.Type.Double
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "input date", "input_date_type", QMetaType.Type.QDate
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "input datetime", "input_datetime_type", QMetaType.Type.QDateTime
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "input time", "input_time_type", QMetaType.Type.QTime
+                ),
+            ]
+        )
+
+        dest_fields = QgsFields()
+        dest_fields.append(
+            QgsField("a_string", QMetaType.Type.QString, "input_string_type")
+        )
+        dest_fields.append(
+            QgsField("short_string", QMetaType.Type.QString, "input_short_string")
+        )
+        dest_fields.append(QgsField("a_int", QMetaType.Type.Int, "input_int_type"))
+        dest_fields.append(
+            QgsField("a_double", QMetaType.Type.Double, "input_double_type")
+        )
+        dest_fields.append(QgsField("a_date", QMetaType.Type.QDate, "input_date_type"))
+        dest_fields.append(
+            QgsField("a_datetime", QMetaType.Type.QDateTime, "input_datetime_type")
+        )
+        dest_fields.append(QgsField("a_time", QMetaType.Type.QTime, "input_time_type"))
+
+        model.setDestinationFields(dest_fields, {})
+
+        self.assertEqual(
+            [m.originalName for m in model.mapping()],
+            [
+                "a_string",
+                "short_string",
+                "a_int",
+                "a_double",
+                "a_date",
+                "a_datetime",
+                "a_time",
+            ],
+        )
+        self.assertEqual(
+            [m.field.name() for m in model.mapping()],
+            [
+                "a_string",
+                "short_string",
+                "a_int",
+                "a_double",
+                "a_date",
+                "a_datetime",
+                "a_time",
+            ],
+        )
+        self.assertEqual(
+            [m.field.type() for m in model.mapping()],
+            [
+                QMetaType.Type.QString,
+                QMetaType.Type.QString,
+                QMetaType.Type.Int,
+                QMetaType.Type.Double,
+                QMetaType.Type.QDate,
+                QMetaType.Type.QDateTime,
+                QMetaType.Type.QTime,
+            ],
+        )
+        self.assertEqual(
+            [m.field.typeName() for m in model.mapping()],
+            [
+                "input_string_type",
+                "input_string_type",
+                "input_int_type",
+                "input_double_type",
+                "input_date_type",
+                "input_datetime_type",
+                "input_time_type",
+            ],
+        )
+        self.assertEqual(
+            [m.expression for m in model.mapping()],
+            [
+                '"a_string"',
+                '"short_string"',
+                '"a_int"',
+                '"a_double"',
+                '"a_date"',
+                '"a_datetime"',
+                '"a_time"',
+            ],
+        )
+
+        # type names don't match, but metatypes do:
+        model.setNativeTypes(
+            [
+                QgsVectorDataProvider.NativeType(
+                    "output string", "output_string_type", QMetaType.Type.QString
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "output short string", "output_short_string", QMetaType.Type.QString
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "output int", "output_int_type", QMetaType.Type.Int
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "output double", "output_double_type", QMetaType.Type.Double
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "output date", "output_date_type", QMetaType.Type.QDate
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "output datetime", "output_datetime_type", QMetaType.Type.QDateTime
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "output time", "output_time_type", QMetaType.Type.QTime
+                ),
+            ]
+        )
+
+        model.setDestinationFields(dest_fields, {})
+
+        self.assertEqual(
+            [m.originalName for m in model.mapping()],
+            [
+                "a_string",
+                "short_string",
+                "a_int",
+                "a_double",
+                "a_date",
+                "a_datetime",
+                "a_time",
+            ],
+        )
+        self.assertEqual(
+            [m.field.name() for m in model.mapping()],
+            [
+                "a_string",
+                "short_string",
+                "a_int",
+                "a_double",
+                "a_date",
+                "a_datetime",
+                "a_time",
+            ],
+        )
+        self.assertEqual(
+            [m.field.typeName() for m in model.mapping()],
+            [
+                "output_string_type",
+                "output_string_type",
+                "output_int_type",
+                "output_double_type",
+                "output_date_type",
+                "output_datetime_type",
+                "output_time_type",
+            ],
+        )
+        self.assertEqual(
+            [m.expression for m in model.mapping()],
+            [
+                '"a_string"',
+                '"short_string"',
+                '"a_int"',
+                '"a_double"',
+                '"a_date"',
+                '"a_datetime"',
+                '"a_time"',
+            ],
+        )
+
+        # type promotion fallback:
+        model.setNativeTypes(
+            [
+                QgsVectorDataProvider.NativeType(
+                    "output string", "output_string_type", QMetaType.Type.QString
+                ),
+                QgsVectorDataProvider.NativeType(
+                    "output longlong", "output_longlong_type", QMetaType.Type.LongLong
+                ),
+            ]
+        )
+
+        model.setDestinationFields(dest_fields, {})
+
+        self.assertEqual(
+            [m.originalName for m in model.mapping()],
+            [
+                "a_string",
+                "short_string",
+                "a_int",
+                "a_double",
+                "a_date",
+                "a_datetime",
+                "a_time",
+            ],
+        )
+        self.assertEqual(
+            [m.field.name() for m in model.mapping()],
+            [
+                "a_string",
+                "short_string",
+                "a_int",
+                "a_double",
+                "a_date",
+                "a_datetime",
+                "a_time",
+            ],
+        )
+        self.assertEqual(
+            [m.field.typeName() for m in model.mapping()],
+            [
+                "output_string_type",
+                "output_string_type",
+                "output_longlong_type",
+                "output_string_type",
+                "output_string_type",
+                "output_string_type",
+                "output_string_type",
+            ],
+        )
+        self.assertEqual(
+            [m.expression for m in model.mapping()],
+            [
+                '"a_string"',
+                '"short_string"',
+                '"a_int"',
+                '"a_double"',
+                '"a_date"',
+                '"a_datetime"',
+                '"a_time"',
+            ],
         )
 
     def testWidget(self):

--- a/tests/src/python/test_qgsvectorlayerexporter.py
+++ b/tests/src/python/test_qgsvectorlayerexporter.py
@@ -82,7 +82,7 @@ class TestQgsVectorLayerExporter(QgisTestCase):
             )
             self.assertEqual(res, Qgis.VectorExportResult.Success)
 
-            # true to read result
+            # try to read result
             layer = QgsVectorLayer(
                 dest_file_name.as_posix() + "|layername=selected_only",
                 "test",
@@ -127,7 +127,7 @@ class TestQgsVectorLayerExporter(QgisTestCase):
             )
             self.assertEqual(res, Qgis.VectorExportResult.Success)
 
-            # true to read result
+            # try to read result
             layer = QgsVectorLayer(
                 dest_file_name.as_posix() + "|layername=selected_only",
                 "test",
@@ -186,7 +186,7 @@ class TestQgsVectorLayerExporter(QgisTestCase):
             )
             self.assertEqual(res, Qgis.VectorExportResult.Success)
 
-            # true to read result
+            # try to read result
             layer = QgsVectorLayer(
                 dest_file_name.as_posix() + "|layername=extent",
                 "test",
@@ -239,7 +239,7 @@ class TestQgsVectorLayerExporter(QgisTestCase):
             )
             self.assertEqual(res, Qgis.VectorExportResult.Success)
 
-            # true to read result
+            # try to read result
             layer = QgsVectorLayer(
                 dest_file_name.as_posix() + "|layername=expression",
                 "test",
@@ -306,7 +306,7 @@ class TestQgsVectorLayerExporter(QgisTestCase):
             )
             self.assertEqual(res, Qgis.VectorExportResult.Success)
 
-            # true to read result
+            # try to read result
             layer = QgsVectorLayer(
                 dest_file_name.as_posix() + "|layername=expression",
                 "test",
@@ -377,7 +377,7 @@ class TestQgsVectorLayerExporter(QgisTestCase):
             )
             self.assertEqual(res, Qgis.VectorExportResult.Success)
 
-            # true to read result
+            # try to read result
             layer = QgsVectorLayer(
                 dest_file_name.as_posix() + "|layername=Must_be_Laundered",
                 "test",


### PR DESCRIPTION
This expands the database table import dialog to add a new field mapping section, which gives users control over the
fields in the created table. Users can rename, set the exact destination field types, and tweak the source expression
for each output field. Fields can also be excluded from the import, or new fields created which don't exist in the source table.

![image](https://github.com/user-attachments/assets/cf59de59-e980-4d5d-9c75-389f901081d9)

Refs https://github.com/qgis/QGIS/issues/24192
Refs https://github.com/qgis/QGIS/issues/45286

Sponsored by City of Canning