### PR TITLE
ci: Build pdal from source in the qt5 version to avoid ubuntugis ppa

### DIFF
--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -166,6 +166,7 @@ FROM binary-for-oracle as binary-only
 
 RUN  apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    grass \
     iproute2 \
     postgresql-client \
     spawn-fcgi \
@@ -200,6 +201,7 @@ RUN  apt-get update \
     clang \
     cmake \
     flex \
+    grass-dev \
     libdraco-dev \
     libexiv2-dev \
     libexpat1-dev \

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -189,6 +189,15 @@ class GdalUtils:
         proc.setStdErrHandler(on_stderr)
 
         res = proc.run(feedback)
+
+        # Ensure to flush the buffers if they are not empty.
+        # For example, this can happen on stdout if the
+        # output did not end with a new line.
+        if on_stdout.buffer:
+            loglines.append(on_stdout.buffer.rstrip())
+        if on_stderr.buffer:
+            loglines.append(on_stderr.buffer.rstrip())
+
         if feedback.isCanceled() and res != 0:
             feedback.pushInfo(GdalUtils.tr("Process was canceled and did not complete"))
         elif (

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
@@ -271,10 +271,10 @@ tests:
         pk: id
 
   - algorithm: native:voronoipolygons
-    name: Voronoi with buffer region (GEOS < 3.12)
+    name: Voronoi with buffer region (GEOS < 3.12.2)
     condition:
       geos:
-        less_than: 31200
+        less_than: 31202
     params:
       BUFFER: 10.0
       INPUT:
@@ -290,10 +290,10 @@ tests:
             normalize: True
 
   - algorithm: native:voronoipolygons
-    name: Voronoi with buffer region (GEOS 3.12+)
+    name: Voronoi with buffer region (GEOS 3.12.2+)
     condition:
       geos:
-        at_least: 31200
+        at_least: 31202
     params:
       BUFFER: 10.0
       INPUT:


### PR DESCRIPTION
## Description

The docker image used to compile the linux qt5 version and to launch
the unit tests is based on ubuntu 24.04. However, this version does
not provide the PDAL package anymore. As a workaround, the `ubuntugis`
ppa has been added to get PDAL. However, this may introduce some
package installation conflicts.

This issue is fixed by downloading the latest PDAL version and compile
it. This way, the ubuntugis ppa can be removed and this solve the
installation conflits. With this change, it is now necessary to
install `GDAL` and `PROJ` dev packages in the `binary-only` only
image because they are needed to compile PDAL from source.

See: https://github.com/qgis/QGIS/pull/60905

Funded by Oslandia