### PR TITLE
Fix crashes in oracle provider when db workspace is set

### DIFF
--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -80,7 +80,7 @@ QgsOracleConn::QgsOracleConn( const QgsDataSourceUri &uri, bool transaction )
 
   // will be used for logging and access connection from connection pool by name,
   // so we don't want login/password here
-  mConnInfo = uri.connectionInfo( false );
+  mConnInfo = toPoolName( uri );
 
   QgsDataSourceUri expandedUri = QgsDataSourceUri( uri.connectionInfo( true ) );
 

--- a/src/providers/oracle/qgsoracleconnpool.h
+++ b/src/providers/oracle/qgsoracleconnpool.h
@@ -18,7 +18,7 @@
 
 #include "qgsconnectionpool.h"
 #include "qgsoracleconn.h"
-
+#include "qgslogger.h"
 
 inline QString qgsConnectionPool_ConnectionToName( QgsOracleConn *c )
 {
@@ -27,11 +27,13 @@ inline QString qgsConnectionPool_ConnectionToName( QgsOracleConn *c )
 
 inline void qgsConnectionPool_ConnectionCreate( const QgsDataSourceUri &uri, QgsOracleConn *&c )
 {
+  QgsDebugMsgLevel( QStringLiteral( "Creating an Oracle connection" ), 2 );
   c = QgsOracleConn::connectDb( uri, false );
 }
 
 inline void qgsConnectionPool_ConnectionDestroy( QgsOracleConn *c )
 {
+  QgsDebugMsgLevel( QStringLiteral( "Disconnecting an Oracle connection" ), 2 );
   c->disconnect(); // will delete itself
 }
 


### PR DESCRIPTION
When a workspace was set, we were using a different connection ID string when creating a connection in the connection pool vs when we were destroying it. This triggered an assert, resulting in crashes when connections were invalidated.

