### PR TITLE
[RasterTemporal] Add fixed date/time to raster temporal mode

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -4644,6 +4644,9 @@ QgsRasterLayerTemporalProperties.FixedRangePerBand.__doc__ = "Layer has a fixed 
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues = Qgis.RasterTemporalMode.RepresentsTemporalValues
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues.is_monkey_patched = True
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues.__doc__ = "Pixel values represent an datetime"
+QgsRasterLayerTemporalProperties.FixedDateTime = Qgis.RasterTemporalMode.FixedDateTime
+QgsRasterLayerTemporalProperties.FixedDateTime.is_monkey_patched = True
+QgsRasterLayerTemporalProperties.FixedDateTime.__doc__ = "Mode when temporal properties have fixed date time instant. \n.. versionadded:: 3.3.44"
 Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
 
 .. versionadded:: 3.22
@@ -4668,6 +4671,10 @@ Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
   .. versionadded:: 3.38
 
 * ``RepresentsTemporalValues``: Pixel values represent an datetime
+* ``FixedDateTime``: Mode when temporal properties have fixed date time instant.
+
+  .. versionadded:: 3.3.44
+
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -4646,7 +4646,7 @@ QgsRasterLayerTemporalProperties.RepresentsTemporalValues.is_monkey_patched = Tr
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues.__doc__ = "Pixel values represent an datetime"
 QgsRasterLayerTemporalProperties.FixedDateTime = Qgis.RasterTemporalMode.FixedDateTime
 QgsRasterLayerTemporalProperties.FixedDateTime.is_monkey_patched = True
-QgsRasterLayerTemporalProperties.FixedDateTime.__doc__ = "Mode when temporal properties have fixed date time instant. \n.. versionadded:: 3.3.44"
+QgsRasterLayerTemporalProperties.FixedDateTime.__doc__ = "Layer has a fixed date time instant. \n.. versionadded:: 3.44"
 Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
 
 .. versionadded:: 3.22
@@ -4671,9 +4671,9 @@ Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
   .. versionadded:: 3.38
 
 * ``RepresentsTemporalValues``: Pixel values represent an datetime
-* ``FixedDateTime``: Mode when temporal properties have fixed date time instant.
+* ``FixedDateTime``: Layer has a fixed date time instant.
 
-  .. versionadded:: 3.3.44
+  .. versionadded:: 3.44
 
 
 """

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1488,6 +1488,7 @@ The development version
       RedrawLayerOnly,
       FixedRangePerBand,
       RepresentsTemporalValues,
+      FixedDateTime,
     };
 
     enum class TemporalIntervalMatchMethod /BaseType=IntEnum/

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -4600,7 +4600,7 @@ QgsRasterLayerTemporalProperties.RepresentsTemporalValues.is_monkey_patched = Tr
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues.__doc__ = "Pixel values represent an datetime"
 QgsRasterLayerTemporalProperties.FixedDateTime = Qgis.RasterTemporalMode.FixedDateTime
 QgsRasterLayerTemporalProperties.FixedDateTime.is_monkey_patched = True
-QgsRasterLayerTemporalProperties.FixedDateTime.__doc__ = "Mode when temporal properties have fixed date time instant. \n.. versionadded:: 3.3.44"
+QgsRasterLayerTemporalProperties.FixedDateTime.__doc__ = "Layer has a fixed date time instant. \n.. versionadded:: 3.44"
 Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
 
 .. versionadded:: 3.22
@@ -4625,9 +4625,9 @@ Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
   .. versionadded:: 3.38
 
 * ``RepresentsTemporalValues``: Pixel values represent an datetime
-* ``FixedDateTime``: Mode when temporal properties have fixed date time instant.
+* ``FixedDateTime``: Layer has a fixed date time instant.
 
-  .. versionadded:: 3.3.44
+  .. versionadded:: 3.44
 
 
 """

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -4598,6 +4598,9 @@ QgsRasterLayerTemporalProperties.FixedRangePerBand.__doc__ = "Layer has a fixed 
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues = Qgis.RasterTemporalMode.RepresentsTemporalValues
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues.is_monkey_patched = True
 QgsRasterLayerTemporalProperties.RepresentsTemporalValues.__doc__ = "Pixel values represent an datetime"
+QgsRasterLayerTemporalProperties.FixedDateTime = Qgis.RasterTemporalMode.FixedDateTime
+QgsRasterLayerTemporalProperties.FixedDateTime.is_monkey_patched = True
+QgsRasterLayerTemporalProperties.FixedDateTime.__doc__ = "Mode when temporal properties have fixed date time instant. \n.. versionadded:: 3.3.44"
 Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
 
 .. versionadded:: 3.22
@@ -4622,6 +4625,10 @@ Qgis.RasterTemporalMode.__doc__ = """Raster layer temporal modes
   .. versionadded:: 3.38
 
 * ``RepresentsTemporalValues``: Pixel values represent an datetime
+* ``FixedDateTime``: Mode when temporal properties have fixed date time instant.
+
+  .. versionadded:: 3.3.44
+
 
 """
 # --

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1488,6 +1488,7 @@ The development version
       RedrawLayerOnly,
       FixedRangePerBand,
       RepresentsTemporalValues,
+      FixedDateTime,
     };
 
     enum class TemporalIntervalMatchMethod

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2539,6 +2539,7 @@ class CORE_EXPORT Qgis
       RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ) = 2, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when raster symbology expressions depend on the time range. \since QGIS 3.22
       FixedRangePerBand = 3, //!< Layer has a fixed temporal range per band \since QGIS 3.38
       RepresentsTemporalValues = 4, //!< Pixel values represent an datetime
+      FixedDateTime = 5, //!< Mode when temporal properties have fixed date time instant. \since QGIS 3.3.44
     };
     Q_ENUM( RasterTemporalMode )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2539,7 +2539,7 @@ class CORE_EXPORT Qgis
       RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ) = 2, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when raster symbology expressions depend on the time range. \since QGIS 3.22
       FixedRangePerBand = 3, //!< Layer has a fixed temporal range per band \since QGIS 3.38
       RepresentsTemporalValues = 4, //!< Pixel values represent an datetime
-      FixedDateTime = 5, //!< Mode when temporal properties have fixed date time instant. \since QGIS 3.3.44
+      FixedDateTime = 5, //!< Layer has a fixed date time instant. \since QGIS 3.44
     };
     Q_ENUM( RasterTemporalMode )
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -324,6 +324,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   {
     switch ( temporalProperties->mode() )
     {
+      case Qgis::RasterTemporalMode::FixedDateTime:
       case Qgis::RasterTemporalMode::FixedTemporalRange:
       case Qgis::RasterTemporalMode::RedrawLayerOnly:
       case Qgis::RasterTemporalMode::FixedRangePerBand:

--- a/src/core/raster/qgsrasterlayertemporalproperties.cpp
+++ b/src/core/raster/qgsrasterlayertemporalproperties.cpp
@@ -33,6 +33,7 @@ bool QgsRasterLayerTemporalProperties::isVisibleInTemporalRange( const QgsDateTi
 
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
     case Qgis::RasterTemporalMode::FixedTemporalRange:
       return range.isInfinite() || mFixedRange.isInfinite() || mFixedRange.overlaps( range );
 
@@ -62,6 +63,7 @@ QgsDateTimeRange QgsRasterLayerTemporalProperties::calculateTemporalExtent( QgsM
 
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
     case Qgis::RasterTemporalMode::FixedTemporalRange:
       return mFixedRange;
 
@@ -112,6 +114,7 @@ QList<QgsDateTimeRange> QgsRasterLayerTemporalProperties::allTemporalRanges( Qgs
 
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
     case Qgis::RasterTemporalMode::FixedTemporalRange:
       return { mFixedRange };
 
@@ -159,6 +162,7 @@ QgsTemporalProperty::Flags QgsRasterLayerTemporalProperties::flags() const
 {
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
     case Qgis::RasterTemporalMode::FixedTemporalRange:
       return QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges;
 
@@ -211,6 +215,7 @@ int QgsRasterLayerTemporalProperties::bandForTemporalRange( QgsRasterLayer *, co
 {
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
     case Qgis::RasterTemporalMode::FixedTemporalRange:
     case Qgis::RasterTemporalMode::TemporalRangeFromDataProvider:
     case Qgis::RasterTemporalMode::RedrawLayerOnly:
@@ -247,6 +252,7 @@ QList<int> QgsRasterLayerTemporalProperties::filteredBandsForTemporalRange( QgsR
 {
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
     case Qgis::RasterTemporalMode::FixedTemporalRange:
     case Qgis::RasterTemporalMode::TemporalRangeFromDataProvider:
     case Qgis::RasterTemporalMode::RedrawLayerOnly:
@@ -335,6 +341,16 @@ bool QgsRasterLayerTemporalProperties::readXml( const QDomElement &element, cons
 
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
+    {
+      const QDomNode instantElement = temporalNode.namedItem( QStringLiteral( "fixedInstant" ) );
+      const QDateTime date = QDateTime::fromString( instantElement.toElement().text(), Qt::ISODate );
+
+      const QgsDateTimeRange range = QgsDateTimeRange( date, date );
+      setFixedTemporalRange( range );
+      break;
+    }
+
     case Qgis::RasterTemporalMode::FixedTemporalRange:
     {
       const QDomNode rangeElement = temporalNode.namedItem( QStringLiteral( "fixedRange" ) );
@@ -398,6 +414,16 @@ QDomElement QgsRasterLayerTemporalProperties::writeXml( QDomElement &element, QD
 
   switch ( mMode )
   {
+    case Qgis::RasterTemporalMode::FixedDateTime:
+    {
+      QDomElement instantElement = document.createElement( QStringLiteral( "fixedInstant" ) );
+      const QDomText instantText = document.createTextNode( mFixedRange.begin().toTimeSpec( Qt::OffsetFromUTC ).toString( Qt::ISODate ) );
+      instantElement.appendChild( instantText );
+
+      temporalElement.appendChild( instantElement );
+      break;
+    }
+
     case Qgis::RasterTemporalMode::FixedTemporalRange:
     {
 

--- a/src/core/raster/qgsrasterlayerutils.cpp
+++ b/src/core/raster/qgsrasterlayerutils.cpp
@@ -63,6 +63,7 @@ int QgsRasterLayerUtils::renderedBandForElevationAndTemporalRange(
   {
     case Qgis::RasterTemporalMode::RedrawLayerOnly:
     case Qgis::RasterTemporalMode::TemporalRangeFromDataProvider:
+    case Qgis::RasterTemporalMode::FixedDateTime:
     case Qgis::RasterTemporalMode::FixedTemporalRange:
     case Qgis::RasterTemporalMode::FixedRangePerBand:
     {

--- a/src/ui/raster/qgsrasterlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/raster/qgsrasterlayertemporalpropertieswidgetbase.ui
@@ -103,8 +103,52 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
           <item row="1" column="0" colspan="2">
            <widget class="QgsStackedWidget" name="mStackedWidget">
             <property name="currentIndex">
-             <number>3</number>
+             <number>0</number>
             </property>
+            <widget class="QWidget" name="mPageFixedDateTime">
+             <layout class="QGridLayout" name="gridLayout_8">
+              <item row="2" column="0">
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>219</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="1">
+               <widget class="QgsDateTimeEdit" name="mFixedDateTimeEdit">
+                <property name="displayFormat">
+                 <string>M/d/yyyy h:mm AP</string>
+                </property>
+                <property name="timeSpec">
+                 <enum>Qt::UTC</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" colspan="2">
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The layer will be rendered whenever the map's temporal range overlaps the date time defined below.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_10">
+                <property name="text">
+                 <string>Date</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
             <widget class="QWidget" name="mPageFixedRange">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -443,15 +487,25 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsRasterBandComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsrasterbandcombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsStackedWidget</class>

--- a/tests/src/python/test_qgsrasterlayertemporalproperties.py
+++ b/tests/src/python/test_qgsrasterlayertemporalproperties.py
@@ -94,12 +94,99 @@ class TestQgsRasterLayerTemporalProperties(QgisTestCase):
 
         props2 = QgsRasterLayerTemporalProperties(None)
         props2.readXml(elem, QgsReadWriteContext())
-        self.assertEqual(props2.mode(), Qgis.RasterElevationMode.FixedElevationRange)
+        self.assertEqual(props2.mode(), Qgis.RasterTemporalMode.FixedTemporalRange)
         self.assertEqual(
             props2.fixedTemporalRange(),
             QgsDateTimeRange(
                 QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
                 QDateTime(QDate(2023, 7, 3), QTime(1, 3, 4)),
+            ),
+        )
+
+    def test_basic_fixed_range(self):
+        """
+        Basic tests for the class using the FixedTemporalRange mode
+        """
+        props = QgsRasterLayerTemporalProperties(None)
+        self.assertTrue(props.fixedTemporalRange().isInfinite())
+
+        props.setIsActive(True)
+        props.setMode(Qgis.RasterTemporalMode.FixedDateTime)
+        props.setFixedTemporalRange(
+            QgsDateTimeRange(
+                QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+                QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+            )
+        )
+        self.assertEqual(
+            props.fixedTemporalRange(),
+            QgsDateTimeRange(
+                QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+                QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+            ),
+        )
+        self.assertFalse(
+            props.isVisibleInTemporalRange(
+                QgsDateTimeRange(
+                    QDateTime(QDate(2022, 5, 6), QTime(12, 13, 14)),
+                    QDateTime(QDate(2022, 7, 3), QTime(1, 3, 4)),
+                )
+            )
+        )
+        self.assertTrue(
+            props.isVisibleInTemporalRange(
+                QgsDateTimeRange(
+                    QDateTime(QDate(2023, 1, 6), QTime(12, 13, 14)),
+                    QDateTime(QDate(2023, 6, 3), QTime(1, 3, 4)),
+                )
+            )
+        )
+        self.assertTrue(
+            props.isVisibleInTemporalRange(
+                QgsDateTimeRange(
+                    QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+                    QDateTime(QDate(2023, 9, 3), QTime(1, 3, 4)),
+                )
+            )
+        )
+        self.assertTrue(
+            props.isVisibleInTemporalRange(
+                QgsDateTimeRange(
+                    QDateTime(QDate(2023, 1, 6), QTime(0, 0, 0)),
+                    QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+                )
+            )
+        )
+        self.assertFalse(
+            props.isVisibleInTemporalRange(
+                QgsDateTimeRange(
+                    QDateTime(QDate(2024, 5, 6), QTime(12, 13, 14)),
+                    QDateTime(QDate(2024, 7, 3), QTime(1, 3, 4)),
+                )
+            )
+        )
+        self.assertEqual(
+            props.allTemporalRanges(None),
+            [
+                QgsDateTimeRange(
+                    QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+                    QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+                )
+            ],
+        )
+
+        doc = QDomDocument("testdoc")
+        elem = doc.createElement("test")
+        props.writeXml(elem, doc, QgsReadWriteContext())
+
+        props2 = QgsRasterLayerTemporalProperties(None)
+        props2.readXml(elem, QgsReadWriteContext())
+        self.assertEqual(props2.mode(), Qgis.RasterTemporalMode.FixedDateTime)
+        self.assertEqual(
+            props2.fixedTemporalRange(),
+            QgsDateTimeRange(
+                QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
+                QDateTime(QDate(2023, 5, 6), QTime(12, 13, 14)),
             ),
         )
 


### PR DESCRIPTION
Allows the user to select a fixed date/time for a raster layer temporal properties so he doesn't have to set the same date/time for start and end of a temporal range.

![rasterdatetime](https://github.com/user-attachments/assets/eea20621-4499-47bf-9a5c-f1278043fb27)

**Funded by Ifremer**
