### PR TITLE
Add country codes config to Nominatim Geocoder Locator filter - 2

### DIFF
--- a/src/app/locator/qgsnominatimlocatorfilter.h
+++ b/src/app/locator/qgsnominatimlocatorfilter.h
@@ -27,10 +27,15 @@ class APP_EXPORT QgsNominatimLocatorFilter : public QgsGeocoderLocatorFilter
     Q_OBJECT
 
   public:
+    static const QgsSettingsEntryString *settingCountryCodes;
+
     QgsNominatimLocatorFilter( QgsGeocoderInterface *geocoder, QgsMapCanvas *canvas );
     QgsNominatimLocatorFilter *clone() const override SIP_FACTORY;
 
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
+    bool hasConfigWidget() const override { return true; }
+    void openConfigWidget( QWidget *parent ) override;
 };
 
 #endif // QGSNOMINATIMLOCATORFILTERS_H

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -25,6 +25,7 @@
 #include "qgis_core.h"
 #include "qgslocatorcontext.h"
 #include "qgslogger.h"
+#include "qgssettingstree.h"
 
 class QgsFeedback;
 class QgsLocatorFilter;
@@ -178,6 +179,9 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
 
   public:
 
+#ifndef SIP_RUN
+    static inline QgsSettingsTreeNamedListNode *sTreeAppLocatorFilters = QgsSettingsTree::sTreeApp->createNamedListNode( QStringLiteral( "locator-filters" ) );
+#endif
     //! Filter priority. Controls the order of results in the locator.
     enum Priority
     {


### PR DESCRIPTION
This adds configuration option to Nominatim Geocoder Locator filter for filtering results to one or more countries. (Two letter [country codes](https://wiki.openstreetmap.org/wiki/Nominatim/Country_Codes), comma separated). Configuration value is optional.

![image](https://github.com/user-attachments/assets/1f8eaff8-ddda-4fa0-869d-513f3f0bbca2)

Funded by level2 https://level2.si/
