### PR TITLE
Add option to use POST requests for a WFS connection

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsnetworkaccessmanager.py
+++ b/python/PyQt6/core/auto_additions/qgsnetworkaccessmanager.py
@@ -12,6 +12,8 @@ try:
     QgsNetworkAccessManager.blockingPost = staticmethod(QgsNetworkAccessManager.blockingPost)
     QgsNetworkAccessManager.setRequestPreprocessor = staticmethod(QgsNetworkAccessManager.setRequestPreprocessor)
     QgsNetworkAccessManager.removeRequestPreprocessor = staticmethod(QgsNetworkAccessManager.removeRequestPreprocessor)
+    QgsNetworkAccessManager.setAdvancedRequestPreprocessor = staticmethod(QgsNetworkAccessManager.setAdvancedRequestPreprocessor)
+    QgsNetworkAccessManager.removeAdvancedRequestPreprocessor = staticmethod(QgsNetworkAccessManager.removeAdvancedRequestPreprocessor)
     QgsNetworkAccessManager.setReplyPreprocessor = staticmethod(QgsNetworkAccessManager.setReplyPreprocessor)
     QgsNetworkAccessManager.removeReplyPreprocessor = staticmethod(QgsNetworkAccessManager.removeReplyPreprocessor)
     QgsNetworkAccessManager.__signal_arguments__ = {'requestAboutToBeCreated': ['request: QgsNetworkRequestParameters'], 'requestCreated': ['request: QgsNetworkRequestParameters'], 'finished': ['reply: QgsNetworkReplyContent'], 'requestTimedOut': ['reply: QNetworkReply'], 'downloadProgress': ['requestId: int', 'bytesReceived: int', 'bytesTotal: int'], 'requestRequiresAuth': ['requestId: int', 'realm: str'], 'requestAuthDetailsAdded': ['requestId: int', 'realm: str', 'user: str', 'password: str'], 'requestEncounteredSslErrors': ['requestId: int', 'errors: List[QSslError]'], 'cookiesChanged': ['cookies: List[QNetworkCookie]']}

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -394,14 +394,14 @@ It should return the desired operation and request data as a tuple, transforming
     QString id;
     Py_XINCREF( a0 );
     Py_BEGIN_ALLOW_THREADS
-    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, QNetworkAccessManager::Operation &op, QByteArray *data )
+    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, int &op, QByteArray *data )
     {
       SIP_BLOCK_THREADS
 
       PyObject *requestObj = sipConvertFromType( reqArg, sipType_QNetworkRequest, NULL );
       PyObject *postDataObj = sipConvertFromType( new QByteArray( *data ), sipType_QByteArray, Py_None );
 
-      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, static_cast<int>( op ), postDataObj );
+      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, op, postDataObj );
 
       Py_XDECREF( requestObj );
       Py_XDECREF( postDataObj );
@@ -412,7 +412,7 @@ It should return the desired operation and request data as a tuple, transforming
         PyObject *opObj = PyTuple_GetItem( result, 0 );
         if ( opObj && PyLong_Check( opObj ) )
         {
-          op = static_cast<QNetworkAccessManager::Operation>( PyLong_AsLong( opObj ) );
+          op = static_cast<int>( PyLong_AsLong( opObj ) );
         }
         PyObject *dataObj = PyTuple_GetItem( result, 1 );
         if ( dataObj && dataObj != Py_None )

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -379,8 +379,11 @@ Returns ``True`` if processor existed and was removed.
 %Docstring
 Sets an advanced request pre-processor function, which allows manipulation of a network request before it is processed.
 
-The ``processor`` function takes the QNetworkRequest, network operation, and request data as its arguments, and can mutate the request if necessary.
-It should return the desired operation and request data as a tuple, transforming as desired.
+The ``processor`` function takes the QNetworkRequest, network operation (a QNetworkAccessManager.Operation cast to an integer value),
+and request data as its arguments, and can mutate the request if necessary.
+
+It should return the desired operation (as a QNetworkAccessManager.Operation cast to an integer value) and request data as a tuple,
+transforming as desired.
 
 :return: An auto-generated string uniquely identifying the preprocessor, which can later be
          used to remove the preprocessor (via a call to :py:func:`~QgsNetworkAccessManager.removeAdvancedRequestPreprocessor`).

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -375,6 +375,90 @@ Returns ``True`` if processor existed and was removed.
     }
 %End
 
+    static QString setAdvancedRequestPreprocessor( SIP_PYCALLABLE / AllowNone / );
+%Docstring
+Sets an advanced request pre-processor function, which allows manipulation of a network request before it is processed.
+
+The ``processor`` function takes the QNetworkRequest, network operation, and request data as its arguments, and can mutate the request if necessary.
+It should return the desired operation and request data as a tuple, transforming as desired.
+
+:return: An auto-generated string uniquely identifying the preprocessor, which can later be
+         used to remove the preprocessor (via a call to :py:func:`~QgsNetworkAccessManager.removeAdvancedRequestPreprocessor`).
+
+.. seealso:: :py:func:`removeAdvancedRequestPreprocessor`
+
+.. versionadded:: 3.44
+%End
+%MethodCode
+    PyObject *s = 0;
+    QString id;
+    Py_XINCREF( a0 );
+    Py_BEGIN_ALLOW_THREADS
+    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, QNetworkAccessManager::Operation &op, QByteArray *data )
+    {
+      SIP_BLOCK_THREADS
+
+      PyObject *requestObj = sipConvertFromType( reqArg, sipType_QNetworkRequest, NULL );
+      PyObject *postDataObj = sipConvertFromType( new QByteArray( *data ), sipType_QByteArray, Py_None );
+
+      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, static_cast<int>( op ), postDataObj );
+
+      Py_XDECREF( requestObj );
+      Py_XDECREF( postDataObj );
+
+      if ( result && PyTuple_Check( result ) && PyTuple_Size( result ) == 2 )
+      {
+        // Extract modified operation
+        PyObject *opObj = PyTuple_GetItem( result, 0 );
+        if ( opObj && PyLong_Check( opObj ) )
+        {
+          op = static_cast<QNetworkAccessManager::Operation>( PyLong_AsLong( opObj ) );
+        }
+        PyObject *dataObj = PyTuple_GetItem( result, 1 );
+        if ( dataObj && dataObj != Py_None )
+        {
+          int dataState;
+          int sipIsErr = 0;
+          QByteArray *modifiedData = reinterpret_cast<QByteArray *>( sipConvertToType( dataObj, sipType_QByteArray, 0, SIP_NOT_NONE, &dataState, &sipIsErr ) );
+          if ( sipIsErr == 0 )
+          {
+            data->clear();
+            data->append( *modifiedData );
+            sipReleaseType( modifiedData, sipType_QByteArray, dataState );
+          }
+        }
+      }
+
+      Py_XDECREF( result );
+      SIP_UNBLOCK_THREADS
+    } );
+    Py_END_ALLOW_THREADS
+
+    s = sipConvertFromNewType( new QString( id ), sipType_QString, 0 );
+    return s;
+%End
+
+    static void removeAdvancedRequestPreprocessor( const QString &id );
+%Docstring
+Removes an advanced request pre-processor function with matching ``id``.
+
+The ``id`` must correspond to a pre-processor previously added via a call to :py:func:`~QgsNetworkAccessManager.setAdvancedRequestPreprocessor`.
+
+Returns ``True`` if processor existed and was removed.
+
+.. seealso:: :py:func:`setAdvancedRequestPreprocessor`
+
+.. versionadded:: 3.44
+%End
+%MethodCode
+    if ( !QgsNetworkAccessManager::removeAdvancedRequestPreprocessor( *a0 ) )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "No processor with id %1 exists." ).arg( *a0 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+%End
+
+
     static QString setReplyPreprocessor( SIP_PYCALLABLE / AllowNone / );
 %Docstring
 Sets a reply pre-processor function, which allows manipulation of QNetworkReply objects after they are created (but before they are fetched).

--- a/python/PyQt6/core/auto_generated/qgstestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstestutils.sip.in
@@ -25,6 +25,13 @@ requesting features from the provider.
 This method returns ``True``... or it segfaults.
 %End
 
+  bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
+%Docstring
+Compares two DOM elements and returns ``True`` if they are equivalent.
+
+Dumps useful diff information to the console if the elements differ.
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -97,6 +97,13 @@ Returns the "test connection" button.
 
 
 
+    Qgis::HttpMethod preferredHttpMethod() const;
+%Docstring
+Returns the selected preferred HTTP method.
+
+.. versionadded:: 3.44
+%End
+
 
     virtual QString wfsSettingsKey( const QString &base, const QString &connectionName ) const;
 %Docstring

--- a/python/core/auto_additions/qgsnetworkaccessmanager.py
+++ b/python/core/auto_additions/qgsnetworkaccessmanager.py
@@ -10,6 +10,8 @@ try:
     QgsNetworkAccessManager.blockingPost = staticmethod(QgsNetworkAccessManager.blockingPost)
     QgsNetworkAccessManager.setRequestPreprocessor = staticmethod(QgsNetworkAccessManager.setRequestPreprocessor)
     QgsNetworkAccessManager.removeRequestPreprocessor = staticmethod(QgsNetworkAccessManager.removeRequestPreprocessor)
+    QgsNetworkAccessManager.setAdvancedRequestPreprocessor = staticmethod(QgsNetworkAccessManager.setAdvancedRequestPreprocessor)
+    QgsNetworkAccessManager.removeAdvancedRequestPreprocessor = staticmethod(QgsNetworkAccessManager.removeAdvancedRequestPreprocessor)
     QgsNetworkAccessManager.setReplyPreprocessor = staticmethod(QgsNetworkAccessManager.setReplyPreprocessor)
     QgsNetworkAccessManager.removeReplyPreprocessor = staticmethod(QgsNetworkAccessManager.removeReplyPreprocessor)
     QgsNetworkAccessManager.__signal_arguments__ = {'requestAboutToBeCreated': ['request: QgsNetworkRequestParameters'], 'requestCreated': ['request: QgsNetworkRequestParameters'], 'finished': ['reply: QgsNetworkReplyContent'], 'requestTimedOut': ['reply: QNetworkReply'], 'downloadProgress': ['requestId: int', 'bytesReceived: int', 'bytesTotal: int'], 'requestRequiresAuth': ['requestId: int', 'realm: str'], 'requestAuthDetailsAdded': ['requestId: int', 'realm: str', 'user: str', 'password: str'], 'requestEncounteredSslErrors': ['requestId: int', 'errors: List[QSslError]'], 'cookiesChanged': ['cookies: List[QNetworkCookie]']}

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -394,14 +394,14 @@ It should return the desired operation and request data as a tuple, transforming
     QString id;
     Py_XINCREF( a0 );
     Py_BEGIN_ALLOW_THREADS
-    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, QNetworkAccessManager::Operation &op, QByteArray *data )
+    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, int &op, QByteArray *data )
     {
       SIP_BLOCK_THREADS
 
       PyObject *requestObj = sipConvertFromType( reqArg, sipType_QNetworkRequest, NULL );
       PyObject *postDataObj = sipConvertFromType( new QByteArray( *data ), sipType_QByteArray, Py_None );
 
-      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, static_cast<int>( op ), postDataObj );
+      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, op, postDataObj );
 
       Py_XDECREF( requestObj );
       Py_XDECREF( postDataObj );
@@ -412,7 +412,7 @@ It should return the desired operation and request data as a tuple, transforming
         PyObject *opObj = PyTuple_GetItem( result, 0 );
         if ( opObj && PyLong_Check( opObj ) )
         {
-          op = static_cast<QNetworkAccessManager::Operation>( PyLong_AsLong( opObj ) );
+          op = static_cast<int>( PyLong_AsLong( opObj ) );
         }
         PyObject *dataObj = PyTuple_GetItem( result, 1 );
         if ( dataObj && dataObj != Py_None )

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -379,8 +379,11 @@ Returns ``True`` if processor existed and was removed.
 %Docstring
 Sets an advanced request pre-processor function, which allows manipulation of a network request before it is processed.
 
-The ``processor`` function takes the QNetworkRequest, network operation, and request data as its arguments, and can mutate the request if necessary.
-It should return the desired operation and request data as a tuple, transforming as desired.
+The ``processor`` function takes the QNetworkRequest, network operation (a QNetworkAccessManager.Operation cast to an integer value),
+and request data as its arguments, and can mutate the request if necessary.
+
+It should return the desired operation (as a QNetworkAccessManager.Operation cast to an integer value) and request data as a tuple,
+transforming as desired.
 
 :return: An auto-generated string uniquely identifying the preprocessor, which can later be
          used to remove the preprocessor (via a call to :py:func:`~QgsNetworkAccessManager.removeAdvancedRequestPreprocessor`).

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -375,6 +375,90 @@ Returns ``True`` if processor existed and was removed.
     }
 %End
 
+    static QString setAdvancedRequestPreprocessor( SIP_PYCALLABLE / AllowNone / );
+%Docstring
+Sets an advanced request pre-processor function, which allows manipulation of a network request before it is processed.
+
+The ``processor`` function takes the QNetworkRequest, network operation, and request data as its arguments, and can mutate the request if necessary.
+It should return the desired operation and request data as a tuple, transforming as desired.
+
+:return: An auto-generated string uniquely identifying the preprocessor, which can later be
+         used to remove the preprocessor (via a call to :py:func:`~QgsNetworkAccessManager.removeAdvancedRequestPreprocessor`).
+
+.. seealso:: :py:func:`removeAdvancedRequestPreprocessor`
+
+.. versionadded:: 3.44
+%End
+%MethodCode
+    PyObject *s = 0;
+    QString id;
+    Py_XINCREF( a0 );
+    Py_BEGIN_ALLOW_THREADS
+    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, QNetworkAccessManager::Operation &op, QByteArray *data )
+    {
+      SIP_BLOCK_THREADS
+
+      PyObject *requestObj = sipConvertFromType( reqArg, sipType_QNetworkRequest, NULL );
+      PyObject *postDataObj = sipConvertFromType( new QByteArray( *data ), sipType_QByteArray, Py_None );
+
+      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, static_cast<int>( op ), postDataObj );
+
+      Py_XDECREF( requestObj );
+      Py_XDECREF( postDataObj );
+
+      if ( result && PyTuple_Check( result ) && PyTuple_Size( result ) == 2 )
+      {
+        // Extract modified operation
+        PyObject *opObj = PyTuple_GetItem( result, 0 );
+        if ( opObj && PyLong_Check( opObj ) )
+        {
+          op = static_cast<QNetworkAccessManager::Operation>( PyLong_AsLong( opObj ) );
+        }
+        PyObject *dataObj = PyTuple_GetItem( result, 1 );
+        if ( dataObj && dataObj != Py_None )
+        {
+          int dataState;
+          int sipIsErr = 0;
+          QByteArray *modifiedData = reinterpret_cast<QByteArray *>( sipConvertToType( dataObj, sipType_QByteArray, 0, SIP_NOT_NONE, &dataState, &sipIsErr ) );
+          if ( sipIsErr == 0 )
+          {
+            data->clear();
+            data->append( *modifiedData );
+            sipReleaseType( modifiedData, sipType_QByteArray, dataState );
+          }
+        }
+      }
+
+      Py_XDECREF( result );
+      SIP_UNBLOCK_THREADS
+    } );
+    Py_END_ALLOW_THREADS
+
+    s = sipConvertFromNewType( new QString( id ), sipType_QString, 0 );
+    return s;
+%End
+
+    static void removeAdvancedRequestPreprocessor( const QString &id );
+%Docstring
+Removes an advanced request pre-processor function with matching ``id``.
+
+The ``id`` must correspond to a pre-processor previously added via a call to :py:func:`~QgsNetworkAccessManager.setAdvancedRequestPreprocessor`.
+
+Returns ``True`` if processor existed and was removed.
+
+.. seealso:: :py:func:`setAdvancedRequestPreprocessor`
+
+.. versionadded:: 3.44
+%End
+%MethodCode
+    if ( !QgsNetworkAccessManager::removeAdvancedRequestPreprocessor( *a0 ) )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "No processor with id %1 exists." ).arg( *a0 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+%End
+
+
     static QString setReplyPreprocessor( SIP_PYCALLABLE / AllowNone / );
 %Docstring
 Sets a reply pre-processor function, which allows manipulation of QNetworkReply objects after they are created (but before they are fetched).

--- a/python/core/auto_generated/qgstestutils.sip.in
+++ b/python/core/auto_generated/qgstestutils.sip.in
@@ -25,6 +25,13 @@ requesting features from the provider.
 This method returns ``True``... or it segfaults.
 %End
 
+  bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
+%Docstring
+Compares two DOM elements and returns ``True`` if they are equivalent.
+
+Dumps useful diff information to the console if the elements differ.
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -97,6 +97,13 @@ Returns the "test connection" button.
 
 
 
+    Qgis::HttpMethod preferredHttpMethod() const;
+%Docstring
+Returns the selected preferred HTTP method.
+
+.. versionadded:: 3.44
+%End
+
 
     virtual QString wfsSettingsKey( const QString &base, const QString &connectionName ) const;
 %Docstring

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -57,6 +57,7 @@ const QgsSettingsEntryInteger *QgsNetworkAccessManager::settingsNetworkTimeout =
 QgsNetworkAccessManager *QgsNetworkAccessManager::sMainNAM = nullptr;
 
 static std::vector< std::pair< QString, std::function< void( QNetworkRequest * ) > > > sCustomPreprocessors;
+static std::vector< std::pair< QString, std::function< void( QNetworkRequest *, QNetworkAccessManager::Operation &op, QByteArray *data ) > > > sCustomAdvancedPreprocessors;
 static std::vector< std::pair< QString, std::function< void( const QNetworkRequest &, QNetworkReply * ) > > > sCustomReplyPreprocessors;
 
 /// @cond PRIVATE
@@ -352,6 +353,11 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   if ( QBuffer *buffer = qobject_cast<QBuffer *>( outgoingData ) )
   {
     content = buffer->buffer();
+  }
+
+  for ( const auto &preprocessor :  sCustomAdvancedPreprocessors )
+  {
+    preprocessor.second( pReq, op, &content );
   }
 
   emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req, requestId, content ) );
@@ -824,6 +830,23 @@ bool QgsNetworkAccessManager::removeRequestPreprocessor( const QString &id )
     return a.first == id;
   } ), sCustomPreprocessors.end() );
   return prevCount != sCustomPreprocessors.size();
+}
+
+bool QgsNetworkAccessManager::removeAdvancedRequestPreprocessor( const QString &id )
+{
+  const size_t prevCount = sCustomAdvancedPreprocessors.size();
+  sCustomAdvancedPreprocessors.erase( std::remove_if( sCustomAdvancedPreprocessors.begin(), sCustomAdvancedPreprocessors.end(), [id]( std::pair< QString, std::function< void( QNetworkRequest *, QNetworkAccessManager::Operation &, QByteArray * ) > > &a )
+  {
+    return a.first == id;
+  } ), sCustomAdvancedPreprocessors.end() );
+  return prevCount != sCustomAdvancedPreprocessors.size();
+}
+
+QString QgsNetworkAccessManager::setAdvancedRequestPreprocessor( const std::function<void ( QNetworkRequest *, QNetworkAccessManager::Operation &, QByteArray * )> &processor )
+{
+  QString id = QUuid::createUuid().toString();
+  sCustomAdvancedPreprocessors.emplace_back( std::make_pair( id, processor ) );
+  return id;
 }
 
 QString QgsNetworkAccessManager::setReplyPreprocessor( const std::function<void ( const QNetworkRequest &, QNetworkReply * )> &processor )

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -571,6 +571,96 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 #endif
 
     /**
+     * Sets an advanced request pre-processor function, which allows manipulation of a network request before it is processed.
+     *
+     * The \a processor function takes the QNetworkRequest, network operation, and request data as its arguments, and can mutate the request if necessary.
+     * It should return the desired operation and request data as a tuple, transforming as desired.
+     *
+     * \returns An auto-generated string uniquely identifying the preprocessor, which can later be
+     * used to remove the preprocessor (via a call to removeAdvancedRequestPreprocessor()).
+     *
+     * \see removeAdvancedRequestPreprocessor()
+     * \since QGIS 3.44
+     */
+#ifndef SIP_RUN
+    static QString setAdvancedRequestPreprocessor( const std::function< void( QNetworkRequest *, QNetworkAccessManager::Operation &op, QByteArray *data )> &processor );
+#else
+    static QString setAdvancedRequestPreprocessor( SIP_PYCALLABLE / AllowNone / );
+    % MethodCode
+    PyObject *s = 0;
+    QString id;
+    Py_XINCREF( a0 );
+    Py_BEGIN_ALLOW_THREADS
+    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, QNetworkAccessManager::Operation &op, QByteArray *data )
+    {
+      SIP_BLOCK_THREADS
+
+      PyObject *requestObj = sipConvertFromType( reqArg, sipType_QNetworkRequest, NULL );
+      PyObject *postDataObj = sipConvertFromType( new QByteArray( *data ), sipType_QByteArray, Py_None );
+
+      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, static_cast<int>( op ), postDataObj );
+
+      Py_XDECREF( requestObj );
+      Py_XDECREF( postDataObj );
+
+      if ( result && PyTuple_Check( result ) && PyTuple_Size( result ) == 2 )
+      {
+        // Extract modified operation
+        PyObject *opObj = PyTuple_GetItem( result, 0 );
+        if ( opObj && PyLong_Check( opObj ) )
+        {
+          op = static_cast<QNetworkAccessManager::Operation>( PyLong_AsLong( opObj ) );
+        }
+        PyObject *dataObj = PyTuple_GetItem( result, 1 );
+        if ( dataObj && dataObj != Py_None )
+        {
+          int dataState;
+          int sipIsErr = 0;
+          QByteArray *modifiedData = reinterpret_cast<QByteArray *>( sipConvertToType( dataObj, sipType_QByteArray, 0, SIP_NOT_NONE, &dataState, &sipIsErr ) );
+          if ( sipIsErr == 0 )
+          {
+            data->clear();
+            data->append( *modifiedData );
+            sipReleaseType( modifiedData, sipType_QByteArray, dataState );
+          }
+        }
+      }
+
+      Py_XDECREF( result );
+      SIP_UNBLOCK_THREADS
+    } );
+    Py_END_ALLOW_THREADS
+
+    s = sipConvertFromNewType( new QString( id ), sipType_QString, 0 );
+    return s;
+    % End
+#endif
+
+    /**
+     * Removes an advanced request pre-processor function with matching \a id.
+     *
+     * The \a id must correspond to a pre-processor previously added via a call to setAdvancedRequestPreprocessor().
+     *
+     * Returns TRUE if processor existed and was removed.
+     *
+     * \see setAdvancedRequestPreprocessor()
+     * \since QGIS 3.44
+     */
+#ifndef SIP_RUN
+    static bool removeAdvancedRequestPreprocessor( const QString &id );
+#else
+    static void removeAdvancedRequestPreprocessor( const QString &id );
+    % MethodCode
+    if ( !QgsNetworkAccessManager::removeAdvancedRequestPreprocessor( *a0 ) )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "No processor with id %1 exists." ).arg( *a0 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    % End
+#endif
+
+
+    /**
      * Sets a reply pre-processor function, which allows manipulation of QNetworkReply objects after they are created (but before they are fetched).
      *
      * The \a processor function takes a QNetworkRequest request and a QNetworkReply as arguments, and can connect to QNetworkReply signals directly as desired.

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -573,8 +573,11 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     /**
      * Sets an advanced request pre-processor function, which allows manipulation of a network request before it is processed.
      *
-     * The \a processor function takes the QNetworkRequest, network operation, and request data as its arguments, and can mutate the request if necessary.
-     * It should return the desired operation and request data as a tuple, transforming as desired.
+     * The \a processor function takes the QNetworkRequest, network operation (a QNetworkAccessManager::Operation cast to an integer value),
+     * and request data as its arguments, and can mutate the request if necessary.
+     *
+     * It should return the desired operation (as a QNetworkAccessManager::Operation cast to an integer value) and request data as a tuple,
+     * transforming as desired.
      *
      * \returns An auto-generated string uniquely identifying the preprocessor, which can later be
      * used to remove the preprocessor (via a call to removeAdvancedRequestPreprocessor()).

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -583,7 +583,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * \since QGIS 3.44
      */
 #ifndef SIP_RUN
-    static QString setAdvancedRequestPreprocessor( const std::function< void( QNetworkRequest *, QNetworkAccessManager::Operation &op, QByteArray *data )> &processor );
+    static QString setAdvancedRequestPreprocessor( const std::function< void( QNetworkRequest *, int &op, QByteArray *data )> &processor );
 #else
     static QString setAdvancedRequestPreprocessor( SIP_PYCALLABLE / AllowNone / );
     % MethodCode
@@ -591,14 +591,14 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     QString id;
     Py_XINCREF( a0 );
     Py_BEGIN_ALLOW_THREADS
-    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, QNetworkAccessManager::Operation &op, QByteArray *data )
+    id = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [a0]( QNetworkRequest *reqArg, int &op, QByteArray *data )
     {
       SIP_BLOCK_THREADS
 
       PyObject *requestObj = sipConvertFromType( reqArg, sipType_QNetworkRequest, NULL );
       PyObject *postDataObj = sipConvertFromType( new QByteArray( *data ), sipType_QByteArray, Py_None );
 
-      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, static_cast<int>( op ), postDataObj );
+      PyObject *result = sipCallMethod( NULL, a0, "RiR", requestObj, op, postDataObj );
 
       Py_XDECREF( requestObj );
       Py_XDECREF( postDataObj );
@@ -609,7 +609,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
         PyObject *opObj = PyTuple_GetItem( result, 0 );
         if ( opObj && PyLong_Check( opObj ) )
         {
-          op = static_cast<QNetworkAccessManager::Operation>( PyLong_AsLong( opObj ) );
+          op = static_cast<int>( PyLong_AsLong( opObj ) );
         }
         PyObject *dataObj = PyTuple_GetItem( result, 1 );
         if ( dataObj && dataObj != Py_None )

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -76,6 +76,7 @@ const QgsSettingsEntryString *QgsOwsConnection::settingsUsername = new QgsSettin
 const QgsSettingsEntryString *QgsOwsConnection::settingsPassword = new QgsSettingsEntryString( QStringLiteral( "password" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsAuthCfg = new QgsSettingsEntryString( QStringLiteral( "authcfg" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryInteger *QgsOwsConnection::settingsFeatureCount = new QgsSettingsEntryInteger( QStringLiteral( "feature-count" ), sTreeOwsConnections, 10 );
+const QgsSettingsEntryEnumFlag<Qgis::HttpMethod> *QgsOwsConnection::settingsPreferredHttpMethod = new QgsSettingsEntryEnumFlag<Qgis::HttpMethod>( QStringLiteral( "http-method" ), sTreeOwsConnections, Qgis::HttpMethod::Get, QString() );
 
 QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connName )
   : mConnName( connName )
@@ -258,6 +259,24 @@ QgsDataSourceUri &QgsOwsConnection::addWfsConnectionSettings( QgsDataSourceUri &
   if ( !maxnumFeatures.isEmpty() )
   {
     uri.setParam( QStringLiteral( "maxNumFeatures" ), maxnumFeatures );
+  }
+
+  const Qgis::HttpMethod httpMethod = settingsPreferredHttpMethod->value( {service.toLower(), connName} );
+  switch ( httpMethod )
+  {
+    case Qgis::HttpMethod::Get:
+      // default, we don't set to explicitly set
+      break;
+
+    case Qgis::HttpMethod::Post:
+      uri.setParam( QStringLiteral( "httpMethod" ), QStringLiteral( "post" ) );
+      break;
+
+    case Qgis::HttpMethod::Head:
+    case Qgis::HttpMethod::Put:
+    case Qgis::HttpMethod::Delete:
+      // not supported
+      break;
   }
 
   return uri;

--- a/src/core/qgsowsconnection.h
+++ b/src/core/qgsowsconnection.h
@@ -116,6 +116,7 @@ class CORE_EXPORT QgsOwsConnection : public QObject
     static const QgsSettingsEntryString *settingsPassword;
     static const QgsSettingsEntryString *settingsAuthCfg;
     static const QgsSettingsEntryInteger *settingsFeatureCount;
+    static const QgsSettingsEntryEnumFlag<Qgis::HttpMethod> *settingsPreferredHttpMethod;
 
 #endif
 

--- a/src/core/qgstestutils.cpp
+++ b/src/core/qgstestutils.cpp
@@ -47,5 +47,106 @@ bool QgsTestUtils::testProviderIteratorThreadSafety( QgsVectorDataProvider *prov
   return true;
 }
 
+bool QgsTestUtils::compareDomElements( const QDomElement &element1, const QDomElement &element2 )
+{
+  QString tag1 = element1.tagName();
+  tag1.replace( QRegularExpression( ".*:" ), QString() );
+  QString tag2 = element2.tagName();
+  tag2.replace( QRegularExpression( ".*:" ), QString() );
+  if ( tag1 != tag2 )
+  {
+    qDebug( "Different tag names: %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data() );
+    return false;
+  }
+
+  if ( element1.hasAttributes() != element2.hasAttributes() )
+  {
+    qDebug( "Different hasAttributes: %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data() );
+    return false;
+  }
+
+  if ( element1.hasAttributes() )
+  {
+    const QDomNamedNodeMap attrs1 = element1.attributes();
+    const QDomNamedNodeMap attrs2 = element2.attributes();
+
+    if ( attrs1.size() != attrs2.size() )
+    {
+      qDebug( "Different attributes size: %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data() );
+      return false;
+    }
+
+    for ( int i = 0; i < attrs1.size(); ++i )
+    {
+      const QDomNode node1 = attrs1.item( i );
+      const QDomAttr attr1 = node1.toAttr();
+
+      if ( !element2.hasAttribute( attr1.name() ) )
+      {
+        qDebug( "Element2 has not attribute: %s, %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data(), attr1.name().toLatin1().data() );
+        return false;
+      }
+
+      if ( element2.attribute( attr1.name() ) != attr1.value() )
+      {
+        qDebug( "Element2 attribute has not the same value: %s, %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data(), attr1.name().toLatin1().data() );
+        return false;
+      }
+    }
+  }
+
+  if ( element1.hasChildNodes() != element2.hasChildNodes() )
+  {
+    qDebug( "Different childNodes: %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data() );
+    return false;
+  }
+
+  if ( element1.hasChildNodes() )
+  {
+    const QDomNodeList nodes1 = element1.childNodes();
+    const QDomNodeList nodes2 = element2.childNodes();
+
+    if ( nodes1.size() != nodes2.size() )
+    {
+      qDebug( "Different childNodes size: %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data() );
+      return false;
+    }
+
+    for ( int i = 0; i < nodes1.size(); ++i )
+    {
+      const QDomNode node1 = nodes1.at( i );
+      const QDomNode node2 = nodes2.at( i );
+      if ( node1.isElement() && node2.isElement() )
+      {
+        QDomElement elt1 = node1.toElement();
+        QDomElement elt2 = node2.toElement();
+
+        if ( !compareDomElements( elt1, elt2 ) )
+          return false;
+      }
+      else if ( node1.isText() && node2.isText() )
+      {
+        const QDomText txt1 = node1.toText();
+        const QDomText txt2 = node2.toText();
+
+        if ( txt1.data() != txt2.data() )
+        {
+          qDebug( "Different text data: %s %s", tag1.toLatin1().data(), txt1.data().toLatin1().data() );
+          qDebug( "Different text data: %s %s", tag2.toLatin1().data(), txt2.data().toLatin1().data() );
+          return false;
+        }
+      }
+    }
+  }
+
+  if ( element1.text() != element2.text() )
+  {
+    qDebug( "Different text: %s %s", tag1.toLatin1().data(), element1.text().toLatin1().data() );
+    qDebug( "Different text: %s %s", tag2.toLatin1().data(), element2.text().toLatin1().data() );
+    return false;
+  }
+
+  return true;
+}
 
 ///@endcond

--- a/src/core/qgstestutils.h
+++ b/src/core/qgstestutils.h
@@ -42,6 +42,13 @@ namespace QgsTestUtils
    */
   CORE_EXPORT bool testProviderIteratorThreadSafety( QgsVectorDataProvider *provider, const QgsFeatureRequest &request = QgsFeatureRequest() );
 
+  /**
+   * Compares two DOM elements and returns TRUE if they are equivalent.
+   *
+   * Dumps useful diff information to the console if the elements differ.
+   */
+  CORE_EXPORT bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
+
 };
 
 ///@endcond

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -527,6 +527,7 @@ QDomDocument QgsManageConnectionsDialog::saveWfsConnections( const QStringList &
     el.setAttribute( QStringLiteral( "invertAxisOrientation" ), QgsOwsConnection::settingsInvertAxisOrientation->value( { QStringLiteral( "wfs" ), connections[i] } ) );
     el.setAttribute( QStringLiteral( "username" ), QgsOwsConnection::settingsUsername->value( { QStringLiteral( "wfs" ), connections[i] } ) );
     el.setAttribute( QStringLiteral( "password" ), QgsOwsConnection::settingsPassword->value( { QStringLiteral( "wfs" ), connections[i] } ) );
+    el.setAttribute( QStringLiteral( "httpMethod" ), QgsOwsConnection::settingsPreferredHttpMethod->value( { QStringLiteral( "wfs" ), connections[i] } ) == Qgis::HttpMethod::Post ? QStringLiteral( "post" ) : QStringLiteral( "get" ) );
     root.appendChild( el );
   }
 
@@ -1080,6 +1081,7 @@ void QgsManageConnectionsDialog::loadWfsConnections( const QDomDocument &doc, co
     QgsOwsConnection::settingsPagingEnabled->setValue( child.attribute( QStringLiteral( "pagingenabled" ) ), { QStringLiteral( "wfs" ), connectionName } );
     QgsOwsConnection::settingsIgnoreAxisOrientation->setValue( child.attribute( QStringLiteral( "ignoreAxisOrientation" ) ).toInt(), { QStringLiteral( "wfs" ), connectionName } );
     QgsOwsConnection::settingsInvertAxisOrientation->setValue( child.attribute( QStringLiteral( "invertAxisOrientation" ) ).toInt(), { QStringLiteral( "wfs" ), connectionName } );
+    QgsOwsConnection::settingsPreferredHttpMethod->setValue( child.attribute( QStringLiteral( "httpMethod" ) ).compare( QLatin1String( "post" ), Qt::CaseInsensitive ) == 0 ? Qgis::HttpMethod::Post : Qgis::HttpMethod::Get, { QStringLiteral( "wfs" ), connectionName } );
 
     if ( !child.attribute( QStringLiteral( "username" ) ).isEmpty() )
     {

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -89,6 +89,10 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
   cmbVersion->addItem( tr( "OGC API - Features" ) );
   connect( cmbVersion, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewHttpConnection::wfsVersionCurrentIndexChanged );
 
+  mComboHttpMethod->addItem( QStringLiteral( "GET" ), QVariant::fromValue( Qgis::HttpMethod::Get ) );
+  mComboHttpMethod->addItem( QStringLiteral( "POST" ), QVariant::fromValue( Qgis::HttpMethod::Post ) );
+  mComboHttpMethod->setCurrentIndex( mComboHttpMethod->findData( QVariant::fromValue( Qgis::HttpMethod::Get ) ) );
+
   cmbFeaturePaging->clear();
   cmbFeaturePaging->addItem( tr( "Default (trust server capabilities)" ) );
   cmbFeaturePaging->addItem( tr( "Enabled" ) );
@@ -287,6 +291,11 @@ QLineEdit *QgsNewHttpConnection::wfsPageSizeLineEdit()
   return txtPageSize;
 }
 
+Qgis::HttpMethod QgsNewHttpConnection::preferredHttpMethod() const
+{
+  return mComboHttpMethod->currentData().value< Qgis::HttpMethod >();
+}
+
 QString QgsNewHttpConnection::wfsSettingsKey( const QString &base, const QString &connectionName ) const
 {
   return base + connectionName;
@@ -347,6 +356,7 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   else
     cmbFeaturePaging->setCurrentIndex( static_cast<int>( QgsNewHttpConnection::WfsFeaturePagingIndex::DEFAULT ) );
 
+  mComboHttpMethod->setCurrentIndex( mComboHttpMethod->findData( QVariant::fromValue( QgsOwsConnection::settingsPreferredHttpMethod->value( detailsParameters ) ) ) );
   txtPageSize->setText( QgsOwsConnection::settingsPagesize->value( detailsParameters ) );
 }
 
@@ -449,6 +459,7 @@ void QgsNewHttpConnection::accept()
     QgsOwsConnection::settingsVersion->setValue( version, detailsParameters );
     QgsOwsConnection::settingsMaxNumFeatures->setValue( txtMaxNumFeatures->text(), detailsParameters );
     QgsOwsConnection::settingsPagesize->setValue( txtPageSize->text(), detailsParameters );
+    QgsOwsConnection::settingsPreferredHttpMethod->setValue( mComboHttpMethod->currentData().value< Qgis::HttpMethod >(), detailsParameters );
 
     QString pagingEnabled = QStringLiteral( "default" );
     switch ( cmbFeaturePaging->currentIndex() )

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -170,6 +170,13 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     QLineEdit *wfsPageSizeLineEdit() SIP_SKIP;
 
     /**
+     * Returns the selected preferred HTTP method.
+     *
+     * \since QGIS 3.44
+     */
+    Qgis::HttpMethod preferredHttpMethod() const;
+
+    /**
      * Returns the url.
      * \since QGIS 3.2
      */

--- a/src/providers/wfs/oapif/qgsoapifcreatefeaturerequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifcreatefeaturerequest.cpp
@@ -55,7 +55,7 @@ QString QgsOapifCreateFeatureRequest::createFeature( const QgsOapifSharedData *s
   QList<QNetworkReply::RawHeaderPair> extraHeaders;
   if ( !contentCrs.isEmpty() )
     extraHeaders.append( QNetworkReply::RawHeaderPair( QByteArray( "Content-Crs" ), contentCrs.toUtf8() ) );
-  if ( !sendPOST( sharedData->mItemsUrl, "application/geo+json", jsonFeature.toUtf8(), extraHeaders ) )
+  if ( !sendPOST( sharedData->mItemsUrl, "application/geo+json", jsonFeature.toUtf8(), true /*synchronous*/, extraHeaders ) )
     return QString();
 
   QString location;

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -375,7 +375,7 @@ bool QgsBaseNetworkRequest::issueRequest( QNetworkRequest &request, const QByteA
   return success;
 }
 
-bool QgsBaseNetworkRequest::sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteArray &verb, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
+bool QgsBaseNetworkRequest::sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteArray &verb, const QString &contentTypeHeader, const QByteArray &data, bool synchronous, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
 {
   abort(); // cancel previous
   mIsAborted = false;
@@ -450,7 +450,7 @@ bool QgsBaseNetworkRequest::sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteAr
   for ( const QNetworkReply::RawHeaderPair &headerPair : std::as_const( mRequestHeaders ) )
     request.setRawHeader( headerPair.first, headerPair.second );
 
-  if ( !issueRequest( request, verb, &data, /*synchronous=*/true ) )
+  if ( !issueRequest( request, verb, &data, synchronous ) )
   {
     return false;
   }
@@ -458,19 +458,19 @@ bool QgsBaseNetworkRequest::sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteAr
   return mErrorMessage.isEmpty();
 }
 
-bool QgsBaseNetworkRequest::sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
+bool QgsBaseNetworkRequest::sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, bool synchronous, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
 {
-  return sendPOSTOrPUTOrPATCH( url, QByteArray( "POST" ), contentTypeHeader, data, extraHeaders );
+  return sendPOSTOrPUTOrPATCH( url, QByteArray( "POST" ), contentTypeHeader, data, synchronous, extraHeaders );
 }
 
 bool QgsBaseNetworkRequest::sendPUT( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
 {
-  return sendPOSTOrPUTOrPATCH( url, QByteArray( "PUT" ), contentTypeHeader, data, extraHeaders );
+  return sendPOSTOrPUTOrPATCH( url, QByteArray( "PUT" ), contentTypeHeader, data, true /*synchronous*/, extraHeaders );
 }
 
 bool QgsBaseNetworkRequest::sendPATCH( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
 {
-  return sendPOSTOrPUTOrPATCH( url, QByteArray( "PATCH" ), contentTypeHeader, data, extraHeaders );
+  return sendPOSTOrPUTOrPATCH( url, QByteArray( "PATCH" ), contentTypeHeader, data, true /*synchronous*/, extraHeaders );
 }
 
 QStringList QgsBaseNetworkRequest::sendOPTIONS( const QUrl &url )

--- a/src/providers/wfs/qgsbasenetworkrequest.h
+++ b/src/providers/wfs/qgsbasenetworkrequest.h
@@ -38,7 +38,7 @@ class QgsBaseNetworkRequest : public QObject
     bool sendGET( const QUrl &url, const QString &acceptHeader, bool synchronous, bool forceRefresh = false, bool cache = true, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
 
     //! \brief proceed to sending a synchronous POST request
-    bool sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
+    bool sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, bool synchronous, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
 
     //! \brief proceed to sending a synchronous PUT request
     bool sendPUT( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
@@ -155,7 +155,7 @@ class QgsBaseNetworkRequest : public QObject
     void logMessageIfEnabled();
 
     //! \brief proceed to sending a synchronous POST, PUT or PATCH request
-    bool sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteArray &verb, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
+    bool sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteArray &verb, const QString &contentTypeHeader, const QByteArray &data, bool synchronous, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
 
     bool issueRequest( QNetworkRequest &request, const QByteArray &verb, const QByteArray *data, bool synchronous );
 };

--- a/src/providers/wfs/qgswfsconnection.cpp
+++ b/src/providers/wfs/qgswfsconnection.cpp
@@ -18,7 +18,7 @@
 #include "qgswfsconstants.h"
 #include "qgslogger.h"
 #include "qgssettingsentryimpl.h"
-
+#include "qgssettingsentryenumflag.h"
 
 static const QString SERVICE_WFS = QStringLiteral( "WFS" );
 
@@ -58,6 +58,27 @@ QgsWfsConnection::QgsWfsConnection( const QString &connName )
   {
     mUri.removeParam( QgsWFSConstants::URI_PARAM_WFST_1_1_PREFER_COORDINATES ); // setParam allow for duplicates!
     mUri.setParam( QgsWFSConstants::URI_PARAM_WFST_1_1_PREFER_COORDINATES, settingsPreferCoordinatesForWfsT11->value( detailsParameters ) ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  }
+
+  if ( settingsPreferredHttpMethod->exists( detailsParameters ) )
+  {
+    mUri.removeParam( QgsWFSConstants::URI_PARAM_HTTPMETHOD ); // setParam allow for duplicates!
+    switch ( settingsPreferredHttpMethod->value( detailsParameters ) )
+    {
+      case Qgis::HttpMethod::Get:
+        // default, we don't set to explicitly set
+        break;
+
+      case Qgis::HttpMethod::Post:
+        mUri.setParam( QgsWFSConstants::URI_PARAM_HTTPMETHOD, QStringLiteral( "post" ) );
+        break;
+
+      case Qgis::HttpMethod::Head:
+      case Qgis::HttpMethod::Put:
+      case Qgis::HttpMethod::Delete:
+        // not supported
+        break;
+    }
   }
 
   QgsDebugMsgLevel( QStringLiteral( "WFS full uri: '%1'." ).arg( QString( mUri.uri() ) ), 4 );

--- a/src/providers/wfs/qgswfsconstants.cpp
+++ b/src/providers/wfs/qgswfsconstants.cpp
@@ -44,5 +44,6 @@ const QString QgsWFSConstants::URI_PARAM_WFST_1_1_PREFER_COORDINATES( QStringLit
 const QString QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE( QStringLiteral( "skipInitialGetFeature" ) );
 const QString QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER( QStringLiteral( "geometryTypeFilter" ) );
 const QString QgsWFSConstants::URI_PARAM_SQL( QStringLiteral( "sql" ) );
+const QString QgsWFSConstants::URI_PARAM_HTTPMETHOD( QStringLiteral( "httpMethod" ) );
 
 const QString QgsWFSConstants::VERSION_AUTO( QStringLiteral( "auto" ) );

--- a/src/providers/wfs/qgswfsconstants.h
+++ b/src/providers/wfs/qgswfsconstants.h
@@ -52,6 +52,7 @@ struct QgsWFSConstants
     static const QString URI_PARAM_SKIP_INITIAL_GET_FEATURE;
     static const QString URI_PARAM_GEOMETRY_TYPE_FILTER;
     static const QString URI_PARAM_SQL;
+    static const QString URI_PARAM_HTTPMETHOD;
 
     //
     static const QString VERSION_AUTO;

--- a/src/providers/wfs/qgswfsdataitemguiprovider.cpp
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.cpp
@@ -22,6 +22,7 @@
 #include "qgswfsconstants.h"
 #include "qgswfsdataitems.h"
 #include "qgsdataitemguiproviderutils.h"
+#include "qgssettingsentryenumflag.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -116,6 +117,8 @@ void QgsWfsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
   QgsOwsConnection::settingsMaxNumFeatures->setValue( QgsOwsConnection::settingsMaxNumFeatures->value( detailsParameters ), newDetailsParameters );
   QgsOwsConnection::settingsPagesize->setValue( QgsOwsConnection::settingsPagesize->value( detailsParameters ), newDetailsParameters );
   QgsOwsConnection::settingsPagingEnabled->setValue( QgsOwsConnection::settingsPagingEnabled->value( detailsParameters ), newDetailsParameters );
+
+  QgsOwsConnection::settingsPreferredHttpMethod->setValue( QgsOwsConnection::settingsPreferredHttpMethod->value( detailsParameters ), newDetailsParameters );
 
   QgsOwsConnection::settingsUsername->setValue( QgsOwsConnection::settingsUsername->value( detailsParameters ), newDetailsParameters );
   QgsOwsConnection::settingsPassword->setValue( QgsOwsConnection::settingsPassword->value( detailsParameters ), newDetailsParameters );

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -253,9 +253,6 @@ QUrl QgsWFSDataSourceURI::requestUrl( const QString &request, Qgis::HttpMethod m
       url = QUrl( mPostEndpoints.contains( request ) ? mPostEndpoints[request] : mURI.param( QgsWFSConstants::URI_PARAM_URL ) );
       urlQuery = QUrlQuery( url );
 
-      if ( method == Qgis::HttpMethod::Get && !request.isEmpty() )
-        urlQuery.addQueryItem( QStringLiteral( "REQUEST" ), request );
-
       const QList<QPair<QString, QString>> items = urlQuery.queryItems();
       bool hasService = false;
       bool hasRequest = false;

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -192,6 +192,7 @@ QSet<QString> QgsWFSDataSourceURI::unknownParamKeys() const
     QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE,
     QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER,
     QgsWFSConstants::URI_PARAM_SQL,
+    QgsWFSConstants::URI_PARAM_HTTPMETHOD
   };
 
   QSet<QString> l_unknownParamKeys;
@@ -416,6 +417,19 @@ void QgsWFSDataSourceURI::setOutputFormat( const QString &outputFormat )
   mURI.removeParam( QgsWFSConstants::URI_PARAM_OUTPUTFORMAT );
   if ( !outputFormat.isEmpty() )
     mURI.setParam( QgsWFSConstants::URI_PARAM_OUTPUTFORMAT, outputFormat );
+}
+
+Qgis::HttpMethod QgsWFSDataSourceURI::httpMethod() const
+{
+  if ( !mURI.hasParam( QgsWFSConstants::URI_PARAM_HTTPMETHOD ) )
+    return Qgis::HttpMethod::Get;
+
+  const QString method = mURI.param( QgsWFSConstants::URI_PARAM_HTTPMETHOD );
+  if ( method.compare( QLatin1String( "post" ), Qt::CaseInsensitive ) == 0 )
+    return Qgis::HttpMethod::Post;
+
+  // default
+  return Qgis::HttpMethod::Get;
 }
 
 bool QgsWFSDataSourceURI::isRestrictedToRequestBBOX() const

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -111,6 +111,9 @@ class QgsWFSDataSourceURI
     //! Sets GetFeature output format
     void setOutputFormat( const QString &outputFormat );
 
+    //! Returns the preferred HTTP method for requests
+    Qgis::HttpMethod httpMethod() const;
+
     //! Returns whether GetFeature request should include the request bounding box. Defaults to false
     bool isRestrictedToRequestBBOX() const;
 

--- a/src/providers/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.cpp
@@ -74,7 +74,7 @@ bool QgsWFSDescribeFeatureType::requestFeatureType( const QString &WFSVersion, c
       // not supported, impossible to hit
       break;
   }
-  BUILTIN_UNREACHABLE
+  return false;
 }
 
 QString QgsWFSDescribeFeatureType::errorMessageWithReason( const QString &reason )

--- a/src/providers/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.cpp
@@ -24,31 +24,57 @@ QgsWFSDescribeFeatureType::QgsWFSDescribeFeatureType( QgsWFSDataSourceURI &uri )
 
 bool QgsWFSDescribeFeatureType::requestFeatureType( const QString &WFSVersion, const QString &typeName, const QgsWfsCapabilities &caps )
 {
-  QUrl url( mUri.requestUrl( QStringLiteral( "DescribeFeatureType" ) ) );
-  QUrlQuery query( url );
-  query.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
+  QUrl url( mUri.requestUrl( QStringLiteral( "DescribeFeatureType" ), mUri.httpMethod() ) );
 
-  const QString namespaceValue( caps.getNamespaceParameterValue( WFSVersion, typeName ) );
-
-  if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+  switch ( mUri.httpMethod() )
   {
-    query.addQueryItem( QStringLiteral( "TYPENAMES" ), typeName );
-    if ( !namespaceValue.isEmpty() )
+    case Qgis::HttpMethod::Get:
     {
-      query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+      QUrlQuery query( url );
+      query.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
+
+      const QString namespaceValue( caps.getNamespaceParameterValue( WFSVersion, typeName ) );
+
+      if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+      {
+        query.addQueryItem( QStringLiteral( "TYPENAMES" ), typeName );
+        if ( !namespaceValue.isEmpty() )
+        {
+          query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+        }
+      }
+
+      // Always add singular form for broken servers
+      // See: https://github.com/qgis/QGIS/issues/41087
+      query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
+      if ( !namespaceValue.isEmpty() )
+      {
+        query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+      }
+
+      url.setQuery( query );
+      return sendGET( url, QString(), true, false );
     }
-  }
 
-  // Always add singular form for broken servers
-  // See: https://github.com/qgis/QGIS/issues/41087
-  query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
-  if ( !namespaceValue.isEmpty() )
-  {
-    query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
-  }
+    case Qgis::HttpMethod::Post:
+    {
+      QDomDocument postDocument = createPostDocument();
+      QDomElement describeFeatureTypeElement = createRootPostElement( caps, WFSVersion, postDocument, QStringLiteral( "wfs:DescribeFeatureType" ), { typeName } );
 
-  url.setQuery( query );
-  return sendGET( url, QString(), true, false );
+      QDomElement typeNameElement = postDocument.createElement( QStringLiteral( "wfs:TypeName" ) );
+      typeNameElement.appendChild( postDocument.createTextNode( typeName ) );
+      describeFeatureTypeElement.appendChild( typeNameElement );
+
+      return sendPOST( url, QStringLiteral( "application/xml; charset=utf-8" ), postDocument.toByteArray(), true, { QNetworkReply::RawHeaderPair { "Accept", "application/xml" } } );
+    }
+
+    case Qgis::HttpMethod::Head:
+    case Qgis::HttpMethod::Put:
+    case Qgis::HttpMethod::Delete:
+      // not supported, impossible to hit
+      break;
+  }
+  BUILTIN_UNREACHABLE
 }
 
 QString QgsWFSDescribeFeatureType::errorMessageWithReason( const QString &reason )

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -146,6 +146,9 @@ bool QgsWFSFeatureDownloaderImpl::useInvertedAxis() const
   bool invertAxis = false;
   if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) && !mShared->mURI.ignoreAxisOrientation() )
   {
+    // cloned branches are intentional here for improved readability
+    // NOLINTBEGIN(bugprone-branch-clone)
+
     // This is a bit nasty, but if the server reports OGC::CRS84
     // mSourceCrs will report hasAxisInverted() == false, but srsName()
     // will be urn:ogc:def:crs:EPSG::4326, so axis inversion is needed...
@@ -157,6 +160,8 @@ bool QgsWFSFeatureDownloaderImpl::useInvertedAxis() const
     {
       invertAxis = true;
     }
+
+    // NOLINTEND(bugprone-branch-clone)
   }
   if ( mShared->mURI.invertAxisOrientation() )
   {

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -477,7 +477,7 @@ std::pair<QUrl, QByteArray> QgsWFSFeatureDownloaderImpl::buildPostRequest( qint6
       QDomElement filterElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:Filter" ) : QStringLiteral( "ogc:Filter" ) );
       if ( filterDoc.setContent( sanitizeFilter( mShared->combineWFSFilters( filters ) ) ) )
       {
-        filterElement.appendChild( filterDoc.documentElement() );
+        filterElement.appendChild( filterDoc.documentElement().firstChildElement() );
       }
       queryElement.appendChild( filterElement );
     }

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -43,13 +43,19 @@ QgsWFSFeatureHitsAsyncRequest::QgsWFSFeatureHitsAsyncRequest( QgsWFSDataSourceUR
   connect( this, &QgsWfsRequest::downloadFinished, this, &QgsWFSFeatureHitsAsyncRequest::hitsReplyFinished );
 }
 
-void QgsWFSFeatureHitsAsyncRequest::launch( const QUrl &url )
+void QgsWFSFeatureHitsAsyncRequest::launchGet( const QUrl &url )
 {
   sendGET( url,
            QString(), // content-type
            false,     /* synchronous */
            true,      /* forceRefresh */
            false /* cache */ );
+}
+
+void QgsWFSFeatureHitsAsyncRequest::launchPost( const QUrl &url, const QByteArray &data )
+{
+  sendPOST( url, QStringLiteral( "application/xml; charset=utf-8" ), data, false, /* synchronous */
+            { QNetworkReply::RawHeaderPair { "Accept", "application/xml" } } );
 }
 
 void QgsWFSFeatureHitsAsyncRequest::hitsReplyFinished()
@@ -105,12 +111,8 @@ QString QgsWFSFeatureDownloaderImpl::sanitizeFilter( QString filter )
   return filter;
 }
 
-QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeatures, bool forHits )
+std::pair<QString, QString> QgsWFSFeatureDownloaderImpl::determineTypeNames() const
 {
-  QUrl getFeatureUrl( mShared->mURI.requestUrl( QStringLiteral( "GetFeature" ) ) );
-  QUrlQuery query( getFeatureUrl );
-  query.addQueryItem( QStringLiteral( "VERSION" ), mShared->mWFSVersion );
-
   QString typenames;
   QString namespaces;
   if ( mShared->mLayerPropertiesList.isEmpty() )
@@ -136,6 +138,42 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
       }
     }
   }
+  return std::make_pair( typenames, namespaces );
+}
+
+bool QgsWFSFeatureDownloaderImpl::useInvertedAxis() const
+{
+  bool invertAxis = false;
+  if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) && !mShared->mURI.ignoreAxisOrientation() )
+  {
+    // This is a bit nasty, but if the server reports OGC::CRS84
+    // mSourceCrs will report hasAxisInverted() == false, but srsName()
+    // will be urn:ogc:def:crs:EPSG::4326, so axis inversion is needed...
+    if ( mShared->srsName() == QLatin1String( "urn:ogc:def:crs:EPSG::4326" ) )
+    {
+      invertAxis = true;
+    }
+    else if ( mShared->mSourceCrs.hasAxisInverted() )
+    {
+      invertAxis = true;
+    }
+  }
+  if ( mShared->mURI.invertAxisOrientation() )
+  {
+    invertAxis = !invertAxis;
+  }
+  return invertAxis;
+}
+
+QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeatures, bool forHits )
+{
+  QUrl getFeatureUrl( mShared->mURI.requestUrl( QStringLiteral( "GetFeature" ), mShared->mHttpMethod ) );
+  QUrlQuery query( getFeatureUrl );
+  query.addQueryItem( QStringLiteral( "VERSION" ), mShared->mWFSVersion );
+
+  QString typenames;
+  QString namespaces;
+  std::tie( typenames, namespaces ) = determineTypeNames();
   if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
   {
     query.addQueryItem( QStringLiteral( "TYPENAMES" ), typenames );
@@ -241,25 +279,7 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
   }
   else if ( !rect.isNull() )
   {
-    bool invertAxis = false;
-    if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) && !mShared->mURI.ignoreAxisOrientation() )
-    {
-      // This is a bit nasty, but if the server reports OGC::CRS84
-      // mSourceCrs will report hasAxisInverted() == false, but srsName()
-      // will be urn:ogc:def:crs:EPSG::4326, so axis inversion is needed...
-      if ( mShared->srsName() == QLatin1String( "urn:ogc:def:crs:EPSG::4326" ) )
-      {
-        invertAxis = true;
-      }
-      else if ( mShared->mSourceCrs.hasAxisInverted() )
-      {
-        invertAxis = true;
-      }
-    }
-    if ( mShared->mURI.invertAxisOrientation() )
-    {
-      invertAxis = !invertAxis;
-    }
+    const bool invertAxis = useInvertedAxis();
     QString bbox( QString( ( invertAxis ) ? "%2,%1,%4,%3" : "%1,%2,%3,%4" )
                     .arg( qgsDoubleToString( rect.xMinimum() ), qgsDoubleToString( rect.yMinimum() ), qgsDoubleToString( rect.xMaximum() ), qgsDoubleToString( rect.yMaximum() ) ) );
     // Some servers like Geomedia need the srsname to be explicitly appended
@@ -297,16 +317,7 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
   }
   else if ( !forHits && mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) )
   {
-    QStringList list;
-    list << QStringLiteral( "text/xml; subtype=gml/3.2.1" );
-    list << QStringLiteral( "application/gml+xml; version=3.2" );
-    list << QStringLiteral( "text/xml; subtype=gml/3.1.1" );
-    list << QStringLiteral( "application/gml+xml; version=3.1" );
-    list << QStringLiteral( "text/xml; subtype=gml/3.0.1" );
-    list << QStringLiteral( "application/gml+xml; version=3.0" );
-    list << QStringLiteral( "GML3" );
-    const auto constList = list;
-    for ( const QString &format : constList )
+    for ( const QString &format : WFS1FORMATS )
     {
       if ( mShared->mCaps.outputFormats.contains( format ) )
       {
@@ -326,6 +337,188 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
   getFeatureUrl.setQuery( query );
   QgsDebugMsgLevel( QStringLiteral( "WFS GetFeature URL: %1" ).arg( getFeatureUrl.toDisplayString() ), 2 );
   return getFeatureUrl;
+}
+
+std::pair<QUrl, QByteArray> QgsWFSFeatureDownloaderImpl::buildPostRequest( qint64 startIndex, long long maxFeatures, bool forHits )
+{
+  QUrl postUrl( mShared->mURI.requestUrl( QStringLiteral( "GetFeature" ), mShared->mHttpMethod ) );
+
+  QString typenames;
+  QString namespaces;
+  std::tie( typenames, namespaces ) = determineTypeNames();
+
+  const QStringList typeNames = typenames.split( ',' );
+
+  QDomDocument postDocument = createPostDocument();
+  QDomElement getFeatureElement = createRootPostElement(
+    mShared->mCaps,
+    mShared->mWFSVersion,
+    postDocument,
+    QStringLiteral( "wfs:GetFeature" ),
+    typeNames
+  );
+
+  if ( forHits )
+  {
+    getFeatureElement.setAttribute( QStringLiteral( "resultType" ), QStringLiteral( "hits" ) );
+  }
+  else if ( maxFeatures > 0 )
+  {
+    if ( mPageSize > 0 )
+    {
+      getFeatureElement.setAttribute( QStringLiteral( "startIndex" ), QString::number( startIndex ) );
+    }
+
+    if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+    {
+      getFeatureElement.setAttribute( QStringLiteral( "count" ), QString::number( maxFeatures ) );
+    }
+    else
+    {
+      getFeatureElement.setAttribute( QStringLiteral( "maxFeatures" ), QString::number( maxFeatures ) );
+    }
+  }
+
+  // Add output format if specified
+  if ( !forHits && !mShared->mURI.outputFormat().isEmpty() )
+  {
+    getFeatureElement.setAttribute( QStringLiteral( "outputFormat" ), mShared->mURI.outputFormat() );
+  }
+  else if ( !forHits && mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) )
+  {
+    for ( const QString &format : WFS1FORMATS )
+    {
+      if ( mShared->mCaps.outputFormats.contains( format ) )
+      {
+        getFeatureElement.setAttribute( QStringLiteral( "outputFormat" ), format );
+        break;
+      }
+    }
+  }
+
+  auto buildQueryElement = [&postDocument, forHits, this]( const QString &typeName, const QString &geometryAttribute ) -> QDomElement {
+    QDomElement queryElement = postDocument.createElement( QStringLiteral( "wfs:Query" ) );
+
+    const bool useVersion2 = mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) );
+    if ( useVersion2 )
+    {
+      queryElement.setAttribute( QStringLiteral( "typeNames" ), typeName );
+    }
+    else
+    {
+      queryElement.setAttribute( QStringLiteral( "typeName" ), typeName );
+    }
+
+    // Add srsName if specified
+    QString srsName( mShared->srsName() );
+    if ( !srsName.isEmpty() && !forHits )
+    {
+      queryElement.setAttribute( QStringLiteral( "srsName" ), srsName );
+    }
+
+    std::vector<QString> filters;
+    if ( !mShared->mServerExpression.isEmpty() )
+    {
+      filters.push_back( mShared->mServerExpression );
+    }
+    if ( !mShared->mWFSFilter.isEmpty() )
+    {
+      filters.push_back( mShared->mWFSFilter );
+    }
+    if ( !mShared->mWFSGeometryTypeFilter.isEmpty() )
+    {
+      filters.push_back( mShared->mWFSGeometryTypeFilter );
+    }
+
+    const QgsRectangle &rect = mShared->currentRect();
+    if ( !rect.isNull() )
+    {
+      QDomDocument bboxDoc;
+      QDomElement bboxElement = useVersion2 ? bboxDoc.createElement( QStringLiteral( "fes:BBOX" ) ) : bboxDoc.createElement( QStringLiteral( "ogc:BBOX" ) );
+      bboxDoc.appendChild( bboxElement );
+
+      if ( useVersion2 )
+      {
+        QDomElement valueRefElement = postDocument.createElement( QStringLiteral( "fes:ValueReference" ) );
+        valueRefElement.appendChild( postDocument.createTextNode( geometryAttribute ) );
+        bboxElement.appendChild( valueRefElement );
+      }
+      else
+      {
+        QDomElement propertyNameElement = postDocument.createElement( QStringLiteral( "ogc:PropertyName" ) );
+        propertyNameElement.appendChild( postDocument.createTextNode( geometryAttribute ) );
+        bboxElement.appendChild( propertyNameElement );
+      }
+
+      const bool invertAxis = useInvertedAxis();
+      if ( mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) )
+      {
+        QDomElement boxElement = QgsOgcUtils::rectangleToGMLBox( &rect, postDocument, srsName, invertAxis );
+        bboxElement.appendChild( boxElement );
+      }
+      else
+      {
+        // WFS 1.1, 2.0 use GML Envelope
+        const QDomElement envelopeElement = QgsOgcUtils::rectangleToGMLEnvelope( &rect, postDocument, srsName, invertAxis );
+        bboxElement.appendChild( envelopeElement );
+      }
+
+      filters.push_back( bboxDoc.toString() );
+    }
+
+    if ( !filters.empty() )
+    {
+      QDomDocument filterDoc;
+      QDomElement filterElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:Filter" ) : QStringLiteral( "ogc:Filter" ) );
+      if ( filterDoc.setContent( sanitizeFilter( mShared->combineWFSFilters( filters ) ) ) )
+      {
+        filterElement.appendChild( filterDoc.documentElement() );
+      }
+      queryElement.appendChild( filterElement );
+    }
+
+    if ( !mShared->mSortBy.isEmpty() && !forHits )
+    {
+      QDomElement sortByElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:SortBy" ) : QStringLiteral( "ogc:SortBy" ) );
+
+      const QStringList sortColumns = mShared->mSortBy.split( QLatin1Char( ',' ) );
+      for ( const QString &sortColumn : sortColumns )
+      {
+        const QStringList sortComponents = sortColumn.split( QLatin1Char( ' ' ) );
+        const QString propertyName = sortComponents[0];
+        const QString sortOrder = ( sortComponents.size() > 1 && sortComponents[1].startsWith( 'D', Qt::CaseInsensitive ) ) ? QStringLiteral( "DESC" ) : QStringLiteral( "ASC" );
+
+        QDomElement sortPropertyElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:SortProperty" ) : QStringLiteral( "ogc:SortProperty" ) );
+
+        QDomElement propertyElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:ValueReference" ) : QStringLiteral( "ogc:PropertyName" ) );
+        propertyElement.appendChild( postDocument.createTextNode( propertyName ) );
+        sortPropertyElement.appendChild( propertyElement );
+
+        QDomElement sortOrderElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:SortOrder" ) : QStringLiteral( "ogc:SortOrder" ) );
+        sortOrderElement.appendChild( postDocument.createTextNode( sortOrder ) );
+        sortPropertyElement.appendChild( sortOrderElement );
+
+        sortByElement.appendChild( sortPropertyElement );
+      }
+
+      queryElement.appendChild( sortByElement );
+    }
+
+    return queryElement;
+  };
+
+  for ( const QString &typeName : typeNames )
+  {
+    QString geometryAttribute = mShared->mGeometryAttribute;
+    if ( mShared->mLayerPropertiesList.size() > 1 )
+    {
+      geometryAttribute = typeName + "/" + geometryAttribute;
+    }
+
+    getFeatureElement.appendChild( buildQueryElement( typenames, geometryAttribute ) );
+  }
+
+  return std::make_pair( postUrl, postDocument.toByteArray() );
 }
 
 // Called when we get the response of the asynchronous RESULTTYPE=hits request
@@ -354,7 +547,26 @@ void QgsWFSFeatureDownloaderImpl::startHitsRequest()
   if ( mNumberMatched < 0 )
   {
     connect( &mFeatureHitsAsyncRequest, &QgsWFSFeatureHitsAsyncRequest::gotHitsResponse, this, &QgsWFSFeatureDownloaderImpl::gotHitsResponse );
-    mFeatureHitsAsyncRequest.launch( buildURL( 0, -1, true ) );
+    switch ( mUri.httpMethod() )
+    {
+      case Qgis::HttpMethod::Get:
+      {
+        mFeatureHitsAsyncRequest.launchGet( buildURL( 0, -1, true ) );
+        break;
+      }
+      case Qgis::HttpMethod::Post:
+      {
+        QByteArray data;
+        QUrl url;
+        std::tie( url, data ) = buildPostRequest( 0, -1, true );
+        mFeatureHitsAsyncRequest.launchPost( url, data );
+        break;
+      }
+      case Qgis::HttpMethod::Head:
+      case Qgis::HttpMethod::Put:
+      case Qgis::HttpMethod::Delete:
+        break;
+    }
   }
 }
 
@@ -432,21 +644,53 @@ void QgsWFSFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFeat
         maxFeaturesThisRequest = mShared->mPageSize;
       }
     }
-    QUrl url( buildURL( mTotalDownloadedFeatureCount, maxFeaturesThisRequest, false ) );
 
-    // Small hack for testing purposes
-    if ( retryIter > 0 && url.toString().contains( QLatin1String( "fake_qgis_http_endpoint" ) ) )
+    QUrl url;
+    switch ( mShared->mHttpMethod )
     {
-      QUrlQuery query( url );
-      query.addQueryItem( QStringLiteral( "RETRY" ), QString::number( retryIter ) );
-      url.setQuery( query );
-    }
+      case Qgis::HttpMethod::Get:
+      {
+        url = buildURL( mTotalDownloadedFeatureCount, maxFeaturesThisRequest, false );
 
-    sendGET( url,
-             QString(), // content-type
-             false,     /* synchronous */
-             true,      /* forceRefresh */
-             false /* cache */ );
+        // Small hack for testing purposes
+        if ( retryIter > 0 && url.toString().contains( QLatin1String( "fake_qgis_http_endpoint" ) ) )
+        {
+          QUrlQuery query( url );
+          query.addQueryItem( QStringLiteral( "RETRY" ), QString::number( retryIter ) );
+          url.setQuery( query );
+        }
+
+        sendGET( url,
+                 QString(), // content-type
+                 false,     /* synchronous */
+                 true,      /* forceRefresh */
+                 false /* cache */ );
+        break;
+      }
+
+      case Qgis::HttpMethod::Post:
+      {
+        QByteArray data;
+        std::tie( url, data ) = buildPostRequest( mTotalDownloadedFeatureCount, maxFeaturesThisRequest, false );
+
+        // Small hack for testing purposes
+        if ( retryIter > 0 && url.toString().contains( QLatin1String( "fake_qgis_http_endpoint" ) ) )
+        {
+          QUrlQuery query( url );
+          query.addQueryItem( QStringLiteral( "RETRY" ), QString::number( retryIter ) );
+          url.setQuery( query );
+        }
+
+        sendPOST( url, QStringLiteral( "application/xml; charset=utf-8" ), data, false, { QNetworkReply::RawHeaderPair { "Accept", "application/xml" } } );
+        break;
+      }
+
+      case Qgis::HttpMethod::Head:
+      case Qgis::HttpMethod::Put:
+      case Qgis::HttpMethod::Delete:
+        // not possible!
+        break;
+    }
 
     long long featureCountForThisResponse = 0;
     bool bytesStillAvailableInReply = false;

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -38,7 +38,8 @@ class QgsWFSFeatureHitsAsyncRequest final : public QgsWfsRequest
   public:
     explicit QgsWFSFeatureHitsAsyncRequest( QgsWFSDataSourceURI &uri );
 
-    void launch( const QUrl &url );
+    void launchGet( const QUrl &url );
+    void launchPost( const QUrl &url, const QByteArray &data );
 
     //! Returns result of request, or -1 if not known/error
     int numberMatched() const { return mNumberMatched; }
@@ -95,8 +96,12 @@ class QgsWFSFeatureDownloaderImpl final : public QgsWfsRequest, public QgsFeatur
 
   private:
     QUrl buildURL( qint64 startIndex, long long maxFeatures, bool forHits );
+    std::pair<QUrl, QByteArray> buildPostRequest( qint64 startIndex, long long maxFeatures, bool forHits );
+
     void pushError( const QString &errorMsg );
     QString sanitizeFilter( QString filter );
+    std::pair<QString, QString> determineTypeNames() const;
+    bool useInvertedAxis() const;
 
     //! Mutable data shared between provider, feature sources and downloader.
     QgsWFSSharedData *mShared = nullptr;
@@ -106,6 +111,8 @@ class QgsWFSFeatureDownloaderImpl final : public QgsWfsRequest, public QgsFeatur
     long long mNumberMatched = -1;
     QgsWFSFeatureHitsAsyncRequest mFeatureHitsAsyncRequest;
     qint64 mTotalDownloadedFeatureCount = 0;
+
+    const QStringList WFS1FORMATS { QStringLiteral( "text/xml; subtype=gml/3.2.1" ), QStringLiteral( "application/gml+xml; version=3.2" ), QStringLiteral( "text/xml; subtype=gml/3.1.1" ), QStringLiteral( "application/gml+xml; version=3.1" ), QStringLiteral( "text/xml; subtype=gml/3.0.1" ), QStringLiteral( "application/gml+xml; version=3.0" ), QStringLiteral( "GML3" ) };
 };
 
 

--- a/src/providers/wfs/qgswfsgetfeature.cpp
+++ b/src/providers/wfs/qgswfsgetfeature.cpp
@@ -110,7 +110,7 @@ bool QgsWFSGetFeature::request( bool synchronous, const QString &WFSVersion, con
       // not supported, impossible to hit
       break;
   }
-  BUILTIN_UNREACHABLE
+  return false;
 }
 
 QString QgsWFSGetFeature::errorMessageWithReason( const QString &reason )

--- a/src/providers/wfs/qgswfsgetfeature.cpp
+++ b/src/providers/wfs/qgswfsgetfeature.cpp
@@ -15,6 +15,8 @@
 
 #include "qgswfsgetfeature.h"
 #include "moc_qgswfsgetfeature.cpp"
+#include "qgsmessagelog.h"
+#include "qgswfsconstants.h"
 #include <QUrlQuery>
 
 QgsWFSGetFeature::QgsWFSGetFeature( QgsWFSDataSourceURI &uri )
@@ -24,42 +26,91 @@ QgsWFSGetFeature::QgsWFSGetFeature( QgsWFSDataSourceURI &uri )
 
 bool QgsWFSGetFeature::request( bool synchronous, const QString &WFSVersion, const QString &typeName, const QString &filter, bool hitsOnly, const QgsWfsCapabilities &caps )
 {
-  QUrl url( mUri.requestUrl( QStringLiteral( "GetFeature" ) ) );
-  QUrlQuery query( url );
-  query.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
+  QUrl url( mUri.requestUrl( QStringLiteral( "GetFeature" ), mUri.httpMethod() ) );
 
-  const QString namespaceValue( caps.getNamespaceParameterValue( WFSVersion, typeName ) );
-
-  if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+  switch ( mUri.httpMethod() )
   {
-    query.addQueryItem( QStringLiteral( "TYPENAMES" ), typeName );
-    if ( !namespaceValue.isEmpty() )
+    case Qgis::HttpMethod::Get:
     {
-      query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+      QUrlQuery query( url );
+      query.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
+
+      const QString namespaceValue( caps.getNamespaceParameterValue( WFSVersion, typeName ) );
+
+      if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+      {
+        query.addQueryItem( QStringLiteral( "TYPENAMES" ), typeName );
+        if ( !namespaceValue.isEmpty() )
+        {
+          query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+        }
+      }
+      else
+      {
+        query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
+      }
+
+      if ( !namespaceValue.isEmpty() )
+      {
+        query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+      }
+
+      if ( !filter.isEmpty() )
+      {
+        query.addQueryItem( QStringLiteral( "FILTER" ), filter );
+      }
+
+      if ( hitsOnly )
+      {
+        query.addQueryItem( QStringLiteral( "RESULTTYPE" ), "hits" );
+      }
+      url.setQuery( query );
+      return sendGET( url, QString(), synchronous, /*forceRefresh=*/true, /* cache=*/false );
     }
-  }
-  else
-  {
-    query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
-  }
+    case Qgis::HttpMethod::Post:
+    {
+      QDomDocument postDocument = createPostDocument();
+      QDomElement getFeatureElement = createRootPostElement( caps, WFSVersion, postDocument, QStringLiteral( "wfs:GetFeature" ), { typeName } );
 
-  if ( !namespaceValue.isEmpty() )
-  {
-    query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
-  }
+      const bool useVersion2 = !WFSVersion.startsWith( QLatin1String( "1." ) );
 
-  if ( !filter.isEmpty() )
-  {
-    query.addQueryItem( QStringLiteral( "FILTER" ), filter );
-  }
+      QDomElement queryElement = postDocument.createElement( QStringLiteral( "wfs:Query" ) );
+      if ( useVersion2 )
+      {
+        queryElement.setAttribute( QStringLiteral( "typeNames" ), typeName );
+      }
+      else
+      {
+        queryElement.setAttribute( QStringLiteral( "typeName" ), typeName );
+      }
 
-  if ( hitsOnly )
-  {
-    query.addQueryItem( QStringLiteral( "RESULTTYPE" ), "hits" );
-  }
+      if ( !filter.isEmpty() )
+      {
+        QDomDocument filterDoc;
+        QDomElement filterElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:Filter" ) : QStringLiteral( "ogc:Filter" ) );
+        if ( filterDoc.setContent( filter ) )
+        {
+          filterElement.appendChild( filterDoc.documentElement() );
+        }
+        queryElement.appendChild( filterElement );
+      }
+      getFeatureElement.appendChild( queryElement );
 
-  url.setQuery( query );
-  return sendGET( url, QString(), synchronous, /*forceRefresh=*/true, /* cache=*/false );
+      if ( hitsOnly )
+      {
+        getFeatureElement.setAttribute( QStringLiteral( "resultType" ), QStringLiteral( "hits" ) );
+      }
+
+      return sendPOST( url, QStringLiteral( "application/xml; charset=utf-8" ), postDocument.toByteArray(), synchronous, { QNetworkReply::RawHeaderPair { "Accept", "application/xml" } } );
+    }
+
+    case Qgis::HttpMethod::Head:
+    case Qgis::HttpMethod::Put:
+    case Qgis::HttpMethod::Delete:
+      // not supported, impossible to hit
+      break;
+  }
+  BUILTIN_UNREACHABLE
 }
 
 QString QgsWFSGetFeature::errorMessageWithReason( const QString &reason )

--- a/src/providers/wfs/qgswfsrequest.h
+++ b/src/providers/wfs/qgswfsrequest.h
@@ -23,6 +23,7 @@
 
 #include "qgswfsdatasourceuri.h"
 #include "qgsbasenetworkrequest.h"
+#include "qgswfscapabilities.h"
 
 //! Abstract base class for a WFS request.
 class QgsWfsRequest : public QgsBaseNetworkRequest
@@ -35,6 +36,15 @@ class QgsWfsRequest : public QgsBaseNetworkRequest
     QUrl requestUrl( const QString &request ) const;
 
   protected:
+    QDomDocument createPostDocument() const;
+    QDomElement createRootPostElement(
+      const QgsWfsCapabilities &capabilities,
+      const QString &wfsVersion,
+      QDomDocument &postDocument,
+      const QString &name,
+      const QStringList &typeNamesForNamespaces = QStringList()
+    ) const;
+
     //! URI
     QgsWFSDataSourceURI mUri;
 };

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -456,40 +456,111 @@ long long QgsWFSFeatureHitsRequest::getFeatureCount( const QString &WFSVersion, 
 {
   const QString typeName = mUri.typeName();
 
-  QUrl getFeatureUrl( mUri.requestUrl( QStringLiteral( "GetFeature" ) ) );
-  QUrlQuery query( getFeatureUrl );
-  query.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
-  if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
-  {
-    query.addQueryItem( QStringLiteral( "TYPENAMES" ), typeName );
-  }
-  else
-  {
-    query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
-  }
+  QUrl getFeatureUrl( mUri.requestUrl( QStringLiteral( "GetFeature" ), mUri.httpMethod() ) );
 
-  const QString namespaceValue( caps.getNamespaceParameterValue( WFSVersion, typeName ) );
-  if ( !namespaceValue.isEmpty() )
+  switch ( mUri.httpMethod() )
   {
-    if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+    case Qgis::HttpMethod::Get:
     {
-      query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+      QUrlQuery query( getFeatureUrl );
+      query.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
+      if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+      {
+        query.addQueryItem( QStringLiteral( "TYPENAMES" ), typeName );
+      }
+      else
+      {
+        query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
+      }
+
+      const QString namespaceValue( caps.getNamespaceParameterValue( WFSVersion, typeName ) );
+      if ( !namespaceValue.isEmpty() )
+      {
+        if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+        {
+          query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+        }
+        else
+        {
+          query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+        }
+      }
+
+      if ( !filter.isEmpty() )
+      {
+        query.addQueryItem( QStringLiteral( "FILTER" ), filter );
+      }
+      query.addQueryItem( QStringLiteral( "RESULTTYPE" ), QStringLiteral( "hits" ) );
+
+      getFeatureUrl.setQuery( query );
+      if ( !sendGET( getFeatureUrl, QString(), true ) )
+        return -1;
+
+      break;
     }
-    else
+    case Qgis::HttpMethod::Post:
     {
-      query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+      QUrlQuery query( getFeatureUrl );
+      const QList<QPair<QString, QString>> items = query.queryItems();
+      bool hasService = false;
+      bool hasRequest = false;
+      for ( const auto &item : items )
+      {
+        if ( item.first.toUpper() == QLatin1String( "SERVICE" ) )
+          hasService = true;
+        if ( item.first.toUpper() == QLatin1String( "REQUEST" ) )
+          hasRequest = true;
+      }
+
+      // add service / request parameters only if they don't exist in the explicitly defined post URL
+      if ( !hasService )
+        query.addQueryItem( QStringLiteral( "SERVICE" ), QStringLiteral( "WFS" ) );
+      if ( !hasRequest )
+        query.addQueryItem( QStringLiteral( "REQUEST" ), QStringLiteral( "GetFeature" ) );
+
+      getFeatureUrl.setQuery( query );
+
+      QDomDocument postDocument = createPostDocument();
+      QDomElement getFeatureElement = createRootPostElement( caps, WFSVersion, postDocument, QStringLiteral( "wfs:GetFeature" ), { typeName } );
+
+      const bool useVersion2 = !WFSVersion.startsWith( QLatin1String( "1." ) );
+
+      QDomElement queryElement = postDocument.createElement( QStringLiteral( "wfs:Query" ) );
+      if ( useVersion2 )
+      {
+        queryElement.setAttribute( QStringLiteral( "typeNames" ), typeName );
+      }
+      else
+      {
+        queryElement.setAttribute( QStringLiteral( "typeName" ), typeName );
+      }
+
+      if ( !filter.isEmpty() )
+      {
+        QDomDocument filterDoc;
+        QDomElement filterElement = postDocument.createElement( useVersion2 ? QStringLiteral( "fes:Filter" ) : QStringLiteral( "ogc:Filter" ) );
+        if ( filterDoc.setContent( filter ) )
+        {
+          filterElement.appendChild( filterDoc.documentElement() );
+        }
+        queryElement.appendChild( filterElement );
+      }
+      getFeatureElement.appendChild( queryElement );
+
+      getFeatureElement.setAttribute( QStringLiteral( "resultType" ), QStringLiteral( "hits" ) );
+
+      if ( !sendPOST( getFeatureUrl, QStringLiteral( "application/xml; charset=utf-8" ), postDocument.toByteArray(), true, { QNetworkReply::RawHeaderPair { "Accept", "application/xml" } } ) )
+        return -1;
+
+      break;
     }
-  }
 
-  if ( !filter.isEmpty() )
-  {
-    query.addQueryItem( QStringLiteral( "FILTER" ), filter );
+    case Qgis::HttpMethod::Head:
+    case Qgis::HttpMethod::Put:
+    case Qgis::HttpMethod::Delete:
+      // not supported, impossible to hit
+      return -1;
   }
-  query.addQueryItem( QStringLiteral( "RESULTTYPE" ), QStringLiteral( "hits" ) );
-
-  getFeatureUrl.setQuery( query );
-  if ( !sendGET( getFeatureUrl, QString(), true ) )
-    return -1;
 
   const QByteArray &buffer = response();
 
@@ -535,31 +606,79 @@ QgsWFSSingleFeatureRequest::QgsWFSSingleFeatureRequest( const QgsWFSSharedData *
 
 QgsRectangle QgsWFSSingleFeatureRequest::getExtent()
 {
-  QUrl getFeatureUrl( mUri.requestUrl( QStringLiteral( "GetFeature" ) ) );
-  QUrlQuery query( getFeatureUrl );
-  query.addQueryItem( QStringLiteral( "VERSION" ), mShared->mWFSVersion );
-  if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
-    query.addQueryItem( QStringLiteral( "TYPENAMES" ), mUri.typeName() );
-  else
-    query.addQueryItem( QStringLiteral( "TYPENAME" ), mUri.typeName() );
+  QUrl getFeatureUrl( mUri.requestUrl( QStringLiteral( "GetFeature" ), mUri.httpMethod() ) );
 
-  const QString namespaceValue( mShared->mCaps.getNamespaceParameterValue( mShared->mWFSVersion, mUri.typeName() ) );
-  if ( !namespaceValue.isEmpty() )
+  switch ( mUri.httpMethod() )
   {
-    if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
-      query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
-    else
-      query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+    case Qgis::HttpMethod::Get:
+    {
+      QUrlQuery query( getFeatureUrl );
+      query.addQueryItem( QStringLiteral( "VERSION" ), mShared->mWFSVersion );
+      if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+        query.addQueryItem( QStringLiteral( "TYPENAMES" ), mUri.typeName() );
+      else
+        query.addQueryItem( QStringLiteral( "TYPENAME" ), mUri.typeName() );
+
+      const QString namespaceValue( mShared->mCaps.getNamespaceParameterValue( mShared->mWFSVersion, mUri.typeName() ) );
+      if ( !namespaceValue.isEmpty() )
+      {
+        if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+          query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+        else
+          query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+      }
+
+      if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+        query.addQueryItem( QStringLiteral( "COUNT" ), QString::number( 1 ) );
+      else
+        query.addQueryItem( QStringLiteral( "MAXFEATURES" ), QString::number( 1 ) );
+
+      getFeatureUrl.setQuery( query );
+      if ( !sendGET( getFeatureUrl, QString(), true ) )
+        return QgsRectangle();
+      break;
+    }
+
+    case Qgis::HttpMethod::Post:
+    {
+      QDomDocument postDocument = createPostDocument();
+      QDomElement getFeatureElement = createRootPostElement( mShared->mCaps, mShared->mWFSVersion, postDocument, QStringLiteral( "wfs:GetFeature" ), { mUri.typeName() } );
+
+      const bool useVersion2 = !mShared->mWFSVersion.startsWith( QLatin1String( "1." ) );
+
+      QDomElement queryElement = postDocument.createElement( QStringLiteral( "wfs:Query" ) );
+      if ( useVersion2 )
+      {
+        queryElement.setAttribute( QStringLiteral( "typeNames" ), mUri.typeName() );
+      }
+      else
+      {
+        queryElement.setAttribute( QStringLiteral( "typeName" ), mUri.typeName() );
+      }
+
+      getFeatureElement.appendChild( queryElement );
+
+      if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+      {
+        getFeatureElement.setAttribute( QStringLiteral( "count" ), QString::number( 1 ) );
+      }
+      else
+      {
+        getFeatureElement.setAttribute( QStringLiteral( "maxFeatures" ), QString::number( 1 ) );
+      }
+
+      if ( !sendPOST( getFeatureUrl, QStringLiteral( "application/xml; charset=utf-8" ), postDocument.toByteArray(), true, { QNetworkReply::RawHeaderPair { "Accept", "application/xml" } } ) )
+        return QgsRectangle();
+
+      break;
+    }
+
+    case Qgis::HttpMethod::Head:
+    case Qgis::HttpMethod::Put:
+    case Qgis::HttpMethod::Delete:
+      // not supported, impossible to hit
+      return QgsRectangle();
   }
-
-  if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
-    query.addQueryItem( QStringLiteral( "COUNT" ), QString::number( 1 ) );
-  else
-    query.addQueryItem( QStringLiteral( "MAXFEATURES" ), QString::number( 1 ) );
-
-  getFeatureUrl.setQuery( query );
-  if ( !sendGET( getFeatureUrl, QString(), true ) )
-    return QgsRectangle();
 
   const QByteArray &buffer = response();
 

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -25,6 +25,7 @@
 QgsWFSSharedData::QgsWFSSharedData( const QString &uri )
   : QgsBackgroundCachedSharedData( "wfs", tr( "WFS" ) )
   , mURI( uri )
+  , mHttpMethod( mURI.httpMethod() )
 {
   mHideProgressDialog = mURI.hideDownloadProgressDialog();
   mServerPrefersCoordinatesForTransactions_1_1 = mURI.preferCoordinatesForWfst11();

--- a/src/providers/wfs/qgswfsshareddata.h
+++ b/src/providers/wfs/qgswfsshareddata.h
@@ -108,6 +108,9 @@ class QgsWFSSharedData : public QObject, public QgsBackgroundCachedSharedData
     //! Map a namespace prefix to its URI
     QMap<QString, QString> mNamespacePrefixToURIMap;
 
+    //! Preferred HTTP method
+    Qgis::HttpMethod mHttpMethod = Qgis::HttpMethod::Get;
+
     //! Page size for WFS 2.0. 0 = disabled
     long long mPageSize = 0;
 

--- a/src/providers/wfs/qgswfstransactionrequest.cpp
+++ b/src/providers/wfs/qgswfstransactionrequest.cpp
@@ -28,7 +28,7 @@ bool QgsWFSTransactionRequest::send( const QDomDocument &doc, QDomDocument &serv
 
   QgsDebugMsgLevel( doc.toString(), 4 );
 
-  if ( sendPOST( url, QStringLiteral( "text/xml" ), doc.toByteArray( -1 ) ) )
+  if ( sendPOST( url, QStringLiteral( "text/xml" ), doc.toByteArray( -1 ), /*synchronous*/ true ) )
   {
     QString errorMsg;
     if ( !serverResponse.setContent( mResponse, true, &errorMsg ) )

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -111,6 +111,16 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblVersion_2">
+           <property name="text">
+            <string>Preferred HTTP method</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" colspan="2">
+          <widget class="QComboBox" name="mComboHttpMethod"/>
+         </item>
         </layout>
        </widget>
       </item>
@@ -380,6 +390,7 @@
   <tabstop>txtUrl</tabstop>
   <tabstop>cmbVersion</tabstop>
   <tabstop>mWfsVersionDetectButton</tabstop>
+  <tabstop>mComboHttpMethod</tabstop>
   <tabstop>txtMaxNumFeatures</tabstop>
   <tabstop>cmbFeaturePaging</tabstop>
   <tabstop>txtPageSize</tabstop>

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -1292,7 +1292,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789Z</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789Z</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>',
             ),
             "wb",
         ) as f:
@@ -1302,7 +1302,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789Z</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>',
+                '?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789Z</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>',
             ),
             "wb",
         ) as f:
@@ -1375,7 +1375,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:geometryProperty</Name><Value xmlns="http://www.opengis.net/wfs"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">3,50</gml:coordinates></gml:Point></Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:geometryProperty</Name><Value xmlns="http://www.opengis.net/wfs"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">3,50</gml:coordinates></gml:Point></Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
             ),
             "wb",
         ) as f:
@@ -1385,7 +1385,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:geometryProperty</Name><Value xmlns="http://www.opengis.net/wfs"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">3,50</gml:coordinates></gml:Point></Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
+                '?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:geometryProperty</Name><Value xmlns="http://www.opengis.net/wfs"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">3,50</gml:coordinates></gml:Point></Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
             ),
             "wb",
         ) as f:
@@ -1436,7 +1436,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789Z</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789Z</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
             ),
             "wb",
         ) as f:
@@ -1446,7 +1446,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789Z</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
+                '?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">my:datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789Z</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>',
             ),
             "wb",
         ) as f:
@@ -1508,7 +1508,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Delete xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Delete></Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Delete xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Delete></Transaction>',
             ),
             "wb",
         ) as f:
@@ -1518,7 +1518,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 transaction_endpoint,
-                '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Delete xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Delete></Transaction>',
+                '?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" version="1.0.0" service="WFS"><Delete xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Delete></Transaction>',
             ),
             "wb",
         ) as f:
@@ -7144,7 +7144,7 @@ Can't recognize service requested.
             ),
             sanitize(
                 endpoint,
-                '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http:__www.opengis.net_wfs" xmlns:xsi="http:__www.w3.org_2001_XMLSchema-instance" xmlns:gml="http:__www.opengis.net_gml" xmlns:ws1="ws1" xsi:schemaLocation="ws1 http:__fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=ws1:polygons" version="1.1.0" service="WFS"><Insert xmlns="http:__www.opengis.net_wfs"><polygons xmlns="ws1"_><_Insert><_Transaction>',
+                '?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction xmlns="http:__www.opengis.net_wfs" xmlns:xsi="http:__www.w3.org_2001_XMLSchema-instance" xmlns:gml="http:__www.opengis.net_gml" xmlns:ws1="ws1" xsi:schemaLocation="ws1 http:__fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=ws1:polygons" version="1.1.0" service="WFS"><Insert xmlns="http:__www.opengis.net_wfs"><polygons xmlns="ws1"_><_Insert><_Transaction>',
             ),
         )
 
@@ -7169,7 +7169,7 @@ Can't recognize service requested.
             ),
             sanitize(
                 endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Insert xmlns="http:__www.opengis.net_wfs"><polygons xmlns="ws1"><name xmlns="ws1">one<_name><value xmlns="ws1">1<_value><geometry xmlns="ws1"><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">45 9 45 10 46 10 46 9 45 9<_gml:posList><_gml:LinearRing><_gml:exterior><_gml:Polygon><_geometry><_polygons><_Insert><_Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Insert xmlns="http:__www.opengis.net_wfs"><polygons xmlns="ws1"><name xmlns="ws1">one<_name><value xmlns="ws1">1<_value><geometry xmlns="ws1"><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">45 9 45 10 46 10 46 9 45 9<_gml:posList><_gml:LinearRing><_gml:exterior><_gml:Polygon><_geometry><_polygons><_Insert><_Transaction>',
             ),
         )
 
@@ -7194,7 +7194,7 @@ Can't recognize service requested.
             ),
             sanitize(
                 endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="ws1:polygons"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">ws1:name</Name><Value xmlns="http://www.opengis.net/wfs">one-one-one</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">ws1:value</Name><Value xmlns="http://www.opengis.net/wfs">111</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="123"/></Filter></Update></Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="ws1:polygons"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">ws1:name</Name><Value xmlns="http://www.opengis.net/wfs">one-one-one</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">ws1:value</Name><Value xmlns="http://www.opengis.net/wfs">111</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="123"/></Filter></Update></Transaction>',
             ),
         )
 
@@ -7216,7 +7216,7 @@ Can't recognize service requested.
             ),
             sanitize(
                 endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="ws1:polygons"><Property xmlns="http:__www.opengis.net_wfs"><Name xmlns="http:__www.opengis.net_wfs">ws1:geometry<_Name><Value xmlns="http:__www.opengis.net_wfs"><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">46 10 46 11 47 11 47 10 46 10<_gml:posList><_gml:LinearRing><_gml:exterior><_gml:Polygon><_Value><_Property><Filter xmlns="http:__www.opengis.net_ogc"><FeatureId xmlns="http:__www.opengis.net_ogc" fid="123"_><_Filter><_Update><_Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Update xmlns="http://www.opengis.net/wfs" typeName="ws1:polygons"><Property xmlns="http:__www.opengis.net_wfs"><Name xmlns="http:__www.opengis.net_wfs">ws1:geometry<_Name><Value xmlns="http:__www.opengis.net_wfs"><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">46 10 46 11 47 11 47 10 46 10<_gml:posList><_gml:LinearRing><_gml:exterior><_gml:Polygon><_Value><_Property><Filter xmlns="http:__www.opengis.net_ogc"><FeatureId xmlns="http:__www.opengis.net_ogc" fid="123"_><_Filter><_Update><_Transaction>',
             ),
         )
 
@@ -7238,7 +7238,7 @@ Can't recognize service requested.
             ),
             sanitize(
                 endpoint,
-                f'?SERVICE=WFS&POSTDATA=<Transaction {attrs}><Delete xmlns="http://www.opengis.net/wfs" typeName="ws1:polygons"><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="123"/></Filter></Delete></Transaction>',
+                f'?SERVICE=WFS&REQUEST=Transaction&POSTDATA=<Transaction {attrs}><Delete xmlns="http://www.opengis.net/wfs" typeName="ws1:polygons"><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="123"/></Filter></Delete></Transaction>',
             ),
         )
 

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -12,6 +12,7 @@ __copyright__ = "Copyright 2016, Even Rouault"
 
 import hashlib
 import http.server
+from pathlib import Path
 import os
 import re
 import shutil
@@ -21,6 +22,8 @@ import threading
 
 # Needed on Qt 5 so that the serialization of XML is consistent among all executions
 os.environ["QT_HASH_SEED"] = "1"
+
+from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
 
 from providertestbase import ProviderTestCase
 from qgis.core import (
@@ -42,6 +45,8 @@ from qgis.core import (
     QgsVectorDataProvider,
     QgsVectorLayer,
     QgsWkbTypes,
+    QgsNetworkAccessManager,
+    QgsNetworkRequestParameters,
 )
 from qgis.PyQt.QtCore import (
     QT_VERSION_STR,
@@ -53,6 +58,8 @@ from qgis.PyQt.QtCore import (
     Qt,
     QTime,
     QVariant,
+    QUrl,
+    QUrlQuery,
 )
 
 import unittest
@@ -8745,6 +8752,427 @@ Can't recognize service requested.
 
         got_f = [f for f in vl.getFeatures()]
         self.assertEqual(len(got_f), 1)
+
+
+class TestPyQgsWFSProviderPost(QgisTestCase, ProviderTestCase):
+    """
+    Test WFS provider, using POST requests
+    """
+
+    def treat_date_as_datetime(self):
+        return True
+
+    def treat_time_as_string(self):
+        return True
+
+    @classmethod
+    def _preprocess_url(cls, url: QUrl, is_post: bool = False):
+        endpoint = url.toString(QUrl.UrlFormattingOption.RemoveQuery)[len("http://") :]
+        local_path = sanitize(endpoint, "?" + url.query())
+        return QUrl.fromLocalFile(local_path)
+
+    @classmethod
+    def _nam_request_preprocessor(cls, request: QNetworkRequest):
+        request.setUrl(cls._preprocess_url(request.url()))
+
+    @classmethod
+    def _nam_advanced_request_preprocessor(cls, request: QNetworkRequest, op, content):
+        if op == QgsNetworkAccessManager.Operation.PostOperation:
+            # maps post data to response
+            RESPONSES = {
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:DescribeFeatureType xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:TypeName>my:typename</wfs:TypeName>\n</wfs:DescribeFeatureType>\n': b"""
+<xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
+  <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
+  <xsd:complexType name="typenameType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <!-- add a trailing space to the name to test https://github.com/qgis/QGIS/issues/13486 -->
+          <xsd:element maxOccurs="1" minOccurs="0" name="pk  " nillable="true" type="xsd:long"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="cnt" nillable="true" type="xsd:long"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="name" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="name2" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="num_char" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="dt" nillable="true" type="xsd:datetime"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="date" nillable="true" type="xsd:datetime"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="time" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="geometryProperty" nillable="true" type="gml:PointPropertyType"/>
+          <!-- check that an element with ref without name doesn't confuse the DescribeFeatureType analyzer -->
+          <xsd:element maxOccurs="0" minOccurs="0" ref="my:somethingElseType"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="typename" substitutionGroup="gml:_Feature" type="my:typenameType"/>
+  <xsd:complexType name="somethingElseType"/>
+</xsd:schema>
+""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326"/>\n</wfs:GetFeature>\n': b"""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="5" numberReturned="5" timeStamp="2016-03-25T14:51:48.998Z">
+  <wfs:member>
+    <my:typename gml:id="typename.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>66.33 -70.332</gml:lowerCorner><gml:upperCorner>66.33 -70.332</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.0"><gml:pos>66.33 -70.332</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>1</my:pk>
+      <my:cnt>100</my:cnt>
+      <my:name>Orange</my:name>
+      <my:name2>oranGe</my:name2>
+      <my:num_char>1</my:num_char>
+      <my:dt>2020-05-03 12:13:14</my:dt>
+      <my:date>2020-05-03</my:date>
+      <my:time>12:13:14</my:time>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>2</my:pk>
+      <my:cnt>200</my:cnt>
+      <my:name>Apple</my:name>
+      <my:name2>Apple</my:name2>
+      <my:num_char>2</my:num_char>
+      <my:dt>2020-05-04 12:14:14</my:dt>
+      <my:date>2020-05-04</my:date>
+      <my:time>12:14:14</my:time>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>4</my:pk>
+      <my:cnt>400</my:cnt>
+      <my:name>Honey</my:name>
+      <my:name2>Honey</my:name2>
+      <my:num_char>4</my:num_char>
+      <my:dt>2021-05-04 13:13:14</my:dt>
+      <my:date>2021-05-04</my:date>
+      <my:time>13:13:14</my:time>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.3">
+      <my:pk>3</my:pk>
+      <my:cnt>300</my:cnt>
+      <my:name>Pear</my:name>
+      <my:name2>PEaR</my:name2>
+      <my:num_char>3</my:num_char>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.23 -71.123</gml:lowerCorner><gml:upperCorner>78.23 -71.123</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.4"><gml:pos>78.23 -71.123</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>5</my:pk>
+      <my:cnt>-200</my:cnt>
+      <my:name2>NuLl</my:name2>
+      <my:num_char>5</my:num_char>
+      <my:dt>2020-05-04 12:13:14</my:dt>
+      <my:date>2020-05-02</my:date>
+      <my:time>12:13:01</my:time>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:And>\n    <fes:PropertyIsGreaterThan>\n     <fes:ValueReference>cnt</fes:ValueReference>\n     <fes:Literal>100</fes:Literal>\n    </fes:PropertyIsGreaterThan>\n    <fes:PropertyIsLessThan>\n     <fes:ValueReference>cnt</fes:ValueReference>\n     <fes:Literal>410</fes:Literal>\n    </fes:PropertyIsLessThan>\n   </fes:And>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="3" numberReturned="3" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.1">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>2</my:pk>
+                          <my:cnt>200</my:cnt>
+                          <my:name>Apple</my:name>
+                          <my:name2>Apple</my:name2>
+                          <my:num_char>2</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.2">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>4</my:pk>
+                          <my:cnt>400</my:cnt>
+                          <my:name>Honey</my:name>
+                          <my:name2>Honey</my:name2>
+                          <my:num_char>4</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.3">
+                          <my:pk>3</my:pk>
+                          <my:cnt>300</my:cnt>
+                          <my:name>Pear</my:name>
+                          <my:name2>PEaR</my:name2>
+                          <my:num_char>3</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsEqualTo>\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>AppleBearOrangePear</fes:Literal>\n   </fes:PropertyIsEqualTo>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+            <wfs:FeatureCollection
+                                   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                   xmlns:gml="http://www.opengis.net/gml/3.2"
+                                   xmlns:my="http://my"
+                                   numberMatched="0" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+            </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0" resultType="hits">\n <wfs:Query typeNames="my:typename"/>\n</wfs:GetFeature>\n': b"""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="5" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0" resultType="hits">\n <wfs:Query typeNames="my:typename">\n  <fes:Filter>\n   <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">\n    <fes:And>\n     <fes:PropertyIsGreaterThan>\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal>100</fes:Literal>\n     </fes:PropertyIsGreaterThan>\n     <fes:PropertyIsLessThan>\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal>410</fes:Literal>\n     </fes:PropertyIsLessThan>\n    </fes:And>\n   </fes:Filter>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           numberMatched="3" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0" resultType="hits">\n <wfs:Query typeNames="my:typename">\n  <fes:Filter>\n   <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">\n    <fes:PropertyIsEqualTo>\n     <fes:ValueReference>name</fes:ValueReference>\n     <fes:Literal>Apple</fes:Literal>\n    </fes:PropertyIsEqualTo>\n   </fes:Filter>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           numberMatched="1" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0" resultType="hits">\n <wfs:Query typeNames="my:typename">\n  <fes:Filter>\n   <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">\n    <fes:PropertyIsEqualTo>\n     <fes:ValueReference>name</fes:ValueReference>\n     <fes:Literal>AppleBearOrangePear</fes:Literal>\n    </fes:PropertyIsEqualTo>\n   </fes:Filter>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           numberMatched="0" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:Not>\n    <fes:PropertyIsEqualTo>\n     <fes:ValueReference>name</fes:ValueReference>\n     <fes:Literal>Apple</fes:Literal>\n    </fes:PropertyIsEqualTo>\n   </fes:Not>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="1" numberReturned="1" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.1">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>2</my:pk>
+                          <my:cnt>200</my:cnt>
+                          <my:name>Apple</my:name>
+                          <my:name2>Apple</my:name2>
+                          <my:num_char>2</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:Not>\n    <fes:PropertyIsNull>\n     <fes:ValueReference>name</fes:ValueReference>\n    </fes:PropertyIsNull>\n   </fes:Not>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="4" numberReturned="4" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.0">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>66.33 -70.332</gml:lowerCorner><gml:upperCorner>66.33 -70.332</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.0"><gml:pos>66.33 -70.332</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>1</my:pk>
+                          <my:cnt>100</my:cnt>
+                          <my:name>Orange</my:name>
+                          <my:name2>oranGe</my:name2>
+                          <my:num_char>1</my:num_char>
+                          <my:dt>2020-05-03 12:13:14</my:dt>
+                          <my:date>2020-05-03</my:date>
+                          <my:time>12:13:14</my:time>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.1">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>2</my:pk>
+                          <my:cnt>200</my:cnt>
+                          <my:name>Apple</my:name>
+                          <my:name2>Apple</my:name2>
+                          <my:num_char>2</my:num_char>
+                          <my:dt>2020-05-04 12:14:14</my:dt>
+                          <my:date>2020-05-04</my:date>
+                          <my:time>12:14:14</my:time>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.2">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>4</my:pk>
+                          <my:cnt>400</my:cnt>
+                          <my:name>Honey</my:name>
+                          <my:name2>Honey</my:name2>
+                          <my:num_char>4</my:num_char>
+                          <my:dt>2021-05-04 13:13:14</my:dt>
+                          <my:date>2021-05-04</my:date>
+                          <my:time>13:13:14</my:time>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.3">
+                          <my:pk>3</my:pk>
+                          <my:cnt>300</my:cnt>
+                          <my:name>Pear</my:name>
+                          <my:name2>PEaR</my:name2>
+                          <my:num_char>3</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:And>\n    <fes:PropertyIsGreaterThan>\n     <fes:ValueReference>cnt</fes:ValueReference>\n     <fes:Literal>100</fes:Literal>\n    </fes:PropertyIsGreaterThan>\n    <fes:PropertyIsLessThan>\n     <fes:ValueReference>cnt</fes:ValueReference>\n     <fes:Literal>400</fes:Literal>\n    </fes:PropertyIsLessThan>\n   </fes:And>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="2" numberReturned="2" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.1">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>2</my:pk>
+                          <my:cnt>200</my:cnt>
+                          <my:name>Apple</my:name>
+                          <my:name2>Apple</my:name2>
+                          <my:num_char>2</my:num_char>
+                          <my:dt>2020-05-04 12:14:14</my:dt>
+                          <my:date>2020-05-04</my:date>
+                          <my:time>12:14:14</my:time>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.3">
+                          <my:pk>3</my:pk>
+                          <my:cnt>300</my:cnt>
+                          <my:name>Pear</my:name>
+                          <my:name2>PEaR</my:name2>
+                          <my:num_char>3</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
+            }
+
+            if content.data() in RESPONSES:
+                endpoint = request.url().toString(QUrl.UrlFormattingOption.RemoveQuery)[
+                    len("http://") :
+                ]
+                local_path = (
+                    sanitize(endpoint, "?" + request.url().query()) + "post_data"
+                )
+                with open(local_path, "wb") as f:
+                    f.write(RESPONSES[content.data()])
+                op = QgsNetworkAccessManager.Operation.GetOperation
+                request.setUrl(QUrl.fromLocalFile(local_path))
+                return op, content
+
+            print(f"\n\n\n\n\n\n\n\n{content}\n\n\n\n\n\n\n")
+
+            assert False
+
+        return op, content
+
+    @classmethod
+    def on_request_about_to_be_created(cls, request):
+        print(request)
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        super().setUpClass()
+
+        QCoreApplication.setOrganizationName("QGIS_Test")
+        QCoreApplication.setOrganizationDomain("TestPyQgsWFSProviderPost.com")
+        QCoreApplication.setApplicationName("TestPyQgsWFSProviderPost")
+        QgsSettings().clear()
+        start_app()
+
+        cls._request_preprocessor_id = QgsNetworkAccessManager.setRequestPreprocessor(
+            cls._nam_request_preprocessor
+        )
+
+        cls._advanced_request_preprocessor_id = (
+            QgsNetworkAccessManager.setAdvancedRequestPreprocessor(
+                cls._nam_advanced_request_preprocessor
+            )
+        )
+
+        # On Windows we must make sure that any backslash in the path is
+        # replaced by a forward slash so that QUrl can process it
+        cls.basetestpath = tempfile.mkdtemp().replace("\\", "/")
+        endpoint = cls.basetestpath + "/fake_post"
+        with open(
+            sanitize(
+                endpoint,
+                "?SERVICE=WFS?REQUEST=GetCapabilities?ACCEPTVERSIONS=2.0.0,1.1.0,1.0.0",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+<wfs:WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://schemas.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">
+  <FeatureTypeList>
+    <FeatureType>
+      <Name>my:typename</Name>
+      <Title>Title</Title>
+      <Abstract>Abstract</Abstract>
+      <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>
+      <WGS84BoundingBox>
+        <LowerCorner>-71.123 66.33</LowerCorner>
+        <UpperCorner>-65.32 78.3</UpperCorner>
+      </WGS84BoundingBox>
+    </FeatureType>
+  </FeatureTypeList>
+</wfs:WFS_Capabilities>"""
+            )
+
+        # Create test layer
+        cls.vl = QgsVectorLayer(
+            "url='http://"
+            + endpoint
+            + "' typename='my:typename' httpMethod='post' skipInitialGetFeature='true'",
+            "test",
+            "WFS",
+        )
+        assert cls.vl.isValid()
+        cls.source = cls.vl.dataProvider()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests"""
+        QgsSettings().clear()
+        # shutil.rmtree(cls.basetestpath, True)
+        cls.vl = (
+            None  # so as to properly close the provider and remove any temporary file
+        )
+        QgsNetworkAccessManager.removeRequestPreprocessor(cls._request_preprocessor_id)
+        QgsNetworkAccessManager.removeAdvancedRequestPreprocessor(
+            cls._advanced_request_preprocessor_id
+        )
+
+        super().tearDownClass()
+
+    def tearDown(self):
+        """Run after each test"""
+        # clear possible settings modification made during test
+        QgsSettings().clear()
+
+    def testWkbType(self):
+        """N/A for WFS provider"""
+        pass
+
+    def providerCompatibleOfSubsetStringWithStableFID(self):
+        """Return whether the provider is expected to have stable FID when changing subsetString.
+        The WFS provider might not always be able to have that guarantee."""
+        return False
+
+    def testExtentSubsetString(self):
+        # can't run the base provider test suite here - WFS/OAPIF extent handling is different
+        # to other providers
+        pass
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -8781,7 +8781,7 @@ class TestPyQgsWFSProviderPost(QgisTestCase, ProviderTestCase):
 
     @classmethod
     def _nam_advanced_request_preprocessor(cls, request: QNetworkRequest, op, content):
-        if op == 4:
+        if op == 4:  # QNetworkAccessManager.Operation.Post
             # maps post data to response
             RESPONSES = {
                 b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:DescribeFeatureType xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:TypeName>my:typename</wfs:TypeName>\n</wfs:DescribeFeatureType>\n': b"""


### PR DESCRIPTION
While the default remains at GET requests, this change allows users to switch a particular WFS connection to prefer POST requests:

![image](https://github.com/user-attachments/assets/01d4947c-8d7c-4685-863d-d2b1cb937ce7)

(For motivation see https://github.com/qgis/QGIS/issues/32348)

Sponsored by Dorset Council