### PR TITLE
[Backport release-3_42]  Apply terrain offset to Z axis instead of Y for vector layer chunked entities

### DIFF
--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -216,37 +216,41 @@ bool QgsRuleBasedChunkedEntity::applyTerrainOffset() const
   QgsRuleBasedChunkLoaderFactory *loaderFactory = static_cast<QgsRuleBasedChunkLoaderFactory *>( mChunkLoaderFactory );
   if ( loaderFactory )
   {
-    QgsRuleBased3DRenderer::Rule *rule = loaderFactory->mRootRule.get();
-    if ( rule->symbol() )
+    QgsRuleBased3DRenderer::Rule *rootRule = loaderFactory->mRootRule.get();
+    const QgsRuleBased3DRenderer::RuleList rules = rootRule->children();
+    for ( const auto &rule : rules )
     {
-      QString symbolType = rule->symbol()->type();
-      if ( symbolType == "line" )
+      if ( rule->symbol() )
       {
-        QgsLine3DSymbol *lineSymbol = static_cast<QgsLine3DSymbol *>( rule->symbol() );
-        if ( lineSymbol && lineSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
+        QString symbolType = rule->symbol()->type();
+        if ( symbolType == "line" )
         {
-          return false;
+          QgsLine3DSymbol *lineSymbol = static_cast<QgsLine3DSymbol *>( rule->symbol() );
+          if ( lineSymbol && lineSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
+          {
+            return false;
+          }
         }
-      }
-      else if ( symbolType == "point" )
-      {
-        QgsPoint3DSymbol *pointSymbol = static_cast<QgsPoint3DSymbol *>( rule->symbol() );
-        if ( pointSymbol && pointSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
+        else if ( symbolType == "point" )
         {
-          return false;
+          QgsPoint3DSymbol *pointSymbol = static_cast<QgsPoint3DSymbol *>( rule->symbol() );
+          if ( pointSymbol && pointSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
+          {
+            return false;
+          }
         }
-      }
-      else if ( symbolType == "polygon" )
-      {
-        QgsPolygon3DSymbol *polygonSymbol = static_cast<QgsPolygon3DSymbol *>( rule->symbol() );
-        if ( polygonSymbol && polygonSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
+        else if ( symbolType == "polygon" )
         {
-          return false;
+          QgsPolygon3DSymbol *polygonSymbol = static_cast<QgsPolygon3DSymbol *>( rule->symbol() );
+          if ( polygonSymbol && polygonSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
+          {
+            return false;
+          }
         }
-      }
-      else
-      {
-        QgsDebugMsgLevel( QStringLiteral( "QgsRuleBasedChunkedEntityChunkedEntity::applyTerrainOffset, unhandled symbol type %1" ).arg( symbolType ), 2 );
+        else
+        {
+          QgsDebugMsgLevel( QStringLiteral( "QgsRuleBasedChunkedEntityChunkedEntity::applyTerrainOffset, unhandled symbol type %1" ).arg( symbolType ), 2 );
+        }
       }
     }
   }

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -196,7 +196,7 @@ QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity( Qgs3DMapSettings *map, Qgs
   mTransform = new Qt3DCore::QTransform;
   if ( applyTerrainOffset() )
   {
-    mTransform->setTranslation( QVector3D( 0.0f, static_cast<float>( map->terrainSettings()->elevationOffset() ), 0.0f ) );
+    mTransform->setTranslation( QVector3D( 0.0f, 0.0f, static_cast<float>( map->terrainSettings()->elevationOffset() ) ) );
   }
   this->addComponent( mTransform );
   connect( map, &Qgs3DMapSettings::terrainSettingsChanged, this, &QgsRuleBasedChunkedEntity::onTerrainElevationOffsetChanged );
@@ -265,7 +265,7 @@ void QgsRuleBasedChunkedEntity::onTerrainElevationOffsetChanged()
 
   if ( newOffset != previousOffset )
   {
-    mTransform->setTranslation( QVector3D( 0.0f, newOffset, 0.0f ) );
+    mTransform->setTranslation( QVector3D( 0.0f, 0.0f, newOffset ) );
   }
 }
 

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -192,7 +192,7 @@ QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( Qgs3DMapSettings *map,
   mTransform = new Qt3DCore::QTransform;
   if ( applyTerrainOffset() )
   {
-    mTransform->setTranslation( QVector3D( 0.0f, static_cast<float>( map->terrainSettings()->elevationOffset() ), 0.0f ) );
+    mTransform->setTranslation( QVector3D( 0.0f, 0.0f, static_cast<float>( map->terrainSettings()->elevationOffset() ) ) );
   }
   this->addComponent( mTransform );
 
@@ -255,7 +255,7 @@ void QgsVectorLayerChunkedEntity::onTerrainElevationOffsetChanged()
   {
     newOffset = 0.0;
   }
-  mTransform->setTranslation( QVector3D( 0.0f, newOffset, 0.0f ) );
+  mTransform->setTranslation( QVector3D( 0.0f, 0.0f, newOffset ) );
 }
 
 QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -134,6 +134,8 @@ class QgsVectorLayerChunkedEntity : public QgsChunkedEntity
     Qt3DCore::QTransform *mTransform = nullptr;
 
     bool applyTerrainOffset() const;
+
+    friend class TestQgsChunkedEntity;
 };
 
 /// @endcond

--- a/tests/src/3d/CMakeLists.txt
+++ b/tests/src/3d/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TESTS
   testqgs3dsymbolregistry.cpp
   testqgs3dutils.cpp
   testqgsaabb.cpp
+  testqgschunkedentity.cpp
   testqgsgltf3dutils.cpp
   testqgslayout3dmap.cpp
   testqgsmaterialregistry.cpp

--- a/tests/src/3d/testqgschunkedentity.cpp
+++ b/tests/src/3d/testqgschunkedentity.cpp
@@ -1,0 +1,196 @@
+/***************************************************************************
+    testqgschhunkedentity.cpp
+    ---------------------
+    begin                : March 2025
+    copyright            : (C) 2025 by Stefanos Natsis
+    email                : uclaros at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgs3d.h"
+#include "qgs3dmapsettings.h"
+#include "qgsproject.h"
+#include "qgsvectorlayer.h"
+#include "qgsrasterlayer.h"
+#include "qgspolygon3dsymbol.h"
+#include "qgsrulebased3drenderer.h"
+#include "qgsvectorlayer3drenderer.h"
+#include "qgsvectorlayerchunkloader_p.h"
+
+
+class TestQgsChunkedEntity : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+    TestQgsChunkedEntity()
+      : QgsTest( QStringLiteral( "3D Rendering Tests" ), QStringLiteral( "3d" ) )
+    {}
+
+  private slots:
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void vectorLayerChunkedEntityElevationOffset();
+    void ruleBasedChunkedEntityElevationOffset();
+
+  private:
+    std::unique_ptr<QgsProject> mProject;
+    QgsRasterLayer *mLayerDtm = nullptr;
+    QgsRasterLayer *mLayerRgb = nullptr;
+    QgsVectorLayer *mLayerBuildings = nullptr;
+};
+
+
+// runs before all tests
+void TestQgsChunkedEntity::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  Qgs3D::initialize();
+
+  mProject.reset( new QgsProject );
+
+  mLayerDtm = new QgsRasterLayer( testDataPath( "/3d/dtm.tif" ), "dtm", "gdal" );
+  QVERIFY( mLayerDtm->isValid() );
+  mProject->addMapLayer( mLayerDtm );
+
+  mLayerRgb = new QgsRasterLayer( testDataPath( "/3d/rgb.tif" ), "rgb", "gdal" );
+  QVERIFY( mLayerRgb->isValid() );
+  mProject->addMapLayer( mLayerRgb );
+
+  mLayerBuildings = new QgsVectorLayer( testDataPath( "/3d/buildings.shp" ), "buildings", "ogr" );
+  QVERIFY( mLayerBuildings->isValid() );
+  mProject->addMapLayer( mLayerBuildings );
+
+  // best to keep buildings without 2D renderer so it is not painted on the terrain
+  // so we do not get some possible artifacts
+  mLayerBuildings->setRenderer( nullptr );
+
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setAmbient( Qt::lightGray );
+  QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
+  symbol3d->setMaterialSettings( materialSettings.clone() );
+  symbol3d->setExtrusionHeight( 10.f );
+  QgsVectorLayer3DRenderer *renderer3d = new QgsVectorLayer3DRenderer( symbol3d );
+  mLayerBuildings->setRenderer3D( renderer3d );
+
+  mProject->setCrs( mLayerDtm->crs() );
+}
+
+//runs after all tests
+void TestQgsChunkedEntity::cleanupTestCase()
+{
+  mProject.reset();
+  QgsApplication::exitQgis();
+}
+
+void TestQgsChunkedEntity::vectorLayerChunkedEntityElevationOffset()
+{
+  Qgs3DMapSettings *map = new Qgs3DMapSettings;
+  map->setLayers( QList<QgsMapLayer *>() << mLayerBuildings );
+
+  QgsPolygon3DSymbol *symbolAbsolute = new QgsPolygon3DSymbol;
+  symbolAbsolute->setAltitudeClamping( Qgis::AltitudeClamping::Absolute );
+  QgsVectorLayer3DRenderer *renderer3d = new QgsVectorLayer3DRenderer( symbolAbsolute );
+  renderer3d->setLayer( mLayerBuildings );
+  mLayerBuildings->setRenderer3D( renderer3d );
+
+  std::unique_ptr<Qt3DCore::QEntity> entity( renderer3d->createEntity( map ) );
+  QVERIFY( entity );
+  QVector<Qt3DCore::QTransform *> trs = entity->componentsOfType<Qt3DCore::QTransform>();
+  QVERIFY( trs.size() == 1 );
+  QVERIFY( trs.constFirst()->translation() == QVector3D( 0.0f, 0.0f, 0.0f ) );
+
+  // set an elevation offset, no change is clamping is absolute
+  const float offset = 42.f;
+  QgsAbstractTerrainSettings *terrainSettings = map->terrainSettings()->clone();
+  terrainSettings->setElevationOffset( offset );
+  map->setTerrainSettings( terrainSettings );
+
+  entity.reset( renderer3d->createEntity( map ) );
+  QVERIFY( entity );
+  trs = entity->componentsOfType<Qt3DCore::QTransform>();
+  QVERIFY( trs.size() == 1 );
+  QVERIFY( trs.constFirst()->translation() == QVector3D( 0.0f, 0.0f, 0.0f ) );
+
+  // if clamping is terrain, offset is applied
+  QgsPolygon3DSymbol *symbolTerrain = static_cast<QgsPolygon3DSymbol *>( symbolAbsolute->clone() );
+  symbolTerrain->setAltitudeClamping( Qgis::AltitudeClamping::Terrain );
+  ;
+  renderer3d->setSymbol( symbolTerrain );
+
+  entity.reset( renderer3d->createEntity( map ) );
+  QVERIFY( entity );
+  trs = entity->componentsOfType<Qt3DCore::QTransform>();
+  QVERIFY( trs.size() == 1 );
+  QVERIFY( trs.constFirst()->translation() == QVector3D( 0.0f, 0.0f, offset ) );
+}
+
+void TestQgsChunkedEntity::ruleBasedChunkedEntityElevationOffset()
+{
+  Qgs3DMapSettings *map = new Qgs3DMapSettings;
+  map->setLayers( QList<QgsMapLayer *>() << mLayerBuildings );
+
+  auto symbolAbsolute = std::make_unique<QgsPolygon3DSymbol>();
+  symbolAbsolute->setAltitudeClamping( Qgis::AltitudeClamping::Absolute );
+  QgsRuleBased3DRenderer::Rule *root = new QgsRuleBased3DRenderer::Rule( nullptr );
+  QgsRuleBased3DRenderer::Rule *rule1 = new QgsRuleBased3DRenderer::Rule( symbolAbsolute->clone(), "ogc_fid < 29069", "rule 1" );
+  QgsRuleBased3DRenderer::Rule *rule2 = new QgsRuleBased3DRenderer::Rule( symbolAbsolute->clone(), "ogc_fid > 29069", "rule 2" );
+  root->appendChild( rule1 );
+  root->appendChild( rule2 );
+  QgsRuleBased3DRenderer *renderer3d = new QgsRuleBased3DRenderer( root );
+  renderer3d->setLayer( mLayerBuildings );
+  mLayerBuildings->setRenderer3D( renderer3d );
+
+  std::unique_ptr<Qt3DCore::QEntity> entity( renderer3d->createEntity( map ) );
+  QVERIFY( entity );
+  QVector<Qt3DCore::QTransform *> trs = entity->componentsOfType<Qt3DCore::QTransform>();
+  QVERIFY( trs.size() == 1 );
+  QVERIFY( trs.constFirst()->translation() == QVector3D( 0.0f, 0.0f, 0.0f ) );
+
+  // set an elevation offset, no change if clamping is absolute for all rules
+  const float offset = 42.f;
+  QgsAbstractTerrainSettings *terrainSettings = map->terrainSettings()->clone();
+  terrainSettings->setElevationOffset( offset );
+  map->setTerrainSettings( terrainSettings );
+
+  entity.reset( renderer3d->createEntity( map ) );
+  QVERIFY( entity );
+  trs = entity->componentsOfType<Qt3DCore::QTransform>();
+  QVERIFY( trs.size() == 1 );
+  QVERIFY( trs.constFirst()->translation() == QVector3D( 0.0f, 0.0f, 0.0f ) );
+
+  // if clamping is terrain for all rules, offset is applied
+  std::unique_ptr<QgsPolygon3DSymbol> symbolTerrain( static_cast<QgsPolygon3DSymbol *>( symbolAbsolute->clone() ) );
+  symbolTerrain->setAltitudeClamping( Qgis::AltitudeClamping::Terrain );
+  rule1->setSymbol( symbolTerrain->clone() );
+  rule2->setSymbol( symbolTerrain->clone() );
+
+  entity.reset( renderer3d->createEntity( map ) );
+  QVERIFY( entity );
+  trs = entity->componentsOfType<Qt3DCore::QTransform>();
+  QVERIFY( trs.size() == 1 );
+  QVERIFY( trs.constFirst()->translation() == QVector3D( 0.0f, 0.0f, offset ) );
+
+  // this is not ideal, but if clamping is absolute in at least one rule, offset is zero
+  rule1->setSymbol( symbolAbsolute->clone() );
+  rule2->setSymbol( symbolTerrain->clone() );
+
+  entity.reset( renderer3d->createEntity( map ) );
+  QVERIFY( entity );
+  trs = entity->componentsOfType<Qt3DCore::QTransform>();
+  QVERIFY( trs.size() == 1 );
+  QVERIFY( trs.constFirst()->translation() == QVector3D( 0.0f, 0.0f, 0.0f ) );
+}
+
+QGSTEST_MAIN( TestQgsChunkedEntity )
+#include "testqgschunkedentity.moc"


### PR DESCRIPTION
## Description
Manual backport of #60953 to release-3_42

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
