### PR TITLE
Install pyogctest from PyPI instead of the GitHub repository

### DIFF
--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -80,16 +80,14 @@ jobs:
 
       - name: Install pyogctest
         run: |
-          sudo apt-get update && sudo apt-get install python3-virtualenv virtualenv git
-          git clone https://github.com/pblottiere/pyogctest
-          cd pyogctest && git checkout 1.1.1 && cd -
-          virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install -e pyogctest/
+          sudo apt-get update && sudo apt-get install python3-virtualenv virtualenv
+          virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install pyogctest
 
       - name: Run WMS 1.3.0 OGC tests
         run: |
-          source venv/bin/activate && ./pyogctest/pyogctest.py -s wms130 -e
+          source venv/bin/activate && pyogctest -s wms130 -e
           docker compose -f .ci/ogc/docker-compose.yml up -d
-          source venv/bin/activate && ./pyogctest/pyogctest.py -n ogc_qgis -s wms130 -v -u http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qgis_server_nginx)/qgisserver_wms130
+          source venv/bin/activate && pyogctest -n ogc_qgis -s wms130 -v -u http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qgis_server_nginx)/qgisserver_wms130
         env:
           DOCKER_IMAGE: ${{ steps.docker-build.outputs.imageid }}
 
@@ -97,6 +95,6 @@ jobs:
         run: |
           cd data && git clone https://github.com/qgis/QGIS-Training-Data && cd -
           docker compose -f .ci/ogc/docker-compose.yml up -d
-          source venv/bin/activate && ./pyogctest/pyogctest.py -n ogc_qgis -s ogcapif -v -u http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qgis_server_nginx)/qgisserver_ogcapif
+          source venv/bin/activate && pyogctest -n ogc_qgis -s ogcapif -v -u http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qgis_server_nginx)/qgisserver_ogcapif
         env:
           DOCKER_IMAGE: ${{ steps.docker-build.outputs.imageid }}


### PR DESCRIPTION
## Description

Hello :),

I recently published `pyogctest` on PyPI, so I suggest updating the OGC workflow to use it directly from there, rather than installing the package from sources.