### PR TITLE
[map canvas] Tweak rotated map canvas preview paint logic to account for zoom changes

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1006,7 +1006,7 @@ void QgsMapCanvas::previewJobFinished()
 
   if ( mMap )
   {
-    mMap->addPreviewImage( job->renderedImage(), job->mapSettings().visibleExtent() );
+    mMap->addPreviewImage( job->renderedImage(), job->mapSettings().visiblePolygon() );
     mPreviewJobs.removeAll( job );
 
     int number = job->property( "number" ).toInt();

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -44,9 +44,9 @@ void QgsMapCanvasMap::setContent( const QImage &image, const QgsRectangle &rect 
   setRect( rect );
 }
 
-void QgsMapCanvasMap::addPreviewImage( const QImage &image, const QgsRectangle &rect )
+void QgsMapCanvasMap::addPreviewImage( const QImage &image, const QPolygonF &visiblePolygon )
 {
-  mPreviewImages.append( qMakePair( image, rect ) );
+  mPreviewImages.append( qMakePair( image, visiblePolygon ) );
   update();
 }
 
@@ -80,14 +80,14 @@ void QgsMapCanvasMap::paint( QPainter *painter )
   const double offsetY = pt.y() - mRect.yMaximum();
 
   //draw preview images first
-  QList<QPair<QImage, QgsRectangle>>::const_iterator imIt = mPreviewImages.constBegin();
+  QList<QPair<QImage, QPolygonF>>::const_iterator imIt = mPreviewImages.constBegin();
   for ( ; imIt != mPreviewImages.constEnd(); ++imIt )
   {
-    const QgsPointXY extentCenter = imIt->second.center();
-    const QPointF canvasCenter = toCanvasCoordinates( QgsPoint( extentCenter.x() + offsetX, extentCenter.y() + offsetY ) );
-    const double imageWidth = imIt->first.width();
-    const double imageHeight = imIt->first.height();
-    painter->drawImage( QRectF( canvasCenter.x() - imageWidth / 2, canvasCenter.y() - imageHeight / 2, imageWidth, imageHeight ), imIt->first, QRect( 0, 0, imIt->first.width(), imIt->first.height() ) );
+    const QPointF mapTopLeft = imIt->second.at( 0 );
+    const QPointF mapBottomRight = imIt->second.at( 2 );
+    const QPointF canvasTopLeft = toCanvasCoordinates( QgsPoint( mapTopLeft.x() + offsetX, mapTopLeft.y() + offsetY ) );
+    const QPointF canvasBottomRight = toCanvasCoordinates( QgsPoint( mapBottomRight.x() + offsetX, mapBottomRight.y() + offsetY ) );
+    painter->drawImage( QRectF( canvasTopLeft, canvasBottomRight ), imIt->first, QRect( 0, 0, imIt->first.width(), imIt->first.height() ) );
   }
 
   if ( scale )

--- a/src/gui/qgsmapcanvasmap.h
+++ b/src/gui/qgsmapcanvasmap.h
@@ -43,7 +43,7 @@ class QgsMapCanvasMap : public QgsMapCanvasItem
 
     void paint( QPainter *painter ) override;
 
-    void addPreviewImage( const QImage &image, const QgsRectangle &rect );
+    void addPreviewImage( const QImage &image, const QPolygonF &visiblePolygon );
 
     QRectF boundingRect() const override;
 
@@ -51,7 +51,7 @@ class QgsMapCanvasMap : public QgsMapCanvasItem
     QImage mImage;
 
     //! Preview images for panning. Usually cover area around the rendered image
-    QList<QPair<QImage, QgsRectangle>> mPreviewImages;
+    QList<QPair<QImage, QPolygonF>> mPreviewImages;
 };
 
 /// @endcond


### PR DESCRIPTION
## Description

Following up on https://github.com/qgis/QGIS/pull/60810 : the logic to unlock map canvas preview on rotated canvas didn't handle zoom change properly. This PR tweaks the logic to support just that.

Not sure why my eyes didn't catch this before now. 