### PR TITLE
[decorations][ui] Fix grid decoration dialog X/Y offset clear value

### DIFF
--- a/src/app/decorations/qgsdecorationgriddialog.cpp
+++ b/src/app/decorations/qgsdecorationgriddialog.cpp
@@ -49,6 +49,11 @@ QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidg
   grpEnable->setChecked( mDeco.enabled() );
   connect( grpEnable, &QGroupBox::toggled, this, [=] { updateSymbolButtons(); } );
 
+  mOffsetXEdit->setShowClearButton( true );
+  mOffsetXEdit->setClearValue( 0 );
+  mOffsetYEdit->setShowClearButton( true );
+  mOffsetYEdit->setClearValue( 0 );
+
   // mXMinLineEdit->setValidator( new QDoubleValidator( mXMinLineEdit ) );
 
   mGridTypeComboBox->addItem( tr( "Line" ), QgsDecorationGrid::Line );


### PR DESCRIPTION
## Description

This PR sets a proper clear value (i.e. 0.0) for the X,Y offset spinbox widgets in the grid decoration dialog:

![image](https://github.com/user-attachments/assets/93b1e37c-4e24-45f7-af5b-4a8cdc42d98c)

Within the fix in, the clear value is set to the spinbox minimum value (i.e. -100000000000000000000 or something :) ).