### PR TITLE
[ServerProperties] Refactor to avoid code duplication

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -682,30 +682,7 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   }
   rebuildCrs3D();
 
-  //legendUrl
-  const QDomElement legendUrlElem = layerElement.firstChildElement( QStringLiteral( "legendUrl" ) );
-  if ( !legendUrlElem.isNull() )
-  {
-    mServerProperties->setLegendUrl( legendUrlElem.text() );
-    mServerProperties->setLegendUrlFormat( legendUrlElem.attribute( QStringLiteral( "format" ), QString() ) );
-  }
-
   serverProperties()->readXml( layerElement );
-
-  if ( serverProperties()->metadataUrls().isEmpty() )
-  {
-    // metadataUrl is still empty, maybe it's a QGIS Project < 3.22
-    // keep for legacy
-    const QDomElement metaUrlElem = layerElement.firstChildElement( QStringLiteral( "metadataUrl" ) );
-    if ( !metaUrlElem.isNull() )
-    {
-      const QString url = metaUrlElem.text();
-      const QString type = metaUrlElem.attribute( QStringLiteral( "type" ), QString() );
-      const QString format = metaUrlElem.attribute( QStringLiteral( "format" ), QString() );
-      const QgsMapLayerServerProperties::MetadataUrl newItem( url, type, format );
-      mServerProperties->setMetadataUrls( QList<QgsMapLayerServerProperties::MetadataUrl>() << newItem );
-    }
-  }
 
   // mMetadata.readFromLayer( this );
   const QDomElement metadataElem = layerElement.firstChildElement( QStringLiteral( "resourceMetadata" ) );
@@ -817,90 +794,6 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   const QDomText layerNameText = document.createTextNode( name() );
   layerName.appendChild( layerNameText );
   layerElement.appendChild( layerName );
-
-  // layer short name
-
-  // TODO -- ideally this would be in QgsMapLayerServerProperties::writeXml, but that's currently
-  // only called for SOME map layer subclasses!
-  if ( !mServerProperties->shortName().isEmpty() )
-  {
-    QDomElement layerShortName = document.createElement( QStringLiteral( "shortname" ) );
-    const QDomText layerShortNameText = document.createTextNode( mServerProperties->shortName() );
-    layerShortName.appendChild( layerShortNameText );
-    layerElement.appendChild( layerShortName );
-  }
-
-  // layer title
-  if ( !mServerProperties->title().isEmpty() )
-  {
-    QDomElement layerTitle = document.createElement( QStringLiteral( "title" ) );
-    const QDomText layerTitleText = document.createTextNode( mServerProperties->title() );
-    layerTitle.appendChild( layerTitleText );
-
-    if ( mServerProperties->title() != mServerProperties->wfsTitle() )
-    {
-      layerTitle.setAttribute( "wfs",  mServerProperties->wfsTitle() );
-    }
-
-    layerElement.appendChild( layerTitle );
-  }
-
-  // layer abstract
-  if ( !mServerProperties->abstract().isEmpty() )
-  {
-    QDomElement layerAbstract = document.createElement( QStringLiteral( "abstract" ) );
-    const QDomText layerAbstractText = document.createTextNode( mServerProperties->abstract() );
-    layerAbstract.appendChild( layerAbstractText );
-    layerElement.appendChild( layerAbstract );
-  }
-
-  // layer keyword list
-  const QStringList keywordStringList = mServerProperties->keywordList().split( ',' );
-  if ( !keywordStringList.isEmpty() )
-  {
-    QDomElement layerKeywordList = document.createElement( QStringLiteral( "keywordList" ) );
-    for ( int i = 0; i < keywordStringList.size(); ++i )
-    {
-      QDomElement layerKeywordValue = document.createElement( QStringLiteral( "value" ) );
-      const QDomText layerKeywordText = document.createTextNode( keywordStringList.at( i ).trimmed() );
-      layerKeywordValue.appendChild( layerKeywordText );
-      layerKeywordList.appendChild( layerKeywordValue );
-    }
-    layerElement.appendChild( layerKeywordList );
-  }
-
-  // layer dataUrl
-  const QString aDataUrl = mServerProperties->dataUrl();
-  if ( !aDataUrl.isEmpty() )
-  {
-    QDomElement layerDataUrl = document.createElement( QStringLiteral( "dataUrl" ) );
-    const QDomText layerDataUrlText = document.createTextNode( aDataUrl );
-    layerDataUrl.appendChild( layerDataUrlText );
-    layerDataUrl.setAttribute( QStringLiteral( "format" ), mServerProperties->dataUrlFormat() );
-    layerElement.appendChild( layerDataUrl );
-  }
-
-  // layer legendUrl
-  const QString aLegendUrl = mServerProperties->legendUrl();
-  if ( !aLegendUrl.isEmpty() )
-  {
-    QDomElement layerLegendUrl = document.createElement( QStringLiteral( "legendUrl" ) );
-    const QDomText layerLegendUrlText = document.createTextNode( aLegendUrl );
-    layerLegendUrl.appendChild( layerLegendUrlText );
-    layerLegendUrl.setAttribute( QStringLiteral( "format" ), mServerProperties->legendUrlFormat() );
-    layerElement.appendChild( layerLegendUrl );
-  }
-
-  // layer attribution
-  const QString aAttribution = mServerProperties->attribution();
-  if ( !aAttribution.isEmpty() )
-  {
-    QDomElement layerAttribution = document.createElement( QStringLiteral( "attribution" ) );
-    const QDomText layerAttributionText = document.createTextNode( aAttribution );
-    layerAttribution.appendChild( layerAttributionText );
-    layerAttribution.setAttribute( QStringLiteral( "href" ), mServerProperties->attributionUrl() );
-    layerElement.appendChild( layerAttribution );
-  }
 
   // timestamp if supported
   if ( timestamp() > QDateTime() )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -822,6 +822,8 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 
   layerElement.setAttribute( QStringLiteral( "legendPlaceholderImage" ), mLegendPlaceholderImage );
 
+  serverProperties()->writeXml( layerElement, document );
+
   // now append layer node to map layer node
   return writeXml( layerElement, document, context );
 }

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -237,20 +237,35 @@ void QgsMapLayerServerProperties::reset() // cppcheck-suppress duplInheritedMemb
   QgsServerWmsDimensionProperties::reset();
 }
 
-void QgsMapLayerServerProperties::readXml( const QDomNode &layer_node ) // cppcheck-suppress duplInheritedMember
+void QgsMapLayerServerProperties::readXml( const QDomNode &layerNode ) // cppcheck-suppress duplInheritedMember
 {
-  QgsServerMetadataUrlProperties::readXml( layer_node );
-  QgsServerWmsDimensionProperties::readXml( layer_node );
+  QgsServerMetadataUrlProperties::readXml( layerNode );
+  if ( metadataUrls().isEmpty() )
+  {
+    // metadataUrl is still empty, maybe it's a QGIS Project < 3.22
+    // keep for legacy
+    const QDomElement metaUrlElem = layerNode.firstChildElement( QStringLiteral( "metadataUrl" ) );
+    if ( !metaUrlElem.isNull() )
+    {
+      const QString url = metaUrlElem.text();
+      const QString type = metaUrlElem.attribute( QStringLiteral( "type" ), QString() );
+      const QString format = metaUrlElem.attribute( QStringLiteral( "format" ), QString() );
+      const QgsMapLayerServerProperties::MetadataUrl newItem( url, type, format );
+      setMetadataUrls( QList<QgsMapLayerServerProperties::MetadataUrl>() << newItem );
+    }
+  }
+
+  QgsServerWmsDimensionProperties::readXml( layerNode );
 
   //short name
-  const QDomElement shortNameElem = layer_node.firstChildElement( QStringLiteral( "shortname" ) );
+  const QDomElement shortNameElem = layerNode.firstChildElement( QStringLiteral( "shortname" ) );
   if ( !shortNameElem.isNull() )
   {
     mShortName = shortNameElem.text();
   }
 
   //title
-  const QDomElement titleElem = layer_node.firstChildElement( QStringLiteral( "title" ) );
+  const QDomElement titleElem = layerNode.firstChildElement( QStringLiteral( "title" ) );
   if ( !titleElem.isNull() )
   {
     mTitle = titleElem.text();
@@ -258,14 +273,14 @@ void QgsMapLayerServerProperties::readXml( const QDomNode &layer_node ) // cppch
   }
 
   //abstract
-  const QDomElement abstractElem = layer_node.firstChildElement( QStringLiteral( "abstract" ) );
+  const QDomElement abstractElem = layerNode.firstChildElement( QStringLiteral( "abstract" ) );
   if ( !abstractElem.isNull() )
   {
     mAbstract = abstractElem.text();
   }
 
   //keywordList
-  const QDomElement keywordListElem = layer_node.firstChildElement( QStringLiteral( "keywordList" ) );
+  const QDomElement keywordListElem = layerNode.firstChildElement( QStringLiteral( "keywordList" ) );
   if ( !keywordListElem.isNull() )
   {
     QStringList kwdList;
@@ -277,7 +292,7 @@ void QgsMapLayerServerProperties::readXml( const QDomNode &layer_node ) // cppch
   }
 
   //dataUrl
-  const QDomElement dataUrlElem = layer_node.firstChildElement( QStringLiteral( "dataUrl" ) );
+  const QDomElement dataUrlElem = layerNode.firstChildElement( QStringLiteral( "dataUrl" ) );
   if ( !dataUrlElem.isNull() )
   {
     mDataUrl = dataUrlElem.text();
@@ -285,20 +300,102 @@ void QgsMapLayerServerProperties::readXml( const QDomNode &layer_node ) // cppch
   }
 
   //attribution
-  const QDomElement attribElem = layer_node.firstChildElement( QStringLiteral( "attribution" ) );
+  const QDomElement attribElem = layerNode.firstChildElement( QStringLiteral( "attribution" ) );
   if ( !attribElem.isNull() )
   {
     mAttribution = attribElem.text();
     mAttributionUrl = attribElem.attribute( QStringLiteral( "href" ), QString() );
   }
+
+  //legendUrl
+  const QDomElement legendUrlElem = layerNode.firstChildElement( QStringLiteral( "legendUrl" ) );
+  if ( !legendUrlElem.isNull() )
+  {
+    mLegendUrl = legendUrlElem.text();
+    mLegendUrlFormat = legendUrlElem.attribute( QStringLiteral( "format" ), QString() );
+  }
 }
 
-void QgsMapLayerServerProperties::writeXml( QDomNode &layer_node, QDomDocument &document ) const // cppcheck-suppress duplInheritedMember
+void QgsMapLayerServerProperties::writeXml( QDomNode &layerNode, QDomDocument &document ) const // cppcheck-suppress duplInheritedMember
 {
-  QgsServerMetadataUrlProperties::writeXml( layer_node, document );
-  QgsServerWmsDimensionProperties::writeXml( layer_node, document );
+  QgsServerMetadataUrlProperties::writeXml( layerNode, document );
+  QgsServerWmsDimensionProperties::writeXml( layerNode, document );
 
-  // TODO -- ideally we should also be writing mTitle, mAbstract etc, but this method is currently
-  // only called for SOME map layer subclasses!
-  // Accordingly that logic is currently left in QgsMapLayer::writeLayerXml
+  // layer short name
+  if ( !mShortName.isEmpty() )
+  {
+    QDomElement layerShortName = document.createElement( QStringLiteral( "shortname" ) );
+    const QDomText layerShortNameText = document.createTextNode( mShortName );
+    layerShortName.appendChild( layerShortNameText );
+    layerNode.appendChild( layerShortName );
+  }
+
+  // layer title
+  if ( !mTitle.isEmpty() )
+  {
+    QDomElement layerTitle = document.createElement( QStringLiteral( "title" ) );
+    const QDomText layerTitleText = document.createTextNode( mTitle );
+    layerTitle.appendChild( layerTitleText );
+
+    if ( mTitle != mWfsTitle )
+    {
+      layerTitle.setAttribute( "wfs",  mWfsTitle );
+    }
+
+    layerNode.appendChild( layerTitle );
+  }
+
+  // layer abstract
+  if ( !mAbstract.isEmpty() )
+  {
+    QDomElement layerAbstract = document.createElement( QStringLiteral( "abstract" ) );
+    const QDomText layerAbstractText = document.createTextNode( mAbstract );
+    layerAbstract.appendChild( layerAbstractText );
+    layerNode.appendChild( layerAbstract );
+  }
+
+  // layer keyword list
+  const QStringList keywordStringList = mKeywordList.split( ',' );
+  if ( !keywordStringList.isEmpty() )
+  {
+    QDomElement layerKeywordList = document.createElement( QStringLiteral( "keywordList" ) );
+    for ( int i = 0; i < keywordStringList.size(); ++i )
+    {
+      QDomElement layerKeywordValue = document.createElement( QStringLiteral( "value" ) );
+      const QDomText layerKeywordText = document.createTextNode( keywordStringList.at( i ).trimmed() );
+      layerKeywordValue.appendChild( layerKeywordText );
+      layerKeywordList.appendChild( layerKeywordValue );
+    }
+    layerNode.appendChild( layerKeywordList );
+  }
+
+  // layer dataUrl
+  if ( !mDataUrl.isEmpty() )
+  {
+    QDomElement layerDataUrl = document.createElement( QStringLiteral( "dataUrl" ) );
+    const QDomText layerDataUrlText = document.createTextNode( mDataUrl );
+    layerDataUrl.appendChild( layerDataUrlText );
+    layerDataUrl.setAttribute( QStringLiteral( "format" ), mDataUrlFormat );
+    layerNode.appendChild( layerDataUrl );
+  }
+
+  // layer legendUrl
+  if ( !mLegendUrl.isEmpty() )
+  {
+    QDomElement layerLegendUrl = document.createElement( QStringLiteral( "legendUrl" ) );
+    const QDomText layerLegendUrlText = document.createTextNode( mLegendUrl );
+    layerLegendUrl.appendChild( layerLegendUrlText );
+    layerLegendUrl.setAttribute( QStringLiteral( "format" ), mLegendUrlFormat );
+    layerNode.appendChild( layerLegendUrl );
+  }
+
+  // layer attribution
+  if ( !mAttribution.isEmpty() )
+  {
+    QDomElement layerAttribution = document.createElement( QStringLiteral( "attribution" ) );
+    const QDomText layerAttributionText = document.createTextNode( mAttribution );
+    layerAttribution.appendChild( layerAttributionText );
+    layerAttribution.setAttribute( QStringLiteral( "href" ), mAttributionUrl );
+    layerNode.appendChild( layerAttribution );
+  }
 }

--- a/src/core/qgsmaplayerserverproperties.h
+++ b/src/core/qgsmaplayerserverproperties.h
@@ -106,10 +106,10 @@ class CORE_EXPORT QgsServerMetadataUrlProperties
 
   protected:
     //! Saves server properties to xml under the layer node
-    void writeXml( QDomNode &layer_node, QDomDocument &document ) const SIP_SKIP;
+    void writeXml( QDomNode &layerNode, QDomDocument &document ) const SIP_SKIP;
 
     //! Reads server properties from project file.
-    void readXml( const QDomNode &layer_node ) SIP_SKIP;
+    void readXml( const QDomNode &layerNode ) SIP_SKIP;
 
     /**
      * Copy properties to another instance

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2591,8 +2591,6 @@ bool QgsRasterLayer::writeXml( QDomNode &layer_node,
 
   writeStyleManager( layer_node, document );
 
-  serverProperties()->writeXml( layer_node, document );
-
   //write out the symbology
   QString errorMsg;
   return writeSymbology( layer_node, document, errorMsg, context );

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2389,9 +2389,6 @@ bool QgsVectorLayer::writeXml( QDomNode &layer_node,
   }
   layer_node.appendChild( asElem );
 
-  // save QGIS Server properties (WMS Dimension, metadata URLS...)
-  mServerProperties->writeXml( layer_node, document );
-
   // renderer specific settings
   QString errorMsg;
   return writeSymbology( layer_node, document, errorMsg, context );

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -199,8 +199,6 @@ bool QgsVectorTileLayer::writeXml( QDomNode &layerNode, QDomDocument &doc, const
 
   writeStyleManager( layerNode, doc );
 
-  serverProperties()->writeXml( layerNode, doc );
-
   QString errorMsg;
   return writeSymbology( layerNode, doc, errorMsg, context );
 }

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -199,6 +199,8 @@ bool QgsVectorTileLayer::writeXml( QDomNode &layerNode, QDomDocument &doc, const
 
   writeStyleManager( layerNode, doc );
 
+  serverProperties()->writeXml( layerNode, doc );
+
   QString errorMsg;
   return writeSymbology( layerNode, doc, errorMsg, context );
 }
@@ -1009,5 +1011,3 @@ void QgsVectorTileLayer::removeSelection()
   mSelectedFeatures.clear();
   emit selectionChanged();
 }
-
-

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -685,6 +685,7 @@ set(QGIS_GUI_SRCS
   qgsmaplayerloadstyledialog.cpp
   qgsmaplayerrefreshsettingswidget.cpp
   qgsmaplayersavestyledialog.cpp
+  qgsmaplayerserverpropertieswidget.cpp
   qgsmaplayerstylecategoriesmodel.cpp
   qgsmaplayerstyleguiutils.cpp
   qgsmaplayerstylemanagerwidget.cpp

--- a/src/gui/qgsmaplayerserverpropertieswidget.cpp
+++ b/src/gui/qgsmaplayerserverpropertieswidget.cpp
@@ -1,0 +1,182 @@
+/***************************************************************************
+    qgsmaplayerserverpropertieswidget.cpp
+    ---------------------
+    begin                : 2025/02/20
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaplayerserverpropertieswidget.h"
+#include "moc_qgsmaplayerserverpropertieswidget.cpp"
+#include "qgsmaplayerserverproperties.h"
+#include "qgsapplication.h"
+#include "qgsmetadataurlitemdelegate.h"
+
+#include <QRegularExpressionValidator>
+#include <QStandardItemModel>
+
+QgsMapLayerServerPropertiesWidget::QgsMapLayerServerPropertiesWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  setupUi( this );
+  connect( buttonRemoveMetadataUrl, &QPushButton::clicked, this, &QgsMapLayerServerPropertiesWidget::removeSelectedMetadataUrl );
+  connect( buttonAddMetadataUrl, &QPushButton::clicked, this, &QgsMapLayerServerPropertiesWidget::addMetadataUrl );
+}
+
+void QgsMapLayerServerPropertiesWidget::setServerProperties( QgsMapLayerServerProperties *serverProperties )
+{
+  mServerProperties = serverProperties;
+  sync();
+}
+
+void QgsMapLayerServerPropertiesWidget::setHasWfsTitle( bool hasWfsTitle )
+{
+  mHasWfsTitle = hasWfsTitle;
+  mLayerOptWfsTitleLineEdit->setVisible( mHasWfsTitle );
+  mLayerOptWfsTitleLabel->setVisible( mHasWfsTitle );
+}
+
+bool QgsMapLayerServerPropertiesWidget::hasWfsTitle() const
+{
+  return mHasWfsTitle;
+}
+
+bool QgsMapLayerServerPropertiesWidget::save()
+{
+  if ( !mServerProperties )
+    return false;
+
+  bool hasChanged = mServerProperties->shortName() != mLayerShortNameLineEdit->text()
+                    || mServerProperties->title() != mLayerTitleLineEdit->text()
+                    || mServerProperties->abstract() != mLayerAbstractTextEdit->toPlainText()
+                    || mServerProperties->keywordList() != mLayerKeywordListLineEdit->text()
+                    || mServerProperties->dataUrl() != mLayerDataUrlLineEdit->text()
+                    || mServerProperties->dataUrlFormat() != mLayerDataUrlFormatComboBox->currentText()
+                    || mServerProperties->attribution() != mLayerAttributionLineEdit->text()
+                    || mServerProperties->attributionUrl() != mLayerAttributionUrlLineEdit->text()
+                    || mServerProperties->legendUrl() != mLayerLegendUrlLineEdit->text()
+                    || mServerProperties->legendUrlFormat() != mLayerLegendUrlFormatComboBox->currentText();
+
+  mServerProperties->setShortName( mLayerShortNameLineEdit->text() );
+  mServerProperties->setTitle( mLayerTitleLineEdit->text() );
+  mServerProperties->setAbstract( mLayerAbstractTextEdit->toPlainText() );
+  mServerProperties->setKeywordList( mLayerKeywordListLineEdit->text() );
+  mServerProperties->setDataUrl( mLayerDataUrlLineEdit->text() );
+  mServerProperties->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
+  mServerProperties->setAttribution( mLayerAttributionLineEdit->text() );
+  mServerProperties->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
+  mServerProperties->setLegendUrl( mLayerLegendUrlLineEdit->text() );
+  mServerProperties->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
+
+  if ( !mLayerOptWfsTitleLineEdit->text().isEmpty() && mLayerOptWfsTitleLineEdit->text() != mLayerTitleLineEdit->text() )
+  {
+    mServerProperties->setWfsTitle( mLayerOptWfsTitleLineEdit->text() );
+    hasChanged = true;
+  }
+  else
+  {
+    mServerProperties->setWfsTitle( QString() );
+  }
+
+  // Metadata URL
+  QList<QgsMapLayerServerProperties::MetadataUrl> metaUrls;
+  for ( int row = 0; row < mMetadataUrlModel->rowCount(); row++ )
+  {
+    QgsMapLayerServerProperties::MetadataUrl metaUrl;
+    metaUrl.url = mMetadataUrlModel->item( row, 0 )->text();
+    metaUrl.type = mMetadataUrlModel->item( row, 1 )->text();
+    metaUrl.format = mMetadataUrlModel->item( row, 2 )->text();
+    metaUrls.append( metaUrl );
+
+    // TODO has not necessary changed
+    hasChanged = true;
+  }
+  mServerProperties->setMetadataUrls( metaUrls );
+
+  return hasChanged;
+}
+
+void QgsMapLayerServerPropertiesWidget::sync()
+{
+  if ( !mServerProperties )
+    return;
+
+  // WMS Name as layer short name
+  mLayerShortNameLineEdit->setText( mServerProperties->shortName() );
+  // WMS Name validator
+  QValidator *shortNameValidator = new QRegularExpressionValidator( QgsApplication::shortNameRegularExpression(), this );
+  mLayerShortNameLineEdit->setValidator( shortNameValidator );
+
+  //layer title and abstract
+  mLayerTitleLineEdit->setText( mServerProperties->title() );
+
+  if ( mServerProperties->wfsTitle() != mServerProperties->title() )
+    mLayerOptWfsTitleLineEdit->setText( mServerProperties->wfsTitle() );
+
+  mLayerAbstractTextEdit->setPlainText( mServerProperties->abstract() );
+  mLayerKeywordListLineEdit->setText( mServerProperties->keywordList() );
+  mLayerDataUrlLineEdit->setText( mServerProperties->dataUrl() );
+  mLayerDataUrlFormatComboBox->setCurrentIndex(
+    mLayerDataUrlFormatComboBox->findText(
+      mServerProperties->dataUrlFormat()
+    )
+  );
+  //layer attribution
+  mLayerAttributionLineEdit->setText( mServerProperties->attribution() );
+  mLayerAttributionUrlLineEdit->setText( mServerProperties->attributionUrl() );
+
+  // Setup the layer metadata URL
+  tableViewMetadataUrl->setSelectionMode( QAbstractItemView::SingleSelection );
+  tableViewMetadataUrl->setSelectionBehavior( QAbstractItemView::SelectRows );
+  tableViewMetadataUrl->horizontalHeader()->setStretchLastSection( true );
+  tableViewMetadataUrl->horizontalHeader()->setSectionResizeMode( QHeaderView::Stretch );
+
+  mMetadataUrlModel = new QStandardItemModel( tableViewMetadataUrl );
+  mMetadataUrlModel->clear();
+  mMetadataUrlModel->setColumnCount( 3 );
+  QStringList metadataUrlHeaders;
+  metadataUrlHeaders << tr( "URL" ) << tr( "Type" ) << tr( "Format" );
+  mMetadataUrlModel->setHorizontalHeaderLabels( metadataUrlHeaders );
+  tableViewMetadataUrl->setModel( mMetadataUrlModel );
+  tableViewMetadataUrl->setItemDelegate( new MetadataUrlItemDelegate( this ) );
+
+  const QList<QgsMapLayerServerProperties::MetadataUrl> &metaUrls = mServerProperties->metadataUrls();
+  for ( const QgsMapLayerServerProperties::MetadataUrl &metaUrl : metaUrls )
+  {
+    const int row = mMetadataUrlModel->rowCount();
+    mMetadataUrlModel->setItem( row, 0, new QStandardItem( metaUrl.url ) );
+    mMetadataUrlModel->setItem( row, 1, new QStandardItem( metaUrl.type ) );
+    mMetadataUrlModel->setItem( row, 2, new QStandardItem( metaUrl.format ) );
+  }
+
+  // layer legend url
+  mLayerLegendUrlLineEdit->setText( mServerProperties->legendUrl() );
+  mLayerLegendUrlFormatComboBox->setCurrentIndex(
+    mLayerLegendUrlFormatComboBox->findText(
+      mServerProperties->legendUrlFormat()
+    )
+  );
+}
+
+void QgsMapLayerServerPropertiesWidget::addMetadataUrl()
+{
+  const int row = mMetadataUrlModel->rowCount();
+  mMetadataUrlModel->setItem( row, 0, new QStandardItem( QLatin1String() ) );
+  mMetadataUrlModel->setItem( row, 1, new QStandardItem( QLatin1String() ) );
+  mMetadataUrlModel->setItem( row, 2, new QStandardItem( QLatin1String() ) );
+}
+
+void QgsMapLayerServerPropertiesWidget::removeSelectedMetadataUrl()
+{
+  const QModelIndexList selectedRows = tableViewMetadataUrl->selectionModel()->selectedRows();
+  if ( selectedRows.empty() )
+    return;
+  mMetadataUrlModel->removeRow( selectedRows[0].row() );
+}

--- a/src/gui/qgsmaplayerserverpropertieswidget.h
+++ b/src/gui/qgsmaplayerserverpropertieswidget.h
@@ -1,0 +1,88 @@
+/***************************************************************************
+    qgsmaplayerserverpropertieswidget.h
+    ---------------------
+    begin                : 2025/02/20
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPLAYERSERVERPROPERTIESWIDGET
+#define QGSMAPLAYERSERVERPROPERTIESWIDGET
+
+#include "ui_qgsmaplayerserverpropertieswidgetbase.h"
+#include "qgis_gui.h"
+
+#define SIP_NO_FILE
+
+class QgsMapLayerServerProperties;
+class QStandardItemModel;
+
+/**
+ * \ingroup gui
+ * \class QgsMapLayerServerPropertiesWidget
+ * Provides widget to edit server properties
+ *
+ * \note Not available in Python bindings
+ * \since QGIS 3.44
+ */
+class GUI_EXPORT QgsMapLayerServerPropertiesWidget : public QWidget, private Ui::QgsMapLayerServerPropertiesWidgetBase
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * Constructor
+     * \param parent parent widget
+     */
+    QgsMapLayerServerPropertiesWidget( QWidget *parent = nullptr );
+
+    /**
+     * Sets the server properties \a serverProperties associated with the widget.
+     */
+    void setServerProperties( QgsMapLayerServerProperties *serverProperties );
+
+    /**
+     * Set whether or not server properties widget has to display a WFS title widget
+     * \param hasWfsTitle TRUE if server properties has to display a WFS title widget
+     * \see hasWfsTitle()
+     */
+    void setHasWfsTitle( bool hasWfsTitle );
+
+    /**
+     * Returns TRUE if widget display a WFS title widget
+     * \see setHasWfsTitle()
+     */
+    bool hasWfsTitle() const;
+
+    /**
+     * Saves the settings to the server properties.
+     *
+     * Returns TRUE if server properties have been modified
+     */
+    bool save();
+
+    /**
+     * Updates the widget state to match the current server properties state.
+     */
+    void sync();
+
+  private slots:
+
+    void addMetadataUrl();
+    void removeSelectedMetadataUrl();
+
+  private:
+    QgsMapLayerServerProperties *mServerProperties = nullptr;
+    QStandardItemModel *mMetadataUrlModel = nullptr;
+    bool mHasWfsTitle = true;
+};
+
+
+#endif

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -134,10 +134,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
     //! \brief slot executed when user changes the layer's CRS
     void mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs );
 
-    // Server properties
-    void addMetadataUrl();
-    void removeSelectedMetadataUrl();
-
     /**
      * updates gamma spinbox on slider changes
      * \since QGIS 3.16
@@ -182,8 +178,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
   private:
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
-
-    QStandardItemModel *mMetadataUrlModel = nullptr;
 
     //! \brief  A constant that signals property not used
     const QString TRSTRING_NOT_SET;

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -92,8 +92,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
     void mButtonRemoveJoin_clicked();
 
     // Server properties
-    void addMetadataUrl();
-    void removeSelectedMetadataUrl();
     void mButtonAddWmsDimension_clicked();
     void mButtonEditWmsDimension_clicked();
     void mWmsDimensionsTreeWidget_itemDoubleClicked( QTreeWidgetItem *item, int column );
@@ -184,7 +182,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
     //! Adds a QGIS Server WMS dimension to mWmsDimensionTreeWidget
     void addWmsDimensionInfoToTreeWidget( const QgsMapLayerServerProperties::WmsDimensionInfo &wmsDim, int insertIndex = -1 );
-    QStandardItemModel *mMetadataUrlModel = nullptr;
 
     void updateAuxiliaryStoragePage();
     void deleteAuxiliaryField( int index );

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -99,6 +99,8 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   setMetadataWidget( mMetadataWidget, mOptsPage_Metadata );
 
+  mMapLayerServerPropertiesWidget->setHasWfsTitle( false );
+
   // update based on lyr's current state
   syncToLayer();
 
@@ -154,25 +156,14 @@ void QgsVectorTileLayerProperties::apply()
   mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );
   mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
 
-  //layer title and abstract
-  mLayer->serverProperties()->setShortName( mLayerShortNameLineEdit->text() );
-  mLayer->serverProperties()->setTitle( mLayerTitleLineEdit->text() );
-  mLayer->serverProperties()->setAbstract( mLayerAbstractTextEdit->toPlainText() );
-  mLayer->serverProperties()->setKeywordList( mLayerKeywordListLineEdit->text() );
-  mLayer->serverProperties()->setDataUrl( mLayerDataUrlLineEdit->text() );
-  mLayer->serverProperties()->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
-
-  //layer attribution
-  mLayer->serverProperties()->setAttribution( mLayerAttributionLineEdit->text() );
-  mLayer->serverProperties()->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
-
-  // LegendURL
-  mLayer->serverProperties()->setLegendUrl( mLayerLegendUrlLineEdit->text() );
-  mLayer->serverProperties()->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
+  mMapLayerServerPropertiesWidget->save();
 }
 
 void QgsVectorTileLayerProperties::syncToLayer()
 {
+  if ( !mLayer )
+    return;
+
   /*
    * Information Tab
    */
@@ -229,31 +220,7 @@ void QgsVectorTileLayerProperties::syncToLayer()
   chkUseScaleDependentRendering->setChecked( mLayer->hasScaleBasedVisibility() );
   mScaleRangeWidget->setScaleRange( mLayer->minimumScale(), mLayer->maximumScale() );
 
-  /*
-   * Server
-   */
-  //layer title and abstract
-  mLayerShortNameLineEdit->setText( mLayer->serverProperties()->shortName() );
-  mLayerTitleLineEdit->setText( mLayer->serverProperties()->title() );
-  mLayerAbstractTextEdit->setPlainText( mLayer->serverProperties()->abstract() );
-  mLayerKeywordListLineEdit->setText( mLayer->serverProperties()->keywordList() );
-  mLayerDataUrlLineEdit->setText( mLayer->serverProperties()->dataUrl() );
-  mLayerDataUrlFormatComboBox->setCurrentIndex(
-    mLayerDataUrlFormatComboBox->findText(
-      mLayer->serverProperties()->dataUrlFormat()
-    )
-  );
-  //layer attribution
-  mLayerAttributionLineEdit->setText( mLayer->serverProperties()->attribution() );
-  mLayerAttributionUrlLineEdit->setText( mLayer->serverProperties()->attributionUrl() );
-
-  // layer legend url
-  mLayerLegendUrlLineEdit->setText( mLayer->serverProperties()->legendUrl() );
-  mLayerLegendUrlFormatComboBox->setCurrentIndex(
-    mLayerLegendUrlFormatComboBox->findText(
-      mLayer->serverProperties()->legendUrlFormat()
-    )
-  );
+  mMapLayerServerPropertiesWidget->setServerProperties( mLayer->serverProperties() );
 }
 
 void QgsVectorTileLayerProperties::saveDefaultStyle()

--- a/src/ui/qgsmaplayerserverpropertieswidgetbase.ui
+++ b/src/ui/qgsmaplayerserverpropertieswidgetbase.ui
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsMapLayerServerPropertiesWidgetBase</class>
+ <widget class="QWidget" name="QgsMapLayerServerPropertiesWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>619</width>
+    <height>866</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Map Layer Server Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="mMetaDescriptionGrpBx">
+     <property name="title">
+      <string>Description</string>
+     </property>
+     <property name="syncGroup">
+      <string notr="true">vectormeta</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="mLayerKeywordListLineEdit">
+        <property name="toolTip">
+         <string>List of keywords separated by comma to help catalog searching.</string>
+        </property>
+        <property name="placeholderText">
+         <string>List of keywords separated by comma to help catalog searching.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="mLayerAbstractLabel">
+        <property name="text">
+         <string>Abstract</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="mLayerDataUrlLabel">
+        <property name="text">
+         <string>Data URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QPlainTextEdit" name="mLayerAbstractTextEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>150</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The abstract is a descriptive narrative providing more information about the layer.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mLayerShortNameLineEdit">
+        <property name="toolTip">
+         <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
+        </property>
+        <property name="inputMask">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mLayerTitleLineEdit">
+        <property name="toolTip">
+         <string>The title is for the benefit of humans to identify layer.</string>
+        </property>
+        <property name="placeholderText">
+         <string>The title is for the benefit of humans to identify layer.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLineEdit" name="mLayerDataUrlLineEdit">
+          <property name="toolTip">
+           <string>A URL of the data presentation.</string>
+          </property>
+          <property name="placeholderText">
+           <string>A URL of the data presentation.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="mLayerDataUrlFormatLabel">
+          <property name="text">
+           <string>Format</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="mLayerDataUrlFormatComboBox">
+          <item>
+           <property name="text">
+            <string notr="true">text/html</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">text/plain</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">application/pdf</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="mLayerOptWfsTitleLabel">
+        <property name="text">
+         <string>WFS title</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mLayerTitleLabel">
+        <property name="text">
+         <string>Title</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mLayerShortNameLabel">
+        <property name="text">
+         <string>Short name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="mLayerOptWfsTitleLineEdit">
+        <property name="toolTip">
+         <string>The alternative title is for the benefit of humans to identify the WFS layer if the original title is only helpful with the WMS grouping.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>Optional alternative title for the layer for use with WFS</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="mLayerKeywordListLabel">
+        <property name="text">
+         <string>Keyword list</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="mMetaAttributionGrpBx">
+     <property name="title">
+      <string>Attribution</string>
+     </property>
+     <property name="syncGroup">
+      <string notr="true">vectormeta</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_7">
+      <item row="0" column="0">
+       <widget class="QLabel" name="mLayerAttributionLabel">
+        <property name="text">
+         <string>Title</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mLayerAttributionLineEdit">
+        <property name="toolTip">
+         <string>Attribution's title indicates the provider of the layer.</string>
+        </property>
+        <property name="placeholderText">
+         <string>Attribution's title indicates the provider of the data layer.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="mLayerAttributionUrlLabel">
+        <property name="text">
+         <string>URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit">
+        <property name="toolTip">
+         <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
+        </property>
+        <property name="placeholderText">
+         <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Metadata URL</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_34">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <spacer name="horizontalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>566</width>
+            <height>21</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="buttonAddMetadataUrl">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="buttonRemoveMetadataUrl">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QTableView" name="tableViewMetadataUrl"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="mMetaLegendGrpBx">
+     <property name="title">
+      <string>Legend URL</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_10">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="QLabel" name="mLayerLegendUrlLabel">
+          <property name="text">
+           <string>URL</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="mLayerLegendUrlLineEdit">
+          <property name="toolTip">
+           <string>A URL of the legend image.</string>
+          </property>
+          <property name="placeholderText">
+           <string>A URL of the legend image.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="mLayerLegendUrlFormatLabel">
+          <property name="text">
+           <string>Format</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="mLayerLegendUrlFormatComboBox">
+          <property name="minimumSize">
+           <size>
+            <width>137</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <item>
+           <property name="text">
+            <string notr="true">image/png</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">image/jpeg</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -287,7 +287,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>10</number>
+          <number>13</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -332,8 +332,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>320</width>
-                <height>455</height>
+                <width>289</width>
+                <height>453</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -362,7 +362,7 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -370,7 +370,7 @@
                    <number>6</number>
                   </property>
                   <item>
-                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -455,8 +455,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>680</height>
+                <width>582</width>
+                <height>335</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -483,7 +483,7 @@
                  <property name="title">
                   <string>Band Rendering</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_14">
@@ -528,13 +528,13 @@
                  <property name="title">
                   <string>Layer Rendering</string>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_2">
@@ -889,13 +889,13 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QHBoxLayout" name="horizontalLayout">
@@ -1025,8 +1025,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
-                <height>39</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1088,7 +1088,7 @@
              <property name="checked">
               <bool>false</bool>
              </property>
-             <property name="syncGroup" stdset="0">
+             <property name="syncGroup">
               <string notr="true">rastergeneral</string>
              </property>
              <layout class="QGridLayout" name="_5">
@@ -1108,7 +1108,7 @@
                <number>6</number>
               </property>
               <item row="0" column="0" colspan="2">
-               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
                 <property name="toolTip">
                  <string/>
                 </property>
@@ -1201,8 +1201,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>504</width>
-                <height>187</height>
+                <width>643</width>
+                <height>677</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1269,12 +1269,9 @@
                       </property>
                       <property name="html">
                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                      </widget>
@@ -1638,8 +1635,8 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>331</width>
-                <height>709</height>
+                <width>643</width>
+                <height>677</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_12">
@@ -1655,303 +1652,7 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                <property name="bottomMargin">
                 <number>0</number>
                </property>
-               <item row="0" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="mMetaDescriptionGrpBx">
-                 <property name="title">
-                  <string>Description</string>
-                 </property>
-                 <property name="syncGroup" stdset="0">
-                  <string notr="true">rastermeta</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_5">
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="mLayerTitleLabel">
-                    <property name="text">
-                     <string>Title</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="mLayerKeywordListLabel_3">
-                    <property name="text">
-                     <string>Data URL</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="1">
-                   <layout class="QHBoxLayout" name="horizontalLayout_13">
-                    <item>
-                     <widget class="QLineEdit" name="mLayerDataUrlLineEdit">
-                      <property name="toolTip">
-                       <string>A URL of the data presentation.</string>
-                      </property>
-                      <property name="placeholderText">
-                       <string>A URL of the data presentation.</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="mLayerDataUrlFormatLabel">
-                      <property name="text">
-                       <string>Format</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="mLayerDataUrlFormatComboBox">
-                      <item>
-                       <property name="text">
-                        <string notr="true">text/html</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string notr="true">text/plain</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string notr="true">application/pdf</string>
-                       </property>
-                      </item>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="5" column="1">
-                   <widget class="QLineEdit" name="mLayerKeywordListLineEdit">
-                    <property name="toolTip">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QLabel" name="mLayerKeywordListLabel">
-                    <property name="text">
-                     <string>Keyword list</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="mLayerShortNameLineEdit">
-                    <property name="toolTip">
-                     <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mLayerShortNameLabel">
-                    <property name="text">
-                     <string>Short name</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="mLayerAbstractLabel">
-                    <property name="text">
-                     <string>Abstract</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QTextEdit" name="mLayerAbstractTextEdit">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>50</height>
-                     </size>
-                    </property>
-                    <property name="toolTip">
-                     <string>The abstract is a descriptive narrative providing more information about the layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="mLayerTitleLineEdit">
-                    <property name="toolTip">
-                     <string>The title is for the benefit of humans to identify layer.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The title is for the benefit of humans to identify layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
                <item row="1" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="mMetaAttributionGrpBx">
-                 <property name="title">
-                  <string>Attribution</string>
-                 </property>
-                 <property name="syncGroup" stdset="0">
-                  <string notr="true">vectormeta</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_7">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mLayerAttributionLabel">
-                    <property name="text">
-                     <string>Title</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="mLayerAttributionLineEdit">
-                    <property name="toolTip">
-                     <string>Attribution's title indicates the provider of the layer.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Attribution's title indicates the provider of the layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="mLayerAttributionUrlLabel">
-                    <property name="text">
-                     <string>URL</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit">
-                    <property name="toolTip">
-                     <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="mMetaMetaUrlGrpBx">
-                 <property name="title">
-                  <string>Metadata URL</string>
-                 </property>
-                 <property name="syncGroup" stdset="0">
-                  <string notr="true">vectormeta</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_18">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_4">
-                    <item>
-                     <spacer name="horizontalSpacer_3">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="buttonAddMetadataUrl">
-                      <property name="text">
-                       <string/>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="buttonRemoveMetadataUrl">
-                      <property name="text">
-                       <string notr="true"/>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <widget class="QTableView" name="tableViewMetadataUrl"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="mMetaLegendGrpBx">
-                 <property name="title">
-                  <string>Legend URL</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_10">
-                  <item row="0" column="0">
-                   <layout class="QHBoxLayout" name="horizontalLayout_11">
-                    <item>
-                     <widget class="QLabel" name="mLayerLegendUrlLabel">
-                      <property name="text">
-                       <string>URL</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="mLayerLegendUrlLineEdit">
-                      <property name="toolTip">
-                       <string>A URL of the legend image.</string>
-                      </property>
-                      <property name="placeholderText">
-                       <string>A URL of the legend image.</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="mLayerLegendUrlFormatLabel">
-                      <property name="text">
-                       <string>Format</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="mLayerLegendUrlFormatComboBox">
-                      <property name="minimumSize">
-                       <size>
-                        <width>137</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="currentIndex">
-                       <number>0</number>
-                      </property>
-                      <item>
-                       <property name="text">
-                        <string notr="true">image/png</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string notr="true">image/jpeg</string>
-                       </property>
-                      </item>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="4" column="0">
                 <widget class="QgsCollapsibleGroupBox" name="mWMSPrintGroupBox">
                  <property name="title">
                   <string>WMS Print layer</string>
@@ -1963,21 +1664,14 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                  </layout>
                 </widget>
                </item>
-               <item row="5" column="0">
-                <widget class="QCheckBox" name="mPublishDataSourceUrlCheckBox">
-                 <property name="text">
-                  <string>Publish WMS/WMTS data source uri</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
+               <item row="3" column="0">
                 <widget class="QCheckBox" name="mBackgroundLayerCheckBox">
                  <property name="text">
                   <string>Advertise as background layer</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="0">
+               <item row="4" column="0">
                 <spacer name="verticalSpacer_4">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
@@ -1989,6 +1683,16 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                   </size>
                  </property>
                 </spacer>
+               </item>
+               <item row="0" column="0">
+                <widget class="QgsMapLayerServerPropertiesWidget" name="mMapLayerServerPropertiesWidget" native="true"/>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="mPublishDataSourceUrlCheckBox">
+                 <property name="text">
+                  <string>Publish WMS/WMTS data source uri</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -2046,15 +1750,10 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
@@ -2063,21 +1762,9 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsBlendModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsblendmodecombobox.h</header>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
@@ -2096,6 +1783,18 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <header>qgsscalerangewidget.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>
    <extends>QWidget</extends>
    <header>qgslayertreeembeddedconfigwidget.h</header>
@@ -2107,15 +1806,26 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <header>qgscodeeditorhtml.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsMapLayerRefreshSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaplayerrefreshsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsImageSourceLineEdit</class>
    <extends>QWidget</extends>
    <header>qgsfilecontentsourcelineedit.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerRefreshSettingsWidget</class>
+   <class>QgsMapLayerServerPropertiesWidget</class>
    <extends>QWidget</extends>
-   <header>qgsmaplayerrefreshsettingswidget.h</header>
+   <header>qgsmaplayerserverpropertieswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -2158,18 +1868,6 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
   <tabstop>cboResamplingMethod</tabstop>
   <tabstop>buttonBuildPyramids</tabstop>
   <tabstop>scrollArea_4</tabstop>
-  <tabstop>mLayerShortNameLineEdit</tabstop>
-  <tabstop>mLayerTitleLineEdit</tabstop>
-  <tabstop>mLayerAbstractTextEdit</tabstop>
-  <tabstop>mLayerKeywordListLineEdit</tabstop>
-  <tabstop>mLayerDataUrlLineEdit</tabstop>
-  <tabstop>mLayerDataUrlFormatComboBox</tabstop>
-  <tabstop>mLayerAttributionLineEdit</tabstop>
-  <tabstop>mLayerAttributionUrlLineEdit</tabstop>
-  <tabstop>buttonAddMetadataUrl</tabstop>
-  <tabstop>buttonRemoveMetadataUrl</tabstop>
-  <tabstop>mLayerLegendUrlLineEdit</tabstop>
-  <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
   <tabstop>mWMSPrintLayerLineEdit</tabstop>
   <tabstop>mPublishDataSourceUrlCheckBox</tabstop>
   <tabstop>mBackgroundLayerCheckBox</tabstop>
@@ -2178,7 +1876,6 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
   <tabstop>mInsertExpressionButton</tabstop>
   <tabstop>mCreateRasterAttributeTableButton</tabstop>
   <tabstop>mLoadRasterAttributeTableFromFileButton</tabstop>
-  <tabstop>tableViewMetadataUrl</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -363,7 +363,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>11</number>
+          <number>18</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -439,8 +439,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>336</width>
-                <height>577</height>
+                <width>271</width>
+                <height>532</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>104</width>
-                <height>102</height>
+                <width>116</width>
+                <height>97</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1644,8 +1644,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>703</width>
-                <height>726</height>
+                <width>601</width>
+                <height>688</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -2226,8 +2226,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>374</width>
-                <height>813</height>
+                <width>677</width>
+                <height>712</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2244,323 +2244,7 @@
                 <number>0</number>
                </property>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="mMetaDescriptionGrpBx">
-                 <property name="title">
-                  <string>Description</string>
-                 </property>
-                 <property name="syncGroup">
-                  <string notr="true">vectormeta</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_5">
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="mLayerTitleLabel">
-                    <property name="text">
-                     <string>Title</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="mLayerOptWfsTitleLabel">
-                    <property name="text">
-                     <string>WFS title</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="mLayerOptWfsTitleLineEdit">
-                    <property name="toolTip">
-                     <string>The alternative title is for the benefit of humans to identify the WFS layer if the original title is only helpful with the WMS grouping.</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Optional alternative title for the layer for use with WFS</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="1">
-                   <widget class="QLineEdit" name="mLayerKeywordListLineEdit">
-                    <property name="toolTip">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="1">
-                   <layout class="QHBoxLayout" name="horizontalLayout_7">
-                    <item>
-                     <widget class="QLineEdit" name="mLayerDataUrlLineEdit">
-                      <property name="toolTip">
-                       <string>A URL of the data presentation.</string>
-                      </property>
-                      <property name="placeholderText">
-                       <string>A URL of the data presentation.</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="mLayerDataUrlFormatLabel">
-                      <property name="text">
-                       <string>Format</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="mLayerDataUrlFormatComboBox">
-                      <item>
-                       <property name="text">
-                        <string notr="true">text/html</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string notr="true">text/plain</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string notr="true">application/pdf</string>
-                       </property>
-                      </item>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="mLayerKeywordListLabel">
-                    <property name="text">
-                     <string>Keyword list</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mLayerShortNameLabel">
-                    <property name="text">
-                     <string>Short name</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="mLayerShortNameLineEdit">
-                    <property name="toolTip">
-                     <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
-                    </property>
-                    <property name="inputMask">
-                     <string/>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="placeholderText">
-                     <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="mLayerTitleLineEdit">
-                    <property name="toolTip">
-                     <string>The title is for the benefit of humans to identify layer.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The title is for the benefit of humans to identify layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="mLayerAbstractLabel">
-                    <property name="text">
-                     <string>Abstract</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QPlainTextEdit" name="mLayerAbstractTextEdit">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>150</height>
-                     </size>
-                    </property>
-                    <property name="toolTip">
-                     <string>The abstract is a descriptive narrative providing more information about the layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="0">
-                   <widget class="QLabel" name="mLayerDataUrlLabel">
-                    <property name="text">
-                     <string>Data URL</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QgsCollapsibleGroupBox" name="mMetaAttributionGrpBx">
-                 <property name="title">
-                  <string>Attribution</string>
-                 </property>
-                 <property name="syncGroup">
-                  <string notr="true">vectormeta</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_7">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mLayerAttributionLabel">
-                    <property name="text">
-                     <string>Title</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="mLayerAttributionLineEdit">
-                    <property name="toolTip">
-                     <string>Attribution's title indicates the provider of the layer.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Attribution's title indicates the provider of the data layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="mLayerAttributionUrlLabel">
-                    <property name="text">
-                     <string>URL</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit">
-                    <property name="toolTip">
-                     <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="groupBox">
-                 <property name="title">
-                  <string>Metadata URL</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_34">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_10">
-                    <item>
-                     <spacer name="horizontalSpacer_6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>566</width>
-                        <height>21</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="buttonAddMetadataUrl">
-                      <property name="text">
-                       <string notr="true"/>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="buttonRemoveMetadataUrl">
-                      <property name="text">
-                       <string notr="true"/>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <widget class="QTableView" name="tableViewMetadataUrl"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QgsCollapsibleGroupBox" name="mMetaLegendGrpBx">
-                 <property name="title">
-                  <string>Legend URL</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_2">
-                  <item row="0" column="0">
-                   <layout class="QHBoxLayout" name="horizontalLayout_2">
-                    <item>
-                     <widget class="QLabel" name="mLayerLegendUrlLabel">
-                      <property name="text">
-                       <string>URL</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="mLayerLegendUrlLineEdit">
-                      <property name="toolTip">
-                       <string>A URL of the legend image.</string>
-                      </property>
-                      <property name="placeholderText">
-                       <string>A URL of the legend image.</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="mLayerLegendUrlFormatLabel">
-                      <property name="text">
-                       <string>Format</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="mLayerLegendUrlFormatComboBox">
-                      <property name="minimumSize">
-                       <size>
-                        <width>137</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="currentIndex">
-                       <number>0</number>
-                      </property>
-                      <item>
-                       <property name="text">
-                        <string>image/png</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>image/jpeg</string>
-                       </property>
-                      </item>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
+                <widget class="QgsMapLayerServerPropertiesWidget" name="mMapLayerServerPropertiesWidget" native="true"/>
                </item>
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="mWmsDimensionsGrpBx">
@@ -2804,6 +2488,12 @@
    <header>qgsmaplayerrefreshsettingswidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsMapLayerServerPropertiesWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaplayerserverpropertieswidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mSearchLineEdit</tabstop>
@@ -2850,18 +2540,6 @@
   <tabstop>mNotifyMessagValueLineEdit</tabstop>
   <tabstop>mLayersDependenciesTreeView</tabstop>
   <tabstop>scrollArea</tabstop>
-  <tabstop>mLayerShortNameLineEdit</tabstop>
-  <tabstop>mLayerTitleLineEdit</tabstop>
-  <tabstop>mLayerAbstractTextEdit</tabstop>
-  <tabstop>mLayerKeywordListLineEdit</tabstop>
-  <tabstop>mLayerDataUrlLineEdit</tabstop>
-  <tabstop>mLayerDataUrlFormatComboBox</tabstop>
-  <tabstop>mLayerAttributionLineEdit</tabstop>
-  <tabstop>mLayerAttributionUrlLineEdit</tabstop>
-  <tabstop>buttonAddMetadataUrl</tabstop>
-  <tabstop>buttonRemoveMetadataUrl</tabstop>
-  <tabstop>mLayerLegendUrlLineEdit</tabstop>
-  <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
   <tabstop>mWmsDimensionsTreeWidget</tabstop>
   <tabstop>mButtonAddWmsDimension</tabstop>
   <tabstop>mButtonEditWmsDimension</tabstop>
@@ -2872,7 +2550,6 @@
   <tabstop>mRadioOverrideSelectionColor</tabstop>
   <tabstop>mSelectionColorButton</tabstop>
   <tabstop>mSelectionSymbolButton</tabstop>
-  <tabstop>tableViewMetadataUrl</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsvectortilelayerpropertiesbase.ui
+++ b/src/ui/qgsvectortilelayerpropertiesbase.ui
@@ -221,7 +221,7 @@
           <enum>QFrame::Plain</enum>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>6</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -269,8 +269,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>661</width>
-                <height>507</height>
+                <width>289</width>
+                <height>376</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -299,7 +299,7 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -307,7 +307,7 @@
                    <number>6</number>
                   </property>
                   <item>
-                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -409,7 +409,7 @@
              <property name="checked">
               <bool>false</bool>
              </property>
-             <property name="syncGroup" stdset="0">
+             <property name="syncGroup">
               <string notr="true">rastergeneral</string>
              </property>
              <layout class="QGridLayout" name="_5">
@@ -429,7 +429,7 @@
                <number>6</number>
               </property>
               <item row="0" column="0" colspan="2">
-               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
                 <property name="toolTip">
                  <string/>
                 </property>
@@ -482,252 +482,7 @@
          <widget class="QWidget" name="mOptsPage_Server">
           <layout class="QVBoxLayout" name="verticalLayout_9">
            <item>
-            <widget class="QgsCollapsibleGroupBox" name="mMetaDescriptionGrpBx">
-             <property name="title">
-              <string>Description</string>
-             </property>
-             <property name="syncGroup" stdset="0">
-              <string notr="true">vectormeta</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_5">
-              <item row="1" column="0">
-               <widget class="QLabel" name="mLayerTitleLabel">
-                <property name="text">
-                 <string>Title</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1">
-               <widget class="QLineEdit" name="mLayerKeywordListLineEdit">
-                <property name="toolTip">
-                 <string>List of keywords separated by comma to help catalog searching.</string>
-                </property>
-                <property name="placeholderText">
-                 <string>List of keywords separated by comma to help catalog searching.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_7">
-                <item>
-                 <widget class="QLineEdit" name="mLayerDataUrlLineEdit">
-                  <property name="toolTip">
-                   <string>A URL of the data presentation.</string>
-                  </property>
-                  <property name="placeholderText">
-                   <string>A URL of the data presentation.</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="mLayerDataUrlFormatLabel">
-                  <property name="text">
-                   <string>Format</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QComboBox" name="mLayerDataUrlFormatComboBox">
-                  <item>
-                   <property name="text">
-                    <string notr="true">text/html</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">text/plain</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">application/pdf</string>
-                   </property>
-                  </item>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="mLayerKeywordListLabel">
-                <property name="text">
-                 <string>Keyword list</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="mLayerShortNameLabel">
-                <property name="text">
-                 <string>Short name</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLineEdit" name="mLayerShortNameLineEdit">
-                <property name="toolTip">
-                 <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
-                </property>
-                <property name="inputMask">
-                 <string/>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="placeholderText">
-                 <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLineEdit" name="mLayerTitleLineEdit">
-                <property name="toolTip">
-                 <string>The title is for the benefit of humans to identify layer.</string>
-                </property>
-                <property name="placeholderText">
-                 <string>The title is for the benefit of humans to identify layer.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="mLayerAbstractLabel">
-                <property name="text">
-                 <string>Abstract</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QPlainTextEdit" name="mLayerAbstractTextEdit">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>150</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string>The abstract is a descriptive narrative providing more information about the layer.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="mLayerDataUrlLabel">
-                <property name="text">
-                 <string>Data URL</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QgsCollapsibleGroupBox" name="mMetaAttributionGrpBx">
-             <property name="title">
-              <string>Attribution</string>
-             </property>
-             <property name="syncGroup" stdset="0">
-              <string notr="true">vectormeta</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_7">
-              <item row="0" column="0">
-               <widget class="QLabel" name="mLayerAttributionLabel">
-                <property name="text">
-                 <string>Title</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLineEdit" name="mLayerAttributionLineEdit">
-                <property name="toolTip">
-                 <string>Attribution's title indicates the provider of the layer.</string>
-                </property>
-                <property name="placeholderText">
-                 <string>Attribution's title indicates the provider of the data layer.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="mLayerAttributionUrlLabel">
-                <property name="text">
-                 <string>URL</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit">
-                <property name="toolTip">
-                 <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
-                </property>
-                <property name="placeholderText">
-                 <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QgsCollapsibleGroupBox" name="mMetaLegendGrpBx">
-             <property name="title">
-              <string>Legend URL</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_10">
-              <item row="0" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_11">
-                <item>
-                 <widget class="QLabel" name="mLayerLegendUrlLabel">
-                  <property name="text">
-                   <string>URL</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="mLayerLegendUrlLineEdit">
-                  <property name="toolTip">
-                   <string>A URL of the legend image.</string>
-                  </property>
-                  <property name="placeholderText">
-                   <string>A URL of the legend image.</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="mLayerLegendUrlFormatLabel">
-                  <property name="text">
-                   <string>Format</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QComboBox" name="mLayerLegendUrlFormatComboBox">
-                  <property name="minimumSize">
-                   <size>
-                    <width>137</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="currentIndex">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <property name="text">
-                    <string notr="true">image/png</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">image/jpeg</string>
-                   </property>
-                  </item>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
+            <widget class="QgsMapLayerServerPropertiesWidget" name="mMapLayerServerPropertiesWidget" native="true"/>
            </item>
            <item>
             <spacer name="verticalSpacer_2">
@@ -811,20 +566,26 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScaleRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalerangewidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsWebView</class>
    <extends>QWidget</extends>
    <header>qgswebview.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerServerPropertiesWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaplayerserverpropertieswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Preliminary work to add ALL server properties editing on group node.

@nyalldawson Regarding this [comment](https://github.com/qgis/QGIS/pull/61042/files#diff-0729690ededf3c3e6d57bc549a6ba208a01428950f18379f0653895a71ae9b31L823), I failed to see what this was a problem, maybe you can shed some light. I've migrated raster layer, vector layer and vector tile layer which are, AFAIK the only ones allowing to set those server properties.

**Funded by Ifremer**
