### PR TITLE
Add protocol values for ESRI Geoportal

### DIFF
--- a/python/plugins/MetaSearch/link_types.py
+++ b/python/plugins/MetaSearch/link_types.py
@@ -54,8 +54,17 @@ WCS_LINK_TYPES = [
     "OGC Web Coverage Service",
 ]
 
-AMS_LINK_TYPES = ["ESRI:ArcGIS:MapServer", "Esri REST: Map Service", "ESRI REST", "MapServer"]
+AMS_LINK_TYPES = [
+    "ESRI:ArcGIS:MapServer",
+    "Esri REST: Map Service",
+    "ESRI REST",
+    "MapServer",
+]
 
-AFS_LINK_TYPES = ["ESRI:ArcGIS:FeatureServer", "Esri REST: Feature Service", "FeatureServer"]
+AFS_LINK_TYPES = [
+    "ESRI:ArcGIS:FeatureServer",
+    "Esri REST: Feature Service",
+    "FeatureServer",
+]
 
 GIS_FILE_LINK_TYPES = ["FILE:GEO"]

--- a/python/plugins/MetaSearch/link_types.py
+++ b/python/plugins/MetaSearch/link_types.py
@@ -54,8 +54,8 @@ WCS_LINK_TYPES = [
     "OGC Web Coverage Service",
 ]
 
-AMS_LINK_TYPES = ["ESRI:ArcGIS:MapServer", "Esri REST: Map Service", "ESRI REST"]
+AMS_LINK_TYPES = ["ESRI:ArcGIS:MapServer", "Esri REST: Map Service", "ESRI REST", "MapServer"]
 
-AFS_LINK_TYPES = ["ESRI:ArcGIS:FeatureServer", "Esri REST: Feature Service"]
+AFS_LINK_TYPES = ["ESRI:ArcGIS:FeatureServer", "Esri REST: Feature Service", "FeatureServer"]
 
 GIS_FILE_LINK_TYPES = ["FILE:GEO"]


### PR DESCRIPTION
## Description

This is to add a new value for identifying ArcGIS FeatureServer, and ArcGIS MapServer.

When using ESRI Geoportal to submit a csw getRecords request, it responses with the following sample xml.

<csw:Record>
			<dc:identifier>hab_rcd_1630999127525_68946</dc:identifier>
			<dc:title>&quot;M&quot; Mark Events</dc:title>
			<dc:subject scheme="keywords">Common Sharable Spatial Data (CSSD)</dc:subject>
			<dc:subject scheme="keywords">Recreation and Culture</dc:subject>
			<dc:subject scheme="keywords">society</dc:subject>
			<dct:modified>2024-11-27T19:16:25.366Z</dct:modified>
			<dct:abstract>&quot;M&quot;mark events calendar</dct:abstract>
			<dct:created>2023-01-04T21:03:34.513Z</dct:created>
			<dc:creator>portaladmin</dc:creator>
			<dct:references scheme="alternate.json">https://portal.csdi.gov.hk/geoportal/rest/metadata/item/hab_rcd_1630999127525_68946</dct:references>
			<dct:references scheme="alternate.html">https://portal.csdi.gov.hk/geoportal/rest/metadata/item/hab_rcd_1630999127525_68946/html</dct:references>
			<dct:references scheme="alternate.xml">https://portal.csdi.gov.hk/geoportal/rest/metadata/item/hab_rcd_1630999127525_68946/xml</dct:references>
			<dct:references scheme="FeatureServer">https://portal.csdi.gov.hk/server/rest/services/common/hab_rcd_1630999127525_68946/FeatureServer</dct:references>
			<dct:references scheme="WMS">https://portal.csdi.gov.hk/server/services/common/hab_rcd_1630999127525_68946/MapServer/WMSServer?service=wms&amp;request=GetCapabilities</dct:references>
			<ows:BoundingBox>
				<ows:LowerCorner>113.815 22.135</ows:LowerCorner>
				<ows:UpperCorner>114.5 22.565</ows:UpperCorner>
			</ows:BoundingBox>
</csw:Record>

As you cam see, one of the URL is pointing to a FeatureServer, it uses scheme="FeatureServer" for identification. However, QGIS's MetaSearch does not know "FeatureServer" because possible value in "scheme" for ArcGIS Map Server (AMS_LINK_TYPES), and ArcGIS FeatureServer (AFS_LINK_TYPES) supports the following values only.

AMS_LINK_TYPES = ["ESRI:ArcGIS:MapServer", "Esri REST: Map Service", "ESRI REST"]

AFS_LINK_TYPES = ["ESRI:ArcGIS:FeatureServer", "Esri REST: Feature Service"]

As a result, I added "MapServer" and "FeatureServer" in the above definitions as I want QGIS's MetaSearch can identify the value generated by ESRI Geoportal in its csw:getRecords request. I've tested it and it works fine.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
