### PR TITLE
add "Add result to project" checkbox to mesh calculator dialog (fix #45245)

### DIFF
--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -707,3 +707,8 @@ void QgsMeshCalculatorDialog::repopulateTimeCombos()
     mEndTimeComboBox->setCurrentIndex( times.size() - 1 );
   }
 }
+
+bool QgsMeshCalculatorDialog::addLayerToProject() const
+{
+  return mAddResultToProjectCheckBox->isChecked();
+}

--- a/src/app/mesh/qgsmeshcalculatordialog.h
+++ b/src/app/mesh/qgsmeshcalculatordialog.h
@@ -39,6 +39,9 @@ class APP_EXPORT QgsMeshCalculatorDialog : public QDialog, private Ui::QgsMeshCa
     //! Returns new mesh calculator created from dialog options
     std::unique_ptr<QgsMeshCalculator> calculator() const;
 
+    QString outputFile() const;
+    bool addLayerToProject() const;
+
   private slots:
     void datasetGroupEntry( const QModelIndex &index );
     void mCurrentLayerExtentButton_clicked();
@@ -80,7 +83,6 @@ class APP_EXPORT QgsMeshCalculatorDialog : public QDialog, private Ui::QgsMeshCa
     QString formulaString() const;
     QgsMeshLayer *meshLayer() const;
 
-    QString outputFile() const;
     QgsRectangle outputExtent() const;
     QgsGeometry maskGeometry() const;
     QString driver() const;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6231,6 +6231,10 @@ void QgisApp::showMeshCalculator()
     switch ( res )
     {
       case QgsMeshCalculator::Success:
+        if ( d.addLayerToProject() )
+        {
+          addMeshLayer( d.outputFile(), QFileInfo( d.outputFile() ).completeBaseName(), QStringLiteral( "mdal" ) );
+        }
         visibleMessageBar()->pushMessage( tr( "Mesh calculator" ), tr( "Calculation complete." ), Qgis::MessageLevel::Success );
         break;
 

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>912</width>
-    <height>902</height>
+    <height>954</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,11 +17,11 @@
    <item>
     <widget class="QSplitter" name="splitter_2">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
       <widget class="QGroupBox" name="mRasterBandsGroupBox">
        <property name="title">
@@ -43,7 +43,7 @@
           <item row="0" column="0" colspan="3">
            <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
             <property name="layoutDirection">
-             <enum>Qt::LeftToRight</enum>
+             <enum>Qt::LayoutDirection::LeftToRight</enum>
             </property>
             <property name="text">
              <string>Create on-the-fly dataset group instead of writing layer to disk</string>
@@ -280,7 +280,7 @@
                 <item>
                  <spacer name="horizontalSpacer_3">
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
@@ -295,7 +295,7 @@
               <item row="2" column="2">
                <spacer name="horizontalSpacer_4">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -320,7 +320,7 @@
            <item row="1" column="2">
             <spacer name="horizontalSpacer">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -362,7 +362,7 @@
              <item>
               <spacer name="horizontalSpacer_2">
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -378,9 +378,19 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
+          <property name="text">
+           <string>Add result to project</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -455,7 +465,7 @@
           <item row="0" column="6">
            <spacer name="horizontalSpacer_1">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -636,10 +646,10 @@
    <item>
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
@@ -656,15 +666,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>


### PR DESCRIPTION
## Description

Adds "Add result to project" checkbox to the mesh calculator dialog, allowing users to load calculator output to the project automatically.

Fixes #45245.