### PR TITLE
[FEATURE] [OGC API provider] Implement Part 5 - Schemas

### DIFF
--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -35,6 +35,7 @@ set(WFS_SRCS
   oapif/qgsoapifoptionsrequest.cpp
   oapif/qgsoapifprovider.cpp
   oapif/qgsoapifqueryablesrequest.cpp
+  oapif/qgsoapifschemarequest.cpp
   oapif/qgsoapifsingleitemrequest.cpp
   oapif/qgsoapifutils.cpp
 )

--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -501,6 +501,8 @@ bool QgsOapifProvider::empty() const
   return !getFeatures( request ).nextFeature( f );
 };
 
+QString QgsOapifProvider::geometryColumnName() const { return mShared->mGeometryColumnName; }
+
 bool QgsOapifProvider::setSubsetString( const QString &filter, bool updateFeatureCount )
 {
   QgsDebugMsgLevel( QStringLiteral( "filter = '%1'" ).arg( filter ), 4 );
@@ -588,6 +590,7 @@ void QgsOapifProvider::handleGetSchemaRequest( const QString &schemaUrl )
   if ( schemaRequest.errorCode() == QgsBaseNetworkRequest::NoError )
   {
     mShared->mFields = schema.mFields;
+    mShared->mGeometryColumnName = schema.mGeometryColumnName;
     if ( schema.mWKBType != Qgis::WkbType::Unknown )
       mShared->mWKBType = schema.mWKBType;
   }

--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -30,6 +30,7 @@
 #include "qgsoapifitemsrequest.h"
 #include "qgsoapifoptionsrequest.h"
 #include "qgsoapifqueryablesrequest.h"
+#include "qgsoapifschemarequest.h"
 #include "qgsoapifsingleitemrequest.h"
 #include "qgswfsconstants.h"
 #include "qgswfsutils.h" // for isCompatibleType()
@@ -167,6 +168,7 @@ bool QgsOapifProvider::init()
 
   bool implementsPart2 = false;
   const QString &conformanceUrl = landingPageRequest.conformanceUrl();
+  bool implementsSchemas = false;
   if ( !conformanceUrl.isEmpty() )
   {
     QgsOapifConformanceRequest conformanceRequest( mShared->mURI.uri() );
@@ -178,6 +180,7 @@ bool QgsOapifProvider::init()
     mShared->mServerSupportsLikeBetweenIn = ( conformanceClasses.contains( QLatin1String( "http://www.opengis.net/spec/cql2/0.0/conf/advanced-comparison-operators" ) ) || conformanceClasses.contains( QLatin1String( "http://www.opengis.net/spec/cql2/1.0/conf/advanced-comparison-operators" ) ) );
     mShared->mServerSupportsCaseI = ( conformanceClasses.contains( QLatin1String( "http://www.opengis.net/spec/cql2/0.0/conf/case-insensitive-comparison" ) ) || conformanceClasses.contains( QLatin1String( "http://www.opengis.net/spec/cql2/1.0/conf/case-insensitive-comparison" ) ) );
     mShared->mServerSupportsBasicSpatialOperators = ( conformanceClasses.contains( QLatin1String( "http://www.opengis.net/spec/cql2/0.0/conf/basic-spatial-operators" ) ) || conformanceClasses.contains( QLatin1String( "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-operators" ) ) );
+    implementsSchemas = conformanceClasses.contains( QLatin1String( "http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/schemas" ) );
   }
 
   mLayerMetadata = collectionRequest->collection().mLayerMetadata;
@@ -285,6 +288,34 @@ bool QgsOapifProvider::init()
   mShared->mWKBType = itemsRequest.wkbType();
   mShared->mFoundIdTopLevel = itemsRequest.foundIdTopLevel();
   mShared->mFoundIdInProperties = itemsRequest.foundIdInProperties();
+
+  if ( implementsSchemas )
+  {
+    QString schemaUrl;
+    // Find a link for rel=http://www.opengis.net/def/rel/ogc/1.0/schema (or [ogc-rel:schema])
+    // whose mime type is in priority "application/schema+json"
+    // Also accept "application/json" as lower priority
+    for ( const QgsAbstractMetadataBase::Link &link : mLayerMetadata.links() )
+    {
+      if ( link.name == QLatin1String( "http://www.opengis.net/def/rel/ogc/1.0/schema" ) || link.name == QLatin1String( "[ogc-rel:schema]" ) )
+      {
+        if ( link.mimeType == "application/schema+json" )
+        {
+          schemaUrl = link.url;
+          break;
+        }
+        else if ( link.mimeType == "application/json" )
+        {
+          schemaUrl = link.url;
+          // Go on in case there is a later mimeType == "application/schema+json"
+        }
+      }
+    }
+    if ( !schemaUrl.isEmpty() )
+    {
+      handleGetSchemaRequest( schemaUrl );
+    }
+  }
 
   computeCapabilities( itemsRequest );
 
@@ -548,6 +579,18 @@ const QString &QgsOapifProvider::clientSideFilterExpression() const
 void QgsOapifProvider::handlePostCloneOperations( QgsVectorDataProvider *source )
 {
   mShared = qobject_cast<QgsOapifProvider *>( source )->mShared;
+}
+
+void QgsOapifProvider::handleGetSchemaRequest( const QString &schemaUrl )
+{
+  QgsOapifSchemaRequest schemaRequest( mShared->mURI.uri() );
+  const QgsOapifSchemaRequest::Schema schema = schemaRequest.schema( schemaUrl );
+  if ( schemaRequest.errorCode() == QgsBaseNetworkRequest::NoError )
+  {
+    mShared->mFields = schema.mFields;
+    if ( schema.mWKBType != Qgis::WkbType::Unknown )
+      mShared->mWKBType = schema.mWKBType;
+  }
 }
 
 bool QgsOapifProvider::addFeatures( QgsFeatureList &flist, Flags flags )
@@ -1382,6 +1425,15 @@ void QgsOapifFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFe
         QgsGeometry g = f.geometry();
         if ( mShared->mSourceCrs.hasAxisInverted() )
           g.get()->swapXy();
+
+        // Promote single geometries to multipart if necessary
+        if ( QgsWkbTypes::flatType( g.wkbType() ) == Qgis::WkbType::Point && mShared->mWKBType == Qgis::WkbType::MultiPoint )
+          g = g.convertToType( Qgis::GeometryType::Point, /* destMultipart = */ true );
+        else if ( QgsWkbTypes::flatType( g.wkbType() ) == Qgis::WkbType::LineString && mShared->mWKBType == Qgis::WkbType::MultiLineString )
+          g = g.convertToType( Qgis::GeometryType::Line, /* destMultipart = */ true );
+        else if ( QgsWkbTypes::flatType( g.wkbType() ) == Qgis::WkbType::Polygon && mShared->mWKBType == Qgis::WkbType::MultiPolygon )
+          g = g.convertToType( Qgis::GeometryType::Polygon, /* destMultipart = */ true );
+
         dstFeat.setGeometry( g );
       }
       const auto srcAttrs = f.attributes();

--- a/src/providers/wfs/oapif/qgsoapifprovider.h
+++ b/src/providers/wfs/oapif/qgsoapifprovider.h
@@ -81,6 +81,8 @@ class QgsOapifProvider final : public QgsVectorDataProvider
 
     bool empty() const override;
 
+    QString geometryColumnName() const override;
+
     enum class FilterTranslationState
     {
       FULLY_CLIENT,
@@ -210,6 +212,9 @@ class QgsOapifSharedData final : public QObject, public QgsBackgroundCachedShare
 
     //! Server filter
     QString mServerFilter;
+
+    //! Geometry column name
+    QString mGeometryColumnName;
 
     //! Translation state of filter to server-side filter.
     QgsOapifProvider::FilterTranslationState mFilterTranslationState = QgsOapifProvider::FilterTranslationState::FULLY_CLIENT;

--- a/src/providers/wfs/oapif/qgsoapifprovider.h
+++ b/src/providers/wfs/oapif/qgsoapifprovider.h
@@ -138,6 +138,9 @@ class QgsOapifProvider final : public QgsVectorDataProvider
 
     //! Compute capabilities
     void computeCapabilities( const QgsOapifItemsRequest &itemsRequest );
+
+    //! Issue a GET /schema request and handle it
+    void handleGetSchemaRequest( const QString &schemaUrl );
 };
 
 class QgsOapifProviderMetadata final : public QgsProviderMetadata

--- a/src/providers/wfs/oapif/qgsoapifschemarequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifschemarequest.cpp
@@ -206,6 +206,7 @@ void QgsOapifSchemaRequest::processReply()
             {
               if ( QString::fromStdString( jOgcRole.get<std::string>() ) == QLatin1String( "primary-geometry" ) )
               {
+                mSchema.mGeometryColumnName = QString::fromStdString( key );
                 mSchema.mWKBType = Qgis::WkbType::Unknown;
                 if ( val.contains( "format" ) )
                 {

--- a/src/providers/wfs/oapif/qgsoapifschemarequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifschemarequest.cpp
@@ -1,0 +1,255 @@
+/***************************************************************************
+    qgsoapifschemarequest.cpp
+    -------------------------
+    begin                : March 2025
+    copyright            : (C) 2025 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <nlohmann/json.hpp>
+using namespace nlohmann;
+
+#include "qgslogger.h"
+#include "qgsmessagelog.h"
+#include "qgsoapifschemarequest.h"
+#include "moc_qgsoapifschemarequest.cpp"
+#include "qgsoapifutils.h"
+#include "qgswfsconstants.h"
+
+#include <algorithm>
+#include <map>
+
+#include <QTextCodec>
+
+QgsOapifSchemaRequest::QgsOapifSchemaRequest( const QgsDataSourceUri &uri )
+  : QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), QgsHttpHeaders(), uri.authConfigId() ), "OAPIF" )
+{
+  // Using Qt::DirectConnection since the download might be running on a different thread.
+  // In this case, the request was sent from the main thread and is executed with the main
+  // thread being blocked in future.waitForFinished() so we can run code on this object which
+  // lives in the main thread without risking havoc.
+  connect( this, &QgsBaseNetworkRequest::downloadFinished, this, &QgsOapifSchemaRequest::processReply, Qt::DirectConnection );
+}
+
+const QgsOapifSchemaRequest::Schema &QgsOapifSchemaRequest::schema( const QUrl &schemaUrl )
+{
+  mUrl = schemaUrl;
+  sendGET( schemaUrl, QString( "application/schema+json" ), /*synchronous=*/true, /*forceRefresh=*/false );
+  return mSchema;
+}
+
+QString QgsOapifSchemaRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Download of schema failed: %1" ).arg( reason );
+}
+
+void QgsOapifSchemaRequest::processReply()
+{
+  if ( mErrorCode != QgsBaseNetworkRequest::NoError )
+  {
+    return;
+  }
+  const QByteArray &buffer = mResponse;
+  if ( buffer.isEmpty() )
+  {
+    mErrorMessage = tr( "empty response" );
+    mErrorCode = QgsBaseNetworkRequest::ServerExceptionError;
+    return;
+  }
+
+  QgsDebugMsgLevel( QStringLiteral( "parsing Schema response: " ) + buffer, 4 );
+
+  QTextCodec::ConverterState state;
+  QTextCodec *codec = QTextCodec::codecForName( "UTF-8" );
+  Q_ASSERT( codec );
+
+  const QString utf8Text = codec->toUnicode( buffer.constData(), buffer.size(), &state );
+  if ( state.invalidChars != 0 )
+  {
+    mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
+    mErrorMessage = errorMessageWithReason( tr( "Invalid UTF-8 content" ) );
+    return;
+  }
+
+  // Key is the explicit x-ogc-propertySeq or a synthetized one
+  std::map<int, QgsField> fields;
+  int seqNumber = 1;
+  int largestSeqNumber = 1;
+  bool seqNumbersAreOk = true;
+  try
+  {
+    const json j = json::parse( utf8Text.toStdString() );
+
+    if ( j.is_object() && j.contains( "properties" ) )
+    {
+      const json jProperties = j["properties"];
+      if ( jProperties.is_object() )
+      {
+        for ( const auto &[key, val] : jProperties.items() )
+        {
+          if ( val.is_object() && val.contains( "type" ) )
+          {
+            QgsField field( QString::fromStdString( key ), QMetaType::Type::QString );
+
+            const json jType = val["type"];
+            if ( jType.is_string() )
+            {
+              const QString type = QString::fromStdString( jType.get<std::string>() );
+              if ( type == QLatin1String( "integer" ) )
+              {
+                field.setType( QMetaType::Type::LongLong );
+              }
+              else if ( type == QLatin1String( "number" ) )
+              {
+                field.setType( QMetaType::Type::Double );
+              }
+              else if ( type == QLatin1String( "boolean" ) )
+              {
+                field.setType( QMetaType::Type::Bool );
+              }
+              else if ( type == QLatin1String( "object" ) )
+              {
+                field.setType( QMetaType::Type::QVariantMap );
+              }
+              else if ( type == QLatin1String( "array" ) )
+              {
+                field.setType( QMetaType::Type::QVariantList );
+              }
+              else if ( type == QLatin1String( "string" ) )
+              {
+                if ( val.contains( "format" ) )
+                {
+                  const json jFormat = val["format"];
+                  if ( jFormat.is_string() )
+                  {
+                    const QString format = QString::fromStdString( jFormat.get<std::string>() );
+                    if ( format == QLatin1String( "date-time" ) )
+                    {
+                      field.setType( QMetaType::Type::QDateTime );
+                    }
+                    else if ( format == QLatin1String( "date" ) )
+                    {
+                      field.setType( QMetaType::Type::QDate );
+                    }
+                  }
+                }
+              }
+              else
+              {
+                QgsDebugMsgLevel( QStringLiteral( "Unhandled OGC API Features schema type: " ) + type, 4 );
+              }
+            }
+
+            if ( val.contains( "title" ) )
+            {
+              const json jTitle = val["title"];
+              if ( jTitle.is_string() )
+              {
+                field.setAlias( QString::fromStdString( jTitle.get<std::string>() ) );
+              }
+            }
+
+            if ( val.contains( "description" ) )
+            {
+              const json jDescription = val["description"];
+              if ( jDescription.is_string() )
+              {
+                field.setComment( QString::fromStdString( jDescription.get<std::string>() ) );
+              }
+            }
+
+            if ( seqNumbersAreOk && val.contains( "x-ogc-propertySeq" ) )
+            {
+              const json jOgcPropertySeq = val["x-ogc-propertySeq"];
+              if ( jOgcPropertySeq.is_number_integer() )
+              {
+                seqNumber = jOgcPropertySeq.get<int>();
+              }
+            }
+
+            if ( val.contains( "readOnly" ) )
+            {
+              const json jReadOnly = val["readOnly"];
+              if ( jReadOnly.is_boolean() )
+              {
+                field.setReadOnly( jReadOnly.get<bool>() );
+              }
+            }
+
+            // Make sure that there are no colliding sequence numbers. If so,
+            // give up honouring them.
+            if ( seqNumbersAreOk && fields.find( seqNumber ) != fields.end() )
+            {
+              QgsMessageLog::logMessage( tr( "Schema at %1 has inconsistent x-ogc-propertySeq" ).arg( mUrl.toString() ), tr( "OAPIF" ) );
+
+              seqNumbersAreOk = false;
+              seqNumber = largestSeqNumber + 1;
+            }
+
+            fields[seqNumber] = std::move( field );
+
+            largestSeqNumber = std::max( largestSeqNumber, seqNumber );
+            ++seqNumber;
+          }
+
+          if ( val.is_object() && val.contains( "x-ogc-role" ) )
+          {
+            const json jOgcRole = val["x-ogc-role"];
+            if ( jOgcRole.is_string() )
+            {
+              if ( QString::fromStdString( jOgcRole.get<std::string>() ) == QLatin1String( "primary-geometry" ) )
+              {
+                mSchema.mWKBType = Qgis::WkbType::Unknown;
+                if ( val.contains( "format" ) )
+                {
+                  const json jFormat = val["format"];
+                  if ( jFormat.is_string() )
+                  {
+                    const QString format = QString::fromStdString( jFormat.get<std::string>() );
+                    const QMap<QString, Qgis::WkbType> mapFormatToWkbType = {
+                      { QStringLiteral( "geometry-point" ), Qgis::WkbType::Point },
+                      { QStringLiteral( "geometry-multipoint" ), Qgis::WkbType::MultiPoint },
+                      { QStringLiteral( "geometry-linestring" ), Qgis::WkbType::LineString },
+                      { QStringLiteral( "geometry-multilinestring" ), Qgis::WkbType::MultiLineString },
+                      { QStringLiteral( "geometry-polygon" ), Qgis::WkbType::Polygon },
+                      { QStringLiteral( "geometry-multipolygon" ), Qgis::WkbType::MultiPolygon },
+                      { QStringLiteral( "geometry-geometrycollection" ), Qgis::WkbType::GeometryCollection },
+                      { QStringLiteral( "geometry-any" ), Qgis::WkbType::Unknown },
+                      { QStringLiteral( "geometry-point-or-multipoint" ), Qgis::WkbType::MultiPoint },
+                      { QStringLiteral( "geometry-linestring-or-multilinestring" ), Qgis::WkbType::MultiLineString },
+                      { QStringLiteral( "geometry-polygon-or-multipolygon" ), Qgis::WkbType::MultiPolygon },
+                    };
+                    const auto it = mapFormatToWkbType.constFind( format );
+                    if ( it != mapFormatToWkbType.end() )
+                    {
+                      mSchema.mWKBType = it.value();
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Order fields by ascending sequence number
+    for ( const auto &[seqNumber, f] : fields )
+    {
+      mSchema.mFields.append( f );
+    }
+  }
+  catch ( const json::parse_error &ex )
+  {
+    mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
+    mErrorMessage = errorMessageWithReason( tr( "Cannot decode JSON document: %1" ).arg( QString::fromStdString( ex.what() ) ) );
+    return;
+  }
+}

--- a/src/providers/wfs/oapif/qgsoapifschemarequest.h
+++ b/src/providers/wfs/oapif/qgsoapifschemarequest.h
@@ -36,6 +36,9 @@ class QgsOapifSchemaRequest : public QgsBaseNetworkRequest
         //! Fields
         QgsFields mFields;
 
+        QString mGeometryColumnName;
+        //! Geometry column name;
+
         //! Geometry type;
         Qgis::WkbType mWKBType = Qgis::WkbType::NoGeometry;
     };

--- a/src/providers/wfs/oapif/qgsoapifschemarequest.h
+++ b/src/providers/wfs/oapif/qgsoapifschemarequest.h
@@ -1,8 +1,8 @@
 /***************************************************************************
-    qgsoapifqueryablesrequest.h
-    ---------------------------
-    begin                : April 2023
-    copyright            : (C) 2023 by Even Rouault
+    qgsoapifschemarequest.h
+    -----------------------
+    begin                : March 2025
+    copyright            : (C) 2025 by Even Rouault
     email                : even.rouault at spatialys.com
  ***************************************************************************
  *                                                                         *
@@ -13,46 +13,46 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSOAPIFQUERYABLESREQUEST_H
-#define QGSOAPIFQUERYABLESREQUEST_H
+#ifndef QGSOAPIFSCHEMAREQUEST_H
+#define QGSOAPIFSCHEMAREQUEST_H
 
 #include <QObject>
 #include <QMap>
 
 #include "qgsdatasourceuri.h"
+#include "qgsfields.h"
 #include "qgsbasenetworkrequest.h"
+#include "qgswkbtypes.h"
 
-//! Manages the queryable request
-class QgsOapifQueryablesRequest : public QgsBaseNetworkRequest
+//! Manages the schema request
+class QgsOapifSchemaRequest : public QgsBaseNetworkRequest
 {
     Q_OBJECT
   public:
-    explicit QgsOapifQueryablesRequest( const QgsDataSourceUri &uri );
+    explicit QgsOapifSchemaRequest( const QgsDataSourceUri &uri );
 
-    //! Describes a queryable parameter.
-    struct Queryable
+    struct Schema
     {
-        //! whether the parameter is a geometry
-        bool mIsGeometry = false;
+        //! Fields
+        QgsFields mFields;
 
-        //! type as in a JSON schema: "string", "integer", "number", etc.
-        QString mType;
-
-        //! format as in JSON schema. e.g "date-time" if mType="string"
-        QString mFormat;
+        //! Geometry type;
+        Qgis::WkbType mWKBType = Qgis::WkbType::NoGeometry;
     };
 
-    //! Issue the request synchronously and return queryables
-    const QMap<QString, Queryable> &queryables( const QUrl &queryablesUrl );
+    //! Issue the request synchronously and return fields
+    const Schema &schema( const QUrl &schemaUrl );
 
   private slots:
     void processReply();
 
   private:
-    QMap<QString, Queryable> mQueryables;
+    QUrl mUrl;
+
+    Schema mSchema;
 
   protected:
     QString errorMessageWithReason( const QString &reason ) override;
 };
 
-#endif // QGSOAPIFQUERYABLESREQUEST_H
+#endif // QGSOAPIFSCHEMAREQUEST_H

--- a/tests/src/python/test_provider_oapif.py
+++ b/tests/src/python/test_provider_oapif.py
@@ -19,7 +19,7 @@ import tempfile
 
 from osgeo import gdal
 
-from qgis.PyQt.QtCore import QCoreApplication, QDateTime, Qt, QVariant
+from qgis.PyQt.QtCore import QCoreApplication, QDateTime, QMetaType, Qt, QVariant
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsApplication,
@@ -30,6 +30,7 @@ from qgis.core import (
     QgsRectangle,
     QgsSettings,
     QgsVectorLayer,
+    QgsWkbTypes,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -81,6 +82,7 @@ ACCEPT_COLLECTION = "Accept=application/json"
 ACCEPT_CONFORMANCE = "Accept=application/json"
 ACCEPT_ITEMS = "Accept=application/geo+json, application/json"
 ACCEPT_QUERYABLES = "Accept=application/schema+json"
+ACCEPT_SCHEMA = "Accept=application/schema+json"
 
 
 def mergeDict(d1, d2):
@@ -101,6 +103,7 @@ def create_landing_page_api_collection(
     bbox=[-71.123, 66.33, -65.32, 78.3],
     additionalApiResponse={},
     additionalConformance=[],
+    collectionLinks=None,
 ):
 
     questionmark_extraparam = "?" + extraparam if extraparam else ""
@@ -191,6 +194,8 @@ def create_landing_page_api_collection(
         collection["storageCrs"] = storageCrs
     if crsList:
         collection["crs"] = crsList
+    if collectionLinks:
+        collection["links"] = collectionLinks
 
     with open(
         sanitize(
@@ -2740,6 +2745,289 @@ class TestPyQgsOapifProvider(QgisTestCase, ProviderTestCase):
         # serialization and deserialization
         values = [f["center"] for f in vl.getFeatures()]
         self.assertEqual(values, [{"coordinates": [6.5, 51.8], "type": "Point"}])
+
+    def testPart5Schema(self):
+        """Base test for OGC API Features Part 5 - Schema"""
+
+        endpoint = (
+            self.__class__.basetestpath + "/fake_qgis_http_endpoint_testPart5Schema"
+        )
+        additionalConformance = [
+            "http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/schemas",
+        ]
+        collectionLinks = [
+            {
+                "type": "text/html",
+                "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                "title": "Schema of collection in HTML",
+                "href": "http://"
+                + endpoint
+                + "/collections/mycollection/schema?f=html",
+            },
+            {
+                "type": "application/schema+json",
+                "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                "title": "Schema of collection in JSON",
+                "href": "http://"
+                + endpoint
+                + "/collections/mycollection/schema?f=json",
+            },
+        ]
+        create_landing_page_api_collection(
+            endpoint,
+            additionalConformance=additionalConformance,
+            collectionLinks=collectionLinks,
+        )
+
+        filename = sanitize(
+            endpoint, "/collections/mycollection/schema?f=json&" + ACCEPT_SCHEMA
+        )
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://" + endpoint + "/collections/mycollection/schema?f=json",
+            "type": "object",
+            "title": "My Collection",
+            "properties": {
+                "id": {
+                    "title": "Feature identifier",
+                    "description": "Long description",
+                    "type": "string",
+                    "readOnly": True,
+                    "x-ogc-role": "id",
+                    "x-ogc-propertySeq": 1,
+                },
+                "intfield": {"type": "integer", "x-ogc-propertySeq": 3},
+                "strfield": {"type": "string", "x-ogc-propertySeq": 2},
+                "doublefield": {"type": "number", "x-ogc-propertySeq": 4},
+                "boolfield": {"type": "boolean", "x-ogc-propertySeq": 5},
+                "datetimefield": {
+                    "type": "string",
+                    "format": "date-time",
+                    "x-ogc-propertySeq": 6,
+                },
+                "datefield": {
+                    "type": "string",
+                    "format": "date",
+                    "x-ogc-propertySeq": 7,
+                },
+                "geometry": {
+                    "x-ogc-role": "primary-geometry",
+                    "format": "geometry-point",
+                    "x-ogc-propertySeq": 8,
+                },
+                "str2field": {"type": "string", "x-ogc-propertySeq": 9},
+                "objectfield": {"type": "object", "x-ogc-propertySeq": 10},
+                "arrayfield": {"type": "array", "x-ogc-propertySeq": 11},
+            },
+        }
+        with open(filename, "wb") as f:
+            f.write(json.dumps(schema).encode("UTF-8"))
+
+        # first items
+        first_items = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "feat.1",
+                    "properties": {
+                        "intfield": 1,
+                        "strfield": "foo",
+                        "doublefield": 1.25,
+                        "boolfield": True,
+                        "datetimefield": "2025-03-17T17:13:00+0100",
+                        "datefield": "2025-03-17",
+                    },
+                    "geometry": {"type": "Point", "coordinates": [66.33, -70.332]},
+                }
+            ],
+        }
+        with open(
+            sanitize(
+                endpoint, "/collections/mycollection/items?limit=10&" + ACCEPT_ITEMS
+            ),
+            "wb",
+        ) as f:
+            f.write(json.dumps(first_items).encode("UTF-8"))
+
+        # real page
+        with open(
+            sanitize(
+                endpoint, "/collections/mycollection/items?limit=1000&" + ACCEPT_ITEMS
+            ),
+            "wb",
+        ) as f:
+            f.write(json.dumps(first_items).encode("UTF-8"))
+
+        vl = QgsVectorLayer(
+            "url='http://"
+            + endpoint
+            + "' typename='mycollection' restrictToRequestBBOX=1",
+            "test",
+            "OAPIF",
+        )
+        self.assertTrue(vl.isValid())
+
+        fields = vl.fields()
+        self.assertEqual(len(fields), 10)
+        self.assertEqual(
+            [fields[i].name() for i in range(len(fields))],
+            [
+                "id",
+                "strfield",
+                "intfield",
+                "doublefield",
+                "boolfield",
+                "datetimefield",
+                "datefield",
+                "str2field",
+                "objectfield",
+                "arrayfield",
+            ],
+        )
+        self.assertEqual(fields[0].alias(), "Feature identifier")
+        self.assertEqual(fields[0].comment(), "Long description")
+        self.assertTrue(fields[0].isReadOnly())
+        self.assertFalse(fields[1].isReadOnly())
+        self.assertEqual(
+            [fields[i].type() for i in range(len(fields))],
+            [
+                QMetaType.Type.QString,
+                QMetaType.Type.QString,
+                QMetaType.Type.LongLong,
+                QMetaType.Type.Double,
+                QMetaType.Type.Bool,
+                QMetaType.Type.QDateTime,
+                QMetaType.Type.QDate,
+                QMetaType.Type.QString,
+                QMetaType.Type.QVariantMap,
+                QMetaType.Type.QVariantList,
+            ],
+        )
+        self.assertEqual(vl.wkbType(), QgsWkbTypes.Type.Point)
+
+        values = [
+            [f["id"], f["strfield"], f["intfield"], f["doublefield"], f["boolfield"]]
+            for f in vl.getFeatures()
+        ]
+        self.assertEqual(values, [["feat.1", "foo", 1, 1.25, True]])
+
+    def _testPart5SchemaSingleOrMulti(
+        self, geometryFormat, geojsonGeom, expectedWkbType, expectedWkt
+    ):
+
+        endpoint = (
+            self.__class__.basetestpath
+            + "/fake_qgis_http_endpoint__testPart5SchemaSingleOrMulti"
+        )
+        additionalConformance = [
+            "http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/schemas",
+        ]
+        collectionLinks = [
+            {
+                "type": "application/schema+json",
+                "rel": "[ogc-rel:schema]",
+                "title": "Schema of collection in JSON",
+                "href": "http://" + endpoint + "/collections/mycollection/schema",
+            }
+        ]
+        create_landing_page_api_collection(
+            endpoint,
+            additionalConformance=additionalConformance,
+            collectionLinks=collectionLinks,
+        )
+
+        filename = sanitize(
+            endpoint, "/collections/mycollection/schema?" + ACCEPT_SCHEMA
+        )
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://" + endpoint + "/collections/mycollection/schema?f=json",
+            "type": "object",
+            "title": "My Collection",
+            "properties": {
+                "id": {"type": "string", "x-ogc-role": "id", "type": "string"},
+                "geometry": {
+                    "x-ogc-role": "primary-geometry",
+                    "format": geometryFormat,
+                },
+            },
+        }
+        with open(filename, "wb") as f:
+            f.write(json.dumps(schema).encode("UTF-8"))
+
+        # first items
+        first_items = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "feat.1",
+                    "properties": {},
+                    "geometry": geojsonGeom,
+                }
+            ],
+        }
+        with open(
+            sanitize(
+                endpoint, "/collections/mycollection/items?limit=10&" + ACCEPT_ITEMS
+            ),
+            "wb",
+        ) as f:
+            f.write(json.dumps(first_items).encode("UTF-8"))
+
+        # real page
+        with open(
+            sanitize(
+                endpoint, "/collections/mycollection/items?limit=1000&" + ACCEPT_ITEMS
+            ),
+            "wb",
+        ) as f:
+            f.write(json.dumps(first_items).encode("UTF-8"))
+
+        vl = QgsVectorLayer(
+            "url='http://"
+            + endpoint
+            + "' typename='mycollection' restrictToRequestBBOX=1",
+            "test",
+            "OAPIF",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), expectedWkbType)
+
+        f = next(vl.getFeatures())
+        self.assertEqual(f.geometry().wkbType(), expectedWkbType)
+        self.assertEqual(f.geometry().asWkt().upper(), expectedWkt)
+
+    def testPart5SchemaPointOrMultiPoint(self):
+        """Test "format": "geometry-point-or-multipoint" """
+        self._testPart5SchemaSingleOrMulti(
+            "geometry-point-or-multipoint",
+            {"type": "Point", "coordinates": [2, 49]},
+            QgsWkbTypes.Type.MultiPoint,
+            "MULTIPOINT ((2 49))",
+        )
+
+    def testPart5SchemaLineStringOrMultiLineString(self):
+        """Test "format": "geometry-linestring-or-multilinestring" """
+        self._testPart5SchemaSingleOrMulti(
+            "geometry-linestring-or-multilinestring",
+            {"type": "LineString", "coordinates": [[2, 49], [3, 50]]},
+            QgsWkbTypes.Type.MultiLineString,
+            "MULTILINESTRING ((2 49, 3 50))",
+        )
+
+    def testPart5SchemaPolygonOrMultiPolygon(self):
+        """Test "format": "geometry-linestring-or-multilinestring" """
+        self._testPart5SchemaSingleOrMulti(
+            "geometry-polygon-or-multipolygon",
+            {
+                "type": "Polygon",
+                "coordinates": [[[2, 49], [2, 50], [3, 50], [3, 49], [2, 49]]],
+            },
+            QgsWkbTypes.Type.MultiPolygon,
+            "MULTIPOLYGON (((2 49, 2 50, 3 50, 3 49, 2 49)))",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_provider_oapif.py
+++ b/tests/src/python/test_provider_oapif.py
@@ -2912,6 +2912,8 @@ class TestPyQgsOapifProvider(QgisTestCase, ProviderTestCase):
         ]
         self.assertEqual(values, [["feat.1", "foo", 1, 1.25, True]])
 
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "geometry")
+
     def _testPart5SchemaSingleOrMulti(
         self, geometryFormat, geojsonGeom, expectedWkbType, expectedWkt
     ):


### PR DESCRIPTION
This enables to correctly infer field names and types, without relying on analyzing a sample of few features, which might miss some attributes. Or this can enable adding new features in an empty layer. This also helps to get the layer geometry type.
