### PR TITLE
[mssql] Fix connection corruption after executing sql

### DIFF
--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -114,7 +114,17 @@ QgsDbImportVectorLayerDialog::QgsDbImportVectorLayerDialog( QgsAbstractDatabaseP
   sourceLayerComboChanged();
 }
 
-QgsDbImportVectorLayerDialog::~QgsDbImportVectorLayerDialog() = default;
+QgsDbImportVectorLayerDialog::~QgsDbImportVectorLayerDialog()
+{
+  // these widgets all potentially access mOwnedSource, so we need to force
+  // them to be deleted BEFORE the layer
+  delete mSourceLayerComboBox;
+  mSourceLayerComboBox = nullptr;
+  delete mFilterExpressionWidget;
+  mFilterExpressionWidget = nullptr;
+  delete mFieldsView;
+  mFieldsView = nullptr;
+}
 
 void QgsDbImportVectorLayerDialog::setDestinationSchema( const QString &schema )
 {

--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -344,10 +344,10 @@ QList<QgsVectorDataProvider::NativeType> QgsMssqlConnection::nativeTypes()
 {
   return QList<QgsVectorDataProvider::NativeType>()
          // integer types
-         << QgsVectorDataProvider::NativeType( QObject::tr( "8 Bytes Integer" ), QStringLiteral( "bigint" ), QMetaType::Type::Int )
-         << QgsVectorDataProvider::NativeType( QObject::tr( "4 Bytes Integer" ), QStringLiteral( "int" ), QMetaType::Type::Int )
-         << QgsVectorDataProvider::NativeType( QObject::tr( "2 Bytes Integer" ), QStringLiteral( "smallint" ), QMetaType::Type::Int )
-         << QgsVectorDataProvider::NativeType( QObject::tr( "1 Bytes Integer" ), QStringLiteral( "tinyint" ), QMetaType::Type::Int )
+         << QgsVectorDataProvider::NativeType( QObject::tr( "8 Bytes Integer (bigint)" ), QStringLiteral( "bigint" ), QMetaType::Type::LongLong )
+         << QgsVectorDataProvider::NativeType( QObject::tr( "4 Bytes Integer (int)" ), QStringLiteral( "int" ), QMetaType::Type::Int )
+         << QgsVectorDataProvider::NativeType( QObject::tr( "2 Bytes Integer (smallint)" ), QStringLiteral( "smallint" ), QMetaType::Type::Int )
+         << QgsVectorDataProvider::NativeType( QObject::tr( "1 Bytes Integer (tinyint)" ), QStringLiteral( "tinyint" ), QMetaType::Type::Int )
          << QgsVectorDataProvider::NativeType( QObject::tr( "Decimal Number (numeric)" ), QStringLiteral( "numeric" ), QMetaType::Type::Double, 1, 20, 0, 20 )
          << QgsVectorDataProvider::NativeType( QObject::tr( "Decimal Number (decimal)" ), QStringLiteral( "decimal" ), QMetaType::Type::Double, 1, 20, 0, 20 )
 

--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -86,10 +86,11 @@ std::shared_ptr<QgsMssqlDatabase> QgsMssqlDatabase::connectDb( const QgsDataSour
 
   QMutexLocker locker( &sMutex );
 
-  QString connName = connectionName( uri.service(), uri.host(), uri.database(), transaction );
+  const QString connName = connectionName( uri.service(), uri.host(), uri.database(), transaction );
 
-  if ( sConnections.contains( connName ) && !sConnections[connName].expired() )
-    return sConnections[connName].lock();
+  auto existingConnectionIt = sConnections.constFind( connName );
+  if ( existingConnectionIt != sConnections.constEnd() && !existingConnectionIt->expired() )
+    return existingConnectionIt->lock();
 
   QSqlDatabase db = getDatabase( uri.service(), uri.host(), uri.database(), uri.username(), uri.password(), transaction );
 

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -259,7 +259,7 @@ QVector<QgsDataItem *> QgsMssqlConnectionItem::createChildren()
     }
 
     // add missing schemas (i.e., empty schemas)
-    const QStringList allSchemas = QgsMssqlConnection::schemas( mConnectionUri, nullptr );
+    const QStringList allSchemas = QgsMssqlConnection::schemas( db, nullptr );
     QStringList excludedSchema = QgsMssqlConnection::excludedSchemasList( mName );
     for ( const QString &schema : allSchemas )
     {

--- a/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
+++ b/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
@@ -48,6 +48,13 @@ void QgsMssqlGeomColumnTypeThread::run()
 {
   mStopped = false;
 
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( mService, mHost, mDatabase, mUsername, mPassword );
+  if ( !db->isValid() )
+  {
+    QgsDebugError( db->errorText() );
+    return;
+  }
+
   for ( QList<QgsMssqlLayerProperty>::iterator it = layerProperties.begin(),
                                                end = layerProperties.end();
         it != end; ++it )
@@ -86,13 +93,6 @@ void QgsMssqlGeomColumnTypeThread::run()
       }
 
       // issue the sql query
-      std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( mService, mHost, mDatabase, mUsername, mPassword );
-      if ( !db->isValid() )
-      {
-        QgsDebugError( db->errorText() );
-        continue;
-      }
-
       QSqlQuery q = QSqlQuery( db->db() );
       q.setForwardOnly( true );
       if ( !q.exec( query ) )

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -2028,7 +2028,7 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
   QgsDataSourceUri dsUri( uri );
 
   // connect to database
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri );
 
   if ( !db->isValid() )
   {
@@ -2235,13 +2235,12 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
 
   const QgsDataProvider::ProviderOptions providerOptions;
   const Qgis::DataProviderReadFlags flags;
-  QgsMssqlProvider *provider = new QgsMssqlProvider( dsUri.uri(), providerOptions, flags );
+  auto provider = std::make_unique< QgsMssqlProvider >( dsUri.uri(), providerOptions, flags );
   if ( !provider->isValid() )
   {
     if ( errorMessage )
       *errorMessage = QObject::tr( "Loading of the MSSQL provider failed" );
 
-    delete provider;
     return Qgis::VectorExportResult::ErrorInvalidLayer;
   }
 
@@ -2276,7 +2275,6 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
         if ( errorMessage )
           *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( fld.name() );
 
-        delete provider;
         return Qgis::VectorExportResult::ErrorAttributeTypeUnsupported;
       }
 
@@ -2290,7 +2288,6 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
       if ( errorMessage )
         *errorMessage = QObject::tr( "Creation of fields failed" );
 
-      delete provider;
       return Qgis::VectorExportResult::ErrorAttributeCreationFailed;
     }
   }

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -2074,26 +2074,6 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
     }
     createdNewPk = true;
   }
-  else
-  {
-    // search for the passed field
-    for ( int i = 0, n = fields.size(); i < n; ++i )
-    {
-      if ( fields.at( i ).name() == primaryKey )
-      {
-        // found, get the field type
-        QgsField fld = fields.at( i );
-        if ( ( options && options->value( QStringLiteral( "skipConvertFields" ), false ).toBool() ) || convertField( fld ) )
-        {
-          primaryKeyType = fld.typeName();
-        }
-      }
-    }
-  }
-
-  // if the field doesn't not exist yet, create it as a serial field
-  if ( primaryKeyType.isEmpty() )
-    primaryKeyType = QStringLiteral( "serial" );
 
   QString sql;
   QSqlQuery q = QSqlQuery( db->db() );

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -2047,16 +2047,12 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
   QString geometryColumn = dsUri.geometryColumn();
 
   QString primaryKey = dsUri.keyColumn();
-  QString primaryKeyType;
 
   if ( schemaName.isEmpty() )
     schemaName = QStringLiteral( "dbo" );
 
   if ( wkbType != Qgis::WkbType::NoGeometry && geometryColumn.isEmpty() )
     geometryColumn = QStringLiteral( "geom" );
-
-  // get the pk's name and type
-  bool createdNewPk = false;
 
   // if no pk name was passed, define the new pk field name
   if ( primaryKey.isEmpty() )
@@ -2072,7 +2068,6 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
         i = 0;
       }
     }
-    createdNewPk = true;
   }
 
   QString sql;
@@ -2230,37 +2225,42 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
 
   if ( fields.size() > 0 )
   {
-    // if we had to create a primary key column, we start the old columns from 1
-    int offset = createdNewPk ? 1 : 0;
+    const QgsFields providerFields = provider->fields();
+    int offset = providerFields.size();
 
     // get the list of fields
     QList<QgsField> flist;
-    for ( int i = 0, n = fields.size(); i < n; ++i )
+    for ( int originalFieldIndex = 0, n = fields.size(); originalFieldIndex < n; ++originalFieldIndex )
     {
-      QgsField fld = fields.at( i );
-      if ( oldToNewAttrIdxMap && fld.name() == primaryKey )
-      {
-        oldToNewAttrIdxMap->insert( fields.lookupField( fld.name() ), 0 );
-        continue;
-      }
-
-      if ( fld.name() == geometryColumn )
+      QgsField field = fields.at( originalFieldIndex );
+      if ( field.name() == geometryColumn )
       {
         // Found a field with the same name of the geometry column. Skip it!
         continue;
       }
 
-      if ( !( options && options->value( QStringLiteral( "skipConvertFields" ), false ).toBool() ) && !convertField( fld ) )
+      const int providerIndex = providerFields.lookupField( field.name() );
+
+      if ( providerIndex >= 0 )
+      {
+        // we've already created this field (i.e. it was set in the CREATE TABLE statement), so
+        // we don't need to re-add it now
+        if ( oldToNewAttrIdxMap )
+          oldToNewAttrIdxMap->insert( originalFieldIndex, providerIndex );
+        continue;
+      }
+
+      if ( !( options && options->value( QStringLiteral( "skipConvertFields" ), false ).toBool() ) && !convertField( field ) )
       {
         if ( errorMessage )
-          *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( fld.name() );
+          *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( field.name() );
 
         return Qgis::VectorExportResult::ErrorAttributeTypeUnsupported;
       }
 
-      flist.append( fld );
+      flist.append( field );
       if ( oldToNewAttrIdxMap )
-        oldToNewAttrIdxMap->insert( fields.lookupField( fld.name() ), offset++ );
+        oldToNewAttrIdxMap->insert( originalFieldIndex, offset++ );
     }
 
     if ( !provider->addAttributes( flist ) )

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -306,7 +306,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsMssqlProviderConnection::e
 }
 
 
-QgssMssqlProviderResultIterator::QgssMssqlProviderResultIterator( bool resolveTypes, int columnCount, std::unique_ptr<QSqlQuery> query )
+QgssMssqlProviderResultIterator::QgssMssqlProviderResultIterator( bool resolveTypes, int columnCount, std::unique_ptr<QgsMssqlQuery> query )
   : mResolveTypes( resolveTypes )
   , mColumnCount( columnCount )
   , mQuery( std::move( query ) )

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -19,17 +19,16 @@
 
 #include "qgsabstractdatabaseproviderconnection.h"
 
-#include <QSqlQuery>
-
+class QgsMssqlQuery;
 
 struct QgssMssqlProviderResultIterator : public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
 {
-    QgssMssqlProviderResultIterator( bool resolveTypes, int columnCount, std::unique_ptr<QSqlQuery> query );
+    QgssMssqlProviderResultIterator( bool resolveTypes, int columnCount, std::unique_ptr<QgsMssqlQuery> query );
 
   private:
     bool mResolveTypes = true;
     int mColumnCount = 0;
-    std::unique_ptr<QSqlQuery> mQuery;
+    std::unique_ptr<QgsMssqlQuery> mQuery;
     QVariantList mNextRow;
 
     QVariantList nextRowPrivate() override;


### PR DESCRIPTION
Executing any SQL on a SQL Server connection would result in the connection being dropped while it was still in use, leaving the provider in a interdeterminate state which would often refuse to run futher queries.

The QSqlQuery class does NOT have a virtual destructor, so we need to explicitly use the QgsMssqlQuery class for the results iterator so that the QgsMssqlQuery destructor gets called and the shared reference to the QgsMssqlDatabase instance gets released correctly.
