### PR TITLE
New OAuth2 authentication flow with client credentials 

### DIFF
--- a/external/o2/src/o2.cpp
+++ b/external/o2/src/o2.cpp
@@ -147,6 +147,8 @@ QString O2::grantType()
         return O2_OAUTH2_GRANT_TYPE_DEVICE;
     case GrantFlowPkce:
         return "pkce";
+    case GrantFlowClientCredentials:
+      return "client_credentials"; // Where are O2_OAUTH2_GRANT_TYPE_DEVICE etc defined? O2_OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS;
     }
 
     return QString();

--- a/external/o2/src/o2.cpp
+++ b/external/o2/src/o2.cpp
@@ -301,10 +301,10 @@ void O2::link() {
       QNetworkReply *tokenReply = getManager()->post(tokenRequest, payload);
 
       connect(tokenReply,
-               &QNetworkReply::finished,
-               this,
-               &O2::onTokenReplyFinished,
-               Qt::QueuedConnection);
+              &QNetworkReply::finished,
+              this,
+              &O2::onTokenReplyFinished,
+              Qt::QueuedConnection);
 #if QT_VERSION < QT_VERSION_CHECK(5,15,0)
       connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
 #else

--- a/external/o2/src/o2.h
+++ b/external/o2/src/o2.h
@@ -22,6 +22,7 @@ public:
         GrantFlowAuthorizationCode, ///< @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.1
         GrantFlowImplicit, ///< @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.2
         GrantFlowResourceOwnerPasswordCredentials,
+        GrantFlowClientCredentials, /// @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.4
         GrantFlowPkce, ///< @see https://www.rfc-editor.org/rfc/rfc7636
         GrantFlowDevice ///< @see https://tools.ietf.org/html/rfc8628#section-1
     };

--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -856,6 +856,8 @@ QString QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::GrantFlow flo
       return tr( "Authorization Code PKCE" );
     case QgsAuthOAuth2Config::GrantFlow::ResourceOwner:
       return tr( "Resource Owner" );
+    case QgsAuthOAuth2Config::GrantFlow::ClientCredentials:
+      return tr( "Client Credentials" );
   }
   BUILTIN_UNREACHABLE
 }

--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -311,6 +311,10 @@ void QgsAuthOAuth2Config::validateConfigId( bool needsId )
   {
     mValid = ( !tokenUrl().isEmpty() && !username().isEmpty() && !password().isEmpty() && ( needsId ? !id().isEmpty() : true ) );
   }
+  else if ( mGrantFlow == GrantFlow::ClientCredentials )
+  {
+    mValid = ( !tokenUrl().isEmpty() && !clientId().isEmpty() && !clientSecret().isEmpty() && ( needsId ? !id().isEmpty() : true ) );
+  }
 
   if ( mValid != oldvalid )
     emit validityChanged( mValid );

--- a/src/auth/oauth2/core/qgsauthoauth2config.h
+++ b/src/auth/oauth2/core/qgsauthoauth2config.h
@@ -44,10 +44,11 @@ class QgsAuthOAuth2Config : public QObject
     //! OAuth2 grant flow
     enum class GrantFlow : int
     {
-      AuthCode,      //!< See http://tools.ietf.org/html/rfc6749#section-4.1
-      Implicit,      //!< See http://tools.ietf.org/html/rfc6749#section-4.2
-      ResourceOwner, //!< See http://tools.ietf.org/html/rfc6749#section-4.3
-      Pkce,          //!< See https://www.rfc-editor.org/rfc/rfc7636
+      AuthCode,           //!< See http://tools.ietf.org/html/rfc6749#section-4.1
+      Implicit,           //!< See http://tools.ietf.org/html/rfc6749#section-4.2
+      ResourceOwner,      //!< See http://tools.ietf.org/html/rfc6749#section-4.3
+      ClientCredentials,  //!< See http://tools.ietf.org/html/rfc6749#section-4.4
+      Pkce,               //!< See https://www.rfc-editor.org/rfc/rfc7636
       Last = Pkce
     };
     Q_ENUM( GrantFlow )

--- a/src/auth/oauth2/core/qgsauthoauth2config.h
+++ b/src/auth/oauth2/core/qgsauthoauth2config.h
@@ -44,11 +44,11 @@ class QgsAuthOAuth2Config : public QObject
     //! OAuth2 grant flow
     enum class GrantFlow : int
     {
-      AuthCode,           //!< See http://tools.ietf.org/html/rfc6749#section-4.1
-      Implicit,           //!< See http://tools.ietf.org/html/rfc6749#section-4.2
-      ResourceOwner,      //!< See http://tools.ietf.org/html/rfc6749#section-4.3
-      ClientCredentials,  //!< See http://tools.ietf.org/html/rfc6749#section-4.4
-      Pkce,               //!< See https://www.rfc-editor.org/rfc/rfc7636
+      AuthCode,          //!< See http://tools.ietf.org/html/rfc6749#section-4.1
+      Implicit,          //!< See http://tools.ietf.org/html/rfc6749#section-4.2
+      ResourceOwner,     //!< See http://tools.ietf.org/html/rfc6749#section-4.3
+      ClientCredentials, //!< See http://tools.ietf.org/html/rfc6749#section-4.4
+      Pkce,              //!< See https://www.rfc-editor.org/rfc/rfc7636
       Last = Pkce
     };
     Q_ENUM( GrantFlow )

--- a/src/auth/oauth2/core/qgsauthoauth2config.h
+++ b/src/auth/oauth2/core/qgsauthoauth2config.h
@@ -47,9 +47,9 @@ class QgsAuthOAuth2Config : public QObject
       AuthCode,          //!< See http://tools.ietf.org/html/rfc6749#section-4.1
       Implicit,          //!< See http://tools.ietf.org/html/rfc6749#section-4.2
       ResourceOwner,     //!< See http://tools.ietf.org/html/rfc6749#section-4.3
-      ClientCredentials, //!< See http://tools.ietf.org/html/rfc6749#section-4.4
       Pkce,              //!< See https://www.rfc-editor.org/rfc/rfc7636
-      Last = Pkce
+      ClientCredentials, //!< See http://tools.ietf.org/html/rfc6749#section-4.4
+      Last = ClientCredentials
     };
     Q_ENUM( GrantFlow )
 

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -139,6 +139,8 @@ void QgsO2::initOAuthConfig()
       setUsername( mOAuth2Config->username() );
       setPassword( mOAuth2Config->password() );
 
+      break;
+
     case QgsAuthOAuth2Config::GrantFlow::ClientCredentials:
       setGrantFlow( O2::GrantFlowClientCredentials );
       setClientId( mOAuth2Config->clientId() );

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -350,7 +350,7 @@ void QgsO2::link()
 
     const QUrl url( tokenUrl_ );
     QNetworkRequest tokenRequest( url );
-    QgsLogger::debug("Test");
+    QgsLogger::debug( "Test" );
     QgsSetRequestInitiatorClass( tokenRequest, QStringLiteral( "QgsO2" ) );
     tokenRequest.setHeader( QNetworkRequest::ContentTypeHeader, QLatin1String( "application/x-www-form-urlencoded" ) );
     QNetworkReply *tokenReply = getManager()->post( tokenRequest, payload );

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -497,6 +497,7 @@ void QgsAuthOAuth2Edit::populateGrantFlows()
   cmbbxGrantFlow->addItem( QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::GrantFlow::AuthCode ), static_cast<int>( QgsAuthOAuth2Config::GrantFlow::AuthCode ) );
   cmbbxGrantFlow->addItem( QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::GrantFlow::Implicit ), static_cast<int>( QgsAuthOAuth2Config::GrantFlow::Implicit ) );
   cmbbxGrantFlow->addItem( QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::GrantFlow::ResourceOwner ), static_cast<int>( QgsAuthOAuth2Config::GrantFlow::ResourceOwner ) );
+  cmbbxGrantFlow->addItem( QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::GrantFlow::ClientCredentials ), static_cast<int>( QgsAuthOAuth2Config::GrantFlow::ClientCredentials ) );
   cmbbxGrantFlow->addItem( QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::GrantFlow::Pkce ), static_cast<int>( QgsAuthOAuth2Config::GrantFlow::Pkce ) );
 }
 
@@ -732,6 +733,7 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   // bool authcode = ( flow == QgsAuthOAuth2Config::AuthCode );
   const bool implicit = ( flow == QgsAuthOAuth2Config::GrantFlow::Implicit );
   const bool resowner = ( flow == QgsAuthOAuth2Config::GrantFlow::ResourceOwner );
+  const bool ccredentials = ( flow == QgsAuthOAuth2Config::GrantFlow::ClientCredentials );
   const bool pkce = ( flow == QgsAuthOAuth2Config::GrantFlow::Pkce );
 
   lblRequestUrl->setVisible( !resowner );
@@ -739,8 +741,8 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   if ( resowner )
     leRequestUrl->setText( QString() );
 
-  lblRedirectUrl->setVisible( !resowner );
-  frameRedirectUrl->setVisible( !resowner );
+  lblRedirectUrl->setVisible( !resowner || !ccredentials);
+  frameRedirectUrl->setVisible( !resowner || !ccredentials);
 
   lblClientSecret->setVisible( !implicit );
   leClientSecret->setVisible( !implicit );
@@ -755,13 +757,13 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   leClientSecret->setPlaceholderText( resowner ? tr( "Optional" ) : tr( "Required" ) );
 
 
-  lblUsername->setVisible( resowner );
-  leUsername->setVisible( resowner );
-  if ( !resowner )
+  lblUsername->setVisible( resowner || !ccredentials);
+  leUsername->setVisible( resowner || !ccredentials);
+  if ( !resowner || !ccredentials)
     leUsername->setText( QString() );
-  lblPassword->setVisible( resowner );
-  lePassword->setVisible( resowner );
-  if ( !resowner )
+  lblPassword->setVisible( resowner || !ccredentials);
+  lePassword->setVisible( resowner || !ccredentials);
+  if ( !resowner || !ccredentials)
     lePassword->setText( QString() );
 }
 

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -756,7 +756,6 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   leClientSecret->setVisible( !pkce );
   leClientSecret->setPlaceholderText( resowner ? tr( "Optional" ) : tr( "Required" ) );
 
-
   lblUsername->setVisible( resowner );
   leUsername->setVisible( resowner );
   if ( !resowner )

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -736,13 +736,13 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   const bool ccredentials = ( flow == QgsAuthOAuth2Config::GrantFlow::ClientCredentials );
   const bool pkce = ( flow == QgsAuthOAuth2Config::GrantFlow::Pkce );
 
-  lblRequestUrl->setVisible( !resowner );
-  leRequestUrl->setVisible( !resowner );
-  if ( resowner )
+  lblRequestUrl->setVisible( !resowner && !ccredentials );
+  leRequestUrl->setVisible( !resowner && !ccredentials );
+  if ( resowner || ccredentials )
     leRequestUrl->setText( QString() );
 
-  lblRedirectUrl->setVisible( !resowner || !ccredentials);
-  frameRedirectUrl->setVisible( !resowner || !ccredentials);
+  lblRedirectUrl->setVisible( !resowner && !ccredentials);
+  frameRedirectUrl->setVisible( !resowner && !ccredentials);
 
   lblClientSecret->setVisible( !implicit );
   leClientSecret->setVisible( !implicit );
@@ -757,13 +757,13 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   leClientSecret->setPlaceholderText( resowner ? tr( "Optional" ) : tr( "Required" ) );
 
 
-  lblUsername->setVisible( resowner || !ccredentials);
-  leUsername->setVisible( resowner || !ccredentials);
-  if ( !resowner || !ccredentials)
+  lblUsername->setVisible( resowner );
+  leUsername->setVisible( resowner );
+  if ( !resowner )
     leUsername->setText( QString() );
-  lblPassword->setVisible( resowner || !ccredentials);
-  lePassword->setVisible( resowner || !ccredentials);
-  if ( !resowner || !ccredentials)
+  lblPassword->setVisible( resowner );
+  lePassword->setVisible( resowner );
+  if ( !resowner )
     lePassword->setText( QString() );
 }
 

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -741,8 +741,8 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   if ( resowner || ccredentials )
     leRequestUrl->setText( QString() );
 
-  lblRedirectUrl->setVisible( !resowner && !ccredentials);
-  frameRedirectUrl->setVisible( !resowner && !ccredentials);
+  lblRedirectUrl->setVisible( !resowner && !ccredentials );
+  frameRedirectUrl->setVisible( !resowner && !ccredentials );
 
   lblClientSecret->setVisible( !implicit );
   leClientSecret->setVisible( !implicit );


### PR DESCRIPTION
## Description

QGIS has existing support for various OAuth 2 flows, however Client Credentials is not one of them. Following the specification at https://datatracker.ietf.org/doc/html/rfc6749#section-4.4, authentication with Client Credentials has now been added as an OAuth2 flow. 

Closes #60534 

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
