### PR TITLE
Use extent selector in Raster and Mesh calculators

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgsextentgroupbox.py
+++ b/python/PyQt6/gui/auto_additions/qgsextentgroupbox.py
@@ -5,7 +5,7 @@ QgsExtentGroupBox.UserExtent = QgsExtentGroupBox.ExtentState.UserExtent
 QgsExtentGroupBox.ProjectLayerExtent = QgsExtentGroupBox.ExtentState.ProjectLayerExtent
 QgsExtentGroupBox.DrawOnCanvas = QgsExtentGroupBox.ExtentState.DrawOnCanvas
 try:
-    QgsExtentGroupBox.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n"}
-    QgsExtentGroupBox.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle']}
+    QgsExtentGroupBox.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n", 'extentLayerChanged': 'Emitted when the extent layer is changed.\n\n.. versionadded:: 3.44\n'}
+    QgsExtentGroupBox.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle'], 'extentLayerChanged': ['layer: QgsMapLayer']}
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_additions/qgsextentwidget.py
+++ b/python/PyQt6/gui/auto_additions/qgsextentwidget.py
@@ -7,7 +7,7 @@ QgsExtentWidget.DrawOnCanvas = QgsExtentWidget.ExtentState.DrawOnCanvas
 QgsExtentWidget.CondensedStyle = QgsExtentWidget.WidgetStyle.CondensedStyle
 QgsExtentWidget.ExpandedStyle = QgsExtentWidget.WidgetStyle.ExpandedStyle
 try:
-    QgsExtentWidget.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n", 'validationChanged': "Emitted when the widget's validation state changes.\n", 'toggleDialogVisibility': 'Emitted when the parent dialog visibility must be changed (e.g.\nto permit access to the map canvas)\n'}
-    QgsExtentWidget.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle'], 'validationChanged': ['valid: bool'], 'toggleDialogVisibility': ['visible: bool']}
+    QgsExtentWidget.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n", 'validationChanged': "Emitted when the widget's validation state changes.\n", 'toggleDialogVisibility': 'Emitted when the parent dialog visibility must be changed (e.g.\nto permit access to the map canvas)\n', 'extentLayerChanged': 'Emitted when the extent layer is changed.\n\n.. versionadded:: 3.44\n'}
+    QgsExtentWidget.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle'], 'validationChanged': ['valid: bool'], 'toggleDialogVisibility': ['visible: bool'], 'extentLayerChanged': ['layer: QgsMapLayer']}
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/qgsextentgroupbox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsextentgroupbox.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsExtentGroupBox : QgsCollapsibleGroupBox
 {
 %Docstring(signature="appended")
@@ -194,6 +193,13 @@ To unset a fixed aspect ratio, set the width and height to zero.
     void extentChanged( const QgsRectangle &r );
 %Docstring
 Emitted when the widget's extent is changed.
+%End
+
+    void extentLayerChanged( QgsMapLayer *layer );
+%Docstring
+Emitted when the extent layer is changed.
+
+.. versionadded:: 3.44
 %End
 
 };

--- a/python/PyQt6/gui/auto_generated/qgsextentwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsextentwidget.sip.in
@@ -229,6 +229,13 @@ Emitted when the parent dialog visibility must be changed (e.g.
 to permit access to the map canvas)
 %End
 
+    void extentLayerChanged( QgsMapLayer *layer );
+%Docstring
+Emitted when the extent layer is changed.
+
+.. versionadded:: 3.44
+%End
+
   protected:
     virtual void dragEnterEvent( QDragEnterEvent *event );
 

--- a/python/gui/auto_additions/qgsextentgroupbox.py
+++ b/python/gui/auto_additions/qgsextentgroupbox.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/qgsextentgroupbox.h
 try:
-    QgsExtentGroupBox.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n"}
-    QgsExtentGroupBox.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle']}
+    QgsExtentGroupBox.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n", 'extentLayerChanged': 'Emitted when the extent layer is changed.\n\n.. versionadded:: 3.44\n'}
+    QgsExtentGroupBox.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle'], 'extentLayerChanged': ['layer: QgsMapLayer']}
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_additions/qgsextentwidget.py
+++ b/python/gui/auto_additions/qgsextentwidget.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/qgsextentwidget.h
 try:
-    QgsExtentWidget.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n", 'validationChanged': "Emitted when the widget's validation state changes.\n", 'toggleDialogVisibility': 'Emitted when the parent dialog visibility must be changed (e.g.\nto permit access to the map canvas)\n'}
-    QgsExtentWidget.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle'], 'validationChanged': ['valid: bool'], 'toggleDialogVisibility': ['visible: bool']}
+    QgsExtentWidget.__attribute_docs__ = {'extentChanged': "Emitted when the widget's extent is changed.\n", 'validationChanged': "Emitted when the widget's validation state changes.\n", 'toggleDialogVisibility': 'Emitted when the parent dialog visibility must be changed (e.g.\nto permit access to the map canvas)\n', 'extentLayerChanged': 'Emitted when the extent layer is changed.\n\n.. versionadded:: 3.44\n'}
+    QgsExtentWidget.__signal_arguments__ = {'extentChanged': ['r: QgsRectangle'], 'validationChanged': ['valid: bool'], 'toggleDialogVisibility': ['visible: bool'], 'extentLayerChanged': ['layer: QgsMapLayer']}
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_generated/qgsextentgroupbox.sip.in
+++ b/python/gui/auto_generated/qgsextentgroupbox.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsExtentGroupBox : QgsCollapsibleGroupBox
 {
 %Docstring(signature="appended")
@@ -194,6 +193,13 @@ To unset a fixed aspect ratio, set the width and height to zero.
     void extentChanged( const QgsRectangle &r );
 %Docstring
 Emitted when the widget's extent is changed.
+%End
+
+    void extentLayerChanged( QgsMapLayer *layer );
+%Docstring
+Emitted when the extent layer is changed.
+
+.. versionadded:: 3.44
 %End
 
 };

--- a/python/gui/auto_generated/qgsextentwidget.sip.in
+++ b/python/gui/auto_generated/qgsextentwidget.sip.in
@@ -229,6 +229,13 @@ Emitted when the parent dialog visibility must be changed (e.g.
 to permit access to the map canvas)
 %End
 
+    void extentLayerChanged( QgsMapLayer *layer );
+%Docstring
+Emitted when the extent layer is changed.
+
+.. versionadded:: 3.44
+%End
+
   protected:
     virtual void dragEnterEvent( QDragEnterEvent *event );
 

--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -25,6 +25,7 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgsvectorlayer.h"
+#include "qgsmapcanvas.h"
 #include "qgsmaplayerproxymodel.h"
 #include "qgswkbtypes.h"
 #include "qgsfeatureiterator.h"
@@ -40,8 +41,10 @@
 #include <QFontDatabase>
 #include <QMap>
 
-QgsMeshCalculatorDialog::QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer, QWidget *parent, Qt::WindowFlags f )
-  : QDialog( parent, f ), mLayer( meshLayer )
+QgsMeshCalculatorDialog::QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer, QgsMapCanvas *mapCanvas, QWidget *parent, Qt::WindowFlags f )
+  : QDialog( parent, f )
+  , mLayer( meshLayer )
+  , mMapCanvas( mapCanvas )
 {
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
@@ -60,18 +63,12 @@ QgsMeshCalculatorDialog::QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer, QWidg
   connect( mOutputGroupNameLineEdit, &QLineEdit::textChanged, this, &QgsMeshCalculatorDialog::updateInfoMessage );
 
   connect( mDatasetsListWidget, &QListView::doubleClicked, this, &QgsMeshCalculatorDialog::datasetGroupEntry );
-  connect( mCurrentLayerExtentButton, &QPushButton::clicked, this, &QgsMeshCalculatorDialog::mCurrentLayerExtentButton_clicked );
   connect( mAllTimesButton, &QPushButton::clicked, this, &QgsMeshCalculatorDialog::mAllTimesButton_clicked );
   connect( mExpressionTextEdit, &QTextEdit::textChanged, this, &QgsMeshCalculatorDialog::updateInfoMessage );
 
   connect( useMaskCb, &QRadioButton::toggled, this, &QgsMeshCalculatorDialog::toggleExtendMask );
   maskBox->setVisible( false );
   useMaskCb->setEnabled( cboLayerMask->count() );
-
-  mXMaxSpinBox->setShowClearButton( false );
-  mXMinSpinBox->setShowClearButton( false );
-  mYMaxSpinBox->setShowClearButton( false );
-  mYMinSpinBox->setShowClearButton( false );
 
   connect( mPlusPushButton, &QPushButton::clicked, this, &QgsMeshCalculatorDialog::mPlusPushButton_clicked );
   connect( mMinusPushButton, &QPushButton::clicked, this, &QgsMeshCalculatorDialog::mMinusPushButton_clicked );
@@ -101,7 +98,16 @@ QgsMeshCalculatorDialog::QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer, QWidg
 
   mExpressionTextEdit->setCurrentFont( QFontDatabase::systemFont( QFontDatabase::FixedFont ) );
 
-  useFullLayerExtent();
+  mExtentGroupBox->setCurrentExtent( mMapCanvas->extent(), mMapCanvas->mapSettings().destinationCrs() );
+  if ( mLayer )
+  {
+    mExtentGroupBox->setOutputExtentFromLayer( mLayer );
+  }
+  else
+  {
+    mExtentGroupBox->setOutputExtentFromCurrent();
+  }
+
   repopulateTimeCombos();
   mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [=] {
@@ -140,13 +146,7 @@ QString QgsMeshCalculatorDialog::outputFile() const
 
 QgsRectangle QgsMeshCalculatorDialog::outputExtent() const
 {
-  const QgsRectangle ret(
-    mXMinSpinBox->value(),
-    mYMinSpinBox->value(),
-    mXMaxSpinBox->value(),
-    mYMaxSpinBox->value()
-  );
-  return ret;
+  return mExtentGroupBox->outputExtent();
 }
 
 QgsGeometry QgsMeshCalculatorDialog::maskGeometry() const
@@ -286,7 +286,7 @@ void QgsMeshCalculatorDialog::datasetGroupEntry( const QModelIndex &index )
 void QgsMeshCalculatorDialog::toggleExtendMask()
 {
   bool visible = useMaskCb->isChecked();
-  extendBox->setVisible( !visible );
+  mExtentGroupBox->setVisible( !visible );
   maskBox->setVisible( visible );
 }
 
@@ -388,11 +388,6 @@ QString QgsMeshCalculatorDialog::datasetGroupName( const QModelIndex &index ) co
     return QString();
 
   return index.data( Qt::DisplayRole ).toString();
-}
-
-void QgsMeshCalculatorDialog::mCurrentLayerExtentButton_clicked()
-{
-  useFullLayerExtent();
 }
 
 void QgsMeshCalculatorDialog::mAllTimesButton_clicked()
@@ -589,19 +584,6 @@ void QgsMeshCalculatorDialog::populateDriversComboBox()
     whileBlocking( mOutputFormatComboBox )->addItem( meta.description(), meta.name() );
   }
   mOutputFormatComboBox->setCurrentIndex( 0 );
-}
-
-void QgsMeshCalculatorDialog::useFullLayerExtent()
-{
-  QgsMeshLayer *layer = meshLayer();
-  if ( !layer )
-    return;
-
-  const QgsRectangle layerExtent = layer->extent();
-  mXMinSpinBox->setValue( layerExtent.xMinimum() );
-  mXMaxSpinBox->setValue( layerExtent.xMaximum() );
-  mYMinSpinBox->setValue( layerExtent.yMinimum() );
-  mYMaxSpinBox->setValue( layerExtent.yMaximum() );
 }
 
 void QgsMeshCalculatorDialog::useAllTimesFromLayer()

--- a/src/app/mesh/qgsmeshcalculatordialog.h
+++ b/src/app/mesh/qgsmeshcalculatordialog.h
@@ -22,6 +22,8 @@
 #include "qgsmeshcalculator.h"
 #include "qgis_app.h"
 
+class QgsMapCanvas;
+
 //! A dialog to enter a mesh calculation expression
 class APP_EXPORT QgsMeshCalculatorDialog : public QDialog, private Ui::QgsMeshCalculatorDialogBase
 {
@@ -33,7 +35,7 @@ class APP_EXPORT QgsMeshCalculatorDialog : public QDialog, private Ui::QgsMeshCa
      * \param parent widget
      * \param f window flags
      */
-    QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer = nullptr, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
+    QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer = nullptr, QgsMapCanvas *mapCanvas = nullptr, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
     ~QgsMeshCalculatorDialog();
 
     //! Returns new mesh calculator created from dialog options
@@ -44,7 +46,6 @@ class APP_EXPORT QgsMeshCalculatorDialog : public QDialog, private Ui::QgsMeshCa
 
   private slots:
     void datasetGroupEntry( const QModelIndex &index );
-    void mCurrentLayerExtentButton_clicked();
     void mAllTimesButton_clicked();
     void toggleExtendMask();
     void updateInfoMessage();
@@ -127,6 +128,7 @@ class APP_EXPORT QgsMeshCalculatorDialog : public QDialog, private Ui::QgsMeshCa
     void populateDriversComboBox();
 
     QgsMeshLayer *mLayer;
+    QgsMapCanvas *mMapCanvas = nullptr;
     QHash<QString, QgsMeshDriverMetadata> mMeshDrivers;
     QStringList mVariableNames;
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6214,7 +6214,7 @@ void QgisApp::showMeshCalculator()
     QMessageBox::information( this, tr( "Mesh Calculator" ), tr( "Mesh calculator with mesh layer in edit mode is not supported." ) );
     return;
   }
-  QgsMeshCalculatorDialog d( meshLayer, this );
+  QgsMeshCalculatorDialog d( meshLayer, mMapCanvas, this );
   if ( d.exec() == QDialog::Accepted )
   {
     //invoke analysis library

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6111,7 +6111,7 @@ void QgisApp::newGpxLayer()
 
 void QgisApp::showRasterCalculator()
 {
-  QgsRasterCalcDialog d( qobject_cast<QgsRasterLayer *>( activeLayer() ), this );
+  QgsRasterCalcDialog d( qobject_cast<QgsRasterLayer *>( activeLayer() ), mMapCanvas, this );
   if ( d.exec() != QDialog::Accepted )
   {
     return;

--- a/src/app/qgsrastercalcdialog.h
+++ b/src/app/qgsrastercalcdialog.h
@@ -23,6 +23,8 @@
 #include "qgshelp.h"
 #include "qgis_app.h"
 
+class QgsMapCanvas;
+
 //! A dialog to enter a raster calculation expression
 class APP_EXPORT QgsRasterCalcDialog : public QDialog, private Ui::QgsRasterCalcDialogBase
 {
@@ -34,7 +36,7 @@ class APP_EXPORT QgsRasterCalcDialog : public QDialog, private Ui::QgsRasterCalc
      * \param parent widget
      * \param f window flags
      */
-    QgsRasterCalcDialog( QgsRasterLayer *rasterLayer = nullptr, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
+    QgsRasterCalcDialog( QgsRasterLayer *rasterLayer = nullptr, QgsMapCanvas *canvas = nullptr, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
 
     QString formulaString() const;
     QString outputFile() const;
@@ -63,8 +65,8 @@ class APP_EXPORT QgsRasterCalcDialog : public QDialog, private Ui::QgsRasterCalc
   private slots:
     void mRasterBandsListWidget_itemDoubleClicked( QListWidgetItem *item );
     void mButtonBox_accepted();
-    void mCurrentLayerExtentButton_clicked();
     void mExpressionTextEdit_textChanged();
+    void extentLayerChanged( QgsMapLayer *layer );
     //! Enables OK button if calculator expression is valid and output file path exists
     void setAcceptButtonState();
     //! Disables some options that are not required if using Virtual Provider
@@ -103,7 +105,7 @@ class APP_EXPORT QgsRasterCalcDialog : public QDialog, private Ui::QgsRasterCalc
 
   private:
     //! Sets the extent and size of the output
-    void setExtentSize( int width, int height, QgsRectangle bbox );
+    void setExtentSize( QgsRasterLayer *layer );
 
     // Insert available GDAL drivers that support the create() option
     void insertAvailableOutputFormats();
@@ -123,6 +125,7 @@ class APP_EXPORT QgsRasterCalcDialog : public QDialog, private Ui::QgsRasterCalc
     QList<QgsRasterCalculatorEntry> mAvailableRasterBands;
 
     bool mExtentSizeSet = false;
+    QgsMapCanvas *mMapCanvas = nullptr;
 
     friend class TestQgsRasterCalcDialog;
 };

--- a/src/gui/qgsextentgroupbox.cpp
+++ b/src/gui/qgsextentgroupbox.cpp
@@ -16,6 +16,7 @@
 #include "qgsextentgroupbox.h"
 #include "moc_qgsextentgroupbox.cpp"
 #include "qgsextentwidget.h"
+#include "qgsmaplayer.h"
 
 QgsExtentGroupBox::QgsExtentGroupBox( QWidget *parent )
   : QgsCollapsibleGroupBox( parent )
@@ -29,6 +30,7 @@ QgsExtentGroupBox::QgsExtentGroupBox( QWidget *parent )
   connect( this, &QGroupBox::toggled, this, &QgsExtentGroupBox::groupBoxClicked );
   connect( mWidget, &QgsExtentWidget::extentChanged, this, &QgsExtentGroupBox::widgetExtentChanged );
   connect( mWidget, &QgsExtentWidget::validationChanged, this, &QgsExtentGroupBox::validationChanged );
+  connect( mWidget, &QgsExtentWidget::extentLayerChanged, this, &QgsExtentGroupBox::extentLayerChanged );
 
   connect( mWidget, &QgsExtentWidget::toggleDialogVisibility, this, [=]( bool visible ) {
     QWidget *w = window();

--- a/src/gui/qgsextentgroupbox.h
+++ b/src/gui/qgsextentgroupbox.h
@@ -23,8 +23,6 @@
 #include "qgsrectangle.h"
 #include "qgis_gui.h"
 
-#include <memory>
-
 class QgsCoordinateReferenceSystem;
 class QgsMapLayer;
 class QgsExtentWidget;
@@ -200,6 +198,12 @@ class GUI_EXPORT QgsExtentGroupBox : public QgsCollapsibleGroupBox
      * Emitted when the widget's extent is changed.
      */
     void extentChanged( const QgsRectangle &r );
+
+    /**
+     * Emitted when the extent layer is changed.
+     * \since QGIS 3.44
+     */
+    void extentLayerChanged( QgsMapLayer *layer );
 
   private slots:
 

--- a/src/gui/qgsextentwidget.cpp
+++ b/src/gui/qgsextentwidget.cpp
@@ -472,6 +472,7 @@ void QgsExtentWidget::setExtentToLayerExtent( const QString &layerId )
   if ( !layer )
     return;
 
+  emit extentLayerChanged( layer );
   setOutputExtentFromLayer( layer );
 }
 

--- a/src/gui/qgsextentwidget.h
+++ b/src/gui/qgsextentwidget.h
@@ -235,6 +235,12 @@ class GUI_EXPORT QgsExtentWidget : public QWidget, private Ui::QgsExtentGroupBox
      */
     void toggleDialogVisibility( bool visible );
 
+    /**
+     * Emitted when the extent layer is changed.
+     * \since QGIS 3.44
+     */
+    void extentLayerChanged( QgsMapLayer *layer );
+
   protected:
     void dragEnterEvent( QDragEnterEvent *event ) override;
     void dragLeaveEvent( QDragLeaveEvent *event ) override;

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>912</width>
-    <height>954</height>
+    <height>982</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -174,138 +174,10 @@
             </widget>
            </item>
            <item>
-            <widget class="QWidget" name="extendBox" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+            <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+             <property name="title">
+              <string>Spatial Extent</string>
              </property>
-             <layout class="QGridLayout" name="gridLayout_3">
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="2" column="4">
-               <widget class="QgsDoubleSpinBox" name="mXMaxSpinBox">
-                <property name="decimals">
-                 <number>5</number>
-                </property>
-                <property name="minimum">
-                 <double>-999999999.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>999999999.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="mYMinLabel">
-                <property name="text">
-                 <string>Y min</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
-               <widget class="QLabel" name="mXMaxLabel">
-                <property name="text">
-                 <string>X max</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QgsDoubleSpinBox" name="mYMinSpinBox">
-                <property name="decimals">
-                 <number>5</number>
-                </property>
-                <property name="minimum">
-                 <double>-999999999.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>999999999.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3">
-               <widget class="QLabel" name="mYMaxLabel">
-                <property name="text">
-                 <string>Y max</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QgsDoubleSpinBox" name="mXMinSpinBox">
-                <property name="decimals">
-                 <number>5</number>
-                </property>
-                <property name="minimum">
-                 <double>-999999999.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>999999999.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="4">
-               <widget class="QgsDoubleSpinBox" name="mYMaxSpinBox">
-                <property name="decimals">
-                 <number>5</number>
-                </property>
-                <property name="minimum">
-                 <double>-999999999.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>999999999.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="mXMinLabel">
-                <property name="text">
-                 <string>X min</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0" colspan="5">
-               <layout class="QHBoxLayout" name="horizontalLayout">
-                <item>
-                 <widget class="QPushButton" name="mCurrentLayerExtentButton">
-                  <property name="text">
-                   <string>Use Selected Layer Extent</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_3">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item row="2" column="2">
-               <spacer name="horizontalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
             </widget>
            </item>
           </layout>
@@ -666,11 +538,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
@@ -681,6 +548,12 @@
    <extends>QComboBox</extends>
    <header>qgsmaplayercombobox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mDatasetsListWidget</tabstop>
@@ -690,11 +563,6 @@
   <tabstop>useExtentCb</tabstop>
   <tabstop>useMaskCb</tabstop>
   <tabstop>cboLayerMask</tabstop>
-  <tabstop>mCurrentLayerExtentButton</tabstop>
-  <tabstop>mXMinSpinBox</tabstop>
-  <tabstop>mXMaxSpinBox</tabstop>
-  <tabstop>mYMinSpinBox</tabstop>
-  <tabstop>mYMaxSpinBox</tabstop>
   <tabstop>mAllTimesButton</tabstop>
   <tabstop>mStartTimeComboBox</tabstop>
   <tabstop>mEndTimeComboBox</tabstop>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1000</width>
-    <height>800</height>
+    <height>939</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -23,15 +23,15 @@
    <item row="1" column="0">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
    <item row="0" column="0" colspan="2">
-    <widget class="QgsScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea" native="true">
      <property name="widgetResizable" stdset="0">
       <bool>true</bool>
      </property>
@@ -41,11 +41,11 @@
         <item row="0" column="0">
          <widget class="QSplitter" name="splitter_2">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <widget class="QSplitter" name="splitter">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <widget class="QGroupBox" name="mRasterBandsGroupBox">
             <property name="title">
@@ -70,129 +70,10 @@
               </widget>
              </item>
              <item row="4" column="0" colspan="4">
-              <widget class="QGroupBox" name="groupBox_2">
+              <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
                <property name="title">
                 <string>Spatial Extent</string>
                </property>
-               <layout class="QGridLayout" name="gridLayout_5">
-                <item row="2" column="1">
-                 <widget class="QgsDoubleSpinBox" name="mXMinSpinBox">
-                  <property name="decimals">
-                   <number>5</number>
-                  </property>
-                  <property name="minimum">
-                   <double>-999999999.000000000000000</double>
-                  </property>
-                  <property name="maximum">
-                   <double>999999999.000000000000000</double>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="3">
-                 <widget class="QLabel" name="mXMaxLabel">
-                  <property name="text">
-                   <string>X max</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="mYMinLabel">
-                  <property name="text">
-                   <string>Y min</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="mXMinLabel">
-                  <property name="text">
-                   <string>X min</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="2">
-                 <spacer name="horizontalSpacer_2">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>10</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item row="2" column="4">
-                 <widget class="QgsDoubleSpinBox" name="mXMaxSpinBox">
-                  <property name="decimals">
-                   <number>5</number>
-                  </property>
-                  <property name="minimum">
-                   <double>-999999999.000000000000000</double>
-                  </property>
-                  <property name="maximum">
-                   <double>999999999.000000000000000</double>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QgsDoubleSpinBox" name="mYMinSpinBox">
-                  <property name="decimals">
-                   <number>5</number>
-                  </property>
-                  <property name="minimum">
-                   <double>-999999999.000000000000000</double>
-                  </property>
-                  <property name="maximum">
-                   <double>999999999.000000000000000</double>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="3">
-                 <widget class="QLabel" name="mYMaxLabel">
-                  <property name="text">
-                   <string>Y max</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="4">
-                 <widget class="QgsDoubleSpinBox" name="mYMaxSpinBox">
-                  <property name="decimals">
-                   <number>5</number>
-                  </property>
-                  <property name="minimum">
-                   <double>-999999999.000000000000000</double>
-                  </property>
-                  <property name="maximum">
-                   <double>999999999.000000000000000</double>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="0" rowspan="2" colspan="5">
-                 <layout class="QGridLayout" name="gridLayout_3">
-                  <item row="0" column="1" rowspan="2" colspan="4">
-                   <spacer name="horizontalSpacer_4">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="0" rowspan="2">
-                   <widget class="QPushButton" name="mCurrentLayerExtentButton">
-                    <property name="text">
-                     <string>Use Selected Layer Extent</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
               </widget>
              </item>
              <item row="3" column="1" colspan="3">
@@ -201,7 +82,7 @@
              <item row="9" column="0">
               <spacer name="verticalSpacer">
                <property name="orientation">
-                <enum>Qt::Vertical</enum>
+                <enum>Qt::Orientation::Vertical</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -212,9 +93,9 @@
               </spacer>
              </item>
              <item row="7" column="1" colspan="3">
-              <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+              <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
                <property name="focusPolicy">
-                <enum>Qt::StrongFocus</enum>
+                <enum>Qt::FocusPolicy::StrongFocus</enum>
                </property>
               </widget>
              </item>
@@ -231,7 +112,7 @@
                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: the result raster will not be usable with any processing algorithm that expects a materialized raster.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="layoutDirection">
-                <enum>Qt::LeftToRight</enum>
+                <enum>Qt::LayoutDirection::LeftToRight</enum>
                </property>
                <property name="text">
                 <string>Create on-the-fly raster instead of writing layer to disk</string>
@@ -266,7 +147,7 @@
               </widget>
              </item>
              <item row="2" column="1" colspan="3">
-              <widget class="QgsFileWidget" name="mOutputLayer"/>
+              <widget class="QgsFileWidget" name="mOutputLayer" native="true"/>
              </item>
              <item row="1" column="1" colspan="3">
               <widget class="QLineEdit" name="mVirtualLayerName">
@@ -301,7 +182,7 @@
                 <item>
                  <spacer name="horizontalSpacer">
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
@@ -400,7 +281,7 @@
                <item row="0" column="7">
                 <spacer name="horizontalSpacer_3">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -607,11 +488,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
@@ -634,17 +510,18 @@
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mRasterBandsListWidget</tabstop>
   <tabstop>mUseVirtualProviderCheckBox</tabstop>
   <tabstop>mVirtualLayerName</tabstop>
   <tabstop>mOutputFormatComboBox</tabstop>
-  <tabstop>mCurrentLayerExtentButton</tabstop>
-  <tabstop>mXMinSpinBox</tabstop>
-  <tabstop>mXMaxSpinBox</tabstop>
-  <tabstop>mYMinSpinBox</tabstop>
-  <tabstop>mYMaxSpinBox</tabstop>
   <tabstop>mNColumnsSpinBox</tabstop>
   <tabstop>mNRowsSpinBox</tabstop>
   <tabstop>mCrsSelector</tabstop>

--- a/tests/src/app/testqgsmeshcalculatordialog.cpp
+++ b/tests/src/app/testqgsmeshcalculatordialog.cpp
@@ -85,7 +85,7 @@ void TestQgsMeshCalculatorDialog::testCalc()
   if ( !QgsTest::runFlakyTests() )
     QSKIP( "This test is disabled on Travis CI environment" );
 
-  auto dialog = std::make_unique<QgsMeshCalculatorDialog>( mpMeshLayer );
+  auto dialog = std::make_unique<QgsMeshCalculatorDialog>( mpMeshLayer, mQgisApp->mapCanvas() );
 
   const int groupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
 


### PR DESCRIPTION
## Description

Use `QgsExtentGroupBox` instead of separate spinboxes to define output extent in Raster and Mesh Calculator dialogs.

Raster Calculator
![raster-calcl](https://github.com/user-attachments/assets/3388f79f-cdae-42ef-a7cd-358fabe10dcd)
Mesh Caclulator
![mesh-calc](https://github.com/user-attachments/assets/00d2b23b-ee5e-4a05-91c4-dea0d5536111)

Fixes #45247, resurrects #47278.