### PR TITLE
fix(system memory): Use robust GDAL version

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1424,38 +1424,8 @@ QString QgsApplication::osName()
 
 int QgsApplication::systemMemorySizeMb()
 {
-#if defined(Q_OS_ANDROID)
-  return -1;
-#elif defined(Q_OS_MAC)
-  return -1;
-#elif defined(Q_OS_WIN)
-  MEMORYSTATUSEX memoryStatus;
-  ZeroMemory( &memoryStatus, sizeof( MEMORYSTATUSEX ) );
-  memoryStatus.dwLength = sizeof( MEMORYSTATUSEX );
-  if ( GlobalMemoryStatusEx( &memoryStatus ) )
-  {
-    return memoryStatus.ullTotalPhys / ( 1024 * 1024 );
-  }
-  else
-  {
-    return -1;
-  }
-#elif defined(Q_OS_LINUX)
-  constexpr int megabyte = 1024 * 1024;
-  struct sysinfo si;
-  sysinfo( &si );
-  return si.totalram / megabyte;
-#elif defined(Q_OS_FREEBSD)
-  return -1;
-#elif defined(Q_OS_OPENBSD)
-  return -1;
-#elif defined(Q_OS_NETBSD)
-  return -1;
-#elif defined(Q_OS_UNIX)
-  return -1;
-#else
-  return -1;
-#endif
+  // Bytes to Mb (using 1024 * 1024)
+  return CPLGetPhysicalRAM() / 1048576;
 }
 
 QString QgsApplication::platform()

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1425,7 +1425,7 @@ QString QgsApplication::osName()
 int QgsApplication::systemMemorySizeMb()
 {
   // Bytes to Mb (using 1024 * 1024)
-  return CPLGetUsablePhysicalRAM() / 1048576;
+  return static_cast<int>( CPLGetUsablePhysicalRAM() / 1048576 );
 }
 
 QString QgsApplication::platform()

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1425,7 +1425,7 @@ QString QgsApplication::osName()
 int QgsApplication::systemMemorySizeMb()
 {
   // Bytes to Mb (using 1024 * 1024)
-  return CPLGetPhysicalRAM() / 1048576;
+  return CPLGetUsablePhysicalRAM() / 1048576;
 }
 
 QString QgsApplication::platform()


### PR DESCRIPTION
## Description

replace https://github.com/qgis/QGIS/pull/60489

As mentioned by @rouault, GDAL have already a robust memory utility.

For *BSD, it works ootb, tested on FreeBSD by myself and @landryb on OpenBSD.

GDAL use pages for us. We could improve using sysctl, but, ootb it's ok, so remove some lines on QGIS and use GDAL method.