### PR TITLE
[Raster] Use HEIGHT_AVERAGE from RPC when available

### DIFF
--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -218,7 +218,7 @@ class CORE_EXPORT QgsGdalUtils
 
     /**
      * This is a copy of GDALAutoCreateWarpedVRT optimized for imagery using RPC georeferencing
-     * that also sets RPC_HEIGHT in GDALCreateGenImgProjTransformer2 based on HEIGHT_OFF.
+     * that also sets RPC_HEIGHT in GDALCreateGenImgProjTransformer2 based on HEIGHT_AVERAGE (and fallbacks to HEIGHT_OFF).
      * By default GDAL would assume that the imagery has zero elevation - if that is not the case,
      * the image would not be shown in the correct location.
      *
@@ -234,7 +234,7 @@ class CORE_EXPORT QgsGdalUtils
 
     /**
      * This is a wrapper around GDALCreateGenImgProjTransformer2() that takes into account RPC
-     * georeferencing (it sets RPC_HEIGHT in GDALCreateGenImgProjTransformer2 based on HEIGHT_OFF).
+     * georeferencing. It sets RPC_HEIGHT in GDALCreateGenImgProjTransformer2 based on HEIGHT_AVERAGE (and fallbacks to HEIGHT_OFF).
      * By default GDAL would assume that the imagery has zero elevation - if that is not the case,
      * the image would not be shown in the correct location.
      *


### PR DESCRIPTION
Improve the georeferencing of DIMAP / Pleiades NEO products. This is the counterpart of the GDAL change of https://github.com/OSGeo/gdal/pull/11989 but it can be applied independently of it.

With this PR dataset MARSEILLE_PRY_NoHD15_NoDHZ_JP2/000251471_1_1_STD_A/IMG_01_PNEO3_PAN/DIM_PNEO3_STD_202111071029297_PAN_SEN_PWOI_000251471_1_1_F from https://geodelivery.intelligence-airbusds.com/main.html?download&weblink=7f828450ac65e2d61bfd5ea4ac8b3feb&realfilename=MARSEILLE_ORT_NoHD15_NoDHZ_JP2.7z overlaps nicely with OSM background

![velodrome_rpc_qgis](https://github.com/user-attachments/assets/a669b867-6037-4f17-aa58-65c13bc4cee2)
