### PR TITLE
[mssql] Fix creation of geometry_columns table

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -2100,16 +2100,14 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
   q.setForwardOnly( true );
 
   // initialize metadata tables (same as OGR SQL)
-  sql = QString( "IF NOT EXISTS (SELECT * FROM sys.objects WHERE "
-                 "object_id = OBJECT_ID(N'[dbo].[geometry_columns]') AND type in (N'U')) "
+  sql = QString( "IF OBJECT_ID(N'[geometry_columns]', N'U') IS NULL "
                  "CREATE TABLE geometry_columns (f_table_catalog varchar(128) not null, "
                  "f_table_schema varchar(128) not null, f_table_name varchar(256) not null, "
                  "f_geometry_column varchar(256) not null, coord_dimension integer not null, "
                  "srid integer not null, geometry_type varchar(30) not null, "
                  "CONSTRAINT geometry_columns_pk PRIMARY KEY (f_table_catalog, "
                  "f_table_schema, f_table_name, f_geometry_column));\n"
-                 "IF NOT EXISTS (SELECT * FROM sys.objects "
-                 "WHERE object_id = OBJECT_ID(N'[dbo].[spatial_ref_sys]') AND type in (N'U')) "
+                 "IF OBJECT_ID(N'[spatial_ref_sys]', N'U') IS NULL "
                  "CREATE TABLE spatial_ref_sys (srid integer not null "
                  "PRIMARY KEY, auth_name varchar(256), auth_srid integer, srtext varchar(2048), proj4text varchar(2048))" );
 


### PR DESCRIPTION
The query was testing whether [dbo].[geometry_columns] exists, but then attempting to create just [geometry_columns] (without "dbo").

This fails if the table will be created in any schema other then "dbo".

Adjust to check whether just [geometry_columns] exists, so that we are checking whether the table exists in the ACTUAL schema we'll be creating it in.

Fixes #57614

This fix will also need porting to GDAL, which uses the same query: -- https://github.com/OSGeo/gdal/blob/08f6aed2490dbdc5eb105d27b51566f4be851411/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp#L1363-L1381