### PR TITLE
[point cloud editing] fix changing the paintbrush size using the wheel on precision mouse

### DIFF
--- a/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
+++ b/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
@@ -146,9 +146,9 @@ void Qgs3DMapToolPointCloudChangeAttributePaintbrush::mouseWheelEvent( QWheelEve
   const bool shrink = reverseZoom ? event->angleDelta().y() > 0 : event->angleDelta().y() < 0;
 
   // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps
-  const float zoomFactor = 1 + 0.25f * std::abs( event->angleDelta().y() ) / 120.f;
+  const float zoomFactor = 1 + 0.25f * std::fabs( static_cast<float>( event->angleDelta().y() ) ) / 120.f;
   const float newWidth = shrink ? mSelectionRubberBand->width() / zoomFactor : mSelectionRubberBand->width() * zoomFactor;
-  mSelectionRubberBand->setWidth( std::clamp<float>( newWidth, 1.f, static_cast<float>( mCanvas->width() ) / 2.f ) );
+  mSelectionRubberBand->setWidth( std::clamp<float>( newWidth, 5.f, static_cast<float>( mCanvas->width() ) / 2.f ) );
 }
 
 void Qgs3DMapToolPointCloudChangeAttributePaintbrush::keyPressEvent( QKeyEvent *event )

--- a/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
+++ b/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
@@ -143,13 +143,12 @@ void Qgs3DMapToolPointCloudChangeAttributePaintbrush::mouseWheelEvent( QWheelEve
   // the circle smaller
   const QgsSettings settings;
   const bool reverseZoom = settings.value( QStringLiteral( "qgis/reverse_wheel_zoom" ), false ).toBool();
-  const bool shrink = reverseZoom ? event->angleDelta().y() < 0 : event->angleDelta().y() > 0;
-  if ( ( shrink && mSelectionRubberBand->width() <= 5 ) || ( !shrink && mSelectionRubberBand->width() >= mCanvas->width() / 2 ) )
-    return;
+  const bool shrink = reverseZoom ? event->angleDelta().y() > 0 : event->angleDelta().y() < 0;
+
   // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps
-  const double zoomFactor = ( shrink ? 0.8 : 1.25 ) / 120.0 * std::fabs( event->angleDelta().y() );
-  const float newWidth = mSelectionRubberBand->width() * zoomFactor < 5 ? 5 : mSelectionRubberBand->width() * static_cast<float>( zoomFactor );
-  mSelectionRubberBand->setWidth( newWidth );
+  const float zoomFactor = 1 + 0.25f * std::abs( event->angleDelta().y() ) / 120.f;
+  const float newWidth = shrink ? mSelectionRubberBand->width() / zoomFactor : mSelectionRubberBand->width() * zoomFactor;
+  mSelectionRubberBand->setWidth( std::clamp<float>( newWidth, 1.f, static_cast<float>( mCanvas->width() ) / 2.f ) );
 }
 
 void Qgs3DMapToolPointCloudChangeAttributePaintbrush::keyPressEvent( QKeyEvent *event )


### PR DESCRIPTION
## Description
Precision mouses send angleDeltas < 120. Now the brush is grown/shrunk proportionally for those cases too.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
