### PR TITLE
[Postgres] Order ENUM values

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1906,7 +1906,7 @@ bool QgsPostgresProvider::parseEnumRange( QStringList &enumValues, const QString
 {
   enumValues.clear();
 
-  QString enumRangeSql = QStringLiteral( "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid=(SELECT atttypid::regclass FROM pg_attribute WHERE attrelid=%1::regclass AND attname=%2)" )
+  QString enumRangeSql = QStringLiteral( "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid=(SELECT atttypid::regclass FROM pg_attribute WHERE attrelid=%1::regclass AND attname=%2) ORDER BY enumsortorder" )
                            .arg( quotedValue( mQuery ), quotedValue( attributeName ) );
   QgsPostgresResult enumRangeRes( connectionRO()->LoggedPQexec( QStringLiteral( "QgsPostgresProvider" ), enumRangeSql ) );
   if ( enumRangeRes.PQresultStatus() != PGRES_TUPLES_OK )


### PR DESCRIPTION
## Description

When a vector layer with Postgres / PostGIS provider with an ENUM type field is edited, the values are loaded with the following query :

```sql
SELECT enumlabel
FROM pg_catalog.pg_enum
WHERE
    enumtypid = (
        SELECT atttypid::regclass
        FROM pg_attribute
        WHERE
            attrelid = '"table_schema"."table_name"'::regclass
            AND attname='field_name'
    )
;
```

In the great majority of cases, the ENUM values are read in the right order, but not always.
This PR adds `ORDER BY enumsortorder` at the end of the query.

Impact : the request is slightly longer (the `quicksort` adds few milliseconds).
