### PR TITLE
[3D] Point cloud editing tools support for cross-section

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -210,6 +210,12 @@ Disables OpenGL clipping.
 
 
 
+    QList<QVector4D> clipPlaneEquations() const;
+%Docstring
+Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+
+.. versionadded:: 3.44
+%End
 
   signals:
     void terrainEntityChanged();

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -210,6 +210,12 @@ Disables OpenGL clipping.
 
 
 
+    QList<QVector4D> clipPlaneEquations() const;
+%Docstring
+Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+
+.. versionadded:: 3.44
+%End
 
   signals:
     void terrainEntityChanged();

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -290,6 +290,13 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
      */
     void removeSceneEntity( Qgs3DMapSceneEntity *entity ) SIP_SKIP;
 
+    /**
+     * Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+     *
+     * \since QGIS 3.44
+     */
+    QList<QVector4D> clipPlaneEquations() const { return mClipPlanesEquations; };
+
 #ifndef SIP_RUN
     //! Static function for returning open 3D map scenes
     static std::function<QMap<QString, Qgs3DMapScene *>()> sOpenScenesFunction;

--- a/src/app/3d/qgs3dmaptoolpointcloudchangeattribute.cpp
+++ b/src/app/3d/qgs3dmaptoolpointcloudchangeattribute.cpp
@@ -16,6 +16,7 @@
 #include "qgs3dmaptoolpointcloudchangeattribute.h"
 #include "moc_qgs3dmaptoolpointcloudchangeattribute.cpp"
 #include "qgs3dmapcanvas.h"
+#include "qgs3dmapscene.h"
 #include "qgs3dmapsettings.h"
 #include "qgs3dutils.h"
 #include "qgscoordinatetransform.h"
@@ -228,6 +229,7 @@ QVector<int> Qgs3DMapToolPointCloudChangeAttribute::selectedPointsInNode( const 
   const double layerZOffset = static_cast<const QgsPointCloudLayerElevationProperties *>( layer->elevationProperties() )->zOffset();
 
   QgsPoint pt;
+  const QList<QVector4D> clipPlanes = mCanvas->scene()->clipPlaneEquations();
 
   for ( int i = 0; i < block->pointCount(); ++i )
   {
@@ -257,6 +259,28 @@ QVector<int> Qgs3DMapToolPointCloudChangeAttribute::selectedPointsInNode( const 
     // check if inside map extent
     if ( !mapExtent.contains( x, y ) )
       continue;
+
+    // check if clipped
+    if ( clipPlanes.size() > 0 )
+    {
+      bool isClipped = false;
+      const QgsVector3D pointInWorldCoords = Qgs3DUtils::mapToWorldCoordinates( QgsVector3D( x, y, z ), mCanvas->mapSettings()->origin() );
+      for ( const QVector4D &clipPlane : clipPlanes )
+      {
+        // we manually calculate the dot product here so we save resources on some transformation
+        const double distance = clipPlane.x() * pointInWorldCoords.x() + clipPlane.y() * pointInWorldCoords.y() + clipPlane.z() * pointInWorldCoords.z() + clipPlane.w();
+        if ( distance < 0 )
+        {
+          isClipped = true;
+          break;
+        }
+      }
+      if ( isClipped )
+      {
+        continue;
+      }
+    }
+
 
     // project to screen (map coords -> world coords -> clip coords -> NDC -> screen coords)
     bool isInFrustum;


### PR DESCRIPTION
## Description

This PR adds support for active cross-section when editing. Essentially the tools will edit only the points inside the cross-section (a.k.a only visible points) as users would expect.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
