### PR TITLE
Error in loading sld-style for interval parameter of markerline #24954

### DIFF
--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -2626,7 +2626,7 @@ QgsSymbolLayer *QgsMarkerLineSymbolLayer::createFromSld( QDomElement &element )
   if ( !gapElem.isNull() )
   {
     bool ok;
-    double d = gapElem.firstChild().nodeValue().toDouble( &ok );
+    double d = gapElem.firstChild().firstChild().nodeValue().toDouble( &ok );
     if ( ok )
       interval = d;
   }

--- a/tests/src/core/testqgssymbol.cpp
+++ b/tests/src/core/testqgssymbol.cpp
@@ -460,15 +460,15 @@ void TestQgsSymbol::symbolProperties()
 
 void TestQgsSymbol::regression24954()
 {
-  QString myFileName (TEST_DATA_DIR);
+  QString myFileName( TEST_DATA_DIR );
   myFileName = myFileName + QDir::separator() + "symbol_layer/QgsMarkerLineSymbolLayer.sld";
 
   bool defaultLoadedFlag = false;
   mpLinesLayer->loadSldStyle( myFileName, defaultLoadedFlag );
-  QgsFeatureRenderer* renderer = mpLinesLayer->renderer();
+  QgsFeatureRenderer *renderer = mpLinesLayer->renderer();
   QgsRenderContext renderContext;
-  QgsSymbol* symbol = renderer->symbols( renderContext ).at( 0 );
-  QgsMarkerLineSymbolLayer* symbolLayer = static_cast<QgsMarkerLineSymbolLayer*>(symbol->symbolLayer(0));
+  QgsSymbol *symbol = renderer->symbols( renderContext ).at( 0 );
+  QgsMarkerLineSymbolLayer *symbolLayer = static_cast<QgsMarkerLineSymbolLayer *>( symbol->symbolLayer( 0 ) );
 
   QVERIFY( symbolLayer->interval() == 3.3 );
 }

--- a/tests/src/core/testqgssymbol.cpp
+++ b/tests/src/core/testqgssymbol.cpp
@@ -68,6 +68,16 @@ class TestQgsSymbol : public QgsTest
     void testParseColor();
     void testParseColorList();
     void symbolProperties();
+
+    //
+    // Regression Testing
+    //
+
+    /** To check if the interval of the marker symbols of a marker line is set
+ *  correctly after loading a style from a sld-file. It is a regression test
+ *  for ticket #24954 which was fixed with change r22a1
+ */
+    void regression24954();
 };
 
 // slots
@@ -446,6 +456,21 @@ void TestQgsSymbol::symbolProperties()
 
   delete fillSymbol;
   delete fillSymbol2;
+}
+
+void TestQgsSymbol::regression24954()
+{
+  QString myFileName (TEST_DATA_DIR);
+  myFileName = myFileName + QDir::separator() + "symbol_layer/QgsMarkerLineSymbolLayer.sld";
+
+  bool defaultLoadedFlag = false;
+  mpLinesLayer->loadSldStyle( myFileName, defaultLoadedFlag );
+  QgsFeatureRenderer* renderer = mpLinesLayer->renderer();
+  QgsRenderContext renderContext;
+  QgsSymbol* symbol = renderer->symbols( renderContext ).at( 0 );
+  QgsMarkerLineSymbolLayer* symbolLayer = static_cast<QgsMarkerLineSymbolLayer*>(symbol->symbolLayer(0));
+
+  QVERIFY( symbolLayer->interval() == 3.3 );
 }
 
 QGSTEST_MAIN( TestQgsSymbol )

--- a/tests/testdata/symbol_layer/QgsMarkerLineSymbolLayer.sld
+++ b/tests/testdata/symbol_layer/QgsMarkerLineSymbolLayer.sld
@@ -11,7 +11,6 @@
             <VendorOption name="placement">centralPoint</VendorOption>
             <se:Stroke>
               <se:GraphicStroke>
-                <se:Gap>3.3</se:Gap>
                 <se:PerpendicularOffset>6.6</se:PerpendicularOffset>
                 <se:Graphic>
                   <se:Mark>
@@ -25,6 +24,9 @@
                   </se:Mark>
                   <se:Size>2</se:Size>
                 </se:Graphic>
+                <se:Gap>
+					<ogc:Literal>3.3</ogc:Literal>
+				</se:Gap>
               </se:GraphicStroke>
             </se:Stroke>
           </se:LineSymbolizer>


### PR DESCRIPTION
Added second `.firstChild()` to get to the `<Literal>` tag holding the actual gap value.

Graphic stroke node of `.sld` file of a marker line: 
```
...
              <se:GraphicStroke>
                <se:Graphic>
                  <se:Mark>
                    <se:WellKnownName>circle</se:WellKnownName>
                    <se:Fill>
                      <se:SvgParameter name="fill">#54b04a</se:SvgParameter>
                    </se:Fill>
                    <se:Stroke>
                      <se:SvgParameter name="stroke">#3d8035</se:SvgParameter>
                      <se:SvgParameter name="stroke-width">1</se:SvgParameter>
                    </se:Stroke>
                  </se:Mark>
                  <se:Size>14</se:Size>
                </se:Graphic>
                **<se:Gap>
                  <ogc:Literal>36</ogc:Literal>
                </se:Gap>**
              </se:GraphicStroke>
        ...
```
In the test file, the interval value was in the `<gap>` tag, so the sld specification probably changed.   

![sldImport](https://github.com/user-attachments/assets/33a6ceca-7350-4553-addd-c406e71bc0d0)
