### PR TITLE
Set default aspect ratio of save map dialog to locked 

### DIFF
--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -64,6 +64,7 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
   mDpi = ms.outputDpi();
   mSize = ms.outputSize();
   mDevicePixelRatio = ms.devicePixelRatio();
+  mLockAspectRatio->setLocked( true );
 
   mResolutionSpinBox->setValue( static_cast<int>( std::round( mDpi ) ) );
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/44f52272-3333-43be-bef2-32d363525fb0)
