### PR TITLE
[wfs] Fix querying sublayers when a query is set in Data Source Manager

### DIFF
--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -225,8 +225,12 @@ QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const 
   if ( caps.version.isEmpty() )
     return res;
 
+  QgsDataSourceUri dsUri( uri );
+  dsUri.removeParam( QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE );
+  dsUri.setParam( QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE, QStringLiteral( "true" ) );
+
   QgsWFSProvider provider(
-    uri + " " + QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE + "='true'",
+    dsUri.uri( false ),
     QgsDataProvider::ProviderOptions(), caps
   );
   if ( provider.metadataRetrievalCanceled() )


### PR DESCRIPTION
We can't just directly string manipulate the URI, as QgsDataSourceUri assumes that the sql query will ALWAYS be the final part of the string uri. If we directly add query components via string literals, then these will just get append to the SQL query and break everything
