### PR TITLE
globe camera controller: rotate with shift+left mouse button or middle button

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -617,6 +617,25 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
 
 void QgsCameraController::onPositionChangedGlobeTerrainNavigation( Qt3DInput::QMouseEvent *mouse )
 {
+  const bool hasShift = ( mouse->modifiers() & Qt::ShiftModifier );
+  const bool hasCtrl = ( mouse->modifiers() & Qt::ControlModifier );
+  const bool hasLeftButton = ( mouse->buttons() & Qt::LeftButton );
+  const bool hasMiddleButton = ( mouse->buttons() & Qt::MiddleButton );
+
+  if ( ( hasLeftButton && hasShift && !hasCtrl ) || ( hasMiddleButton && !hasShift && !hasCtrl ) )
+  {
+    setMouseParameters( MouseOperation::RotationCenter, mMousePos );
+
+    float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
+    float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
+    float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
+
+    mCameraPose.setPitchAngle( mRotationPitch + pitchDiff );
+    mCameraPose.setHeadingAngle( mRotationYaw + yawDiff );
+    updateCameraFromPose();
+    return;
+  }
+
   if ( !( mouse->buttons() & Qt::LeftButton ) )
     return;
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -626,9 +626,9 @@ void QgsCameraController::onPositionChangedGlobeTerrainNavigation( Qt3DInput::QM
   {
     setMouseParameters( MouseOperation::RotationCenter, mMousePos );
 
-    float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
-    float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
-    float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
+    const float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
+    const float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
+    const float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
     mCameraPose.setPitchAngle( mRotationPitch + pitchDiff );
     mCameraPose.setHeadingAngle( mRotationYaw + yawDiff );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -421,8 +421,8 @@ class _3D_EXPORT QgsCameraController : public QObject
     bool mRotationCenterCalculated = false;
     QVector3D mRotationCenter;
     double mRotationDistanceFromCenter = 0;
-    double mRotationPitch = 0;
-    double mRotationYaw = 0;
+    float mRotationPitch = 0;
+    float mRotationYaw = 0;
 
     bool mDragPointCalculated = false;
     QVector3D mDragPoint;


### PR DESCRIPTION
This makes it possible to rotate the globe with shift + left mouse button or with middle button... just like what's already supported in local scenes.

There is a small difference that pivot point is in the center of the 3D view (just like globe's zoom with mouse wheel uses center as the pivot point) - using pivot point where the mouse is should be addressed in a future PR.