### PR TITLE
fix(3DAxis): keyboard shortcuts were broken due to missing widget dep…

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -21,26 +21,19 @@
 #include <Qt3DExtras/QPhongMaterial>
 #include <Qt3DExtras/QConeMesh>
 #include <Qt3DRender/qcameralens.h>
-#include <Qt3DRender/QCameraSelector>
-#include <Qt3DRender/QClearBuffers>
-#include <Qt3DRender/QLayer>
-#include <Qt3DRender/QLayerFilter>
 #include <Qt3DRender/QPointLight>
 #include <Qt3DRender/QSortPolicy>
 #include <QWidget>
 #include <QScreen>
-#include <QShortcut>
 #include <QFontDatabase>
 #include <ctime>
 #include <QApplication>
 #include <QActionGroup>
 
-#include "qgsmapsettings.h"
 #include "qgs3dmapsettings.h"
 #include "qgs3dmapscene.h"
 #include "qgsterrainentity.h"
 #include "qgscoordinatereferencesystemutils.h"
-#include "qgscoordinatereferencesystem.h"
 #include "qgswindow3dengine.h"
 #include "qgsraycastingutils_p.h"
 #include "qgs3dwiredmesh_p.h"
@@ -76,8 +69,6 @@ Qgs3DAxis::Qgs3DAxis( Qgs3DMapCanvas *canvas, Qt3DCore::QEntity *parent3DScene, 
   onAxisViewportSizeUpdate();
 
   init3DObjectPicking();
-
-  createKeyboardShortCut();
 }
 
 Qgs3DAxis::~Qgs3DAxis()
@@ -125,15 +116,15 @@ void Qgs3DAxis::init3DObjectPicking()
   mAxisSceneEntity->addComponent( mScreenRayCaster );
 
   QObject::connect( mScreenRayCaster, &Qt3DRender::QScreenRayCaster::hitsChanged, this, &Qgs3DAxis::onTouchedByRay );
-
-  // we need event filter (see Qgs3DAxis::eventFilter) to handle the mouse click event as this event is not catchable via the Qt3DRender::QObjectPicker
-  mCanvas->installEventFilter( this );
 }
 
-bool Qgs3DAxis::eventFilter( QObject *watched, QEvent *event )
+// will be called by Qgs3DMapCanvas::eventFilter
+bool Qgs3DAxis::handleEvent( QEvent *event )
 {
-  if ( watched != mCanvas )
-    return false;
+  if ( event->type() == QEvent::ShortcutOverride )
+  {
+    return handleKeyEvent( static_cast<QKeyEvent *>( event ) );
+  }
 
   if ( event->type() == QEvent::MouseButtonPress )
   {
@@ -448,37 +439,48 @@ void Qgs3DAxis::createAxisScene()
   }
 }
 
-void Qgs3DAxis::createKeyboardShortCut()
+bool Qgs3DAxis::handleKeyEvent( QKeyEvent *keyEvent )
 {
-  QgsWindow3DEngine *eng = dynamic_cast<QgsWindow3DEngine *>( mMapScene->engine() );
-  if ( eng )
+  bool ret = false;
+  if ( keyEvent->modifiers() | Qt::ControlModifier )
   {
-    QWidget *mapCanvas = dynamic_cast<QWidget *>( eng->parent() );
-    if ( !mapCanvas )
+    ret = true;
+    switch ( keyEvent->key() )
     {
-      QgsLogger::warning( "Qgs3DAxis: no canvas defined!" );
-    }
-    else
-    {
-      QShortcut *shortcutHome = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_1 ), mapCanvas );
-      connect( shortcutHome, &QShortcut::activated, this, [this]() { onCameraViewChangeHome(); } );
+      case Qt::Key_8:
+        onCameraViewChangeNorth();
+        break;
 
-      QShortcut *shortcutTop = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_5 ), mapCanvas );
-      connect( shortcutTop, &QShortcut::activated, this, [this]() { onCameraViewChangeTop(); } );
+      case Qt::Key_6:
+        onCameraViewChangeEast();
+        break;
 
-      QShortcut *shortcutNorth = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_8 ), mapCanvas );
-      connect( shortcutNorth, &QShortcut::activated, this, [this]() { onCameraViewChangeNorth(); } );
+      case Qt::Key_2:
+        onCameraViewChangeSouth();
+        break;
 
-      QShortcut *shortcutEast = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_6 ), mapCanvas );
-      connect( shortcutEast, &QShortcut::activated, this, [this]() { onCameraViewChangeEast(); } );
+      case Qt::Key_4:
+        onCameraViewChangeWest();
+        break;
 
-      QShortcut *shortcutSouth = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_2 ), mapCanvas );
-      connect( shortcutSouth, &QShortcut::activated, this, [this]() { onCameraViewChangeSouth(); } );
+      case Qt::Key_9:
+        onCameraViewChangeTop();
+        break;
 
-      QShortcut *shortcutWest = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_4 ), mapCanvas );
-      connect( shortcutWest, &QShortcut::activated, this, [this]() { onCameraViewChangeWest(); } );
+      case Qt::Key_3:
+        onCameraViewChangeBottom();
+        break;
+
+      case Qt::Key_5:
+        onCameraViewChangeHome();
+        break;
+
+      default:
+        ret = false;
+        break;
     }
   }
+  return ret;
 }
 
 void Qgs3DAxis::createMenu()

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -23,12 +23,9 @@
 #include <Qt3DCore/QEntity>
 #include <Qt3DExtras/QText2DEntity>
 #include <Qt3DRender/QCamera>
-#include <Qt3DRender/QPickEvent>
+#include <Qt3DRender/QRenderSettings>
 #include <Qt3DRender/QScreenRayCaster>
 #include <QVector3D>
-
-#include <Qt3DRender/QLayer>
-#include <Qt3DRender/QRenderSettings>
 
 #include <QtWidgets/QMenu>
 #include "qgs3daxissettings.h"
@@ -84,6 +81,14 @@ class _3D_EXPORT Qgs3DAxis : public QObject
      */
     void onViewportScaleFactorChanged( double scaleFactor );
 
+    /**
+     * Returns if the 3D axis controller will handle the specified \a event.
+     *
+     * - TRUE when event is key within Ctrl+[2345689] to handle view orientation
+     * - FALSE when event is mouse click within the 3Daxis space to handle menu and orientation by clicking on cube faces
+     */
+    bool handleEvent( QEvent *event );
+
   public slots:
 
     //! Force update of the axis and the viewport when a setting has changed
@@ -124,8 +129,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
 
     // axis picking and menu
     void init3DObjectPicking();
-    bool eventFilter( QObject *watched, QEvent *event ) override;
-    void createKeyboardShortCut();
+    bool handleKeyEvent( QKeyEvent *keyEvent );
     void createMenu();
     void hideMenu();
     void displayMenuAt( const QPoint &position );

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -24,6 +24,7 @@
 #include <Qt3DLogic/QLogicAspect>
 #include <Qt3DLogic/QFrameAction>
 
+#include "qgs3daxis.h"
 #include "qgs3dmapcanvas.h"
 #include "qgs3dmapscene.h"
 #include "qgswindow3dengine.h"
@@ -269,6 +270,12 @@ bool Qgs3DMapCanvas::eventFilter( QObject *watched, QEvent *event )
 {
   if ( watched != this )
     return false;
+
+  if ( mScene && mScene->get3DAxis() && mScene->get3DAxis()->handleEvent( event ) )
+  {
+    event->accept();
+    return true;
+  }
 
   if ( event->type() == QEvent::ShortcutOverride )
   {


### PR DESCRIPTION
Keyboard shortcuts need a QWidget to be added (qgs3dmapcanvaswidget is this case). Since previous refactor, Qgs3DMapCanvas was no more attached to the qgs3dmapcanvaswidget. We readd this as a class member and not as a Qt inheritance.
