### PR TITLE
Fix for 60864

### DIFF
--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -99,11 +99,10 @@ void QgsMeshRendererScalarSettingsWidget::setActiveDatasetGroup( int groupIndex 
 QgsMeshRendererScalarSettings QgsMeshRendererScalarSettingsWidget::settings() const
 {
   QgsMeshRendererScalarSettings settings;
+  settings.setClassificationMinimumMaximum( spinBoxValue( mScalarMinSpinBox ), spinBoxValue( mScalarMaxSpinBox ) );
   settings.setColorRampShader( mScalarColorRampShaderWidget->shader() );
   settings.setOpacity( mOpacityWidget->opacity() );
   settings.setDataResamplingMethod( dataIntepolationMethod() );
-
-  settings.setClassificationMinimumMaximum( spinBoxValue( mScalarMinSpinBox ), spinBoxValue( mScalarMaxSpinBox ) );
 
   settings.setExtent( mMinMaxValueTypeComboBox->currentData().value<Qgis::MeshRangeExtent>() );
 

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -81,6 +81,7 @@ set(TESTS
   testqgsmaskingwidget.cpp
   testqgssvgselectorwidget.cpp
   testqgslabelingwidget.cpp
+  testqgsmeshrendererscalarsettingswidget.cpp
 )
 
 foreach(TESTSRC ${TESTS})

--- a/tests/src/gui/testqgsmeshrendererscalarsettingswidget.cpp
+++ b/tests/src/gui/testqgsmeshrendererscalarsettingswidget.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+    testqgsmeshrendererscalarsettingswidget
+     --------------------------------------
+    Date                 : May 2025
+    Copyright            : (C) 2025 Jan Caha
+    Email                : jan.caha@outlook.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+
+#include "qgsapplication.h"
+#include "qgsmeshlayer.h"
+#include "qgsmaplayertemporalproperties.h"
+#include "qgsmeshrendererscalarsettingswidget.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test to verify that raster histogram works
+ */
+class TestQgsMeshRendererScalarSettingsWidget : public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsMeshRendererScalarSettingsWidget() {}
+
+  private:
+    QgsMeshLayer *mMeshLayer = nullptr;
+    const QString mTestDataDir = QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/mesh/" );
+
+  private slots:
+
+    // init / cleanup
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+
+    // tests
+    void testScalarSettingsShader();
+};
+
+void TestQgsMeshRendererScalarSettingsWidget::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  const QString mMeshFile = mTestDataDir + QStringLiteral( "quad_and_triangle.2dm" );
+
+  mMeshLayer = new QgsMeshLayer( mMeshFile, QStringLiteral( "mesh" ), QStringLiteral( "mdal" ) );
+  QVERIFY( mMeshLayer->isValid() );
+
+  mMeshLayer->updateTriangularMesh();
+  mMeshLayer->temporalProperties()->setIsActive( false );
+
+  QgsMeshDatasetIndex meshDatasetIndex = QgsMeshDatasetIndex( 0, 0 );
+  mMeshLayer->setStaticScalarDatasetIndex( meshDatasetIndex );
+}
+
+void TestQgsMeshRendererScalarSettingsWidget::cleanupTestCase()
+{
+  delete mMeshLayer;
+}
+
+void TestQgsMeshRendererScalarSettingsWidget::testScalarSettingsShader()
+{
+  // related to https://github.com/qgis/QGIS/issues/60864
+  // mesh scalar settings shader improperly created resulting in changes in labels and values of the shader
+
+  QgsMeshRendererSettings settings = mMeshLayer->rendererSettings();
+  int activeScalarDatasetGroup = settings.activeScalarDatasetGroup();
+
+  // manual styling for layer
+  const QString style = mTestDataDir + QStringLiteral( "mesh_custom_shader.qml" );
+
+  bool res;
+  mMeshLayer->loadNamedStyle( style, res );
+
+  QVERIFY( res );
+
+  // check ramp shader after the the style load
+  QgsMeshRendererScalarSettings scalarSettings = mMeshLayer->rendererSettings().scalarSettings( activeScalarDatasetGroup );
+  QgsColorRampShader shader = scalarSettings.colorRampShader();
+  qgsDoubleNear( shader.minimumValue(), 24, 0.1 );
+  qgsDoubleNear( shader.maximumValue(), 35, 0.1 );
+  QCOMPARE( shader.colorRampItemList().size(), 30 );
+  QCOMPARE( shader.colorRampItemList().first().label, QStringLiteral( "<=24" ) );
+  QCOMPARE( shader.colorRampItemList().last().label, QStringLiteral( ">=35" ) );
+
+  // create widget, sync it to layer
+  QgsMeshRendererScalarSettingsWidget *widget = new QgsMeshRendererScalarSettingsWidget( nullptr );
+  widget->setLayer( mMeshLayer );
+  widget->setActiveDatasetGroup( activeScalarDatasetGroup );
+  widget->syncToLayer();
+
+  // get scalar renderer settings from layer - this was source of error as shader was recalculated here (labels and values would change)
+  QgsMeshRendererScalarSettings widgetMeshRendererScalarSettings = widget->settings();
+
+  // check that it fits what was loaded from qml file, no changes and recalculations
+  shader = widgetMeshRendererScalarSettings.colorRampShader();
+  qgsDoubleNear( shader.minimumValue(), 24, 0.1 );
+  qgsDoubleNear( shader.maximumValue(), 35, 0.1 );
+  QCOMPARE( shader.colorRampItemList().size(), 30 );
+  QCOMPARE( shader.colorRampItemList().first().label, QStringLiteral( "<=24" ) );
+  QCOMPARE( shader.colorRampItemList().last().label, QStringLiteral( ">=35" ) );
+}
+
+QGSTEST_MAIN( TestQgsMeshRendererScalarSettingsWidget )
+#include "testqgsmeshrendererscalarsettingswidget.moc"

--- a/tests/testdata/mesh/mesh_custom_shader.qml
+++ b/tests/testdata/mesh/mesh_custom_shader.qml
@@ -1,0 +1,216 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis autoRefreshTime="0" version="3.43.0-Master" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" autoRefreshMode="Disabled">
+  <renderer-3d layer="quad_and_triangle_2dfde00e_ca67_4bc7_a618_3c9b2cbae58d" type="mesh">
+    <symbol type="mesh">
+      <data alt-clamping="absolute" add-back-faces="0" height="0"/>
+      <material diffuse="178,178,178,255,rgb:0.69999237048905161,0.69999237048905161,0.69999237048905161,1" specular="255,255,255,255,rgb:1,1,1,1" shininess="0" opacity="1" ka="1" ks="1" kd="1" ambient="26,26,26,255,rgb:0.10000762951094835,0.10000762951094835,0.10000762951094835,1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data-defined-properties>
+      </material>
+      <advanced-settings culling-mode="no-culling" vertical-group-index="-1" min-color-ramp-shader="0" max-color-ramp-shader="255" arrows-spacing="25" arrows-fixed-size="0" wireframe-line-width="1" vertical-scale="1" texture-type="0" texture-single-color="0,128,0,255,rgb:0,0.50196078431372548,0,1" wireframe-line-color="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" wireframe-enabled="0" vertical-relative="0" smoothed-triangle="0" arrows-enabled="0" renderer-3d-enabled="0" level-of-detail="-99">
+        <colorrampshader colorRampType="INTERPOLATED" minimumValue="0" maximumValue="255" classificationMode="1" labelPrecision="6" clip="0">
+          <rampLegendSettings maximumLabel="" prefix="" direction="0" suffix="" useContinuousLegend="1" minimumLabel="" orientation="2">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option type="invalid" name="decimal_separator"/>
+                <Option type="int" name="decimals" value="6"/>
+                <Option type="int" name="rounding_type" value="0"/>
+                <Option type="bool" name="show_plus" value="false"/>
+                <Option type="bool" name="show_thousand_separator" value="true"/>
+                <Option type="bool" name="show_trailing_zeros" value="false"/>
+                <Option type="invalid" name="thousand_separator"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
+        </colorrampshader>
+      </advanced-settings>
+      <data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" name="name" value=""/>
+          <Option name="properties"/>
+          <Option type="QString" name="type" value="collection"/>
+        </Option>
+      </data-defined-properties>
+    </symbol>
+  </renderer-3d>
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal end-time-extent="2025-03-28T00:00:00Z" matching-method="0" reference-time="2025-03-28T00:00:00Z" temporal-active="0" start-time-extent="2025-03-28T00:00:00Z" always-load-reference-time-from-source="0"/>
+  <elevation zoffset="0" zscale="1" symbology="Line" mode="FromVertices">
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" name="name" value=""/>
+        <Option name="properties"/>
+        <Option type="QString" name="type" value="collection"/>
+      </Option>
+    </data-defined-properties>
+    <profileLineSymbol>
+      <symbol type="line" name="" alpha="1" frame_rate="10" clip_to_extent="1" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{d1a80210-45cd-4b91-8e83-db59987de94e}" class="SimpleLine" enabled="1" pass="0" locked="0">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="231,113,72,255,rgb:0.90588235294117647,0.44313725490196076,0.28235294117647058,1"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.6"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileLineSymbol>
+    <profileFillSymbol>
+      <symbol type="fill" name="" alpha="1" frame_rate="10" clip_to_extent="1" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{bae880ae-9686-4c4a-9eb4-32fa3f658dbe}" class="SimpleFill" enabled="1" pass="0" locked="0">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="231,113,72,255,rgb:0.90588235294117647,0.44313725490196076,0.28235294117647058,1"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="solid"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileFillSymbol>
+  </elevation>
+  <customproperties>
+    <Option/>
+  </customproperties>
+  <mesh-renderer-settings>
+    <active-dataset-group scalar="0" vector="-1"/>
+    <scalar-settings interpolation-method="no-resampling" group="0" min-val="24" opacity="1" max-val="35">
+      <colorrampshader colorRampType="INTERPOLATED" minimumValue="24" maximumValue="35" classificationMode="1" labelPrecision="6" clip="0">
+        <colorramp type="gradient" name="[source]">
+          <Option type="Map">
+            <Option type="QString" name="color1" value="156,23,158,255,rgb:0.61176470588235299,0.09019607843137255,0.61960784313725492,1"/>
+            <Option type="QString" name="color2" value="252,206,37,255,rgb:0.9882352941176471,0.80784313725490198,0.14509803921568629,1"/>
+            <Option type="QString" name="direction" value="ccw"/>
+            <Option type="QString" name="discrete" value="0"/>
+            <Option type="QString" name="rampType" value="gradient"/>
+            <Option type="QString" name="spec" value="rgb"/>
+            <Option type="QString" name="stops" value="0.034483;162,29,154,255,rgb:0.63529411764705879,0.11372549019607843,0.60392156862745094,1;rgb;ccw:0.068966;168,34,150,255,rgb:0.6588235294117647,0.13333333333333333,0.58823529411764708,1;rgb;ccw:0.103449;174,40,146,255,rgb:0.68235294117647061,0.15686274509803921,0.5725490196078431,1;rgb;ccw:0.137932;180,46,141,255,rgb:0.70588235294117652,0.1803921568627451,0.55294117647058827,1;rgb;ccw:0.172415;186,51,136,255,rgb:0.72941176470588232,0.20000000000000001,0.53333333333333333,1;rgb;ccw:0.206896;191,57,132,255,rgb:0.74901960784313726,0.22352941176470589,0.51764705882352946,1;rgb;ccw:0.241379;196,62,127,255,rgb:0.7686274509803922,0.24313725490196078,0.49803921568627452,1;rgb;ccw:0.275862;201,68,122,255,rgb:0.78823529411764703,0.26666666666666666,0.47843137254901963,1;rgb;ccw:0.310345;205,74,118,255,rgb:0.80392156862745101,0.29019607843137257,0.46274509803921571,1;rgb;ccw:0.344828;210,79,113,255,rgb:0.82352941176470584,0.30980392156862746,0.44313725490196076,1;rgb;ccw:0.379311;214,85,109,255,rgb:0.83921568627450982,0.33333333333333331,0.42745098039215684,1;rgb;ccw:0.413792;218,91,105,255,rgb:0.85490196078431369,0.35686274509803922,0.41176470588235292,1;rgb;ccw:0.448275;222,97,100,255,rgb:0.87058823529411766,0.38039215686274508,0.39215686274509803,1;rgb;ccw:0.482758;226,102,96,255,rgb:0.88627450980392153,0.40000000000000002,0.37647058823529411,1;rgb;ccw:0.517242;230,108,92,255,rgb:0.90196078431372551,0.42352941176470588,0.36078431372549019,1;rgb;ccw:0.551725;233,114,87,255,rgb:0.9137254901960784,0.44705882352941179,0.3411764705882353,1;rgb;ccw:0.586208;237,121,83,255,rgb:0.92941176470588238,0.47450980392156861,0.32549019607843138,1;rgb;ccw:0.620691;240,127,79,255,rgb:0.94117647058823528,0.49803921568627452,0.30980392156862746,1;rgb;ccw:0.655172;243,133,75,255,rgb:0.95294117647058818,0.52156862745098043,0.29411764705882354,1;rgb;ccw:0.689655;245,140,70,255,rgb:0.96078431372549022,0.5490196078431373,0.27450980392156865,1;rgb;ccw:0.724138;247,147,66,255,rgb:0.96862745098039216,0.57647058823529407,0.25882352941176473,1;rgb;ccw:0.758621;249,154,62,255,rgb:0.97647058823529409,0.60392156862745094,0.24313725490196078,1;rgb;ccw:0.793104;251,161,57,255,rgb:0.98431372549019602,0.63137254901960782,0.22352941176470589,1;rgb;ccw:0.827587;252,168,53,255,rgb:0.9882352941176471,0.6588235294117647,0.20784313725490197,1;rgb;ccw:0.862068;253,175,49,255,rgb:0.99215686274509807,0.68627450980392157,0.19215686274509805,1;rgb;ccw:0.896551;254,183,45,255,rgb:0.99607843137254903,0.71764705882352942,0.17647058823529413,1;rgb;ccw:0.931034;254,190,42,255,rgb:0.99607843137254903,0.74509803921568629,0.16470588235294117,1;rgb;ccw:0.965517;253,198,39,255,rgb:0.99215686274509807,0.77647058823529413,0.15294117647058825,1;rgb;ccw"/>
+          </Option>
+        </colorramp>
+        <item color="#9c179e" alpha="255" value="24" label="&lt;=24"/>
+        <item color="#a21d9a" alpha="255" value="24.379313" label="24,379313"/>
+        <item color="#a82296" alpha="255" value="24.758626" label="24,758626"/>
+        <item color="#ae2892" alpha="255" value="25.137939" label="25,137939"/>
+        <item color="#b42e8d" alpha="255" value="25.517252" label="25,517252"/>
+        <item color="#ba3388" alpha="255" value="25.896565" label="25,896565"/>
+        <item color="#bf3984" alpha="255" value="26.275856" label="26,275856"/>
+        <item color="#c43e7f" alpha="255" value="26.655169" label="26,655169"/>
+        <item color="#c9447a" alpha="255" value="27.034482" label="27,034482"/>
+        <item color="#cd4a76" alpha="255" value="27.413795" label="27,413795"/>
+        <item color="#d24f71" alpha="255" value="27.793108" label="27,793108"/>
+        <item color="#d6556d" alpha="255" value="28.172421" label="28,172421"/>
+        <item color="#da5b69" alpha="255" value="28.551712000000002" label="28,551712"/>
+        <item color="#de6164" alpha="255" value="28.931024999999998" label="28,931025"/>
+        <item color="#e26660" alpha="255" value="29.310338" label="29,310338"/>
+        <item color="#e66c5c" alpha="255" value="29.689662" label="29,689662"/>
+        <item color="#e97257" alpha="255" value="30.068975000000002" label="30,068975"/>
+        <item color="#ed7953" alpha="255" value="30.448287999999998" label="30,448288"/>
+        <item color="#f07f4f" alpha="255" value="30.827601" label="30,827601"/>
+        <item color="#f3854b" alpha="255" value="31.206892" label="31,206892"/>
+        <item color="#f58c46" alpha="255" value="31.586205" label="31,586205"/>
+        <item color="#f79342" alpha="255" value="31.965518" label="31,965518"/>
+        <item color="#f99a3e" alpha="255" value="32.344831" label="32,344831"/>
+        <item color="#fba139" alpha="255" value="32.724144" label="32,724144"/>
+        <item color="#fca835" alpha="255" value="33.103457" label="33,103457"/>
+        <item color="#fdaf31" alpha="255" value="33.482748" label="33,482748"/>
+        <item color="#feb72d" alpha="255" value="33.862061" label="33,862061"/>
+        <item color="#febe2a" alpha="255" value="34.241374" label="34,241374"/>
+        <item color="#fdc627" alpha="255" value="34.620687000000004" label="34,620687"/>
+        <item color="#fcce25" alpha="255" value="35" label=">=35"/>
+        <rampLegendSettings maximumLabel="" prefix="" direction="0" suffix="" useContinuousLegend="1" minimumLabel="" orientation="2">
+          <numericFormat id="basic">
+            <Option type="Map">
+              <Option type="invalid" name="decimal_separator"/>
+              <Option type="int" name="decimals" value="6"/>
+              <Option type="int" name="rounding_type" value="0"/>
+              <Option type="bool" name="show_plus" value="false"/>
+              <Option type="bool" name="show_thousand_separator" value="true"/>
+              <Option type="bool" name="show_trailing_zeros" value="false"/>
+              <Option type="invalid" name="thousand_separator"/>
+            </Option>
+          </numericFormat>
+        </rampLegendSettings>
+      </colorrampshader>
+      <edge-settings stroke-width-unit="0">
+        <mesh-stroke-width maximum-value="10" maximum-width="3" fixed-width="0.26000000000000001" minimum-width="0.26000000000000001" minimum-value="0" ignore-out-of-range="0" use-absolute-value="0" width-varying="0"/>
+      </edge-settings>
+    </scalar-settings>
+    <mesh-settings-native line-width-unit="MM" enabled="0" color="0,0,0,255,rgb:0,0,0,1" line-width="0.26000000000000001"/>
+    <mesh-settings-edge line-width-unit="MM" enabled="0" color="0,0,0,255,rgb:0,0,0,1" line-width="0.26000000000000001"/>
+    <mesh-settings-triangular line-width-unit="MM" enabled="0" color="0,0,0,255,rgb:0,0,0,1" line-width="0.26000000000000001"/>
+    <averaging-3d method="1">
+      <sigma-settings end-fraction="1" start-fraction="0"/>
+    </averaging-3d>
+  </mesh-renderer-settings>
+  <name-to-global-index global-index="0" name="Bed Elevation"/>
+  <mesh-simplify-settings reduction-factor="10" enabled="0" mesh-resolution="5"/>
+  <blendMode>0</blendMode>
+  <layerOpacity>1</layerOpacity>
+</qgis>


### PR DESCRIPTION
## Description

Wrong order of operations caused `QgsMeshRendererScalarSettings` `shader` to be recalculated from minimum and maximum instead of properly set up from `mScalarColorRampShaderWidget`. We first setup minimum maximum and then use shader from `mScalarColorRampShaderWidget` .

Fixes #60864
