### PR TITLE
[3d] axis renview init fix

### DIFF
--- a/src/3d/framegraph/qgs3daxisrenderview.cpp
+++ b/src/3d/framegraph/qgs3daxisrenderview.cpp
@@ -87,9 +87,6 @@ Qgs3DAxisRenderView::Qgs3DAxisRenderView( const QString &viewName, Qgs3DMapCanva
   Qt3DRender::QClearBuffers *objectClearBuffers = new Qt3DRender::QClearBuffers( objectSortPolicy );
   objectClearBuffers->setBuffers( Qt3DRender::QClearBuffers::DepthBuffer );
 
-  // render pass for the axis label
-  // mTwoDLabelceneEntity->addComponent( twoDLayer );
-
   Qt3DRender::QLayerFilter *labelFilter = new Qt3DRender::QLayerFilter( mViewport );
   labelFilter->addLayer( mLabelLayer );
 
@@ -186,7 +183,6 @@ void Qgs3DAxisRenderView::onViewportSizeUpdate( int width, int height )
 
   if ( heightRatio > settings.maxViewportRatio() || widthRatio > settings.maxViewportRatio() )
   {
-    qDebug() << heightRatio << settings.maxViewportRatio() << widthRatio << settings.maxViewportRatio();
     QgsDebugMsgLevel( QString( "3DAxis viewport takes too much place into the 3d view, disabling it (maxViewportRatio: %1)." ).arg( settings.maxViewportRatio() ), 2 );
     // take too much place into the 3d view
     mViewport->setEnabled( false );

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -942,6 +942,12 @@ void Qgs3DAxis::onAxisViewportSizeUpdate()
 
 void Qgs3DAxis::onViewportScaleFactorChanged( double scaleFactor )
 {
+  // if the axis scene has not been created, don't do anything
+  if ( !mAxisRoot || !mCubeRoot )
+  {
+    return;
+  }
+
   if ( scaleFactor > 0.0 )
   {
     Qgs3DAxisSettings settings = mMapSettings->get3DAxisSettings();


### PR DESCRIPTION
## Description

When a renderview is created it handles the window resizes by calling
`updateWindowResize()`. In the case of the 3d axis, the renderview
calls `onViewportSizeUpdate()` which itself calls
`Qgs3DAxis::onAxisViewportSizeUpdate()`. This functions updates the
the cube and axis visibility. However, when the renderview is created
the scene has not been created yet and the cube and axis do not exist. 
Therefore, this results in a segmentation fault.

This issue is fixed by not doing anything in
`Qgs3DAxis::onAxisViewportSizeUpdate()` if the 3d axis scene has not
been created yet.

Fixes: 75ee85e2309b5aa87e358355c22cf8fdafb87411