### PR TITLE
fix(postprocessing): Restore showFeatureCount option

### DIFF
--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -324,7 +324,10 @@ def handleAlgorithmResults(
         if project and insertion_point:
             project.layerTreeRegistryBridge().setLayerInsertionPoint(insertion_point)
 
-        project.addMapLayer(layer_node.layer())
+        added_layer = project.addMapLayer(layer_node.layer())
+        if project and layer_node.customProperty("showFeatureCount"):
+            added_layer_tree_layer = project.layerTreeRoot().findLayer(added_layer.id())
+            added_layer_tree_layer.setCustomProperty("showFeatureCount", True)
 
         if not have_set_active_layer and iface is not None:
             iface.setActiveLayer(layer_node.layer())


### PR DESCRIPTION
## Description

With the introduction of the `insertionPoint` logic to add a layer to the tree, the "showFeaturecount" option was lost.
This is fixed by setting this property to the added layer if necessary.

fixes: a46f3e97528fdcd7271db844266e4d8bd703cd6e
Closes: https://github.com/qgis/QGIS/issues/61146
