### PR TITLE
Use class with static public methods instead of namespace for PyQGIS exposed methods

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmeshutils.py
+++ b/python/PyQt6/core/auto_additions/qgsmeshutils.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/mesh/qgsmeshutils.h
+try:
+    QgsMeshUtils.__group__ = ['mesh']
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -11,13 +11,10 @@
 
 
 
+%ModuleHeaderCode
+#include "qgsmeshutils.h"
+%End
 
-
-typedef QgsPoint QgsMeshVertex;
-
-typedef QVector<int> QgsMeshFace;
-
-typedef QPair<int, int> QgsMeshEdge;
 
 struct QgsMesh
 {

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshlayerinterpolator.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshlayerinterpolator.sip.in
@@ -12,46 +12,9 @@
 
 
 
-%ModuleHeaderCode
-#include "qgsmeshlayerinterpolator.h"
-%End
 
 
 
-
-namespace QgsMeshUtils
-{
-
-  QgsRasterBlock *exportRasterBlock(
-    const QgsMeshLayer &layer,
-    const QgsMeshDatasetIndex &datasetIndex,
-    const QgsCoordinateReferenceSystem &destinationCrs,
-    const QgsCoordinateTransformContext &transformContext,
-    double mapUnitsPerPixel,
-    const QgsRectangle &extent,
-    QgsRasterBlockFeedback *feedback = 0
-  ) /Factory/;
-%Docstring
-Exports mesh layer's dataset values as raster block
-
-The function always fetches native mesh and dataset data
-from data provider and calculates triangular mesh
-
-:param layer: mesh layer
-:param datasetIndex: index from layer defining group and dataset (time) to export
-:param destinationCrs: destination/map CRS. Used to create triangular mesh from native mesh
-:param transformContext: Transform context to transform layer CRS to destination CRS
-:param mapUnitsPerPixel: map units per pixel for block
-:param extent: extent of block in destination CRS
-:param feedback: optional raster feedback object for cancellation/preview
-
-:return: raster block with Float.64 values. ``None`` on error
-
-.. versionadded:: 3.6
-%End
-
-
-};
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshutils.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshutils.sip.in
@@ -1,0 +1,80 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/mesh/qgsmeshutils.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+
+typedef QgsPoint QgsMeshVertex;
+
+typedef QVector<int> QgsMeshFace;
+
+typedef QPair<int, int> QgsMeshEdge;
+
+
+class QgsMeshUtils
+{
+%Docstring(signature="appended")
+Provides utility functions for working with mesh data.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsmeshutils.h"
+%End
+  public:
+
+    static QgsRasterBlock *exportRasterBlock(
+      const QgsMeshLayer &layer,
+      const QgsMeshDatasetIndex &datasetIndex,
+      const QgsCoordinateReferenceSystem &destinationCrs,
+      const QgsCoordinateTransformContext &transformContext,
+      double mapUnitsPerPixel,
+      const QgsRectangle &extent,
+      QgsRasterBlockFeedback *feedback = 0
+    ) /Factory/;
+%Docstring
+Exports mesh layer's dataset values as raster block
+
+The function always fetches native mesh and dataset data
+from data provider and calculates triangular mesh
+
+:param layer: mesh layer
+:param datasetIndex: index from layer defining group and dataset (time) to export
+:param destinationCrs: destination/map CRS. Used to create triangular mesh from native mesh
+:param transformContext: Transform context to transform layer CRS to destination CRS
+:param mapUnitsPerPixel: map units per pixel for block
+:param extent: extent of block in destination CRS
+:param feedback: optional raster feedback object for cancellation/preview
+
+:return: raster block with Float.64 values. ``None`` on error
+
+.. versionadded:: 3.6
+%End
+
+
+
+
+
+
+
+
+
+
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/mesh/qgsmeshutils.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/PyQt6/core/auto_generated/qgshstoreutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgshstoreutils.sip.in
@@ -8,14 +8,20 @@
 
 
 
-%ModuleHeaderCode
-#include "qgshstoreutils.h"
+class QgsHstoreUtils
+{
+%Docstring(signature="appended")
+Provides utility functions for handling hstore-formatted strings.
+
+.. versionadded:: 3.4
 %End
 
-namespace QgsHstoreUtils
-{
+%TypeHeaderCode
+#include "qgshstoreutils.h"
+%End
+  public:
 
-  QVariantMap parse( const QString &string );
+    static QVariantMap parse( const QString &string );
 %Docstring
 Returns a QVariantMap object containing the key and values from a hstore-formatted string.
 
@@ -24,7 +30,7 @@ Returns a QVariantMap object containing the key and values from a hstore-formatt
 .. versionadded:: 3.4
 %End
 
-  QString build( const QVariantMap &map );
+    static QString build( const QVariantMap &map );
 %Docstring
 Build a hstore-formatted string from a QVariantMap.
 

--- a/python/PyQt6/core/auto_generated/qgstestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstestutils.sip.in
@@ -9,15 +9,16 @@
 
 
 
-%ModuleHeaderCode
-#include "qgstestutils.h"
-%End
 
-
-namespace QgsTestUtils
+class QgsTestUtils
 {
 
-  bool testProviderIteratorThreadSafety( QgsVectorDataProvider *provider, const QgsFeatureRequest &request = QgsFeatureRequest() );
+%TypeHeaderCode
+#include "qgstestutils.h"
+%End
+  public:
+
+    static bool testProviderIteratorThreadSafety( QgsVectorDataProvider *provider, const QgsFeatureRequest &request = QgsFeatureRequest() );
 %Docstring
 Runs a thready safety test on iterators from a vector data ``provider``, by concurrently
 requesting features from the provider.
@@ -25,7 +26,7 @@ requesting features from the provider.
 This method returns ``True``... or it segfaults.
 %End
 
-  bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
+    static bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
 %Docstring
 Compares two DOM elements and returns ``True`` if they are equivalent.
 

--- a/python/PyQt6/core/auto_generated/qgsziputils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsziputils.sip.in
@@ -8,14 +8,20 @@
 
 
 
-%ModuleHeaderCode
-#include "qgsziputils.h"
+class QgsZipUtils
+{
+%Docstring(signature="appended")
+Provides utility functions for working with zip files.
+
+.. versionadded:: 3.0
 %End
 
-namespace QgsZipUtils
-{
+%TypeHeaderCode
+#include "qgsziputils.h"
+%End
+  public:
 
-  bool isZipFile( const QString &filename );
+    static bool isZipFile( const QString &filename );
 %Docstring
 Returns ``True`` if the file name is a zipped file ( i.e with a '.qgz'
 extension, ``False`` otherwise.
@@ -25,7 +31,7 @@ extension, ``False`` otherwise.
 :return: ``True`` if the file is zipped, ``False`` otherwise
 %End
 
-  bool unzip( const QString &zip, const QString &dir, QStringList &files /Out/, bool checkConsistency = true );
+    static bool unzip( const QString &zip, const QString &dir, QStringList &files /Out/, bool checkConsistency = true );
 %Docstring
 Unzip a zip file in an output directory.
 
@@ -37,7 +43,7 @@ Unzip a zip file in an output directory.
          - files: The absolute path of unzipped files
 %End
 
-  bool zip( const QString &zip, const QStringList &files );
+    static bool zip( const QString &zip, const QStringList &files );
 %Docstring
 Zip the list of files in the zip file. If the zip file already exists or is
 empty, an error is returned. If an input file does not exist, an error is
@@ -50,8 +56,7 @@ also returned.
 
 
 
-
-  const QStringList files( const QString &zip );
+    static const QStringList files( const QString &zip );
 %Docstring
 Returns the list of files within a ``zip`` file
 

--- a/python/PyQt6/core/core_auto.sip
+++ b/python/PyQt6/core/core_auto.sip
@@ -502,6 +502,7 @@
 %Include auto_generated/mesh/qgsmeshadvancedediting.sip
 %Include auto_generated/mesh/qgsmeshforcebypolylines.sip
 %Include auto_generated/mesh/qgsmeshlayerlabeling.sip
+%Include auto_generated/mesh/qgsmeshutils.sip
 %Include auto_generated/painting/qgsgeometrypaintdevice.sip
 %Include auto_generated/painting/qgsmaskpaintdevice.sip
 %Include auto_generated/painting/qgsnullpainterdevice.sip

--- a/python/PyQt6/server/auto_generated/qgsserverfeatureid.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverfeatureid.sip.in
@@ -11,15 +11,19 @@
 
 
 
+class QgsServerFeatureId
+{
+%Docstring(signature="appended")
+Contains utility functions for using primary keys for feature IDs.
 
-%ModuleHeaderCode
-#include "qgsserverfeatureid.h"
+.. versionadded:: 3.4.9
 %End
 
-
-  namespace QgsServerFeatureId
-{
-  QString getServerFid( const QgsFeature &feature, const QgsAttributeList &pkAttributes );
+%TypeHeaderCode
+#include "qgsserverfeatureid.h"
+%End
+  public:
+    static QString getServerFid( const QgsFeature &feature, const QgsAttributeList &pkAttributes );
 %Docstring
 Returns the feature id based on primary keys.
 
@@ -31,12 +35,12 @@ Returns the feature id based on primary keys.
 .. versionadded:: 3.4.9
 %End
 
-  QgsFeatureRequest updateFeatureRequestFromServerFids( QgsFeatureRequest & featureRequest, const QStringList &serverFids, const QgsVectorDataProvider *provider );
+    static QgsFeatureRequest updateFeatureRequestFromServerFids( QgsFeatureRequest &featureRequest, const QStringList &serverFids, const QgsVectorDataProvider *provider );
 %Docstring
 Returns the feature request based on feature ids build with primary keys.
 
 :param featureRequest: the feature request to update
-:param serverFids: the feature ids build with :py:class:`QgsServerFeatureId`.getServerFid
+:param serverFids: the feature ids build with QgsServerFeatureId.getServerFid
 :param provider: the vector layer provider to provide fields and primary keys list
 
 :return: the feature request updated
@@ -44,7 +48,7 @@ Returns the feature request based on feature ids build with primary keys.
 .. versionadded:: 3.4.9
 %End
 
-  QString getExpressionFromServerFid( const QString &serverFid, const QgsVectorDataProvider *provider );
+    static QString getExpressionFromServerFid( const QString &serverFid, const QgsVectorDataProvider *provider );
 %Docstring
 Returns the expression feature id based on primary keys.
 
@@ -56,7 +60,7 @@ Returns the expression feature id based on primary keys.
 .. versionadded:: 3.4.9
 %End
 
-  QString pkSeparator();
+    static QString pkSeparator();
 %Docstring
 Returns the primary keys separator
 

--- a/python/PyQt6/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverprojectutils.sip.in
@@ -11,16 +11,20 @@
 
 
 
-%ModuleHeaderCode
-#include "qgsserverprojectutils.h"
+class QgsServerProjectUtils
+{
+%Docstring(signature="appended")
+The :py:class:`QgsServerProjectUtils` namespace provides a way to retrieve specific
+entries from a :py:class:`QgsProject`.
 %End
 
+%TypeHeaderCode
+#include "qgsserverprojectutils.h"
+%End
+  public:
 
-  namespace QgsServerProjectUtils
-{
 
-
-  bool owsServiceCapabilities( const QgsProject &project );
+    static bool owsServiceCapabilities( const QgsProject &project );
 %Docstring
 Returns if owsService capabilities are enabled.
 
@@ -29,7 +33,7 @@ Returns if owsService capabilities are enabled.
 :return: if owsService capabilities are enabled.
 %End
 
-  QString owsServiceTitle( const QgsProject &project );
+    static QString owsServiceTitle( const QgsProject &project );
 %Docstring
 Returns the owsService title defined in project.
 
@@ -38,7 +42,7 @@ Returns the owsService title defined in project.
 :return: the owsService title if defined in project with project title as fallback, "Untitled" otherwise.
 %End
 
-  QString owsServiceAbstract( const QgsProject &project );
+    static QString owsServiceAbstract( const QgsProject &project );
 %Docstring
 Returns the owsService abstract defined in project.
 
@@ -47,7 +51,7 @@ Returns the owsService abstract defined in project.
 :return: the owsService abstract if defined in project.
 %End
 
-  QStringList owsServiceKeywords( const QgsProject &project );
+    static QStringList owsServiceKeywords( const QgsProject &project );
 %Docstring
 Returns the owsService keywords defined in project.
 
@@ -56,7 +60,7 @@ Returns the owsService keywords defined in project.
 :return: the owsService keywords if defined in project.
 %End
 
-  QString owsServiceOnlineResource( const QgsProject &project );
+    static QString owsServiceOnlineResource( const QgsProject &project );
 %Docstring
 Returns the owsService online resource defined in project.
 
@@ -65,7 +69,7 @@ Returns the owsService online resource defined in project.
 :return: the owsService online resource if defined in project.
 %End
 
-  QString owsServiceContactOrganization( const QgsProject &project );
+    static QString owsServiceContactOrganization( const QgsProject &project );
 %Docstring
 Returns the owsService contact organization defined in project.
 
@@ -74,7 +78,7 @@ Returns the owsService contact organization defined in project.
 :return: the owsService contact organization if defined in project.
 %End
 
-  QString owsServiceContactPosition( const QgsProject &project );
+    static QString owsServiceContactPosition( const QgsProject &project );
 %Docstring
 Returns the owsService contact position defined in project.
 
@@ -83,7 +87,7 @@ Returns the owsService contact position defined in project.
 :return: the owsService contact position if defined in project.
 %End
 
-  QString owsServiceContactPerson( const QgsProject &project );
+    static QString owsServiceContactPerson( const QgsProject &project );
 %Docstring
 Returns the owsService contact person defined in project.
 
@@ -92,7 +96,7 @@ Returns the owsService contact person defined in project.
 :return: the owsService contact person if defined in project.
 %End
 
-  QString owsServiceContactMail( const QgsProject &project );
+    static QString owsServiceContactMail( const QgsProject &project );
 %Docstring
 Returns the owsService contact mail defined in project.
 
@@ -101,7 +105,7 @@ Returns the owsService contact mail defined in project.
 :return: the owsService contact mail if defined in project.
 %End
 
-  QString owsServiceContactPhone( const QgsProject &project );
+    static QString owsServiceContactPhone( const QgsProject &project );
 %Docstring
 Returns the owsService contact phone defined in project.
 
@@ -110,7 +114,7 @@ Returns the owsService contact phone defined in project.
 :return: the owsService contact phone if defined in project.
 %End
 
-  QString owsServiceFees( const QgsProject &project );
+    static QString owsServiceFees( const QgsProject &project );
 %Docstring
 Returns the owsService fees defined in project.
 
@@ -119,7 +123,7 @@ Returns the owsService fees defined in project.
 :return: the owsService fees if defined in project.
 %End
 
-  QString owsServiceAccessConstraints( const QgsProject &project );
+    static QString owsServiceAccessConstraints( const QgsProject &project );
 %Docstring
 Returns the owsService access constraints defined in project.
 
@@ -128,7 +132,7 @@ Returns the owsService access constraints defined in project.
 :return: the owsService access constraints if defined in project.
 %End
 
-  int wmsMaxWidth( const QgsProject &project );
+    static int wmsMaxWidth( const QgsProject &project );
 %Docstring
 Returns the maximum width for WMS images defined in a QGIS project.
 
@@ -137,7 +141,7 @@ Returns the maximum width for WMS images defined in a QGIS project.
 :return: width if defined in project, -1 otherwise.
 %End
 
-  int wmsMaxHeight( const QgsProject &project );
+    static int wmsMaxHeight( const QgsProject &project );
 %Docstring
 Returns the maximum height for WMS images defined in a QGIS project.
 
@@ -146,7 +150,7 @@ Returns the maximum height for WMS images defined in a QGIS project.
 :return: height if defined in project, -1 otherwise.
 %End
 
-  int wmsImageQuality( const QgsProject &project );
+    static int wmsImageQuality( const QgsProject &project );
 %Docstring
 Returns the quality for WMS images defined in a QGIS project.
 
@@ -155,7 +159,7 @@ Returns the quality for WMS images defined in a QGIS project.
 :return: quality if defined in project, -1 otherwise.
 %End
 
-  int wmsTileBuffer( const QgsProject &project );
+    static int wmsTileBuffer( const QgsProject &project );
 %Docstring
 Returns the tile buffer in pixels for WMS images defined in a QGIS project.
 
@@ -166,7 +170,7 @@ Returns the tile buffer in pixels for WMS images defined in a QGIS project.
 .. versionadded:: 3.10
 %End
 
-  bool wmsRenderMapTiles( const QgsProject &project );
+    static bool wmsRenderMapTiles( const QgsProject &project );
 %Docstring
 Returns ``True`` if WMS requests should use the :py:class:`QgsMapSettings`.RenderMapTile flag,
 so that no visible artifacts are visible between adjacent tiles.
@@ -181,7 +185,7 @@ setting is enabled in the project.
 .. versionadded:: 3.18
 %End
 
-  int wmsMaxAtlasFeatures( const QgsProject &project );
+    static int wmsMaxAtlasFeatures( const QgsProject &project );
 %Docstring
 Returns the maximum number of atlas features which can be printed in a request
 
@@ -190,7 +194,7 @@ Returns the maximum number of atlas features which can be printed in a request
 :return: the number of atlas features
 %End
 
-  double wmsDefaultMapUnitsPerMm( const QgsProject &project );
+    static double wmsDefaultMapUnitsPerMm( const QgsProject &project );
 %Docstring
 Returns the default number of map units per millimeters in case of the scale is not given
 
@@ -201,7 +205,7 @@ Returns the default number of map units per millimeters in case of the scale is 
 .. versionadded:: 3.4
 %End
 
-  bool wmsUseLayerIds( const QgsProject &project );
+    static bool wmsUseLayerIds( const QgsProject &project );
 %Docstring
 Returns if layer ids are used as name in WMS.
 
@@ -210,7 +214,7 @@ Returns if layer ids are used as name in WMS.
 :return: if layer ids are used as name.
 %End
 
-  bool wmsInfoFormatSia2045( const QgsProject &project );
+    static bool wmsInfoFormatSia2045( const QgsProject &project );
 %Docstring
 Returns if the info format is SIA20145.
 
@@ -219,7 +223,7 @@ Returns if the info format is SIA20145.
 :return: if the info format is SIA20145.
 %End
 
-  bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
+    static bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
 %Docstring
 Returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
 
@@ -228,7 +232,7 @@ Returns if the geometry is displayed as Well Known Text in GetFeatureInfo reques
 :return: if the geometry is displayed as Well Known Text in GetFeatureInfo request.
 %End
 
-  bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
+    static bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
 %Docstring
 Returns if feature form settings should be considered for the format of the feature info response
 
@@ -237,7 +241,7 @@ Returns if feature form settings should be considered for the format of the feat
 :return: true if the feature form settings shall be considered for the feature info response
 %End
 
-  bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
+    static bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
 %Docstring
 Returns if the geometry has to be segmentize in GetFeatureInfo request.
 
@@ -246,7 +250,7 @@ Returns if the geometry has to be segmentize in GetFeatureInfo request.
 :return: if the geometry has to be segmentize in GetFeatureInfo request.
 %End
 
-  bool wmsAddLegendGroupsLegendGraphic( const QgsProject &project );
+    static bool wmsAddLegendGroupsLegendGraphic( const QgsProject &project );
 %Docstring
 Returns if legend groups should be in the legend graphic response if GetLegendGraphic is called on a layer group.
 
@@ -255,7 +259,7 @@ Returns if legend groups should be in the legend graphic response if GetLegendGr
 :return: if the GetLegendGraphic response has to contain legend groups
 %End
 
-  bool wmsSkipNameForGroup( const QgsProject &project );
+    static bool wmsSkipNameForGroup( const QgsProject &project );
 %Docstring
 Returns if name attribute should be skipped for groups in WMS capabilities document.
 
@@ -266,7 +270,7 @@ Returns if name attribute should be skipped for groups in WMS capabilities docum
 .. versionadded:: 3.36
 %End
 
-  int wmsFeatureInfoPrecision( const QgsProject &project );
+    static int wmsFeatureInfoPrecision( const QgsProject &project );
 %Docstring
 Returns the geometry precision for GetFeatureInfo request.
 
@@ -275,7 +279,7 @@ Returns the geometry precision for GetFeatureInfo request.
 :return: the geometry precision for GetFeatureInfo request.
 %End
 
-  QString wmsFeatureInfoDocumentElement( const QgsProject &project );
+    static QString wmsFeatureInfoDocumentElement( const QgsProject &project );
 %Docstring
 Returns the document element name for XML GetFeatureInfo request.
 
@@ -284,7 +288,7 @@ Returns the document element name for XML GetFeatureInfo request.
 :return: the document element name for XML GetFeatureInfo request.
 %End
 
-  QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
+    static QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
 %Docstring
 Returns the document element namespace for XML GetFeatureInfo request.
 
@@ -293,7 +297,7 @@ Returns the document element namespace for XML GetFeatureInfo request.
 :return: the document element namespace for XML GetFeatureInfo request.
 %End
 
-  QString wmsFeatureInfoSchema( const QgsProject &project );
+    static QString wmsFeatureInfoSchema( const QgsProject &project );
 %Docstring
 Returns the schema URL for XML GetFeatureInfo request.
 
@@ -302,7 +306,7 @@ Returns the schema URL for XML GetFeatureInfo request.
 :return: the schema URL for XML GetFeatureInfo request.
 %End
 
-  QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
+    static QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
 %Docstring
 Returns the mapping between layer name and wms layer name for GetFeatureInfo request.
 
@@ -311,7 +315,7 @@ Returns the mapping between layer name and wms layer name for GetFeatureInfo req
 :return: the mapping between layer name and wms layer name for GetFeatureInfo request.
 %End
 
-  bool wmsInspireActivate( const QgsProject &project );
+    static bool wmsInspireActivate( const QgsProject &project );
 %Docstring
 Returns if Inspire is activated.
 
@@ -320,7 +324,7 @@ Returns if Inspire is activated.
 :return: if Inspire is activated.
 %End
 
-  QString wmsInspireLanguage( const QgsProject &project );
+    static QString wmsInspireLanguage( const QgsProject &project );
 %Docstring
 Returns the Inspire language.
 
@@ -329,7 +333,7 @@ Returns the Inspire language.
 :return: the Inspire language if defined in project.
 %End
 
-  QString wmsInspireMetadataUrl( const QgsProject &project );
+    static QString wmsInspireMetadataUrl( const QgsProject &project );
 %Docstring
 Returns the Inspire metadata URL.
 
@@ -338,7 +342,7 @@ Returns the Inspire metadata URL.
 :return: the Inspire metadata URL if defined in project.
 %End
 
-  QString wmsInspireMetadataUrlType( const QgsProject &project );
+    static QString wmsInspireMetadataUrlType( const QgsProject &project );
 %Docstring
 Returns the Inspire metadata URL type.
 
@@ -347,7 +351,7 @@ Returns the Inspire metadata URL type.
 :return: the Inspire metadata URL type if defined in project.
 %End
 
-  QString wmsInspireTemporalReference( const QgsProject &project );
+    static QString wmsInspireTemporalReference( const QgsProject &project );
 %Docstring
 Returns the Inspire temporal reference.
 
@@ -356,7 +360,7 @@ Returns the Inspire temporal reference.
 :return: the Inspire temporal reference if defined in project.
 %End
 
-  QString wmsInspireMetadataDate( const QgsProject &project );
+    static QString wmsInspireMetadataDate( const QgsProject &project );
 %Docstring
 Returns the Inspire metadata date.
 
@@ -365,7 +369,7 @@ Returns the Inspire metadata date.
 :return: the Inspire metadata date if defined in project.
 %End
 
-  QStringList wmsRestrictedComposers( const QgsProject &project );
+    static QStringList wmsRestrictedComposers( const QgsProject &project );
 %Docstring
 Returns the restricted composer list.
 
@@ -374,7 +378,7 @@ Returns the restricted composer list.
 :return: the restricted composer list if defined in project.
 %End
 
-  QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WMS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -386,7 +390,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 :return: url to use for this service
 %End
 
-  QString wmsRootName( const QgsProject &project );
+    static QString wmsRootName( const QgsProject &project );
 %Docstring
 Returns the WMS root layer name defined in a QGIS project.
 
@@ -395,7 +399,7 @@ Returns the WMS root layer name defined in a QGIS project.
 :return: root layer name to use for this service
 %End
 
-  QStringList wmsRestrictedLayers( const QgsProject &project );
+    static QStringList wmsRestrictedLayers( const QgsProject &project );
 %Docstring
 Returns the restricted layer name list.
 
@@ -404,7 +408,7 @@ Returns the restricted layer name list.
 :return: the restricted layer name list if defined in project.
 %End
 
-  QStringList wmsOutputCrsList( const QgsProject &project );
+    static QStringList wmsOutputCrsList( const QgsProject &project );
 %Docstring
 Returns the WMS output CRS list.
 
@@ -413,7 +417,7 @@ Returns the WMS output CRS list.
 :return: the WMS output CRS list.
 %End
 
-  QgsRectangle wmsExtent( const QgsProject &project );
+    static QgsRectangle wmsExtent( const QgsProject &project );
 %Docstring
 Returns the WMS Extent restriction.
 
@@ -422,7 +426,7 @@ Returns the WMS Extent restriction.
 :return: the WMS Extent restriction.
 %End
 
-  QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WFS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -434,7 +438,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 :return: url to use for this service
 %End
 
-  QStringList wfsLayerIds( const QgsProject &project );
+    static QStringList wfsLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published in WFS.
 
@@ -444,7 +448,7 @@ Returns the Layer ids list defined in a QGIS project as published in WFS.
 %End
 
 
-  int wfsLayerPrecision( const QgsProject &project, const QString &layerId );
+    static int wfsLayerPrecision( const QgsProject &project, const QString &layerId );
 %Docstring
 Returns the Layer precision defined in a QGIS project for the WFS GetFeature.
 
@@ -454,7 +458,7 @@ Returns the Layer precision defined in a QGIS project for the WFS GetFeature.
 :return: the layer precision for WFS GetFeature.
 %End
 
-  QStringList wfstUpdateLayerIds( const QgsProject &project );
+    static QStringList wfstUpdateLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published as WFS-T with update capabilities.
 
@@ -463,7 +467,7 @@ Returns the Layer ids list defined in a QGIS project as published as WFS-T with 
 :return: the Layer ids list.
 %End
 
-  QStringList wfstInsertLayerIds( const QgsProject &project );
+    static QStringList wfstInsertLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published as WFS-T with insert capabilities.
 
@@ -472,7 +476,7 @@ Returns the Layer ids list defined in a QGIS project as published as WFS-T with 
 :return: the Layer ids list.
 %End
 
-  QStringList wfstDeleteLayerIds( const QgsProject &project );
+    static QStringList wfstDeleteLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published as WFS-T with delete capabilities.
 
@@ -481,7 +485,7 @@ Returns the Layer ids list defined in a QGIS project as published as WFS-T with 
 :return: the Layer ids list.
 %End
 
-  QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WCS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -493,7 +497,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 :return: url to use for this service
 %End
 
-  QStringList wcsLayerIds( const QgsProject &project );
+    static QStringList wcsLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published in WCS.
 
@@ -502,7 +506,7 @@ Returns the Layer ids list defined in a QGIS project as published in WCS.
 :return: the Layer ids list.
 %End
 
-  QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WMTS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -516,7 +520,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 .. versionadded:: 3.4
 %End
 
-  QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
+    static QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
 %Docstring
 Returns the service url defined in the environment variable or with HTTP header.
 This is calculated from (in order of precedence):

--- a/python/core/auto_additions/qgsmeshutils.py
+++ b/python/core/auto_additions/qgsmeshutils.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/mesh/qgsmeshutils.h
+try:
+    QgsMeshUtils.__group__ = ['mesh']
+except (NameError, AttributeError):
+    pass

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -11,13 +11,10 @@
 
 
 
+%ModuleHeaderCode
+#include "qgsmeshutils.h"
+%End
 
-
-typedef QgsPoint QgsMeshVertex;
-
-typedef QVector<int> QgsMeshFace;
-
-typedef QPair<int, int> QgsMeshEdge;
 
 struct QgsMesh
 {

--- a/python/core/auto_generated/mesh/qgsmeshlayerinterpolator.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayerinterpolator.sip.in
@@ -12,46 +12,9 @@
 
 
 
-%ModuleHeaderCode
-#include "qgsmeshlayerinterpolator.h"
-%End
 
 
 
-
-namespace QgsMeshUtils
-{
-
-  QgsRasterBlock *exportRasterBlock(
-    const QgsMeshLayer &layer,
-    const QgsMeshDatasetIndex &datasetIndex,
-    const QgsCoordinateReferenceSystem &destinationCrs,
-    const QgsCoordinateTransformContext &transformContext,
-    double mapUnitsPerPixel,
-    const QgsRectangle &extent,
-    QgsRasterBlockFeedback *feedback = 0
-  ) /Factory/;
-%Docstring
-Exports mesh layer's dataset values as raster block
-
-The function always fetches native mesh and dataset data
-from data provider and calculates triangular mesh
-
-:param layer: mesh layer
-:param datasetIndex: index from layer defining group and dataset (time) to export
-:param destinationCrs: destination/map CRS. Used to create triangular mesh from native mesh
-:param transformContext: Transform context to transform layer CRS to destination CRS
-:param mapUnitsPerPixel: map units per pixel for block
-:param extent: extent of block in destination CRS
-:param feedback: optional raster feedback object for cancellation/preview
-
-:return: raster block with Float.64 values. ``None`` on error
-
-.. versionadded:: 3.6
-%End
-
-
-};
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/mesh/qgsmeshutils.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshutils.sip.in
@@ -1,0 +1,80 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/mesh/qgsmeshutils.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+
+typedef QgsPoint QgsMeshVertex;
+
+typedef QVector<int> QgsMeshFace;
+
+typedef QPair<int, int> QgsMeshEdge;
+
+
+class QgsMeshUtils
+{
+%Docstring(signature="appended")
+Provides utility functions for working with mesh data.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsmeshutils.h"
+%End
+  public:
+
+    static QgsRasterBlock *exportRasterBlock(
+      const QgsMeshLayer &layer,
+      const QgsMeshDatasetIndex &datasetIndex,
+      const QgsCoordinateReferenceSystem &destinationCrs,
+      const QgsCoordinateTransformContext &transformContext,
+      double mapUnitsPerPixel,
+      const QgsRectangle &extent,
+      QgsRasterBlockFeedback *feedback = 0
+    ) /Factory/;
+%Docstring
+Exports mesh layer's dataset values as raster block
+
+The function always fetches native mesh and dataset data
+from data provider and calculates triangular mesh
+
+:param layer: mesh layer
+:param datasetIndex: index from layer defining group and dataset (time) to export
+:param destinationCrs: destination/map CRS. Used to create triangular mesh from native mesh
+:param transformContext: Transform context to transform layer CRS to destination CRS
+:param mapUnitsPerPixel: map units per pixel for block
+:param extent: extent of block in destination CRS
+:param feedback: optional raster feedback object for cancellation/preview
+
+:return: raster block with Float.64 values. ``None`` on error
+
+.. versionadded:: 3.6
+%End
+
+
+
+
+
+
+
+
+
+
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/mesh/qgsmeshutils.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgshstoreutils.sip.in
+++ b/python/core/auto_generated/qgshstoreutils.sip.in
@@ -8,14 +8,20 @@
 
 
 
-%ModuleHeaderCode
-#include "qgshstoreutils.h"
+class QgsHstoreUtils
+{
+%Docstring(signature="appended")
+Provides utility functions for handling hstore-formatted strings.
+
+.. versionadded:: 3.4
 %End
 
-namespace QgsHstoreUtils
-{
+%TypeHeaderCode
+#include "qgshstoreutils.h"
+%End
+  public:
 
-  QVariantMap parse( const QString &string );
+    static QVariantMap parse( const QString &string );
 %Docstring
 Returns a QVariantMap object containing the key and values from a hstore-formatted string.
 
@@ -24,7 +30,7 @@ Returns a QVariantMap object containing the key and values from a hstore-formatt
 .. versionadded:: 3.4
 %End
 
-  QString build( const QVariantMap &map );
+    static QString build( const QVariantMap &map );
 %Docstring
 Build a hstore-formatted string from a QVariantMap.
 

--- a/python/core/auto_generated/qgstestutils.sip.in
+++ b/python/core/auto_generated/qgstestutils.sip.in
@@ -9,15 +9,16 @@
 
 
 
-%ModuleHeaderCode
-#include "qgstestutils.h"
-%End
 
-
-namespace QgsTestUtils
+class QgsTestUtils
 {
 
-  bool testProviderIteratorThreadSafety( QgsVectorDataProvider *provider, const QgsFeatureRequest &request = QgsFeatureRequest() );
+%TypeHeaderCode
+#include "qgstestutils.h"
+%End
+  public:
+
+    static bool testProviderIteratorThreadSafety( QgsVectorDataProvider *provider, const QgsFeatureRequest &request = QgsFeatureRequest() );
 %Docstring
 Runs a thready safety test on iterators from a vector data ``provider``, by concurrently
 requesting features from the provider.
@@ -25,7 +26,7 @@ requesting features from the provider.
 This method returns ``True``... or it segfaults.
 %End
 
-  bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
+    static bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
 %Docstring
 Compares two DOM elements and returns ``True`` if they are equivalent.
 

--- a/python/core/auto_generated/qgsziputils.sip.in
+++ b/python/core/auto_generated/qgsziputils.sip.in
@@ -8,14 +8,20 @@
 
 
 
-%ModuleHeaderCode
-#include "qgsziputils.h"
+class QgsZipUtils
+{
+%Docstring(signature="appended")
+Provides utility functions for working with zip files.
+
+.. versionadded:: 3.0
 %End
 
-namespace QgsZipUtils
-{
+%TypeHeaderCode
+#include "qgsziputils.h"
+%End
+  public:
 
-  bool isZipFile( const QString &filename );
+    static bool isZipFile( const QString &filename );
 %Docstring
 Returns ``True`` if the file name is a zipped file ( i.e with a '.qgz'
 extension, ``False`` otherwise.
@@ -25,7 +31,7 @@ extension, ``False`` otherwise.
 :return: ``True`` if the file is zipped, ``False`` otherwise
 %End
 
-  bool unzip( const QString &zip, const QString &dir, QStringList &files /Out/, bool checkConsistency = true );
+    static bool unzip( const QString &zip, const QString &dir, QStringList &files /Out/, bool checkConsistency = true );
 %Docstring
 Unzip a zip file in an output directory.
 
@@ -37,7 +43,7 @@ Unzip a zip file in an output directory.
          - files: The absolute path of unzipped files
 %End
 
-  bool zip( const QString &zip, const QStringList &files );
+    static bool zip( const QString &zip, const QStringList &files );
 %Docstring
 Zip the list of files in the zip file. If the zip file already exists or is
 empty, an error is returned. If an input file does not exist, an error is
@@ -50,8 +56,7 @@ also returned.
 
 
 
-
-  const QStringList files( const QString &zip );
+    static const QStringList files( const QString &zip );
 %Docstring
 Returns the list of files within a ``zip`` file
 

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -502,6 +502,7 @@
 %Include auto_generated/mesh/qgsmeshadvancedediting.sip
 %Include auto_generated/mesh/qgsmeshforcebypolylines.sip
 %Include auto_generated/mesh/qgsmeshlayerlabeling.sip
+%Include auto_generated/mesh/qgsmeshutils.sip
 %Include auto_generated/painting/qgsgeometrypaintdevice.sip
 %Include auto_generated/painting/qgsmaskpaintdevice.sip
 %Include auto_generated/painting/qgsnullpainterdevice.sip

--- a/python/server/auto_generated/qgsserverfeatureid.sip.in
+++ b/python/server/auto_generated/qgsserverfeatureid.sip.in
@@ -11,15 +11,19 @@
 
 
 
+class QgsServerFeatureId
+{
+%Docstring(signature="appended")
+Contains utility functions for using primary keys for feature IDs.
 
-%ModuleHeaderCode
-#include "qgsserverfeatureid.h"
+.. versionadded:: 3.4.9
 %End
 
-
-  namespace QgsServerFeatureId
-{
-  QString getServerFid( const QgsFeature &feature, const QgsAttributeList &pkAttributes );
+%TypeHeaderCode
+#include "qgsserverfeatureid.h"
+%End
+  public:
+    static QString getServerFid( const QgsFeature &feature, const QgsAttributeList &pkAttributes );
 %Docstring
 Returns the feature id based on primary keys.
 
@@ -31,12 +35,12 @@ Returns the feature id based on primary keys.
 .. versionadded:: 3.4.9
 %End
 
-  QgsFeatureRequest updateFeatureRequestFromServerFids( QgsFeatureRequest & featureRequest, const QStringList &serverFids, const QgsVectorDataProvider *provider );
+    static QgsFeatureRequest updateFeatureRequestFromServerFids( QgsFeatureRequest &featureRequest, const QStringList &serverFids, const QgsVectorDataProvider *provider );
 %Docstring
 Returns the feature request based on feature ids build with primary keys.
 
 :param featureRequest: the feature request to update
-:param serverFids: the feature ids build with :py:class:`QgsServerFeatureId`.getServerFid
+:param serverFids: the feature ids build with QgsServerFeatureId.getServerFid
 :param provider: the vector layer provider to provide fields and primary keys list
 
 :return: the feature request updated
@@ -44,7 +48,7 @@ Returns the feature request based on feature ids build with primary keys.
 .. versionadded:: 3.4.9
 %End
 
-  QString getExpressionFromServerFid( const QString &serverFid, const QgsVectorDataProvider *provider );
+    static QString getExpressionFromServerFid( const QString &serverFid, const QgsVectorDataProvider *provider );
 %Docstring
 Returns the expression feature id based on primary keys.
 
@@ -56,7 +60,7 @@ Returns the expression feature id based on primary keys.
 .. versionadded:: 3.4.9
 %End
 
-  QString pkSeparator();
+    static QString pkSeparator();
 %Docstring
 Returns the primary keys separator
 

--- a/python/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/server/auto_generated/qgsserverprojectutils.sip.in
@@ -11,16 +11,20 @@
 
 
 
-%ModuleHeaderCode
-#include "qgsserverprojectutils.h"
+class QgsServerProjectUtils
+{
+%Docstring(signature="appended")
+The :py:class:`QgsServerProjectUtils` namespace provides a way to retrieve specific
+entries from a :py:class:`QgsProject`.
 %End
 
+%TypeHeaderCode
+#include "qgsserverprojectutils.h"
+%End
+  public:
 
-  namespace QgsServerProjectUtils
-{
 
-
-  bool owsServiceCapabilities( const QgsProject &project );
+    static bool owsServiceCapabilities( const QgsProject &project );
 %Docstring
 Returns if owsService capabilities are enabled.
 
@@ -29,7 +33,7 @@ Returns if owsService capabilities are enabled.
 :return: if owsService capabilities are enabled.
 %End
 
-  QString owsServiceTitle( const QgsProject &project );
+    static QString owsServiceTitle( const QgsProject &project );
 %Docstring
 Returns the owsService title defined in project.
 
@@ -38,7 +42,7 @@ Returns the owsService title defined in project.
 :return: the owsService title if defined in project with project title as fallback, "Untitled" otherwise.
 %End
 
-  QString owsServiceAbstract( const QgsProject &project );
+    static QString owsServiceAbstract( const QgsProject &project );
 %Docstring
 Returns the owsService abstract defined in project.
 
@@ -47,7 +51,7 @@ Returns the owsService abstract defined in project.
 :return: the owsService abstract if defined in project.
 %End
 
-  QStringList owsServiceKeywords( const QgsProject &project );
+    static QStringList owsServiceKeywords( const QgsProject &project );
 %Docstring
 Returns the owsService keywords defined in project.
 
@@ -56,7 +60,7 @@ Returns the owsService keywords defined in project.
 :return: the owsService keywords if defined in project.
 %End
 
-  QString owsServiceOnlineResource( const QgsProject &project );
+    static QString owsServiceOnlineResource( const QgsProject &project );
 %Docstring
 Returns the owsService online resource defined in project.
 
@@ -65,7 +69,7 @@ Returns the owsService online resource defined in project.
 :return: the owsService online resource if defined in project.
 %End
 
-  QString owsServiceContactOrganization( const QgsProject &project );
+    static QString owsServiceContactOrganization( const QgsProject &project );
 %Docstring
 Returns the owsService contact organization defined in project.
 
@@ -74,7 +78,7 @@ Returns the owsService contact organization defined in project.
 :return: the owsService contact organization if defined in project.
 %End
 
-  QString owsServiceContactPosition( const QgsProject &project );
+    static QString owsServiceContactPosition( const QgsProject &project );
 %Docstring
 Returns the owsService contact position defined in project.
 
@@ -83,7 +87,7 @@ Returns the owsService contact position defined in project.
 :return: the owsService contact position if defined in project.
 %End
 
-  QString owsServiceContactPerson( const QgsProject &project );
+    static QString owsServiceContactPerson( const QgsProject &project );
 %Docstring
 Returns the owsService contact person defined in project.
 
@@ -92,7 +96,7 @@ Returns the owsService contact person defined in project.
 :return: the owsService contact person if defined in project.
 %End
 
-  QString owsServiceContactMail( const QgsProject &project );
+    static QString owsServiceContactMail( const QgsProject &project );
 %Docstring
 Returns the owsService contact mail defined in project.
 
@@ -101,7 +105,7 @@ Returns the owsService contact mail defined in project.
 :return: the owsService contact mail if defined in project.
 %End
 
-  QString owsServiceContactPhone( const QgsProject &project );
+    static QString owsServiceContactPhone( const QgsProject &project );
 %Docstring
 Returns the owsService contact phone defined in project.
 
@@ -110,7 +114,7 @@ Returns the owsService contact phone defined in project.
 :return: the owsService contact phone if defined in project.
 %End
 
-  QString owsServiceFees( const QgsProject &project );
+    static QString owsServiceFees( const QgsProject &project );
 %Docstring
 Returns the owsService fees defined in project.
 
@@ -119,7 +123,7 @@ Returns the owsService fees defined in project.
 :return: the owsService fees if defined in project.
 %End
 
-  QString owsServiceAccessConstraints( const QgsProject &project );
+    static QString owsServiceAccessConstraints( const QgsProject &project );
 %Docstring
 Returns the owsService access constraints defined in project.
 
@@ -128,7 +132,7 @@ Returns the owsService access constraints defined in project.
 :return: the owsService access constraints if defined in project.
 %End
 
-  int wmsMaxWidth( const QgsProject &project );
+    static int wmsMaxWidth( const QgsProject &project );
 %Docstring
 Returns the maximum width for WMS images defined in a QGIS project.
 
@@ -137,7 +141,7 @@ Returns the maximum width for WMS images defined in a QGIS project.
 :return: width if defined in project, -1 otherwise.
 %End
 
-  int wmsMaxHeight( const QgsProject &project );
+    static int wmsMaxHeight( const QgsProject &project );
 %Docstring
 Returns the maximum height for WMS images defined in a QGIS project.
 
@@ -146,7 +150,7 @@ Returns the maximum height for WMS images defined in a QGIS project.
 :return: height if defined in project, -1 otherwise.
 %End
 
-  int wmsImageQuality( const QgsProject &project );
+    static int wmsImageQuality( const QgsProject &project );
 %Docstring
 Returns the quality for WMS images defined in a QGIS project.
 
@@ -155,7 +159,7 @@ Returns the quality for WMS images defined in a QGIS project.
 :return: quality if defined in project, -1 otherwise.
 %End
 
-  int wmsTileBuffer( const QgsProject &project );
+    static int wmsTileBuffer( const QgsProject &project );
 %Docstring
 Returns the tile buffer in pixels for WMS images defined in a QGIS project.
 
@@ -166,7 +170,7 @@ Returns the tile buffer in pixels for WMS images defined in a QGIS project.
 .. versionadded:: 3.10
 %End
 
-  bool wmsRenderMapTiles( const QgsProject &project );
+    static bool wmsRenderMapTiles( const QgsProject &project );
 %Docstring
 Returns ``True`` if WMS requests should use the :py:class:`QgsMapSettings`.RenderMapTile flag,
 so that no visible artifacts are visible between adjacent tiles.
@@ -181,7 +185,7 @@ setting is enabled in the project.
 .. versionadded:: 3.18
 %End
 
-  int wmsMaxAtlasFeatures( const QgsProject &project );
+    static int wmsMaxAtlasFeatures( const QgsProject &project );
 %Docstring
 Returns the maximum number of atlas features which can be printed in a request
 
@@ -190,7 +194,7 @@ Returns the maximum number of atlas features which can be printed in a request
 :return: the number of atlas features
 %End
 
-  double wmsDefaultMapUnitsPerMm( const QgsProject &project );
+    static double wmsDefaultMapUnitsPerMm( const QgsProject &project );
 %Docstring
 Returns the default number of map units per millimeters in case of the scale is not given
 
@@ -201,7 +205,7 @@ Returns the default number of map units per millimeters in case of the scale is 
 .. versionadded:: 3.4
 %End
 
-  bool wmsUseLayerIds( const QgsProject &project );
+    static bool wmsUseLayerIds( const QgsProject &project );
 %Docstring
 Returns if layer ids are used as name in WMS.
 
@@ -210,7 +214,7 @@ Returns if layer ids are used as name in WMS.
 :return: if layer ids are used as name.
 %End
 
-  bool wmsInfoFormatSia2045( const QgsProject &project );
+    static bool wmsInfoFormatSia2045( const QgsProject &project );
 %Docstring
 Returns if the info format is SIA20145.
 
@@ -219,7 +223,7 @@ Returns if the info format is SIA20145.
 :return: if the info format is SIA20145.
 %End
 
-  bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
+    static bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
 %Docstring
 Returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
 
@@ -228,7 +232,7 @@ Returns if the geometry is displayed as Well Known Text in GetFeatureInfo reques
 :return: if the geometry is displayed as Well Known Text in GetFeatureInfo request.
 %End
 
-  bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
+    static bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
 %Docstring
 Returns if feature form settings should be considered for the format of the feature info response
 
@@ -237,7 +241,7 @@ Returns if feature form settings should be considered for the format of the feat
 :return: true if the feature form settings shall be considered for the feature info response
 %End
 
-  bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
+    static bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
 %Docstring
 Returns if the geometry has to be segmentize in GetFeatureInfo request.
 
@@ -246,7 +250,7 @@ Returns if the geometry has to be segmentize in GetFeatureInfo request.
 :return: if the geometry has to be segmentize in GetFeatureInfo request.
 %End
 
-  bool wmsAddLegendGroupsLegendGraphic( const QgsProject &project );
+    static bool wmsAddLegendGroupsLegendGraphic( const QgsProject &project );
 %Docstring
 Returns if legend groups should be in the legend graphic response if GetLegendGraphic is called on a layer group.
 
@@ -255,7 +259,7 @@ Returns if legend groups should be in the legend graphic response if GetLegendGr
 :return: if the GetLegendGraphic response has to contain legend groups
 %End
 
-  bool wmsSkipNameForGroup( const QgsProject &project );
+    static bool wmsSkipNameForGroup( const QgsProject &project );
 %Docstring
 Returns if name attribute should be skipped for groups in WMS capabilities document.
 
@@ -266,7 +270,7 @@ Returns if name attribute should be skipped for groups in WMS capabilities docum
 .. versionadded:: 3.36
 %End
 
-  int wmsFeatureInfoPrecision( const QgsProject &project );
+    static int wmsFeatureInfoPrecision( const QgsProject &project );
 %Docstring
 Returns the geometry precision for GetFeatureInfo request.
 
@@ -275,7 +279,7 @@ Returns the geometry precision for GetFeatureInfo request.
 :return: the geometry precision for GetFeatureInfo request.
 %End
 
-  QString wmsFeatureInfoDocumentElement( const QgsProject &project );
+    static QString wmsFeatureInfoDocumentElement( const QgsProject &project );
 %Docstring
 Returns the document element name for XML GetFeatureInfo request.
 
@@ -284,7 +288,7 @@ Returns the document element name for XML GetFeatureInfo request.
 :return: the document element name for XML GetFeatureInfo request.
 %End
 
-  QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
+    static QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
 %Docstring
 Returns the document element namespace for XML GetFeatureInfo request.
 
@@ -293,7 +297,7 @@ Returns the document element namespace for XML GetFeatureInfo request.
 :return: the document element namespace for XML GetFeatureInfo request.
 %End
 
-  QString wmsFeatureInfoSchema( const QgsProject &project );
+    static QString wmsFeatureInfoSchema( const QgsProject &project );
 %Docstring
 Returns the schema URL for XML GetFeatureInfo request.
 
@@ -302,7 +306,7 @@ Returns the schema URL for XML GetFeatureInfo request.
 :return: the schema URL for XML GetFeatureInfo request.
 %End
 
-  QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
+    static QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
 %Docstring
 Returns the mapping between layer name and wms layer name for GetFeatureInfo request.
 
@@ -311,7 +315,7 @@ Returns the mapping between layer name and wms layer name for GetFeatureInfo req
 :return: the mapping between layer name and wms layer name for GetFeatureInfo request.
 %End
 
-  bool wmsInspireActivate( const QgsProject &project );
+    static bool wmsInspireActivate( const QgsProject &project );
 %Docstring
 Returns if Inspire is activated.
 
@@ -320,7 +324,7 @@ Returns if Inspire is activated.
 :return: if Inspire is activated.
 %End
 
-  QString wmsInspireLanguage( const QgsProject &project );
+    static QString wmsInspireLanguage( const QgsProject &project );
 %Docstring
 Returns the Inspire language.
 
@@ -329,7 +333,7 @@ Returns the Inspire language.
 :return: the Inspire language if defined in project.
 %End
 
-  QString wmsInspireMetadataUrl( const QgsProject &project );
+    static QString wmsInspireMetadataUrl( const QgsProject &project );
 %Docstring
 Returns the Inspire metadata URL.
 
@@ -338,7 +342,7 @@ Returns the Inspire metadata URL.
 :return: the Inspire metadata URL if defined in project.
 %End
 
-  QString wmsInspireMetadataUrlType( const QgsProject &project );
+    static QString wmsInspireMetadataUrlType( const QgsProject &project );
 %Docstring
 Returns the Inspire metadata URL type.
 
@@ -347,7 +351,7 @@ Returns the Inspire metadata URL type.
 :return: the Inspire metadata URL type if defined in project.
 %End
 
-  QString wmsInspireTemporalReference( const QgsProject &project );
+    static QString wmsInspireTemporalReference( const QgsProject &project );
 %Docstring
 Returns the Inspire temporal reference.
 
@@ -356,7 +360,7 @@ Returns the Inspire temporal reference.
 :return: the Inspire temporal reference if defined in project.
 %End
 
-  QString wmsInspireMetadataDate( const QgsProject &project );
+    static QString wmsInspireMetadataDate( const QgsProject &project );
 %Docstring
 Returns the Inspire metadata date.
 
@@ -365,7 +369,7 @@ Returns the Inspire metadata date.
 :return: the Inspire metadata date if defined in project.
 %End
 
-  QStringList wmsRestrictedComposers( const QgsProject &project );
+    static QStringList wmsRestrictedComposers( const QgsProject &project );
 %Docstring
 Returns the restricted composer list.
 
@@ -374,7 +378,7 @@ Returns the restricted composer list.
 :return: the restricted composer list if defined in project.
 %End
 
-  QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WMS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -386,7 +390,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 :return: url to use for this service
 %End
 
-  QString wmsRootName( const QgsProject &project );
+    static QString wmsRootName( const QgsProject &project );
 %Docstring
 Returns the WMS root layer name defined in a QGIS project.
 
@@ -395,7 +399,7 @@ Returns the WMS root layer name defined in a QGIS project.
 :return: root layer name to use for this service
 %End
 
-  QStringList wmsRestrictedLayers( const QgsProject &project );
+    static QStringList wmsRestrictedLayers( const QgsProject &project );
 %Docstring
 Returns the restricted layer name list.
 
@@ -404,7 +408,7 @@ Returns the restricted layer name list.
 :return: the restricted layer name list if defined in project.
 %End
 
-  QStringList wmsOutputCrsList( const QgsProject &project );
+    static QStringList wmsOutputCrsList( const QgsProject &project );
 %Docstring
 Returns the WMS output CRS list.
 
@@ -413,7 +417,7 @@ Returns the WMS output CRS list.
 :return: the WMS output CRS list.
 %End
 
-  QgsRectangle wmsExtent( const QgsProject &project );
+    static QgsRectangle wmsExtent( const QgsProject &project );
 %Docstring
 Returns the WMS Extent restriction.
 
@@ -422,7 +426,7 @@ Returns the WMS Extent restriction.
 :return: the WMS Extent restriction.
 %End
 
-  QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WFS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -434,7 +438,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 :return: url to use for this service
 %End
 
-  QStringList wfsLayerIds( const QgsProject &project );
+    static QStringList wfsLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published in WFS.
 
@@ -444,7 +448,7 @@ Returns the Layer ids list defined in a QGIS project as published in WFS.
 %End
 
 
-  int wfsLayerPrecision( const QgsProject &project, const QString &layerId );
+    static int wfsLayerPrecision( const QgsProject &project, const QString &layerId );
 %Docstring
 Returns the Layer precision defined in a QGIS project for the WFS GetFeature.
 
@@ -454,7 +458,7 @@ Returns the Layer precision defined in a QGIS project for the WFS GetFeature.
 :return: the layer precision for WFS GetFeature.
 %End
 
-  QStringList wfstUpdateLayerIds( const QgsProject &project );
+    static QStringList wfstUpdateLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published as WFS-T with update capabilities.
 
@@ -463,7 +467,7 @@ Returns the Layer ids list defined in a QGIS project as published as WFS-T with 
 :return: the Layer ids list.
 %End
 
-  QStringList wfstInsertLayerIds( const QgsProject &project );
+    static QStringList wfstInsertLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published as WFS-T with insert capabilities.
 
@@ -472,7 +476,7 @@ Returns the Layer ids list defined in a QGIS project as published as WFS-T with 
 :return: the Layer ids list.
 %End
 
-  QStringList wfstDeleteLayerIds( const QgsProject &project );
+    static QStringList wfstDeleteLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published as WFS-T with delete capabilities.
 
@@ -481,7 +485,7 @@ Returns the Layer ids list defined in a QGIS project as published as WFS-T with 
 :return: the Layer ids list.
 %End
 
-  QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WCS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -493,7 +497,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 :return: url to use for this service
 %End
 
-  QStringList wcsLayerIds( const QgsProject &project );
+    static QStringList wcsLayerIds( const QgsProject &project );
 %Docstring
 Returns the Layer ids list defined in a QGIS project as published in WCS.
 
@@ -502,7 +506,7 @@ Returns the Layer ids list defined in a QGIS project as published in WCS.
 :return: the Layer ids list.
 %End
 
-  QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Returns the WMTS service url.
 The URL defined in the project or if not defined the URL from serviceUrl.
@@ -516,7 +520,7 @@ The URL defined in the project or if not defined the URL from serviceUrl.
 .. versionadded:: 3.4
 %End
 
-  QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
+    static QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
 %Docstring
 Returns the service url defined in the environment variable or with HTTP header.
 This is calculated from (in order of precedence):

--- a/scripts/sipify.py
+++ b/scripts/sipify.py
@@ -2813,6 +2813,11 @@ while CONTEXT.line_idx < CONTEXT.line_count:
         r"^(\s*struct )\w+_EXPORT (.+)$", r"\1\2", CONTEXT.current_line
     )
 
+    if re.search(r"\bnamespace\b", CONTEXT.current_line):
+        exit_with_error(
+            "Use classes with public static methods instead of namespaces when methods are exposed to PyQGIS"
+        )
+
     # Skip comments
     if re.match(
         r"^\s*typedef\s+\w+\s*<\s*\w+\s*>\s+\w+\s+.*SIP_DOC_TEMPLATE",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -854,6 +854,7 @@ set(QGIS_CORE_SRCS
   mesh/qgsmeshforcebypolylines.cpp
   mesh/qgsmeshlayerlabeling.cpp
   mesh/qgsmeshlayerlabelprovider.cpp
+  mesh/qgsmeshutils.cpp
 
   pointcloud/qgspointcloudattribute.cpp
   pointcloud/qgspointcloudattributebyramprenderer.cpp
@@ -1696,6 +1697,7 @@ set(QGIS_CORE_HDRS
   mesh/qgsmeshforcebypolylines.h
   mesh/qgsmeshlayerlabeling.h
   mesh/qgsmeshlayerlabelprovider.h
+  mesh/qgsmeshutils.h
 
   painting/qgsgeometrypaintdevice.h
   painting/qgsmaskpaintdevice.h

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -26,27 +26,19 @@
 #include <limits>
 
 #include "qgis_core.h"
-#include "qgspoint.h"
 #include "qgsdataprovider.h"
 #include "qgsprovidermetadata.h"
 #include "qgsmeshdataset.h"
 #include "qgsmeshdataprovidertemporalcapabilities.h"
+#include "qgsmeshutils.h"
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+#include "qgsmeshutils.h"
+% End
+#endif
 
 class QgsRectangle;
-
-//! xyz coords of vertex
-typedef QgsPoint QgsMeshVertex;
-
-//! List of vertex indexes
-typedef QVector<int> QgsMeshFace;
-
-/**
- * Edge is a straight line seqment between 2 points.
- * Stores the pair of vertex indexes
- * \since QGIS 3.14
- */
-typedef QPair<int, int> QgsMeshEdge;
 
 /**
  * \ingroup core

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -24,6 +24,7 @@
 #include "qgsmeshadvancedediting.h"
 #include "qgsgeometryutils.h"
 #include "qgspolygon.h"
+#include "qgsmeshutils.h"
 
 #include <poly2tri.h>
 

--- a/src/core/mesh/qgsmeshlayerinterpolator.h
+++ b/src/core/mesh/qgsmeshlayerinterpolator.h
@@ -31,16 +31,8 @@ class QgsMeshDatasetIndex;
 #include "qgsmaplayerrenderer.h"
 #include "qgstriangularmesh.h"
 #include "qgsrasterinterface.h"
-#include "qgssinglebandpseudocolorrenderer.h"
-#include "qgsrastershader.h"
 
 class QgsRenderContext;
-
-#ifdef SIP_RUN
-% ModuleHeaderCode
-#include "qgsmeshlayerinterpolator.h"
-% End
-#endif
 
 ///@cond PRIVATE
 
@@ -88,62 +80,5 @@ class QgsMeshLayerInterpolator : public QgsRasterInterface SIP_SKIP
 
 ///@endcond
 
-namespace QgsMeshUtils
-{
-
-  /**
-   * Exports mesh layer's dataset values as raster block
-   *
-   * The function always fetches native mesh and dataset data
-   * from data provider and calculates triangular mesh
-   *
-   * \param layer mesh layer
-   * \param datasetIndex index from layer defining group and dataset (time) to export
-   * \param destinationCrs destination/map CRS. Used to create triangular mesh from native mesh
-   * \param transformContext Transform context to transform layer CRS to destination CRS
-   * \param mapUnitsPerPixel map units per pixel for block
-   * \param extent extent of block in destination CRS
-   * \param feedback optional raster feedback object for cancellation/preview
-   * \returns raster block with Float::64 values. NULLPTR on error
-   *
-   * \since QGIS 3.6
-   */
-  CORE_EXPORT QgsRasterBlock *exportRasterBlock(
-    const QgsMeshLayer &layer,
-    const QgsMeshDatasetIndex &datasetIndex,
-    const QgsCoordinateReferenceSystem &destinationCrs,
-    const QgsCoordinateTransformContext &transformContext,
-    double mapUnitsPerPixel,
-    const QgsRectangle &extent,
-    QgsRasterBlockFeedback *feedback = nullptr
-  ) SIP_FACTORY;
-
-
-  /**
-   * Exports mesh layer's dataset values as raster block
-   *
-   * \param triangularMesh the triangular mesh of the mesh layer
-   * \param datasetValues dataset values used to build the raster block
-   * \param activeFlags active flag values
-   * \param dataType the data type iof the dataset values
-   * \param transform the coordinate transform used to export the raster block
-   * \param mapUnitsPerPixel map units per pixel for block
-   * \param extent extent of block in destination CRS
-   * \param feedback optional raster feedback object for cancellation/preview
-   * \returns raster block with Float::64 values. NULLPTR on error
-   *
-   * \since QGIS 3.18
-   */
-  CORE_EXPORT QgsRasterBlock *exportRasterBlock(
-    const QgsTriangularMesh &triangularMesh,
-    const QgsMeshDataBlock &datasetValues,
-    const QgsMeshDataBlock &activeFlags,
-    const QgsMeshDatasetGroupMetadata::DataType dataType,
-    const QgsCoordinateTransform &transform,
-    double mapUnitsPerPixel,
-    const QgsRectangle &extent,
-    QgsRasterBlockFeedback *feedback = nullptr
-  ) SIP_SKIP;
-};
 
 #endif // QGSMESHLAYERINTERPOLATOR_H

--- a/src/core/mesh/qgsmeshtracerenderer.cpp
+++ b/src/core/mesh/qgsmeshtracerenderer.cpp
@@ -21,6 +21,8 @@
 #include "qgslinestring.h"
 #include "qgsmeshlayerinterpolator.h"
 #include "qgsmeshlayerutils.h"
+#include "qgsrastershader.h"
+#include "qgssinglebandpseudocolorrenderer.h"
 
 #include <QPointer>
 

--- a/src/core/mesh/qgsmeshutils.cpp
+++ b/src/core/mesh/qgsmeshutils.cpp
@@ -1,0 +1,319 @@
+/***************************************************************************
+                         qgsmeshutils.cpp
+                         ----------------------------
+    begin                : April 2018
+    copyright            : (C) 2018 by Peter Petrik
+    email                : zilolv at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmeshutils.h"
+#include "qgsmeshlayer.h"
+#include "qgsmaptopixel.h"
+#include "qgsrendercontext.h"
+#include "qgstriangularmesh.h"
+#include "qgsmeshlayerutils.h"
+#include "qgsmeshlayerinterpolator.h"
+#include "qgsgeometry.h"
+#include "qgspolygon.h"
+#include "qgslinestring.h"
+
+#include <memory>
+
+QgsRasterBlock *QgsMeshUtils::exportRasterBlock(
+  const QgsMeshLayer &layer,
+  const QgsMeshDatasetIndex &datasetIndex,
+  const QgsCoordinateReferenceSystem &destinationCrs,
+  const QgsCoordinateTransformContext &transformContext,
+  double mapUnitsPerPixel,
+  const QgsRectangle &extent,
+  QgsRasterBlockFeedback *feedback )
+{
+  if ( !layer.dataProvider() )
+    return nullptr;
+
+  if ( !datasetIndex.isValid() )
+    return nullptr;
+
+  const int widthPixel = static_cast<int>( extent.width() / mapUnitsPerPixel );
+  const int heightPixel = static_cast<int>( extent.height() / mapUnitsPerPixel );
+
+  const QgsPointXY center = extent.center();
+  const QgsMapToPixel mapToPixel( mapUnitsPerPixel,
+                                  center.x(),
+                                  center.y(),
+                                  widthPixel,
+                                  heightPixel,
+                                  0 );
+  const QgsCoordinateTransform transform( layer.crs(), destinationCrs, transformContext );
+
+  QgsRenderContext renderContext;
+  renderContext.setCoordinateTransform( transform );
+  renderContext.setMapToPixel( mapToPixel );
+  renderContext.setExtent( extent );
+
+  auto nativeMesh = std::make_unique<QgsMesh>();
+  layer.dataProvider()->populateMesh( nativeMesh.get() );
+  auto triangularMesh = std::make_unique<QgsTriangularMesh>();
+  triangularMesh->update( nativeMesh.get(), transform );
+
+  const QgsMeshDatasetGroupMetadata metadata = layer.datasetGroupMetadata( datasetIndex );
+  const QgsMeshDatasetGroupMetadata::DataType scalarDataType = QgsMeshLayerUtils::datasetValuesType( metadata.dataType() );
+  const int count =  QgsMeshLayerUtils::datasetValuesCount( nativeMesh.get(), scalarDataType );
+  const QgsMeshDataBlock vals = QgsMeshLayerUtils::datasetValues(
+                                  &layer,
+                                  datasetIndex,
+                                  0,
+                                  count );
+  if ( !vals.isValid() )
+    return nullptr;
+
+  const QVector<double> datasetValues = QgsMeshLayerUtils::calculateMagnitudes( vals );
+  const QgsMeshDataBlock activeFaceFlagValues = layer.areFacesActive(
+        datasetIndex,
+        0,
+        nativeMesh->faces.count() );
+
+  QgsMeshLayerInterpolator interpolator(
+    *( triangularMesh.get() ),
+    datasetValues,
+    activeFaceFlagValues,
+    scalarDataType,
+    renderContext,
+    QSize( widthPixel, heightPixel )
+  );
+
+  return interpolator.block( 0, extent, widthPixel, heightPixel, feedback );
+}
+
+QgsRasterBlock *QgsMeshUtils::exportRasterBlock(
+  const QgsTriangularMesh &triangularMesh,
+  const QgsMeshDataBlock &datasetValues,
+  const QgsMeshDataBlock &activeFlags,
+  const QgsMeshDatasetGroupMetadata::DataType dataType,
+  const QgsCoordinateTransform &transform,
+  double mapUnitsPerPixel,
+  const QgsRectangle &extent,
+  QgsRasterBlockFeedback *feedback )
+{
+
+  const int widthPixel = static_cast<int>( extent.width() / mapUnitsPerPixel );
+  const int heightPixel = static_cast<int>( extent.height() / mapUnitsPerPixel );
+
+  const QgsPointXY center = extent.center();
+  const QgsMapToPixel mapToPixel( mapUnitsPerPixel,
+                                  center.x(),
+                                  center.y(),
+                                  widthPixel,
+                                  heightPixel,
+                                  0 );
+
+  QgsRenderContext renderContext;
+  renderContext.setCoordinateTransform( transform );
+  renderContext.setMapToPixel( mapToPixel );
+  renderContext.setExtent( extent );
+
+  const QVector<double> magnitudes = QgsMeshLayerUtils::calculateMagnitudes( datasetValues );
+
+  QgsMeshLayerInterpolator interpolator(
+    triangularMesh,
+    magnitudes,
+    activeFlags,
+    dataType,
+    renderContext,
+    QSize( widthPixel, heightPixel )
+  );
+
+  return interpolator.block( 0, extent, widthPixel, heightPixel, feedback );
+}
+
+std::unique_ptr< QgsPolygon > QgsMeshUtils::toPolygon( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
+{
+  QVector<QgsPoint> ring;
+  for ( int j = 0; j < face.size(); ++j )
+  {
+    int vertexId = face[j];
+    Q_ASSERT( vertexId < vertices.size() );
+    const QgsPoint &vertex = vertices[vertexId];
+    ring.append( vertex );
+  }
+  auto polygon = std::make_unique< QgsPolygon >();
+  polygon->setExteriorRing( new QgsLineString( ring ) );
+  return polygon;
+}
+
+QgsGeometry QgsMeshUtils::toGeometry( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
+{
+  return QgsGeometry( QgsMeshUtils::toPolygon( face, vertices ) );
+}
+
+static QSet<int> _nativeElementsFromElements( const QList<int> &indexes, const QVector<int> &elementToNativeElements )
+{
+  QSet<int> nativeElements;
+  for ( const int index : indexes )
+  {
+    if ( index < elementToNativeElements.count() )
+    {
+      const int nativeIndex = elementToNativeElements[index];
+      nativeElements.insert( nativeIndex );
+    }
+  }
+  return nativeElements;
+}
+
+QSet<int> QgsMeshUtils::nativeFacesFromTriangles( const QList<int> &triangleIndexes, const QVector<int> &trianglesToNativeFaces )
+{
+  return _nativeElementsFromElements( triangleIndexes, trianglesToNativeFaces );
+}
+
+QSet<int> QgsMeshUtils::nativeEdgesFromEdges( const QList<int> &edgesIndexes, const QVector<int> &edgesToNativeEdges )
+{
+  return _nativeElementsFromElements( edgesIndexes, edgesToNativeEdges );
+}
+
+static double _isLeft2D( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &p )
+{
+  return ( p2.x() - p1.x() ) * ( p.y() - p1.y() ) - ( p.x() - p1.x() ) * ( p2.y() - p1.y() );
+}
+
+static bool _isInTriangle2D( const QgsPoint &p, const QVector<QgsMeshVertex> &triangle )
+{
+  return ( ( _isLeft2D( triangle[2], triangle[0], p ) * _isLeft2D( triangle[2], triangle[0], triangle[1] ) >= 0 )
+           && ( _isLeft2D( triangle[0], triangle[1], p ) * _isLeft2D( triangle[0], triangle[1], triangle[2] ) >= 0 )
+           && ( _isLeft2D( triangle[2], triangle[1], p ) * _isLeft2D( triangle[2], triangle[1], triangle[0] ) >= 0 ) );
+}
+
+bool QgsMeshUtils::isInTriangleFace( const QgsPointXY point, const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
+{
+  if ( face.count() != 3 )
+    return false;
+
+  QVector<QgsMeshVertex> triangle( 3 );
+  for ( int i = 0; i < 3; ++i )
+  {
+    if ( face[i] >= vertices.count() )
+      return false;
+    triangle[i] = vertices[face[i]];
+  }
+
+  const QgsPoint p( point.x(), point.y() );
+
+  return _isInTriangle2D( p, triangle );
+}
+
+QSet<int> QgsMeshUtils::nativeVerticesFromTriangles( const QList<int> &triangleIndexes, const QVector<QgsMeshFace> &triangles )
+{
+  QSet<int> uniqueVertices;
+  for ( int triangleIndex : triangleIndexes )
+  {
+    const QgsMeshFace triangle = triangles[triangleIndex];
+    for ( int i : triangle )
+    {
+      uniqueVertices.insert( i );
+    }
+  }
+  return uniqueVertices;
+}
+
+QSet<int> QgsMeshUtils::nativeVerticesFromEdges( const QList<int> &edgesIndexes, const QVector<QgsMeshEdge> &edges )
+{
+  QSet<int> uniqueVertices;
+  for ( int edgeIndex : edgesIndexes )
+  {
+    const QgsMeshEdge edge = edges[edgeIndex];
+    uniqueVertices.insert( edge.first );
+    uniqueVertices.insert( edge.second );
+  }
+  return uniqueVertices;
+}
+
+static void ENP_centroid_step( const QPolygonF &pX, double &cx, double &cy, double &signedArea, int i, int i1 )
+{
+  double x0 = 0.0; // Current vertex X
+  double y0 = 0.0; // Current vertex Y
+  double x1 = 0.0; // Next vertex X
+  double y1 = 0.0; // Next vertex Y
+  double a = 0.0;  // Partial signed area
+
+  x0 = pX[i].x();
+  y0 = pX[i].y();
+  x1 = pX[i1].x();
+  y1 = pX[i1].y();
+  a = x0 * y1 - x1 * y0;
+  signedArea += a;
+  cx += ( x0 + x1 ) * a;
+  cy += ( y0 + y1 ) * a;
+}
+
+static void ENP_centroid( const QPolygonF &pX, double &cx, double &cy )
+{
+  // http://stackoverflow.com/questions/2792443/finding-the-centroid-of-a-polygon/2792459#2792459
+  cx = 0;
+  cy = 0;
+
+  if ( pX.isEmpty() )
+    return;
+
+  double signedArea = 0.0;
+
+  const QPointF &pt0 = pX.first();
+  QPolygonF localPolygon( pX.count() );
+  for ( int i = 0; i < pX.count(); ++i )
+    localPolygon[i] = pX.at( i ) - pt0;
+
+  // For all vertices except last
+  int i = 0;
+  for ( ; i < localPolygon.size() - 1; ++i )
+  {
+    ENP_centroid_step( localPolygon, cx, cy, signedArea, i, i + 1 );
+  }
+  // Do last vertex separately to avoid performing an expensive
+  // modulus operation in each iteration.
+  ENP_centroid_step( localPolygon, cx, cy, signedArea, i, 0 );
+
+  signedArea *= 0.5;
+  cx /= ( 6.0 * signedArea );
+  cy /= ( 6.0 * signedArea );
+
+  cx = cx + pt0.x();
+  cy = cy + pt0.y();
+}
+
+QgsMeshVertex QgsMeshUtils::centroid( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
+{
+  QVector<QPointF> points( face.size() );
+  for ( int j = 0; j < face.size(); ++j )
+  {
+    int index = face.at( j );
+    const QgsMeshVertex &vertex = vertices.at( index ); // we need vertices in map coordinate
+    points[j] = vertex.toQPointF();
+  }
+  QPolygonF poly( points );
+  double cx, cy;
+  ENP_centroid( poly, cx, cy );
+  return QgsMeshVertex( cx, cy );
+}
+
+void QgsMeshUtils::setCounterClockwise( QgsMeshFace &triangle, const QgsMeshVertex &v0, const QgsMeshVertex &v1, const QgsMeshVertex &v2 )
+{
+  //To have consistent clock wise orientation of triangles which is necessary for 3D rendering
+  //Check the clock wise, and if it is not counter clock wise, swap indexes to make the oientation counter clock wise
+  double ux = v1.x() - v0.x();
+  double uy = v1.y() - v0.y();
+  double vx = v2.x() - v0.x();
+  double vy = v2.y() - v0.y();
+
+  double crossProduct = ux * vy - uy * vx;
+  if ( crossProduct < 0 ) //CW -->change the orientation
+  {
+    std::swap( triangle[1], triangle[2] );
+  }
+}

--- a/src/core/mesh/qgsmeshutils.cpp
+++ b/src/core/mesh/qgsmeshutils.cpp
@@ -155,7 +155,7 @@ QgsGeometry QgsMeshUtils::toGeometry( const QgsMeshFace &face, const QVector<Qgs
   return QgsGeometry( QgsMeshUtils::toPolygon( face, vertices ) );
 }
 
-static QSet<int> _nativeElementsFromElements( const QList<int> &indexes, const QVector<int> &elementToNativeElements )
+static QSet<int> nativeElementsFromElements( const QList<int> &indexes, const QVector<int> &elementToNativeElements )
 {
   QSet<int> nativeElements;
   for ( const int index : indexes )
@@ -171,24 +171,24 @@ static QSet<int> _nativeElementsFromElements( const QList<int> &indexes, const Q
 
 QSet<int> QgsMeshUtils::nativeFacesFromTriangles( const QList<int> &triangleIndexes, const QVector<int> &trianglesToNativeFaces )
 {
-  return _nativeElementsFromElements( triangleIndexes, trianglesToNativeFaces );
+  return nativeElementsFromElements( triangleIndexes, trianglesToNativeFaces );
 }
 
 QSet<int> QgsMeshUtils::nativeEdgesFromEdges( const QList<int> &edgesIndexes, const QVector<int> &edgesToNativeEdges )
 {
-  return _nativeElementsFromElements( edgesIndexes, edgesToNativeEdges );
+  return nativeElementsFromElements( edgesIndexes, edgesToNativeEdges );
 }
 
-static double _isLeft2D( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &p )
+static double isLeft2D( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &p )
 {
   return ( p2.x() - p1.x() ) * ( p.y() - p1.y() ) - ( p.x() - p1.x() ) * ( p2.y() - p1.y() );
 }
 
-static bool _isInTriangle2D( const QgsPoint &p, const QVector<QgsMeshVertex> &triangle )
+static bool isInTriangle2D( const QgsPoint &p, const QVector<QgsMeshVertex> &triangle )
 {
-  return ( ( _isLeft2D( triangle[2], triangle[0], p ) * _isLeft2D( triangle[2], triangle[0], triangle[1] ) >= 0 )
-           && ( _isLeft2D( triangle[0], triangle[1], p ) * _isLeft2D( triangle[0], triangle[1], triangle[2] ) >= 0 )
-           && ( _isLeft2D( triangle[2], triangle[1], p ) * _isLeft2D( triangle[2], triangle[1], triangle[0] ) >= 0 ) );
+  return ( ( isLeft2D( triangle[2], triangle[0], p ) * isLeft2D( triangle[2], triangle[0], triangle[1] ) >= 0 )
+           && ( isLeft2D( triangle[0], triangle[1], p ) * isLeft2D( triangle[0], triangle[1], triangle[2] ) >= 0 )
+           && ( isLeft2D( triangle[2], triangle[1], p ) * isLeft2D( triangle[2], triangle[1], triangle[0] ) >= 0 ) );
 }
 
 bool QgsMeshUtils::isInTriangleFace( const QgsPointXY point, const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
@@ -206,7 +206,7 @@ bool QgsMeshUtils::isInTriangleFace( const QgsPointXY point, const QgsMeshFace &
 
   const QgsPoint p( point.x(), point.y() );
 
-  return _isInTriangle2D( p, triangle );
+  return isInTriangle2D( p, triangle );
 }
 
 QSet<int> QgsMeshUtils::nativeVerticesFromTriangles( const QList<int> &triangleIndexes, const QVector<QgsMeshFace> &triangles )

--- a/src/core/mesh/qgsmeshutils.h
+++ b/src/core/mesh/qgsmeshutils.h
@@ -1,0 +1,179 @@
+/***************************************************************************
+                         qgsmeshutils.h
+                         --------------------------
+    begin                : April 2018
+    copyright            : (C) 2018 by Peter Petrik
+    email                : zilolv at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMESHUTILS_H
+#define QGSMESHUTILS_H
+
+#include "qgis.h"
+#include "qgis_sip.h"
+#include "qgsmeshdataset.h"
+#include "qgspoint.h"
+
+class QgsRasterBlock;
+class QgsMeshLayer;
+class QgsMeshDatasetIndex;
+class QgsCoordinateReferenceSystem;
+class QgsCoordinateTransform;
+class QgsCoordinateTransformContext;
+class QgsRectangle;
+class QgsRasterBlockFeedback;
+class QgsTriangularMesh;
+class QgsMeshDataBlock;
+class QgsPointXY;
+class QgsGeometry;
+class QgsPolygon;
+
+//! xyz coords of vertex
+typedef QgsPoint QgsMeshVertex;
+
+//! List of vertex indexes
+typedef QVector<int> QgsMeshFace;
+
+/**
+ * Edge is a straight line seqment between 2 points.
+ * Stores the pair of vertex indexes
+ * \since QGIS 3.14
+ */
+typedef QPair<int, int> QgsMeshEdge;
+
+
+/**
+ * \ingroup core
+ * \brief Provides utility functions for working with mesh data.
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsMeshUtils
+{
+  public:
+
+    /**
+     * Exports mesh layer's dataset values as raster block
+     *
+     * The function always fetches native mesh and dataset data
+     * from data provider and calculates triangular mesh
+     *
+     * \param layer mesh layer
+     * \param datasetIndex index from layer defining group and dataset (time) to export
+     * \param destinationCrs destination/map CRS. Used to create triangular mesh from native mesh
+     * \param transformContext Transform context to transform layer CRS to destination CRS
+     * \param mapUnitsPerPixel map units per pixel for block
+     * \param extent extent of block in destination CRS
+     * \param feedback optional raster feedback object for cancellation/preview
+     * \returns raster block with Float::64 values. NULLPTR on error
+     *
+     * \since QGIS 3.6
+     */
+    static QgsRasterBlock *exportRasterBlock(
+      const QgsMeshLayer &layer,
+      const QgsMeshDatasetIndex &datasetIndex,
+      const QgsCoordinateReferenceSystem &destinationCrs,
+      const QgsCoordinateTransformContext &transformContext,
+      double mapUnitsPerPixel,
+      const QgsRectangle &extent,
+      QgsRasterBlockFeedback *feedback = nullptr
+    ) SIP_FACTORY;
+
+
+    /**
+     * Exports mesh layer's dataset values as raster block
+     *
+     * \param triangularMesh the triangular mesh of the mesh layer
+     * \param datasetValues dataset values used to build the raster block
+     * \param activeFlags active flag values
+     * \param dataType the data type iof the dataset values
+     * \param transform the coordinate transform used to export the raster block
+     * \param mapUnitsPerPixel map units per pixel for block
+     * \param extent extent of block in destination CRS
+     * \param feedback optional raster feedback object for cancellation/preview
+     * \returns raster block with Float::64 values. NULLPTR on error
+     *
+     * \since QGIS 3.18
+     */
+    static QgsRasterBlock *exportRasterBlock(
+      const QgsTriangularMesh &triangularMesh,
+      const QgsMeshDataBlock &datasetValues,
+      const QgsMeshDataBlock &activeFlags,
+      const QgsMeshDatasetGroupMetadata::DataType dataType,
+      const QgsCoordinateTransform &transform,
+      double mapUnitsPerPixel,
+      const QgsRectangle &extent,
+      QgsRasterBlockFeedback *feedback = nullptr
+    ) SIP_SKIP;
+
+    /**
+     * Returns face as polygon geometry.
+     * \note Not available in Python bindings
+     */
+    SIP_SKIP static QgsGeometry toGeometry( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices );
+
+    /**
+     * Returns the centroid of the \a face.
+     * \note Not available in Python bindings
+     */
+    SIP_SKIP static QgsMeshVertex centroid( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices );
+
+    /**
+     * Returns face as polygon geometry, caller is responsible for delete
+     * \note Not available in Python bindings
+     */
+    SIP_SKIP static std::unique_ptr< QgsPolygon > toPolygon( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices );
+
+    /**
+     * Returns unique native faces indexes from list of triangle indexes
+     * \note Not available in Python bindings
+     * \since QGIS 3.4
+     */
+    SIP_SKIP static QSet<int> nativeFacesFromTriangles( const QList<int> &triangleIndexes, const QVector<int> &trianglesToNativeFaces );
+
+    /**
+     * Returns unique native faces indexes from list of triangle indexes
+     * \note Not available in Python bindings
+     * \since QGIS 3.14
+     */
+    SIP_SKIP static QSet<int> nativeEdgesFromEdges( const QList<int> &edgesIndexes, const QVector<int> &edgesToNativeEdges );
+
+    /**
+     * Returns unique native vertex indexes from list of vertices of triangles
+     * \note Not available in Python bindings
+     * \since QGIS 3.14
+     */
+    SIP_SKIP static QSet<int> nativeVerticesFromTriangles( const QList<int> &triangleIndexes, const QVector<QgsMeshFace> &triangles );
+
+    /**
+     * Returns unique native faces indexes from list of vertices of triangles
+     * \note Not available in Python bindings
+     * \since QGIS 3.14
+     */
+    SIP_SKIP static QSet<int> nativeVerticesFromEdges( const QList<int> &edgesIndexes, const QVector<QgsMeshEdge> &edges );
+
+    /**
+     * Tests if point p is on the face defined with vertices
+     * \note Not available in Python bindings
+     * \since QGIS 3.12
+    */
+    SIP_SKIP static bool isInTriangleFace( const QgsPointXY point, const QgsMeshFace &face,  const QVector<QgsMeshVertex> &vertices );
+
+    /**
+     * Checks if the triangle is counter clockwise, if not sets it counter clockwise
+     * \note Not available in Python bindings
+     * \since QGIS 3.22
+    */
+    SIP_SKIP static void setCounterClockwise( QgsMeshFace &triangle, const QgsMeshVertex &v0, const QgsMeshVertex &v1, const QgsMeshVertex &v2 );
+
+};
+
+#endif // QGSMESHUTILS_H

--- a/src/core/mesh/qgsmeshvectorrenderer.cpp
+++ b/src/core/mesh/qgsmeshvectorrenderer.cpp
@@ -20,6 +20,7 @@
 #include "qgsmaptopixel.h"
 #include "qgsmeshlayerutils.h"
 #include "qgsmeshtracerenderer.h"
+#include "qgsmeshutils.h"
 
 #include <cstdlib>
 #include <ctime>

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -15,71 +15,16 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <memory>
 #include <QList>
-#include "qgspolygon.h"
-#include "qgslinestring.h"
 #include "qgstriangularmesh.h"
-#include "qgsrendercontext.h"
 #include "qgscoordinatetransform.h"
 #include "qgsgeometry.h"
 #include "qgsrectangle.h"
 #include "qgslogger.h"
 #include "qgsmeshspatialindex.h"
 #include "qgsmeshlayerutils.h"
+#include "qgsmeshutils.h"
 #include "meshOptimizer/meshoptimizer.h"
-
-static void ENP_centroid_step( const QPolygonF &pX, double &cx, double &cy, double &signedArea, int i, int i1 )
-{
-  double x0 = 0.0; // Current vertex X
-  double y0 = 0.0; // Current vertex Y
-  double x1 = 0.0; // Next vertex X
-  double y1 = 0.0; // Next vertex Y
-  double a = 0.0;  // Partial signed area
-
-  x0 = pX[i].x();
-  y0 = pX[i].y();
-  x1 = pX[i1].x();
-  y1 = pX[i1].y();
-  a = x0 * y1 - x1 * y0;
-  signedArea += a;
-  cx += ( x0 + x1 ) * a;
-  cy += ( y0 + y1 ) * a;
-}
-
-static void ENP_centroid( const QPolygonF &pX, double &cx, double &cy )
-{
-  // http://stackoverflow.com/questions/2792443/finding-the-centroid-of-a-polygon/2792459#2792459
-  cx = 0;
-  cy = 0;
-
-  if ( pX.isEmpty() )
-    return;
-
-  double signedArea = 0.0;
-
-  const QPointF &pt0 = pX.first();
-  QPolygonF localPolygon( pX.count() );
-  for ( int i = 0; i < pX.count(); ++i )
-    localPolygon[i] = pX.at( i ) - pt0;
-
-  // For all vertices except last
-  int i = 0;
-  for ( ; i < localPolygon.size() - 1; ++i )
-  {
-    ENP_centroid_step( localPolygon, cx, cy, signedArea, i, i + 1 );
-  }
-  // Do last vertex separately to avoid performing an expensive
-  // modulus operation in each iteration.
-  ENP_centroid_step( localPolygon, cx, cy, signedArea, i, 0 );
-
-  signedArea *= 0.5;
-  cx /= ( 6.0 * signedArea );
-  cy /= ( 6.0 * signedArea );
-
-  cx = cx + pt0.x();
-  cy = cy + pt0.y();
-}
 
 static void triangulateFaces( const QgsMeshFace &face,
                               int nativeIndex,
@@ -625,107 +570,6 @@ QVector<QgsTriangularMesh *> QgsTriangularMesh::simplifyMesh( double reductionFa
   return simplifiedMeshes;
 }
 
-std::unique_ptr< QgsPolygon > QgsMeshUtils::toPolygon( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
-{
-  QVector<QgsPoint> ring;
-  for ( int j = 0; j < face.size(); ++j )
-  {
-    int vertexId = face[j];
-    Q_ASSERT( vertexId < vertices.size() );
-    const QgsPoint &vertex = vertices[vertexId];
-    ring.append( vertex );
-  }
-  auto polygon = std::make_unique< QgsPolygon >();
-  polygon->setExteriorRing( new QgsLineString( ring ) );
-  return polygon;
-}
-
-QgsGeometry QgsMeshUtils::toGeometry( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
-{
-  return QgsGeometry( QgsMeshUtils::toPolygon( face, vertices ) );
-}
-
-static QSet<int> _nativeElementsFromElements( const QList<int> &indexes, const QVector<int> &elementToNativeElements )
-{
-  QSet<int> nativeElements;
-  for ( const int index : indexes )
-  {
-    if ( index < elementToNativeElements.count() )
-    {
-      const int nativeIndex = elementToNativeElements[index];
-      nativeElements.insert( nativeIndex );
-    }
-  }
-  return nativeElements;
-}
-
-QSet<int> QgsMeshUtils::nativeFacesFromTriangles( const QList<int> &triangleIndexes, const QVector<int> &trianglesToNativeFaces )
-{
-  return _nativeElementsFromElements( triangleIndexes, trianglesToNativeFaces );
-}
-
-QSet<int> QgsMeshUtils::nativeEdgesFromEdges( const QList<int> &edgesIndexes, const QVector<int> &edgesToNativeEdges )
-{
-  return _nativeElementsFromElements( edgesIndexes, edgesToNativeEdges );
-}
-
-
-static double _isLeft2D( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &p )
-{
-  return ( p2.x() - p1.x() ) * ( p.y() - p1.y() ) - ( p.x() - p1.x() ) * ( p2.y() - p1.y() );
-}
-
-static bool _isInTriangle2D( const QgsPoint &p, const QVector<QgsMeshVertex> &triangle )
-{
-  return ( ( _isLeft2D( triangle[2], triangle[0], p ) * _isLeft2D( triangle[2], triangle[0], triangle[1] ) >= 0 )
-           && ( _isLeft2D( triangle[0], triangle[1], p ) * _isLeft2D( triangle[0], triangle[1], triangle[2] ) >= 0 )
-           && ( _isLeft2D( triangle[2], triangle[1], p ) * _isLeft2D( triangle[2], triangle[1], triangle[0] ) >= 0 ) );
-}
-
-bool QgsMeshUtils::isInTriangleFace( const QgsPointXY point, const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
-{
-  if ( face.count() != 3 )
-    return false;
-
-  QVector<QgsMeshVertex> triangle( 3 );
-  for ( int i = 0; i < 3; ++i )
-  {
-    if ( face[i] >= vertices.count() )
-      return false;
-    triangle[i] = vertices[face[i]];
-  }
-
-  const QgsPoint p( point.x(), point.y() );
-
-  return _isInTriangle2D( p, triangle );
-}
-
-QSet<int> QgsMeshUtils::nativeVerticesFromTriangles( const QList<int> &triangleIndexes, const QVector<QgsMeshFace> &triangles )
-{
-  QSet<int> uniqueVertices;
-  for ( int triangleIndex : triangleIndexes )
-  {
-    const QgsMeshFace triangle = triangles[triangleIndex];
-    for ( int i : triangle )
-    {
-      uniqueVertices.insert( i );
-    }
-  }
-  return uniqueVertices;
-}
-
-QSet<int> QgsMeshUtils::nativeVerticesFromEdges( const QList<int> &edgesIndexes, const QVector<QgsMeshEdge> &edges )
-{
-  QSet<int> uniqueVertices;
-  for ( int edgeIndex : edgesIndexes )
-  {
-    const QgsMeshEdge edge = edges[edgeIndex];
-    uniqueVertices.insert( edge.first );
-    uniqueVertices.insert( edge.second );
-  }
-  return uniqueVertices;
-}
-
 void QgsTriangularMesh::applyChanges( const QgsTriangularMesh::Changes &changes )
 {
   //if necessary defined removes triangles index
@@ -955,35 +799,4 @@ QgsTriangularMesh::Changes::Changes( const QgsTopologicalMesh::Changes &topologi
   mNativeFacesGeometryChanged.resize( mNativeFaceIndexesGeometryChanged.count() );
   for ( int i = 0; i < mNativeFaceIndexesGeometryChanged.count(); ++i )
     mNativeFacesGeometryChanged[i] = nativeMesh.face( mNativeFaceIndexesGeometryChanged.at( i ) );
-}
-
-QgsMeshVertex QgsMeshUtils::centroid( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )
-{
-  QVector<QPointF> points( face.size() );
-  for ( int j = 0; j < face.size(); ++j )
-  {
-    int index = face.at( j );
-    const QgsMeshVertex &vertex = vertices.at( index ); // we need vertices in map coordinate
-    points[j] = vertex.toQPointF();
-  }
-  QPolygonF poly( points );
-  double cx, cy;
-  ENP_centroid( poly, cx, cy );
-  return QgsMeshVertex( cx, cy );
-}
-
-void QgsMeshUtils::setCounterClockwise( QgsMeshFace &triangle, const QgsMeshVertex &v0, const QgsMeshVertex &v1, const QgsMeshVertex &v2 )
-{
-  //To have consistent clock wise orientation of triangles which is necessary for 3D rendering
-  //Check the clock wise, and if it is not counter clock wise, swap indexes to make the oientation counter clock wise
-  double ux = v1.x() - v0.x();
-  double uy = v1.y() - v0.y();
-  double vx = v2.x() - v0.x();
-  double vy = v2.y() - v0.y();
-
-  double crossProduct = ux * vy - uy * vx;
-  if ( crossProduct < 0 ) //CW -->change the orientation
-  {
-    std::swap( triangle[1], triangle[2] );
-  }
 }

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -384,53 +384,5 @@ class CORE_EXPORT QgsTriangularMesh // TODO rename to QgsRendererMesh in QGIS 4
     friend class TestQgsTriangularMesh;
 };
 
-namespace QgsMeshUtils
-{
-  //! Returns face as polygon geometry
-  CORE_EXPORT QgsGeometry toGeometry( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices );
-
-  //! Returns the centroid of the \a face
-  CORE_EXPORT QgsMeshVertex centroid( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices );
-
-  //! Returns face as polygon geometry, caller is responsible for delete
-  CORE_EXPORT std::unique_ptr< QgsPolygon > toPolygon( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices );
-
-  /**
-   * Returns unique native faces indexes from list of triangle indexes
-   * \since QGIS 3.4
-   */
-  CORE_EXPORT QSet<int> nativeFacesFromTriangles( const QList<int> &triangleIndexes, const QVector<int> &trianglesToNativeFaces );
-
-  /**
-   * Returns unique native faces indexes from list of triangle indexes
-   * \since QGIS 3.14
-   */
-  CORE_EXPORT QSet<int> nativeEdgesFromEdges( const QList<int> &edgesIndexes, const QVector<int> &edgesToNativeEdges );
-
-  /**
-   * Returns unique native vertex indexes from list of vertices of triangles
-   * \since QGIS 3.14
-   */
-  CORE_EXPORT QSet<int> nativeVerticesFromTriangles( const QList<int> &triangleIndexes, const QVector<QgsMeshFace> &triangles );
-
-  /**
-   * Returns unique native faces indexes from list of vertices of triangles
-   * \since QGIS 3.14
-   */
-  CORE_EXPORT QSet<int> nativeVerticesFromEdges( const QList<int> &edgesIndexes, const QVector<QgsMeshEdge> &edges );
-
-  /**
-   * Tests if point p is on the face defined with vertices
-   * \since QGIS 3.12
-  */
-  bool isInTriangleFace( const QgsPointXY point, const QgsMeshFace &face,  const QVector<QgsMeshVertex> &vertices );
-
-  /**
-   * Checks if the triangle is counter clockwise, if not sets it counter clockwise
-   * \since QGIS 3.22
-  */
-  void setCounterClockwise( QgsMeshFace &triangle, const QgsMeshVertex &v0, const QgsMeshVertex &v1, const QgsMeshVertex &v2 );
-
-};
 
 #endif // QGSTRIANGULARMESH_H

--- a/src/core/qgshstoreutils.h
+++ b/src/core/qgshstoreutils.h
@@ -19,33 +19,28 @@
 #include "qgis_core.h"
 #include "qgis.h"
 
-#ifdef SIP_RUN
-% ModuleHeaderCode
-#include "qgshstoreutils.h"
-% End
-#endif
-
 /**
  * \ingroup core
- * \brief The QgsHstoreUtils namespace provides functions to handle hstore-formatted strings.
+ * \brief Provides utility functions for handling hstore-formatted strings.
  * \since QGIS 3.4
  */
-namespace QgsHstoreUtils
+class CORE_EXPORT QgsHstoreUtils
 {
+  public:
 
-  /**
-   * Returns a QVariantMap object containing the key and values from a hstore-formatted string.
-   * \param string The hstored-formatted string
-   * \since QGIS 3.4
-   */
-  CORE_EXPORT QVariantMap parse( const QString &string );
+    /**
+     * Returns a QVariantMap object containing the key and values from a hstore-formatted string.
+     * \param string The hstored-formatted string
+     * \since QGIS 3.4
+     */
+    static QVariantMap parse( const QString &string );
 
-  /**
-   * Build a hstore-formatted string from a QVariantMap.
-   * \param map The map to format as a string
-   * \since QGIS 3.4
-   */
-  CORE_EXPORT QString build( const QVariantMap &map );
+    /**
+     * Build a hstore-formatted string from a QVariantMap.
+     * \param map The map to format as a string
+     * \since QGIS 3.4
+     */
+    static QString build( const QVariantMap &map );
 
 };
 

--- a/src/core/qgstestutils.h
+++ b/src/core/qgstestutils.h
@@ -22,32 +22,27 @@
 
 class QgsVectorDataProvider;
 
-#ifdef SIP_RUN
-% ModuleHeaderCode
-#include "qgstestutils.h"
-% End
-#endif
-
 ///@cond PRIVATE
 
 // Used only for utilities required for the QGIS Python unit tests - not stable or public API
-namespace QgsTestUtils
+class CORE_EXPORT QgsTestUtils
 {
+  public:
 
-  /**
-   * Runs a thready safety test on iterators from a vector data \a provider, by concurrently
-   * requesting features from the provider.
-   *
-   * This method returns TRUE... or it segfaults.
-   */
-  CORE_EXPORT bool testProviderIteratorThreadSafety( QgsVectorDataProvider *provider, const QgsFeatureRequest &request = QgsFeatureRequest() );
+    /**
+     * Runs a thready safety test on iterators from a vector data \a provider, by concurrently
+     * requesting features from the provider.
+     *
+     * This method returns TRUE... or it segfaults.
+     */
+    static bool testProviderIteratorThreadSafety( QgsVectorDataProvider *provider, const QgsFeatureRequest &request = QgsFeatureRequest() );
 
-  /**
-   * Compares two DOM elements and returns TRUE if they are equivalent.
-   *
-   * Dumps useful diff information to the console if the elements differ.
-   */
-  CORE_EXPORT bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
+    /**
+     * Compares two DOM elements and returns TRUE if they are equivalent.
+     *
+     * Dumps useful diff information to the console if the elements differ.
+     */
+    static bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
 
 };
 

--- a/src/core/qgsziputils.h
+++ b/src/core/qgsziputils.h
@@ -20,73 +20,72 @@
 #include "qgis_sip.h"
 #include <QStringList>
 
-#ifdef SIP_RUN
-% ModuleHeaderCode
-#include "qgsziputils.h"
-% End
-#endif
-
-namespace QgsZipUtils
+/**
+ * \ingroup core
+ * \brief Provides utility functions for working with zip files.
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsZipUtils
 {
+  public:
 
-  /**
-   * Returns TRUE if the file name is a zipped file ( i.e with a '.qgz'
-   *  extension, FALSE otherwise.
-   * \param filename The name of the file
-   * \returns TRUE if the file is zipped, FALSE otherwise
-   */
-  CORE_EXPORT bool isZipFile( const QString &filename );
+    /**
+     * Returns TRUE if the file name is a zipped file ( i.e with a '.qgz'
+     *  extension, FALSE otherwise.
+     * \param filename The name of the file
+     * \returns TRUE if the file is zipped, FALSE otherwise
+     */
+    static bool isZipFile( const QString &filename );
 
-  /**
-   * Unzip a zip file in an output directory.
-   * \param zip The zip filename
-   * \param dir The output directory
-   * \param files The absolute path of unzipped files
-   * \param checkConsistency Perform additional stricter consistency checks on the archive, and error if they fail (since QGIS 3.30)
-   * \returns FALSE if the zip filename does not exist, the output directory does not exist or is not writable.
-   */
-  CORE_EXPORT bool unzip( const QString &zip, const QString &dir, QStringList &files SIP_OUT, bool checkConsistency = true );
+    /**
+     * Unzip a zip file in an output directory.
+     * \param zip The zip filename
+     * \param dir The output directory
+     * \param files The absolute path of unzipped files
+     * \param checkConsistency Perform additional stricter consistency checks on the archive, and error if they fail (since QGIS 3.30)
+     * \returns FALSE if the zip filename does not exist, the output directory does not exist or is not writable.
+     */
+    static bool unzip( const QString &zip, const QString &dir, QStringList &files SIP_OUT, bool checkConsistency = true );
 
-  /**
-   * Zip the list of files in the zip file. If the zip file already exists or is
-   * empty, an error is returned. If an input file does not exist, an error is
-   * also returned.
-   * \param zip The zip filename
-   * \param files The absolute path to files to embed within the zip
-   */
-  CORE_EXPORT bool zip( const QString &zip, const QStringList &files );
+    /**
+     * Zip the list of files in the zip file. If the zip file already exists or is
+     * empty, an error is returned. If an input file does not exist, an error is
+     * also returned.
+     * \param zip The zip filename
+     * \param files The absolute path to files to embed within the zip
+     */
+    static bool zip( const QString &zip, const QStringList &files );
 
+    /**
+     * Decodes gzip byte stream, returns TRUE on success. Useful for reading vector tiles.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+     */
+    static bool decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut ) SIP_SKIP;
 
-  /**
-   * Decodes gzip byte stream, returns TRUE on success. Useful for reading vector tiles.
-   *
-   * \note Not available in Python bindings
-   * \since QGIS 3.26
-   */
-  CORE_EXPORT bool decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut ) SIP_SKIP;
+    /**
+     * Decodes gzip byte stream, returns TRUE on success. Useful for reading vector tiles.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+     */
+    static bool decodeGzip( const char *bytesIn, std::size_t size, QByteArray &bytesOut ) SIP_SKIP;
 
-  /**
-   * Decodes gzip byte stream, returns TRUE on success. Useful for reading vector tiles.
-   *
-   * \note Not available in Python bindings
-   * \since QGIS 3.26
-   */
-  CORE_EXPORT bool decodeGzip( const char *bytesIn, std::size_t size, QByteArray &bytesOut ) SIP_SKIP;
+    /**
+     * Encodes gzip byte stream, returns TRUE on success. Useful for writing vector tiles.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+     */
+    static bool encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut ) SIP_SKIP;
 
-  /**
-   * Encodes gzip byte stream, returns TRUE on success. Useful for writing vector tiles.
-   *
-   * \note Not available in Python bindings
-   * \since QGIS 3.26
-   */
-  CORE_EXPORT bool encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut ) SIP_SKIP;
-
-  /**
-   * Returns the list of files within a \a zip file
-   *
-   * \since QGIS 3.30
-   */
-  CORE_EXPORT const QStringList files( const QString &zip );
+    /**
+     * Returns the list of files within a \a zip file
+     *
+     * \since QGIS 3.30
+     */
+    static const QStringList files( const QString &zip );
 
 };
 

--- a/src/server/qgsserverfeatureid.h
+++ b/src/server/qgsserverfeatureid.h
@@ -28,32 +28,24 @@ class QgsVectorDataProvider;
 class QgsFeature;
 class QgsFeatureRequest;
 
-
-#ifdef SIP_RUN
-% ModuleHeaderCode
-#include "qgsserverfeatureid.h"
-  % End
-#endif
-
-
-  /**
+/**
  * \ingroup server
- * \brief The QgsServerFeatureId namespace provides a way to use primary keys for
- * feature id.
+ * \brief Contains utility functions for using primary keys for feature IDs.
  * \since QGIS 3.4.9
  */
-  namespace QgsServerFeatureId
+class SERVER_EXPORT QgsServerFeatureId
 {
-  /**
+  public:
+    /**
    * Returns the feature id based on primary keys.
    * \param feature the feature
    * \param pkAttributes the primary keys list
    * \returns the feature id based on primary keys
    * \since QGIS 3.4.9
    */
-  SERVER_EXPORT QString getServerFid( const QgsFeature &feature, const QgsAttributeList &pkAttributes );
+    static QString getServerFid( const QgsFeature &feature, const QgsAttributeList &pkAttributes );
 
-  /**
+    /**
    * Returns the feature request based on feature ids build with primary keys.
    * \param featureRequest the feature request to update
    * \param serverFids the feature ids build with QgsServerFeatureId::getServerFid
@@ -61,23 +53,23 @@ class QgsFeatureRequest;
    * \returns the feature request updated
    * \since QGIS 3.4.9
    */
-  SERVER_EXPORT QgsFeatureRequest updateFeatureRequestFromServerFids( QgsFeatureRequest & featureRequest, const QStringList &serverFids, const QgsVectorDataProvider *provider );
+    static QgsFeatureRequest updateFeatureRequestFromServerFids( QgsFeatureRequest &featureRequest, const QStringList &serverFids, const QgsVectorDataProvider *provider );
 
-  /**
+    /**
    * Returns the expression feature id based on primary keys.
    * \param serverFid the feature id build with primary keys
    * \param provider the vector layer provider to provide fields and primary keys list
    * \returns the feature id based on primary keys
    * \since QGIS 3.4.9
    */
-  SERVER_EXPORT QString getExpressionFromServerFid( const QString &serverFid, const QgsVectorDataProvider *provider );
+    static QString getExpressionFromServerFid( const QString &serverFid, const QgsVectorDataProvider *provider );
 
-  /**
+    /**
    * Returns the primary keys separator
    * \returns @@ the primary keys separator
    * \since QGIS 3.4.9
    */
-  SERVER_EXPORT QString pkSeparator();
+    static QString pkSeparator();
 };
 
 #endif

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -30,148 +30,142 @@
 class QgsProject;
 class QgsRectangle;
 
-#ifdef SIP_RUN
-% ModuleHeaderCode
-#include "qgsserverprojectutils.h"
-  % End
-#endif
-
-
-  /**
+/**
  * \ingroup server
  * \brief The QgsServerProjectUtils namespace provides a way to retrieve specific
  * entries from a QgsProject.
  */
-  namespace QgsServerProjectUtils
+class SERVER_EXPORT QgsServerProjectUtils
 {
-  /**
+  public:
+    /**
    * Returns a double greater than \a number to the specified number of \a places.
    *
    * \since QGIS 3.10.1
    */
-  SERVER_EXPORT double ceilWithPrecision( double number, int places ) SIP_SKIP;
+    static double ceilWithPrecision( double number, int places ) SIP_SKIP;
 
-  /**
+    /**
    * Returns a double less than \a number to the specified number of \a places.
    *
    * \since QGIS 3.10.1
    */
-  SERVER_EXPORT double floorWithPrecision( double number, int places ) SIP_SKIP;
+    static double floorWithPrecision( double number, int places ) SIP_SKIP;
 
-  /**
+    /**
    * Returns if owsService capabilities are enabled.
    * \param project the QGIS project
    * \returns if owsService capabilities are enabled.
    */
-  SERVER_EXPORT bool owsServiceCapabilities( const QgsProject &project );
+    static bool owsServiceCapabilities( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService title defined in project.
    * \param project the QGIS project
    * \returns the owsService title if defined in project with project title as fallback, "Untitled" otherwise.
    */
-  SERVER_EXPORT QString owsServiceTitle( const QgsProject &project );
+    static QString owsServiceTitle( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService abstract defined in project.
    * \param project the QGIS project
    * \returns the owsService abstract if defined in project.
    */
-  SERVER_EXPORT QString owsServiceAbstract( const QgsProject &project );
+    static QString owsServiceAbstract( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService keywords defined in project.
    * \param project the QGIS project
    * \returns the owsService keywords if defined in project.
    */
-  SERVER_EXPORT QStringList owsServiceKeywords( const QgsProject &project );
+    static QStringList owsServiceKeywords( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService online resource defined in project.
    * \param project the QGIS project
    * \returns the owsService online resource if defined in project.
    */
-  SERVER_EXPORT QString owsServiceOnlineResource( const QgsProject &project );
+    static QString owsServiceOnlineResource( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService contact organization defined in project.
    * \param project the QGIS project
    * \returns the owsService contact organization if defined in project.
    */
-  SERVER_EXPORT QString owsServiceContactOrganization( const QgsProject &project );
+    static QString owsServiceContactOrganization( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService contact position defined in project.
    * \param project the QGIS project
    * \returns the owsService contact position if defined in project.
    */
-  SERVER_EXPORT QString owsServiceContactPosition( const QgsProject &project );
+    static QString owsServiceContactPosition( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService contact person defined in project.
    * \param project the QGIS project
    * \returns the owsService contact person if defined in project.
    */
-  SERVER_EXPORT QString owsServiceContactPerson( const QgsProject &project );
+    static QString owsServiceContactPerson( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService contact mail defined in project.
    * \param project the QGIS project
    * \returns the owsService contact mail if defined in project.
    */
-  SERVER_EXPORT QString owsServiceContactMail( const QgsProject &project );
+    static QString owsServiceContactMail( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService contact phone defined in project.
    * \param project the QGIS project
    * \returns the owsService contact phone if defined in project.
    */
-  SERVER_EXPORT QString owsServiceContactPhone( const QgsProject &project );
+    static QString owsServiceContactPhone( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService fees defined in project.
    * \param project the QGIS project
    * \returns the owsService fees if defined in project.
    */
-  SERVER_EXPORT QString owsServiceFees( const QgsProject &project );
+    static QString owsServiceFees( const QgsProject &project );
 
-  /**
+    /**
    * Returns the owsService access constraints defined in project.
    * \param project the QGIS project
    * \returns the owsService access constraints if defined in project.
    */
-  SERVER_EXPORT QString owsServiceAccessConstraints( const QgsProject &project );
+    static QString owsServiceAccessConstraints( const QgsProject &project );
 
-  /**
+    /**
    * Returns the maximum width for WMS images defined in a QGIS project.
    * \param project the QGIS project
    * \returns width if defined in project, -1 otherwise.
    */
-  SERVER_EXPORT int wmsMaxWidth( const QgsProject &project );
+    static int wmsMaxWidth( const QgsProject &project );
 
-  /**
+    /**
    * Returns the maximum height for WMS images defined in a QGIS project.
    * \param project the QGIS project
    * \returns height if defined in project, -1 otherwise.
    */
-  SERVER_EXPORT int wmsMaxHeight( const QgsProject &project );
+    static int wmsMaxHeight( const QgsProject &project );
 
-  /**
+    /**
    * Returns the quality for WMS images defined in a QGIS project.
    * \param project the QGIS project
    * \returns quality if defined in project, -1 otherwise.
    */
-  SERVER_EXPORT int wmsImageQuality( const QgsProject &project );
+    static int wmsImageQuality( const QgsProject &project );
 
-  /**
+    /**
    * Returns the tile buffer in pixels for WMS images defined in a QGIS project.
    * \param project the QGIS project
    * \returns tile buffer if defined in project, 0 otherwise.
    * \since QGIS 3.10
    */
-  SERVER_EXPORT int wmsTileBuffer( const QgsProject &project );
+    static int wmsTileBuffer( const QgsProject &project );
 
-  /**
+    /**
    * Returns TRUE if WMS requests should use the QgsMapSettings::RenderMapTile flag,
    * so that no visible artifacts are visible between adjacent tiles.
    *
@@ -183,158 +177,158 @@ class QgsRectangle;
    *
    * \since QGIS 3.18
    */
-  SERVER_EXPORT bool wmsRenderMapTiles( const QgsProject &project );
+    static bool wmsRenderMapTiles( const QgsProject &project );
 
-  /**
+    /**
    * Returns the maximum number of atlas features which can be printed in a request
    * \param project the QGIS project
    * \return the number of atlas features
    */
-  SERVER_EXPORT int wmsMaxAtlasFeatures( const QgsProject &project );
+    static int wmsMaxAtlasFeatures( const QgsProject &project );
 
-  /**
+    /**
    * Returns the default number of map units per millimeters in case of the scale is not given
    * \param project the QGIS project
    * \returns the default number of map units per millimeter
    * \since QGIS 3.4
    */
-  SERVER_EXPORT double wmsDefaultMapUnitsPerMm( const QgsProject &project );
+    static double wmsDefaultMapUnitsPerMm( const QgsProject &project );
 
-  /**
+    /**
    * Returns if layer ids are used as name in WMS.
    * \param project the QGIS project
    * \returns if layer ids are used as name.
    */
-  SERVER_EXPORT bool wmsUseLayerIds( const QgsProject &project );
+    static bool wmsUseLayerIds( const QgsProject &project );
 
-  /**
+    /**
    * Returns if the info format is SIA20145.
    * \param project the QGIS project
    * \returns if the info format is SIA20145.
    */
-  SERVER_EXPORT bool wmsInfoFormatSia2045( const QgsProject &project );
+    static bool wmsInfoFormatSia2045( const QgsProject &project );
 
-  /**
+    /**
    * Returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
    * \param project the QGIS project
    * \returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
    */
-  SERVER_EXPORT bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
+    static bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
 
-  /**
+    /**
     * Returns if feature form settings should be considered for the format of the feature info response
     * \param project the QGIS project
     * \returns true if the feature form settings shall be considered for the feature info response
    */
-  SERVER_EXPORT bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
+    static bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
 
-  /**
+    /**
    * Returns if the geometry has to be segmentize in GetFeatureInfo request.
    * \param project the QGIS project
    * \returns if the geometry has to be segmentize in GetFeatureInfo request.
    */
-  SERVER_EXPORT bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
+    static bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
 
-  /**
+    /**
    * Returns if legend groups should be in the legend graphic response if GetLegendGraphic is called on a layer group.
    * \param project the QGIS project
    * \returns if the GetLegendGraphic response has to contain legend groups
    */
-  SERVER_EXPORT bool wmsAddLegendGroupsLegendGraphic( const QgsProject &project );
+    static bool wmsAddLegendGroupsLegendGraphic( const QgsProject &project );
 
-  /**
+    /**
    * Returns if name attribute should be skipped for groups in WMS capabilities document.
    * \param project the QGIS project
    * \returns if name attribute should be skipped for groups in capabilities
    * \since QGIS 3.36
    */
-  SERVER_EXPORT bool wmsSkipNameForGroup( const QgsProject &project );
+    static bool wmsSkipNameForGroup( const QgsProject &project );
 
-  /**
+    /**
    * Returns the geometry precision for GetFeatureInfo request.
    * \param project the QGIS project
    * \returns the geometry precision for GetFeatureInfo request.
    */
-  SERVER_EXPORT int wmsFeatureInfoPrecision( const QgsProject &project );
+    static int wmsFeatureInfoPrecision( const QgsProject &project );
 
-  /**
+    /**
    * Returns the document element name for XML GetFeatureInfo request.
    * \param project the QGIS project
    * \returns the document element name for XML GetFeatureInfo request.
    */
-  SERVER_EXPORT QString wmsFeatureInfoDocumentElement( const QgsProject &project );
+    static QString wmsFeatureInfoDocumentElement( const QgsProject &project );
 
-  /**
+    /**
    * Returns the document element namespace for XML GetFeatureInfo request.
    * \param project the QGIS project
    * \returns the document element namespace for XML GetFeatureInfo request.
    */
-  SERVER_EXPORT QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
+    static QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
 
-  /**
+    /**
    * Returns the schema URL for XML GetFeatureInfo request.
    * \param project the QGIS project
    * \returns the schema URL for XML GetFeatureInfo request.
    */
-  SERVER_EXPORT QString wmsFeatureInfoSchema( const QgsProject &project );
+    static QString wmsFeatureInfoSchema( const QgsProject &project );
 
-  /**
+    /**
    * Returns the mapping between layer name and wms layer name for GetFeatureInfo request.
    * \param project the QGIS project
    * \returns the mapping between layer name and wms layer name for GetFeatureInfo request.
    */
-  SERVER_EXPORT QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
+    static QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
 
-  /**
+    /**
    * Returns if Inspire is activated.
    * \param project the QGIS project
    * \returns if Inspire is activated.
    */
-  SERVER_EXPORT bool wmsInspireActivate( const QgsProject &project );
+    static bool wmsInspireActivate( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Inspire language.
    * \param project the QGIS project
    * \returns the Inspire language if defined in project.
    */
-  SERVER_EXPORT QString wmsInspireLanguage( const QgsProject &project );
+    static QString wmsInspireLanguage( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Inspire metadata URL.
    * \param project the QGIS project
    * \returns the Inspire metadata URL if defined in project.
    */
-  SERVER_EXPORT QString wmsInspireMetadataUrl( const QgsProject &project );
+    static QString wmsInspireMetadataUrl( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Inspire metadata URL type.
    * \param project the QGIS project
    * \returns the Inspire metadata URL type if defined in project.
    */
-  SERVER_EXPORT QString wmsInspireMetadataUrlType( const QgsProject &project );
+    static QString wmsInspireMetadataUrlType( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Inspire temporal reference.
    * \param project the QGIS project
    * \returns the Inspire temporal reference if defined in project.
    */
-  SERVER_EXPORT QString wmsInspireTemporalReference( const QgsProject &project );
+    static QString wmsInspireTemporalReference( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Inspire metadata date.
    * \param project the QGIS project
    * \returns the Inspire metadata date if defined in project.
    */
-  SERVER_EXPORT QString wmsInspireMetadataDate( const QgsProject &project );
+    static QString wmsInspireMetadataDate( const QgsProject &project );
 
-  /**
+    /**
    * Returns the restricted composer list.
    * \param project the QGIS project
    * \returns the restricted composer list if defined in project.
    */
-  SERVER_EXPORT QStringList wmsRestrictedComposers( const QgsProject &project );
+    static QStringList wmsRestrictedComposers( const QgsProject &project );
 
-  /**
+    /**
    * Returns the WMS service url.
    * The URL defined in the project or if not defined the URL from serviceUrl.
    *
@@ -343,37 +337,37 @@ class QgsRectangle;
    * \param settings the server settings
    * \returns url to use for this service
    */
-  SERVER_EXPORT QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 
-  /**
+    /**
    * Returns the WMS root layer name defined in a QGIS project.
    * \param project the QGIS project
    * \returns root layer name to use for this service
    */
-  SERVER_EXPORT QString wmsRootName( const QgsProject &project );
+    static QString wmsRootName( const QgsProject &project );
 
-  /**
+    /**
    * Returns the restricted layer name list.
    * \param project the QGIS project
    * \returns the restricted layer name list if defined in project.
    */
-  SERVER_EXPORT QStringList wmsRestrictedLayers( const QgsProject &project );
+    static QStringList wmsRestrictedLayers( const QgsProject &project );
 
-  /**
+    /**
    * Returns the WMS output CRS list.
    * \param project the QGIS project
    * \returns the WMS output CRS list.
    */
-  SERVER_EXPORT QStringList wmsOutputCrsList( const QgsProject &project );
+    static QStringList wmsOutputCrsList( const QgsProject &project );
 
-  /**
+    /**
    * Returns the WMS Extent restriction.
    * \param project the QGIS project
    * \returns the WMS Extent restriction.
    */
-  SERVER_EXPORT QgsRectangle wmsExtent( const QgsProject &project );
+    static QgsRectangle wmsExtent( const QgsProject &project );
 
-  /**
+    /**
    * Returns the WFS service url.
    * The URL defined in the project or if not defined the URL from serviceUrl.
    *
@@ -382,46 +376,46 @@ class QgsRectangle;
    * \param settings the server settings
    * \returns url to use for this service
    */
-  SERVER_EXPORT QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 
-  /**
+    /**
    * Returns the Layer ids list defined in a QGIS project as published in WFS.
    * \param project the QGIS project
    * \return the Layer ids list.
    */
-  SERVER_EXPORT QStringList wfsLayerIds( const QgsProject &project );
+    static QStringList wfsLayerIds( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Layer precision defined in a QGIS project for the WFS GetFeature.
    * \param project the QGIS project
    * \param layerId the layer id in the project
    * \return the layer precision for WFS GetFeature.
    */
 
-  SERVER_EXPORT int wfsLayerPrecision( const QgsProject &project, const QString &layerId );
+    static int wfsLayerPrecision( const QgsProject &project, const QString &layerId );
 
-  /**
+    /**
    * Returns the Layer ids list defined in a QGIS project as published as WFS-T with update capabilities.
    * \param project the QGIS project
    * \return the Layer ids list.
    */
-  SERVER_EXPORT QStringList wfstUpdateLayerIds( const QgsProject &project );
+    static QStringList wfstUpdateLayerIds( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Layer ids list defined in a QGIS project as published as WFS-T with insert capabilities.
    * \param project the QGIS project
    * \return the Layer ids list.
    */
-  SERVER_EXPORT QStringList wfstInsertLayerIds( const QgsProject &project );
+    static QStringList wfstInsertLayerIds( const QgsProject &project );
 
-  /**
+    /**
    * Returns the Layer ids list defined in a QGIS project as published as WFS-T with delete capabilities.
    * \param project the QGIS project
    * \return the Layer ids list.
    */
-  SERVER_EXPORT QStringList wfstDeleteLayerIds( const QgsProject &project );
+    static QStringList wfstDeleteLayerIds( const QgsProject &project );
 
-  /**
+    /**
    * Returns the WCS service url.
    * The URL defined in the project or if not defined the URL from serviceUrl.
    *
@@ -430,16 +424,16 @@ class QgsRectangle;
    * \param settings the server settings
    * \returns url to use for this service
    */
-  SERVER_EXPORT QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 
-  /**
+    /**
    * Returns the Layer ids list defined in a QGIS project as published in WCS.
    * \param project the QGIS project
    * \returns the Layer ids list.
    */
-  SERVER_EXPORT QStringList wcsLayerIds( const QgsProject &project );
+    static QStringList wcsLayerIds( const QgsProject &project );
 
-  /**
+    /**
    * Returns the WMTS service url.
    * The URL defined in the project or if not defined the URL from serviceUrl.
    *
@@ -449,9 +443,9 @@ class QgsRectangle;
    * \returns url to use for this service
    * \since QGIS 3.4
    */
-  SERVER_EXPORT QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+    static QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 
-  /**
+    /**
    * Returns the service url defined in the environment variable or with HTTP header.
    * This is calculated from (in order of precedence):
    *
@@ -471,7 +465,7 @@ class QgsRectangle;
    * \returns url to use for this service
    * \since QGIS 3.20
    */
-  SERVER_EXPORT QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
+    static QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
 };
 
 #endif


### PR DESCRIPTION
Namespaces don't play well with sip, eg losing the class docstrings and having no knowledge that these are static functions.

See eg https://www.qgis.org/pyqgis/master/core/QgsHstoreUtils.html


