### PR TITLE
In the QgsSplitLinesByLengthAlgorithm adds field 'order' and fill it with an increasing number from 0 to x

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
@@ -112,8 +112,8 @@ Qgis::WkbType QgsSplitLinesByLengthAlgorithm::outputWkbType( Qgis::WkbType input
 
 QgsFields QgsSplitLinesByLengthAlgorithm::outputFields( const QgsFields &inputFields ) const
 {
-  QgsFields fields = QgsFields(inputFields);
-  fields.append(QgsField("order", QMetaType::Type::Int));
+  QgsFields fields = QgsFields( inputFields );
+  fields.append( QgsField( "order", QMetaType::Type::Int ) );
   return fields;
 }
 
@@ -145,7 +145,7 @@ QgsFeatureList QgsSplitLinesByLengthAlgorithm::processFeature( const QgsFeature 
       while ( start < length )
       {
         outputFeature.setGeometry( QgsGeometry( part->curveSubstring( start, end ) ) );
-        outputFeature.setAttributes( f.attributes() << order);
+        outputFeature.setAttributes( f.attributes() << order );
         order++;
         start += distance;
         end += distance;

--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
@@ -110,6 +110,13 @@ Qgis::WkbType QgsSplitLinesByLengthAlgorithm::outputWkbType( Qgis::WkbType input
   return QgsWkbTypes::singleType( inputWkbType );
 }
 
+QgsFields QgsSplitLinesByLengthAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  QgsFields fields = QgsFields(inputFields);
+  fields.append(QgsField("order", QMetaType::Type::Int));
+  return fields;
+}
+
 QgsFeatureList QgsSplitLinesByLengthAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   if ( !f.hasGeometry() )
@@ -123,9 +130,9 @@ QgsFeatureList QgsSplitLinesByLengthAlgorithm::processFeature( const QgsFeature 
       distance = mLengthProperty.valueAsDouble( context.expressionContext(), distance );
 
     QgsFeature outputFeature;
-    outputFeature.setAttributes( f.attributes() );
     QgsFeatureList features;
     const QgsGeometry inputGeom = f.geometry();
+    int order = 0;
     for ( auto it = inputGeom.const_parts_begin(); it != inputGeom.const_parts_end(); ++it )
     {
       const QgsCurve *part = qgsgeometry_cast<const QgsCurve *>( *it );
@@ -138,6 +145,8 @@ QgsFeatureList QgsSplitLinesByLengthAlgorithm::processFeature( const QgsFeature 
       while ( start < length )
       {
         outputFeature.setGeometry( QgsGeometry( part->curveSubstring( start, end ) ) );
+        outputFeature.setAttributes( f.attributes() << order);
+        order++;
         start += distance;
         end += distance;
         features << outputFeature;

--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
@@ -52,6 +52,8 @@ class QgsSplitLinesByLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsFeatureList processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     Qgis::ProcessingFeatureSourceFlags sourceFlags() const override;
     QgsFeatureSink::SinkFlags sinkFlags() const override;
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+
 
   private:
     double mLength = 0.0;


### PR DESCRIPTION
We want to be able to put the new feature-geometries in the order they are created from the original line.

In that way you can afterwards change the original attributes (which are dumb copies at first) based on the order in the original line.

If there is a test I have to update, please let me know.

Below is an example of 2 feature in a SINGLE-line gpkg, split by length of 1000m:

![Screenshot From 2025-03-28 14-36-40](https://github.com/user-attachments/assets/0a3664ca-8491-43e0-a0f8-d46144aac3c6)

Below is an example of 2 features in a MULTI-line gpkg, split by length of 1000m.

The top line has one part, the bottom line has three parts:

![Screenshot From 2025-03-28 14-32-53](https://github.com/user-attachments/assets/9f4aca99-b430-41f3-b1f8-cf1f999e6b99)

Both test files below:

[test_lines.zip](https://github.com/user-attachments/files/19506596/test_lines.zip)

@zoot-inge
