### PR TITLE
Fix `QgsMapLayerProxyModel::layerMatchesFilters()` to support WritableLayer flag

### DIFF
--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -41,6 +41,9 @@ QgsMapLayerProxyModel *QgsMapLayerProxyModel::setFilters( Qgis::LayerFilters fil
 
 bool QgsMapLayerProxyModel::layerMatchesFilters( const QgsMapLayer *layer, const Qgis::LayerFilters &filters )
 {
+  if ( filters.testFlag( Qgis::LayerFilter::WritableLayer ) && layer->readOnly() )
+    return false;
+
   if ( filters.testFlag( Qgis::LayerFilter::All ) )
     return true;
 
@@ -59,8 +62,7 @@ bool QgsMapLayerProxyModel::layerMatchesFilters( const QgsMapLayer *layer, const
   const bool detectGeometry = filters.testFlag( Qgis::LayerFilter::NoGeometry ) ||
                               filters.testFlag( Qgis::LayerFilter::PointLayer ) ||
                               filters.testFlag( Qgis::LayerFilter::LineLayer ) ||
-                              filters.testFlag( Qgis::LayerFilter::PolygonLayer ) ||
-                              filters.testFlag( Qgis::LayerFilter::HasGeometry );
+                              filters.testFlag( Qgis::LayerFilter::PolygonLayer );
   if ( detectGeometry && layer->type() == Qgis::LayerType::Vector )
   {
     if ( const QgsVectorLayer *vl = qobject_cast<const QgsVectorLayer *>( layer ) )
@@ -152,9 +154,6 @@ bool QgsMapLayerProxyModel::acceptsLayer( QgsMapLayer *layer ) const
     return false;
 
   if ( layer->dataProvider() && mExcludedProviders.contains( layer->providerType() ) )
-    return false;
-
-  if ( mFilters.testFlag( Qgis::LayerFilter::WritableLayer ) && layer->readOnly() )
     return false;
 
   if ( !layer->name().contains( mFilterString, Qt::CaseInsensitive ) )


### PR DESCRIPTION
## Description
The static method `QgsMapLayerProxyModel::layerMatchesFilters()` is ignoring the `Qgis::LayerFilter::WritableLayer` flag.

This flag is a little awkward, as while all other `Qgis::LayerFilter` flags are combined using _OR_, this one is combined using _AND_, ie. one of the other flags need to match as well. So if this is the _only_ flag then `false` is always returned.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
