### PR TITLE
Fix MSSQL connection string backslash

### DIFF
--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -417,6 +417,8 @@ QString QgsMssqlLayerItem::createUri()
   }
 
   QgsDataSourceUri uri = QgsDataSourceUri( connItem->connectionUri() );
+  QString escapedSchemaName = mLayerProperty.schemaName;
+  escapedSchemaName.replace('\\', QLatin1String("\\\\"));
   uri.setDataSource( mLayerProperty.schemaName, mLayerProperty.tableName, mLayerProperty.geometryColName, mLayerProperty.sql, pkColName );
   uri.setSrid( mLayerProperty.srid );
   uri.setWkbType( QgsMssqlUtils::wkbTypeFromGeometryType( mLayerProperty.type ) );

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -418,7 +418,7 @@ QString QgsMssqlLayerItem::createUri()
 
   QgsDataSourceUri uri = QgsDataSourceUri( connItem->connectionUri() );
   QString escapedSchemaName = mLayerProperty.schemaName;
-  escapedSchemaName.replace('\\', QLatin1String("\\\\"));
+  escapedSchemaName.replace( '\\', QLatin1String( "\\\\" ) );
   uri.setDataSource( mLayerProperty.schemaName, mLayerProperty.tableName, mLayerProperty.geometryColName, mLayerProperty.sql, pkColName );
   uri.setSrid( mLayerProperty.srid );
   uri.setWkbType( QgsMssqlUtils::wkbTypeFromGeometryType( mLayerProperty.type ) );


### PR DESCRIPTION




## Description

Resolves issue where layers from MS SQL Server schemas containing backslashes (e.g., 'DOMAIN\User') could not be loaded. The QgsDataSourceUri parser expects backslashes to be escaped ('\\').

This change modifies QgsMssqlLayerItem::createUri to escape backslashes in the schema name before passing it to QgsDataSourceUri::setDataSource. This ensures the URI is constructed correctly and can be parsed properly by the provider, allowing layers with such schema names to be loaded.

Fixes #59264

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!


  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
