### PR TITLE
add scrollareas to raster and mesh calculator dialogs to make them more usable

### DIFF
--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -15,89 +15,532 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QSplitter" name="splitter_2">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
+    <widget class="QgsScrollArea" name="scrollArea_2">
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
-     <widget class="QSplitter" name="splitter">
-      <property name="orientation">
-       <enum>Qt::Orientation::Horizontal</enum>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>900</width>
+        <height>906</height>
+       </rect>
       </property>
-      <widget class="QGroupBox" name="mRasterBandsGroupBox">
-       <property name="title">
-        <string>Datasets</string>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QListView" name="mDatasetsListWidget"/>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QGroupBox" name="mResultGroupBox">
-       <property name="title">
-        <string>Result Layer</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="0" column="0" colspan="3">
-           <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
-            <property name="layoutDirection">
-             <enum>Qt::LayoutDirection::LeftToRight</enum>
-            </property>
-            <property name="text">
-             <string>Create on-the-fly dataset group instead of writing layer to disk</string>
-            </property>
-            <property name="tristate">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="mOutputFormatLabel_2">
-            <property name="text">
-             <string>Group name</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="mOutputFormatLabel">
-            <property name="text">
-             <string>Output format</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QgsFileWidget" name="mOutputDatasetFileWidget" native="true"/>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="mOutputFormatComboBox"/>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QLineEdit" name="mOutputGroupNameLineEdit"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mOutputDatasetFileLabel">
-            <property name="text">
-             <string>Output file</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_3">
-          <property name="title">
-           <string>Spatial Extent</string>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QSplitter" name="splitter_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <widget class="QSplitter" name="splitter">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_5">
+          <widget class="QGroupBox" name="mRasterBandsGroupBox">
+           <property name="title">
+            <string>Datasets</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="0" column="0">
+             <widget class="QListView" name="mDatasetsListWidget"/>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QGroupBox" name="mResultGroupBox">
+           <property name="title">
+            <string>Result Layer</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <item>
+             <widget class="QgsScrollArea" name="scrollArea">
+              <property name="frameShape">
+               <enum>QFrame::Shape::NoFrame</enum>
+              </property>
+              <property name="widgetResizable">
+               <bool>true</bool>
+              </property>
+              <widget class="QWidget" name="scrollAreaWidgetContents">
+               <property name="geometry">
+                <rect>
+                 <x>0</x>
+                 <y>0</y>
+                 <width>509</width>
+                 <height>406</height>
+                </rect>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_6">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <layout class="QGridLayout" name="gridLayout_5">
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="mOutputFormatLabel_2">
+                    <property name="text">
+                     <string>Group name</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0" colspan="3">
+                   <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
+                    <property name="layoutDirection">
+                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                    </property>
+                    <property name="text">
+                     <string>Create on-the-fly dataset group instead of writing layer to disk</string>
+                    </property>
+                    <property name="tristate">
+                     <bool>false</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="2">
+                   <widget class="QgsFileWidget" name="mOutputDatasetFileWidget" native="true"/>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="mOutputDatasetFileLabel">
+                    <property name="text">
+                     <string>Output file</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="2">
+                   <widget class="QLineEdit" name="mOutputGroupNameLineEdit"/>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="mOutputFormatLabel">
+                    <property name="text">
+                     <string>Output format</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1" colspan="2">
+                   <widget class="QComboBox" name="mOutputFormatComboBox"/>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_3">
+                  <property name="title">
+                   <string>Spatial Extent</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_5">
+                   <item>
+                    <widget class="QWidget" name="horizontalWidget" native="true">
+                     <layout class="QHBoxLayout" name="horizontalLayout_5">
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="QRadioButton" name="useExtentCb">
+                        <property name="text">
+                         <string>Custom extent</string>
+                        </property>
+                        <property name="checked">
+                         <bool>true</bool>
+                        </property>
+                        <attribute name="buttonGroup">
+                         <string notr="true">buttonGroup</string>
+                        </attribute>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QRadioButton" name="useMaskCb">
+                        <property name="toolTip">
+                         <string>Clips the datasets using features from vector polygon layer.</string>
+                        </property>
+                        <property name="text">
+                         <string>Mask layer</string>
+                        </property>
+                        <attribute name="buttonGroup">
+                         <string notr="true">buttonGroup</string>
+                        </attribute>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QWidget" name="maskBox" native="true">
+                     <layout class="QHBoxLayout" name="maskBoxLayout" stretch="0,0">
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="QLabel" name="label_3">
+                        <property name="minimumSize">
+                         <size>
+                          <width>206</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="text">
+                         <string>Mask layer</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QgsMapLayerComboBox" name="cboLayerMask">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="editable">
+                         <bool>false</bool>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+                     <property name="title">
+                      <string>Spatial Extent</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_2">
+                  <property name="title">
+                   <string>Temporal Extent</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_6">
+                   <item row="1" column="2">
+                    <spacer name="horizontalSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>10</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="1" column="3">
+                    <widget class="QLabel" name="label_2">
+                     <property name="text">
+                      <string>End time</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label">
+                     <property name="text">
+                      <string>Start time</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QComboBox" name="mStartTimeComboBox"/>
+                   </item>
+                   <item row="1" column="4">
+                    <widget class="QComboBox" name="mEndTimeComboBox"/>
+                   </item>
+                   <item row="0" column="0" colspan="5">
+                    <layout class="QHBoxLayout" name="horizontalLayout_2">
+                     <item>
+                      <widget class="QPushButton" name="mAllTimesButton">
+                       <property name="text">
+                        <string>Use all Selected Dataset Times</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_2">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
+                  <property name="text">
+                   <string>Add result to project</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+         <widget class="QWidget" name="verticalLayoutWidget">
+          <layout class="QVBoxLayout" name="verticalLayout">
            <item>
-            <widget class="QWidget" name="horizontalWidget" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <widget class="QgsCollapsibleGroupBox" name="mOperatorsGroupBox">
+             <property name="title">
+              <string>Operators</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout">
               <property name="leftMargin">
                <number>0</number>
               </property>
-              <property name="topMargin">
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="mPlusPushButton">
+                <property name="text">
+                 <string>+</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="mMultiplyPushButton">
+                <property name="text">
+                 <string>*</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QPushButton" name="mOpenBracketPushButton">
+                <property name="text">
+                 <string>(</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QPushButton" name="mMinButton">
+                <property name="text">
+                 <string>min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="QPushButton" name="mIfButton">
+                <property name="text">
+                 <string>IF</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QPushButton" name="mSumAggrButton">
+                <property name="text">
+                 <string>sum (aggr)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <spacer name="horizontalSpacer_1">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="0">
+               <widget class="QPushButton" name="mMinusPushButton">
+                <property name="text">
+                 <string>-</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QPushButton" name="mDividePushButton">
+                <property name="text">
+                 <string>/</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QPushButton" name="mCloseBracketPushButton">
+                <property name="text">
+                 <string>)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QPushButton" name="mMaxButton">
+                <property name="text">
+                 <string>max</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
+               <widget class="QPushButton" name="mAndButton">
+                <property name="text">
+                 <string>AND</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="5">
+               <widget class="QPushButton" name="mMaxAggrButton">
+                <property name="text">
+                 <string>max (aggr)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QPushButton" name="mLessButton">
+                <property name="text">
+                 <string>&lt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QPushButton" name="mGreaterButton">
+                <property name="text">
+                 <string>&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QPushButton" name="mEqualButton">
+                <property name="text">
+                 <string>=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QPushButton" name="mAbsButton">
+                <property name="text">
+                 <string>abs</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="4">
+               <widget class="QPushButton" name="mOrButton">
+                <property name="text">
+                 <string>OR</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="5">
+               <widget class="QPushButton" name="mMinAggrButton">
+                <property name="text">
+                 <string>min (aggr)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QPushButton" name="mLesserEqualButton">
+                <property name="text">
+                 <string>&lt;=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QPushButton" name="mGreaterEqualButton">
+                <property name="text">
+                 <string>&gt;=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QPushButton" name="mNotEqualButton">
+                <property name="text">
+                 <string>!=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QPushButton" name="mPowButton">
+                <property name="text">
+                 <string>^</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="4">
+               <widget class="QPushButton" name="mNotButton">
+                <property name="text">
+                 <string>NOT</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="5">
+               <widget class="QPushButton" name="mAverageAggrButton">
+                <property name="text">
+                 <string>average (aggr)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0" colspan="6">
+               <widget class="QPushButton" name="mNoDataButton">
+                <property name="text">
+                 <string>NODATA</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="groupBox">
+             <property name="title">
+              <string>Mesh Calculator Expression</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <property name="leftMargin">
                <number>0</number>
               </property>
               <property name="rightMargin">
@@ -107,401 +550,13 @@
                <number>0</number>
               </property>
               <item>
-               <widget class="QRadioButton" name="useExtentCb">
-                <property name="text">
-                 <string>Custom extent</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-                <attribute name="buttonGroup">
-                 <string notr="true">buttonGroup</string>
-                </attribute>
-               </widget>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="useMaskCb">
-                <property name="toolTip">
-                 <string>Clips the datasets using features from vector polygon layer.</string>
-                </property>
-                <property name="text">
-                 <string>Mask layer</string>
-                </property>
-                <attribute name="buttonGroup">
-                 <string notr="true">buttonGroup</string>
-                </attribute>
-               </widget>
+               <widget class="QTextEdit" name="mExpressionTextEdit"/>
               </item>
              </layout>
             </widget>
            </item>
-           <item>
-            <widget class="QWidget" name="maskBox" native="true">
-             <layout class="QHBoxLayout" name="maskBoxLayout" stretch="0,0">
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="label_3">
-                <property name="minimumSize">
-                 <size>
-                  <width>206</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string>Mask layer</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QgsMapLayerComboBox" name="cboLayerMask">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="editable">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
-             <property name="title">
-              <string>Spatial Extent</string>
-             </property>
-            </widget>
-           </item>
           </layout>
          </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_2">
-          <property name="title">
-           <string>Temporal Extent</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_6">
-           <item row="1" column="2">
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>10</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="1" column="3">
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>End time</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Start time</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QComboBox" name="mStartTimeComboBox"/>
-           </item>
-           <item row="1" column="4">
-            <widget class="QComboBox" name="mEndTimeComboBox"/>
-           </item>
-           <item row="0" column="0" colspan="5">
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <item>
-              <widget class="QPushButton" name="mAllTimesButton">
-               <property name="text">
-                <string>Use all Selected Dataset Times</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
-          <property name="text">
-           <string>Add result to project</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-     <widget class="QWidget" name="verticalLayoutWidget">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QgsCollapsibleGroupBox" name="mOperatorsGroupBox">
-         <property name="title">
-          <string>Operators</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QPushButton" name="mPlusPushButton">
-            <property name="text">
-             <string>+</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QPushButton" name="mMultiplyPushButton">
-            <property name="text">
-             <string>*</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QPushButton" name="mOpenBracketPushButton">
-            <property name="text">
-             <string>(</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QPushButton" name="mMinButton">
-            <property name="text">
-             <string>min</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QPushButton" name="mIfButton">
-            <property name="text">
-             <string>IF</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
-           <widget class="QPushButton" name="mSumAggrButton">
-            <property name="text">
-             <string>sum (aggr)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="6">
-           <spacer name="horizontalSpacer_1">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="0">
-           <widget class="QPushButton" name="mMinusPushButton">
-            <property name="text">
-             <string>-</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="mDividePushButton">
-            <property name="text">
-             <string>/</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="mCloseBracketPushButton">
-            <property name="text">
-             <string>)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QPushButton" name="mMaxButton">
-            <property name="text">
-             <string>max</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4">
-           <widget class="QPushButton" name="mAndButton">
-            <property name="text">
-             <string>AND</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="5">
-           <widget class="QPushButton" name="mMaxAggrButton">
-            <property name="text">
-             <string>max (aggr)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QPushButton" name="mLessButton">
-            <property name="text">
-             <string>&lt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="mGreaterButton">
-            <property name="text">
-             <string>&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QPushButton" name="mEqualButton">
-            <property name="text">
-             <string>=</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QPushButton" name="mAbsButton">
-            <property name="text">
-             <string>abs</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
-           <widget class="QPushButton" name="mOrButton">
-            <property name="text">
-             <string>OR</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="5">
-           <widget class="QPushButton" name="mMinAggrButton">
-            <property name="text">
-             <string>min (aggr)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QPushButton" name="mLesserEqualButton">
-            <property name="text">
-             <string>&lt;=</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QPushButton" name="mGreaterEqualButton">
-            <property name="text">
-             <string>&gt;=</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QPushButton" name="mNotEqualButton">
-            <property name="text">
-             <string>!=</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QPushButton" name="mPowButton">
-            <property name="text">
-             <string>^</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="4">
-           <widget class="QPushButton" name="mNotButton">
-            <property name="text">
-             <string>NOT</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="5">
-           <widget class="QPushButton" name="mAverageAggrButton">
-            <property name="text">
-             <string>average (aggr)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="6">
-           <widget class="QPushButton" name="mNoDataButton">
-            <property name="text">
-             <string>NODATA</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Mesh Calculator Expression</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QTextEdit" name="mExpressionTextEdit"/>
-          </item>
-         </layout>
         </widget>
        </item>
       </layout>
@@ -528,7 +583,7 @@
   </layout>
   <zorder>mButtonBox</zorder>
   <zorder>mExpressionValidLabel</zorder>
-  <zorder>splitter_2</zorder>
+  <zorder>scrollArea_2</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -544,15 +599,21 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsExtentGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -6,224 +6,86 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
-    <height>939</height>
+    <width>931</width>
+    <height>576</height>
    </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>640</width>
-    <height>530</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Raster Calculator</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_6">
-   <item row="1" column="0">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QgsScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QgsScrollArea" name="scrollArea" native="true">
-     <property name="widgetResizable" stdset="0">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_8">
-      <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_7">
-        <item row="0" column="0">
-         <widget class="QSplitter" name="splitter_2">
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>919</width>
+        <height>500</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QSplitter" name="splitter_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <widget class="QSplitter" name="splitter">
           <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
-          <widget class="QSplitter" name="splitter">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+          <widget class="QGroupBox" name="mRasterBandsGroupBox">
+           <property name="title">
+            <string>Raster Bands</string>
            </property>
-           <widget class="QGroupBox" name="mRasterBandsGroupBox">
-            <property name="title">
-             <string>Raster Bands</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_2">
-             <item row="0" column="0">
-              <widget class="QListWidget" name="mRasterBandsListWidget"/>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QGroupBox" name="mResultGroupBox">
-            <property name="title">
-             <string>Result Layer</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,0,0,0">
-             <item row="2" column="1" colspan="3">
-              <widget class="QgsFileWidget" name="mOutputLayer" native="true"/>
-             </item>
-             <item row="4" column="0" colspan="4">
-              <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
-               <property name="title">
-                <string>Spatial Extent</string>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="0" column="0">
+             <widget class="QListWidget" name="mRasterBandsListWidget"/>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QGroupBox" name="mResultGroupBox">
+           <property name="title">
+            <string>Result Layer</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_4" columnstretch="0">
+            <item row="0" column="0">
+             <widget class="QgsScrollArea" name="scrollArea_2">
+              <property name="frameShape">
+               <enum>QFrame::Shape::NoFrame</enum>
+              </property>
+              <property name="widgetResizable">
+               <bool>true</bool>
+              </property>
+              <widget class="QWidget" name="scrollAreaWidgetContents_2">
+               <property name="geometry">
+                <rect>
+                 <x>0</x>
+                 <y>0</y>
+                 <width>504</width>
+                 <height>326</height>
+                </rect>
                </property>
-              </widget>
-             </item>
-             <item row="6" column="0" colspan="4">
-              <widget class="QGroupBox" name="groupBox_3">
-               <property name="title">
-                <string>Resolution</string>
-               </property>
-               <layout class="QHBoxLayout" name="horizontalLayout">
-                <item>
-                 <widget class="QLabel" name="mColumnsLabel">
-                  <property name="text">
-                   <string>Columns</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QgsSpinBox" name="mNColumnsSpinBox">
-                  <property name="maximum">
-                   <number>999999999</number>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QLabel" name="mRowsLabel">
-                  <property name="text">
-                   <string>Rows</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QgsSpinBox" name="mNRowsSpinBox">
-                  <property name="maximum">
-                   <number>999999999</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item row="7" column="1" colspan="3">
-              <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
-               <property name="focusPolicy">
-                <enum>Qt::FocusPolicy::StrongFocus</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1" colspan="3">
-              <widget class="QComboBox" name="mOutputFormatComboBox"/>
-             </item>
-             <item row="1" column="1" colspan="3">
-              <widget class="QLineEdit" name="mVirtualLayerName">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="placeholderText">
-                <string>Autogenerated from expression</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="mOutputLayerLabel">
-               <property name="text">
-                <string>Output layer</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="mVirtualLayerLabel">
-               <property name="text">
-                <string>Layer name</string>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="0">
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>Output CRS</string>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="0" colspan="4">
-              <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
-               <property name="text">
-                <string>Add result to project</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="0">
-              <spacer name="verticalSpacer">
-               <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="0" column="0" colspan="4">
-              <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: the result raster will not be usable with any processing algorithm that expects a materialized raster.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="layoutDirection">
-                <enum>Qt::LayoutDirection::LeftToRight</enum>
-               </property>
-               <property name="text">
-                <string>Create on-the-fly raster instead of writing layer to disk</string>
-               </property>
-               <property name="tristate">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="mOutputFormatLabel">
-               <property name="text">
-                <string>Output format</string>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="0" colspan="4">
-              <widget class="QgsCollapsibleGroupBox" name="mCreateOptionsGroupBox">
-               <property name="title">
-                <string>Create Options</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-               <property name="checked">
-                <bool>false</bool>
-               </property>
-               <property name="collapsed" stdset="0">
-                <bool>true</bool>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_3">
+               <layout class="QGridLayout" name="gridLayout_3">
                 <property name="leftMargin">
                  <number>0</number>
                 </property>
@@ -236,279 +98,453 @@
                 <property name="bottomMargin">
                  <number>0</number>
                 </property>
-                <item>
-                 <widget class="QgsRasterFormatSaveOptionsWidget" name="mCreateOptionsWidget" native="true"/>
+                <item row="5" column="0" colspan="2">
+                 <widget class="QGroupBox" name="groupBox_3">
+                  <property name="title">
+                   <string>Resolution</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout">
+                   <item>
+                    <widget class="QLabel" name="mColumnsLabel">
+                     <property name="text">
+                      <string>Columns</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QgsSpinBox" name="mNColumnsSpinBox">
+                     <property name="maximum">
+                      <number>999999999</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="mRowsLabel">
+                     <property name="text">
+                      <string>Rows</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QgsSpinBox" name="mNRowsSpinBox">
+                     <property name="maximum">
+                      <number>999999999</number>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QLabel" name="mOutputFormatLabel">
+                  <property name="text">
+                   <string>Output format</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QgsFileWidget" name="mOutputLayer" native="true"/>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QLineEdit" name="mVirtualLayerName">
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="placeholderText">
+                   <string>Autogenerated from expression</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="0" colspan="2">
+                 <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+                  <property name="title">
+                   <string>Spatial Extent</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1">
+                 <widget class="QComboBox" name="mOutputFormatComboBox"/>
+                </item>
+                <item row="7" column="1">
+                 <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                  <property name="focusPolicy">
+                   <enum>Qt::FocusPolicy::StrongFocus</enum>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="0">
+                 <widget class="QLabel" name="label">
+                  <property name="text">
+                   <string>Output CRS</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="mOutputLayerLabel">
+                  <property name="text">
+                   <string>Output layer</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="mVirtualLayerLabel">
+                  <property name="text">
+                   <string>Layer name</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0" colspan="2">
+                 <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: the result raster will not be usable with any processing algorithm that expects a materialized raster.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="layoutDirection">
+                   <enum>Qt::LayoutDirection::LeftToRight</enum>
+                  </property>
+                  <property name="text">
+                   <string>Create on-the-fly raster instead of writing layer to disk</string>
+                  </property>
+                  <property name="tristate">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="9" column="0">
+                 <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
+                  <property name="text">
+                   <string>Add result to project</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="8" column="0" colspan="2">
+                 <widget class="QgsCollapsibleGroupBox" name="mCreateOptionsGroupBox">
+                  <property name="title">
+                   <string>Create Options</string>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <property name="checked">
+                   <bool>false</bool>
+                  </property>
+                  <property name="collapsed" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_3">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QgsRasterFormatSaveOptionsWidget" name="mCreateOptionsWidget" native="true"/>
+                   </item>
+                  </layout>
+                 </widget>
                 </item>
                </layout>
               </widget>
-             </item>
-            </layout>
-           </widget>
-          </widget>
-          <widget class="QWidget" name="verticalLayoutWidget">
-           <layout class="QVBoxLayout" name="verticalLayout">
-            <item>
-             <widget class="QgsCollapsibleGroupBox" name="mOperatorsGroupBox">
-              <property name="title">
-               <string>Operators</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item row="0" column="0">
-                <widget class="QPushButton" name="mPlusPushButton">
-                 <property name="text">
-                  <string notr="true">+</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QPushButton" name="mMultiplyPushButton">
-                 <property name="text">
-                  <string notr="true">*</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QPushButton" name="mOpenBracketPushButton">
-                 <property name="text">
-                  <string notr="true">(</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <widget class="QPushButton" name="mMinButton">
-                 <property name="text">
-                  <string notr="true">min</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="4">
-                <widget class="QPushButton" name="mConditionalStatButton">
-                 <property name="text">
-                  <string notr="true">IF</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="5">
-                <widget class="QPushButton" name="mCosButton">
-                 <property name="text">
-                  <string notr="true">cos</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="6">
-                <widget class="QPushButton" name="mACosButton">
-                 <property name="text">
-                  <string notr="true">acos</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="7">
-                <spacer name="horizontalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>5</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="1" column="0">
-                <widget class="QPushButton" name="mMinusPushButton">
-                 <property name="text">
-                  <string notr="true">-</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QPushButton" name="mDividePushButton">
-                 <property name="text">
-                  <string notr="true">/</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="2">
-                <widget class="QPushButton" name="mCloseBracketPushButton">
-                 <property name="text">
-                  <string notr="true">)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QPushButton" name="mMaxButton">
-                 <property name="text">
-                  <string notr="true">max</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="4">
-                <widget class="QPushButton" name="mAndButton">
-                 <property name="text">
-                  <string notr="true">AND</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="5">
-                <widget class="QPushButton" name="mSinButton">
-                 <property name="text">
-                  <string notr="true">sin</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="6">
-                <widget class="QPushButton" name="mASinButton">
-                 <property name="text">
-                  <string notr="true">asin</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QPushButton" name="mLessButton">
-                 <property name="text">
-                  <string notr="true">&lt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QPushButton" name="mGreaterButton">
-                 <property name="text">
-                  <string notr="true">&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
-                <widget class="QPushButton" name="mEqualButton">
-                 <property name="text">
-                  <string notr="true">=</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="3">
-                <widget class="QPushButton" name="mAbsButton">
-                 <property name="text">
-                  <string notr="true">abs</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="4">
-                <widget class="QPushButton" name="mOrButton">
-                 <property name="text">
-                  <string notr="true">OR</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="5">
-                <widget class="QPushButton" name="mTanButton">
-                 <property name="text">
-                  <string notr="true">tan</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="6">
-                <widget class="QPushButton" name="mATanButton">
-                 <property name="text">
-                  <string notr="true">atan</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QPushButton" name="mLesserEqualButton">
-                 <property name="text">
-                  <string notr="true">&lt;=</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
-                <widget class="QPushButton" name="mGreaterEqualButton">
-                 <property name="text">
-                  <string notr="true">&gt;=</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QPushButton" name="mNotEqualButton">
-                 <property name="text">
-                  <string notr="true">!=</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="3">
-                <widget class="QPushButton" name="mExpButton">
-                 <property name="text">
-                  <string notr="true">^</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="4">
-                <widget class="QPushButton" name="mSqrtButton">
-                 <property name="text">
-                  <string notr="true">sqrt</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="5">
-                <widget class="QPushButton" name="mLogButton">
-                 <property name="text">
-                  <string notr="true">log10</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="6">
-                <widget class="QPushButton" name="mLnButton">
-                 <property name="text">
-                  <string notr="true">ln</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox">
-              <property name="title">
-               <string>Raster Calculator Expression</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_2">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QTextEdit" name="mExpressionTextEdit"/>
-               </item>
-              </layout>
              </widget>
             </item>
            </layout>
           </widget>
          </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="mExpressionValidLabel">
-          <property name="text">
-           <string/>
-          </property>
+         <widget class="QWidget" name="layoutWidget">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="mOperatorsGroupBox">
+             <property name="title">
+              <string>Operators</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="mPlusPushButton">
+                <property name="text">
+                 <string notr="true">+</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="mMultiplyPushButton">
+                <property name="text">
+                 <string notr="true">*</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QPushButton" name="mOpenBracketPushButton">
+                <property name="text">
+                 <string notr="true">(</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QPushButton" name="mMinButton">
+                <property name="text">
+                 <string notr="true">min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="QPushButton" name="mConditionalStatButton">
+                <property name="text">
+                 <string notr="true">IF</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QPushButton" name="mCosButton">
+                <property name="text">
+                 <string notr="true">cos</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QPushButton" name="mACosButton">
+                <property name="text">
+                 <string notr="true">acos</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="7">
+               <spacer name="horizontalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>5</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="0">
+               <widget class="QPushButton" name="mMinusPushButton">
+                <property name="text">
+                 <string notr="true">-</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QPushButton" name="mDividePushButton">
+                <property name="text">
+                 <string notr="true">/</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QPushButton" name="mCloseBracketPushButton">
+                <property name="text">
+                 <string notr="true">)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QPushButton" name="mMaxButton">
+                <property name="text">
+                 <string notr="true">max</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
+               <widget class="QPushButton" name="mAndButton">
+                <property name="text">
+                 <string notr="true">AND</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="5">
+               <widget class="QPushButton" name="mSinButton">
+                <property name="text">
+                 <string notr="true">sin</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="6">
+               <widget class="QPushButton" name="mASinButton">
+                <property name="text">
+                 <string notr="true">asin</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QPushButton" name="mLessButton">
+                <property name="text">
+                 <string notr="true">&lt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QPushButton" name="mGreaterButton">
+                <property name="text">
+                 <string notr="true">&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QPushButton" name="mEqualButton">
+                <property name="text">
+                 <string notr="true">=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QPushButton" name="mAbsButton">
+                <property name="text">
+                 <string notr="true">abs</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="4">
+               <widget class="QPushButton" name="mOrButton">
+                <property name="text">
+                 <string notr="true">OR</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="5">
+               <widget class="QPushButton" name="mTanButton">
+                <property name="text">
+                 <string notr="true">tan</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="6">
+               <widget class="QPushButton" name="mATanButton">
+                <property name="text">
+                 <string notr="true">atan</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QPushButton" name="mLesserEqualButton">
+                <property name="text">
+                 <string notr="true">&lt;=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QPushButton" name="mGreaterEqualButton">
+                <property name="text">
+                 <string notr="true">&gt;=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QPushButton" name="mNotEqualButton">
+                <property name="text">
+                 <string notr="true">!=</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QPushButton" name="mExpButton">
+                <property name="text">
+                 <string notr="true">^</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="4">
+               <widget class="QPushButton" name="mSqrtButton">
+                <property name="text">
+                 <string notr="true">sqrt</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="5">
+               <widget class="QPushButton" name="mLogButton">
+                <property name="text">
+                 <string notr="true">log10</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="6">
+               <widget class="QPushButton" name="mLnButton">
+                <property name="text">
+                 <string notr="true">ln</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="groupBox">
+             <property name="title">
+              <string>Raster Calculator Expression</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QTextEdit" name="mExpressionTextEdit"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
          </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="mExpressionValidLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
     </widget>
    </item>
   </layout>
@@ -527,6 +563,18 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
@@ -538,64 +586,12 @@
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QWidget</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsExtentGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsRasterFormatSaveOptionsWidget</class>
    <extends>QWidget</extends>
    <header>qgsrasterformatsaveoptionswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>mRasterBandsListWidget</tabstop>
-  <tabstop>mUseVirtualProviderCheckBox</tabstop>
-  <tabstop>mVirtualLayerName</tabstop>
-  <tabstop>mOutputFormatComboBox</tabstop>
-  <tabstop>mNColumnsSpinBox</tabstop>
-  <tabstop>mNRowsSpinBox</tabstop>
-  <tabstop>mCrsSelector</tabstop>
-  <tabstop>mAddResultToProjectCheckBox</tabstop>
-  <tabstop>mPlusPushButton</tabstop>
-  <tabstop>mMultiplyPushButton</tabstop>
-  <tabstop>mOpenBracketPushButton</tabstop>
-  <tabstop>mMinButton</tabstop>
-  <tabstop>mConditionalStatButton</tabstop>
-  <tabstop>mCosButton</tabstop>
-  <tabstop>mACosButton</tabstop>
-  <tabstop>mMinusPushButton</tabstop>
-  <tabstop>mDividePushButton</tabstop>
-  <tabstop>mCloseBracketPushButton</tabstop>
-  <tabstop>mMaxButton</tabstop>
-  <tabstop>mAndButton</tabstop>
-  <tabstop>mSinButton</tabstop>
-  <tabstop>mASinButton</tabstop>
-  <tabstop>mLessButton</tabstop>
-  <tabstop>mGreaterButton</tabstop>
-  <tabstop>mEqualButton</tabstop>
-  <tabstop>mAbsButton</tabstop>
-  <tabstop>mOrButton</tabstop>
-  <tabstop>mTanButton</tabstop>
-  <tabstop>mATanButton</tabstop>
-  <tabstop>mLesserEqualButton</tabstop>
-  <tabstop>mGreaterEqualButton</tabstop>
-  <tabstop>mNotEqualButton</tabstop>
-  <tabstop>mExpButton</tabstop>
-  <tabstop>mSqrtButton</tabstop>
-  <tabstop>mLogButton</tabstop>
-  <tabstop>mLnButton</tabstop>
-  <tabstop>mExpressionTextEdit</tabstop>
-  <tabstop>mButtonBox</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
## Description

Add scrollareas to the raster and mesh calculator dialogs to make them more usable on small screens.

[Screencast_20250330_142038.webm](https://github.com/user-attachments/assets/0f4e33fd-f348-402e-bd68-c50d94babb52)

Fixes #61242.