### PR TITLE
[api] Methods to create geocentric CRS from ellipsoid/other crs

### DIFF
--- a/python/PyQt6/core/auto_additions/qgscoordinatereferencesystem.py
+++ b/python/PyQt6/core/auto_additions/qgscoordinatereferencesystem.py
@@ -11,6 +11,7 @@ try:
     QgsCoordinateReferenceSystem.fromWkt = staticmethod(QgsCoordinateReferenceSystem.fromWkt)
     QgsCoordinateReferenceSystem.fromSrsId = staticmethod(QgsCoordinateReferenceSystem.fromSrsId)
     QgsCoordinateReferenceSystem.createCompoundCrs = staticmethod(QgsCoordinateReferenceSystem.createCompoundCrs)
+    QgsCoordinateReferenceSystem.createGeocentricCrs = staticmethod(QgsCoordinateReferenceSystem.createGeocentricCrs)
     QgsCoordinateReferenceSystem.setupESRIWktFix = staticmethod(QgsCoordinateReferenceSystem.setupESRIWktFix)
     QgsCoordinateReferenceSystem.syncDatabase = staticmethod(QgsCoordinateReferenceSystem.syncDatabase)
     QgsCoordinateReferenceSystem.recentProjections = staticmethod(QgsCoordinateReferenceSystem.recentProjections)

--- a/python/PyQt6/core/auto_additions/qgsellipsoidutils.py
+++ b/python/PyQt6/core/auto_additions/qgsellipsoidutils.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/core/proj/qgsellipsoidutils.h
 try:
-    QgsEllipsoidUtils.EllipsoidParameters.__attribute_docs__ = {'valid': 'Whether ellipsoid parameters are valid', 'semiMajor': 'Semi-major axis', 'semiMinor': 'Semi-minor axis', 'useCustomParameters': 'Whether custom parameters alone should be used (semiMajor/semiMinor only)', 'inverseFlattening': 'Inverse flattening', 'crs': 'Associated coordinate reference system'}
+    QgsEllipsoidUtils.EllipsoidParameters.__attribute_docs__ = {'valid': 'Whether ellipsoid parameters are valid', 'semiMajor': 'Semi-major axis, in meters', 'semiMinor': 'Semi-minor axis, in meters', 'useCustomParameters': 'Whether custom parameters alone should be used (semiMajor/semiMinor only)', 'inverseFlattening': 'Inverse flattening', 'crs': 'Associated coordinate reference system'}
     QgsEllipsoidUtils.EllipsoidParameters.__doc__ = """Contains parameters for an ellipsoid."""
     QgsEllipsoidUtils.EllipsoidParameters.__group__ = ['proj']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -363,6 +363,15 @@ Creates a geocentric CRS given an ``ellipsoid`` definition.
 
 Returns an invalid CRS if the ellipsoid definition is not valid.
 
+.. warning::
+
+   The returned CRS will be based on the ellipsoid parameters only,
+   and will not have any datum associated with it. This prevents accurate
+   datum shifts from occurring when transforming coordinates to
+   or from the returned CRS. Any transformations involving this CRS
+   will result in a ballpark (null) datum shift. The returned object should
+   NOT be used when high accuracy transformations are required.
+
 .. seealso:: :py:func:`toGeocentricCrs`
 
 .. versionadded:: 3.44

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -357,6 +357,17 @@ or the compound CRS could not be created for the combination.
 .. versionadded:: 3.38
 %End
 
+    static QgsCoordinateReferenceSystem createGeocentricCrs( const QString &ellipsoid );
+%Docstring
+Creates a geocentric CRS given an ``ellipsoid`` definition.
+
+Returns an invalid CRS if the ellipsoid definition is not valid.
+
+.. seealso:: :py:func:`toGeocentricCrs`
+
+.. versionadded:: 3.44
+%End
+
 
 
  bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated="Since 3.10. We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format."/;
@@ -1119,6 +1130,20 @@ May return an invalid CRS if the geographic CRS could not be determined.
    This method will always return a longitude, latitude ordered CRS.
 
 .. versionadded:: 3.24
+%End
+
+    QgsCoordinateReferenceSystem toGeocentricCrs() const;
+%Docstring
+Returns a new geocentric CRS based on this CRS object.
+
+If possible, the returned geocentric CRS will have the same datum (or
+datum ensemble) as this object.
+
+May return an invalid CRS if the geocentric CRS could not be determined.
+
+.. seealso:: :py:func:`createGeocentricCrs`
+
+.. versionadded:: 3.44
 %End
 
     QgsCoordinateReferenceSystem horizontalCrs() const;

--- a/python/core/auto_additions/qgscoordinatereferencesystem.py
+++ b/python/core/auto_additions/qgscoordinatereferencesystem.py
@@ -8,6 +8,7 @@ try:
     QgsCoordinateReferenceSystem.fromWkt = staticmethod(QgsCoordinateReferenceSystem.fromWkt)
     QgsCoordinateReferenceSystem.fromSrsId = staticmethod(QgsCoordinateReferenceSystem.fromSrsId)
     QgsCoordinateReferenceSystem.createCompoundCrs = staticmethod(QgsCoordinateReferenceSystem.createCompoundCrs)
+    QgsCoordinateReferenceSystem.createGeocentricCrs = staticmethod(QgsCoordinateReferenceSystem.createGeocentricCrs)
     QgsCoordinateReferenceSystem.setupESRIWktFix = staticmethod(QgsCoordinateReferenceSystem.setupESRIWktFix)
     QgsCoordinateReferenceSystem.syncDatabase = staticmethod(QgsCoordinateReferenceSystem.syncDatabase)
     QgsCoordinateReferenceSystem.recentProjections = staticmethod(QgsCoordinateReferenceSystem.recentProjections)

--- a/python/core/auto_additions/qgsellipsoidutils.py
+++ b/python/core/auto_additions/qgsellipsoidutils.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/core/proj/qgsellipsoidutils.h
 try:
-    QgsEllipsoidUtils.EllipsoidParameters.__attribute_docs__ = {'valid': 'Whether ellipsoid parameters are valid', 'semiMajor': 'Semi-major axis', 'semiMinor': 'Semi-minor axis', 'useCustomParameters': 'Whether custom parameters alone should be used (semiMajor/semiMinor only)', 'inverseFlattening': 'Inverse flattening', 'crs': 'Associated coordinate reference system'}
+    QgsEllipsoidUtils.EllipsoidParameters.__attribute_docs__ = {'valid': 'Whether ellipsoid parameters are valid', 'semiMajor': 'Semi-major axis, in meters', 'semiMinor': 'Semi-minor axis, in meters', 'useCustomParameters': 'Whether custom parameters alone should be used (semiMajor/semiMinor only)', 'inverseFlattening': 'Inverse flattening', 'crs': 'Associated coordinate reference system'}
     QgsEllipsoidUtils.EllipsoidParameters.__doc__ = """Contains parameters for an ellipsoid."""
     QgsEllipsoidUtils.EllipsoidParameters.__group__ = ['proj']
 except (NameError, AttributeError):

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -363,6 +363,15 @@ Creates a geocentric CRS given an ``ellipsoid`` definition.
 
 Returns an invalid CRS if the ellipsoid definition is not valid.
 
+.. warning::
+
+   The returned CRS will be based on the ellipsoid parameters only,
+   and will not have any datum associated with it. This prevents accurate
+   datum shifts from occurring when transforming coordinates to
+   or from the returned CRS. Any transformations involving this CRS
+   will result in a ballpark (null) datum shift. The returned object should
+   NOT be used when high accuracy transformations are required.
+
 .. seealso:: :py:func:`toGeocentricCrs`
 
 .. versionadded:: 3.44

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -357,6 +357,17 @@ or the compound CRS could not be created for the combination.
 .. versionadded:: 3.38
 %End
 
+    static QgsCoordinateReferenceSystem createGeocentricCrs( const QString &ellipsoid );
+%Docstring
+Creates a geocentric CRS given an ``ellipsoid`` definition.
+
+Returns an invalid CRS if the ellipsoid definition is not valid.
+
+.. seealso:: :py:func:`toGeocentricCrs`
+
+.. versionadded:: 3.44
+%End
+
 
 
  bool createFromId( long id, CrsType type = PostgisCrsId ) /Deprecated="Since 3.10. We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format."/;
@@ -1119,6 +1130,20 @@ May return an invalid CRS if the geographic CRS could not be determined.
    This method will always return a longitude, latitude ordered CRS.
 
 .. versionadded:: 3.24
+%End
+
+    QgsCoordinateReferenceSystem toGeocentricCrs() const;
+%Docstring
+Returns a new geocentric CRS based on this CRS object.
+
+If possible, the returned geocentric CRS will have the same datum (or
+datum ensemble) as this object.
+
+May return an invalid CRS if the geocentric CRS could not be determined.
+
+.. seealso:: :py:func:`createGeocentricCrs`
+
+.. versionadded:: 3.44
 %End
 
     QgsCoordinateReferenceSystem horizontalCrs() const;

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -3148,8 +3148,15 @@ QgsCoordinateReferenceSystem QgsCoordinateReferenceSystem::toGeocentricCrs() con
   {
     PJ_CONTEXT *pjContext = QgsProjContext::get();
 
-    QgsProjUtils::proj_pj_unique_ptr datum( proj_crs_get_datum( pjContext, obj ) );
-    QgsProjUtils::proj_pj_unique_ptr datumEnsemble( proj_crs_get_datum_ensemble( pjContext, obj ) );
+    // we need the horizontal, unbound crs in order to extract the datum:
+    QgsProjUtils::proj_pj_unique_ptr horizontalCrs = QgsProjUtils::crsToHorizontalCrs( obj );
+    if ( !horizontalCrs )
+    {
+      return QgsCoordinateReferenceSystem();
+    }
+
+    QgsProjUtils::proj_pj_unique_ptr datum( proj_crs_get_datum( pjContext, horizontalCrs.get() ) );
+    QgsProjUtils::proj_pj_unique_ptr datumEnsemble( proj_crs_get_datum_ensemble( pjContext, horizontalCrs.get() ) );
     if ( !datum && !datumEnsemble )
       return QgsCoordinateReferenceSystem();
 

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -364,6 +364,16 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     static QgsCoordinateReferenceSystem createCompoundCrs( const QgsCoordinateReferenceSystem &horizontalCrs, const QgsCoordinateReferenceSystem &verticalCrs, QString &error SIP_OUT );
 
+    /**
+     * Creates a geocentric CRS given an \a ellipsoid definition.
+     *
+     * Returns an invalid CRS if the ellipsoid definition is not valid.
+     *
+     * \see toGeocentricCrs()
+     * \since QGIS 3.44
+     */
+    static QgsCoordinateReferenceSystem createGeocentricCrs( const QString &ellipsoid );
+
     // Misc helper functions -----------------------
 
     // TODO QGIS 4: remove type and always use EPSG code, rename to createFromEpsg
@@ -1018,6 +1028,19 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \since QGIS 3.24
      */
     QgsCoordinateReferenceSystem toGeographicCrs() const;
+
+    /**
+     * Returns a new geocentric CRS based on this CRS object.
+     *
+     * If possible, the returned geocentric CRS will have the same datum (or
+     * datum ensemble) as this object.
+     *
+     * May return an invalid CRS if the geocentric CRS could not be determined.
+     *
+     * \see createGeocentricCrs()
+     * \since QGIS 3.44
+     */
+    QgsCoordinateReferenceSystem toGeocentricCrs() const;
 
     /**
      * Returns the horizontal CRS associated with this CRS object.

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -369,6 +369,13 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *
      * Returns an invalid CRS if the ellipsoid definition is not valid.
      *
+     * \warning The returned CRS will be based on the ellipsoid parameters only,
+     * and will not have any datum associated with it. This prevents accurate
+     * datum shifts from occurring when transforming coordinates to
+     * or from the returned CRS. Any transformations involving this CRS
+     * will result in a ballpark (null) datum shift. The returned object should
+     * NOT be used when high accuracy transformations are required.
+     *
      * \see toGeocentricCrs()
      * \since QGIS 3.44
      */

--- a/src/core/proj/qgsellipsoidutils.h
+++ b/src/core/proj/qgsellipsoidutils.h
@@ -41,9 +41,9 @@ class CORE_EXPORT QgsEllipsoidUtils
       //! Whether ellipsoid parameters are valid
       bool valid{ true };
 
-      //! Semi-major axis
+      //! Semi-major axis, in meters
       double semiMajor{ -1.0 };
-      //! Semi-minor axis
+      //! Semi-minor axis, in meters
       double semiMinor{ -1.0 };
 
       //! Whether custom parameters alone should be used (semiMajor/semiMinor only)

--- a/tests/src/python/test_qgscoordinatereferencesystem.py
+++ b/tests/src/python/test_qgscoordinatereferencesystem.py
@@ -57,6 +57,90 @@ class TestQgsCoordinateReferenceSystem(QgisTestCase):
             [Qgis.CrsAxisDirection.East, Qgis.CrsAxisDirection.North],
         )
 
+    def test_create_geocentric_crs(self):
+        self.assertFalse(QgsCoordinateReferenceSystem.createGeocentricCrs("").isValid())
+        self.assertFalse(
+            QgsCoordinateReferenceSystem.createGeocentricCrs("xxxxxx").isValid()
+        )
+
+        # using ellipsoid code
+        crs = QgsCoordinateReferenceSystem.createGeocentricCrs("EPSG:7030")
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(), "+proj=geocent +ellps=WGS84 +units=m +no_defs +type=crs"
+        )
+        self.assertEqual(
+            crs.ellipsoidAcronym(), "PARAMETER:6378137:6356752.31424517929553986"
+        )
+        self.assertEqual(crs.celestialBodyName(), "Earth")
+
+        # non-earth ellipsoid
+        crs = QgsCoordinateReferenceSystem.createGeocentricCrs("IAU_2015:49901")
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(),
+            "+proj=geocent +a=3396190 +rf=169.894447223612 +units=m +no_defs +type=crs",
+        )
+        self.assertEqual(crs.ellipsoidAcronym(), "PARAMETER:3396190:3376200")
+        self.assertEqual(crs.celestialBodyName(), "Mars")
+
+        # custom ellipsoid
+        crs = QgsCoordinateReferenceSystem.createGeocentricCrs("PARAMETER:1200:800")
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(), "+proj=geocent +a=1200 +rf=3 +units=m +no_defs +type=crs"
+        )
+        self.assertEqual(crs.ellipsoidAcronym()[:18], "PARAMETER:1200:800")
+        self.assertEqual(crs.celestialBodyName(), "Non-Earth body")
+
+    def test_to_geocentric_crs(self):
+        self.assertFalse(QgsCoordinateReferenceSystem().toGeocentricCrs().isValid())
+
+        # using WGS84 datum
+        crs = QgsCoordinateReferenceSystem("EPSG:4326").toGeocentricCrs()
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(), "+proj=geocent +datum=WGS84 +units=m +no_defs +type=crs"
+        )
+        self.assertEqual(crs.ellipsoidAcronym(), "EPSG:7030")
+        self.assertEqual(crs.celestialBodyName(), "Earth")
+
+        # non WGS84 datum
+        crs = QgsCoordinateReferenceSystem("EPSG:28356").toGeocentricCrs()
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(), "+proj=geocent +ellps=GRS80 +units=m +no_defs +type=crs"
+        )
+        self.assertEqual(crs.ellipsoidAcronym(), "EPSG:7019")
+        self.assertEqual(crs.celestialBodyName(), "Earth")
+
+        # non-earth ellipsoid, spherical
+        crs = QgsCoordinateReferenceSystem("ESRI:103883").toGeocentricCrs()
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(),
+            "+proj=geocent +R=3396190 +units=m +no_defs +type=crs",
+        )
+        self.assertEqual(crs.ellipsoidAcronym(), "PARAMETER:3396190:3396190")
+        self.assertEqual(crs.celestialBodyName(), "Mars")
+
+        # non-earth ellipsoid, ellipsoidal
+        crs = QgsCoordinateReferenceSystem("IAU_2015:49936").toGeocentricCrs()
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(),
+            "+proj=geocent +a=3396190 +b=3376200 +units=m +no_defs +type=crs",
+        )
+        self.assertEqual(crs.ellipsoidAcronym(), "IAU_2015:49901")
+        self.assertEqual(crs.celestialBodyName(), "Mars")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgscoordinatereferencesystem.py
+++ b/tests/src/python/test_qgscoordinatereferencesystem.py
@@ -141,6 +141,43 @@ class TestQgsCoordinateReferenceSystem(QgisTestCase):
         self.assertEqual(crs.ellipsoidAcronym(), "IAU_2015:49901")
         self.assertEqual(crs.celestialBodyName(), "Mars")
 
+        # vertical crs
+        crs = QgsCoordinateReferenceSystem("EPSG:5703").toGeocentricCrs()
+        self.assertFalse(crs.isValid())
+
+        # compound crs
+        crs = QgsCoordinateReferenceSystem("EPSG:5500").toGeocentricCrs()
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(),
+            "+proj=geocent +ellps=GRS80 +units=m +no_defs +type=crs",
+        )
+        self.assertEqual(crs.ellipsoidAcronym(), "EPSG:7019")
+        self.assertEqual(crs.celestialBodyName(), "Earth")
+
+        # bound crs
+        bound_crs = QgsCoordinateReferenceSystem()
+        bound_crs.createFromWkt(
+            """BOUNDCRS[SOURCECRS[PROJCRS["MGI / Austria Lambert",BASEGEOGCRS["MGI",DATUM["Militar-Geographische Institut",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]]],CONVERSION["unnamed",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Longitude of false origin",13.3333333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of false origin",47.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Easting at false origin",400000,LENGTHUNIT["m",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",400000,LENGTHUNIT["m",1],ID["EPSG",8827]],PARAMETER["scale_factor",1,SCALEUNIT["unity",1]],PARAMETER["Latitude of 2nd standard parallel",46,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]]],CS[Cartesian,2],AXIS["easting",east,ORDER[1],LENGTHUNIT["m",1]],AXIS["northing",north,ORDER[2],LENGTHUNIT["m",1]],ID["EPSG",31287]]],TARGETCRS[GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["latitude",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["longitude",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]]],ABRIDGEDTRANSFORMATION["Transformation from MGI to WGS84",METHOD["Position Vector transformation (geog2D domain)",ID["EPSG",9606]],PARAMETER["X-axis translation",601.705,ID["EPSG",8605]],PARAMETER["Y-axis translation",84.263,ID["EPSG",8606]],PARAMETER["Z-axis translation",485.227,ID["EPSG",8607]],PARAMETER["X-axis rotation",4.7354,ID["EPSG",8608]],PARAMETER["Y-axis rotation",-1.3145,ID["EPSG",8609]],PARAMETER["Z-axis rotation",-5.393,ID["EPSG",8610]],PARAMETER["Scale difference",0.9999976113,ID["EPSG",8611]]]]"""
+        )
+        self.assertTrue(bound_crs.isValid())
+        self.assertEqual(bound_crs.type(), Qgis.CrsType.Bound)
+        crs = bound_crs.toGeocentricCrs()
+        self.assertTrue(crs.isValid())
+        self.assertEqual(crs.type(), Qgis.CrsType.Geocentric)
+        self.assertEqual(
+            crs.toProj(),
+            "+proj=geocent +ellps=bessel +units=m +no_defs +type=crs",
+        )
+        self.assertAlmostEqual(
+            float(crs.ellipsoidAcronym().split(":")[1]), 6377397.155, -1
+        )
+        self.assertAlmostEqual(
+            float(crs.ellipsoidAcronym().split(":")[2]), 6356078.962818189, -1
+        )
+        self.assertEqual(crs.celestialBodyName(), "Earth")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds:

- QgsCoordinateReferenceSystem::createGeocentricCrs, which takes an ellipsoid acronym and builds a matching geocentric CRS
- QgsCoordinateReferenceSystem::toGeocentricCrs, which takes an existing CRS and returns a corresponding geocentric CRS with the same datum/datum ensemble