### PR TITLE
[3D] Fix empty scene with cross-section and extent not intersecting

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -210,6 +210,12 @@ Disables OpenGL clipping.
 
 
 
+    QList<QVector4D> clipPlaneEquations() const;
+%Docstring
+Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+
+.. versionadded:: 3.44
+%End
 
   signals:
     void terrainEntityChanged();

--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -212,7 +212,8 @@ Disables OpenGL clipping.
 
     QList<QVector4D> clipPlaneEquations() const;
 %Docstring
-Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+Returns list of clipping planes if clipping is enabled, otherwise an
+empty list.
 
 .. versionadded:: 3.44
 %End

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -210,6 +210,12 @@ Disables OpenGL clipping.
 
 
 
+    QList<QVector4D> clipPlaneEquations() const;
+%Docstring
+Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+
+.. versionadded:: 3.44
+%End
 
   signals:
     void terrainEntityChanged();

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -212,7 +212,8 @@ Disables OpenGL clipping.
 
     QList<QVector4D> clipPlaneEquations() const;
 %Docstring
-Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+Returns list of clipping planes if clipping is enabled, otherwise an
+empty list.
 
 .. versionadded:: 3.44
 %End

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -291,7 +291,8 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     void removeSceneEntity( Qgs3DMapSceneEntity *entity ) SIP_SKIP;
 
     /**
-     * Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+     * Returns list of clipping planes if clipping is enabled, otherwise an
+     * empty list.
      *
      * \since QGIS 3.44
      */

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -290,6 +290,13 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
      */
     void removeSceneEntity( Qgs3DMapSceneEntity *entity ) SIP_SKIP;
 
+    /**
+     * Returns list of clipping planes if clipping is enabled, otherwise an empty list.
+     *
+     * \since QGIS 3.44
+     */
+    QList<QVector4D> clipPlaneEquations() const { return mClipPlanesEquations; };
+
 #ifndef SIP_RUN
     //! Static function for returning open 3D map scenes
     static std::function<QMap<QString, Qgs3DMapScene *>()> sOpenScenesFunction;

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1180,6 +1180,15 @@ void Qgs3DMapCanvasWidget::setSceneExtent( const QgsRectangle &extent )
   if ( !extent.isEmpty() )
     mCanvas->mapSettings()->setExtent( extent );
 
+  if ( !mapCanvas3D()->scene()->clipPlaneEquations().isEmpty() )
+  {
+    if ( !mMapToolClippingPlanes->clippedPolygon().intersects( extent ) )
+    {
+      disableClippingPlanes();
+      mMessageBar->pushInfo( QString(), tr( "Cross-section has been disabled, because it's outside current extent" ) );
+    }
+  }
+
   if ( mMapToolPrevious )
     mMainCanvas->setMapTool( mMapToolPrevious );
   else

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1185,7 +1185,7 @@ void Qgs3DMapCanvasWidget::setSceneExtent( const QgsRectangle &extent )
     if ( !mMapToolClippingPlanes->clippedPolygon().intersects( extent ) )
     {
       disableClippingPlanes();
-      mMessageBar->pushInfo( QString(), tr( "Cross-section has been disabled, because it's outside current extent" ) );
+      mMessageBar->pushInfo( QString(), tr( "Cross-section has been disabled, because it is outside the current extent" ) );
     }
   }
 

--- a/src/app/3d/qgsmaptoolclippingplanes.cpp
+++ b/src/app/3d/qgsmaptoolclippingplanes.cpp
@@ -186,3 +186,8 @@ void QgsMapToolClippingPlanes::clearHighLightedArea() const
 {
   mRubberBandPolygon->reset( Qgis::GeometryType::Polygon );
 }
+
+QgsGeometry QgsMapToolClippingPlanes::clippedPolygon() const
+{
+  return mRubberBandPolygon->asGeometry();
+}

--- a/src/app/3d/qgsmaptoolclippingplanes.h
+++ b/src/app/3d/qgsmaptoolclippingplanes.h
@@ -49,6 +49,8 @@ class QgsMapToolClippingPlanes : public QgsMapTool
     void clear() const;
     //! Removes the tool's rubber band from canvas, which highlights the cross-section.
     void clearHighLightedArea() const;
+    //! Returns the Geometry of clipped area
+    QgsGeometry clippedPolygon() const;
 
   private:
     void clearRubberBand() const;


### PR DESCRIPTION
## Description
This PR builds on top of #61162 and fixes a bug found by @ptitjano in #61057. Now the set cross-section will get disabled if the new extent is outside of the cross-section with a warning.

https://github.com/user-attachments/assets/3886997d-71ca-4d3a-85cf-a4215dbb3270



