### PR TITLE
add creation options support to the raster terrain analysis class

### DIFF
--- a/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -52,20 +52,20 @@ Starts the calculation, reads from mInputFile and stores the result in mOutputFi
     double outputNodataValue() const;
     void setOutputNodataValue( double value );
 
-    void setCreateOptions( const QStringList &list );
+    void setCreationOptions( const QStringList &list );
 %Docstring
 Sets a list of data source creation options to use when creating the output raster file.
 
-.. seealso:: :py:func:`createOptions`
+.. seealso:: :py:func:`creationOptions`
 
 .. versionadded:: 3.44
 %End
 
-    QStringList createOptions() const;
+    QStringList creationOptions() const;
 %Docstring
 Returns the list of data source creation options which will be used when creating the output raster file.
 
-.. seealso:: :py:func:`setCreateOptions`
+.. seealso:: :py:func:`setCreationOptions`
 
 .. versionadded:: 3.44
 %End

--- a/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -52,6 +52,24 @@ Starts the calculation, reads from mInputFile and stores the result in mOutputFi
     double outputNodataValue() const;
     void setOutputNodataValue( double value );
 
+    void setCreateOptions( const QStringList &list );
+%Docstring
+Sets a list of data source creation options to use when creating the output raster file.
+
+.. seealso:: :py:func:`createOptions`
+
+.. versionadded:: 3.44
+%End
+
+    QStringList createOptions() const;
+%Docstring
+Returns the list of data source creation options which will be used when creating the output raster file.
+
+.. seealso:: :py:func:`setCreateOptions`
+
+.. versionadded:: 3.44
+%End
+
     virtual float processNineCellWindow( float *x11, float *x21, float *x31, float *x12, float *x22, float *x32, float *x13, float *x23, float *x33 ) = 0;
 %Docstring
 Calculates output value from nine input values. The input values and the output

--- a/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -52,20 +52,20 @@ Starts the calculation, reads from mInputFile and stores the result in mOutputFi
     double outputNodataValue() const;
     void setOutputNodataValue( double value );
 
-    void setCreateOptions( const QStringList &list );
+    void setCreationOptions( const QStringList &list );
 %Docstring
 Sets a list of data source creation options to use when creating the output raster file.
 
-.. seealso:: :py:func:`createOptions`
+.. seealso:: :py:func:`creationOptions`
 
 .. versionadded:: 3.44
 %End
 
-    QStringList createOptions() const;
+    QStringList creationOptions() const;
 %Docstring
 Returns the list of data source creation options which will be used when creating the output raster file.
 
-.. seealso:: :py:func:`setCreateOptions`
+.. seealso:: :py:func:`setCreationOptions`
 
 .. versionadded:: 3.44
 %End

--- a/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -52,6 +52,24 @@ Starts the calculation, reads from mInputFile and stores the result in mOutputFi
     double outputNodataValue() const;
     void setOutputNodataValue( double value );
 
+    void setCreateOptions( const QStringList &list );
+%Docstring
+Sets a list of data source creation options to use when creating the output raster file.
+
+.. seealso:: :py:func:`createOptions`
+
+.. versionadded:: 3.44
+%End
+
+    QStringList createOptions() const;
+%Docstring
+Returns the list of data source creation options which will be used when creating the output raster file.
+
+.. seealso:: :py:func:`setCreateOptions`
+
+.. versionadded:: 3.44
+%End
+
     virtual float processNineCellWindow( float *x11, float *x21, float *x31, float *x12, float *x22, float *x32, float *x13, float *x23, float *x33 ) = 0;
 %Docstring
 Calculates output value from nine input values. The input values and the output

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -130,6 +130,7 @@ gdal::dataset_unique_ptr QgsNineCellFilter::openOutputFile( GDALDatasetH inputDa
   //open output file
   char **papszOptions = QgsGdalUtils::papszFromStringList( mCreateOptions );
   gdal::dataset_unique_ptr outputDataset( GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 1, GDT_Float32, papszOptions ) );
+  CSLDestroy( papszOptions );
   if ( !outputDataset )
   {
     return outputDataset;

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -128,7 +128,7 @@ gdal::dataset_unique_ptr QgsNineCellFilter::openOutputFile( GDALDatasetH inputDa
   const int ySize = GDALGetRasterYSize( inputDataset );
 
   //open output file
-  char **papszOptions = QgsGdalUtils::papszFromStringList( mCreateOptions );
+  char **papszOptions = QgsGdalUtils::papszFromStringList( mCreationOptions );
   gdal::dataset_unique_ptr outputDataset( GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 1, GDT_Float32, papszOptions ) );
   CSLDestroy( papszOptions );
   if ( !outputDataset )

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -33,7 +33,6 @@
 #include <QFileInfo>
 #include <iterator>
 
-
 QgsNineCellFilter::QgsNineCellFilter( const QString &inputFile, const QString &outputFile, const QString &outputFormat )
   : mInputFile( inputFile )
   , mOutputFile( outputFile )
@@ -129,7 +128,7 @@ gdal::dataset_unique_ptr QgsNineCellFilter::openOutputFile( GDALDatasetH inputDa
   const int ySize = GDALGetRasterYSize( inputDataset );
 
   //open output file
-  char **papszOptions = nullptr;
+  char **papszOptions = QgsGdalUtils::papszFromStringList( mCreateOptions );
   gdal::dataset_unique_ptr outputDataset( GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 1, GDT_Float32, papszOptions ) );
   if ( !outputDataset )
   {

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -202,9 +202,8 @@ int QgsNineCellFilter::processRasterGPU( const QString &source, QgsFeedback *fee
   {
     return 5;
   }
-  //try to set -9999 as nodata value
-  GDALSetRasterNoDataValue( outputRasterBand, -9999 );
-  mOutputNodataValue = GDALGetRasterNoDataValue( outputRasterBand, nullptr );
+  // set nodata value
+  GDALSetRasterNoDataValue( outputRasterBand, mOutputNodataValue );
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {
@@ -377,9 +376,8 @@ int QgsNineCellFilter::processRasterCPU( QgsFeedback *feedback )
   {
     return 5;
   }
-  //try to set -9999 as nodata value
-  GDALSetRasterNoDataValue( outputRasterBand, -9999 );
-  mOutputNodataValue = GDALGetRasterNoDataValue( outputRasterBand, nullptr );
+  // set nodata value
+  GDALSetRasterNoDataValue( outputRasterBand, mOutputNodataValue );
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -64,18 +64,18 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     /**
      * Sets a list of data source creation options to use when creating the output raster file.
      *
-     * \see createOptions()
+     * \see creationOptions()
      * \since QGIS 3.44
      */
-    void setCreateOptions( const QStringList &list ) { mCreateOptions = list; }
+    void setCreationOptions( const QStringList &list ) { mCreationOptions = list; }
 
     /**
      * Returns the list of data source creation options which will be used when creating the output raster file.
      *
-     * \see setCreateOptions()
+     * \see setCreationOptions()
      * \since QGIS 3.44
      */
-    QStringList createOptions() const { return mCreateOptions; }
+    QStringList creationOptions() const { return mCreationOptions; }
 
     /**
      * Calculates output value from nine input values. The input values and the output
@@ -154,7 +154,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     QString mInputFile;
     QString mOutputFile;
     QString mOutputFormat;
-    QStringList mCreateOptions;
+    QStringList mCreationOptions;
 
     double mCellSizeX = -1.0;
     double mCellSizeY = -1.0;

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -62,6 +62,22 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     void setOutputNodataValue( double value ) { mOutputNodataValue = value; }
 
     /**
+     * Sets a list of data source creation options to use when creating the output raster file.
+     *
+     * \see createOptions()
+     * \since QGIS 3.44
+     */
+    void setCreateOptions( const QStringList &list ) { mCreateOptions = list; }
+
+    /**
+     * Returns the list of data source creation options which will be used when creating the output raster file.
+     *
+     * \see setCreateOptions()
+     * \since QGIS 3.44
+     */
+    QStringList createOptions() const { return mCreateOptions; }
+
+    /**
      * Calculates output value from nine input values. The input values and the output
      * value can be equal to the nodata value if not present or outside of the border.
      * Must be implemented by subclasses.
@@ -138,6 +154,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     QString mInputFile;
     QString mOutputFile;
     QString mOutputFormat;
+    QStringList mCreateOptions;
 
     double mCellSizeX = -1.0;
     double mCellSizeY = -1.0;

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -159,9 +159,9 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     double mCellSizeX = -1.0;
     double mCellSizeY = -1.0;
     //! The nodata value of the input layer
-    float mInputNodataValue = -1.0;
+    double mInputNodataValue = -1.0;
     //! The nodata value of the output layer
-    float mOutputNodataValue = -1.0;
+    double mOutputNodataValue = -9999.0;
     //! Scale factor for z-value if x-/y- units are different to z-units (111120 for degree->meters and 370400 for degree->feet)
     double mZFactor = 1.0;
 };

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -697,6 +697,7 @@ gdal::dataset_unique_ptr QgsRasterCalculator::openOutputFile( GDALDriverH output
   //open output file
   char **papszOptions = QgsGdalUtils::papszFromStringList( mCreateOptions );
   gdal::dataset_unique_ptr outputDataset( GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), mNumOutputColumns, mNumOutputRows, 1, GDT_Float32, papszOptions ) );
+  CSLDestroy( papszOptions );
   if ( !outputDataset )
   {
     return nullptr;

--- a/tests/src/analysis/testqgsninecellfilters.cpp
+++ b/tests/src/analysis/testqgsninecellfilters.cpp
@@ -60,7 +60,7 @@ class TestNineCellFilters : public QgsTest
     void testRuggednessCl();
 #endif
 
-    void testCreationOptinos();
+    void testCreationOptions();
     void testNoDataValue();
 
   private:
@@ -226,7 +226,7 @@ void TestNineCellFilters::testTotalCurvature()
   _testAlg<QgsTotalCurvatureFilter>( QStringLiteral( "totalcurvature" ) );
 }
 
-void TestNineCellFilters::testCreationOptinos()
+void TestNineCellFilters::testCreationOptions()
 {
   QString tmpFile( tempFile( QStringLiteral( "createopts" ) ) );
 
@@ -235,7 +235,7 @@ void TestNineCellFilters::testCreationOptinos()
   QVERIFY( !worldFile.exists() );
 
   QgsAspectFilter ninecellFilter( SRC_FILE, tmpFile, "GTiff" );
-  ninecellFilter.setCreateOptions( QStringList() << "TFW=YES" );
+  ninecellFilter.setCreationOptions( QStringList() << "TFW=YES" );
   const int res = ninecellFilter.processRaster();
   QVERIFY( res == 0 );
 


### PR DESCRIPTION
## Description

Add support for raster creation options and user-defined NODATA value to `QgsNineCellFilter` class which is used in various terrain analysis tools (e.g. slope, aspect, etc.)

This is API-only change, GUI part is coming in the follow-up pull-request.