### PR TITLE
[symbology] Fix [categorized,graduated] symbol renderer UUID collision leading to unstable experience

### DIFF
--- a/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -144,6 +144,7 @@ document and ``element``.
 %End
 
   protected:
+
 };
 
 typedef QList<QgsRendererCategory> QgsCategoryList;

--- a/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -184,6 +184,7 @@ Creates a DOM element representing the range in SLD format.
 %End
 
   protected:
+
 };
 
 typedef QList<QgsRendererRange> QgsRangeList;

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -144,6 +144,7 @@ document and ``element``.
 %End
 
   protected:
+
 };
 
 typedef QList<QgsRendererCategory> QgsCategoryList;

--- a/python/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -184,6 +184,7 @@ Creates a DOM element representing the range in SLD format.
 %End
 
   protected:
+
 };
 
 typedef QList<QgsRendererRange> QgsRangeList;

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -773,6 +773,7 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
 
   QDomElement catElem = catsElem.firstChildElement();
   int i = 0;
+  QStringList usedUuids;
   while ( !catElem.isNull() )
   {
     if ( catElem.tagName() == QLatin1String( "category" ) )
@@ -801,10 +802,15 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
       QString label = catElem.attribute( QStringLiteral( "label" ) );
       bool render = catElem.attribute( QStringLiteral( "render" ) ) != QLatin1String( "false" );
       QString uuid = catElem.attribute( QStringLiteral( "uuid" ), QString::number( i++ ) );
+      while ( usedUuids.contains( uuid ) )
+      {
+        uuid = QUuid::createUuid().toString();
+      }
       if ( symbolMap.contains( symbolName ) )
       {
         QgsSymbol *symbol = symbolMap.take( symbolName );
         cats.append( QgsRendererCategory( value, symbol, label, render, uuid ) );
+        usedUuids << uuid;
       }
     }
     catElem = catElem.nextSiblingElement();

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -773,7 +773,7 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
 
   QDomElement catElem = catsElem.firstChildElement();
   int i = 0;
-  QStringList usedUuids;
+  QSet<QString> usedUuids;
   while ( !catElem.isNull() )
   {
     if ( catElem.tagName() == QLatin1String( "category" ) )

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -147,6 +147,8 @@ class CORE_EXPORT QgsRendererCategory
 #endif
 
   protected:
+    friend class QgsCategorizedSymbolRendererWidget;
+
     QVariant mValue;
     std::unique_ptr<QgsSymbol> mSymbol;
     QString mLabel;

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -492,6 +492,7 @@ QgsFeatureRenderer *QgsGraduatedSymbolRenderer::create( QDomElement &element, co
 
   QDomElement rangeElem = rangesElem.firstChildElement();
   int i = 0;
+  QStringList usedUuids;
   while ( !rangeElem.isNull() )
   {
     if ( rangeElem.tagName() == QLatin1String( "range" ) )
@@ -502,10 +503,15 @@ QgsFeatureRenderer *QgsGraduatedSymbolRenderer::create( QDomElement &element, co
       QString label = rangeElem.attribute( QStringLiteral( "label" ) );
       bool render = rangeElem.attribute( QStringLiteral( "render" ), QStringLiteral( "true" ) ) != QLatin1String( "false" );
       QString uuid = rangeElem.attribute( QStringLiteral( "uuid" ), QString::number( i++ ) );
+      while ( usedUuids.contains( uuid ) )
+      {
+        uuid = QUuid::createUuid().toString();
+      }
       if ( symbolMap.contains( symbolName ) )
       {
         QgsSymbol *symbol = symbolMap.take( symbolName );
         ranges.append( QgsRendererRange( lowerValue, upperValue, symbol, label, render, uuid ) );
+        usedUuids << uuid;
       }
     }
     rangeElem = rangeElem.nextSiblingElement();

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -492,7 +492,7 @@ QgsFeatureRenderer *QgsGraduatedSymbolRenderer::create( QDomElement &element, co
 
   QDomElement rangeElem = rangesElem.firstChildElement();
   int i = 0;
-  QStringList usedUuids;
+  QSet<QString> usedUuids;
   while ( !rangeElem.isNull() )
   {
     if ( rangeElem.tagName() == QLatin1String( "range" ) )

--- a/src/core/symbology/qgsrendererrange.h
+++ b/src/core/symbology/qgsrendererrange.h
@@ -192,6 +192,8 @@ class CORE_EXPORT QgsRendererRange
 #endif
 
   protected:
+    friend class QgsGraduatedSymbolRendererWidget;
+
     double mLowerValue = 0, mUpperValue = 0;
     std::unique_ptr<QgsSymbol> mSymbol;
     QString mLabel;

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -51,6 +51,7 @@
 #include <QClipboard>
 #include <QPointer>
 #include <QScreen>
+#include <QUuid>
 
 ///@cond PRIVATE
 
@@ -1361,9 +1362,10 @@ void QgsCategorizedSymbolRendererWidget::keyPressEvent( QKeyEvent *event )
   }
   else if ( event->key() == Qt::Key_V && event->modifiers() == Qt::ControlModifier )
   {
-    QgsCategoryList::const_iterator rIt = mCopyBuffer.constBegin();
-    for ( ; rIt != mCopyBuffer.constEnd(); ++rIt )
+    QgsCategoryList::iterator rIt = mCopyBuffer.begin();
+    for ( ; rIt != mCopyBuffer.end(); ++rIt )
     {
+      rIt->mUuid = QUuid::createUuid().toString();
       mModel->addCategory( *rIt );
     }
   }

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -24,6 +24,7 @@
 #include <QCompleter>
 #include <QPointer>
 #include <QScreen>
+#include <QUuid>
 
 #include "qgsgraduatedsymbolrendererwidget.h"
 #include "moc_qgsgraduatedsymbolrendererwidget.cpp"
@@ -1453,9 +1454,10 @@ void QgsGraduatedSymbolRendererWidget::keyPressEvent( QKeyEvent *event )
   }
   else if ( event->key() == Qt::Key_V && event->modifiers() == Qt::ControlModifier )
   {
-    QgsRangeList::const_iterator rIt = mCopyBuffer.constBegin();
-    for ( ; rIt != mCopyBuffer.constEnd(); ++rIt )
+    QgsRangeList::iterator rIt = mCopyBuffer.begin();
+    for ( ; rIt != mCopyBuffer.end(); ++rIt )
     {
+      rIt->mUuid = QUuid::createUuid().toString();
       mModel->addClass( *rIt );
     }
     emit widgetChanged();


### PR DESCRIPTION
## Description

A long time ago, we added UUIDs to our categorized and graduated symbol renderers' categories/ranges to allow for stable map themes visibility experience.

One blind-spot has led to the introduction of duplicate UUIDs into user projects: when copy pasting (Ctrl+C, Ctrl+V) categories or ranges, the UUID of the copied item is pasted into the new item. This leads to issues when toggling the visibility of these categories and ranges via the layer tree panel, vector layer properties dialog, and style panel.

The PR fixes that by introducing a unique UUID when pasting items through the renderers' widget. In addition, logic was added to heal saved projects with duplicate UUIDs.