### PR TITLE
chore(code_layout): use env var and pipe to bypass the "Argument list too long" error (again)

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -170,8 +170,8 @@ jobs:
       - name: Spell Test
         if: steps.changed_files.outputs.any_changed == 'true'
         env:
-          ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}
-        run: echo "$ALL_CHANGED_FILES" | ./scripts/spell_check/check_spelling.sh
+          ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.changed_files }}
+        run: ./scripts/spell_check/check_spelling.sh
 
   sip_check:
     runs-on: ubuntu-latest

--- a/scripts/spell_check/check_spelling.sh
+++ b/scripts/spell_check/check_spelling.sh
@@ -61,16 +61,24 @@ while getopts ":rdl:" opt; do
 done
 shift $((OPTIND - 1))
 
-# check pipe or command line
-if [ -p /dev/stdin ]; then
-  # with pipe input
+# check if file list is provided
+# * from a pipe or from a file
+# * from ALL_CHANGED_FILES env var
+# * from command line parameters
+if [ -p /dev/stdin ] || [ ! -t 0 ]; then
+  # read from pipe input or file
   read SCRIPT_INPUT
   if [ -z "$SCRIPT_INPUT" ]; then
     exit 0
   fi
 else
-  # no pipe input
-  SCRIPT_INPUT="$@"
+  if [ -z "$ALL_CHANGED_FILES" ]; then
+    # read from command line parameters
+    SCRIPT_INPUT="$@"
+  else
+    # read from env var
+    SCRIPT_INPUT="$ALL_CHANGED_FILES"
+  fi
 fi
 
 if [ -n "$SCRIPT_INPUT" ]; then
@@ -82,6 +90,7 @@ if [ -n "$SCRIPT_INPUT" ]; then
   echo "Running spell check on files: $INPUTFILES"
 else
   INPUTFILES="."
+  echo "Running spell check on all files!"
 fi
 
 # regex to find escape string


### PR DESCRIPTION
When there are too many files the command `echo "$ALL_CHANGED_FILES" | ./scripts/spell_check/check_spelling.sh` failed with error "Argument list too long". This PR allows `check_spelling.sh` to read file list from `ALL_CHANGED_FILES` env var.