### PR TITLE
[core] Allow for changing the connection pool's maximum number of concurrent connections count

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -132,7 +132,7 @@ const QgsSettingsEntryBool *QgsApplication::settingsLocaleShowGroupSeparator = n
 
 const QgsSettingsEntryStringList *QgsApplication::settingsSearchPathsForSVG = new QgsSettingsEntryStringList( QStringLiteral( "searchPathsForSVG" ), QgsSettingsTree::sTreeSvg, QStringList() );
 
-const QgsSettingsEntryInteger *QgsApplication::settingsConnectionPoolMaximumConcurrentConnections = new QgsSettingsEntryInteger( QStringLiteral( "connection-pool-maximum-concurrent-connections" ), QgsSettingsTree::sTreeCore, 4, QObject::tr( "Maximum number of concurrent connections per connection pool" ) );
+const QgsSettingsEntryInteger *QgsApplication::settingsConnectionPoolMaximumConcurrentConnections = new QgsSettingsEntryInteger( QStringLiteral( "connection-pool-maximum-concurrent-connections" ), QgsSettingsTree::sTreeCore, 4, QObject::tr( "Maximum number of concurrent connections per connection pool" ), Qgis::SettingsOptions(), 4, 999 );
 
 #ifndef Q_OS_WIN
 #include <netinet/in.h>

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -132,6 +132,8 @@ const QgsSettingsEntryBool *QgsApplication::settingsLocaleShowGroupSeparator = n
 
 const QgsSettingsEntryStringList *QgsApplication::settingsSearchPathsForSVG = new QgsSettingsEntryStringList( QStringLiteral( "searchPathsForSVG" ), QgsSettingsTree::sTreeSvg, QStringList() );
 
+const QgsSettingsEntryInteger *QgsApplication::settingsConnectionPoolMaximumConcurrentConnections = new QgsSettingsEntryInteger( QStringLiteral( "connection-pool-maximum-concurrent-connections" ), QgsSettingsTree::sTreeCore, 4, QObject::tr( "Maximum number of concurrent connections per connection pool" ) );
+
 #ifndef Q_OS_WIN
 #include <netinet/in.h>
 #include <pwd.h>
@@ -2105,7 +2107,7 @@ int QgsApplication::scaleIconSize( int standardSize, bool applyDevicePixelRatio 
 
 int QgsApplication::maxConcurrentConnectionsPerPool() const
 {
-  return CONN_POOL_MAX_CONCURRENT_CONNS;
+  return settingsConnectionPoolMaximumConcurrentConnections->value();
 }
 
 void QgsApplication::setTranslation( const QString &translation )

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -1090,6 +1090,8 @@ class CORE_EXPORT QgsApplication : public QApplication
     static const QgsSettingsEntryBool *settingsLocaleShowGroupSeparator;
     //! Settings entry search path for SVG
     static const QgsSettingsEntryStringList *settingsSearchPathsForSVG;
+    //! Settings entry to configure the maximum number of concurrent connections within connection pools
+    static const QgsSettingsEntryInteger *settingsConnectionPoolMaximumConcurrentConnections;
 #endif
 
 #ifdef SIP_RUN


### PR DESCRIPTION

## Description

This PR introduces an advanced setting allowing users to modify the maximum number of concurrent connections per connection pool:

![Screenshot From 2025-04-03 18-18-40](https://github.com/user-attachments/assets/b44656c5-4b50-4d02-a123-2cc822c4433b)

Until now, the maximum was hardcoded to 4. While it works without problem for most scenarios, there complex scenarios where that arbitrary value leads to a hard deadlock of QGIS. 

Over time, the API has tried to allow for some form of flexibility (see QgsFeatureRequest's requestMayBeNested), but ultimately, sometimes there's nothing but increase the value that would do.

I've got this project here with the following setup:
- 5 vector layers all located within a single geopackage file
- 3-4 virtual vector layer with complex definition that involves joining 4 of those above-mentioned 5 vector layers

The virtual vector layers are defined within .qlr files. If dragging more than one vector layer, QGIS will simply deadlock while doing parallel rendering as multiple threads will only be able to acquire a partial number of its connections for a virtual layer.

In this above scenario, 4 concurrent connections is just not enough.