### PR TITLE
use enum for return value instead of plain int in the QgsNineCellFilter

### DIFF
--- a/python/PyQt6/analysis/auto_additions/qgsninecellfilter.py
+++ b/python/PyQt6/analysis/auto_additions/qgsninecellfilter.py
@@ -1,12 +1,27 @@
 # The following has been generated automatically from src/analysis/raster/qgsninecellfilter.h
-QgsNineCellFilter.Success = QgsNineCellFilter.Result.Success
-QgsNineCellFilter.InputLayerError = QgsNineCellFilter.Result.InputLayerError
-QgsNineCellFilter.DriverError = QgsNineCellFilter.Result.DriverError
-QgsNineCellFilter.CreateOutputError = QgsNineCellFilter.Result.CreateOutputError
-QgsNineCellFilter.InputBandError = QgsNineCellFilter.Result.InputBandError
-QgsNineCellFilter.OutputBandError = QgsNineCellFilter.Result.OutputBandError
-QgsNineCellFilter.RasterSizeError = QgsNineCellFilter.Result.RasterSizeError
-QgsNineCellFilter.Canceled = QgsNineCellFilter.Result.Canceled
+# monkey patching scoped based enum
+QgsNineCellFilter.Result.Success.__doc__ = "Operation completed successfully"
+QgsNineCellFilter.Result.InputLayerError.__doc__ = "Error reading input file"
+QgsNineCellFilter.Result.DriverError.__doc__ = "Could not open the driver for the specified format"
+QgsNineCellFilter.Result.CreateOutputError.__doc__ = "Error creating output file"
+QgsNineCellFilter.Result.InputBandError.__doc__ = "Error reading input raster band"
+QgsNineCellFilter.Result.OutputBandError.__doc__ = "Error reading output raster band"
+QgsNineCellFilter.Result.RasterSizeError.__doc__ = "Raster height is too small (need at least 3 rows)"
+QgsNineCellFilter.Result.Canceled.__doc__ = "User canceled calculation"
+QgsNineCellFilter.Result.__doc__ = """
+.. versionadded:: 3.44
+
+* ``Success``: Operation completed successfully
+* ``InputLayerError``: Error reading input file
+* ``DriverError``: Could not open the driver for the specified format
+* ``CreateOutputError``: Error creating output file
+* ``InputBandError``: Error reading input raster band
+* ``OutputBandError``: Error reading output raster band
+* ``RasterSizeError``: Raster height is too small (need at least 3 rows)
+* ``Canceled``: User canceled calculation
+
+"""
+# --
 try:
     QgsNineCellFilter.__abstract_methods__ = ['processNineCellWindow']
     QgsNineCellFilter.__group__ = ['raster']

--- a/python/PyQt6/analysis/auto_additions/qgsninecellfilter.py
+++ b/python/PyQt6/analysis/auto_additions/qgsninecellfilter.py
@@ -1,4 +1,12 @@
 # The following has been generated automatically from src/analysis/raster/qgsninecellfilter.h
+QgsNineCellFilter.Success = QgsNineCellFilter.Result.Success
+QgsNineCellFilter.InputLayerError = QgsNineCellFilter.Result.InputLayerError
+QgsNineCellFilter.DriverError = QgsNineCellFilter.Result.DriverError
+QgsNineCellFilter.CreateOutputError = QgsNineCellFilter.Result.CreateOutputError
+QgsNineCellFilter.InputBandError = QgsNineCellFilter.Result.InputBandError
+QgsNineCellFilter.OutputBandError = QgsNineCellFilter.Result.OutputBandError
+QgsNineCellFilter.RasterSizeError = QgsNineCellFilter.Result.RasterSizeError
+QgsNineCellFilter.Canceled = QgsNineCellFilter.Result.Canceled
 try:
     QgsNineCellFilter.__abstract_methods__ = ['processNineCellWindow']
     QgsNineCellFilter.__group__ = ['raster']

--- a/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -27,7 +27,7 @@ subclass
 #include "qgsninecellfilter.h"
 %End
   public:
-    enum Result /BaseType=IntEnum/
+    enum class Result /BaseType=IntEnum/
     {
       Success,
       InputLayerError,

--- a/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -27,6 +27,18 @@ subclass
 #include "qgsninecellfilter.h"
 %End
   public:
+    enum Result /BaseType=IntEnum/
+    {
+      Success,
+      InputLayerError,
+      DriverError,
+      CreateOutputError,
+      InputBandError,
+      OutputBandError,
+      RasterSizeError,
+      Canceled,
+    };
+
     QgsNineCellFilter( const QString &inputFile, const QString &outputFile, const QString &outputFormat );
 %Docstring
 Constructor that takes input file, output file and output format (GDAL
@@ -34,7 +46,7 @@ string)
 %End
     virtual ~QgsNineCellFilter();
 
-    int processRaster( QgsFeedback *feedback = 0 );
+    Result processRaster( QgsFeedback *feedback = 0 );
 %Docstring
 Starts the calculation, reads from mInputFile and stores the result in
 mOutputFile
@@ -42,7 +54,8 @@ mOutputFile
 :param feedback: feedback object that receives update and that is
                  checked for cancellation.
 
-:return: 0 in case of success
+:return: QgsNineCellFilter.Success in case of success or error value on
+         failure.
 %End
 
     double cellSizeX() const;

--- a/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -54,8 +54,8 @@ mOutputFile
 :param feedback: feedback object that receives update and that is
                  checked for cancellation.
 
-:return: QgsNineCellFilter.Success in case of success or error value on
-         failure.
+:return: QgsNineCellFilter.Result.Success in case of success or error
+         value on failure.
 %End
 
     double cellSizeX() const;

--- a/python/analysis/auto_additions/qgsninecellfilter.py
+++ b/python/analysis/auto_additions/qgsninecellfilter.py
@@ -1,4 +1,27 @@
 # The following has been generated automatically from src/analysis/raster/qgsninecellfilter.h
+# monkey patching scoped based enum
+QgsNineCellFilter.Result.Success.__doc__ = "Operation completed successfully"
+QgsNineCellFilter.Result.InputLayerError.__doc__ = "Error reading input file"
+QgsNineCellFilter.Result.DriverError.__doc__ = "Could not open the driver for the specified format"
+QgsNineCellFilter.Result.CreateOutputError.__doc__ = "Error creating output file"
+QgsNineCellFilter.Result.InputBandError.__doc__ = "Error reading input raster band"
+QgsNineCellFilter.Result.OutputBandError.__doc__ = "Error reading output raster band"
+QgsNineCellFilter.Result.RasterSizeError.__doc__ = "Raster height is too small (need at least 3 rows)"
+QgsNineCellFilter.Result.Canceled.__doc__ = "User canceled calculation"
+QgsNineCellFilter.Result.__doc__ = """
+.. versionadded:: 3.44
+
+* ``Success``: Operation completed successfully
+* ``InputLayerError``: Error reading input file
+* ``DriverError``: Could not open the driver for the specified format
+* ``CreateOutputError``: Error creating output file
+* ``InputBandError``: Error reading input raster band
+* ``OutputBandError``: Error reading output raster band
+* ``RasterSizeError``: Raster height is too small (need at least 3 rows)
+* ``Canceled``: User canceled calculation
+
+"""
+# --
 try:
     QgsNineCellFilter.__abstract_methods__ = ['processNineCellWindow']
     QgsNineCellFilter.__group__ = ['raster']

--- a/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -27,7 +27,7 @@ subclass
 #include "qgsninecellfilter.h"
 %End
   public:
-    enum Result
+    enum class Result
     {
       Success,
       InputLayerError,

--- a/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -54,8 +54,8 @@ mOutputFile
 :param feedback: feedback object that receives update and that is
                  checked for cancellation.
 
-:return: QgsNineCellFilter.Success in case of success or error value on
-         failure.
+:return: QgsNineCellFilter.Result.Success in case of success or error
+         value on failure.
 %End
 
     double cellSizeX() const;

--- a/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -27,6 +27,18 @@ subclass
 #include "qgsninecellfilter.h"
 %End
   public:
+    enum Result
+    {
+      Success,
+      InputLayerError,
+      DriverError,
+      CreateOutputError,
+      InputBandError,
+      OutputBandError,
+      RasterSizeError,
+      Canceled,
+    };
+
     QgsNineCellFilter( const QString &inputFile, const QString &outputFile, const QString &outputFormat );
 %Docstring
 Constructor that takes input file, output file and output format (GDAL
@@ -34,7 +46,7 @@ string)
 %End
     virtual ~QgsNineCellFilter();
 
-    int processRaster( QgsFeedback *feedback = 0 );
+    Result processRaster( QgsFeedback *feedback = 0 );
 %Docstring
 Starts the calculation, reads from mInputFile and stores the result in
 mOutputFile
@@ -42,7 +54,8 @@ mOutputFile
 :param feedback: feedback object that receives update and that is
                  checked for cancellation.
 
-:return: 0 in case of success
+:return: QgsNineCellFilter.Success in case of success or error value on
+         failure.
 %End
 
     double cellSizeX() const;

--- a/scripts/sipify.py
+++ b/scripts/sipify.py
@@ -426,6 +426,7 @@ ALLOWED_NON_CLASS_ENUMS = [
     "QgsNewHttpConnection::ConnectionType",
     "QgsNewHttpConnection::Flag",
     "QgsNewHttpConnection::WfsVersionIndex",
+    "QgsNineCellFilter::Result",
     "QgsOfflineEditing::ContainerType",
     "QgsOfflineEditing::ProgressMode",
     "QgsOgcUtils::FilterVersion",

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -40,8 +40,7 @@ QgsNineCellFilter::QgsNineCellFilter( const QString &inputFile, const QString &o
 {
 }
 
-// TODO: return an anum instead of an int
-int QgsNineCellFilter::processRaster( QgsFeedback *feedback )
+QgsNineCellFilter::Result QgsNineCellFilter::processRaster( QgsFeedback *feedback )
 {
 #ifdef HAVE_OPENCL
   if ( QgsOpenClUtils::enabled() && QgsOpenClUtils::available() && !openClProgramBaseName().isEmpty() )
@@ -74,7 +73,7 @@ int QgsNineCellFilter::processRaster( QgsFeedback *feedback )
     return processRasterCPU( feedback );
   }
 #ifndef _MSC_VER
-  return 1;
+  return InputLayerError;
 #endif
 #else
   return processRasterCPU( feedback );
@@ -115,7 +114,6 @@ GDALDriverH QgsNineCellFilter::openOutputDriver()
 
   return outputDriver;
 }
-
 
 gdal::dataset_unique_ptr QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver )
 {
@@ -164,8 +162,7 @@ gdal::dataset_unique_ptr QgsNineCellFilter::openOutputFile( GDALDatasetH inputDa
 
 #ifdef HAVE_OPENCL
 
-// TODO: return an anum instead of an int
-int QgsNineCellFilter::processRasterGPU( const QString &source, QgsFeedback *feedback )
+QgsNineCellFilter::Result QgsNineCellFilter::processRasterGPU( const QString &source, QgsFeedback *feedback )
 {
   GDALAllRegister();
 
@@ -174,41 +171,41 @@ int QgsNineCellFilter::processRasterGPU( const QString &source, QgsFeedback *fee
   const gdal::dataset_unique_ptr inputDataset( openInputFile( xSize, ySize ) );
   if ( !inputDataset )
   {
-    return 1; //opening of input file failed
+    return InputLayerError; //opening of input file failed
   }
 
   //output driver
   GDALDriverH outputDriver = openOutputDriver();
   if ( !outputDriver )
   {
-    return 2;
+    return DriverError;
   }
 
   gdal::dataset_unique_ptr outputDataset( openOutputFile( inputDataset.get(), outputDriver ) );
   if ( !outputDataset )
   {
-    return 3; //create operation on output file failed
+    return CreateOutputError; //create operation on output file failed
   }
 
   //open first raster band for reading (operation is only for single band raster)
   GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !rasterBand )
   {
-    return 4;
+    return InputBandError;
   }
   mInputNodataValue = GDALGetRasterNoDataValue( rasterBand, nullptr );
 
   GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
   if ( !outputRasterBand )
   {
-    return 5;
+    return OutputBandError;
   }
   // set nodata value
   GDALSetRasterNoDataValue( outputRasterBand, mOutputNodataValue );
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {
-    return 6;
+    return RasterSizeError;
   }
 
   // Prepare context and queue
@@ -331,15 +328,14 @@ int QgsNineCellFilter::processRasterGPU( const QString &source, QgsFeedback *fee
   {
     //delete the dataset without closing (because it is faster)
     gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-    return 7;
+    return Canceled;
   }
-  return 0;
+  return Success;
 }
 #endif
 
 
-// TODO: return an anum instead of an int
-int QgsNineCellFilter::processRasterCPU( QgsFeedback *feedback )
+QgsNineCellFilter::Result QgsNineCellFilter::processRasterCPU( QgsFeedback *feedback )
 {
   GDALAllRegister();
 
@@ -348,41 +344,41 @@ int QgsNineCellFilter::processRasterCPU( QgsFeedback *feedback )
   const gdal::dataset_unique_ptr inputDataset( openInputFile( xSize, ySize ) );
   if ( !inputDataset )
   {
-    return 1; //opening of input file failed
+    return InputLayerError; //opening of input file failed
   }
 
   //output driver
   GDALDriverH outputDriver = openOutputDriver();
   if ( !outputDriver )
   {
-    return 2;
+    return DriverError;
   }
 
   gdal::dataset_unique_ptr outputDataset( openOutputFile( inputDataset.get(), outputDriver ) );
   if ( !outputDataset )
   {
-    return 3; //create operation on output file failed
+    return CreateOutputError; //create operation on output file failed
   }
 
   //open first raster band for reading (operation is only for single band raster)
   GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !rasterBand )
   {
-    return 4;
+    return InputBandError;
   }
   mInputNodataValue = GDALGetRasterNoDataValue( rasterBand, nullptr );
 
   GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
   if ( !outputRasterBand )
   {
-    return 5;
+    return OutputBandError;
   }
   // set nodata value
   GDALSetRasterNoDataValue( outputRasterBand, mOutputNodataValue );
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {
-    return 6;
+    return RasterSizeError;
   }
 
   //keep only three scanlines in memory at a time, make room for initial and final nodata
@@ -471,7 +467,7 @@ int QgsNineCellFilter::processRasterCPU( QgsFeedback *feedback )
   {
     //delete the dataset without closing (because it is faster)
     gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-    return 7;
+    return Canceled;
   }
-  return 0;
+  return Success;
 }

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -73,7 +73,7 @@ QgsNineCellFilter::Result QgsNineCellFilter::processRaster( QgsFeedback *feedbac
     return processRasterCPU( feedback );
   }
 #ifndef _MSC_VER
-  return InputLayerError;
+  return QgsNineCellFilter::Result::InputLayerError;
 #endif
 #else
   return processRasterCPU( feedback );
@@ -171,41 +171,41 @@ QgsNineCellFilter::Result QgsNineCellFilter::processRasterGPU( const QString &so
   const gdal::dataset_unique_ptr inputDataset( openInputFile( xSize, ySize ) );
   if ( !inputDataset )
   {
-    return InputLayerError; //opening of input file failed
+    return QgsNineCellFilter::Result::InputLayerError; //opening of input file failed
   }
 
   //output driver
   GDALDriverH outputDriver = openOutputDriver();
   if ( !outputDriver )
   {
-    return DriverError;
+    return QgsNineCellFilter::Result::DriverError;
   }
 
   gdal::dataset_unique_ptr outputDataset( openOutputFile( inputDataset.get(), outputDriver ) );
   if ( !outputDataset )
   {
-    return CreateOutputError; //create operation on output file failed
+    return QgsNineCellFilter::Result::CreateOutputError; //create operation on output file failed
   }
 
   //open first raster band for reading (operation is only for single band raster)
   GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !rasterBand )
   {
-    return InputBandError;
+    return QgsNineCellFilter::Result::InputBandError;
   }
   mInputNodataValue = GDALGetRasterNoDataValue( rasterBand, nullptr );
 
   GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
   if ( !outputRasterBand )
   {
-    return OutputBandError;
+    return QgsNineCellFilter::Result::OutputBandError;
   }
   // set nodata value
   GDALSetRasterNoDataValue( outputRasterBand, mOutputNodataValue );
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {
-    return RasterSizeError;
+    return QgsNineCellFilter::Result::RasterSizeError;
   }
 
   // Prepare context and queue
@@ -328,9 +328,9 @@ QgsNineCellFilter::Result QgsNineCellFilter::processRasterGPU( const QString &so
   {
     //delete the dataset without closing (because it is faster)
     gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-    return Canceled;
+    return QgsNineCellFilter::Result::Canceled;
   }
-  return Success;
+  return QgsNineCellFilter::Result::Success;
 }
 #endif
 
@@ -344,41 +344,41 @@ QgsNineCellFilter::Result QgsNineCellFilter::processRasterCPU( QgsFeedback *feed
   const gdal::dataset_unique_ptr inputDataset( openInputFile( xSize, ySize ) );
   if ( !inputDataset )
   {
-    return InputLayerError; //opening of input file failed
+    return QgsNineCellFilter::Result::InputLayerError; //opening of input file failed
   }
 
   //output driver
   GDALDriverH outputDriver = openOutputDriver();
   if ( !outputDriver )
   {
-    return DriverError;
+    return QgsNineCellFilter::Result::DriverError;
   }
 
   gdal::dataset_unique_ptr outputDataset( openOutputFile( inputDataset.get(), outputDriver ) );
   if ( !outputDataset )
   {
-    return CreateOutputError; //create operation on output file failed
+    return QgsNineCellFilter::Result::CreateOutputError; //create operation on output file failed
   }
 
   //open first raster band for reading (operation is only for single band raster)
   GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !rasterBand )
   {
-    return InputBandError;
+    return QgsNineCellFilter::Result::InputBandError;
   }
   mInputNodataValue = GDALGetRasterNoDataValue( rasterBand, nullptr );
 
   GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
   if ( !outputRasterBand )
   {
-    return OutputBandError;
+    return QgsNineCellFilter::Result::OutputBandError;
   }
   // set nodata value
   GDALSetRasterNoDataValue( outputRasterBand, mOutputNodataValue );
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {
-    return RasterSizeError;
+    return QgsNineCellFilter::Result::RasterSizeError;
   }
 
   //keep only three scanlines in memory at a time, make room for initial and final nodata
@@ -467,7 +467,7 @@ QgsNineCellFilter::Result QgsNineCellFilter::processRasterCPU( QgsFeedback *feed
   {
     //delete the dataset without closing (because it is faster)
     gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-    return Canceled;
+    return QgsNineCellFilter::Result::Canceled;
   }
-  return Success;
+  return QgsNineCellFilter::Result::Success;
 }

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -57,7 +57,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     /**
      * Starts the calculation, reads from mInputFile and stores the result in mOutputFile
      * \param feedback feedback object that receives update and that is checked for cancellation.
-     * \returns QgsNineCellFilter::Success in case of success or error value on failure.
+     * \returns QgsNineCellFilter::Result::Success in case of success or error value on failure.
      */
     Result processRaster( QgsFeedback *feedback = nullptr );
 
@@ -132,7 +132,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     /**
      * \brief processRasterCPU executes the computation on the CPU
      * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancellation
-     * \returns QgsNineCellFilter::Success in case of success or error value on failure
+     * \returns QgsNineCellFilter::Result::Success in case of success or error value on failure
      */
     Result processRasterCPU( QgsFeedback *feedback = nullptr );
 
@@ -142,7 +142,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
      * \brief processRasterGPU executes the computation on the GPU
      * \param source path to the OpenCL source file
      * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancellation
-     * \returns QgsNineCellFilter::Success in case of success or error value on failure
+     * \returns QgsNineCellFilter::Result::Success in case of success or error value on failure
      */
     Result processRasterGPU( const QString &source, QgsFeedback *feedback = nullptr );
 

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -38,7 +38,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
 {
   public:
     //! Result of the calculation \since QGIS 3.44
-    enum Result
+    enum class Result : int
     {
       Success = 0,           //!< Operation completed successfully
       InputLayerError = 1,   //!< Error reading input file

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -37,6 +37,19 @@ class QgsFeedback;
 class ANALYSIS_EXPORT QgsNineCellFilter
 {
   public:
+    //! Result of the calculation \since QGIS 3.44
+    enum Result
+    {
+      Success = 0,           //!< Operation completed successfully
+      InputLayerError = 1,   //!< Error reading input file
+      DriverError = 2,       //!< Could not open the driver for the specified format
+      CreateOutputError = 3, //!< Error creating output file
+      InputBandError = 4,    //!< Error reading input raster band
+      OutputBandError = 5,   //!< Error reading output raster band
+      RasterSizeError = 6,   //!< Raster height is too small (need at least 3 rows)
+      Canceled = 7,          //!< User canceled calculation
+    };
+
     //! Constructor that takes input file, output file and output format (GDAL string)
     QgsNineCellFilter( const QString &inputFile, const QString &outputFile, const QString &outputFormat );
     virtual ~QgsNineCellFilter() = default;
@@ -44,9 +57,9 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     /**
      * Starts the calculation, reads from mInputFile and stores the result in mOutputFile
      * \param feedback feedback object that receives update and that is checked for cancellation.
-     * \returns 0 in case of success
+     * \returns QgsNineCellFilter::Success in case of success or error value on failure.
      */
-    int processRaster( QgsFeedback *feedback = nullptr );
+    Result processRaster( QgsFeedback *feedback = nullptr );
 
     double cellSizeX() const { return mCellSizeX; }
     void setCellSizeX( double size ) { mCellSizeX = size; }
@@ -119,9 +132,9 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     /**
      * \brief processRasterCPU executes the computation on the CPU
      * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancellation
-     * \return an opaque integer for error codes: 0 in case of success
+     * \returns QgsNineCellFilter::Success in case of success or error value on failure
      */
-    int processRasterCPU( QgsFeedback *feedback = nullptr );
+    Result processRasterCPU( QgsFeedback *feedback = nullptr );
 
 #ifdef HAVE_OPENCL
 
@@ -129,9 +142,9 @@ class ANALYSIS_EXPORT QgsNineCellFilter
      * \brief processRasterGPU executes the computation on the GPU
      * \param source path to the OpenCL source file
      * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancellation
-     * \return an opaque integer for error codes: 0 in case of success
+     * \returns QgsNineCellFilter::Success in case of success or error value on failure
      */
-    int processRasterGPU( const QString &source, QgsFeedback *feedback = nullptr );
+    Result processRasterGPU( const QString &source, QgsFeedback *feedback = nullptr );
 
     /**
      * \brief addExtraRasterParams allow derived classes to add parameters needed

--- a/tests/src/analysis/testqgsninecellfilters.cpp
+++ b/tests/src/analysis/testqgsninecellfilters.cpp
@@ -112,8 +112,7 @@ void TestNineCellFilters::_testAlg( const QString &name, bool useOpenCl )
 #endif
   const QString refFile( referenceFile( name ) );
   T ninecellFilter( SRC_FILE, tmpFile, "GTiff" );
-  const int res = ninecellFilter.processRaster();
-  QVERIFY( res == 0 );
+  QCOMPARE( static_cast<int>( ninecellFilter.processRaster() ), 0 );
 
   // Produced file
   QgsAlignRaster::RasterInfo out( tmpFile );
@@ -131,7 +130,6 @@ void TestNineCellFilters::_testAlg( const QString &name, bool useOpenCl )
 
   // Reference
   QgsAlignRaster::RasterInfo ref( refFile );
-  //qDebug() << "Comparing " << tmpFile << refFile;
   _rasterCompare( out, ref );
 }
 
@@ -215,8 +213,6 @@ void TestNineCellFilters::_rasterCompare( QgsAlignRaster::RasterInfo &out, QgsAl
     const double outVal = out.identify( x, y );
     const double refVal = ref.identify( x, y );
     const double diff( qAbs( outVal - refVal ) );
-    //qDebug() << outVal << refVal;
-    //qDebug() << "Identify " <<  x << "," << y << " diff " << diff << " check: < " << tolerance;
     QVERIFY( diff <= tolerance );
   }
 }
@@ -236,8 +232,7 @@ void TestNineCellFilters::testCreationOptions()
 
   QgsAspectFilter ninecellFilter( SRC_FILE, tmpFile, "GTiff" );
   ninecellFilter.setCreationOptions( QStringList() << "TFW=YES" );
-  const int res = ninecellFilter.processRaster();
-  QVERIFY( res == 0 );
+  QCOMPARE( static_cast<int>( ninecellFilter.processRaster() ), 0 );
 
   QVERIFY( worldFile.exists() );
   worldFile.remove();
@@ -249,8 +244,7 @@ void TestNineCellFilters::testNoDataValue()
 
   QgsAspectFilter ninecellFilter( SRC_FILE, tmpFile, "GTiff" );
   ninecellFilter.setOutputNodataValue( -5555.0 );
-  const int res = ninecellFilter.processRaster();
-  QVERIFY( res == 0 );
+  QCOMPARE( static_cast<int>( ninecellFilter.processRaster() ), 0 );
 
   //open output file and check results
   const std::unique_ptr<QgsRasterLayer> result = std::make_unique<QgsRasterLayer>( tmpFile, QStringLiteral( "raster" ), QStringLiteral( "gdal" ) );

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -1185,13 +1185,13 @@ void TestQgsRasterCalculator::testNoDataValue()
   tmpFile.close();
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" + 2" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  rc.setNoDataValue( -9999.0 );
+  rc.setNoDataValue( -5555.0 );
   QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
 
   //open output file and check results
   const std::unique_ptr<QgsRasterLayer> result = std::make_unique<QgsRasterLayer>( tmpName, QStringLiteral( "raster" ), QStringLiteral( "gdal" ) );
   QVERIFY( result->dataProvider()->sourceHasNoDataValue( 1 ) );
-  QCOMPARE( result->dataProvider()->sourceNoDataValue( 1 ), -9999.0 );
+  QCOMPARE( result->dataProvider()->sourceNoDataValue( 1 ), -5555.0 );
 }
 
 

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -412,6 +412,7 @@ ADD_PYTHON_TEST(PyQgsVectorTile test_qgsvectortile.py)
 ADD_PYTHON_TEST(PyQgsVtpk test_qgsvtpk.py)
 ADD_PYTHON_TEST(PyQgsProcessingAlgsGdalGdalUtils test_processing_algs_gdal_gdalutils.py)
 ADD_PYTHON_TEST(PyQgsInterpolation test_analysis_interpolation.py)
+ADD_PYTHON_TEST(PyQgsNineCellFilter test_analysis_ninecellfilter.py)
 
 if (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_analysis_ninecellfilter.py
+++ b/tests/src/python/test_analysis_ninecellfilter.py
@@ -1,0 +1,58 @@
+"""
+***************************************************************************
+    test_analysis_ninecellfilter.py
+    ---------------------
+    Date                 : April 2025
+    Copyright            : (C) 2025 by Alexander Bruy
+    Email                : alexander dot bruy at gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = "Alexander Bruy"
+__date__ = "April 2025"
+__copyright__ = "(C) 2025, Alexander Bruy"
+
+import os
+import tempfile
+
+from qgis.core import (
+    QgsRasterChecker,
+)
+from qgis.analysis import (
+    QgsAspectFilter,
+)
+
+import unittest
+from qgis.testing import QgisTestCase
+
+from utilities import unitTestDataPath, start_app
+
+TEST_DATA_DIR = unitTestDataPath()
+start_app()
+
+
+class TestInterpolation(QgisTestCase):
+
+    def __init__(self, methodName):
+        QgisTestCase.__init__(self, methodName)
+        self.report = "<h1>Python Raster Analysis nine cell filter Tests</h1>\n"
+
+    def test_aspect(self):
+        input_file = os.path.join(TEST_DATA_DIR, "analysis", "dem.tif")
+        output_file = os.path.join(tempfile.gettempdir(), "aspect.tif")
+
+        aspect = QgsAspectFilter(input_file, output_file, "GTiff")
+        aspect.setZFactor(1.0)
+        result = aspect.processRaster()
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Introduces `Result` enum and use its values as a return value from the `processRaster()` method to provide users with more informative return value than plain integer.

Fixes long-standing TODO in `QgsNineCellFilter` class and harmonizes it with the rest of raster analysis tools like `QgsKernelDensityEstimation` and raster calculator.