### PR TITLE
Make unset field default merge policy when reading xml

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2597,7 +2597,7 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
       {
         const QDomElement mergePolicyElem = mergePolicyNodeList.at( i ).toElement();
         const QString field = mergePolicyElem.attribute( QStringLiteral( "field" ) );
-        const Qgis::FieldDomainMergePolicy policy = qgsEnumKeyToValue( mergePolicyElem.attribute( QStringLiteral( "policy" ) ), Qgis::FieldDomainMergePolicy::DefaultValue );
+        const Qgis::FieldDomainMergePolicy policy = qgsEnumKeyToValue( mergePolicyElem.attribute( QStringLiteral( "policy" ) ), Qgis::FieldDomainMergePolicy::UnsetField );
         mAttributeMergePolicy.insert( field, policy );
       }
     }


### PR DESCRIPTION
Fixes an issue in PR #60710 where default merge policy was different for QgsField from the one when reading XML data.