### PR TITLE
Speed up layout legend rendering

### DIFF
--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4412,6 +4412,7 @@ class CORE_EXPORT Qgis
       Symbol, //!< Symbol icon (excluding label)
       SymbolLabel, //!< Symbol label (excluding icon)
     };
+    // !!! WARNING: If adding new values to this enum, make sure you update QgsLegendSettings constructor accordingly!!
     Q_ENUM( LegendComponent )
 
     /**

--- a/src/core/qgslegendsettings.cpp
+++ b/src/core/qgslegendsettings.cpp
@@ -25,6 +25,8 @@ QgsLegendSettings::QgsLegendSettings()
   , mWmsLegendSize( 50, 25 )
   , mRasterStrokeColor( Qt::black )
 {
+  mStyleMap.resize( static_cast< int >( Qgis::LegendComponent::SymbolLabel ) + 1 );
+
   rstyle( Qgis::LegendComponent::Title ).setMargin( QgsLegendStyle::Bottom, 3.5 );
   rstyle( Qgis::LegendComponent::Group ).setMargin( QgsLegendStyle::Top, 3 );
   rstyle( Qgis::LegendComponent::Subgroup ).setMargin( QgsLegendStyle::Top, 3 );

--- a/src/core/qgslegendsettings.h
+++ b/src/core/qgslegendsettings.h
@@ -78,21 +78,21 @@ class CORE_EXPORT QgsLegendSettings
      *
      * \note Not available in Python bindings.
      */
-    SIP_SKIP QgsLegendStyle &rstyle( Qgis::LegendComponent s ) SIP_SKIP { return mStyleMap[s]; }
+    SIP_SKIP QgsLegendStyle &rstyle( Qgis::LegendComponent s ) SIP_SKIP { return mStyleMap[static_cast< int >( s )]; }
 
     /**
      * Returns the style for a legend component.
      *
      * \see setStyle()
      */
-    QgsLegendStyle style( Qgis::LegendComponent s ) const { return mStyleMap.value( s ); }
+    QgsLegendStyle style( Qgis::LegendComponent s ) const { return mStyleMap[ static_cast< int >( s ) ]; }
 
     /**
      * Sets the \a style for a legend component.
      *
      * \see style()
      */
-    void setStyle( Qgis::LegendComponent s, const QgsLegendStyle &style ) { mStyleMap[s] = style; }
+    void setStyle( Qgis::LegendComponent s, const QgsLegendStyle &style ) { mStyleMap[ static_cast< int >( s ) ] = style; }
 
     /**
      * Returns the legend box space (in millimeters), which is the empty margin around the inside of the legend's
@@ -579,7 +579,7 @@ class CORE_EXPORT QgsLegendSettings
     QColor mRasterStrokeColor;
     double mRasterStrokeWidth = 0.0;
 
-    QMap<Qgis::LegendComponent, QgsLegendStyle> mStyleMap;
+    QVector<QgsLegendStyle> mStyleMap;
 
     //! Conversion ratio between millimeters and map units - for symbols with size given in map units
     double mMmPerMapUnit = 1;


### PR DESCRIPTION
Don't use a QMap for legend styles in QgsLegendSettings.

We can easily replace this with a simple vector, as we'll only ever be accessing a fixed number of elements by a unique integer key. This avoids the map lookup costs, but, more importantly, avoids the unwanted default value constructor costs for QgsLegendStyle which the QMap accessor methods incur.

And these costs are quite substantial, as QgsLegendStyle constructor involves a bunch of work for symbol and text format creation which in turn incur QgsSettings access costs.
