### PR TITLE
[Postgres] Use session role for ALL requests

### DIFF
--- a/src/providers/postgres/qgscolumntypethread.cpp
+++ b/src/providers/postgres/qgscolumntypethread.cpp
@@ -43,10 +43,10 @@ void QgsGeomColumnTypeThread::stop()
 void QgsGeomColumnTypeThread::run()
 {
   QgsDataSourceUri uri = QgsPostgresConn::connUri( mName );
-  mConn = QgsPostgresConnPool::instance()->acquireConnection( uri.connectionInfo( false ) );
+  mConn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( uri, false ) );
   if ( !mConn )
   {
-    QgsDebugError( "Connection failed - " + uri.connectionInfo( false ) );
+    QgsDebugError( "Connection failed - " + QgsPostgresConn::connectionInfo( uri, false ) );
     return;
   }
 

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -431,7 +431,7 @@ void QgsPgSourceSelect::btnConnect_clicked()
   // populate the table list
   QgsDataSourceUri uri = QgsPostgresConn::connUri( cmbConnections->currentText() );
 
-  QgsDebugMsgLevel( "Connection info: " + uri.connectionInfo( false ), 2 );
+  QgsDebugMsgLevel( "Connection info: " + QgsPostgresConn::connectionInfo( uri, false ), 2 );
 
   mDataSrcUri = uri;
   mUseEstimatedMetadata = uri.useEstimatedMetadata();
@@ -484,7 +484,7 @@ QStringList QgsPgSourceSelect::selectedTables()
 
 QString QgsPgSourceSelect::connectionInfo( bool expandAuthCfg )
 {
-  return mDataSrcUri.connectionInfo( expandAuthCfg );
+  return QgsPostgresConn::connectionInfo( mDataSrcUri, expandAuthCfg );
 }
 
 QgsDataSourceUri QgsPgSourceSelect::dataSourceUri()

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -263,37 +263,7 @@ QgsPostgresConn *QgsPostgresConn::connectDb( const QString &conninfo, bool reado
 
 QgsPostgresConn *QgsPostgresConn::connectDb( const QgsDataSourceUri &uri, bool readonly, bool shared, bool transaction, bool allowRequestCredentials )
 {
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), readonly, shared, transaction, allowRequestCredentials );
-  if ( !conn )
-  {
-    return conn;
-  }
-
-  const QString sessionRoleKey = QStringLiteral( "session_role" );
-  if ( uri.hasParam( sessionRoleKey ) )
-  {
-    const QString sessionRole = uri.param( sessionRoleKey );
-    if ( !sessionRole.isEmpty() )
-    {
-      if ( !conn->setSessionRole( sessionRole ) )
-      {
-        QgsDebugMsgLevel(
-          QStringLiteral(
-            "Set session role failed for ROLE %1"
-          )
-            .arg( quotedValue( sessionRole ) ),
-          2
-        );
-        conn->unref();
-        return nullptr;
-      }
-    }
-  }
-  else
-  {
-    conn->resetSessionRole();
-  }
-  return conn;
+  return QgsPostgresConn::connectDb( QgsPostgresConn::connectionInfo( uri, false ), readonly, shared, transaction, allowRequestCredentials );
 }
 
 static void noticeProcessor( void *arg, const char *message )
@@ -411,8 +381,8 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
       if ( !password.isEmpty() )
         mUri.setPassword( password );
 
-      QgsDebugMsgLevel( "Connecting to " + mUri.connectionInfo( false ), 2 );
-      QString connectString = mUri.connectionInfo();
+      QgsDebugMsgLevel( "Connecting to " + QgsPostgresConn::connectionInfo( mUri, false ), 2 );
+      QString connectString = QgsPostgresConn::connectionInfo( mUri );
       addDefaultTimeoutAndClientEncoding( connectString );
       // use conninfo for log, connectString - can contain clear text username & password
       logWrapper = std::make_unique<QgsDatabaseQueryLogWrapper>( QStringLiteral( "libpq::PQconnectdb()" ), conninfo, QStringLiteral( "postgres" ), QStringLiteral( "QgsPostgresConn" ), QGS_QUERY_LOG_ORIGIN_PG_CON );
@@ -433,6 +403,28 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
     QgsMessageLog::logMessage( tr( "Connection to database failed" ) + '\n' + errorMsg, tr( "PostGIS" ) );
     mRef = 0;
     return;
+  }
+
+  const QString sessionRoleKey = QStringLiteral( "session_role" );
+  if ( mUri.hasParam( sessionRoleKey ) )
+  {
+    const QString sessionRole = mUri.param( sessionRoleKey );
+    if ( !sessionRole.isEmpty() )
+    {
+      if ( !setSessionRole( sessionRole ) )
+      {
+        QgsDebugMsgLevel(
+          QStringLiteral(
+            "Set session role failed for ROLE %1"
+          )
+            .arg( quotedValue( sessionRole ) ),
+          2
+        );
+
+        mRef = 0;
+        return;
+      }
+    }
   }
 
   logWrapper = nullptr;
@@ -1335,49 +1327,9 @@ QString QgsPostgresConn::postgisVersion() const
   return mPostgisVersionInfo;
 }
 
-/* Functions for determining available features in postGIS */
 bool QgsPostgresConn::setSessionRole( const QString &sessionRole )
 {
-  if ( sessionRole.isEmpty() )
-    return resetSessionRole();
-  else
-  {
-    if ( sessionRole == mCurrentSessionRole )
-    {
-      return true;
-    }
-    else
-    {
-      if ( !LoggedPQexecNR( "QgsPostgresConn", QStringLiteral( "SET ROLE %1" ).arg( quotedValue( sessionRole ) ) ) )
-      {
-        return false;
-      }
-      else
-      {
-        mCurrentSessionRole = sessionRole;
-        return true;
-      }
-    }
-  }
-}
-bool QgsPostgresConn::resetSessionRole()
-{
-  if ( mCurrentSessionRole.isEmpty() )
-  {
-    return true;
-  }
-  else
-  {
-    if ( !LoggedPQexecNR( "QgsPostgresConn", QStringLiteral( "RESET ROLE" ) ) )
-    {
-      return false;
-    }
-    else
-    {
-      mCurrentSessionRole.clear();
-      return true;
-    }
-  }
+  return LoggedPQexecNR( "QgsPostgresConn", QStringLiteral( "SET ROLE %1" ).arg( quotedValue( sessionRole ) ) );
 }
 
 QString QgsPostgresConn::quotedIdentifier( const QString &ident )
@@ -2756,6 +2708,12 @@ QgsDataSourceUri QgsPostgresConn::connUri( const QString &connName )
   }
   uri.setUseEstimatedMetadata( estimatedMetadata );
 
+  const QString sessionRole = QgsPostgresConn::sessionRole( connName );
+  if ( !sessionRole.isEmpty() )
+  {
+    uri.setParam( "session_role", sessionRole );
+  }
+
   return uri;
 }
 
@@ -2786,7 +2744,6 @@ bool QgsPostgresConn::useEstimatedMetadata( const QString &connName )
   return settings.value( "/PostgreSQL/connections/" + connName + "/estimatedMetadata", false ).toBool();
 }
 
-
 bool QgsPostgresConn::allowGeometrylessTables( const QString &connName )
 {
   QgsSettings settings;
@@ -2809,6 +2766,12 @@ QString QgsPostgresConn::schemaToRestrict( const QString &connName )
 {
   QgsSettings settings;
   return settings.value( QStringLiteral( "/PostgreSQL/connections/" ) + connName + QStringLiteral( "/schema" ) ).toString();
+}
+
+QString QgsPostgresConn::sessionRole( const QString &connName )
+{
+  QgsSettings settings;
+  return settings.value( "/PostgreSQL/connections/" + connName + "/session_role" ).toString();
 }
 
 void QgsPostgresConn::deleteConnection( const QString &connName )
@@ -2974,4 +2937,15 @@ int QgsPostgresConn::crsToSrid( const QgsCoordinateReferenceSystem &crs )
   }
 
   return -1;
+}
+
+QString QgsPostgresConn::connectionInfo( const QgsDataSourceUri &uri, const bool expandAuthCfg )
+{
+  QString strUri = uri.connectionInfo( expandAuthCfg );
+  if ( uri.hasParam( "session_role" ) )
+  {
+    strUri += " session_role=" + uri.param( "session_role" );
+  }
+
+  return strUri;
 }

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -305,16 +305,6 @@ class QgsPostgresConn : public QObject
      */
     bool setSessionRole( const QString &sessionRole );
 
-    /**
-     * Resets the current user identifier of the current PostgreSQL session
-     * to the current session user identifier (user used to log in)
-     *
-     * \returns TRUE if successful
-     *
-     * \since QGIS 3.28.0
-     */
-    bool resetSessionRole();
-
     //! run a query and free result buffer
     bool PQexecNR( const QString &query, const QString &originatorClass = QString(), const QString &queryOrigin = QString() );
 
@@ -480,6 +470,7 @@ class QgsPostgresConn : public QObject
     static bool allowMetadataInDatabase( const QString &connName );
     static bool allowRasterOverviewTables( const QString &connName );
     static QString schemaToRestrict( const QString &connName );
+    static QString sessionRole( const QString &connName );
 
     /**
      * Duplicates \a src connection settings to a new \a dst connection.
@@ -494,6 +485,17 @@ class QgsPostgresConn : public QObject
     QgsCoordinateReferenceSystem sridToCrs( int srsId );
 
     int crsToSrid( const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Returns the connection part of the \a uri URI.
+     *
+     * If set, add session_role to the connection information. This method should be used instead of
+     * QgsDataSourceUri::connectionInfo()
+     *
+     * \param expandAuthCfg TRUE if returned URI must be updated with authentication information
+     * \since QGIS 3.44
+     */
+    static QString connectionInfo( const QgsDataSourceUri &uri, const bool expandAuthCfg = true );
 
   private:
     int mRef;

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -44,11 +44,11 @@ QVector<QgsDataItem *> QgsPGConnectionItem::createChildren()
 
   QgsDataSourceUri uri = QgsPostgresConn::connUri( mName );
   // TODO: we need to cancel somehow acquireConnection() if deleteLater() was called on this item to avoid later credential dialog if connection failed
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( uri.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( uri, false ) );
   if ( !conn )
   {
     items.append( new QgsErrorItem( this, tr( "Connection failed" ), mPath + "/error" ) );
-    QgsDebugError( "Connection failed - " + uri.connectionInfo( false ) );
+    QgsDebugError( "Connection failed - " + QgsPostgresConn::connectionInfo( uri, false ) );
     return items;
   }
 
@@ -134,7 +134,7 @@ QString QgsPGLayerItem::createUri()
 
   const QString &connName = connItem->name();
 
-  QgsDataSourceUri uri( QgsPostgresConn::connUri( connName ).connectionInfo( false ) );
+  QgsDataSourceUri uri( QgsPostgresConn::connectionInfo( QgsPostgresConn::connUri( connName ), false ) );
 
   const QgsSettings &settings = QgsSettings();
   QString basekey = QStringLiteral( "/PostgreSQL/connections/%1" ).arg( connName );
@@ -176,12 +176,12 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
   QVector<QgsDataItem *> items;
 
   QgsDataSourceUri uri = QgsPostgresConn::connUri( mConnectionName );
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( uri.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( uri, false ) );
 
   if ( !conn )
   {
     items.append( new QgsErrorItem( this, tr( "Connection failed" ), mPath + "/error" ) );
-    QgsDebugError( "Connection failed - " + uri.connectionInfo( false ) );
+    QgsDebugError( "Connection failed - " + QgsPostgresConn::connectionInfo( uri, false ) );
     return items;
   }
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -999,7 +999,7 @@ void QgsPostgresFeatureIterator::getFeatureAttribute( int idx, QgsPostgresResult
 //  ------------------
 
 QgsPostgresFeatureSource::QgsPostgresFeatureSource( const QgsPostgresProvider *p )
-  : mConnInfo( p->mUri.connectionInfo( false ) )
+  : mConnInfo( QgsPostgresConn::connectionInfo( p->mUri, false ) )
   , mGeometryColumn( p->mGeometryColumn )
   , mBoundingBoxColumn( p->mBoundingBoxColumn )
   , mSqlWhereClause( p->filterWhereClause() )

--- a/src/providers/postgres/qgspostgresprojectstorage.cpp
+++ b/src/providers/postgres/qgspostgresprojectstorage.cpp
@@ -71,7 +71,7 @@ QStringList QgsPostgresProjectStorage::listProjects( const QString &uri )
   if ( !projectUri.valid )
     return lst;
 
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( projectUri.connInfo.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( projectUri.connInfo, false ) );
   if ( !conn )
     return lst;
 
@@ -105,10 +105,10 @@ bool QgsPostgresProjectStorage::readProject( const QString &uri, QIODevice *devi
     return false;
   }
 
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( projectUri.connInfo.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( projectUri.connInfo, false ) );
   if ( !conn )
   {
-    context.pushMessage( QObject::tr( "Could not connect to the database: " ) + projectUri.connInfo.connectionInfo( false ), Qgis::MessageLevel::Critical );
+    context.pushMessage( QObject::tr( "Could not connect to the database: " ) + QgsPostgresConn::connectionInfo( projectUri.connInfo, false ), Qgis::MessageLevel::Critical );
     return false;
   }
 
@@ -154,10 +154,10 @@ bool QgsPostgresProjectStorage::writeProject( const QString &uri, QIODevice *dev
     return false;
   }
 
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( projectUri.connInfo.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( projectUri.connInfo, false ) );
   if ( !conn )
   {
-    context.pushMessage( QObject::tr( "Could not connect to the database: " ) + projectUri.connInfo.connectionInfo( false ), Qgis::MessageLevel::Critical );
+    context.pushMessage( QObject::tr( "Could not connect to the database: " ) + QgsPostgresConn::connectionInfo( projectUri.connInfo, false ), Qgis::MessageLevel::Critical );
     return false;
   }
 
@@ -208,7 +208,7 @@ bool QgsPostgresProjectStorage::removeProject( const QString &uri )
   if ( !projectUri.valid )
     return false;
 
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( projectUri.connInfo.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( projectUri.connInfo, false ) );
   if ( !conn )
     return false;
 
@@ -232,7 +232,7 @@ bool QgsPostgresProjectStorage::readProjectStorageMetadata( const QString &uri, 
   if ( !projectUri.valid )
     return false;
 
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( projectUri.connInfo.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( projectUri.connInfo, false ) );
   if ( !conn )
     return false;
 

--- a/src/providers/postgres/qgspostgresprojectstoragedialog.cpp
+++ b/src/providers/postgres/qgspostgresprojectstoragedialog.cpp
@@ -100,11 +100,11 @@ void QgsPostgresProjectStorageDialog::populateSchemas()
 
   QApplication::setOverrideCursor( Qt::WaitCursor );
 
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( uri.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( uri, false ) );
   if ( !conn )
   {
     QApplication::restoreOverrideCursor();
-    QMessageBox::critical( this, tr( "Error" ), tr( "Connection failed" ) + "\n" + uri.connectionInfo( false ) );
+    QMessageBox::critical( this, tr( "Error" ), tr( "Connection failed" ) + "\n" + QgsPostgresConn::connectionInfo( uri, false ) );
     return;
   }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -147,7 +147,7 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
   }
   mSelectAtIdDisabled = mUri.selectAtIdDisabled();
 
-  QgsDebugMsgLevel( QStringLiteral( "Connection info is %1" ).arg( mUri.connectionInfo( false ) ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Connection info is %1" ).arg( QgsPostgresConn::connectionInfo( mUri, false ) ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "Geometry column is: %1" ).arg( mGeometryColumn ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "Schema is: %1" ).arg( mSchemaName ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "Table name is: %1" ).arg( mTableName ), 2 );
@@ -332,7 +332,7 @@ void QgsPostgresProvider::setListening( bool isListening )
 
   if ( isListening && !mListener )
   {
-    mListener = QgsPostgresListener::create( mUri.connectionInfo( false ) );
+    mListener = QgsPostgresListener::create( QgsPostgresConn::connectionInfo( mUri, false ) );
     connect( mListener.get(), &QgsPostgresListener::notify, this, &QgsPostgresProvider::notify );
   }
   else if ( !isListening && mListener )
@@ -4400,7 +4400,7 @@ Qgis::VectorExportResult QgsPostgresProvider::createEmptyLayer( const QString &u
   schemaTableName += quotedIdentifier( tableName );
   createdLayerUri = uri;
 
-  QgsDebugMsgLevel( QStringLiteral( "Connection info is: %1" ).arg( dsUri.connectionInfo( false ) ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Connection info is: %1" ).arg( QgsPostgresConn::connectionInfo( dsUri, false ) ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "Geometry column is: %1" ).arg( geometryColumn ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "Schema is: %1" ).arg( schemaName ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "Table name is: %1" ).arg( tableName ), 2 );
@@ -4959,7 +4959,7 @@ QList<QgsVectorLayer *> QgsPostgresProvider::searchLayers( const QList<QgsVector
   for ( QgsVectorLayer *layer : constLayers )
   {
     const QgsPostgresProvider *pgProvider = qobject_cast<QgsPostgresProvider *>( layer->dataProvider() );
-    if ( pgProvider && pgProvider->mUri.connectionInfo( false ) == connectionInfo && pgProvider->mSchemaName == schema && pgProvider->mTableName == tableName )
+    if ( pgProvider && QgsPostgresConn::connectionInfo( pgProvider->mUri, false ) == connectionInfo && pgProvider->mSchemaName == schema && pgProvider->mTableName == tableName )
     {
       result.append( layer );
     }
@@ -5044,7 +5044,7 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer 
     }
     const QString refColumn = sqlResult.PQgetvalue( row, 4 );
     // try to find if we have layers for the referenced table
-    const QList<QgsVectorLayer *> foundLayers = searchLayers( layers, mUri.connectionInfo( false ), refSchema, refTable );
+    const QList<QgsVectorLayer *> foundLayers = searchLayers( layers, QgsPostgresConn::connectionInfo( mUri, false ), refSchema, refTable );
     if ( !refTableFound.contains( refTable ) )
     {
       for ( const QgsVectorLayer *foundLayer : foundLayers )

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -83,7 +83,7 @@ QgsPostgresProviderConnection::QgsPostgresProviderConnection( const QString &nam
 }
 
 QgsPostgresProviderConnection::QgsPostgresProviderConnection( const QString &uri, const QVariantMap &configuration )
-  : QgsAbstractDatabaseProviderConnection( QgsDataSourceUri( uri ).connectionInfo( false ), configuration )
+  : QgsAbstractDatabaseProviderConnection( QgsPostgresConn::connectionInfo( uri, false ), configuration )
 {
   mProviderKey = QStringLiteral( "postgres" );
   setDefaultCapabilities();
@@ -166,6 +166,7 @@ void QgsPostgresProviderConnection::createVectorTable( const QString &schema, co
   {
     newUri.setGeometryColumn( options->value( QStringLiteral( "geometryColumn" ), QStringLiteral( "geom" ) ).toString() );
   }
+
   QMap<int, int> map;
   QString errCause;
   QString createdLayerUri;
@@ -234,7 +235,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsPostgresProviderC
   QString errCause;
   // TODO: set flags from the connection if flags argument is 0
   const QgsDataSourceUri dsUri { uri() };
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ), -1, false, feedback );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( dsUri, false ), -1, false, feedback );
   if ( feedback && feedback->isCanceled() )
     return {};
 
@@ -423,7 +424,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsPostgresProviderConnection
 {
   if ( !pgconn )
   {
-    pgconn = std::make_shared<QgsPoolPostgresConn>( QgsDataSourceUri( uri() ).connectionInfo( false ) );
+    pgconn = std::make_shared<QgsPoolPostgresConn>( QgsPostgresConn::connectionInfo( QgsDataSourceUri( uri() ), false ) );
   }
 
   std::shared_ptr<QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator> iterator = std::make_shared<QgsPostgresProviderResultIterator>( resolveTypes );
@@ -776,7 +777,7 @@ QStringList QgsPostgresProviderConnection::schemas() const
   QStringList schemas;
   QString errCause;
   const QgsDataSourceUri dsUri { uri() };
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( dsUri, false ) );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection failed: %1" ).arg( uri() );
@@ -856,7 +857,7 @@ QIcon QgsPostgresProviderConnection::icon() const
 QList<QgsVectorDataProvider::NativeType> QgsPostgresProviderConnection::nativeTypes() const
 {
   QList<QgsVectorDataProvider::NativeType> types;
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsDataSourceUri { uri() }.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( QgsDataSourceUri { uri() }, false ) );
   if ( conn )
   {
     types = conn->nativeTypes();

--- a/src/providers/postgres/qgspostgresprovidermetadatautils.cpp
+++ b/src/providers/postgres/qgspostgresprovidermetadatautils.cpp
@@ -81,7 +81,7 @@ QList<QgsLayerMetadataProviderResult> QgsPostgresProviderMetadataUtils::searchLa
 
     if ( res.PQresultStatus() != PGRES_TUPLES_OK )
     {
-      throw QgsProviderConnectionException( QObject::tr( "Error while fetching metadata from %1: %2" ).arg( dsUri.connectionInfo( false ), res.PQresultErrorMessage() ) );
+      throw QgsProviderConnectionException( QObject::tr( "Error while fetching metadata from %1: %2" ).arg( QgsPostgresConn::connectionInfo( dsUri, false ), res.PQresultErrorMessage() ) );
     }
 
     for ( int row = 0; row < res.PQntuples(); ++row )
@@ -132,7 +132,7 @@ QList<QgsLayerMetadataProviderResult> QgsPostgresProviderMetadataUtils::searchLa
   }
   else
   {
-    throw QgsProviderConnectionException( QObject::tr( "Connection to database %1 failed" ).arg( dsUri.connectionInfo( false ) ) );
+    throw QgsProviderConnectionException( QObject::tr( "Connection to database %1 failed" ).arg( QgsPostgresConn::connectionInfo( dsUri, false ) ) );
   }
   return results;
 }

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -76,7 +76,7 @@ QgsPostgresRasterProvider::QgsPostgresRasterProvider( const QString &uri, const 
   // TODO: for now always true
   // mUseEstimatedMetadata = mUri.useEstimatedMetadata();
 
-  QgsDebugMsgLevel( QStringLiteral( "Connection info is %1" ).arg( mUri.connectionInfo( false ) ), 4 );
+  QgsDebugMsgLevel( QStringLiteral( "Connection info is %1" ).arg( QgsPostgresConn::connectionInfo( mUri, false ) ), 4 );
   QgsDebugMsgLevel( QStringLiteral( "Schema is: %1" ).arg( mSchemaName ), 4 );
   QgsDebugMsgLevel( QStringLiteral( "Table name is: %1" ).arg( mTableName ), 4 );
   QgsDebugMsgLevel( QStringLiteral( "Query is: %1" ).arg( mQuery ), 4 );

--- a/tests/testdata/provider/testdata_pg_role.sql
+++ b/tests/testdata/provider/testdata_pg_role.sql
@@ -1,5 +1,6 @@
 DROP GROUP IF EXISTS qgis_test_group;
 CREATE USER qgis_test_group NOLOGIN;
+GRANT USAGE, CREATE ON SCHEMA public TO qgis_test_group;
 
 DROP USER IF EXISTS qgis_test_user;
 CREATE USER qgis_test_user PASSWORD 'qgis_test_user_password' LOGIN;
@@ -8,3 +9,7 @@ ALTER GROUP qgis_test_group ADD USER qgis_test_user;
 DROP USER IF EXISTS qgis_test_unprivileged_user;
 CREATE USER qgis_test_unprivileged_user WITH PASSWORD
 'qgis_test_unprivileged_user_password' LOGIN;
+
+DROP USER IF EXISTS qgis_test_another_user;
+CREATE USER qgis_test_another_user PASSWORD 'qgis_test_another_user_password' LOGIN;
+ALTER GROUP qgis_test_group ADD USER qgis_test_another_user;


### PR DESCRIPTION
Adds session_role to the connection information so:
- It's automatically used for every request. The old system was only working for provider requests and was error prone because it was easy to forget to set the session role before the request.
- Avoid setting/resetting role request if different request sender were sharing the same connection information to the exception of the session role.

New contribution would have to use the new QgsPostresConn::connectionInfo() method to avoid new issue. I can see no way to enforce this instead of adding session role to QgsDataSourceUri (which has been already refused before, and IMHO for good reasons)

FYI @rldhont 

Fixes #58516

**Funded by Les agences de l'eau - DSIUN**
