### PR TITLE
[Server] Consistently accept GRID_INTERVAL_X/Y >= 0

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1748,7 +1748,7 @@ namespace QgsWms
       gridy = wmsParam.toDouble();
     }
 
-    if ( gridx != -1 && gridy != -1 )
+    if ( gridx >= 0 && gridy >= 0 )
     {
       param.mGridX = gridx;
       param.mGridY = gridy;

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -901,7 +901,7 @@ namespace QgsWms
       }
 
       //grid space x / y
-      if ( cMapParams.mGridX > 0 && cMapParams.mGridY > 0 )
+      if ( cMapParams.mGridX >= 0 && cMapParams.mGridY >= 0 )
       {
         map->grid()->setIntervalX( static_cast<double>( cMapParams.mGridX ) );
         map->grid()->setIntervalY( static_cast<double>( cMapParams.mGridY ) );


### PR DESCRIPTION
## Description

Currently, in `qgswmsparameters.cpp`, the request grid parameters are copied to the `QgsWmsParametersComposerMap` if they are not `-1`, while in `qgswmsrenderer.cpp`, they are applied to the composer map grid if they are greater than zero.

This PR consistently copies the request parameters to `QgsWmsParametersComposerMap` and applies them to the map grid if they are `>= 0`.

Note: `GRID_INTERVAL_X/Y = 0` is useful to disable a pre-defined grid in the print layout, as it won't be rendered with zero intervals. 