### PR TITLE
qgsgroupwmsdatadialog: Remove Q_DECL_DEPRECATED from constructor

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -18,16 +18,12 @@ A dialog for configuring a WMS group.
 #include "qgsgroupwmsdatadialog.h"
 %End
   public:
- QgsGroupWmsDataDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags ) /Deprecated="Since 3.44. Use constructor which has a server properties parameter."/;
+    QgsGroupWmsDataDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 %Docstring
 Constructor
 
 :param parent: parent widget
 :param fl: dialog window flags
-
-.. deprecated:: 3.44
-
-   Use constructor which has a server properties parameter.
 %End
 
     QgsGroupWmsDataDialog( const QgsMapLayerServerProperties &serverProperties, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );

--- a/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -18,16 +18,12 @@ A dialog for configuring a WMS group.
 #include "qgsgroupwmsdatadialog.h"
 %End
   public:
- QgsGroupWmsDataDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags ) /Deprecated="Since 3.44. Use constructor which has a server properties parameter."/;
+    QgsGroupWmsDataDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 %Docstring
 Constructor
 
 :param parent: parent widget
 :param fl: dialog window flags
-
-.. deprecated:: 3.44
-
-   Use constructor which has a server properties parameter.
 %End
 
     QgsGroupWmsDataDialog( const QgsMapLayerServerProperties &serverProperties, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );

--- a/src/gui/qgsgroupwmsdatadialog.h
+++ b/src/gui/qgsgroupwmsdatadialog.h
@@ -35,10 +35,8 @@ class GUI_EXPORT QgsGroupWmsDataDialog : public QDialog, private Ui::QgsGroupWMS
      * Constructor
      * \param parent parent widget
      * \param fl dialog window flags
-     *
-     * \deprecated QGIS 3.44. Use constructor which has a server properties parameter.
      */
-    Q_DECL_DEPRECATED QgsGroupWmsDataDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags ) SIP_DEPRECATED;
+    QgsGroupWmsDataDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
     /**
      * Constructor


### PR DESCRIPTION
## Description

Even though this class is deprecated, this breaks the qt 6 on qt 6.7+.

It looks like this is the only available fix at the moment.

Related: https://github.com/qgis/QGIS/commit/07d7668c60684905eebc26b8d227e3bcab2b1d5b

Funded By: Oslandia