### PR TITLE
Fix animation with globe (and large local scenes)

### DIFF
--- a/src/3d/qgs3danimationsettings.h
+++ b/src/3d/qgs3danimationsettings.h
@@ -45,7 +45,7 @@ class _3D_EXPORT Qgs3DAnimationSettings
     struct Keyframe
     {
         float time = 0;    //!< Relative time of the keyframe in seconds
-        QgsVector3D point; //!< Point towards which the camera is looking in 3D world coords
+        QgsVector3D point; //!< Point towards which the camera is looking in 3D map coords
         float dist = 0;    //!< Distance of the camera from the focal point
         float pitch = 0;   //!< Tilt of the camera in degrees (0 = looking from the top, 90 = looking from the side, 180 = looking from the bottom)
         float yaw = 0;     //!< Horizontal rotation around the focal point in degrees

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -256,7 +256,7 @@ bool Qgs3DUtils::exportAnimation( const Qgs3DAnimationSettings &animationSetting
     ++frameNo;
 
     const Qgs3DAnimationSettings::Keyframe kf = animationSettings.interpolate( time );
-    scene->cameraController()->setLookingAtPoint( kf.point, kf.dist, kf.pitch, kf.yaw );
+    scene->cameraController()->setLookingAtMapPoint( kf.point, kf.dist, kf.pitch, kf.yaw );
 
     QString fileName( fileNameTemplate );
     const QString frameNoPaddedLeft( QStringLiteral( "%1" ).arg( frameNo, numberOfDigits, 10, QChar( '0' ) ) ); // e.g. 0001

--- a/src/app/3d/qgs3danimationwidget.cpp
+++ b/src/app/3d/qgs3danimationwidget.cpp
@@ -114,7 +114,7 @@ void Qgs3DAnimationWidget::setDefaultAnimation()
   Qgs3DAnimationSettings::Keyframes kf;
   Qgs3DAnimationSettings::Keyframe f1, f2;
   f1.time = 0;
-  f1.point = mCameraController->lookingAtPoint();
+  f1.point = mCameraController->lookingAtMapPoint();
   f1.dist = mCameraController->distance();
   f1.pitch = mCameraController->pitch();
   f1.yaw = mCameraController->yaw();
@@ -235,7 +235,7 @@ void Qgs3DAnimationWidget::onSliderValueChanged()
     cboKeyframe->setCurrentIndex( 0 );
 
   const Qgs3DAnimationSettings::Keyframe kf = mAnimationSettings->interpolate( sliderTime->value() / 100. );
-  mCameraController->setLookingAtPoint( kf.point, kf.dist, kf.pitch, kf.yaw );
+  mCameraController->setLookingAtMapPoint( kf.point, kf.dist, kf.pitch, kf.yaw );
 }
 
 void Qgs3DAnimationWidget::onCameraChanged()
@@ -246,7 +246,7 @@ void Qgs3DAnimationWidget::onCameraChanged()
   // update keyframe's camera position/rotation
   const int i = cboKeyframe->currentIndex();
   Qgs3DAnimationSettings::Keyframe kf = cboKeyframe->itemData( i, Qt::UserRole + 1 ).value<Qgs3DAnimationSettings::Keyframe>();
-  kf.point = mCameraController->lookingAtPoint();
+  kf.point = mCameraController->lookingAtMapPoint();
   kf.dist = mCameraController->distance();
   kf.pitch = mCameraController->pitch();
   kf.yaw = mCameraController->yaw();
@@ -269,7 +269,7 @@ void Qgs3DAnimationWidget::onKeyframeChanged()
   const Qgs3DAnimationSettings::Keyframe kf = cboKeyframe->itemData( cboKeyframe->currentIndex(), Qt::UserRole + 1 ).value<Qgs3DAnimationSettings::Keyframe>();
 
   whileBlocking( sliderTime )->setValue( kf.time * 100 );
-  mCameraController->setLookingAtPoint( kf.point, kf.dist, kf.pitch, kf.yaw );
+  mCameraController->setLookingAtMapPoint( kf.point, kf.dist, kf.pitch, kf.yaw );
 }
 
 int Qgs3DAnimationWidget::findIndexForKeyframe( float time )
@@ -316,7 +316,7 @@ void Qgs3DAnimationWidget::onAddKeyframe()
 
   Qgs3DAnimationSettings::Keyframe kf;
   kf.time = t;
-  kf.point = mCameraController->lookingAtPoint();
+  kf.point = mCameraController->lookingAtMapPoint();
   kf.dist = mCameraController->distance();
   kf.pitch = mCameraController->pitch();
   kf.yaw = mCameraController->yaw();


### PR DESCRIPTION
Previously, in keyframes for animation we were storing camera's center point in world coordinates. This however does not work when the scene origin can be rebased, so we switch to using map coordinates, which do not change even if the scene origin changes.
