### PR TITLE
Fix 3D rubber band with globe (and large scenes)

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1242,6 +1242,12 @@ void Qgs3DMapScene::onOriginChanged()
     transform->setOrigin( mMap.origin() );
   }
 
+  const QList<QgsGeoTransform *> rubberBandGeoTransforms = mEngine->frameGraph()->rubberBandsRootEntity()->findChildren<QgsGeoTransform *>();
+  for ( QgsGeoTransform *transform : rubberBandGeoTransforms )
+  {
+    transform->setOrigin( mMap.origin() );
+  }
+
   const QgsVector3D oldOrigin = mCameraController->origin();
   mCameraController->setOrigin( mMap.origin() );
 

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -417,7 +417,7 @@ void QgsRubberBand3D::updateGeometry()
 {
   // figure out a reasonable origin for the coordinates to keep them as small as possible
   const QgsBox3D box = mGeometry.constGet()->boundingBox3D();
-  QgsVector3D dataOrigin = box.isNull() ? mMapSettings->origin() : box.center();
+  const QgsVector3D dataOrigin = box.isNull() ? mMapSettings->origin() : box.center();
 
   QgsLineVertexData lineData;
   lineData.withAdjacency = true;
@@ -461,7 +461,7 @@ void QgsRubberBand3D::updateGeometry()
     {
       // TODO: tessellator should handle origins with non-zero Z to make
       // things work well in large scenes
-      QgsVector3D polygonOrigin( mMapSettings->origin().x(), mMapSettings->origin().y(), 0 );
+      const QgsVector3D polygonOrigin( mMapSettings->origin().x(), mMapSettings->origin().y(), 0 );
       QgsTessellator tessellator( polygonOrigin.x(), polygonOrigin.y(), true );
       tessellator.setOutputZUp( true );
       tessellator.addPolygon( *polygon, 0 );

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -416,13 +416,7 @@ void QgsRubberBand3D::moveLastPoint( const QgsPoint &pt )
 void QgsRubberBand3D::updateGeometry()
 {
   // figure out a reasonable origin for the coordinates to keep them as small as possible
-  QgsBox3D box;
-  QgsVertexIterator vit = mGeometry.vertices();
-  while ( vit.hasNext() )
-  {
-    const QgsPoint pt = vit.next();
-    box.combineWith( pt.x(), pt.y(), pt.z() );
-  }
+  const QgsBox3D box = mGeometry.constGet()->boundingBox3D();
   QgsVector3D dataOrigin = box.isNull() ? mMapSettings->origin() : box.center();
 
   QgsLineVertexData lineData;

--- a/src/3d/qgsrubberband3d.h
+++ b/src/3d/qgsrubberband3d.h
@@ -47,6 +47,7 @@ class Qgs3DMapSettings;
 class QgsBillboardGeometry;
 class QgsMarkerSymbol;
 class QgsPoint3DBillboardMaterial;
+class QgsGeoTransform;
 
 namespace Qt3DCore
 {
@@ -239,6 +240,10 @@ class _3D_EXPORT QgsRubberBand3D
     Qt3DCore::QEntity *mLineEntity = nullptr;    // owned by parentEntity (from constructor)
     Qt3DCore::QEntity *mPolygonEntity = nullptr; // owned by parentEntity (from constructor)
     Qt3DCore::QEntity *mMarkerEntity = nullptr;  // owned by parentEntity (from constructor)
+
+    QgsGeoTransform *mLineTransform = nullptr;
+    QgsGeoTransform *mPolygonTransform = nullptr;
+    QgsGeoTransform *mMarkerTransform = nullptr;
 
     // all these are owned by mPolygonEntity
     QgsTessellatedPolygonGeometry *mPolygonGeometry = nullptr;

--- a/src/3d/symbols/qgslinevertexdata_p.cpp
+++ b/src/3d/symbols/qgslinevertexdata_p.cpp
@@ -145,7 +145,7 @@ void QgsLineVertexData::addLineString( const QgsLineString &lineString, float ex
     }
     else
     {
-      float z = Qgs3DUtils::clampAltitude( p, altClamping, altBinding, baseHeight + extraHeightOffset, centroid, renderContext );
+      const float z = Qgs3DUtils::clampAltitude( p, altClamping, altBinding, baseHeight + extraHeightOffset, centroid, renderContext );
       vertices << QVector3D( static_cast<float>( p.x() - origin.x() ), static_cast<float>( p.y() - origin.y() ), static_cast<float>( z - origin.z() ) );
     }
     indexes << vertices.count() - 1;

--- a/src/3d/symbols/qgslinevertexdata_p.cpp
+++ b/src/3d/symbols/qgslinevertexdata_p.cpp
@@ -137,9 +137,17 @@ void QgsLineVertexData::addLineString( const QgsLineString &lineString, float ex
   for ( int i = 0; i < lineString.vertexCount(); ++i )
   {
     QgsPoint p = lineString.pointN( i );
-    float z = Qgs3DUtils::clampAltitude( p, altClamping, altBinding, baseHeight + extraHeightOffset, centroid, renderContext );
-
-    vertices << QVector3D( static_cast<float>( p.x() - origin.x() ), static_cast<float>( p.y() - origin.y() ), z );
+    if ( geocentricCoordinates )
+    {
+      // TODO: implement altitude clamping when dealing with geocentric coordinates
+      // where Z coordinate is not altitude and can't be used directly...
+      vertices << QVector3D( static_cast<float>( p.x() - origin.x() ), static_cast<float>( p.y() - origin.y() ), static_cast<float>( p.z() - origin.z() ) );
+    }
+    else
+    {
+      float z = Qgs3DUtils::clampAltitude( p, altClamping, altBinding, baseHeight + extraHeightOffset, centroid, renderContext );
+      vertices << QVector3D( static_cast<float>( p.x() - origin.x() ), static_cast<float>( p.y() - origin.y() ), static_cast<float>( z - origin.z() ) );
+    }
     indexes << vertices.count() - 1;
   }
 

--- a/src/3d/symbols/qgslinevertexdata_p.h
+++ b/src/3d/symbols/qgslinevertexdata_p.h
@@ -80,8 +80,8 @@ struct QgsLineVertexData
     Qgis::AltitudeClamping altClamping = Qgis::AltitudeClamping::Absolute;
     Qgis::AltitudeBinding altBinding = Qgis::AltitudeBinding::Vertex;
     float baseHeight = 0;
-    Qgs3DRenderContext renderContext; // used for altitude clamping
-    QgsVector3D origin;               // all coordinates are relative to this origin (e.g. center of the chunk)
+    Qgs3DRenderContext renderContext;   // used for altitude clamping
+    QgsVector3D origin;                 // all coordinates are relative to this origin (e.g. center of the chunk)
     bool geocentricCoordinates = false; // whether input coordinates are geocentric (i.e. Z can't be interpreted as elevation)
 
     QgsLineVertexData();

--- a/src/3d/symbols/qgslinevertexdata_p.h
+++ b/src/3d/symbols/qgslinevertexdata_p.h
@@ -82,6 +82,7 @@ struct QgsLineVertexData
     float baseHeight = 0;
     Qgs3DRenderContext renderContext; // used for altitude clamping
     QgsVector3D origin;               // all coordinates are relative to this origin (e.g. center of the chunk)
+    bool geocentricCoordinates = false; // whether input coordinates are geocentric (i.e. Z can't be interpreted as elevation)
 
     QgsLineVertexData();
 


### PR DESCRIPTION
The individual 3D entities need QgsGeoTransform attached so they work well with origin changes.

We also need to handle altitude clamping with geocentric coordinates differently, because the assumption that Z coordinates means altitude does not hold anymore. Full support is left as a TODO for future implementation (when dealing with vector layers in globe).

Also, polygon entity of 3D rubber band will need improvements in tessellator, so that it can handle origin with non-zero Z coordinates - also left as a TODO for later when dealing with vector layers in globe.
