### PR TITLE
qgsgeos: Handle GEOS 3.13 change of NaN points in QgsGeos::fromGeos

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -1588,7 +1588,15 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
       const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( context, geos );
       unsigned int nPoints = 0;
       GEOSCoordSeq_getSize_r( context, cs, &nPoints );
-      return nPoints > 0 ? std::unique_ptr<QgsAbstractGeometry>( coordSeqPoint( cs, 0, hasZ, hasM ).clone() ) : nullptr;
+      if ( nPoints == 0 )
+      {
+        return nullptr;
+      }
+      // Since GEOS 3.13, Points with NAN coordinates are not considered empty anymore
+      // See: https://github.com/libgeos/geos/pull/927
+      // Handle this change by checking if QgsPoint is empty
+      const QgsPoint point = coordSeqPoint( cs, 0, hasZ, hasM );
+      return !point.isEmpty() ? std::unique_ptr<QgsAbstractGeometry>( point.clone() ) : nullptr;
     }
     case GEOS_LINESTRING:
     {


### PR DESCRIPTION
## Description

Since GEOS 3.13, Points with NaN coordinates are not considered empty anymore. Therefore, `GEOSisEmpty_r` will not return true if the input GeosGeometry contains NaN coordinates.

This change is handled by checking if the generated QgsPoint is empty. If that's the case, a `nullptr` is returned to preserve QGIS backward compatibility.

See: https://github.com/libgeos/geos/pull/927

Funded By: Oslandia