### PR TITLE
Use correct camera for depth buffer queries

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -1165,3 +1165,17 @@ QgsCameraPose Qgs3DUtils::lineSegmentToCameraPose( const QgsVector3D &startPoint
 
   return cameraPose;
 }
+
+std::unique_ptr<Qt3DRender::QCamera> Qgs3DUtils::copyCamera( Qt3DRender::QCamera *cam )
+{
+  std::unique_ptr<Qt3DRender::QCamera> copy = std::make_unique<Qt3DRender::QCamera>();
+  copy->setPosition( cam->position() );
+  copy->setViewCenter( cam->viewCenter() );
+  copy->setUpVector( cam->upVector() );
+  copy->setProjectionMatrix( cam->projectionMatrix() );
+  copy->setNearPlane( cam->nearPlane() );
+  copy->setFarPlane( cam->farPlane() );
+  copy->setAspectRatio( cam->aspectRatio() );
+  copy->setFieldOfView( cam->fieldOfView() );
+  return copy;
+}

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -389,6 +389,12 @@ class _3D_EXPORT Qgs3DUtils
      * \since QGIS 3.44
      */
     static QgsCameraPose lineSegmentToCameraPose( const QgsVector3D &startPoint, const QgsVector3D &endPoint, const QgsDoubleRange &elevationRange, float fieldOfView, const QgsVector3D &worldOrigin );
+
+    /**
+     * Returns new camera object with copied properties.
+     * \since QGIS 3.44
+     */
+    static std::unique_ptr<Qt3DRender::QCamera> copyCamera( Qt3DRender::QCamera *cam ) SIP_SKIP;
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -395,7 +395,7 @@ class _3D_EXPORT QgsCameraController : public QObject
 
 #ifndef SIP_RUN
     //! Converts screen point to world position
-    bool screenPointToWorldPos( QPoint position, Qt3DRender::QCamera *cameraBefore, double &depth, QVector3D &worldPosition );
+    bool screenPointToWorldPos( QPoint position, double &depth, QVector3D &worldPosition );
 #endif
 
     // Moves given point (in ECEF) by specified lat/lon angle difference (in degrees) and returns new ECEF point
@@ -421,6 +421,8 @@ class _3D_EXPORT QgsCameraController : public QObject
     // -1 when unset
     // TODO: Change to std::optional<double>
     double mDepthBufferNonVoidAverage = -1;
+    // nullptr when !mDepthBufferIsReady
+    std::unique_ptr<Qt3DRender::QCamera> mDepthBufferCamera;
 
     std::unique_ptr<Qt3DRender::QCamera> mCameraBefore;
 

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -527,8 +527,8 @@ void TestQgs3DCameraController::testRotationCenterZoomWheelRotationCenter()
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   scene->cameraController()->depthBufferCaptured( depthImage );
 
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( 312.936, -950.772, -125.381 ), 3.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( 98.4, -294.6, -38.7 ), 3.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( 282.946, -923.381, -25.824 ), 3.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( 89.1, -286.1, -7.8 ), 3.0 );
   QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1723.55, 3.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
@@ -860,9 +860,9 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -17.2, 17.2, 0.0 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -11.9, 11.9, 0.0 ), 1.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -17.2, 17.2, 0.0 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -11.9, 11.9, 0.0 ), 1.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 


### PR DESCRIPTION
## Description

Currently QgsCameraController uses `mCameraBefore` to compute depths in world-space units from the captured depth buffer. This property is saved right after a depth buffer capture is requested, but since the actual frame might be rendered a nontrivial amount of time later, `mCameraBefore` sometimes doesn't match the camera used to render the depth buffer. This manifests mainly as the possibility to sometimes "zoom past" the terrain.

This PR fixes this issue by adding a new copy of the camera, `mDepthBufferCamera`, which is saved right *after* the depth buffer is captured.

There's still no formal guarantee that this camera will match the one used for rendering, but practically this has fixed all the resulting issues I knew about. If anyone more knowledgeable in Qt3D internals knows if there's some "working copy" of the camera I could use, please let me know.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
