### PR TITLE
[sensorthings] Fix geometry types shown for entities without geometry

### DIFF
--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.cpp
@@ -387,7 +387,7 @@ void QgsSensorThingsSourceWidget::setCurrentEntityType( Qgis::SensorThingsEntity
     mComboGeometryType->addItem( QgsIconUtils::iconForWkbType( Qgis::WkbType::NoGeometry ), tr( "No Geometry" ), QVariant::fromValue( Qgis::WkbType::NoGeometry ) );
     setCurrentGeometryTypeFromString( mSourceParts.value( QStringLiteral( "geometryType" ) ).toString() );
   }
-  else if ( geometryTypeForEntity == Qgis::GeometryType::Null && mComboGeometryType->findData( QVariant::fromValue( Qgis::WkbType::NoGeometry ) ) < 0 )
+  else if ( geometryTypeForEntity == Qgis::GeometryType::Null && ( mComboGeometryType->findData( QVariant::fromValue( Qgis::WkbType::NoGeometry ) ) < 0 || mComboGeometryType->count() > 1 ) )
   {
     mComboGeometryType->clear();
     mComboGeometryType->addItem( QgsIconUtils::iconForWkbType( Qgis::WkbType::NoGeometry ), tr( "No Geometry" ), QVariant::fromValue( Qgis::WkbType::NoGeometry ) );


### PR DESCRIPTION
In some circumstances it was possible that the geometry type combo was incorrectly offering choices of geometries for non-spatial entity types.

Fixes #61402
