### PR TITLE
[postgres] Add connection setting for restricting schema

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -559,7 +559,7 @@ QDomDocument QgsManageConnectionsDialog::savePgConnections( const QStringList &c
     el.setAttribute( QStringLiteral( "allowGeometrylessTables" ), settings.value( path + "/allowGeometrylessTables", "0" ).toString() );
     el.setAttribute( QStringLiteral( "geometryColumnsOnly" ), settings.value( path + "/geometryColumnsOnly", "0" ).toString() );
     el.setAttribute( QStringLiteral( "publicOnly" ), settings.value( path + "/publicOnly", "0" ).toString() );
-
+    el.setAttribute( QStringLiteral( "schema" ), settings.value( path + "/schema" ).toString() );
     el.setAttribute( QStringLiteral( "saveUsername" ), settings.value( path + "/saveUsername", "false" ).toString() );
 
     if ( settings.value( path + "/saveUsername", "false" ).toString() == QLatin1String( "true" ) )
@@ -1182,6 +1182,7 @@ void QgsManageConnectionsDialog::loadPgConnections( const QDomDocument &doc, con
     settings.setValue( QStringLiteral( "/username" ), child.attribute( QStringLiteral( "username" ) ) );
     settings.setValue( QStringLiteral( "/savePassword" ), child.attribute( QStringLiteral( "savePassword" ) ) );
     settings.setValue( QStringLiteral( "/password" ), child.attribute( QStringLiteral( "password" ) ) );
+    settings.setValue( QStringLiteral( "/schema" ), child.attribute( QStringLiteral( "schema" ) ) );
     settings.endGroup();
 
     child = child.nextSiblingElement();

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -620,13 +620,24 @@ void QgsMssqlProviderConnection::store( const QString &name ) const
     {
       settings.setValue( param, dsUri.param( param ) == QLatin1String( "true" ) || dsUri.param( param ) == '1' );
     }
+    else
+    {
+      settings.remove( param );
+    }
   }
 
   // From configuration
   const auto config { configuration().keys() };
   for ( const auto &p : config )
   {
-    settings.setValue( p, configuration().value( p ) == QLatin1String( "true" ) || configuration().value( p ) == '1' );
+    if ( configuration().contains( p ) )
+    {
+      settings.setValue( p, configuration().value( p ) == QLatin1String( "true" ) || configuration().value( p ) == '1' );
+    }
+    else
+    {
+      settings.remove( p );
+    }
   }
 
   settings.endGroup();

--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -1015,7 +1015,7 @@ bool QgsOracleConn::userTablesOnly( const QString &connName )
   return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/userTablesOnly" ), false ).toBool();
 }
 
-QString QgsOracleConn::restrictToSchema( const QString &connName )
+QString QgsOracleConn::schemaToRestrict( const QString &connName )
 {
   QgsSettings settings;
   return settings.value( QStringLiteral( "/Oracle/connections/" ) + connName + QStringLiteral( "/schema" ) ).toString();

--- a/src/providers/oracle/qgsoracleconn.h
+++ b/src/providers/oracle/qgsoracleconn.h
@@ -241,7 +241,7 @@ class QgsOracleConn : public QObject
     static void setSelectedConnection( const QString &connName );
     static QgsDataSourceUri connUri( const QString &connName );
     static bool userTablesOnly( const QString &connName );
-    static QString restrictToSchema( const QString &connName );
+    static QString schemaToRestrict( const QString &connName );
     static bool geometryColumnsOnly( const QString &connName );
     static bool allowGeometrylessTables( const QString &connName );
     static bool allowProjectsInDatabase( const QString &connName );

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -188,7 +188,7 @@ QVector<QgsDataItem *> QgsOracleConnectionItem::createChildren()
 
   if ( !mColumnTypeTask )
   {
-    mColumnTypeTask = new QgsOracleColumnTypeTask( mName, QgsOracleConn::restrictToSchema( mName ),
+    mColumnTypeTask = new QgsOracleColumnTypeTask( mName, QgsOracleConn::schemaToRestrict( mName ),
                                                    /* useEstimatedMetadata */ true, QgsOracleConn::allowGeometrylessTables( mName ) );
 
     connect( mColumnTypeTask, &QgsOracleColumnTypeTask::setLayerType, this, &QgsOracleConnectionItem::setLayerType );

--- a/src/providers/oracle/qgsoracleproviderconnection.cpp
+++ b/src/providers/oracle/qgsoracleproviderconnection.cpp
@@ -326,6 +326,10 @@ void QgsOracleProviderConnection::store( const QString &name ) const
     {
       settings.setValue( param, dsUri.param( param ) );
     }
+    else
+    {
+      settings.remove( param );
+    }
   }
 
   // From configuration
@@ -334,6 +338,10 @@ void QgsOracleProviderConnection::store( const QString &name ) const
     if ( configuration().contains( p ) )
     {
       settings.setValue( p, configuration().value( p ) );
+    }
+    else
+    {
+      settings.remove( p );
     }
   }
   settings.endGroup();

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -396,7 +396,7 @@ void QgsOracleSourceSelect::btnConnect_clicked()
   mIsConnected = true;
   mTablesTreeDelegate->setConnectionInfo( uri );
 
-  mColumnTypeTask = new QgsOracleColumnTypeTask( cmbConnections->currentText(), QgsOracleConn::restrictToSchema( cmbConnections->currentText() ), uri.useEstimatedMetadata(), cbxAllowGeometrylessTables->isChecked() );
+  mColumnTypeTask = new QgsOracleColumnTypeTask( cmbConnections->currentText(), QgsOracleConn::schemaToRestrict( cmbConnections->currentText() ), uri.useEstimatedMetadata(), cbxAllowGeometrylessTables->isChecked() );
 
   connect( mColumnTypeTask, &QgsOracleColumnTypeTask::setLayerType, this, &QgsOracleSourceSelect::setLayerType );
   connect( mColumnTypeTask, &QgsTask::taskCompleted, this, &QgsOracleSourceSelect::columnTaskFinished );

--- a/src/providers/postgres/qgscolumntypethread.cpp
+++ b/src/providers/postgres/qgscolumntypethread.cpp
@@ -53,11 +53,11 @@ void QgsGeomColumnTypeThread::run()
   mStopped = false;
 
   const bool dontResolveType = QgsPostgresConn::dontResolveType( mName );
-  const QString schemaToRestrict = QgsPostgresConn::schemaToRestrict( mName );
+  const QString schemaToRestrict = QgsPostgresConn::publicSchemaOnly( mName ) ? QStringLiteral( "public" ) : QgsPostgresConn::schemaToRestrict( mName );
 
   emit progressMessage( tr( "Retrieving tables of %1…" ).arg( mName ) );
   QVector<QgsPostgresLayerProperty> layerProperties;
-  if ( !mConn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mName ), QgsPostgresConn::publicSchemaOnly( mName ), mAllowGeometrylessTables, false, schemaToRestrict ) || layerProperties.isEmpty() )
+  if ( !mConn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mName ), mAllowGeometrylessTables, false, schemaToRestrict ) || layerProperties.isEmpty() )
   {
     QgsPostgresConnPool::instance()->releaseConnection( mConn );
     mConn = nullptr;

--- a/src/providers/postgres/qgscolumntypethread.cpp
+++ b/src/providers/postgres/qgscolumntypethread.cpp
@@ -27,7 +27,6 @@ QgsGeomColumnTypeThread::QgsGeomColumnTypeThread( const QString &name, bool useE
   : mName( name )
   , mUseEstimatedMetadata( useEstimatedMetaData )
   , mAllowGeometrylessTables( allowGeometrylessTables )
-  , mStopped( false )
 {
   qRegisterMetaType<QgsPostgresLayerProperty>( "QgsPostgresLayerProperty" );
 }
@@ -53,11 +52,12 @@ void QgsGeomColumnTypeThread::run()
 
   mStopped = false;
 
-  bool dontResolveType = QgsPostgresConn::dontResolveType( mName );
+  const bool dontResolveType = QgsPostgresConn::dontResolveType( mName );
+  const QString restrictToSchema = QgsPostgresConn::restrictToSchema( mName );
 
   emit progressMessage( tr( "Retrieving tables of %1…" ).arg( mName ) );
   QVector<QgsPostgresLayerProperty> layerProperties;
-  if ( !mConn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mName ), QgsPostgresConn::publicSchemaOnly( mName ), mAllowGeometrylessTables ) || layerProperties.isEmpty() )
+  if ( !mConn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mName ), QgsPostgresConn::publicSchemaOnly( mName ), mAllowGeometrylessTables, false, restrictToSchema ) || layerProperties.isEmpty() )
   {
     QgsPostgresConnPool::instance()->releaseConnection( mConn );
     mConn = nullptr;

--- a/src/providers/postgres/qgscolumntypethread.cpp
+++ b/src/providers/postgres/qgscolumntypethread.cpp
@@ -53,11 +53,11 @@ void QgsGeomColumnTypeThread::run()
   mStopped = false;
 
   const bool dontResolveType = QgsPostgresConn::dontResolveType( mName );
-  const QString restrictToSchema = QgsPostgresConn::restrictToSchema( mName );
+  const QString schemaToRestrict = QgsPostgresConn::schemaToRestrict( mName );
 
   emit progressMessage( tr( "Retrieving tables of %1…" ).arg( mName ) );
   QVector<QgsPostgresLayerProperty> layerProperties;
-  if ( !mConn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mName ), QgsPostgresConn::publicSchemaOnly( mName ), mAllowGeometrylessTables, false, restrictToSchema ) || layerProperties.isEmpty() )
+  if ( !mConn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mName ), QgsPostgresConn::publicSchemaOnly( mName ), mAllowGeometrylessTables, false, schemaToRestrict ) || layerProperties.isEmpty() )
   {
     QgsPostgresConnPool::instance()->releaseConnection( mConn );
     mConn = nullptr;

--- a/src/providers/postgres/qgscolumntypethread.h
+++ b/src/providers/postgres/qgscolumntypethread.h
@@ -47,9 +47,9 @@ class QgsGeomColumnTypeThread : public QThread
 
     QgsPostgresConn *mConn = nullptr;
     QString mName;
-    bool mUseEstimatedMetadata;
-    bool mAllowGeometrylessTables;
-    bool mStopped;
+    bool mUseEstimatedMetadata = false;
+    bool mAllowGeometrylessTables = false;
+    bool mStopped = false;
     QList<QgsPostgresLayerProperty> layerProperties;
 };
 

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -184,7 +184,7 @@ void QgsPgNewConnection::accept()
   configuration.insert( "metadataInDatabase", cb_metadataInDatabase->isChecked() );
   configuration.insert( "session_role", txtSessionRole->text() );
   configuration.insert( "allowRasterOverviewTables", cb_allowRasterOverviewTables->isChecked() );
-  if ( !txtSchema->text().trimmed().isEmpty() )
+  if ( !cb_publicSchemaOnly->isChecked() && !txtSchema->text().trimmed().isEmpty() )
   {
     configuration.insert( "schema", txtSchema->text().trimmed() );
   }

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -39,6 +39,8 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
 
+  txtSchema->setShowClearButton( true );
+
   connect( btnConnect, &QPushButton::clicked, this, &QgsPgNewConnection::btnConnect_clicked );
   connect( cb_geometryColumnsOnly, &QCheckBox::clicked, this, &QgsPgNewConnection::cb_geometryColumnsOnly_clicked );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPgNewConnection::showHelp );
@@ -119,6 +121,8 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
     QString authcfg = settings.value( key + "/authcfg" ).toString();
     mAuthSettings->setConfigId( authcfg );
 
+    txtSchema->setText( settings.value( key + QStringLiteral( "/schema" ) ).toString() );
+
     txtName->setText( connName );
   }
   txtName->setValidator( new QRegularExpressionValidator( QRegularExpression( "[^\\/]*" ), txtName ) );
@@ -179,6 +183,10 @@ void QgsPgNewConnection::accept()
   configuration.insert( "metadataInDatabase", cb_metadataInDatabase->isChecked() );
   configuration.insert( "session_role", txtSessionRole->text() );
   configuration.insert( "allowRasterOverviewTables", cb_allowRasterOverviewTables->isChecked() );
+  if ( !txtSchema->text().trimmed().isEmpty() )
+  {
+    configuration.insert( "schema", txtSchema->text().trimmed() );
+  }
 
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
   std::unique_ptr<QgsPostgresProviderConnection> providerConnection( qgis::down_cast<QgsPostgresProviderConnection *>( providerMetadata->createConnection( txtName->text() ) ) );

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -51,6 +51,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
   connect( txtHost, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
   connect( txtPort, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
   connect( txtDatabase, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
+  connect( cb_publicSchemaOnly, &QCheckBox::toggled, txtSchema, &QgsFilterLineEdit::setDisabled );
 
   cbxSSLmode->addItem( tr( "disable" ), QgsDataSourceUri::SslDisable );
   cbxSSLmode->addItem( tr( "allow" ), QgsDataSourceUri::SslAllow );

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -2814,7 +2814,7 @@ bool QgsPostgresConn::allowRasterOverviewTables( const QString &connName )
   return settings.value( "/PostgreSQL/connections/" + connName + "/allowRasterOverviewTables", true ).toBool();
 }
 
-QString QgsPostgresConn::restrictToSchema( const QString &connName )
+QString QgsPostgresConn::schemaToRestrict( const QString &connName )
 {
   QgsSettings settings;
   return settings.value( QStringLiteral( "/PostgreSQL/connections/" ) + connName + QStringLiteral( "/schema" ) ).toString();

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -481,7 +481,7 @@ class QgsPostgresConn : public QObject
     static void deleteConnection( const QString &connName );
     static bool allowMetadataInDatabase( const QString &connName );
     static bool allowRasterOverviewTables( const QString &connName );
-    static QString restrictToSchema( const QString &connName );
+    static QString schemaToRestrict( const QString &connName );
 
     /**
      * Duplicates \a src connection settings to a new \a dst connection.

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -405,9 +405,10 @@ class QgsPostgresConn : public QObject
     /**
      * Gets the list of database schemas
      * \param schemas list to store schemas in
+     * \param restrictToSchemas optional list of schemas to filter to results to. If set, only schemas from this list will be included in the results.
      * \returns true if schemas where fetched successfully
      */
-    bool getSchemas( QList<QgsPostgresSchemaProperty> &schemas );
+    bool getSchemas( QList<QgsPostgresSchemaProperty> &schemas, const QStringList &restrictToSchemas = QStringList() );
 
     /**
      * Determine type and srid of a layer from data (possibly estimated)
@@ -480,6 +481,7 @@ class QgsPostgresConn : public QObject
     static void deleteConnection( const QString &connName );
     static bool allowMetadataInDatabase( const QString &connName );
     static bool allowRasterOverviewTables( const QString &connName );
+    static QString restrictToSchema( const QString &connName );
 
     /**
      * Duplicates \a src connection settings to a new \a dst connection.

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -386,13 +386,12 @@ class QgsPostgresConn : public QObject
      * \param layers list to store layers in
      * \param searchGeometryColumnsOnly only look for geometry columns which are
      * contained in the geometry_columns metatable
-     * \param searchPublicOnly
      * \param allowGeometrylessTables
      * \param allowRasterOverviewTables list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool allowRasterOverviewTables = false, const QString &schema = QString() );
+    bool supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool allowGeometrylessTables = false, bool allowRasterOverviewTables = false, const QString &schema = QString() );
 
     /**
      * Get the information about a supported layer
@@ -424,14 +423,13 @@ class QgsPostgresConn : public QObject
      * Gets information about the spatial tables
      * \param searchGeometryColumnsOnly only look for geometry columns which are
      * contained in the geometry_columns metatable
-     * \param searchPublicOnly
      * \param allowGeometrylessTables
      * \param allowRasterOverviewTables list raster layer overviews
      * \param schema restrict tables to those within specified schema
      * \param name restrict tables to those with specified name
      * \returns true if tables were successfully queried
      */
-    bool getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, bool allowRasterOverviewTables = false, const QString &schema = QString(), const QString &name = QString() );
+    bool getTableInfo( bool searchGeometryColumnsOnly, bool allowGeometrylessTables, bool allowRasterOverviewTables = false, const QString &schema = QString(), const QString &name = QString() );
 
     qint64 getBinaryInt( QgsPostgresResult &queryResult, int row, int col );
 
@@ -552,14 +550,13 @@ class QgsPostgresConn : public QObject
      * \param layers list to store layers in
      * \param searchGeometryColumnsOnly only look for geometry columns which are
      * contained in the geometry_columns metatable
-     * \param searchPublicOnly
      * \param allowGeometrylessTables
      * \param allowRasterOverviewTables list raster layer overviews
      * \param schema restrict layers to layers within specified schema
      * \param table restrict tables to those with specified table
      * \returns true if layers were fetched successfully
      */
-    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool searchPublicOnly = true, bool allowGeometrylessTables = false, bool allowRasterOverviewTables = false, const QString &schema = QString(), const QString &table = QString() );
+    bool supportedLayersPrivate( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly = true, bool allowGeometrylessTables = false, bool allowRasterOverviewTables = false, const QString &schema = QString(), const QString &table = QString() );
 
     //! List of the supported layers
     QVector<QgsPostgresLayerProperty> mLayersSupported;

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -55,7 +55,9 @@ QVector<QgsDataItem *> QgsPGConnectionItem::createChildren()
   }
 
   QList<QgsPostgresSchemaProperty> schemas;
-  bool ok = conn->getSchemas( schemas );
+  const QString restrictToSchema = QgsPostgresConn::restrictToSchema( mName );
+  const bool ok = conn->getSchemas( schemas, !restrictToSchema.isEmpty() ? QStringList { restrictToSchema } : QStringList {} );
+
   QgsPostgresConnPool::instance()->releaseConnection( conn );
 
   if ( !ok )
@@ -64,8 +66,7 @@ QVector<QgsDataItem *> QgsPGConnectionItem::createChildren()
     return items;
   }
 
-  const auto constSchemas = schemas;
-  for ( const QgsPostgresSchemaProperty &schema : constSchemas )
+  for ( const QgsPostgresSchemaProperty &schema : std::as_const( schemas ) )
   {
     QgsPGSchemaItem *schemaItem = new QgsPGSchemaItem( this, mName, schema.name, mPath + '/' + schema.name );
     if ( !schema.description.isEmpty() )

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -53,7 +53,7 @@ QVector<QgsDataItem *> QgsPGConnectionItem::createChildren()
   }
 
   QList<QgsPostgresSchemaProperty> schemas;
-  const QString restrictToSchema = QgsPostgresConn::schemaToRestrict( mName );
+  const QString restrictToSchema = QgsPostgresConn::publicSchemaOnly( mName ) ? QStringLiteral( "public" ) : QgsPostgresConn::schemaToRestrict( mName );
   const bool ok = conn->getSchemas( schemas, !restrictToSchema.isEmpty() ? QStringList { restrictToSchema } : QStringList {} );
 
   QgsPostgresConnPool::instance()->releaseConnection( conn );

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -29,8 +29,6 @@
 #include "qgsprovidermetadata.h"
 #include "qgsabstractdatabaseproviderconnection.h"
 
-#include <QMessageBox>
-#include <climits>
 
 // ---------------------------------------------------------------------------
 QgsPGConnectionItem::QgsPGConnectionItem( QgsDataItem *parent, const QString &name, const QString &path )
@@ -141,17 +139,17 @@ QString QgsPGLayerItem::createUri()
   const QgsSettings &settings = QgsSettings();
   QString basekey = QStringLiteral( "/PostgreSQL/connections/%1" ).arg( connName );
 
-  QStringList defPk( settings.value(
-                               QStringLiteral( "%1/keys/%2/%3" ).arg( basekey, mLayerProperty.schemaName, mLayerProperty.tableName ),
-                               QVariant( !mLayerProperty.pkCols.isEmpty() ? QStringList( mLayerProperty.pkCols.at( 0 ) ) : QStringList() )
+  const QStringList defPk( settings.value(
+                                     QStringLiteral( "%1/keys/%2/%3" ).arg( basekey, mLayerProperty.schemaName, mLayerProperty.tableName ),
+                                     QVariant( !mLayerProperty.pkCols.isEmpty() ? QStringList( mLayerProperty.pkCols.at( 0 ) ) : QStringList() )
   )
-                       .toStringList() );
+                             .toStringList() );
 
   const bool useEstimatedMetadata = QgsPostgresConn::useEstimatedMetadata( connName );
   uri.setUseEstimatedMetadata( useEstimatedMetadata );
 
   QStringList cols;
-  for ( const auto &col : defPk )
+  for ( const QString &col : defPk )
   {
     cols << QgsPostgresConn::quotedIdentifier( col );
   }
@@ -351,7 +349,7 @@ QgsPGLayerItem *QgsPGSchemaItem::createLayer( QgsPostgresLayerProperty layerProp
       default:
         if ( !layerProperty.geometryColName.isEmpty() )
         {
-          QgsDebugMsgLevel( QStringLiteral( "Adding layer item %1.%2 without type constraint as geometryless table" ).arg( layerProperty.schemaName ).arg( layerProperty.tableName ), 2 );
+          QgsDebugMsgLevel( QStringLiteral( "Adding layer item %1.%2 without type constraint as geometryless table" ).arg( layerProperty.schemaName, layerProperty.tableName ), 2 );
         }
         layerType = Qgis::BrowserLayerType::TableLayer;
         tip = tr( "as geometryless table" );

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -55,7 +55,7 @@ QVector<QgsDataItem *> QgsPGConnectionItem::createChildren()
   }
 
   QList<QgsPostgresSchemaProperty> schemas;
-  const QString restrictToSchema = QgsPostgresConn::restrictToSchema( mName );
+  const QString restrictToSchema = QgsPostgresConn::schemaToRestrict( mName );
   const bool ok = conn->getSchemas( schemas, !restrictToSchema.isEmpty() ? QStringList { restrictToSchema } : QStringList {} );
 
   QgsPostgresConnPool::instance()->releaseConnection( conn );

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -188,7 +188,7 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
   }
 
   QVector<QgsPostgresLayerProperty> layerProperties;
-  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::publicSchemaOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), QgsPostgresConn::allowRasterOverviewTables( mConnectionName ), mName );
+  const bool ok = conn->supportedLayers( layerProperties, QgsPostgresConn::geometryColumnsOnly( mConnectionName ), QgsPostgresConn::allowGeometrylessTables( mConnectionName ), QgsPostgresConn::allowRasterOverviewTables( mConnectionName ), mName );
 
   if ( !ok )
   {

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -258,7 +258,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsPostgresProviderC
     }
     else
     {
-      ok = conn->supportedLayers( properties, false, schema == QStringLiteral( "public" ), aspatial, false, schema );
+      ok = conn->supportedLayers( properties, false, aspatial, false, schema );
     }
 
     if ( !ok )

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -833,6 +833,10 @@ void QgsPostgresProviderConnection::store( const QString &name ) const
     {
       settings.setValue( p, configuration().value( p ) );
     }
+    else
+    {
+      settings.remove( p );
+    }
   }
   settings.endGroup();
   settings.endGroup();

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -46,6 +46,7 @@ const QStringList QgsPostgresProviderConnection::CONFIGURATION_PARAMETERS = {
   QStringLiteral( "metadataInDatabase" ),
   QStringLiteral( "session_role" ),
   QStringLiteral( "allowRasterOverviewTables" ),
+  QStringLiteral( "schema" ),
 };
 
 const QString QgsPostgresProviderConnection::SETTINGS_BASE_KEY = QStringLiteral( "/PostgreSQL/connections/" );

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -218,6 +218,9 @@
         <property name="echoMode">
          <enum>QLineEdit::Normal</enum>
         </property>
+        <property name="placeholderText">
+         <string>Limit to tables from specific schema</string>
+        </property>
        </widget>
       </item>
       <item row="6" column="0" colspan="2">

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -6,15 +6,9 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>878</width>
     <height>637</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Create a New Oracle Connection</string>
@@ -25,12 +19,12 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout">
+  <layout class="QGridLayout" columnstretch="1,1">
    <property name="leftMargin">
     <number>9</number>
    </property>
    <property name="topMargin">
-    <number>9</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
     <number>9</number>
@@ -41,19 +35,33 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="GroupBox1">
      <property name="title">
-      <string>Connection Information</string>
+      <string>Connection Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtName">
+        <property name="toolTip">
+         <string>Name of the new connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="TextLabel3_4">
+        <property name="text">
+         <string>Workspace</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="TextLabel3_3">
+        <property name="text">
+         <string>Options</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
@@ -64,42 +72,10 @@
         </property>
        </widget>
       </item>
-      <item row="15" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_onlyExistingTypes">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;Only list the existing geometry types and don't offer to add others.&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Only existing geometry types</string>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_useEstimatedMetadata">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;Use estimated table statistics for the layer metadata.&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Use estimated table metadata</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="TextLabel2_2">
-        <property name="text">
-         <string>Port</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtPort</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="TextLabel3_5">
-        <property name="text">
-         <string>Schema</string>
+      <item row="5" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtWorkspace">
+        <property name="echoMode">
+         <enum>QLineEdit::Normal</enum>
         </property>
        </widget>
       </item>
@@ -110,20 +86,13 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtHost"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="TextLabel3_3">
+      <item row="2" column="0">
+       <widget class="QLabel" name="TextLabel1">
         <property name="text">
-         <string>Options</string>
+         <string>Host</string>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtPort">
-        <property name="text">
-         <string>1521</string>
+        <property name="buddy">
+         <cstring>txtHost</cstring>
         </property>
        </widget>
       </item>
@@ -134,15 +103,18 @@
         </property>
        </widget>
       </item>
-      <item row="13" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
+      <item row="0" column="0">
+       <widget class="QLabel" name="TextLabel1_2">
         <property name="text">
-         <string>Also list tables with no geometry</string>
+         <string>Name</string>
         </property>
-        <property name="checked">
-         <bool>false</bool>
+        <property name="buddy">
+         <cstring>txtName</cstring>
         </property>
        </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtHost"/>
       </item>
       <item row="7" column="0" colspan="3">
        <widget class="QGroupBox" name="mAuthGroupBox">
@@ -163,12 +135,82 @@
           <number>6</number>
          </property>
          <item row="0" column="0">
-          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true">
+           <property name="focusPolicy">
+            <enum>Qt::StrongFocus</enum>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="6" column="1" colspan="2">
+      <item row="3" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtPort">
+        <property name="text">
+         <string>1521</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="TextLabel2_2">
+        <property name="text">
+         <string>Port</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtPort</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0" colspan="3">
+       <widget class="QPushButton" name="btnConnect">
+        <property name="text">
+         <string>&amp;Test Connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Database Details</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="7" column="0">
+       <widget class="QLabel" name="TextLabel3_5">
+        <property name="text">
+         <string>Schema</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="7" column="1">
        <widget class="QgsFilterLineEdit" name="txtSchema">
         <property name="toolTip">
          <string>If specified, only tables from the matching schema will be fetched and listed for the provider</string>
@@ -178,61 +220,14 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtName">
-        <property name="toolTip">
-         <string>Name of the new connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="2">
-       <widget class="QPushButton" name="btnConnect">
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_projectsInDatabase">
         <property name="text">
-         <string>&amp;Test Connect</string>
+         <string>Allow saving/loading QGIS projects in the database</string>
         </property>
        </widget>
       </item>
-      <item row="12" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_userTablesOnly">
-        <property name="toolTip">
-         <string>When searching for spatial tables restrict the search to tables that are owned by the user.</string>
-        </property>
-        <property name="text">
-         <string>Only look for user's tables</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restricts the displayed tables to those that are in the all_sdo_geom_metadata view. This can speed up the initial display of spatial tables.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Only look in metadata table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="TextLabel1_2">
-        <property name="text">
-         <string>Name</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtName</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="TextLabel1">
-        <property name="text">
-         <string>Host</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtHost</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="16" column="0" colspan="3">
+      <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="cb_includeGeoAttributes">
         <property name="toolTip">
          <string/>
@@ -242,42 +237,75 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="TextLabel3_4">
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_onlyExistingTypes">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;Only list the existing geometry types and don't offer to add others.&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
-         <string>Workspace</string>
+         <string>Only existing geometry types</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtWorkspace">
-        <property name="echoMode">
-         <enum>QLineEdit::Normal</enum>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_useEstimatedMetadata">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;Use estimated table statistics for the layer metadata.&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use estimated table metadata</string>
         </property>
        </widget>
       </item>
-      <item row="17" column="0">
-       <widget class="QCheckBox" name="cb_projectsInDatabase">
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
         <property name="text">
-         <string>Allow saving/loading QGIS projects in the database</string>
+         <string>Also list tables with no geometry</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_userTablesOnly">
+        <property name="toolTip">
+         <string>When searching for spatial tables restrict the search to tables that are owned by the user.</string>
+        </property>
+        <property name="text">
+         <string>Only look for user's tables</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restricts the displayed tables to those that are in the all_sdo_geom_metadata view. This can speed up the initial display of spatial tables.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Only look in metadata table</string>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="3" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
     <widget class="QgsMessageBar" name="bar" native="true"/>
    </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
-  <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
   <customwidget>
    <class>QgsMessageBar</class>
    <extends>QWidget</extends>
@@ -290,6 +318,11 @@
    <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>txtName</tabstop>
@@ -298,7 +331,7 @@
   <tabstop>txtPort</tabstop>
   <tabstop>txtOptions</tabstop>
   <tabstop>txtWorkspace</tabstop>
-  <tabstop>txtSchema</tabstop>
+  <tabstop>mAuthSettings</tabstop>
   <tabstop>btnConnect</tabstop>
   <tabstop>cb_geometryColumnsOnly</tabstop>
   <tabstop>cb_userTablesOnly</tabstop>
@@ -306,6 +339,7 @@
   <tabstop>cb_useEstimatedMetadata</tabstop>
   <tabstop>cb_onlyExistingTypes</tabstop>
   <tabstop>cb_includeGeoAttributes</tabstop>
+  <tabstop>cb_projectsInDatabase</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -192,7 +192,41 @@
       <string>Database Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="9" column="1">
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
+        <property name="text">
+         <string>Also list tables with no geometry</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_projectsInDatabase">
+        <property name="text">
+         <string>Allow saving/loading QGIS projects in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
+        <property name="toolTip">
+         <string>Restricts the displayed tables to those that are found in the layer registries (geometry_columns, geography_columns, topology.layer). This can speed up the initial display of spatial tables.</string>
+        </property>
+        <property name="text">
+         <string>Only show layers in the layer registries</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_dontResolveType">
+        <property name="text">
+         <string>Don't resolve type of unrestricted columns (GEOMETRY)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
        <spacer name="verticalSpacer_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -205,14 +239,21 @@
         </property>
        </spacer>
       </item>
-      <item row="8" column="0">
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_metadataInDatabase">
+        <property name="text">
+         <string>Allow saving/loading QGIS layer metadata in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
        <widget class="QLabel" name="TextLabel3_5">
         <property name="text">
          <string>Schema</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
+      <item row="9" column="1">
        <widget class="QgsFilterLineEdit" name="txtSchema">
         <property name="toolTip">
          <string>If specified, only tables from the matching schema will be fetched and listed for the provider</string>
@@ -226,20 +267,6 @@
        <widget class="QCheckBox" name="cb_allowRasterOverviewTables">
         <property name="text">
          <string>Also list raster overview tables</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_metadataInDatabase">
-        <property name="text">
-         <string>Allow saving/loading QGIS layer metadata in the database</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_projectsInDatabase">
-        <property name="text">
-         <string>Allow saving/loading QGIS projects in the database</string>
         </property>
        </widget>
       </item>
@@ -262,40 +289,13 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
-        <property name="text">
-         <string>Also list tables with no geometry</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
        <widget class="QCheckBox" name="cb_publicSchemaOnly">
         <property name="toolTip">
          <string>When searching for spatial tables that are not in the geometry_columns tables, restrict the search to tables that are in the public schema (for some databases this can save lots of time)</string>
         </property>
         <property name="text">
          <string>Only look in the 'public' schema</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_dontResolveType">
-        <property name="text">
-         <string>Don't resolve type of unrestricted columns (GEOMETRY)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
-        <property name="toolTip">
-         <string>Restricts the displayed tables to those that are found in the layer registries (geometry_columns, geography_columns, topology.layer). This can speed up the initial display of spatial tables.</string>
-        </property>
-        <property name="text">
-         <string>Only show layers in the layer registries</string>
         </property>
        </widget>
       </item>
@@ -346,12 +346,13 @@
   <tabstop>btnConnect</tabstop>
   <tabstop>cb_geometryColumnsOnly</tabstop>
   <tabstop>cb_dontResolveType</tabstop>
-  <tabstop>cb_publicSchemaOnly</tabstop>
   <tabstop>cb_allowGeometrylessTables</tabstop>
   <tabstop>cb_useEstimatedMetadata</tabstop>
   <tabstop>cb_projectsInDatabase</tabstop>
   <tabstop>cb_metadataInDatabase</tabstop>
   <tabstop>cb_allowRasterOverviewTables</tabstop>
+  <tabstop>cb_publicSchemaOnly</tabstop>
+  <tabstop>txtSchema</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -261,6 +261,9 @@
         <property name="echoMode">
          <enum>QLineEdit::Normal</enum>
         </property>
+        <property name="placeholderText">
+         <string>Limit to tables from specific schema</string>
+        </property>
        </widget>
       </item>
       <item row="7" column="0" colspan="2">

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>448</width>
-    <height>573</height>
+    <width>821</width>
+    <height>664</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,14 +25,14 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <widget class="QgsMessageBar" name="bar" native="true"/>
-   </item>
-   <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <item row="1" column="0">
     <widget class="QGroupBox" name="GroupBox1">
      <property name="title">
-      <string>Connection Information</string>
+      <string>Connection Details</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
@@ -154,7 +154,11 @@
           <number>6</number>
          </property>
          <item row="0" column="0">
-          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true">
+           <property name="focusPolicy">
+            <enum>Qt::StrongFocus</enum>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -163,83 +167,6 @@
        <widget class="QPushButton" name="btnConnect">
         <property name="text">
          <string>&amp;Test Connection</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
-        <property name="toolTip">
-         <string>Restricts the displayed tables to those that are found in the layer registries (geometry_columns, geography_columns, topology.layer). This can speed up the initial display of spatial tables.</string>
-        </property>
-        <property name="text">
-         <string>Only show layers in the layer registries</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_dontResolveType">
-        <property name="text">
-         <string>Don't resolve type of unrestricted columns (GEOMETRY)</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_publicSchemaOnly">
-        <property name="toolTip">
-         <string>When searching for spatial tables that are not in the geometry_columns tables, restrict the search to tables that are in the public schema (for some databases this can save lots of time)</string>
-        </property>
-        <property name="text">
-         <string>Only look in the 'public' schema</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
-        <property name="text">
-         <string>Also list tables with no geometry</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_useEstimatedMetadata">
-        <property name="toolTip">
-         <string>&lt;html&gt;
-&lt;body&gt;
-&lt;p&gt;&lt;b&gt;Use estimated table statistics for the layer metadata.&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;When the layer is setup various metadata is required for the PostGIS table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;
-&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;
-&lt;p&gt;1) Row count is determined from results of running the PostgreSQL Analyze function on the table.&lt;/p&gt;
-&lt;p&gt;2) Table extents are always determined with the estimated_extent PostGIS function even if a layer filter is applied.&lt;/p&gt;
-&lt;p&gt;3) If the table geometry type is unknown and is not exclusively taken from the geometry_columns table, then it is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;
-&lt;/body&gt;
-&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Use estimated table metadata</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_projectsInDatabase">
-        <property name="text">
-         <string>Allow saving/loading QGIS projects in the database</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_metadataInDatabase">
-        <property name="text">
-         <string>Allow saving/loading QGIS layer metadata in the database</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cb_allowRasterOverviewTables">
-        <property name="text">
-         <string>Also list raster overview tables</string>
         </property>
        </widget>
       </item>
@@ -259,27 +186,129 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Database Details</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
+        <property name="toolTip">
+         <string>Restricts the displayed tables to those that are found in the layer registries (geometry_columns, geography_columns, topology.layer). This can speed up the initial display of spatial tables.</string>
+        </property>
+        <property name="text">
+         <string>Only show layers in the layer registries</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="cb_useEstimatedMetadata">
+        <property name="toolTip">
+         <string>&lt;html&gt;
+&lt;body&gt;
+&lt;p&gt;&lt;b&gt;Use estimated table statistics for the layer metadata.&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;When the layer is setup various metadata is required for the PostGIS table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;
+&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;
+&lt;p&gt;1) Row count is determined from results of running the PostgreSQL Analyze function on the table.&lt;/p&gt;
+&lt;p&gt;2) Table extents are always determined with the estimated_extent PostGIS function even if a layer filter is applied.&lt;/p&gt;
+&lt;p&gt;3) If the table geometry type is unknown and is not exclusively taken from the geometry_columns table, then it is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;
+&lt;/body&gt;
+&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use estimated table metadata</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="cb_allowRasterOverviewTables">
+        <property name="text">
+         <string>Also list raster overview tables</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="cb_publicSchemaOnly">
+        <property name="toolTip">
+         <string>When searching for spatial tables that are not in the geometry_columns tables, restrict the search to tables that are in the public schema (for some databases this can save lots of time)</string>
+        </property>
+        <property name="text">
+         <string>Only look in the 'public' schema</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="cb_dontResolveType">
+        <property name="text">
+         <string>Don't resolve type of unrestricted columns (GEOMETRY)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="cb_projectsInDatabase">
+        <property name="text">
+         <string>Allow saving/loading QGIS projects in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QCheckBox" name="cb_metadataInDatabase">
+        <property name="text">
+         <string>Allow saving/loading QGIS layer metadata in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
+        <property name="text">
+         <string>Also list tables with no geometry</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QgsMessageBar" name="bar" native="true"/>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsAuthSettingsWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsauthsettingswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsMessageBar</class>
    <extends>QWidget</extends>
    <header>qgsmessagebar.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -290,6 +319,8 @@
   <tabstop>txtPort</tabstop>
   <tabstop>txtDatabase</tabstop>
   <tabstop>cbxSSLmode</tabstop>
+  <tabstop>txtSessionRole</tabstop>
+  <tabstop>mAuthSettings</tabstop>
   <tabstop>btnConnect</tabstop>
   <tabstop>cb_geometryColumnsOnly</tabstop>
   <tabstop>cb_dontResolveType</tabstop>
@@ -297,6 +328,8 @@
   <tabstop>cb_allowGeometrylessTables</tabstop>
   <tabstop>cb_useEstimatedMetadata</tabstop>
   <tabstop>cb_projectsInDatabase</tabstop>
+  <tabstop>cb_metadataInDatabase</tabstop>
+  <tabstop>cb_allowRasterOverviewTables</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -25,7 +25,7 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
+  <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1">
    <property name="topMargin">
     <number>0</number>
    </property>
@@ -192,17 +192,58 @@
       <string>Database Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
-        <property name="toolTip">
-         <string>Restricts the displayed tables to those that are found in the layer registries (geometry_columns, geography_columns, topology.layer). This can speed up the initial display of spatial tables.</string>
+      <item row="9" column="1">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
         </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="TextLabel3_5">
         <property name="text">
-         <string>Only show layers in the layer registries</string>
+         <string>Schema</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="8" column="1">
+       <widget class="QgsFilterLineEdit" name="txtSchema">
+        <property name="toolTip">
+         <string>If specified, only tables from the matching schema will be fetched and listed for the provider</string>
+        </property>
+        <property name="echoMode">
+         <enum>QLineEdit::Normal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_allowRasterOverviewTables">
+        <property name="text">
+         <string>Also list raster overview tables</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_metadataInDatabase">
+        <property name="text">
+         <string>Allow saving/loading QGIS layer metadata in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_projectsInDatabase">
+        <property name="text">
+         <string>Allow saving/loading QGIS projects in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="cb_useEstimatedMetadata">
         <property name="toolTip">
          <string>&lt;html&gt;
@@ -221,45 +262,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
-       <widget class="QCheckBox" name="cb_allowRasterOverviewTables">
-        <property name="text">
-         <string>Also list raster overview tables</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="cb_publicSchemaOnly">
-        <property name="toolTip">
-         <string>When searching for spatial tables that are not in the geometry_columns tables, restrict the search to tables that are in the public schema (for some databases this can save lots of time)</string>
-        </property>
-        <property name="text">
-         <string>Only look in the 'public' schema</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="cb_dontResolveType">
-        <property name="text">
-         <string>Don't resolve type of unrestricted columns (GEOMETRY)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QCheckBox" name="cb_projectsInDatabase">
-        <property name="text">
-         <string>Allow saving/loading QGIS projects in the database</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QCheckBox" name="cb_metadataInDatabase">
-        <property name="text">
-         <string>Allow saving/loading QGIS layer metadata in the database</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="cb_allowGeometrylessTables">
         <property name="text">
          <string>Also list tables with no geometry</string>
@@ -269,18 +272,32 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_publicSchemaOnly">
+        <property name="toolTip">
+         <string>When searching for spatial tables that are not in the geometry_columns tables, restrict the search to tables that are in the public schema (for some databases this can save lots of time)</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
+        <property name="text">
+         <string>Only look in the 'public' schema</string>
         </property>
-       </spacer>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_dontResolveType">
+        <property name="text">
+         <string>Don't resolve type of unrestricted columns (GEOMETRY)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
+        <property name="toolTip">
+         <string>Restricts the displayed tables to those that are found in the layer registries (geometry_columns, geography_columns, topology.layer). This can speed up the initial display of spatial tables.</string>
+        </property>
+        <property name="text">
+         <string>Only show layers in the layer registries</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -310,6 +327,11 @@
    <extends>QWidget</extends>
    <header>qgsauthsettingswidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -21,7 +21,6 @@
 #include "qgspostgresprovider.h"
 #include "qgsdatasourceuri.h"
 #include "qgspostgresutils.h"
-#include "qgscolumntypethread.h"
 
 // Helper function for QCOMPARE
 char *toString( const QgsPostgresGeometryColumnType &t )
@@ -175,7 +174,6 @@ class TestQgsPostgresConn : public QObject
       const bool success = conn->supportedLayers(
         layers,
         false,      // searchGeometryColumnsOnly
-        false,      // searchPublicOnly
         false,      // allowGeometrylessTables
         false,      // allowRasterOverviewTables
         "qgis_test" // schema


### PR DESCRIPTION
Like the equivalent Oracle provider setting, this allows users to specify a single schema to limit a Postgres connection to.

When set, only tables from the matching schema will be included in the browser panel and data source select for the connection.

This can be used to limit the database work required to populate tables for a connection pointing to a large database store.

Sponsored by Regiodata

![image](https://github.com/user-attachments/assets/375aa972-c416-4fef-aaed-c6c8712a40f6)
