### PR TITLE
Update terrain textures of globe when visible map layers change

### DIFF
--- a/src/3d/qgsglobechunkedentity.cpp
+++ b/src/3d/qgsglobechunkedentity.cpp
@@ -433,7 +433,7 @@ class QgsGlobeMapUpdateJob : public QgsChunkQueueJob
       Q_ASSERT( materials.count() == 1 );
       QVector<Qt3DRender::QAbstractTextureImage *> texImages = materials[0]->texture()->textureImages();
       Q_ASSERT( texImages.count() == 1 );
-      QgsTerrainTextureImage* terrainTexImage = qobject_cast<QgsTerrainTextureImage*>( texImages[0] );
+      QgsTerrainTextureImage *terrainTexImage = qobject_cast<QgsTerrainTextureImage *>( texImages[0] );
       Q_ASSERT( terrainTexImage );
 
       connect( textureGenerator, &QgsTerrainTextureGenerator::tileReady, this, [=]( int jobId, const QImage &image ) {
@@ -443,7 +443,7 @@ class QgsGlobeMapUpdateJob : public QgsChunkQueueJob
           mJobId = -1;
           emit finished();
         }
-      });
+      } );
       mJobId = textureGenerator->render( terrainTexImage->imageExtent(), node->tileId(), terrainTexImage->imageDebugText() );
     }
 
@@ -479,7 +479,6 @@ class QgsGlobeMapUpdateJobFactory : public QgsChunkQueueJobFactory
   private:
     QgsTerrainTextureGenerator *mTextureGenerator = nullptr;
 };
-
 
 
 // ---------------
@@ -570,7 +569,7 @@ void QgsGlobeEntity::invalidateMapImages()
     if ( mActiveNodes.contains( node ) )
       continue;
     if ( !node->parent() )
-      continue;   // skip root node because it is not proper QEntity with data
+      continue; // skip root node because it is not proper QEntity with data
     inactiveNodes << node;
   }
 

--- a/src/3d/qgsglobechunkedentity.h
+++ b/src/3d/qgsglobechunkedentity.h
@@ -59,12 +59,10 @@ class _3D_EXPORT QgsGlobeEntity : public QgsChunkedEntity
     void connectToLayersRepaintRequest();
 
   private:
-
     std::unique_ptr<QgsGlobeMapUpdateJobFactory> mUpdateJobFactory;
 
     //! layers that are currently being used for map rendering (and thus being watched for renderer updates)
     QList<QgsMapLayer *> mLayers;
-
 };
 
 

--- a/src/3d/qgsglobechunkedentity.h
+++ b/src/3d/qgsglobechunkedentity.h
@@ -34,6 +34,9 @@
 
 #include "qgschunkedentity.h"
 
+class QgsMapLayer;
+class QgsGlobeMapUpdateJobFactory;
+
 
 /**
  * 3D chunked entity implementation to generate globe mesh with constant elevation
@@ -47,6 +50,21 @@ class _3D_EXPORT QgsGlobeEntity : public QgsChunkedEntity
     ~QgsGlobeEntity();
 
     QVector<QgsRayCastingUtils::RayHit> rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const override;
+
+  private slots:
+    void invalidateMapImages();
+    void onLayersChanged();
+
+  private:
+    void connectToLayersRepaintRequest();
+
+  private:
+
+    std::unique_ptr<QgsGlobeMapUpdateJobFactory> mUpdateJobFactory;
+
+    //! layers that are currently being used for map rendering (and thus being watched for renderer updates)
+    QList<QgsMapLayer *> mLayers;
+
 };
 
 


### PR DESCRIPTION
To update the textures, we use the same approach as for "local" terrain entity - there's a map update job and a factory responsible for scheduling the updates using the texture generator. Globe 3D entities are not recreated, only their texture gets updated.

We also react to the change of map theme, background color, whether to show labels on the map, and whether to show tile info (for debugging). As a bonus, we react to whether terrain's bounding boxes are shown or not.


https://github.com/user-attachments/assets/8484ea1e-d8fc-4e6d-932e-8562da5e10a3

