### PR TITLE
[WMS][Time dimension] Allow group node to expose time dimension

### DIFF
--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -301,7 +301,7 @@ Returns QGIS Server Properties for the layer tree group
 
     void setHasWmsTimeDimension( const bool hasWmsTimeDimension );
 %Docstring
-Set whether the WMS time dimension should be computed for this group or
+Sets whether the WMS time dimension should be computed for this group or
 not
 
 :param hasWmsTimeDimension: if ``True``, when a GetCapabilities request

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -299,6 +299,34 @@ Returns QGIS Server Properties for the layer tree group
 %End
 
 
+    void setHasWmsTimeDimension( const bool hasWmsTimeDimension );
+%Docstring
+Set whether the WMS time dimension should be computed for this group or
+not
+
+:param hasWmsTimeDimension: if ``True``, when a GetCapabilities request
+                            is sent, QGIS server would return a TIME
+                            dimension computed as an union of all time
+                            dimensions of its children recursively.
+                            Else, no TIME dimension will be returned.
+
+.. seealso:: :py:func:`hasWmsTimeDimension`
+
+.. versionadded:: 3.44
+%End
+
+    bool hasWmsTimeDimension() const;
+%Docstring
+Returns whether the WMS time dimension should be computed for this group
+or not. if ``True``, when a GetCapabilities request is sent, QGIS server
+would return a TIME dimension computed as an union of all time
+dimensions of its children recursively. Else, no TIME dimension will be
+returned.
+
+.. seealso:: :py:func:`setHasWmsTimeDimension`
+
+.. versionadded:: 3.44
+%End
 
   protected slots:
 
@@ -310,6 +338,7 @@ Returns QGIS Server Properties for the layer tree group
 %Docstring
 Set check state of children - if mutually exclusive
 %End
+
 
 
 

--- a/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -93,7 +93,7 @@ Sets group WMS abstract
 
     void setHasTimeDimension( bool hasTimeDimension );
 %Docstring
-Set whether the time dimension should be computed for this group or not
+Sets whether the time dimension should be computed for this group or not
 
 :param hasTimeDimension: if ``True``, when a GetCapabilities request is
                          sent, QGIS server would return a TIME dimension

--- a/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -91,6 +91,34 @@ Sets group WMS abstract
    Use :py:func:`~QgsGroupWmsDataDialog.serverProperties`->:py:func:`~QgsGroupWmsDataDialog.setAbstract` instead.
 %End
 
+    void setHasTimeDimension( bool hasTimeDimension );
+%Docstring
+Set whether the time dimension should be computed for this group or not
+
+:param hasTimeDimension: if ``True``, when a GetCapabilities request is
+                         sent, QGIS server would return a TIME dimension
+                         computed as an union of all time dimensions of
+                         its children recursively. Else, no TIME
+                         dimension will be returned.
+
+.. seealso:: :py:func:`hasTimeDimension`
+
+.. versionadded:: 3.44
+%End
+
+    bool hasTimeDimension() const;
+%Docstring
+Returns whether the time dimension should be computed for this group or
+not. if ``True``, when a GetCapabilities request is sent, QGIS server
+would return a TIME dimension computed as an union of all time
+dimensions of its children recursively. Else, no TIME dimension will be
+returned.
+
+.. seealso:: :py:func:`setHasTimeDimension`
+
+.. versionadded:: 3.44
+%End
+
     QgsMapLayerServerProperties *serverProperties();
 %Docstring
 Returns QGIS Server Properties for the layer tree group

--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -301,7 +301,7 @@ Returns QGIS Server Properties for the layer tree group
 
     void setHasWmsTimeDimension( const bool hasWmsTimeDimension );
 %Docstring
-Set whether the WMS time dimension should be computed for this group or
+Sets whether the WMS time dimension should be computed for this group or
 not
 
 :param hasWmsTimeDimension: if ``True``, when a GetCapabilities request

--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -299,6 +299,34 @@ Returns QGIS Server Properties for the layer tree group
 %End
 
 
+    void setHasWmsTimeDimension( const bool hasWmsTimeDimension );
+%Docstring
+Set whether the WMS time dimension should be computed for this group or
+not
+
+:param hasWmsTimeDimension: if ``True``, when a GetCapabilities request
+                            is sent, QGIS server would return a TIME
+                            dimension computed as an union of all time
+                            dimensions of its children recursively.
+                            Else, no TIME dimension will be returned.
+
+.. seealso:: :py:func:`hasWmsTimeDimension`
+
+.. versionadded:: 3.44
+%End
+
+    bool hasWmsTimeDimension() const;
+%Docstring
+Returns whether the WMS time dimension should be computed for this group
+or not. if ``True``, when a GetCapabilities request is sent, QGIS server
+would return a TIME dimension computed as an union of all time
+dimensions of its children recursively. Else, no TIME dimension will be
+returned.
+
+.. seealso:: :py:func:`setHasWmsTimeDimension`
+
+.. versionadded:: 3.44
+%End
 
   protected slots:
 
@@ -310,6 +338,7 @@ Returns QGIS Server Properties for the layer tree group
 %Docstring
 Set check state of children - if mutually exclusive
 %End
+
 
 
 

--- a/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -93,7 +93,7 @@ Sets group WMS abstract
 
     void setHasTimeDimension( bool hasTimeDimension );
 %Docstring
-Set whether the time dimension should be computed for this group or not
+Sets whether the time dimension should be computed for this group or not
 
 :param hasTimeDimension: if ``True``, when a GetCapabilities request is
                          sent, QGIS server would return a TIME dimension

--- a/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
+++ b/python/gui/auto_generated/qgsgroupwmsdatadialog.sip.in
@@ -91,6 +91,34 @@ Sets group WMS abstract
    Use :py:func:`~QgsGroupWmsDataDialog.serverProperties`->:py:func:`~QgsGroupWmsDataDialog.setAbstract` instead.
 %End
 
+    void setHasTimeDimension( bool hasTimeDimension );
+%Docstring
+Set whether the time dimension should be computed for this group or not
+
+:param hasTimeDimension: if ``True``, when a GetCapabilities request is
+                         sent, QGIS server would return a TIME dimension
+                         computed as an union of all time dimensions of
+                         its children recursively. Else, no TIME
+                         dimension will be returned.
+
+.. seealso:: :py:func:`hasTimeDimension`
+
+.. versionadded:: 3.44
+%End
+
+    bool hasTimeDimension() const;
+%Docstring
+Returns whether the time dimension should be computed for this group or
+not. if ``True``, when a GetCapabilities request is sent, QGIS server
+would return a TIME dimension computed as an union of all time
+dimensions of its children recursively. Else, no TIME dimension will be
+returned.
+
+.. seealso:: :py:func:`setHasTimeDimension`
+
+.. versionadded:: 3.44
+%End
+
     QgsMapLayerServerProperties *serverProperties();
 %Docstring
 Returns QGIS Server Properties for the layer tree group

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12124,12 +12124,13 @@ void QgisApp::legendGroupSetWmsData()
     return;
 
   QgsGroupWmsDataDialog dlg( *currentGroup->serverProperties(), this );
-  if ( dlg.exec() )
+  dlg.setHasTimeDimension( currentGroup->hasWmsTimeDimension() );
+  if ( dlg.exec() && ( *dlg.serverProperties() != *currentGroup->serverProperties() || dlg.hasTimeDimension() != currentGroup->hasWmsTimeDimension() ) )
   {
-    if ( *dlg.serverProperties() != *currentGroup->serverProperties() )
-      QgsProject::instance()->setDirty( true );
+    QgsProject::instance()->setDirty( true );
 
     dlg.serverProperties()->copyTo( currentGroup->serverProperties() );
+    currentGroup->setHasWmsTimeDimension( dlg.hasTimeDimension() );
   }
 }
 

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -20,7 +20,6 @@
 #include "qgslayertreeutils.h"
 #include "qgsmaplayer.h"
 #include "qgsgrouplayer.h"
-#include "qgspainting.h"
 
 #include <QDomElement>
 #include <QStringList>
@@ -40,6 +39,7 @@ QgsLayerTreeGroup::QgsLayerTreeGroup( const QgsLayerTreeGroup &other )
   , mChangingChildVisibility( other.mChangingChildVisibility )
   , mMutuallyExclusive( other.mMutuallyExclusive )
   , mMutuallyExclusiveChildIndex( other.mMutuallyExclusiveChildIndex )
+  , mWmsHasTimeDimension( other.mWmsHasTimeDimension )
   , mGroupLayer( other.mGroupLayer )
   , mServerProperties( std::make_unique<QgsMapLayerServerProperties>() )
 {
@@ -370,6 +370,8 @@ QgsLayerTreeGroup *QgsLayerTreeGroup::readXml( const QDomElement &element, const
 
   groupNode->setIsMutuallyExclusive( isMutuallyExclusive, mutuallyExclusiveChildIndex );
 
+  groupNode->mWmsHasTimeDimension = element.attribute( QStringLiteral( "wms-has-time-dimension" ), QStringLiteral( "0" ) ) == QLatin1String( "1" );
+
   groupNode->mGroupLayer = QgsMapLayerRef( element.attribute( QStringLiteral( "groupLayer" ) ) );
 
   readLegacyServerProperties( groupNode );
@@ -426,6 +428,12 @@ void QgsLayerTreeGroup::writeXml( QDomElement &parentElement, const QgsReadWrite
     elem.setAttribute( QStringLiteral( "mutually-exclusive" ), QStringLiteral( "1" ) );
     elem.setAttribute( QStringLiteral( "mutually-exclusive-child" ), mMutuallyExclusiveChildIndex );
   }
+
+  if ( mWmsHasTimeDimension )
+  {
+    elem.setAttribute( QStringLiteral( "wms-has-time-dimension" ), QStringLiteral( "1" ) );
+  }
+
   elem.setAttribute( QStringLiteral( "groupLayer" ), mGroupLayer.layerId );
 
   writeCommonXml( elem );
@@ -685,4 +693,14 @@ QgsMapLayerServerProperties *QgsLayerTreeGroup::serverProperties()
 const QgsMapLayerServerProperties *QgsLayerTreeGroup::serverProperties() const
 {
   return mServerProperties.get();
+}
+
+void QgsLayerTreeGroup::setHasWmsTimeDimension( const bool hasWmsTimeDimension )
+{
+  mWmsHasTimeDimension = hasWmsTimeDimension;
+}
+
+bool QgsLayerTreeGroup::hasWmsTimeDimension() const
+{
+  return mWmsHasTimeDimension;
 }

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -288,7 +288,7 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     const QgsMapLayerServerProperties *serverProperties() const SIP_SKIP;
 
     /**
-     * Set whether the WMS time dimension should be computed for this group or not
+     * Sets whether the WMS time dimension should be computed for this group or not
      * \param hasWmsTimeDimension if TRUE, when a GetCapabilities request is sent,
      * QGIS server would return a TIME dimension computed as an union of all time
      * dimensions of its children recursively. Else, no TIME dimension will be returned.

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -287,6 +287,27 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
      */
     const QgsMapLayerServerProperties *serverProperties() const SIP_SKIP;
 
+    /**
+     * Set whether the WMS time dimension should be computed for this group or not
+     * \param hasWmsTimeDimension if TRUE, when a GetCapabilities request is sent,
+     * QGIS server would return a TIME dimension computed as an union of all time
+     * dimensions of its children recursively. Else, no TIME dimension will be returned.
+     *
+     * \see hasWmsTimeDimension()
+     * \since QGIS 3.44
+     */
+    void setHasWmsTimeDimension( const bool hasWmsTimeDimension );
+
+    /**
+     * Returns whether the WMS time dimension should be computed for this group or not.
+     * if TRUE, when a GetCapabilities request is sent, QGIS server would return a TIME
+     * dimension computed as an union of all time dimensions of its children recursively.
+     * Else, no TIME dimension will be returned.
+     *
+     * \see setHasWmsTimeDimension()
+     * \since QGIS 3.44
+     */
+    bool hasWmsTimeDimension() const;
 
   protected slots:
 
@@ -311,6 +332,8 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
      * (so if the whole group is unchecked and checked again, we know which child to check)
      */
     int mMutuallyExclusiveChildIndex = -1;
+
+    bool mWmsHasTimeDimension = false;
 
     //! Sets parent to NULLPTR and disconnects all external and forwarded signals
     virtual void makeOrphan() override SIP_SKIP;

--- a/src/gui/qgsgroupwmsdatadialog.cpp
+++ b/src/gui/qgsgroupwmsdatadialog.cpp
@@ -87,3 +87,13 @@ void QgsGroupWmsDataDialog::accept()
   mMapLayerServerPropertiesWidget->save();
   QDialog::accept();
 }
+
+bool QgsGroupWmsDataDialog::hasTimeDimension() const
+{
+  return mComputeTimeDimension->checkState() == Qt::Checked;
+}
+
+void QgsGroupWmsDataDialog::setHasTimeDimension( bool hasTimeDimension )
+{
+  mComputeTimeDimension->setCheckState( hasTimeDimension ? Qt::Checked : Qt::Unchecked );
+}

--- a/src/gui/qgsgroupwmsdatadialog.h
+++ b/src/gui/qgsgroupwmsdatadialog.h
@@ -91,6 +91,28 @@ class GUI_EXPORT QgsGroupWmsDataDialog : public QDialog, private Ui::QgsGroupWMS
     Q_DECL_DEPRECATED void setGroupAbstract( const QString &abstract ) SIP_DEPRECATED;
 
     /**
+     * Set whether the time dimension should be computed for this group or not
+     * \param hasTimeDimension if TRUE, when a GetCapabilities request is sent,
+     * QGIS server would return a TIME dimension computed as an union of all time
+     * dimensions of its children recursively. Else, no TIME dimension will be returned.
+     *
+     * \see hasTimeDimension()
+     * \since QGIS 3.44
+     */
+    void setHasTimeDimension( bool hasTimeDimension );
+
+    /**
+     * Returns whether the time dimension should be computed for this group or not.
+     * if TRUE, when a GetCapabilities request is sent, QGIS server would return a TIME
+     * dimension computed as an union of all time dimensions of its children recursively.
+     * Else, no TIME dimension will be returned.
+     *
+     * \see setHasTimeDimension()
+     * \since QGIS 3.44
+     */
+    bool hasTimeDimension() const;
+
+    /**
      * Returns QGIS Server Properties for the layer tree group
      * \since QGIS 3.44
      */

--- a/src/gui/qgsgroupwmsdatadialog.h
+++ b/src/gui/qgsgroupwmsdatadialog.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsGroupWmsDataDialog : public QDialog, private Ui::QgsGroupWMS
     Q_DECL_DEPRECATED void setGroupAbstract( const QString &abstract ) SIP_DEPRECATED;
 
     /**
-     * Set whether the time dimension should be computed for this group or not
+     * Sets whether the time dimension should be computed for this group or not
      * \param hasTimeDimension if TRUE, when a GetCapabilities request is sent,
      * QGIS server would return a TIME dimension computed as an union of all time
      * dimensions of its children recursively. Else, no TIME dimension will be returned.

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -19,8 +19,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <optional>
-
 #include "qgswmsutils.h"
 #include "qgswmsgetcapabilities.h"
 #include "qgsserverprojectutils.h"
@@ -1102,12 +1100,12 @@ namespace QgsWms
       const QString dateFormat = hasDateTime ? QStringLiteral( "yyyy-MM-ddTHH:mm:ss" ) : QStringLiteral( "yyyy-MM-dd" );
 
       QStringList strValues;
-      for ( const QgsDateTimeRange &r : dateRanges )
+      for ( const QgsDateTimeRange &range : dateRanges )
       {
         // Standard ISO8601 doesn't support range with no defined begin or end
-        if ( r.begin().isValid() && r.end().isValid() )
+        if ( range.begin().isValid() && range.end().isValid() )
         {
-          strValues << ( r.isInstant() ? r.begin().toString( dateFormat ) : QStringLiteral( "%1/%2" ).arg( r.begin().toString( dateFormat ) ).arg( r.end().toString( dateFormat ) ) );
+          strValues << ( range.isInstant() ? range.begin().toString( dateFormat ) : QStringLiteral( "%1/%2" ).arg( range.begin().toString( dateFormat ) ).arg( range.end().toString( dateFormat ) ) );
         }
       }
 
@@ -1364,7 +1362,7 @@ namespace QgsWms
 
             // Add all values
             const QList<QgsDateTimeRange> allRanges { l->temporalProperties()->allTemporalRanges( l ) };
-            bool isDateList = writeTimeDimensionNode( doc, layerElem, allRanges );
+            const bool isDateList = writeTimeDimensionNode( doc, layerElem, allRanges );
 
             parentDateRanges.append( allRanges );
 

--- a/src/ui/qgsgroupwmsdatadialogbase.ui
+++ b/src/ui/qgsgroupwmsdatadialogbase.ui
@@ -10,12 +10,21 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff/>
-   </iconset>
+    <normaloff>.</normaloff>.</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QgsMapLayerServerPropertiesWidget" name="mMapLayerServerPropertiesWidget" native="true"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="mComputeTimeDimension">
+     <property name="toolTip">
+      <string>When a GetCapabilities request is sent, QGIS server will return a TIME dimension computed as an union of all time dimension of its children recursively</string>
+     </property>
+     <property name="text">
+      <string>Compute TIME dimension from children</string>
+     </property>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">

--- a/src/ui/qgsgroupwmsdatadialogbase.ui
+++ b/src/ui/qgsgroupwmsdatadialogbase.ui
@@ -10,7 +10,8 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+   </iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -27,13 +27,16 @@ import osgeo.gdal  # NOQA
 
 from lxml import etree as et
 from qgis.core import (
+    Qgis,
     QgsFeature,
     QgsGeometry,
     QgsProject,
     QgsVectorLayer,
     QgsVectorLayerTemporalProperties,
+    QgsDateTimeRange,
     QgsTextFormat,
     QgsPalLayerSettings,
+    QgsRasterLayer,
     QgsVectorLayerSimpleLabeling,
     QgsFontUtils,
 )
@@ -43,7 +46,7 @@ from qgis.server import (
     QgsBufferServerResponse,
 )
 
-from qgis.PyQt.QtCore import QDate, QDateTime, QTime
+from qgis.PyQt.QtCore import QDate, QDateTime, QTime, Qt
 from qgis.PyQt.QtGui import QColor, QImage
 from qgis.testing import unittest
 from test_qgsserver import QgsServerTestBase
@@ -2891,6 +2894,10 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         )
 
         project = QgsProject()
+
+        # Set a filename to avoid capabilities cache breaking test
+        project.setFileName("test_temporal_properties")
+
         project.addMapLayers([layer_date, layer_range])
 
         qs = "?" + "&".join(
@@ -3017,6 +3024,156 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         )[0]
         self.assertEqual(range_extent.attrib, {"name": "TIME"})
         self.assertEqual(range_extent.text, "2003-03-03/2004-04-04")
+
+    def test_get_capabilities_time_dimension(self):
+        """Test if get capabilities return correct time dimension"""
+
+        # Test get capabilities
+        qs = "?" + "&".join(
+            [
+                "%s=%s" % i
+                for i in list(
+                    {
+                        "SERVICE": "WMS",
+                        "VERSION": "1.3.0",
+                        "REQUEST": "GetCapabilities",
+                    }.items()
+                )
+            ]
+        )
+
+        rl1 = QgsRasterLayer(
+            self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_1"
+        )
+        rl2 = QgsRasterLayer(
+            self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_2"
+        )
+        rl3 = QgsRasterLayer(
+            self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_3"
+        )
+        rl4 = QgsRasterLayer(
+            self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_4"
+        )
+        for rl in [rl1, rl2, rl3, rl4]:
+            timeProps = rl.temporalProperties()
+            timeProps.setIsActive(True)
+            timeProps.setMode(Qgis.RasterTemporalMode.FixedTemporalRange)
+
+        rl1.temporalProperties().setFixedTemporalRange(
+            QgsDateTimeRange(
+                QDateTime.fromString("2025-01-12T12:34:56", Qt.ISODate),
+                QDateTime.fromString("2025-01-15T09:12:34", Qt.ISODate),
+            )
+        )
+
+        rl2.temporalProperties().setFixedTemporalRange(
+            QgsDateTimeRange(
+                QDateTime.fromString("2025-01-12T00:00:00", Qt.ISODate),
+                QDateTime.fromString("2025-01-12T00:00:00", Qt.ISODate),
+            )
+        )
+
+        rl3.temporalProperties().setFixedTemporalRange(
+            QgsDateTimeRange(
+                QDateTime.fromString("2025-01-13T00:00:00", Qt.ISODate),
+                QDateTime.fromString("2025-01-13T00:00:00", Qt.ISODate),
+            )
+        )
+
+        project = QgsProject()
+
+        # Set a filename to avoid capabilities cache breaking test
+        project.setFileName("test_get_capabilities_time_dimension")
+
+        project.addMapLayers([rl1, rl2, rl3, rl4], False)
+
+        groupWithTimeDim = project.layerTreeRoot().addGroup("GroupWithTimeDimension")
+        groupWithTimeDim.setHasWmsTimeDimension(True)
+        groupWithoutTimeDim = project.layerTreeRoot().addGroup(
+            "GroupWithoutTimeDimension"
+        )
+
+        groupWithTimeDim.addLayer(rl1)
+        group = groupWithTimeDim.addGroup("SubGroupWithTimeDimension")
+        group.setHasWmsTimeDimension(True)
+        group.addLayer(rl2)
+        group.addLayer(rl4)
+        groupWithTimeDim.addGroup("SubGroupWithoutTimeDimension").addLayer(rl3)
+
+        groupWithoutTimeDim.addLayer(rl1)
+        group = groupWithoutTimeDim.addGroup("OtherSubGroupWithTimeDimension")
+        group.setHasWmsTimeDimension(True)
+        group.addLayer(rl2)
+        group.addLayer(rl4)
+        groupWithoutTimeDim.addGroup("OtherSubGroupWithoutTimeDimension").addLayer(rl3)
+
+        def get_time_dim(layer_name):
+            r, h = self._result(self._execute_request_project(qs, project))
+            t = et.fromstring(r)
+            ns = t.nsmap
+            del ns[None]
+            ns["wms"] = "http://www.opengis.net/wms"
+
+            dims = t.xpath(
+                f"//wms:Layer/wms:Name[text()='{layer_name}']/../wms:Dimension",
+                namespaces=ns,
+            )
+
+            return dims[0] if dims else None
+
+        # range date time
+        date_dimension = get_time_dim("test_date_1")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(date_dimension.text, "2025-01-12T12:34:56/2025-01-15T09:12:34")
+
+        # instant date
+        date_dimension = get_time_dim("test_date_2")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(date_dimension.text, "2025-01-12")
+
+        # instant date
+        date_dimension = get_time_dim("test_date_3")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(date_dimension.text, "2025-01-13")
+
+        # date time not set (expect a time Dimension but no value)
+        date_dimension = get_time_dim("test_date_4")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(date_dimension.text, None)
+
+        # group without time dimension option
+        date_dimension = get_time_dim("GroupWithoutTimeDimension")
+        self.assertEqual(date_dimension, None)
+
+        # group with time dimension option
+        date_dimension = get_time_dim("GroupWithTimeDimension")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(
+            date_dimension.text,
+            "2025-01-12T12:34:56/2025-01-15T09:12:34,2025-01-12T00:00:00",
+        )
+
+        # Test different cases for group recursivity
+
+        date_dimension = get_time_dim("SubGroupWithTimeDimension")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(
+            date_dimension.text,
+            "2025-01-12T00:00:00",
+        )
+
+        date_dimension = get_time_dim("SubGroupWithoutTimeDimension")
+        self.assertEqual(date_dimension, None)
+
+        date_dimension = get_time_dim("OtherSubGroupWithTimeDimension")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(
+            date_dimension.text,
+            "2025-01-12T00:00:00",
+        )
+
+        date_dimension = get_time_dim("OtherSubGroupWithoutTimeDimension")
+        self.assertEqual(date_dimension, None)
 
     def test_get_map_labeling_opacities(self):
         """Test if OPACITIES is also applied to labels"""


### PR DESCRIPTION
Allow layer tree group node to expose time dimension

A new checkbox allows to enable or disable the computation of this time dimension. If enabled, it would recursively generate the time dimension based upon its children time dimension. A group which time dimension computation is disabled would not propage the time dimension of its children to its parent.

![computetime](https://github.com/user-attachments/assets/c4f8e176-de60-4222-aaed-603449298f3a)

Add also support of date range in time dimension with respect to the OGC WMS and ISO8601 standard.

**Funded by Ifremer**
