### PR TITLE
testqgsproject: Properly check for signal emission in testDirtySet

### DIFF
--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -107,11 +107,10 @@ void TestQgsProject::cleanupTestCase()
 
 void TestQgsProject::testDirtySet()
 {
-  QgsProject p;
-  bool dirtySet = false;
-  connect( &p, &QgsProject::dirtySet, [&] { dirtySet = true; } );
-  p.setDirty( true );
-  QVERIFY( dirtySet );
+  QgsProject project;
+  QSignalSpy dirtySetSpy( &project, &QgsProject::dirtySet );
+  project.setDirty( true );
+  QVERIFY( dirtySetSpy.count() == 1 );
 }
 
 void TestQgsProject::testReadPath()


### PR DESCRIPTION
## Description

By using `QSignalSpy`, this ensures to properly check the signal emission and this also prevents a segfault if the signal has not been emitted at the end of the test.

Funded By: Oslandia