### PR TITLE
Globe: hide some options in configuration GUI

### DIFF
--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -460,6 +460,11 @@ QgsRectangle Qgs3DMapSettings::extent() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
+  if ( sceneMode() == Qgis::SceneMode::Globe )
+  {
+    QgsDebugError( QStringLiteral( "extent() should not be used with globe!" ) );
+  }
+
   return mExtent;
 }
 
@@ -469,6 +474,11 @@ void Qgs3DMapSettings::setExtent( const QgsRectangle &extent )
 
   if ( extent == mExtent )
     return;
+
+  if ( sceneMode() == Qgis::SceneMode::Globe )
+  {
+    QgsDebugError( QStringLiteral( "setExtent() should not be used with globe!" ) );
+  }
 
   mExtent = extent;
   const QgsPointXY center = mExtent.center();

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -710,6 +710,9 @@ void Qgs3DMapCanvasWidget::setMapSettings( Qgs3DMapSettings *map )
   mMapToolClippingPlanes = std::make_unique<QgsMapToolClippingPlanes>( mMainCanvas, this );
   mMapToolClippingPlanes->setAction( mActionSetClippingPlanes );
 
+  // none of the actions in the Camera menu are supported by globe yet, so just hide it completely
+  mActionCamera->setVisible( map->sceneMode() == Qgis::SceneMode::Local );
+
   connect( map, &Qgs3DMapSettings::viewFrustumVisualizationEnabledChanged, this, &Qgs3DMapCanvasWidget::onViewFrustumVisualizationEnabledChanged );
   connect( map, &Qgs3DMapSettings::extentChanged, this, &Qgs3DMapCanvasWidget::onExtentChanged );
   connect( map, &Qgs3DMapSettings::showExtentIn2DViewChanged, this, &Qgs3DMapCanvasWidget::onExtentChanged );


### PR DESCRIPTION
Hides or disables configuration options that either do not make sense in the context of globe scenes (e.g. scene's 2D extent) or the options are not implemented yet and their availability would confuse users (e.g. different terrain types, terrain vertical offset, terrain shading, sync between 2D/3D canvas)