### PR TITLE
Fix QGIS 3.42 build on arm64

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -49,6 +49,9 @@
 #include <QOpenGLFunctions>
 #include <Qt3DLogic/QFrameAction>
 
+#if !defined(Q_OS_MAC)
+#include <GL/gl.h>
+#endif
 
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
 #include <Qt3DRender/QBuffer>

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -49,7 +49,7 @@
 #include <QOpenGLFunctions>
 #include <Qt3DLogic/QFrameAction>
 
-#if !defined(Q_OS_MAC)
+#if !defined( Q_OS_MAC )
 #include <GL/gl.h>
 #endif
 


### PR DESCRIPTION
## Description

This missing include blocked the flathub builds of 3.42. The header is needed because we need GL_MAX_CLIP_PLANES.

Fixes https://github.com/qgis/QGIS/issues/60882

