### PR TITLE
Globe - fix identify tool

### DIFF
--- a/src/3d/terrain/qgsterrainentity.cpp
+++ b/src/3d/terrain/qgsterrainentity.cpp
@@ -107,7 +107,7 @@ QVector<QgsRayCastingUtils::RayHit> QgsTerrainEntity::rayIntersection( const Qgs
       if ( ray.direction().z() == 0 )
         break; // the ray is parallel to the flat terrain
 
-      const float dist = static_cast<float>( mMapSettings->terrainSettings()->elevationOffset() - ray.origin().z() ) / ray.direction().z();
+      const float dist = static_cast<float>( mMapSettings->terrainSettings()->elevationOffset() - ray.origin().z() - mMapSettings->origin().z() ) / ray.direction().z();
       const QVector3D terrainPlanePoint = ray.origin() + ray.direction() * dist;
       const QgsVector3D mapCoords = Qgs3DUtils::worldToMapCoordinates( terrainPlanePoint, mMapSettings->origin() );
       if ( mMapSettings->extent().contains( mapCoords.x(), mapCoords.y() ) )


### PR DESCRIPTION
This PR fixes identify tool for globe scenes, making sure that also Z coordinates are used.

As a bonus, it also fixes ray casting for local scenes with flat terrain in large scenes, fixing identify tool there as well.

https://github.com/user-attachments/assets/902f0950-a1ee-4a32-8623-bc74fb18e0f4
