### PR TITLE
Properly silence overloaded-virtual warning on Fedora 42

### DIFF
--- a/python/PyQt6/core/auto_additions/qgstriangle.py
+++ b/python/PyQt6/core/auto_additions/qgstriangle.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/core/geometry/qgstriangle.h
 try:
-    QgsTriangle.__overridden_methods__ = ['operator==', 'operator!=', 'geometryType', 'clone', 'clear', 'fromWkb', 'fromWkt', 'asGml3', 'surfaceToPolygon', 'toCurveType', 'addInteriorRing', 'deleteVertex', 'insertVertex', 'moveVertex', 'setExteriorRing', 'boundary', 'createEmptyWithSameType']
+    QgsTriangle.__overridden_methods__ = ['operator==', 'operator!=', 'geometryType', 'clone', 'clear', 'fromWkb', 'fromWkt', 'asGml3', 'surfaceToPolygon', 'toCurveType', 'addInteriorRing', 'deleteVertex', 'insertVertex', 'moveVertex', 'setExteriorRing', 'boundary', 'vertexAt', 'createEmptyWithSameType']
     QgsTriangle.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/geometry/qgstriangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgstriangle.sip.in
@@ -108,6 +108,7 @@ directly. Returns always ``False``.
 
 
 
+    virtual QgsPoint vertexAt( QgsVertexId id ) const;
 
 
     QgsPoint vertexAt( int atVertex ) const /HoldGIL/;

--- a/python/core/auto_additions/qgstriangle.py
+++ b/python/core/auto_additions/qgstriangle.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/core/geometry/qgstriangle.h
 try:
-    QgsTriangle.__overridden_methods__ = ['operator==', 'operator!=', 'geometryType', 'clone', 'clear', 'fromWkb', 'fromWkt', 'asGml3', 'surfaceToPolygon', 'toCurveType', 'addInteriorRing', 'deleteVertex', 'insertVertex', 'moveVertex', 'setExteriorRing', 'boundary', 'createEmptyWithSameType']
+    QgsTriangle.__overridden_methods__ = ['operator==', 'operator!=', 'geometryType', 'clone', 'clear', 'fromWkb', 'fromWkt', 'asGml3', 'surfaceToPolygon', 'toCurveType', 'addInteriorRing', 'deleteVertex', 'insertVertex', 'moveVertex', 'setExteriorRing', 'boundary', 'vertexAt', 'createEmptyWithSameType']
     QgsTriangle.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/geometry/qgstriangle.sip.in
+++ b/python/core/auto_generated/geometry/qgstriangle.sip.in
@@ -108,6 +108,7 @@ directly. Returns always ``False``.
 
 
 
+    virtual QgsPoint vertexAt( QgsVertexId id ) const;
 
 
     QgsPoint vertexAt( int atVertex ) const /HoldGIL/;

--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -361,6 +361,11 @@ QgsCurve *QgsTriangle::boundary() const
   return mExteriorRing->clone();
 }
 
+QgsPoint QgsTriangle::vertexAt( QgsVertexId id ) const
+{
+  return QgsPolygon::vertexAt( id );
+}
+
 QgsPoint QgsTriangle::vertexAt( int atVertex ) const
 {
   if ( isEmpty() )

--- a/src/core/geometry/qgstriangle.h
+++ b/src/core/geometry/qgstriangle.h
@@ -101,11 +101,8 @@ class CORE_EXPORT QgsTriangle : public QgsPolygon
 
     // inherited: double pointDistanceToBoundary( double x, double y ) const;
 
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Woverloaded-virtual"
-#endif
+    // override QgsPolygon method to avoid unwanted overloaded-virtual warning caused by int variant of vertexAt defined below
+    QgsPoint vertexAt( QgsVertexId id ) const override;
 
     /**
      *  Returns coordinates of a vertex.
@@ -113,9 +110,6 @@ class CORE_EXPORT QgsTriangle : public QgsPolygon
      *  \returns Coordinates of the vertex or empty QgsPoint on error (\a atVertex < 0 or > 3).
      */
     QgsPoint vertexAt( int atVertex ) const SIP_HOLDGIL;
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
     /**
      * Returns the three lengths of the triangle.


### PR DESCRIPTION
The previous pragma no longer silences this warning on newer compilers...