### PR TITLE
Fixes for a couple of map layer notes's GUI papercuts

### DIFF
--- a/src/app/qgslayernotesmanager.cpp
+++ b/src/app/qgslayernotesmanager.cpp
@@ -68,5 +68,5 @@ void QgsLayerNotesDialog::setNotes( const QString &notes )
 
 QString QgsLayerNotesDialog::notes() const
 {
-  return mEditor->toHtml();
+  return !mEditor->textEdit()->toPlainText().trimmed().isEmpty() ? mEditor->toHtml() : QString();
 }

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -466,7 +466,7 @@ void QgsRichTextEditor::textLink( bool checked )
   mergeFormatOnWordOrSelection( format );
 }
 
-void QgsRichTextEditor::textStyle( int )
+void QgsRichTextEditor::textStyle( int index )
 {
   QTextCursor cursor = mTextEdit->textCursor();
   cursor.beginEditBlock();
@@ -480,7 +480,7 @@ void QgsRichTextEditor::textStyle( int )
   cursor.setCharFormat( format );
   mTextEdit->setCurrentCharFormat( format );
 
-  const ParagraphItems style = static_cast<ParagraphItems>( mParagraphStyleCombo->currentData().toInt() );
+  const ParagraphItems style = static_cast<ParagraphItems>( mParagraphStyleCombo->itemData( index ).toInt() );
 
   switch ( style )
   {

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -642,19 +642,19 @@ void QgsRichTextEditor::fontChanged( const QFont &f )
   mActionItalic->setChecked( f.italic() );
   mActionUnderline->setChecked( f.underline() );
   mActionStrikeOut->setChecked( f.strikeOut() );
-  if ( f.pointSize() == mFontSizeH1 )
+  if ( f.bold() && f.pointSize() == mFontSizeH1 )
   {
     mParagraphStyleCombo->setCurrentIndex( ParagraphHeading1 );
   }
-  else if ( f.pointSize() == mFontSizeH2 )
+  else if ( f.bold() && f.pointSize() == mFontSizeH2 )
   {
     mParagraphStyleCombo->setCurrentIndex( ParagraphHeading2 );
   }
-  else if ( f.pointSize() == mFontSizeH3 )
+  else if ( f.bold() && f.pointSize() == mFontSizeH3 )
   {
     mParagraphStyleCombo->setCurrentIndex( ParagraphHeading3 );
   }
-  else if ( f.pointSize() == mFontSizeH4 )
+  else if ( f.bold() && f.pointSize() == mFontSizeH4 )
   {
     mParagraphStyleCombo->setCurrentIndex( ParagraphHeading4 );
   }


### PR DESCRIPTION
## Description

While adding map layer notes support within QField, I stumbled on a few papercuts with the notes editor. This PR addresses these.

The worse one was that an empty text editor would not result in an empty note because while users had cleared the content, the HTML source still had html tags representing an empty HTML document.