### PR TITLE
Fix duplicate layer using the shared pointer and do not update feature count

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3536,6 +3536,9 @@ bool QgsPostgresProvider::setSubsetString( const QString &theSQL, bool updateFea
   }
 #endif
 
+  // clone the share because the feature subset differs (and thus also the feature count etc)
+  mShared = mShared->clone();
+
   // Update datasource uri too
   mUri.setSql( theSQL );
   // Update yet another copy of the uri. Why are there 3 copies of the

--- a/src/providers/postgres/qgspostgresutils.cpp
+++ b/src/providers/postgres/qgspostgresutils.cpp
@@ -45,6 +45,8 @@ void QgsPostgresSharedData::ensureFeaturesCountedAtLeast( long long fetched )
 
 std::shared_ptr<QgsPostgresSharedData> QgsPostgresSharedData::clone() const
 {
+  QMutexLocker locker( &mMutex );
+
   auto copy = std::make_shared<QgsPostgresSharedData>();
   copy->mFeaturesCounted = mFeaturesCounted;
   copy->mFidCounter = mFidCounter;

--- a/src/providers/postgres/qgspostgresutils.cpp
+++ b/src/providers/postgres/qgspostgresutils.cpp
@@ -43,6 +43,17 @@ void QgsPostgresSharedData::ensureFeaturesCountedAtLeast( long long fetched )
   }
 }
 
+std::shared_ptr<QgsPostgresSharedData> QgsPostgresSharedData::clone() const
+{
+  auto copy = std::make_shared<QgsPostgresSharedData>();
+  copy->mFeaturesCounted = mFeaturesCounted;
+  copy->mFidCounter = mFidCounter;
+  copy->mKeyToFid = mKeyToFid;
+  copy->mFidToKey = mFidToKey;
+  copy->mFieldSupportsEnumValues = mFieldSupportsEnumValues;
+  return copy;
+}
+
 long long QgsPostgresSharedData::featuresCounted()
 {
   QMutexLocker locker( &mMutex );

--- a/src/providers/postgres/qgspostgresutils.h
+++ b/src/providers/postgres/qgspostgresutils.h
@@ -51,7 +51,7 @@ class QgsPostgresSharedData
     void setFieldSupportsEnumValues( int index, bool isSupported );
 
   protected:
-    QMutex mMutex; //!< Access to all data members is guarded by the mutex
+    mutable QMutex mMutex; //!< Access to all data members is guarded by the mutex
 
     long long mFeaturesCounted = -1; //!< Number of features in the layer
 

--- a/src/providers/postgres/qgspostgresutils.h
+++ b/src/providers/postgres/qgspostgresutils.h
@@ -30,6 +30,9 @@ class QgsPostgresSharedData
   public:
     QgsPostgresSharedData() = default;
 
+    //! Creates a deep copy of this shared data
+    std::shared_ptr<QgsPostgresSharedData> clone() const;
+
     long long featuresCounted();
     void setFeaturesCounted( long long count );
     void addFeaturesCounted( long long diff );


### PR DESCRIPTION
Solved with cloning the shared pointer `mShared` on `setSubset`. Since it needs a new one (at least for feature count) on having a new (or no) subset of features.

This fixes #60926
