### PR TITLE
convert enums to enum classes in raster analysis tools

### DIFF
--- a/python/PyQt6/analysis/auto_additions/qgsinterpolator.py
+++ b/python/PyQt6/analysis/auto_additions/qgsinterpolator.py
@@ -1,25 +1,61 @@
 # The following has been generated automatically from src/analysis/interpolation/qgsinterpolator.h
 # monkey patching scoped based enum
-QgsInterpolator.SourceType.SourcePoints.__doc__ = "Point source"
-QgsInterpolator.SourceType.SourceStructureLines.__doc__ = "Structure lines"
-QgsInterpolator.SourceType.SourceBreakLines.__doc__ = "Break lines"
+QgsInterpolator.SourcePoints = QgsInterpolator.SourceType.Points
+QgsInterpolator.SourceType.SourcePoints = QgsInterpolator.SourceType.Points
+QgsInterpolator.SourcePoints.is_monkey_patched = True
+QgsInterpolator.SourcePoints.__doc__ = "Point source"
+QgsInterpolator.SourceStructureLines = QgsInterpolator.SourceType.StructureLines
+QgsInterpolator.SourceType.SourceStructureLines = QgsInterpolator.SourceType.StructureLines
+QgsInterpolator.SourceStructureLines.is_monkey_patched = True
+QgsInterpolator.SourceStructureLines.__doc__ = "Structure lines"
+QgsInterpolator.SourceBreakLines = QgsInterpolator.SourceType.BreakLines
+QgsInterpolator.SourceType.SourceBreakLines = QgsInterpolator.SourceType.BreakLines
+QgsInterpolator.SourceBreakLines.is_monkey_patched = True
+QgsInterpolator.SourceBreakLines.__doc__ = "Break lines"
 QgsInterpolator.SourceType.__doc__ = """Describes the type of input data
 
-* ``SourcePoints``: Point source
-* ``SourceStructureLines``: Structure lines
-* ``SourceBreakLines``: Break lines
+* ``Points``: Point source
+
+  Available as ``QgsInterpolator.SourcePoints`` in older QGIS releases.
+
+* ``StructureLines``: Structure lines
+
+  Available as ``QgsInterpolator.SourceStructureLines`` in older QGIS releases.
+
+* ``BreakLines``: Break lines
+
+  Available as ``QgsInterpolator.SourceBreakLines`` in older QGIS releases.
+
 
 """
 # --
 # monkey patching scoped based enum
-QgsInterpolator.ValueSource.ValueAttribute.__doc__ = "Take value from feature's attribute"
-QgsInterpolator.ValueSource.ValueZ.__doc__ = "Use feature's geometry Z values for interpolation"
-QgsInterpolator.ValueSource.ValueM.__doc__ = "Use feature's geometry M values for interpolation"
+QgsInterpolator.ValueAttribute = QgsInterpolator.ValueSource.Attribute
+QgsInterpolator.ValueSource.ValueAttribute = QgsInterpolator.ValueSource.Attribute
+QgsInterpolator.ValueAttribute.is_monkey_patched = True
+QgsInterpolator.ValueAttribute.__doc__ = "Take value from feature's attribute"
+QgsInterpolator.ValueZ = QgsInterpolator.ValueSource.Z
+QgsInterpolator.ValueSource.ValueZ = QgsInterpolator.ValueSource.Z
+QgsInterpolator.ValueZ.is_monkey_patched = True
+QgsInterpolator.ValueZ.__doc__ = "Use feature's geometry Z values for interpolation"
+QgsInterpolator.ValueM = QgsInterpolator.ValueSource.M
+QgsInterpolator.ValueSource.ValueM = QgsInterpolator.ValueSource.M
+QgsInterpolator.ValueM.is_monkey_patched = True
+QgsInterpolator.ValueM.__doc__ = "Use feature's geometry M values for interpolation"
 QgsInterpolator.ValueSource.__doc__ = """Source for interpolated values from features
 
-* ``ValueAttribute``: Take value from feature's attribute
-* ``ValueZ``: Use feature's geometry Z values for interpolation
-* ``ValueM``: Use feature's geometry M values for interpolation
+* ``Attribute``: Take value from feature's attribute
+
+  Available as ``QgsInterpolator.ValueAttribute`` in older QGIS releases.
+
+* ``Z``: Use feature's geometry Z values for interpolation
+
+  Available as ``QgsInterpolator.ValueZ`` in older QGIS releases.
+
+* ``M``: Use feature's geometry M values for interpolation
+
+  Available as ``QgsInterpolator.ValueM`` in older QGIS releases.
+
 
 """
 # --

--- a/python/PyQt6/analysis/auto_additions/qgsinterpolator.py
+++ b/python/PyQt6/analysis/auto_additions/qgsinterpolator.py
@@ -1,14 +1,42 @@
 # The following has been generated automatically from src/analysis/interpolation/qgsinterpolator.h
-QgsInterpolator.SourcePoints = QgsInterpolator.SourceType.SourcePoints
-QgsInterpolator.SourceStructureLines = QgsInterpolator.SourceType.SourceStructureLines
-QgsInterpolator.SourceBreakLines = QgsInterpolator.SourceType.SourceBreakLines
-QgsInterpolator.ValueAttribute = QgsInterpolator.ValueSource.ValueAttribute
-QgsInterpolator.ValueZ = QgsInterpolator.ValueSource.ValueZ
-QgsInterpolator.ValueM = QgsInterpolator.ValueSource.ValueM
-QgsInterpolator.Success = QgsInterpolator.Result.Success
-QgsInterpolator.Canceled = QgsInterpolator.Result.Canceled
-QgsInterpolator.InvalidSource = QgsInterpolator.Result.InvalidSource
-QgsInterpolator.FeatureGeometryError = QgsInterpolator.Result.FeatureGeometryError
+# monkey patching scoped based enum
+QgsInterpolator.SourceType.SourcePoints.__doc__ = "Point source"
+QgsInterpolator.SourceType.SourceStructureLines.__doc__ = "Structure lines"
+QgsInterpolator.SourceType.SourceBreakLines.__doc__ = "Break lines"
+QgsInterpolator.SourceType.__doc__ = """Describes the type of input data
+
+* ``SourcePoints``: Point source
+* ``SourceStructureLines``: Structure lines
+* ``SourceBreakLines``: Break lines
+
+"""
+# --
+# monkey patching scoped based enum
+QgsInterpolator.ValueSource.ValueAttribute.__doc__ = "Take value from feature's attribute"
+QgsInterpolator.ValueSource.ValueZ.__doc__ = "Use feature's geometry Z values for interpolation"
+QgsInterpolator.ValueSource.ValueM.__doc__ = "Use feature's geometry M values for interpolation"
+QgsInterpolator.ValueSource.__doc__ = """Source for interpolated values from features
+
+* ``ValueAttribute``: Take value from feature's attribute
+* ``ValueZ``: Use feature's geometry Z values for interpolation
+* ``ValueM``: Use feature's geometry M values for interpolation
+
+"""
+# --
+# monkey patching scoped based enum
+QgsInterpolator.Result.Success.__doc__ = "Operation was successful"
+QgsInterpolator.Result.Canceled.__doc__ = "Operation was manually canceled"
+QgsInterpolator.Result.InvalidSource.__doc__ = "Operation failed due to invalid source"
+QgsInterpolator.Result.FeatureGeometryError.__doc__ = "Operation failed due to invalid feature geometry"
+QgsInterpolator.Result.__doc__ = """Result of an interpolation operation
+
+* ``Success``: Operation was successful
+* ``Canceled``: Operation was manually canceled
+* ``InvalidSource``: Operation failed due to invalid source
+* ``FeatureGeometryError``: Operation failed due to invalid feature geometry
+
+"""
+# --
 try:
     QgsInterpolatorVertexData.__attribute_docs__ = {'x': 'X-coordinate', 'y': 'Y-coordinate', 'z': 'Z-coordinate'}
     QgsInterpolatorVertexData.__annotations__ = {'x': float, 'y': float, 'z': float}

--- a/python/PyQt6/analysis/auto_additions/qgskde.py
+++ b/python/PyQt6/analysis/auto_additions/qgskde.py
@@ -1,16 +1,46 @@
 # The following has been generated automatically from src/analysis/raster/qgskde.h
-QgsKernelDensityEstimation.KernelQuartic = QgsKernelDensityEstimation.KernelShape.KernelQuartic
-QgsKernelDensityEstimation.KernelTriangular = QgsKernelDensityEstimation.KernelShape.KernelTriangular
-QgsKernelDensityEstimation.KernelUniform = QgsKernelDensityEstimation.KernelShape.KernelUniform
-QgsKernelDensityEstimation.KernelTriweight = QgsKernelDensityEstimation.KernelShape.KernelTriweight
-QgsKernelDensityEstimation.KernelEpanechnikov = QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov
-QgsKernelDensityEstimation.OutputRaw = QgsKernelDensityEstimation.OutputValues.OutputRaw
-QgsKernelDensityEstimation.OutputScaled = QgsKernelDensityEstimation.OutputValues.OutputScaled
-QgsKernelDensityEstimation.Success = QgsKernelDensityEstimation.Result.Success
-QgsKernelDensityEstimation.DriverError = QgsKernelDensityEstimation.Result.DriverError
-QgsKernelDensityEstimation.InvalidParameters = QgsKernelDensityEstimation.Result.InvalidParameters
-QgsKernelDensityEstimation.FileCreationError = QgsKernelDensityEstimation.Result.FileCreationError
-QgsKernelDensityEstimation.RasterIoError = QgsKernelDensityEstimation.Result.RasterIoError
+# monkey patching scoped based enum
+QgsKernelDensityEstimation.KernelShape.KernelQuartic.__doc__ = "Quartic kernel"
+QgsKernelDensityEstimation.KernelShape.KernelTriangular.__doc__ = "Triangular kernel"
+QgsKernelDensityEstimation.KernelShape.KernelUniform.__doc__ = "Uniform (flat) kernel"
+QgsKernelDensityEstimation.KernelShape.KernelTriweight.__doc__ = "Triweight kernel"
+QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov.__doc__ = "Epanechnikov kernel"
+QgsKernelDensityEstimation.KernelShape.__doc__ = """Kernel shape type
+
+* ``KernelQuartic``: Quartic kernel
+* ``KernelTriangular``: Triangular kernel
+* ``KernelUniform``: Uniform (flat) kernel
+* ``KernelTriweight``: Triweight kernel
+* ``KernelEpanechnikov``: Epanechnikov kernel
+
+"""
+# --
+# monkey patching scoped based enum
+QgsKernelDensityEstimation.OutputValues.OutputRaw.__doc__ = "Output the raw KDE values"
+QgsKernelDensityEstimation.OutputValues.OutputScaled.__doc__ = "Output mathematically correct scaled values"
+QgsKernelDensityEstimation.OutputValues.__doc__ = """Output values type
+
+* ``OutputRaw``: Output the raw KDE values
+* ``OutputScaled``: Output mathematically correct scaled values
+
+"""
+# --
+# monkey patching scoped based enum
+QgsKernelDensityEstimation.Result.Success.__doc__ = "Operation completed successfully"
+QgsKernelDensityEstimation.Result.DriverError.__doc__ = "Could not open the driver for the specified format"
+QgsKernelDensityEstimation.Result.InvalidParameters.__doc__ = "Input parameters were not valid"
+QgsKernelDensityEstimation.Result.FileCreationError.__doc__ = "Error creating output file"
+QgsKernelDensityEstimation.Result.RasterIoError.__doc__ = "Error writing to raster"
+QgsKernelDensityEstimation.Result.__doc__ = """Result of operation
+
+* ``Success``: Operation completed successfully
+* ``DriverError``: Could not open the driver for the specified format
+* ``InvalidParameters``: Input parameters were not valid
+* ``FileCreationError``: Error creating output file
+* ``RasterIoError``: Error writing to raster
+
+"""
+# --
 try:
     QgsKernelDensityEstimation.Parameters.__attribute_docs__ = {'source': 'Point feature source', 'radius': 'Fixed radius, in map units', 'radiusField': 'Field for radius, or empty if using a fixed radius', 'weightField': 'Field name for weighting field, or empty if not using weights', 'pixelSize': 'Size of pixel in output file', 'shape': 'Kernel shape', 'decayRatio': 'Decay ratio (Triangular kernels only)', 'outputValues': 'Type of output value'}
     QgsKernelDensityEstimation.Parameters.__annotations__ = {'source': 'QgsFeatureSource', 'radius': float, 'radiusField': str, 'weightField': str, 'pixelSize': float, 'shape': 'QgsKernelDensityEstimation.KernelShape', 'decayRatio': float, 'outputValues': 'QgsKernelDensityEstimation.OutputValues'}

--- a/python/PyQt6/analysis/auto_additions/qgskde.py
+++ b/python/PyQt6/analysis/auto_additions/qgskde.py
@@ -1,27 +1,69 @@
 # The following has been generated automatically from src/analysis/raster/qgskde.h
 # monkey patching scoped based enum
-QgsKernelDensityEstimation.KernelShape.KernelQuartic.__doc__ = "Quartic kernel"
-QgsKernelDensityEstimation.KernelShape.KernelTriangular.__doc__ = "Triangular kernel"
-QgsKernelDensityEstimation.KernelShape.KernelUniform.__doc__ = "Uniform (flat) kernel"
-QgsKernelDensityEstimation.KernelShape.KernelTriweight.__doc__ = "Triweight kernel"
-QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov.__doc__ = "Epanechnikov kernel"
+QgsKernelDensityEstimation.KernelQuartic = QgsKernelDensityEstimation.KernelShape.Quartic
+QgsKernelDensityEstimation.KernelShape.KernelQuartic = QgsKernelDensityEstimation.KernelShape.Quartic
+QgsKernelDensityEstimation.KernelQuartic.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelQuartic.__doc__ = "Quartic kernel"
+QgsKernelDensityEstimation.KernelTriangular = QgsKernelDensityEstimation.KernelShape.Triangular
+QgsKernelDensityEstimation.KernelShape.KernelTriangular = QgsKernelDensityEstimation.KernelShape.Triangular
+QgsKernelDensityEstimation.KernelTriangular.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelTriangular.__doc__ = "Triangular kernel"
+QgsKernelDensityEstimation.KernelUniform = QgsKernelDensityEstimation.KernelShape.Uniform
+QgsKernelDensityEstimation.KernelShape.KernelUniform = QgsKernelDensityEstimation.KernelShape.Uniform
+QgsKernelDensityEstimation.KernelUniform.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelUniform.__doc__ = "Uniform (flat) kernel"
+QgsKernelDensityEstimation.KernelTriweight = QgsKernelDensityEstimation.KernelShape.Triweight
+QgsKernelDensityEstimation.KernelShape.KernelTriweight = QgsKernelDensityEstimation.KernelShape.Triweight
+QgsKernelDensityEstimation.KernelTriweight.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelTriweight.__doc__ = "Triweight kernel"
+QgsKernelDensityEstimation.KernelEpanechnikov = QgsKernelDensityEstimation.KernelShape.Epanechnikov
+QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov = QgsKernelDensityEstimation.KernelShape.Epanechnikov
+QgsKernelDensityEstimation.KernelEpanechnikov.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelEpanechnikov.__doc__ = "Epanechnikov kernel"
 QgsKernelDensityEstimation.KernelShape.__doc__ = """Kernel shape type
 
-* ``KernelQuartic``: Quartic kernel
-* ``KernelTriangular``: Triangular kernel
-* ``KernelUniform``: Uniform (flat) kernel
-* ``KernelTriweight``: Triweight kernel
-* ``KernelEpanechnikov``: Epanechnikov kernel
+* ``Quartic``: Quartic kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelQuartic`` in older QGIS releases.
+
+* ``Triangular``: Triangular kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelTriangular`` in older QGIS releases.
+
+* ``Uniform``: Uniform (flat) kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelUniform`` in older QGIS releases.
+
+* ``Triweight``: Triweight kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelTriweight`` in older QGIS releases.
+
+* ``Epanechnikov``: Epanechnikov kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelEpanechnikov`` in older QGIS releases.
+
 
 """
 # --
 # monkey patching scoped based enum
-QgsKernelDensityEstimation.OutputValues.OutputRaw.__doc__ = "Output the raw KDE values"
-QgsKernelDensityEstimation.OutputValues.OutputScaled.__doc__ = "Output mathematically correct scaled values"
+QgsKernelDensityEstimation.OutputRaw = QgsKernelDensityEstimation.OutputValues.Raw
+QgsKernelDensityEstimation.OutputValues.OutputRaw = QgsKernelDensityEstimation.OutputValues.Raw
+QgsKernelDensityEstimation.OutputRaw.is_monkey_patched = True
+QgsKernelDensityEstimation.OutputRaw.__doc__ = "Output the raw KDE values"
+QgsKernelDensityEstimation.OutputScaled = QgsKernelDensityEstimation.OutputValues.Scaled
+QgsKernelDensityEstimation.OutputValues.OutputScaled = QgsKernelDensityEstimation.OutputValues.Scaled
+QgsKernelDensityEstimation.OutputScaled.is_monkey_patched = True
+QgsKernelDensityEstimation.OutputScaled.__doc__ = "Output mathematically correct scaled values"
 QgsKernelDensityEstimation.OutputValues.__doc__ = """Output values type
 
-* ``OutputRaw``: Output the raw KDE values
-* ``OutputScaled``: Output mathematically correct scaled values
+* ``Raw``: Output the raw KDE values
+
+  Available as ``QgsKernelDensityEstimation.OutputRaw`` in older QGIS releases.
+
+* ``Scaled``: Output mathematically correct scaled values
+
+  Available as ``QgsKernelDensityEstimation.OutputScaled`` in older QGIS releases.
+
 
 """
 # --

--- a/python/PyQt6/analysis/auto_additions/qgsrastercalculator.py
+++ b/python/PyQt6/analysis/auto_additions/qgsrastercalculator.py
@@ -1,12 +1,26 @@
 # The following has been generated automatically from src/analysis/raster/qgsrastercalculator.h
-QgsRasterCalculator.Success = QgsRasterCalculator.Result.Success
-QgsRasterCalculator.CreateOutputError = QgsRasterCalculator.Result.CreateOutputError
-QgsRasterCalculator.InputLayerError = QgsRasterCalculator.Result.InputLayerError
-QgsRasterCalculator.Canceled = QgsRasterCalculator.Result.Canceled
-QgsRasterCalculator.ParserError = QgsRasterCalculator.Result.ParserError
-QgsRasterCalculator.MemoryError = QgsRasterCalculator.Result.MemoryError
-QgsRasterCalculator.BandError = QgsRasterCalculator.Result.BandError
-QgsRasterCalculator.CalculationError = QgsRasterCalculator.Result.CalculationError
+# monkey patching scoped based enum
+QgsRasterCalculator.Result.Success.__doc__ = "Calculation successful"
+QgsRasterCalculator.Result.CreateOutputError.__doc__ = "Error creating output data file"
+QgsRasterCalculator.Result.InputLayerError.__doc__ = "Error reading input layer"
+QgsRasterCalculator.Result.Canceled.__doc__ = "User canceled calculation"
+QgsRasterCalculator.Result.ParserError.__doc__ = "Error parsing formula"
+QgsRasterCalculator.Result.MemoryError.__doc__ = "Error allocating memory for result"
+QgsRasterCalculator.Result.BandError.__doc__ = "Invalid band number for input"
+QgsRasterCalculator.Result.CalculationError.__doc__ = "Error occurred while performing calculation"
+QgsRasterCalculator.Result.__doc__ = """Result of the calculation
+
+* ``Success``: Calculation successful
+* ``CreateOutputError``: Error creating output data file
+* ``InputLayerError``: Error reading input layer
+* ``Canceled``: User canceled calculation
+* ``ParserError``: Error parsing formula
+* ``MemoryError``: Error allocating memory for result
+* ``BandError``: Invalid band number for input
+* ``CalculationError``: Error occurred while performing calculation
+
+"""
+# --
 try:
     QgsRasterCalculatorEntry.__attribute_docs__ = {'ref': 'Name of entry.', 'raster': 'Raster layer associated with entry.', 'bandNumber': 'Band number for entry. Numbering for bands usually starts at 1 for the first band, not 0.'}
     QgsRasterCalculatorEntry.__annotations__ = {'ref': str, 'raster': 'QgsRasterLayer', 'bandNumber': int}

--- a/python/PyQt6/analysis/auto_additions/qgstininterpolator.py
+++ b/python/PyQt6/analysis/auto_additions/qgstininterpolator.py
@@ -1,6 +1,14 @@
 # The following has been generated automatically from src/analysis/interpolation/qgstininterpolator.h
-QgsTinInterpolator.Linear = QgsTinInterpolator.TinInterpolation.Linear
-QgsTinInterpolator.CloughTocher = QgsTinInterpolator.TinInterpolation.CloughTocher
+# monkey patching scoped based enum
+QgsTinInterpolator.TinInterpolation.Linear.__doc__ = "Linear interpolation"
+QgsTinInterpolator.TinInterpolation.CloughTocher.__doc__ = "Clough-Tocher interpolation"
+QgsTinInterpolator.TinInterpolation.__doc__ = """Indicates the type of interpolation to be performed
+
+* ``Linear``: Linear interpolation
+* ``CloughTocher``: Clough-Tocher interpolation
+
+"""
+# --
 try:
     QgsTinInterpolator.triangulationFields = staticmethod(QgsTinInterpolator.triangulationFields)
     QgsTinInterpolator.__overridden_methods__ = ['interpolatePoint']

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -43,21 +43,21 @@ z-Value can be an attribute or the z-coordinates in case of 3D types.
 #include "qgsinterpolator.h"
 %End
   public:
-    enum SourceType /BaseType=IntEnum/
+    enum class SourceType /BaseType=IntEnum/
     {
       SourcePoints,
       SourceStructureLines,
       SourceBreakLines,
     };
 
-    enum ValueSource /BaseType=IntEnum/
+    enum class ValueSource /BaseType=IntEnum/
     {
       ValueAttribute,
       ValueZ,
       ValueM,
     };
 
-    enum Result /BaseType=IntEnum/
+    enum class Result /BaseType=IntEnum/
     {
       Success,
       Canceled,

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -45,16 +45,16 @@ z-Value can be an attribute or the z-coordinates in case of 3D types.
   public:
     enum class SourceType /BaseType=IntEnum/
     {
-      SourcePoints,
-      SourceStructureLines,
-      SourceBreakLines,
+      Points,
+      StructureLines,
+      BreakLines,
     };
 
     enum class ValueSource /BaseType=IntEnum/
     {
-      ValueAttribute,
-      ValueZ,
-      ValueM,
+      Attribute,
+      Z,
+      M,
     };
 
     enum class Result /BaseType=IntEnum/

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
@@ -20,13 +20,13 @@ Interpolation in a triangular irregular network.
 #include "qgstininterpolator.h"
 %End
   public:
-    enum TinInterpolation /BaseType=IntEnum/
+    enum class TinInterpolation /BaseType=IntEnum/
     {
       Linear,
       CloughTocher,
     };
 
-    QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, TinInterpolation interpolation = Linear, QgsFeedback *feedback = 0 );
+    QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, QgsTinInterpolator::TinInterpolation interpolation = QgsTinInterpolator::TinInterpolation::Linear, QgsFeedback *feedback = 0 );
 %Docstring
 Constructor for QgsTinInterpolator. The ``feedback`` object specifies an
 optional :py:class:`QgsFeedback` object for progress reports and

--- a/python/PyQt6/analysis/auto_generated/raster/qgskde.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgskde.sip.in
@@ -22,7 +22,7 @@ layer.
 #include "qgskde.h"
 %End
   public:
-    enum KernelShape /BaseType=IntEnum/
+    enum class KernelShape /BaseType=IntEnum/
     {
       KernelQuartic,
       KernelTriangular,
@@ -31,13 +31,13 @@ layer.
       KernelEpanechnikov,
     };
 
-    enum OutputValues /BaseType=IntEnum/
+    enum class OutputValues /BaseType=IntEnum/
     {
       OutputRaw,
       OutputScaled,
     };
 
-    enum Result /BaseType=IntEnum/
+    enum class Result /BaseType=IntEnum/
     {
       Success,
       DriverError,
@@ -117,7 +117,6 @@ Finalises the output file. Must be called after adding all features via
   private:
     QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other );
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/PyQt6/analysis/auto_generated/raster/qgskde.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgskde.sip.in
@@ -24,17 +24,17 @@ layer.
   public:
     enum class KernelShape /BaseType=IntEnum/
     {
-      KernelQuartic,
-      KernelTriangular,
-      KernelUniform,
-      KernelTriweight,
-      KernelEpanechnikov,
+      Quartic,
+      Triangular,
+      Uniform,
+      Triweight,
+      Epanechnikov,
     };
 
     enum class OutputValues /BaseType=IntEnum/
     {
-      OutputRaw,
-      OutputScaled,
+      Raw,
+      Scaled,
     };
 
     enum class Result /BaseType=IntEnum/

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -51,7 +51,7 @@ Performs raster layer calculations.
 #include "qgsrastercalculator.h"
 %End
   public:
-    enum Result /BaseType=IntEnum/
+    enum class Result /BaseType=IntEnum/
     {
       Success,
       CreateOutputError,
@@ -143,9 +143,9 @@ Starts the calculation and writes a new raster.
 The optional ``feedback`` argument can be used for progress reporting
 and cancellation support.
 
-:return: QgsRasterCalculator.Success in case of success. If an error is
-         encountered then a description of the error can be obtained by
-         calling :py:func:`~QgsRasterCalculator.lastError`.
+:return: QgsRasterCalculator.Result.Success in case of success. If an
+         error is encountered then a description of the error can be
+         obtained by calling :py:func:`~QgsRasterCalculator.lastError`.
 %End
 
     QString lastError() const;

--- a/python/analysis/auto_additions/qgsinterpolator.py
+++ b/python/analysis/auto_additions/qgsinterpolator.py
@@ -1,25 +1,61 @@
 # The following has been generated automatically from src/analysis/interpolation/qgsinterpolator.h
 # monkey patching scoped based enum
-QgsInterpolator.SourceType.SourcePoints.__doc__ = "Point source"
-QgsInterpolator.SourceType.SourceStructureLines.__doc__ = "Structure lines"
-QgsInterpolator.SourceType.SourceBreakLines.__doc__ = "Break lines"
+QgsInterpolator.SourcePoints = QgsInterpolator.SourceType.Points
+QgsInterpolator.SourceType.SourcePoints = QgsInterpolator.SourceType.Points
+QgsInterpolator.SourcePoints.is_monkey_patched = True
+QgsInterpolator.SourcePoints.__doc__ = "Point source"
+QgsInterpolator.SourceStructureLines = QgsInterpolator.SourceType.StructureLines
+QgsInterpolator.SourceType.SourceStructureLines = QgsInterpolator.SourceType.StructureLines
+QgsInterpolator.SourceStructureLines.is_monkey_patched = True
+QgsInterpolator.SourceStructureLines.__doc__ = "Structure lines"
+QgsInterpolator.SourceBreakLines = QgsInterpolator.SourceType.BreakLines
+QgsInterpolator.SourceType.SourceBreakLines = QgsInterpolator.SourceType.BreakLines
+QgsInterpolator.SourceBreakLines.is_monkey_patched = True
+QgsInterpolator.SourceBreakLines.__doc__ = "Break lines"
 QgsInterpolator.SourceType.__doc__ = """Describes the type of input data
 
-* ``SourcePoints``: Point source
-* ``SourceStructureLines``: Structure lines
-* ``SourceBreakLines``: Break lines
+* ``Points``: Point source
+
+  Available as ``QgsInterpolator.SourcePoints`` in older QGIS releases.
+
+* ``StructureLines``: Structure lines
+
+  Available as ``QgsInterpolator.SourceStructureLines`` in older QGIS releases.
+
+* ``BreakLines``: Break lines
+
+  Available as ``QgsInterpolator.SourceBreakLines`` in older QGIS releases.
+
 
 """
 # --
 # monkey patching scoped based enum
-QgsInterpolator.ValueSource.ValueAttribute.__doc__ = "Take value from feature's attribute"
-QgsInterpolator.ValueSource.ValueZ.__doc__ = "Use feature's geometry Z values for interpolation"
-QgsInterpolator.ValueSource.ValueM.__doc__ = "Use feature's geometry M values for interpolation"
+QgsInterpolator.ValueAttribute = QgsInterpolator.ValueSource.Attribute
+QgsInterpolator.ValueSource.ValueAttribute = QgsInterpolator.ValueSource.Attribute
+QgsInterpolator.ValueAttribute.is_monkey_patched = True
+QgsInterpolator.ValueAttribute.__doc__ = "Take value from feature's attribute"
+QgsInterpolator.ValueZ = QgsInterpolator.ValueSource.Z
+QgsInterpolator.ValueSource.ValueZ = QgsInterpolator.ValueSource.Z
+QgsInterpolator.ValueZ.is_monkey_patched = True
+QgsInterpolator.ValueZ.__doc__ = "Use feature's geometry Z values for interpolation"
+QgsInterpolator.ValueM = QgsInterpolator.ValueSource.M
+QgsInterpolator.ValueSource.ValueM = QgsInterpolator.ValueSource.M
+QgsInterpolator.ValueM.is_monkey_patched = True
+QgsInterpolator.ValueM.__doc__ = "Use feature's geometry M values for interpolation"
 QgsInterpolator.ValueSource.__doc__ = """Source for interpolated values from features
 
-* ``ValueAttribute``: Take value from feature's attribute
-* ``ValueZ``: Use feature's geometry Z values for interpolation
-* ``ValueM``: Use feature's geometry M values for interpolation
+* ``Attribute``: Take value from feature's attribute
+
+  Available as ``QgsInterpolator.ValueAttribute`` in older QGIS releases.
+
+* ``Z``: Use feature's geometry Z values for interpolation
+
+  Available as ``QgsInterpolator.ValueZ`` in older QGIS releases.
+
+* ``M``: Use feature's geometry M values for interpolation
+
+  Available as ``QgsInterpolator.ValueM`` in older QGIS releases.
+
 
 """
 # --

--- a/python/analysis/auto_additions/qgsinterpolator.py
+++ b/python/analysis/auto_additions/qgsinterpolator.py
@@ -1,4 +1,42 @@
 # The following has been generated automatically from src/analysis/interpolation/qgsinterpolator.h
+# monkey patching scoped based enum
+QgsInterpolator.SourceType.SourcePoints.__doc__ = "Point source"
+QgsInterpolator.SourceType.SourceStructureLines.__doc__ = "Structure lines"
+QgsInterpolator.SourceType.SourceBreakLines.__doc__ = "Break lines"
+QgsInterpolator.SourceType.__doc__ = """Describes the type of input data
+
+* ``SourcePoints``: Point source
+* ``SourceStructureLines``: Structure lines
+* ``SourceBreakLines``: Break lines
+
+"""
+# --
+# monkey patching scoped based enum
+QgsInterpolator.ValueSource.ValueAttribute.__doc__ = "Take value from feature's attribute"
+QgsInterpolator.ValueSource.ValueZ.__doc__ = "Use feature's geometry Z values for interpolation"
+QgsInterpolator.ValueSource.ValueM.__doc__ = "Use feature's geometry M values for interpolation"
+QgsInterpolator.ValueSource.__doc__ = """Source for interpolated values from features
+
+* ``ValueAttribute``: Take value from feature's attribute
+* ``ValueZ``: Use feature's geometry Z values for interpolation
+* ``ValueM``: Use feature's geometry M values for interpolation
+
+"""
+# --
+# monkey patching scoped based enum
+QgsInterpolator.Result.Success.__doc__ = "Operation was successful"
+QgsInterpolator.Result.Canceled.__doc__ = "Operation was manually canceled"
+QgsInterpolator.Result.InvalidSource.__doc__ = "Operation failed due to invalid source"
+QgsInterpolator.Result.FeatureGeometryError.__doc__ = "Operation failed due to invalid feature geometry"
+QgsInterpolator.Result.__doc__ = """Result of an interpolation operation
+
+* ``Success``: Operation was successful
+* ``Canceled``: Operation was manually canceled
+* ``InvalidSource``: Operation failed due to invalid source
+* ``FeatureGeometryError``: Operation failed due to invalid feature geometry
+
+"""
+# --
 try:
     QgsInterpolatorVertexData.__attribute_docs__ = {'x': 'X-coordinate', 'y': 'Y-coordinate', 'z': 'Z-coordinate'}
     QgsInterpolatorVertexData.__annotations__ = {'x': float, 'y': float, 'z': float}

--- a/python/analysis/auto_additions/qgskde.py
+++ b/python/analysis/auto_additions/qgskde.py
@@ -1,4 +1,46 @@
 # The following has been generated automatically from src/analysis/raster/qgskde.h
+# monkey patching scoped based enum
+QgsKernelDensityEstimation.KernelShape.KernelQuartic.__doc__ = "Quartic kernel"
+QgsKernelDensityEstimation.KernelShape.KernelTriangular.__doc__ = "Triangular kernel"
+QgsKernelDensityEstimation.KernelShape.KernelUniform.__doc__ = "Uniform (flat) kernel"
+QgsKernelDensityEstimation.KernelShape.KernelTriweight.__doc__ = "Triweight kernel"
+QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov.__doc__ = "Epanechnikov kernel"
+QgsKernelDensityEstimation.KernelShape.__doc__ = """Kernel shape type
+
+* ``KernelQuartic``: Quartic kernel
+* ``KernelTriangular``: Triangular kernel
+* ``KernelUniform``: Uniform (flat) kernel
+* ``KernelTriweight``: Triweight kernel
+* ``KernelEpanechnikov``: Epanechnikov kernel
+
+"""
+# --
+# monkey patching scoped based enum
+QgsKernelDensityEstimation.OutputValues.OutputRaw.__doc__ = "Output the raw KDE values"
+QgsKernelDensityEstimation.OutputValues.OutputScaled.__doc__ = "Output mathematically correct scaled values"
+QgsKernelDensityEstimation.OutputValues.__doc__ = """Output values type
+
+* ``OutputRaw``: Output the raw KDE values
+* ``OutputScaled``: Output mathematically correct scaled values
+
+"""
+# --
+# monkey patching scoped based enum
+QgsKernelDensityEstimation.Result.Success.__doc__ = "Operation completed successfully"
+QgsKernelDensityEstimation.Result.DriverError.__doc__ = "Could not open the driver for the specified format"
+QgsKernelDensityEstimation.Result.InvalidParameters.__doc__ = "Input parameters were not valid"
+QgsKernelDensityEstimation.Result.FileCreationError.__doc__ = "Error creating output file"
+QgsKernelDensityEstimation.Result.RasterIoError.__doc__ = "Error writing to raster"
+QgsKernelDensityEstimation.Result.__doc__ = """Result of operation
+
+* ``Success``: Operation completed successfully
+* ``DriverError``: Could not open the driver for the specified format
+* ``InvalidParameters``: Input parameters were not valid
+* ``FileCreationError``: Error creating output file
+* ``RasterIoError``: Error writing to raster
+
+"""
+# --
 try:
     QgsKernelDensityEstimation.Parameters.__attribute_docs__ = {'source': 'Point feature source', 'radius': 'Fixed radius, in map units', 'radiusField': 'Field for radius, or empty if using a fixed radius', 'weightField': 'Field name for weighting field, or empty if not using weights', 'pixelSize': 'Size of pixel in output file', 'shape': 'Kernel shape', 'decayRatio': 'Decay ratio (Triangular kernels only)', 'outputValues': 'Type of output value'}
     QgsKernelDensityEstimation.Parameters.__annotations__ = {'source': 'QgsFeatureSource', 'radius': float, 'radiusField': str, 'weightField': str, 'pixelSize': float, 'shape': 'QgsKernelDensityEstimation.KernelShape', 'decayRatio': float, 'outputValues': 'QgsKernelDensityEstimation.OutputValues'}

--- a/python/analysis/auto_additions/qgskde.py
+++ b/python/analysis/auto_additions/qgskde.py
@@ -1,27 +1,69 @@
 # The following has been generated automatically from src/analysis/raster/qgskde.h
 # monkey patching scoped based enum
-QgsKernelDensityEstimation.KernelShape.KernelQuartic.__doc__ = "Quartic kernel"
-QgsKernelDensityEstimation.KernelShape.KernelTriangular.__doc__ = "Triangular kernel"
-QgsKernelDensityEstimation.KernelShape.KernelUniform.__doc__ = "Uniform (flat) kernel"
-QgsKernelDensityEstimation.KernelShape.KernelTriweight.__doc__ = "Triweight kernel"
-QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov.__doc__ = "Epanechnikov kernel"
+QgsKernelDensityEstimation.KernelQuartic = QgsKernelDensityEstimation.KernelShape.Quartic
+QgsKernelDensityEstimation.KernelShape.KernelQuartic = QgsKernelDensityEstimation.KernelShape.Quartic
+QgsKernelDensityEstimation.KernelQuartic.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelQuartic.__doc__ = "Quartic kernel"
+QgsKernelDensityEstimation.KernelTriangular = QgsKernelDensityEstimation.KernelShape.Triangular
+QgsKernelDensityEstimation.KernelShape.KernelTriangular = QgsKernelDensityEstimation.KernelShape.Triangular
+QgsKernelDensityEstimation.KernelTriangular.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelTriangular.__doc__ = "Triangular kernel"
+QgsKernelDensityEstimation.KernelUniform = QgsKernelDensityEstimation.KernelShape.Uniform
+QgsKernelDensityEstimation.KernelShape.KernelUniform = QgsKernelDensityEstimation.KernelShape.Uniform
+QgsKernelDensityEstimation.KernelUniform.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelUniform.__doc__ = "Uniform (flat) kernel"
+QgsKernelDensityEstimation.KernelTriweight = QgsKernelDensityEstimation.KernelShape.Triweight
+QgsKernelDensityEstimation.KernelShape.KernelTriweight = QgsKernelDensityEstimation.KernelShape.Triweight
+QgsKernelDensityEstimation.KernelTriweight.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelTriweight.__doc__ = "Triweight kernel"
+QgsKernelDensityEstimation.KernelEpanechnikov = QgsKernelDensityEstimation.KernelShape.Epanechnikov
+QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov = QgsKernelDensityEstimation.KernelShape.Epanechnikov
+QgsKernelDensityEstimation.KernelEpanechnikov.is_monkey_patched = True
+QgsKernelDensityEstimation.KernelEpanechnikov.__doc__ = "Epanechnikov kernel"
 QgsKernelDensityEstimation.KernelShape.__doc__ = """Kernel shape type
 
-* ``KernelQuartic``: Quartic kernel
-* ``KernelTriangular``: Triangular kernel
-* ``KernelUniform``: Uniform (flat) kernel
-* ``KernelTriweight``: Triweight kernel
-* ``KernelEpanechnikov``: Epanechnikov kernel
+* ``Quartic``: Quartic kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelQuartic`` in older QGIS releases.
+
+* ``Triangular``: Triangular kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelTriangular`` in older QGIS releases.
+
+* ``Uniform``: Uniform (flat) kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelUniform`` in older QGIS releases.
+
+* ``Triweight``: Triweight kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelTriweight`` in older QGIS releases.
+
+* ``Epanechnikov``: Epanechnikov kernel
+
+  Available as ``QgsKernelDensityEstimation.KernelEpanechnikov`` in older QGIS releases.
+
 
 """
 # --
 # monkey patching scoped based enum
-QgsKernelDensityEstimation.OutputValues.OutputRaw.__doc__ = "Output the raw KDE values"
-QgsKernelDensityEstimation.OutputValues.OutputScaled.__doc__ = "Output mathematically correct scaled values"
+QgsKernelDensityEstimation.OutputRaw = QgsKernelDensityEstimation.OutputValues.Raw
+QgsKernelDensityEstimation.OutputValues.OutputRaw = QgsKernelDensityEstimation.OutputValues.Raw
+QgsKernelDensityEstimation.OutputRaw.is_monkey_patched = True
+QgsKernelDensityEstimation.OutputRaw.__doc__ = "Output the raw KDE values"
+QgsKernelDensityEstimation.OutputScaled = QgsKernelDensityEstimation.OutputValues.Scaled
+QgsKernelDensityEstimation.OutputValues.OutputScaled = QgsKernelDensityEstimation.OutputValues.Scaled
+QgsKernelDensityEstimation.OutputScaled.is_monkey_patched = True
+QgsKernelDensityEstimation.OutputScaled.__doc__ = "Output mathematically correct scaled values"
 QgsKernelDensityEstimation.OutputValues.__doc__ = """Output values type
 
-* ``OutputRaw``: Output the raw KDE values
-* ``OutputScaled``: Output mathematically correct scaled values
+* ``Raw``: Output the raw KDE values
+
+  Available as ``QgsKernelDensityEstimation.OutputRaw`` in older QGIS releases.
+
+* ``Scaled``: Output mathematically correct scaled values
+
+  Available as ``QgsKernelDensityEstimation.OutputScaled`` in older QGIS releases.
+
 
 """
 # --

--- a/python/analysis/auto_additions/qgsrastercalculator.py
+++ b/python/analysis/auto_additions/qgsrastercalculator.py
@@ -1,4 +1,26 @@
 # The following has been generated automatically from src/analysis/raster/qgsrastercalculator.h
+# monkey patching scoped based enum
+QgsRasterCalculator.Result.Success.__doc__ = "Calculation successful"
+QgsRasterCalculator.Result.CreateOutputError.__doc__ = "Error creating output data file"
+QgsRasterCalculator.Result.InputLayerError.__doc__ = "Error reading input layer"
+QgsRasterCalculator.Result.Canceled.__doc__ = "User canceled calculation"
+QgsRasterCalculator.Result.ParserError.__doc__ = "Error parsing formula"
+QgsRasterCalculator.Result.MemoryError.__doc__ = "Error allocating memory for result"
+QgsRasterCalculator.Result.BandError.__doc__ = "Invalid band number for input"
+QgsRasterCalculator.Result.CalculationError.__doc__ = "Error occurred while performing calculation"
+QgsRasterCalculator.Result.__doc__ = """Result of the calculation
+
+* ``Success``: Calculation successful
+* ``CreateOutputError``: Error creating output data file
+* ``InputLayerError``: Error reading input layer
+* ``Canceled``: User canceled calculation
+* ``ParserError``: Error parsing formula
+* ``MemoryError``: Error allocating memory for result
+* ``BandError``: Invalid band number for input
+* ``CalculationError``: Error occurred while performing calculation
+
+"""
+# --
 try:
     QgsRasterCalculatorEntry.__attribute_docs__ = {'ref': 'Name of entry.', 'raster': 'Raster layer associated with entry.', 'bandNumber': 'Band number for entry. Numbering for bands usually starts at 1 for the first band, not 0.'}
     QgsRasterCalculatorEntry.__annotations__ = {'ref': str, 'raster': 'QgsRasterLayer', 'bandNumber': int}

--- a/python/analysis/auto_additions/qgstininterpolator.py
+++ b/python/analysis/auto_additions/qgstininterpolator.py
@@ -1,4 +1,14 @@
 # The following has been generated automatically from src/analysis/interpolation/qgstininterpolator.h
+# monkey patching scoped based enum
+QgsTinInterpolator.TinInterpolation.Linear.__doc__ = "Linear interpolation"
+QgsTinInterpolator.TinInterpolation.CloughTocher.__doc__ = "Clough-Tocher interpolation"
+QgsTinInterpolator.TinInterpolation.__doc__ = """Indicates the type of interpolation to be performed
+
+* ``Linear``: Linear interpolation
+* ``CloughTocher``: Clough-Tocher interpolation
+
+"""
+# --
 try:
     QgsTinInterpolator.triangulationFields = staticmethod(QgsTinInterpolator.triangulationFields)
     QgsTinInterpolator.__overridden_methods__ = ['interpolatePoint']

--- a/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -43,21 +43,21 @@ z-Value can be an attribute or the z-coordinates in case of 3D types.
 #include "qgsinterpolator.h"
 %End
   public:
-    enum SourceType
+    enum class SourceType
     {
       SourcePoints,
       SourceStructureLines,
       SourceBreakLines,
     };
 
-    enum ValueSource
+    enum class ValueSource
     {
       ValueAttribute,
       ValueZ,
       ValueM,
     };
 
-    enum Result
+    enum class Result
     {
       Success,
       Canceled,

--- a/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -45,16 +45,16 @@ z-Value can be an attribute or the z-coordinates in case of 3D types.
   public:
     enum class SourceType
     {
-      SourcePoints,
-      SourceStructureLines,
-      SourceBreakLines,
+      Points,
+      StructureLines,
+      BreakLines,
     };
 
     enum class ValueSource
     {
-      ValueAttribute,
-      ValueZ,
-      ValueM,
+      Attribute,
+      Z,
+      M,
     };
 
     enum class Result

--- a/python/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
@@ -20,13 +20,13 @@ Interpolation in a triangular irregular network.
 #include "qgstininterpolator.h"
 %End
   public:
-    enum TinInterpolation
+    enum class TinInterpolation
     {
       Linear,
       CloughTocher,
     };
 
-    QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, TinInterpolation interpolation = Linear, QgsFeedback *feedback = 0 );
+    QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, QgsTinInterpolator::TinInterpolation interpolation = QgsTinInterpolator::TinInterpolation::Linear, QgsFeedback *feedback = 0 );
 %Docstring
 Constructor for QgsTinInterpolator. The ``feedback`` object specifies an
 optional :py:class:`QgsFeedback` object for progress reports and

--- a/python/analysis/auto_generated/raster/qgskde.sip.in
+++ b/python/analysis/auto_generated/raster/qgskde.sip.in
@@ -24,17 +24,17 @@ layer.
   public:
     enum class KernelShape
     {
-      KernelQuartic,
-      KernelTriangular,
-      KernelUniform,
-      KernelTriweight,
-      KernelEpanechnikov,
+      Quartic,
+      Triangular,
+      Uniform,
+      Triweight,
+      Epanechnikov,
     };
 
     enum class OutputValues
     {
-      OutputRaw,
-      OutputScaled,
+      Raw,
+      Scaled,
     };
 
     enum class Result

--- a/python/analysis/auto_generated/raster/qgskde.sip.in
+++ b/python/analysis/auto_generated/raster/qgskde.sip.in
@@ -22,7 +22,7 @@ layer.
 #include "qgskde.h"
 %End
   public:
-    enum KernelShape
+    enum class KernelShape
     {
       KernelQuartic,
       KernelTriangular,
@@ -31,13 +31,13 @@ layer.
       KernelEpanechnikov,
     };
 
-    enum OutputValues
+    enum class OutputValues
     {
       OutputRaw,
       OutputScaled,
     };
 
-    enum Result
+    enum class Result
     {
       Success,
       DriverError,
@@ -117,7 +117,6 @@ Finalises the output file. Must be called after adding all features via
   private:
     QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other );
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -51,7 +51,7 @@ Performs raster layer calculations.
 #include "qgsrastercalculator.h"
 %End
   public:
-    enum Result
+    enum class Result
     {
       Success,
       CreateOutputError,
@@ -143,9 +143,9 @@ Starts the calculation and writes a new raster.
 The optional ``feedback`` argument can be used for progress reporting
 and cancellation support.
 
-:return: QgsRasterCalculator.Success in case of success. If an error is
-         encountered then a description of the error can be obtained by
-         calling :py:func:`~QgsRasterCalculator.lastError`.
+:return: QgsRasterCalculator.Result.Success in case of success. If an
+         error is encountered then a description of the error can be
+         obtained by calling :py:func:`~QgsRasterCalculator.lastError`.
 %End
 
     QString lastError() const;

--- a/python/plugins/processing/algs/qgis/Heatmap.py
+++ b/python/plugins/processing/algs/qgis/Heatmap.py
@@ -83,33 +83,33 @@ class Heatmap(QgisAlgorithm):
             [
                 (
                     self.tr("Quartic"),
-                    QgsKernelDensityEstimation.KernelShape.KernelQuartic,
+                    QgsKernelDensityEstimation.KernelShape.Quartic,
                 ),
                 (
                     self.tr("Triangular"),
-                    QgsKernelDensityEstimation.KernelShape.KernelTriangular,
+                    QgsKernelDensityEstimation.KernelShape.Triangular,
                 ),
                 (
                     self.tr("Uniform"),
-                    QgsKernelDensityEstimation.KernelShape.KernelUniform,
+                    QgsKernelDensityEstimation.KernelShape.Uniform,
                 ),
                 (
                     self.tr("Triweight"),
-                    QgsKernelDensityEstimation.KernelShape.KernelTriweight,
+                    QgsKernelDensityEstimation.KernelShape.Triweight,
                 ),
                 (
                     self.tr("Epanechnikov"),
-                    QgsKernelDensityEstimation.KernelShape.KernelEpanechnikov,
+                    QgsKernelDensityEstimation.KernelShape.Epanechnikov,
                 ),
             ]
         )
 
         self.OUTPUT_VALUES = OrderedDict(
             [
-                (self.tr("Raw"), QgsKernelDensityEstimation.OutputValues.OutputRaw),
+                (self.tr("Raw"), QgsKernelDensityEstimation.OutputValues.Raw),
                 (
                     self.tr("Scaled"),
-                    QgsKernelDensityEstimation.OutputValues.OutputScaled,
+                    QgsKernelDensityEstimation.OutputValues.Scaled,
                 ),
             ]
         )

--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -169,7 +169,7 @@ class IdwInterpolation(QgisAlgorithm):
             data.valueSource = QgsInterpolator.ValueSource(int(v[1]))
             data.interpolationAttribute = int(v[2])
             if (
-                data.valueSource == QgsInterpolator.ValueSource.ValueAttribute
+                data.valueSource == QgsInterpolator.ValueSource.Attribute
                 and data.interpolationAttribute == -1
             ):
                 raise QgsProcessingException(

--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -166,7 +166,7 @@ class IdwInterpolation(QgisAlgorithm):
             data.transformContext = context.transformContext()
             layers.append(layer)
 
-            data.valueSource = int(v[1])
+            data.valueSource = QgsInterpolator.ValueSource(int(v[1]))
             data.interpolationAttribute = int(v[2])
             if (
                 data.valueSource == QgsInterpolator.ValueSource.ValueAttribute
@@ -178,12 +178,7 @@ class IdwInterpolation(QgisAlgorithm):
                     ).format(i + 1)
                 )
 
-            if v[3] == "0":
-                data.sourceType = QgsInterpolator.SourceType.SourcePoints
-            elif v[3] == "1":
-                data.sourceType = QgsInterpolator.SourceType.SourceStructureLines
-            else:
-                data.sourceType = QgsInterpolator.SourceType.SourceBreakLines
+            data.sourceType = QgsInterpolator.SourceType(int(v[3]))
             layerData.append(data)
 
         interpolator = QgsIDWInterpolator(layerData)

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -183,7 +183,7 @@ class TinInterpolation(QgisAlgorithm):
             data.valueSource = QgsInterpolator.ValueSource(int(v[1]))
             data.interpolationAttribute = int(v[2])
             if (
-                data.valueSource == QgsInterpolator.ValueSource.ValueAttribute
+                data.valueSource == QgsInterpolator.ValueSource.Attribute
                 and data.interpolationAttribute == -1
             ):
                 raise QgsProcessingException(

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -180,7 +180,7 @@ class TinInterpolation(QgisAlgorithm):
             if not crs.isValid():
                 crs = layer.sourceCrs()
 
-            data.valueSource = int(v[1])
+            data.valueSource = QgsInterpolator.ValueSource(int(v[1]))
             data.interpolationAttribute = int(v[2])
             if (
                 data.valueSource == QgsInterpolator.ValueSource.ValueAttribute
@@ -192,12 +192,7 @@ class TinInterpolation(QgisAlgorithm):
                     ).format(i + 1)
                 )
 
-            if v[3] == "0":
-                data.sourceType = QgsInterpolator.SourceType.SourcePoints
-            elif v[3] == "1":
-                data.sourceType = QgsInterpolator.SourceType.SourceStructureLines
-            else:
-                data.sourceType = QgsInterpolator.SourceType.SourceBreakLines
+            data.sourceType = QgsInterpolator.SourceType(int(v[3]))
             layerData.append(data)
 
         if method == 0:

--- a/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
@@ -194,9 +194,9 @@ class InterpolationDataWidget(BASE, WIDGET):
                     continue
 
                 interpolationAttribute = item.text(1)
-                interpolationSource = QgsInterpolator.ValueSource.ValueAttribute
+                interpolationSource = QgsInterpolator.ValueSource.Attribute
                 if interpolationAttribute == "Z_COORD":
-                    interpolationSource = QgsInterpolator.ValueSource.ValueZ
+                    interpolationSource = QgsInterpolator.ValueSource.Z
                     fieldIndex = -1
                 else:
                     fieldIndex = layer.fields().indexFromName(interpolationAttribute)
@@ -206,11 +206,11 @@ class InterpolationDataWidget(BASE, WIDGET):
                 )
                 inputTypeName = comboBox.currentText()
                 if inputTypeName == self.tr("Points"):
-                    inputType = QgsInterpolator.SourceType.SourcePoints
+                    inputType = QgsInterpolator.SourceType.Points
                 elif inputTypeName == self.tr("Structure lines"):
-                    inputType = QgsInterpolator.SourceType.SourceStructureLines
+                    inputType = QgsInterpolator.SourceType.StructureLines
                 else:
-                    inputType = QgsInterpolator.SourceType.SourceBreakLines
+                    inputType = QgsInterpolator.SourceType.BreakLines
 
                 layers += "{}::~::{:d}::~::{:d}::~::{:d}::|::".format(
                     layer.source(), interpolationSource, fieldIndex, inputType

--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -287,10 +287,11 @@ class AlgorithmsTest:
                 tmp = ""
                 for r in param["name"].split("::|::"):
                     v = r.split("::~::")
-                    tmp += "{}::~::{}::~::{}::~::{};".format(
+                    tmp += "{}::~::{}::~::{}::~::{}::|::".format(
                         os.path.join(prefix, v[0]), v[1], v[2], v[3]
                     )
-                return tmp[:-1]
+                # trim final separator ::|::
+                return tmp[:-5]
         except TypeError:
             # No type specified, use whatever is there
             return param

--- a/src/analysis/interpolation/qgsdualedgetriangulation.cpp
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.cpp
@@ -1373,9 +1373,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
     if ( mHalfEdge[actEdge]->getPoint() == p2 )
     {
       mHalfEdge[actEdge]->setForced( true );
-      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
       mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
       return actEdge;
     }
 
@@ -1386,9 +1386,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
     {
       //mark actedge and Dual(actedge) as forced, reset p1 and start the method from the beginning
       mHalfEdge[actEdge]->setForced( true );
-      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
       mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
       const int a = insertForcedSegment( mHalfEdge[actEdge]->getPoint(), p2, segmentType );
       return a;
     }
@@ -1413,7 +1413,7 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
 
     if ( MathUtils::lineIntersection( point1, point2, mPointVector[mHalfEdge[oppositeEdge]->getPoint()], mPointVector[mHalfEdge[mHalfEdge[oppositeEdge]->getDual()]->getPoint()] ) )
     {
-      if ( mHalfEdge[mHalfEdge[actEdge]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::SnappingTypeVertex ) //if the crossed edge is a forced edge, we have to snap the forced line to the next node
+      if ( mHalfEdge[mHalfEdge[actEdge]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::ForcedCrossBehavior::SnappingTypeVertex ) //if the crossed edge is a forced edge, we have to snap the forced line to the next node
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1436,7 +1436,7 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
         }
       }
 
-      if ( mHalfEdge[mHalfEdge[actEdge]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::InsertVertex ) //if the crossed edge is a forced edge, we have to insert a new vertice on this edge
+      if ( mHalfEdge[mHalfEdge[actEdge]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::ForcedCrossBehavior::InsertVertex ) //if the crossed edge is a forced edge, we have to insert a new vertice on this edge
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1453,9 +1453,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
           {
             //mark actEdge and Dual(actEdge) as forced, reset p1 and start the method from the beginning
             mHalfEdge[actEdge]->setForced( true );
-            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
             mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
             const int a = insertForcedSegment( p4, p2, segmentType );
             return a;
           }
@@ -1463,9 +1463,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
           {
             //mark actEdge and Dual(actEdge) as forced, reset p1 and start the method from the beginning
             mHalfEdge[actEdge]->setForced( true );
-            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
             mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
             if ( p3 != p2 )
             {
               const int a = insertForcedSegment( p3, p2, segmentType );
@@ -1506,7 +1506,7 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
 
     if ( MathUtils::lineIntersection( lastEdgePoint1, lastEdgeOppositePoint, point1, point2 ) )
     {
-      if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::SnappingTypeVertex ) //if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
+      if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::ForcedCrossBehavior::SnappingTypeVertex ) //if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1528,7 +1528,7 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
           return e;
         }
       }
-      else if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::InsertVertex ) //if the crossed edge is a forced edge, we have to insert a new vertice on this edge
+      else if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::ForcedCrossBehavior::InsertVertex ) //if the crossed edge is a forced edge, we have to insert a new vertice on this edge
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1552,7 +1552,7 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
     }
     else if ( MathUtils::lineIntersection( lastEdgePoint2, lastEdgeOppositePoint, point1, point2 ) )
     {
-      if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::SnappingTypeVertex ) //if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
+      if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::ForcedCrossBehavior::SnappingTypeVertex ) //if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1574,7 +1574,7 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
           return e;
         }
       }
-      else if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::InsertVertex ) //if the crossed edge is a forced edge, we have to insert a new vertice on this edge
+      else if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::ForcedCrossBehavior::InsertVertex ) //if the crossed edge is a forced edge, we have to insert a new vertice on this edge
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1632,11 +1632,11 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
   //insert the forced edge and enter the corresponding halfedges as the first edges in the left and right polygons. The nexts and points are set later because of the algorithm to build two polygons from 'crossedEdges'
   const int firstedge = freelist.first(); //edge pointing from p1 to p2
   mHalfEdge[firstedge]->setForced( true );
-  mHalfEdge[firstedge]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+  mHalfEdge[firstedge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
   leftPolygon.append( firstedge );
   const int dualfirstedge = mHalfEdge[freelist.first()]->getDual(); //edge pointing from p2 to p1
   mHalfEdge[dualfirstedge]->setForced( true );
-  mHalfEdge[dualfirstedge]->setBreak( segmentType == QgsInterpolator::SourceBreakLines );
+  mHalfEdge[dualfirstedge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
   rightPolygon.append( dualfirstedge );
   freelist.pop_front(); //delete the first entry from the freelist
 

--- a/src/analysis/interpolation/qgsdualedgetriangulation.cpp
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.cpp
@@ -1373,9 +1373,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
     if ( mHalfEdge[actEdge]->getPoint() == p2 )
     {
       mHalfEdge[actEdge]->setForced( true );
-      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
       mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
       return actEdge;
     }
 
@@ -1386,9 +1386,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
     {
       //mark actedge and Dual(actedge) as forced, reset p1 and start the method from the beginning
       mHalfEdge[actEdge]->setForced( true );
-      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+      mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
       mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+      mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
       const int a = insertForcedSegment( mHalfEdge[actEdge]->getPoint(), p2, segmentType );
       return a;
     }
@@ -1453,9 +1453,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
           {
             //mark actEdge and Dual(actEdge) as forced, reset p1 and start the method from the beginning
             mHalfEdge[actEdge]->setForced( true );
-            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
             mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
             const int a = insertForcedSegment( p4, p2, segmentType );
             return a;
           }
@@ -1463,9 +1463,9 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
           {
             //mark actEdge and Dual(actEdge) as forced, reset p1 and start the method from the beginning
             mHalfEdge[actEdge]->setForced( true );
-            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+            mHalfEdge[actEdge]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
             mHalfEdge[mHalfEdge[actEdge]->getDual()]->setForced( true );
-            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+            mHalfEdge[mHalfEdge[actEdge]->getDual()]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
             if ( p3 != p2 )
             {
               const int a = insertForcedSegment( p3, p2, segmentType );
@@ -1632,11 +1632,11 @@ int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolat
   //insert the forced edge and enter the corresponding halfedges as the first edges in the left and right polygons. The nexts and points are set later because of the algorithm to build two polygons from 'crossedEdges'
   const int firstedge = freelist.first(); //edge pointing from p1 to p2
   mHalfEdge[firstedge]->setForced( true );
-  mHalfEdge[firstedge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+  mHalfEdge[firstedge]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
   leftPolygon.append( firstedge );
   const int dualfirstedge = mHalfEdge[freelist.first()]->getDual(); //edge pointing from p2 to p1
   mHalfEdge[dualfirstedge]->setForced( true );
-  mHalfEdge[dualfirstedge]->setBreak( segmentType == QgsInterpolator::SourceType::SourceBreakLines );
+  mHalfEdge[dualfirstedge]->setBreak( segmentType == QgsInterpolator::SourceType::BreakLines );
   rightPolygon.append( dualfirstedge );
   freelist.pop_front(); //delete the first entry from the freelist
 

--- a/src/analysis/interpolation/qgsdualedgetriangulation.h
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.h
@@ -121,7 +121,7 @@ class ANALYSIS_EXPORT QgsDualEdgeTriangulation : public QgsTriangulation
     //! Association to an interpolator object
     TriangleInterpolator *mTriangleInterpolator = nullptr;
     //! Member to store the behavior in case of crossing forced segments
-    QgsTriangulation::ForcedCrossBehavior mForcedCrossBehavior = QgsTriangulation::DeleteFirst;
+    QgsTriangulation::ForcedCrossBehavior mForcedCrossBehavior = QgsTriangulation::ForcedCrossBehavior::DeleteFirst;
     //! Inserts an edge and makes sure, everything is OK with the storage of the edge. The number of the HalfEdge is returned
     unsigned int insertEdge( int dual, int next, int point, bool mbreak, bool forced );
     //! Inserts a forced segment between the points with the numbers p1 and p2 into the triangulation and returns the number of a HalfEdge belonging to this forced edge or -100 in case of failure

--- a/src/analysis/interpolation/qgsinterpolator.cpp
+++ b/src/analysis/interpolation/qgsinterpolator.cpp
@@ -32,7 +32,7 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
 {
   if ( mLayerData.empty() )
   {
-    return Success;
+    return QgsInterpolator::Result::Success;
   }
 
   //reserve initial memory for 100000 vertices
@@ -46,23 +46,23 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
   for ( const LayerData &layer : std::as_const( mLayerData ) )
   {
     if ( feedback && feedback->isCanceled() )
-      return Canceled;
+      return QgsInterpolator::Result::Canceled;
 
     QgsFeatureSource *source = layer.source;
     if ( !source )
     {
-      return InvalidSource;
+      return QgsInterpolator::Result::InvalidSource;
     }
 
     QgsAttributeList attList;
     switch ( layer.valueSource )
     {
-      case ValueAttribute:
+      case QgsInterpolator::ValueSource::ValueAttribute:
         attList.push_back( layer.interpolationAttribute );
         break;
 
-      case ValueZ:
-      case ValueM:
+      case QgsInterpolator::ValueSource::ValueZ:
+      case QgsInterpolator::ValueSource::ValueM:
         break;
     }
 
@@ -77,7 +77,7 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
     while ( fit.nextFeature( feature ) )
     {
       if ( feedback && feedback->isCanceled() )
-        return Canceled;
+        return QgsInterpolator::Result::Canceled;
 
       progress += featureStep;
       if ( feedback )
@@ -85,7 +85,7 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
 
       switch ( layer.valueSource )
       {
-        case ValueAttribute:
+        case QgsInterpolator::ValueSource::ValueAttribute:
         {
           QVariant attributeVariant = feature.attribute( layer.interpolationAttribute );
           if ( QgsVariantUtils::isNull( attributeVariant ) ) //attribute not found, something must be wrong (e.g. NULL value)
@@ -100,18 +100,18 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
           break;
         }
 
-        case ValueZ:
-        case ValueM:
+        case QgsInterpolator::ValueSource::ValueZ:
+        case QgsInterpolator::ValueSource::ValueM:
           break;
       }
 
       if ( !addVerticesToCache( feature.geometry(), layer.valueSource, attributeValue ) )
-        return FeatureGeometryError;
+        return QgsInterpolator::Result::FeatureGeometryError;
     }
     layerCount++;
   }
 
-  return Success;
+  return QgsInterpolator::Result::Success;
 }
 
 bool QgsInterpolator::addVerticesToCache( const QgsGeometry &geom, ValueSource source, double attributeValue )
@@ -122,16 +122,16 @@ bool QgsInterpolator::addVerticesToCache( const QgsGeometry &geom, ValueSource s
   //validate source
   switch ( source )
   {
-    case ValueAttribute:
+    case QgsInterpolator::ValueSource::ValueAttribute:
       break;
 
-    case ValueM:
+    case QgsInterpolator::ValueSource::ValueM:
       if ( !geom.constGet()->isMeasure() )
         return false;
       else
         break;
 
-    case ValueZ:
+    case QgsInterpolator::ValueSource::ValueZ:
       if ( !geom.constGet()->is3D() )
         return false;
       else
@@ -142,15 +142,15 @@ bool QgsInterpolator::addVerticesToCache( const QgsGeometry &geom, ValueSource s
   {
     switch ( source )
     {
-      case ValueM:
+      case QgsInterpolator::ValueSource::ValueM:
         mCachedBaseData.push_back( QgsInterpolatorVertexData( ( *point ).x(), ( *point ).y(), ( *point ).m() ) );
         break;
 
-      case ValueZ:
+      case QgsInterpolator::ValueSource::ValueZ:
         mCachedBaseData.push_back( QgsInterpolatorVertexData( ( *point ).x(), ( *point ).y(), ( *point ).z() ) );
         break;
 
-      case ValueAttribute:
+      case QgsInterpolator::ValueSource::ValueAttribute:
         mCachedBaseData.push_back( QgsInterpolatorVertexData( ( *point ).x(), ( *point ).y(), attributeValue ) );
         break;
     }

--- a/src/analysis/interpolation/qgsinterpolator.cpp
+++ b/src/analysis/interpolation/qgsinterpolator.cpp
@@ -57,12 +57,12 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
     QgsAttributeList attList;
     switch ( layer.valueSource )
     {
-      case QgsInterpolator::ValueSource::ValueAttribute:
+      case QgsInterpolator::ValueSource::Attribute:
         attList.push_back( layer.interpolationAttribute );
         break;
 
-      case QgsInterpolator::ValueSource::ValueZ:
-      case QgsInterpolator::ValueSource::ValueM:
+      case QgsInterpolator::ValueSource::Z:
+      case QgsInterpolator::ValueSource::M:
         break;
     }
 
@@ -85,7 +85,7 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
 
       switch ( layer.valueSource )
       {
-        case QgsInterpolator::ValueSource::ValueAttribute:
+        case QgsInterpolator::ValueSource::Attribute:
         {
           QVariant attributeVariant = feature.attribute( layer.interpolationAttribute );
           if ( QgsVariantUtils::isNull( attributeVariant ) ) //attribute not found, something must be wrong (e.g. NULL value)
@@ -100,8 +100,8 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
           break;
         }
 
-        case QgsInterpolator::ValueSource::ValueZ:
-        case QgsInterpolator::ValueSource::ValueM:
+        case QgsInterpolator::ValueSource::Z:
+        case QgsInterpolator::ValueSource::M:
           break;
       }
 
@@ -122,16 +122,16 @@ bool QgsInterpolator::addVerticesToCache( const QgsGeometry &geom, ValueSource s
   //validate source
   switch ( source )
   {
-    case QgsInterpolator::ValueSource::ValueAttribute:
+    case QgsInterpolator::ValueSource::Attribute:
       break;
 
-    case QgsInterpolator::ValueSource::ValueM:
+    case QgsInterpolator::ValueSource::M:
       if ( !geom.constGet()->isMeasure() )
         return false;
       else
         break;
 
-    case QgsInterpolator::ValueSource::ValueZ:
+    case QgsInterpolator::ValueSource::Z:
       if ( !geom.constGet()->is3D() )
         return false;
       else
@@ -142,15 +142,15 @@ bool QgsInterpolator::addVerticesToCache( const QgsGeometry &geom, ValueSource s
   {
     switch ( source )
     {
-      case QgsInterpolator::ValueSource::ValueM:
+      case QgsInterpolator::ValueSource::M:
         mCachedBaseData.push_back( QgsInterpolatorVertexData( ( *point ).x(), ( *point ).y(), ( *point ).m() ) );
         break;
 
-      case QgsInterpolator::ValueSource::ValueZ:
+      case QgsInterpolator::ValueSource::Z:
         mCachedBaseData.push_back( QgsInterpolatorVertexData( ( *point ).x(), ( *point ).y(), ( *point ).z() ) );
         break;
 
-      case QgsInterpolator::ValueSource::ValueAttribute:
+      case QgsInterpolator::ValueSource::Attribute:
         mCachedBaseData.push_back( QgsInterpolatorVertexData( ( *point ).x(), ( *point ).y(), attributeValue ) );
         break;
     }

--- a/src/analysis/interpolation/qgsinterpolator.h
+++ b/src/analysis/interpolation/qgsinterpolator.h
@@ -72,19 +72,19 @@ class ANALYSIS_EXPORT QgsInterpolator
 {
   public:
     //! Describes the type of input data
-    enum class SourceType : int
+    enum class SourceType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsInterpolator, SourceType ) : int
     {
-      SourcePoints,         //!< Point source
-      SourceStructureLines, //!< Structure lines
-      SourceBreakLines,     //!< Break lines
+      Points SIP_MONKEYPATCH_COMPAT_NAME( SourcePoints ),                 //!< Point source
+      StructureLines SIP_MONKEYPATCH_COMPAT_NAME( SourceStructureLines ), //!< Structure lines
+      BreakLines SIP_MONKEYPATCH_COMPAT_NAME( SourceBreakLines ),         //!< Break lines
     };
 
     //! Source for interpolated values from features
-    enum class ValueSource : int
+    enum class ValueSource SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsInterpolator, ValueSource ) : int
     {
-      ValueAttribute, //!< Take value from feature's attribute
-      ValueZ,         //!< Use feature's geometry Z values for interpolation
-      ValueM,         //!< Use feature's geometry M values for interpolation
+      Attribute SIP_MONKEYPATCH_COMPAT_NAME( ValueAttribute ), //!< Take value from feature's attribute
+      Z SIP_MONKEYPATCH_COMPAT_NAME( ValueZ ),                 //!< Use feature's geometry Z values for interpolation
+      M SIP_MONKEYPATCH_COMPAT_NAME( ValueM ),                 //!< Use feature's geometry M values for interpolation
     };
 
     //! Result of an interpolation operation
@@ -102,11 +102,11 @@ class ANALYSIS_EXPORT QgsInterpolator
         //! Feature source
         QgsFeatureSource *source = nullptr;
         //! Source for feature values to interpolate
-        QgsInterpolator::ValueSource valueSource = QgsInterpolator::ValueSource::ValueAttribute;
+        QgsInterpolator::ValueSource valueSource = QgsInterpolator::ValueSource::Attribute;
         //! Index of feature attribute to use for interpolation
         int interpolationAttribute = -1;
         //! Source type
-        QgsInterpolator::SourceType sourceType = QgsInterpolator::SourceType::SourcePoints;
+        QgsInterpolator::SourceType sourceType = QgsInterpolator::SourceType::Points;
 
         /**
        * Coordinate transform context.

--- a/src/analysis/interpolation/qgsinterpolator.h
+++ b/src/analysis/interpolation/qgsinterpolator.h
@@ -72,7 +72,7 @@ class ANALYSIS_EXPORT QgsInterpolator
 {
   public:
     //! Describes the type of input data
-    enum SourceType
+    enum class SourceType : int
     {
       SourcePoints,         //!< Point source
       SourceStructureLines, //!< Structure lines
@@ -80,7 +80,7 @@ class ANALYSIS_EXPORT QgsInterpolator
     };
 
     //! Source for interpolated values from features
-    enum ValueSource
+    enum class ValueSource : int
     {
       ValueAttribute, //!< Take value from feature's attribute
       ValueZ,         //!< Use feature's geometry Z values for interpolation
@@ -88,7 +88,7 @@ class ANALYSIS_EXPORT QgsInterpolator
     };
 
     //! Result of an interpolation operation
-    enum Result
+    enum class Result : int
     {
       Success = 0,          //!< Operation was successful
       Canceled,             //!< Operation was manually canceled
@@ -102,11 +102,11 @@ class ANALYSIS_EXPORT QgsInterpolator
         //! Feature source
         QgsFeatureSource *source = nullptr;
         //! Source for feature values to interpolate
-        QgsInterpolator::ValueSource valueSource = QgsInterpolator::ValueAttribute;
+        QgsInterpolator::ValueSource valueSource = QgsInterpolator::ValueSource::ValueAttribute;
         //! Index of feature attribute to use for interpolation
         int interpolationAttribute = -1;
         //! Source type
-        QgsInterpolator::SourceType sourceType = SourcePoints;
+        QgsInterpolator::SourceType sourceType = QgsInterpolator::SourceType::SourcePoints;
 
         /**
        * Coordinate transform context.

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -32,7 +32,7 @@
 #include "qgscurvepolygon.h"
 #include "qgsmultisurface.h"
 
-QgsTinInterpolator::QgsTinInterpolator( const QList<LayerData> &inputData, TinInterpolation interpolation, QgsFeedback *feedback )
+QgsTinInterpolator::QgsTinInterpolator( const QList<LayerData> &inputData, QgsTinInterpolator::TinInterpolation interpolation, QgsFeedback *feedback )
   : QgsInterpolator( inputData )
   , mIsInitialized( false )
   , mFeedback( feedback )
@@ -80,7 +80,7 @@ void QgsTinInterpolator::setTriangulationSink( QgsFeatureSink *sink )
 void QgsTinInterpolator::initialize()
 {
   QgsDualEdgeTriangulation *dualEdgeTriangulation = new QgsDualEdgeTriangulation( 100000 );
-  if ( mInterpolation == CloughTocher )
+  if ( mInterpolation == QgsTinInterpolator::TinInterpolation::CloughTocher )
   {
     NormVecDecorator *dec = new NormVecDecorator();
     dec->addTriangulation( dualEdgeTriangulation );
@@ -115,12 +115,12 @@ void QgsTinInterpolator::initialize()
       QgsAttributeList attList;
       switch ( layer.valueSource )
       {
-        case QgsInterpolator::ValueAttribute:
+        case QgsInterpolator::ValueSource::ValueAttribute:
           attList.push_back( layer.interpolationAttribute );
           break;
 
-        case QgsInterpolator::ValueM:
-        case QgsInterpolator::ValueZ:
+        case QgsInterpolator::ValueSource::ValueM:
+        case QgsInterpolator::ValueSource::ValueZ:
           break;
       }
 
@@ -143,7 +143,7 @@ void QgsTinInterpolator::initialize()
     }
   }
 
-  if ( mInterpolation == CloughTocher )
+  if ( mInterpolation == QgsTinInterpolator::TinInterpolation::CloughTocher )
   {
     NormVecDecorator *dec = dynamic_cast<NormVecDecorator *>( mTriangulation );
     if ( dec )
@@ -168,7 +168,7 @@ void QgsTinInterpolator::initialize()
   }
 }
 
-int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueSource source, int attr, SourceType type )
+int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueSource source, int attr, QgsInterpolator::SourceType type )
 {
   QgsGeometry g = f.geometry();
   if ( g.isNull() || g.isEmpty() )
@@ -181,7 +181,7 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
   bool attributeConversionOk = false;
   switch ( source )
   {
-    case ValueAttribute:
+    case QgsInterpolator::ValueSource::ValueAttribute:
     {
       QVariant attributeVariant = f.attribute( attr );
       if ( QgsVariantUtils::isNull( attributeVariant ) ) //attribute not found, something must be wrong (e.g. NULL value)
@@ -196,31 +196,30 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
       break;
     }
 
-    case ValueM:
+    case QgsInterpolator::ValueSource::ValueM:
       if ( !g.constGet()->isMeasure() )
         return 3;
       else
         break;
 
-    case ValueZ:
+    case QgsInterpolator::ValueSource::ValueZ:
       if ( !g.constGet()->is3D() )
         return 3;
       else
         break;
   }
 
-
   switch ( type )
   {
-    case SourcePoints:
+    case QgsInterpolator::SourceType::SourcePoints:
     {
       if ( addPointsFromGeometry( g, source, attributeValue ) != 0 )
         return -1;
       break;
     }
 
-    case SourceBreakLines:
-    case SourceStructureLines:
+    case QgsInterpolator::SourceType::SourceBreakLines:
+    case QgsInterpolator::SourceType::SourceStructureLines:
     {
       switch ( QgsWkbTypes::geometryType( g.wkbType() ) )
       {
@@ -293,21 +292,21 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
             {
               switch ( source )
               {
-                case ValueAttribute:
+                case QgsInterpolator::ValueSource::ValueAttribute:
                   if ( point.is3D() )
                     point.setZ( attributeValue );
                   else
                     point.addZValue( attributeValue );
                   break;
 
-                case ValueM:
+                case QgsInterpolator::ValueSource::ValueM:
                   if ( point.is3D() )
                     point.setZ( point.m() );
                   else
                     point.addZValue( point.m() );
                   break;
 
-                case ValueZ:
+                case QgsInterpolator::ValueSource::ValueZ:
                   break;
               }
             }
@@ -327,7 +326,7 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
 }
 
 
-int QgsTinInterpolator::addPointsFromGeometry( const QgsGeometry &g, ValueSource source, double attributeValue )
+int QgsTinInterpolator::addPointsFromGeometry( const QgsGeometry &g, QgsInterpolator::ValueSource source, double attributeValue )
 {
   // loop through all vertices and add to triangulation
   for ( auto point = g.vertices_begin(); point != g.vertices_end(); ++point )
@@ -336,15 +335,15 @@ int QgsTinInterpolator::addPointsFromGeometry( const QgsGeometry &g, ValueSource
     double z = 0;
     switch ( source )
     {
-      case ValueAttribute:
+      case QgsInterpolator::ValueSource::ValueAttribute:
         z = attributeValue;
         break;
 
-      case ValueZ:
+      case QgsInterpolator::ValueSource::ValueZ:
         z = p.z();
         break;
 
-      case ValueM:
+      case QgsInterpolator::ValueSource::ValueM:
         z = p.m();
         break;
     }

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -115,12 +115,12 @@ void QgsTinInterpolator::initialize()
       QgsAttributeList attList;
       switch ( layer.valueSource )
       {
-        case QgsInterpolator::ValueSource::ValueAttribute:
+        case QgsInterpolator::ValueSource::Attribute:
           attList.push_back( layer.interpolationAttribute );
           break;
 
-        case QgsInterpolator::ValueSource::ValueM:
-        case QgsInterpolator::ValueSource::ValueZ:
+        case QgsInterpolator::ValueSource::M:
+        case QgsInterpolator::ValueSource::Z:
           break;
       }
 
@@ -181,7 +181,7 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
   bool attributeConversionOk = false;
   switch ( source )
   {
-    case QgsInterpolator::ValueSource::ValueAttribute:
+    case QgsInterpolator::ValueSource::Attribute:
     {
       QVariant attributeVariant = f.attribute( attr );
       if ( QgsVariantUtils::isNull( attributeVariant ) ) //attribute not found, something must be wrong (e.g. NULL value)
@@ -196,13 +196,13 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
       break;
     }
 
-    case QgsInterpolator::ValueSource::ValueM:
+    case QgsInterpolator::ValueSource::M:
       if ( !g.constGet()->isMeasure() )
         return 3;
       else
         break;
 
-    case QgsInterpolator::ValueSource::ValueZ:
+    case QgsInterpolator::ValueSource::Z:
       if ( !g.constGet()->is3D() )
         return 3;
       else
@@ -211,15 +211,15 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
 
   switch ( type )
   {
-    case QgsInterpolator::SourceType::SourcePoints:
+    case QgsInterpolator::SourceType::Points:
     {
       if ( addPointsFromGeometry( g, source, attributeValue ) != 0 )
         return -1;
       break;
     }
 
-    case QgsInterpolator::SourceType::SourceBreakLines:
-    case QgsInterpolator::SourceType::SourceStructureLines:
+    case QgsInterpolator::SourceType::BreakLines:
+    case QgsInterpolator::SourceType::StructureLines:
     {
       switch ( QgsWkbTypes::geometryType( g.wkbType() ) )
       {
@@ -292,21 +292,21 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
             {
               switch ( source )
               {
-                case QgsInterpolator::ValueSource::ValueAttribute:
+                case QgsInterpolator::ValueSource::Attribute:
                   if ( point.is3D() )
                     point.setZ( attributeValue );
                   else
                     point.addZValue( attributeValue );
                   break;
 
-                case QgsInterpolator::ValueSource::ValueM:
+                case QgsInterpolator::ValueSource::M:
                   if ( point.is3D() )
                     point.setZ( point.m() );
                   else
                     point.addZValue( point.m() );
                   break;
 
-                case QgsInterpolator::ValueSource::ValueZ:
+                case QgsInterpolator::ValueSource::Z:
                   break;
               }
             }
@@ -335,15 +335,15 @@ int QgsTinInterpolator::addPointsFromGeometry( const QgsGeometry &g, QgsInterpol
     double z = 0;
     switch ( source )
     {
-      case QgsInterpolator::ValueSource::ValueAttribute:
+      case QgsInterpolator::ValueSource::Attribute:
         z = attributeValue;
         break;
 
-      case QgsInterpolator::ValueSource::ValueZ:
+      case QgsInterpolator::ValueSource::Z:
         z = p.z();
         break;
 
-      case QgsInterpolator::ValueSource::ValueM:
+      case QgsInterpolator::ValueSource::M:
         z = p.m();
         break;
     }

--- a/src/analysis/interpolation/qgstininterpolator.h
+++ b/src/analysis/interpolation/qgstininterpolator.h
@@ -37,7 +37,7 @@ class ANALYSIS_EXPORT QgsTinInterpolator : public QgsInterpolator
 {
   public:
     //! Indicates the type of interpolation to be performed
-    enum TinInterpolation
+    enum class TinInterpolation : int
     {
       Linear,       //!< Linear interpolation
       CloughTocher, //!< Clough-Tocher interpolation
@@ -48,7 +48,7 @@ class ANALYSIS_EXPORT QgsTinInterpolator : public QgsInterpolator
      * The \a feedback object specifies an optional QgsFeedback object for progress reports and cancellation support.
      * Ownership of \a feedback is not transferred and callers must ensure that it exists for the lifetime of this object.
      */
-    QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, TinInterpolation interpolation = Linear, QgsFeedback *feedback = nullptr );
+    QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, QgsTinInterpolator::TinInterpolation interpolation = QgsTinInterpolator::TinInterpolation::Linear, QgsFeedback *feedback = nullptr );
     ~QgsTinInterpolator() override;
 
     int interpolatePoint( double x, double y, double &result SIP_OUT, QgsFeedback *feedback ) override;
@@ -80,7 +80,7 @@ class ANALYSIS_EXPORT QgsTinInterpolator : public QgsInterpolator
     //! Feature sink for triangulation
     QgsFeatureSink *mTriangulationSink = nullptr;
     //! Type of interpolation
-    TinInterpolation mInterpolation;
+    QgsTinInterpolator::TinInterpolation mInterpolation;
 
     //! Create dual edge triangulation
     void initialize();
@@ -93,9 +93,9 @@ class ANALYSIS_EXPORT QgsTinInterpolator : public QgsInterpolator
      * \param type point/structure line, break line
      * \returns 0 in case of success, -1 if the feature could not be inserted because of numerical problems
     */
-    int insertData( const QgsFeature &f, QgsInterpolator::ValueSource source, int attr, SourceType type );
+    int insertData( const QgsFeature &f, QgsInterpolator::ValueSource source, int attr, QgsInterpolator::SourceType type );
 
-    int addPointsFromGeometry( const QgsGeometry &g, ValueSource source, double attributeValue );
+    int addPointsFromGeometry( const QgsGeometry &g, QgsInterpolator::ValueSource source, double attributeValue );
 };
 
 #endif

--- a/src/analysis/interpolation/qgstriangulation.h
+++ b/src/analysis/interpolation/qgstriangulation.h
@@ -42,7 +42,7 @@ class ANALYSIS_EXPORT QgsTriangulation
 {
   public:
     //! Enumeration describing the behavior, if two forced lines cross.
-    enum ForcedCrossBehavior
+    enum class ForcedCrossBehavior : int
     {
       SnappingTypeVertex, //!< The second inserted forced line is snapped to the closest vertice of the first inserted forced line.
       DeleteFirst,        //!< The status of the first inserted forced line is reset to that of a normal edge (so that the second inserted forced line remain and the first not)

--- a/src/analysis/mesh/qgsmeshtriangulation.cpp
+++ b/src/analysis/mesh/qgsmeshtriangulation.cpp
@@ -243,7 +243,7 @@ void QgsMeshTriangulation::addBreakLinesFromFeature( const QgsFeature &feature, 
         }
       }
 
-    mTriangulation->addLine( linePoints, QgsInterpolator::SourceType::SourceBreakLines );
+    mTriangulation->addLine( linePoints, QgsInterpolator::SourceType::BreakLines );
   }
 }
 

--- a/src/analysis/mesh/qgsmeshtriangulation.cpp
+++ b/src/analysis/mesh/qgsmeshtriangulation.cpp
@@ -243,7 +243,7 @@ void QgsMeshTriangulation::addBreakLinesFromFeature( const QgsFeature &feature, 
         }
       }
 
-    mTriangulation->addLine( linePoints, QgsInterpolator::SourceBreakLines );
+    mTriangulation->addLine( linePoints, QgsInterpolator::SourceType::SourceBreakLines );
   }
 }
 

--- a/src/analysis/processing/qgsalgorithmrastercalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmrastercalculator.cpp
@@ -187,17 +187,17 @@ QVariantMap QgsRasterCalculatorAlgorithm::processAlgorithm( const QVariantMap &p
   mLayers.clear();
   switch ( result )
   {
-    case QgsRasterCalculator::CreateOutputError:
+    case QgsRasterCalculator::Result::CreateOutputError:
       throw QgsProcessingException( QObject::tr( "Error creating output file." ) );
-    case QgsRasterCalculator::InputLayerError:
+    case QgsRasterCalculator::Result::InputLayerError:
       throw QgsProcessingException( QObject::tr( "Error reading input layer." ) );
-    case QgsRasterCalculator::ParserError:
+    case QgsRasterCalculator::Result::ParserError:
       throw QgsProcessingException( QObject::tr( "Error parsing formula." ) );
-    case QgsRasterCalculator::MemoryError:
+    case QgsRasterCalculator::Result::MemoryError:
       throw QgsProcessingException( QObject::tr( "Error allocating memory for result." ) );
-    case QgsRasterCalculator::BandError:
+    case QgsRasterCalculator::Result::BandError:
       throw QgsProcessingException( QObject::tr( "Invalid band number for input." ) );
-    case QgsRasterCalculator::CalculationError:
+    case QgsRasterCalculator::Result::CalculationError:
       throw QgsProcessingException( QObject::tr( "Error occurred while performing calculation." ) );
     default:
       break;
@@ -327,17 +327,17 @@ QVariantMap QgsRasterCalculatorModelerAlgorithm::processAlgorithm( const QVarian
   mLayers.clear();
   switch ( result )
   {
-    case QgsRasterCalculator::CreateOutputError:
+    case QgsRasterCalculator::Result::CreateOutputError:
       throw QgsProcessingException( QObject::tr( "Error creating output file." ) );
-    case QgsRasterCalculator::InputLayerError:
+    case QgsRasterCalculator::Result::InputLayerError:
       throw QgsProcessingException( QObject::tr( "Error reading input layer." ) );
-    case QgsRasterCalculator::ParserError:
+    case QgsRasterCalculator::Result::ParserError:
       throw QgsProcessingException( QObject::tr( "Error parsing formula." ) );
-    case QgsRasterCalculator::MemoryError:
+    case QgsRasterCalculator::Result::MemoryError:
       throw QgsProcessingException( QObject::tr( "Error allocating memory for result." ) );
-    case QgsRasterCalculator::BandError:
+    case QgsRasterCalculator::Result::BandError:
       throw QgsProcessingException( QObject::tr( "Invalid band number for input." ) );
-    case QgsRasterCalculator::CalculationError:
+    case QgsRasterCalculator::Result::CalculationError:
       throw QgsProcessingException( QObject::tr( "Error occurred while performing calculation." ) );
     default:
       break;

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -263,19 +263,19 @@ double QgsKernelDensityEstimation::calculateKernelValue( const double distance, 
 {
   switch ( shape )
   {
-    case QgsKernelDensityEstimation::KernelShape::KernelTriangular:
+    case QgsKernelDensityEstimation::KernelShape::Triangular:
       return triangularKernel( distance, bandwidth, outputType );
 
-    case QgsKernelDensityEstimation::KernelShape::KernelUniform:
+    case QgsKernelDensityEstimation::KernelShape::Uniform:
       return uniformKernel( distance, bandwidth, outputType );
 
-    case QgsKernelDensityEstimation::KernelShape::KernelQuartic:
+    case QgsKernelDensityEstimation::KernelShape::Quartic:
       return quarticKernel( distance, bandwidth, outputType );
 
-    case QgsKernelDensityEstimation::KernelShape::KernelTriweight:
+    case QgsKernelDensityEstimation::KernelShape::Triweight:
       return triweightKernel( distance, bandwidth, outputType );
 
-    case QgsKernelDensityEstimation::KernelShape::KernelEpanechnikov:
+    case QgsKernelDensityEstimation::KernelShape::Epanechnikov:
       return epanechnikovKernel( distance, bandwidth, outputType );
   }
   return 0; //no warnings
@@ -294,7 +294,7 @@ double QgsKernelDensityEstimation::uniformKernel( const double distance, const d
   Q_UNUSED( distance )
   switch ( outputType )
   {
-    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::Scaled:
     {
       // Normalizing constant
       const double k = 2. / ( M_PI * bandwidth );
@@ -302,7 +302,7 @@ double QgsKernelDensityEstimation::uniformKernel( const double distance, const d
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 0.5 / bandwidth );
     }
-    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::Raw:
       return 1.0;
   }
   return 0.0; // NO warnings!!!!!
@@ -312,7 +312,7 @@ double QgsKernelDensityEstimation::quarticKernel( const double distance, const d
 {
   switch ( outputType )
   {
-    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::Scaled:
     {
       // Normalizing constant
       const double k = 16. / ( 5. * M_PI * std::pow( bandwidth, 2 ) );
@@ -320,7 +320,7 @@ double QgsKernelDensityEstimation::quarticKernel( const double distance, const d
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 15. / 16. ) * std::pow( 1. - std::pow( distance / bandwidth, 2 ), 2 );
     }
-    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::Raw:
       return std::pow( 1. - std::pow( distance / bandwidth, 2 ), 2 );
   }
   return 0.0; //no, seriously, I told you NO WARNINGS!
@@ -330,7 +330,7 @@ double QgsKernelDensityEstimation::triweightKernel( const double distance, const
 {
   switch ( outputType )
   {
-    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::Scaled:
     {
       // Normalizing constant
       const double k = 128. / ( 35. * M_PI * std::pow( bandwidth, 2 ) );
@@ -338,7 +338,7 @@ double QgsKernelDensityEstimation::triweightKernel( const double distance, const
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 35. / 32. ) * std::pow( 1. - std::pow( distance / bandwidth, 2 ), 3 );
     }
-    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::Raw:
       return std::pow( 1. - std::pow( distance / bandwidth, 2 ), 3 );
   }
   return 0.0; // this is getting ridiculous... don't you ever listen to a word I say?
@@ -348,7 +348,7 @@ double QgsKernelDensityEstimation::epanechnikovKernel( const double distance, co
 {
   switch ( outputType )
   {
-    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::Scaled:
     {
       // Normalizing constant
       const double k = 8. / ( 3. * M_PI * std::pow( bandwidth, 2 ) );
@@ -356,7 +356,7 @@ double QgsKernelDensityEstimation::epanechnikovKernel( const double distance, co
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 3. / 4. ) * ( 1. - std::pow( distance / bandwidth, 2 ) );
     }
-    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::Raw:
       return ( 1. - std::pow( distance / bandwidth, 2 ) );
   }
 
@@ -367,7 +367,7 @@ double QgsKernelDensityEstimation::triangularKernel( const double distance, cons
 {
   switch ( outputType )
   {
-    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::Scaled:
     {
       // Normalizing constant. In this case it's calculated a little different
       // due to the inclusion of the non-standard "decay" parameter
@@ -385,7 +385,7 @@ double QgsKernelDensityEstimation::triangularKernel( const double distance, cons
         return ( 1. - ( 1. - mDecay ) * ( distance / bandwidth ) );
       }
     }
-    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::Raw:
       return ( 1. - ( 1. - mDecay ) * ( distance / bandwidth ) );
   }
   return 0.0; // ....

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -44,7 +44,7 @@ QgsKernelDensityEstimation::QgsKernelDensityEstimation( const QgsKernelDensityEs
 QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::run()
 {
   const Result result = prepare();
-  if ( result != Success )
+  if ( result != QgsKernelDensityEstimation::Result::Success )
     return result;
 
   QgsAttributeList requiredAttributes;
@@ -73,35 +73,35 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
   GDALDriverH driver = GDALGetDriverByName( mOutputFormat.toUtf8() );
   if ( !driver )
   {
-    return DriverError;
+    return QgsKernelDensityEstimation::Result::DriverError;
   }
 
   if ( !mSource )
-    return InvalidParameters;
+    return QgsKernelDensityEstimation::Result::InvalidParameters;
 
   mBounds = calculateBounds();
   if ( mBounds.isNull() )
-    return InvalidParameters;
+    return QgsKernelDensityEstimation::Result::InvalidParameters;
 
   const int rows = std::max( std::ceil( mBounds.height() / mPixelSize ) + 1, 1.0 );
   const int cols = std::max( std::ceil( mBounds.width() / mPixelSize ) + 1, 1.0 );
 
   if ( !createEmptyLayer( driver, mBounds, rows, cols ) )
-    return FileCreationError;
+    return QgsKernelDensityEstimation::Result::FileCreationError;
 
   // open the raster in GA_Update mode
   mDatasetH.reset( GDALOpen( mOutputFile.toUtf8().constData(), GA_Update ) );
   if ( !mDatasetH )
-    return FileCreationError;
+    return QgsKernelDensityEstimation::Result::FileCreationError;
   mRasterBandH = GDALGetRasterBand( mDatasetH.get(), 1 );
   if ( !mRasterBandH )
-    return FileCreationError;
+    return QgsKernelDensityEstimation::Result::FileCreationError;
 
   mBufferSize = -1;
   if ( mRadiusField < 0 )
     mBufferSize = radiusSizeInPixels( mRadius );
 
-  return Success;
+  return QgsKernelDensityEstimation::Result::Success;
 }
 
 QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const QgsFeature &feature )
@@ -109,7 +109,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
   const QgsGeometry featureGeometry = feature.geometry();
   if ( featureGeometry.isNull() )
   {
-    return Success;
+    return QgsKernelDensityEstimation::Result::Success;
   }
 
   // convert the geometry to multipoint
@@ -119,7 +119,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
     const QgsPointXY p = featureGeometry.asPoint();
     // avoiding any empty points or out of extent points
     if ( !mBounds.contains( p ) )
-      return Success;
+      return QgsKernelDensityEstimation::Result::Success;
 
     multiPoints << p;
   }
@@ -145,7 +145,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
     weight = feature.attribute( mWeightField ).toDouble();
   }
 
-  Result result = Success;
+  QgsKernelDensityEstimation::Result result = QgsKernelDensityEstimation::Result::Success;
 
   //loop through all points in multipoint
   for ( QgsMultiPointXY::const_iterator pointIt = multiPoints.constBegin(); pointIt != multiPoints.constEnd(); ++pointIt )
@@ -166,7 +166,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
     float *dataBuffer = ( float * ) CPLMalloc( sizeof( float ) * blockSize * blockSize );
     if ( GDALRasterIO( mRasterBandH, GF_Read, xPosition, yPositionIO, blockSize, blockSize, dataBuffer, blockSize, blockSize, GDT_Float32, 0, 0 ) != CE_None )
     {
-      result = RasterIoError;
+      result = QgsKernelDensityEstimation::Result::RasterIoError;
     }
 
     for ( int xp = 0; xp < blockSize; xp++ )
@@ -195,7 +195,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
     }
     if ( GDALRasterIO( mRasterBandH, GF_Write, xPosition, yPositionIO, blockSize, blockSize, dataBuffer, blockSize, blockSize, GDT_Float32, 0, 0 ) != CE_None )
     {
-      result = RasterIoError;
+      result = QgsKernelDensityEstimation::Result::RasterIoError;
     }
     CPLFree( dataBuffer );
   }
@@ -207,7 +207,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::finalise()
 {
   mDatasetH.reset();
   mRasterBandH = nullptr;
-  return Success;
+  return QgsKernelDensityEstimation::Result::Success;
 }
 
 int QgsKernelDensityEstimation::radiusSizeInPixels( double radius ) const
@@ -263,19 +263,19 @@ double QgsKernelDensityEstimation::calculateKernelValue( const double distance, 
 {
   switch ( shape )
   {
-    case KernelTriangular:
+    case QgsKernelDensityEstimation::KernelShape::KernelTriangular:
       return triangularKernel( distance, bandwidth, outputType );
 
-    case KernelUniform:
+    case QgsKernelDensityEstimation::KernelShape::KernelUniform:
       return uniformKernel( distance, bandwidth, outputType );
 
-    case KernelQuartic:
+    case QgsKernelDensityEstimation::KernelShape::KernelQuartic:
       return quarticKernel( distance, bandwidth, outputType );
 
-    case KernelTriweight:
+    case QgsKernelDensityEstimation::KernelShape::KernelTriweight:
       return triweightKernel( distance, bandwidth, outputType );
 
-    case KernelEpanechnikov:
+    case QgsKernelDensityEstimation::KernelShape::KernelEpanechnikov:
       return epanechnikovKernel( distance, bandwidth, outputType );
   }
   return 0; //no warnings
@@ -294,7 +294,7 @@ double QgsKernelDensityEstimation::uniformKernel( const double distance, const d
   Q_UNUSED( distance )
   switch ( outputType )
   {
-    case OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
     {
       // Normalizing constant
       const double k = 2. / ( M_PI * bandwidth );
@@ -302,7 +302,7 @@ double QgsKernelDensityEstimation::uniformKernel( const double distance, const d
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 0.5 / bandwidth );
     }
-    case OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
       return 1.0;
   }
   return 0.0; // NO warnings!!!!!
@@ -312,7 +312,7 @@ double QgsKernelDensityEstimation::quarticKernel( const double distance, const d
 {
   switch ( outputType )
   {
-    case OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
     {
       // Normalizing constant
       const double k = 16. / ( 5. * M_PI * std::pow( bandwidth, 2 ) );
@@ -320,7 +320,7 @@ double QgsKernelDensityEstimation::quarticKernel( const double distance, const d
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 15. / 16. ) * std::pow( 1. - std::pow( distance / bandwidth, 2 ), 2 );
     }
-    case OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
       return std::pow( 1. - std::pow( distance / bandwidth, 2 ), 2 );
   }
   return 0.0; //no, seriously, I told you NO WARNINGS!
@@ -330,7 +330,7 @@ double QgsKernelDensityEstimation::triweightKernel( const double distance, const
 {
   switch ( outputType )
   {
-    case OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
     {
       // Normalizing constant
       const double k = 128. / ( 35. * M_PI * std::pow( bandwidth, 2 ) );
@@ -338,7 +338,7 @@ double QgsKernelDensityEstimation::triweightKernel( const double distance, const
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 35. / 32. ) * std::pow( 1. - std::pow( distance / bandwidth, 2 ), 3 );
     }
-    case OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
       return std::pow( 1. - std::pow( distance / bandwidth, 2 ), 3 );
   }
   return 0.0; // this is getting ridiculous... don't you ever listen to a word I say?
@@ -348,7 +348,7 @@ double QgsKernelDensityEstimation::epanechnikovKernel( const double distance, co
 {
   switch ( outputType )
   {
-    case OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
     {
       // Normalizing constant
       const double k = 8. / ( 3. * M_PI * std::pow( bandwidth, 2 ) );
@@ -356,7 +356,7 @@ double QgsKernelDensityEstimation::epanechnikovKernel( const double distance, co
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 3. / 4. ) * ( 1. - std::pow( distance / bandwidth, 2 ) );
     }
-    case OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
       return ( 1. - std::pow( distance / bandwidth, 2 ) );
   }
 
@@ -367,7 +367,7 @@ double QgsKernelDensityEstimation::triangularKernel( const double distance, cons
 {
   switch ( outputType )
   {
-    case OutputScaled:
+    case QgsKernelDensityEstimation::OutputValues::OutputScaled:
     {
       // Normalizing constant. In this case it's calculated a little different
       // due to the inclusion of the non-standard "decay" parameter
@@ -385,7 +385,7 @@ double QgsKernelDensityEstimation::triangularKernel( const double distance, cons
         return ( 1. - ( 1. - mDecay ) * ( distance / bandwidth ) );
       }
     }
-    case OutputRaw:
+    case QgsKernelDensityEstimation::OutputValues::OutputRaw:
       return ( 1. - ( 1. - mDecay ) * ( distance / bandwidth ) );
   }
   return 0.0; // ....

--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -39,20 +39,20 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
 {
   public:
     //! Kernel shape type
-    enum class KernelShape : int
+    enum class KernelShape SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsKernelDensityEstimation, KernelShape ) : int
     {
-      KernelQuartic = 0,  //!< Quartic kernel
-      KernelTriangular,   //!< Triangular kernel
-      KernelUniform,      //!< Uniform (flat) kernel
-      KernelTriweight,    //!< Triweight kernel
-      KernelEpanechnikov, //!< Epanechnikov kernel
+      Quartic SIP_MONKEYPATCH_COMPAT_NAME( KernelQuartic ) = 0,       //!< Quartic kernel
+      Triangular SIP_MONKEYPATCH_COMPAT_NAME( KernelTriangular ),     //!< Triangular kernel
+      Uniform SIP_MONKEYPATCH_COMPAT_NAME( KernelUniform ),           //!< Uniform (flat) kernel
+      Triweight SIP_MONKEYPATCH_COMPAT_NAME( KernelTriweight ),       //!< Triweight kernel
+      Epanechnikov SIP_MONKEYPATCH_COMPAT_NAME( KernelEpanechnikov ), //!< Epanechnikov kernel
     };
 
     //! Output values type
-    enum class OutputValues : int
+    enum class OutputValues SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsKernelDensityEstimation, OutputValues ) : int
     {
-      OutputRaw = 0, //!< Output the raw KDE values
-      OutputScaled,  //!< Output mathematically correct scaled values
+      Raw SIP_MONKEYPATCH_COMPAT_NAME( OutputRaw ) = 0,   //!< Output the raw KDE values
+      Scaled SIP_MONKEYPATCH_COMPAT_NAME( OutputScaled ), //!< Output mathematically correct scaled values
     };
 
     //! Result of operation

--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -39,7 +39,7 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
 {
   public:
     //! Kernel shape type
-    enum KernelShape
+    enum class KernelShape : int
     {
       KernelQuartic = 0,  //!< Quartic kernel
       KernelTriangular,   //!< Triangular kernel
@@ -49,14 +49,14 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
     };
 
     //! Output values type
-    enum OutputValues
+    enum class OutputValues : int
     {
       OutputRaw = 0, //!< Output the raw KDE values
       OutputScaled,  //!< Output mathematically correct scaled values
     };
 
     //! Result of operation
-    enum Result
+    enum class Result : int
     {
       Success,           //!< Operation completed successfully
       DriverError,       //!< Could not open the driver for the specified format
@@ -174,6 +174,5 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
     QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other );
 #endif
 };
-
 
 #endif // QGSKDE_H

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -141,7 +141,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
   if ( !calcNode )
   {
     //error
-    return ParserError;
+    return QgsRasterCalculator::Result::ParserError;
   }
 
   // Check input layers and bands
@@ -150,12 +150,12 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
     if ( !entry.raster ) // no raster layer in entry
     {
       mLastError = QObject::tr( "No raster layer for entry %1" ).arg( entry.ref );
-      return InputLayerError;
+      return QgsRasterCalculator::Result::InputLayerError;
     }
     if ( entry.bandNumber <= 0 || entry.bandNumber > entry.raster->bandCount() )
     {
       mLastError = QObject::tr( "Band number %1 is not valid for entry %2" ).arg( entry.bandNumber ).arg( entry.ref );
-      return BandError;
+      return QgsRasterCalculator::Result::BandError;
     }
   }
 
@@ -177,14 +177,14 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
   if ( !outputDriver )
   {
     mLastError = QObject::tr( "Could not obtain driver for %1" ).arg( mOutputFormat );
-    return CreateOutputError;
+    return QgsRasterCalculator::Result::CreateOutputError;
   }
 
   gdal::dataset_unique_ptr outputDataset( openOutputFile( outputDriver ) );
   if ( !outputDataset )
   {
     mLastError = QObject::tr( "Could not create output %1" ).arg( mOutputFile );
-    return CreateOutputError;
+    return QgsRasterCalculator::Result::CreateOutputError;
   }
 
   GDALSetProjection( outputDataset.get(), mOutputCrs.toWkt( Qgis::CrsWktVariant::PreferredGdal ).toLocal8Bit().data() );
@@ -277,7 +277,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
       {
         //delete the dataset without closing (because it is faster)
         gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-        return CalculationError;
+        return QgsRasterCalculator::Result::CalculationError;
       }
     }
 
@@ -307,7 +307,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
         if ( rasterBlockFeedback->isCanceled() )
         {
           qDeleteAll( inputBlocks );
-          return Canceled;
+          return QgsRasterCalculator::Result::Canceled;
         }
       }
       else
@@ -318,7 +318,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
       {
         mLastError = QObject::tr( "Could not allocate required memory for %1" ).arg( it->ref );
         qDeleteAll( inputBlocks );
-        return MemoryError;
+        return QgsRasterCalculator::Result::MemoryError;
       }
       inputBlocks.insert( it->ref, block.release() );
     }
@@ -362,7 +362,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
         qDeleteAll( inputBlocks );
         inputBlocks.clear();
         gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-        return CalculationError;
+        return QgsRasterCalculator::Result::CalculationError;
       }
     }
 
@@ -381,12 +381,12 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
   {
     //delete the dataset without closing (because it is faster)
     gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-    return Canceled;
+    return QgsRasterCalculator::Result::Canceled;
   }
 
   GDALComputeRasterStatistics( outputRasterBand, true, nullptr, nullptr, nullptr, nullptr, GdalProgressCallback, feedback );
 
-  return Success;
+  return QgsRasterCalculator::Result::Success;
 }
 
 #ifdef HAVE_OPENCL
@@ -474,7 +474,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
       case Qgis::DataType::ARGB32:
       case Qgis::DataType::ARGB32_Premultiplied:
       case Qgis::DataType::UnknownDataType:
-        return BandError;
+        return QgsRasterCalculator::Result::BandError;
     }
     entry.bufferSize = entry.dataSize * mNumOutputColumns;
     entry.index = refCounter;
@@ -568,14 +568,14 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
     if ( !outputDriver )
     {
       mLastError = QObject::tr( "Could not obtain driver for %1" ).arg( mOutputFormat );
-      return CreateOutputError;
+      return QgsRasterCalculator::Result::CreateOutputError;
     }
 
     gdal::dataset_unique_ptr outputDataset( openOutputFile( outputDriver ) );
     if ( !outputDataset )
     {
       mLastError = QObject::tr( "Could not create output %1" ).arg( mOutputFile );
-      return CreateOutputError;
+      return QgsRasterCalculator::Result::CreateOutputError;
     }
 
     GDALSetProjection( outputDataset.get(), mOutputCrs.toWkt( Qgis::CrsWktVariant::PreferredGdal ).toLocal8Bit().data() );
@@ -583,7 +583,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
 
     GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
     if ( !outputRasterBand )
-      return BandError;
+      return QgsRasterCalculator::Result::BandError;
 
     GDALSetRasterNoDataValue( outputRasterBand, mNoDataValue );
 
@@ -649,7 +649,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
 
       if ( GDALRasterIO( outputRasterBand, GF_Write, 0, line, mNumOutputColumns, 1, resultLine.get(), mNumOutputColumns, 1, GDT_Float32, 0, 0 ) != CE_None )
       {
-        return CreateOutputError;
+        return QgsRasterCalculator::Result::CreateOutputError;
       }
     }
 
@@ -657,7 +657,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
     {
       //delete the dataset without closing (because it is faster)
       gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
-      return Canceled;
+      return QgsRasterCalculator::Result::Canceled;
     }
 
     inputBuffers.clear();
@@ -667,10 +667,10 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
   catch ( cl::Error &e )
   {
     mLastError = e.what();
-    return CreateOutputError;
+    return QgsRasterCalculator::Result::CreateOutputError;
   }
 
-  return Success;
+  return QgsRasterCalculator::Result::Success;
 }
 #endif
 

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -75,7 +75,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
 {
   public:
     //! Result of the calculation
-    enum Result
+    enum class Result : int
     {
       Success = 0,           //!< Calculation successful
       CreateOutputError = 1, //!< Error creating output data file
@@ -149,7 +149,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
      *
      * The optional \a feedback argument can be used for progress reporting and cancellation support.
      *
-     * \returns QgsRasterCalculator::Success in case of success. If an error is encountered then
+     * \returns QgsRasterCalculator::Result::Success in case of success. If an error is encountered then
      * a description of the error can be obtained by calling lastError().
     */
     Result processCalculation( QgsFeedback *feedback = nullptr );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6174,7 +6174,7 @@ void QgisApp::showRasterCalculator()
     QgsRasterCalculator::Result res = rc.processCalculation( &feedback );
     switch ( res )
     {
-      case QgsRasterCalculator::Success:
+      case QgsRasterCalculator::Result::Success:
         if ( d.addLayerToProject() )
         {
           addRasterLayer( d.outputFile(), QFileInfo( d.outputFile() ).completeBaseName(), QStringLiteral( "gdal" ) );
@@ -6182,30 +6182,30 @@ void QgisApp::showRasterCalculator()
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "Calculation complete." ), Qgis::MessageLevel::Success );
         break;
 
-      case QgsRasterCalculator::CreateOutputError:
+      case QgsRasterCalculator::Result::CreateOutputError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "Could not create destination file." ), Qgis::MessageLevel::Critical );
         break;
 
-      case QgsRasterCalculator::InputLayerError:
+      case QgsRasterCalculator::Result::InputLayerError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "Could not read input layer." ), Qgis::MessageLevel::Critical );
         break;
 
-      case QgsRasterCalculator::Canceled:
+      case QgsRasterCalculator::Result::Canceled:
         break;
 
-      case QgsRasterCalculator::ParserError:
+      case QgsRasterCalculator::Result::ParserError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "Could not parse raster formula." ), Qgis::MessageLevel::Critical );
         break;
 
-      case QgsRasterCalculator::MemoryError:
+      case QgsRasterCalculator::Result::MemoryError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "Insufficient memory available for operation." ), Qgis::MessageLevel::Critical );
         break;
 
-      case QgsRasterCalculator::BandError:
+      case QgsRasterCalculator::Result::BandError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "Invalid band number for input layer." ), Qgis::MessageLevel::Critical );
         break;
 
-      case QgsRasterCalculator::CalculationError:
+      case QgsRasterCalculator::Result::CalculationError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "An error occurred while performing the calculation." ), Qgis::MessageLevel::Critical );
         break;
     }

--- a/tests/src/analysis/testqgsinterpolator.cpp
+++ b/tests/src/analysis/testqgsinterpolator.cpp
@@ -325,7 +325,7 @@ void TestQgsInterpolator::TIN_IDW_Interpolator_with_Z()
 
   QgsInterpolator::LayerData layerdata;
   layerdata.source = mLayerPoint.get();
-  layerdata.valueSource = QgsInterpolator::ValueSource::ValueZ;
+  layerdata.valueSource = QgsInterpolator::ValueSource::Z;
   QList<QgsInterpolator::LayerData> layerDataList;
   layerDataList.append( layerdata );
 

--- a/tests/src/analysis/testqgsinterpolator.cpp
+++ b/tests/src/analysis/testqgsinterpolator.cpp
@@ -325,7 +325,7 @@ void TestQgsInterpolator::TIN_IDW_Interpolator_with_Z()
 
   QgsInterpolator::LayerData layerdata;
   layerdata.source = mLayerPoint.get();
-  layerdata.valueSource = QgsInterpolator::ValueZ;
+  layerdata.valueSource = QgsInterpolator::ValueSource::ValueZ;
   QList<QgsInterpolator::LayerData> layerDataList;
   layerDataList.append( layerdata );
 

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -467,7 +467,7 @@ void TestQgsRasterCalculator::calcWithLayers()
   tmpFile.close();
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" + 2" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   QgsRasterLayer *result = new QgsRasterLayer( tmpName, QStringLiteral( "result" ) );
@@ -485,7 +485,7 @@ void TestQgsRasterCalculator::calcWithLayers()
 
   //now try with 2 raster bands
   QgsRasterCalculator rc2( QStringLiteral( "\"landsat@1\" + \"landsat@2\"" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc2.processCalculation() ), 0 );
+  QCOMPARE( rc2.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   result = new QgsRasterLayer( tmpName, QStringLiteral( "result" ) );
@@ -526,7 +526,7 @@ void TestQgsRasterCalculator::calcWithReprojectedLayers()
   tmpFile.close();
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" + \"landsat_4326@2\"" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   QgsRasterLayer *result = new QgsRasterLayer( tmpName, QStringLiteral( "result" ) );
@@ -672,7 +672,7 @@ void TestQgsRasterCalculator::calcWithDataType()
   entries << entry1;
 
   QgsRasterCalculator rc( QStringLiteral( "\"dem@1\" * 2" ), tempResultFilePath, QStringLiteral( "GTiff" ), extent, crs, 2, 2, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
 
   auto result = std::make_unique<QgsRasterLayer>( tempResultFilePath, QStringLiteral( "result" ) );
   QCOMPARE( result->width(), 2 );
@@ -782,16 +782,15 @@ void TestQgsRasterCalculator::errors()
   tmpFile.close();
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@0\"" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 6 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::BandError );
   QCOMPARE( rc.lastError(), QStringLiteral( "Band number 0 is not valid for entry landsat@0" ) );
 
   entry1.bandNumber = 10; // bad band
   entries.clear();
   entries << entry1;
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 6 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::BandError );
   QCOMPARE( rc.lastError(), QStringLiteral( "Band number 10 is not valid for entry landsat@0" ) );
-
 
   // no raster
   entry1.raster = nullptr;
@@ -799,7 +798,7 @@ void TestQgsRasterCalculator::errors()
   entries.clear();
   entries << entry1;
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 2 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::InputLayerError );
   QCOMPARE( rc.lastError(), QStringLiteral( "No raster layer for entry landsat@0" ) );
 
   // bad driver
@@ -808,19 +807,19 @@ void TestQgsRasterCalculator::errors()
   entries.clear();
   entries << entry1;
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ), tmpName, QStringLiteral( "xxxxx" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 1 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::CreateOutputError );
   QCOMPARE( rc.lastError(), QStringLiteral( "Could not obtain driver for xxxxx" ) );
 
   // bad filename
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ), QStringLiteral( "/goodluckwritinghere/blah/blah.tif" ), QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 1 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::CreateOutputError );
   QCOMPARE( rc.lastError(), QStringLiteral( "Could not create output /goodluckwritinghere/blah/blah.tif" ) );
 
   // canceled
   QgsFeedback feedback;
   feedback.cancel();
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation( &feedback ) ), 3 );
+  QCOMPARE( rc.processCalculation( &feedback ), QgsRasterCalculator::Result::Canceled );
   QVERIFY( rc.lastError().isEmpty() );
 }
 
@@ -884,7 +883,7 @@ void TestQgsRasterCalculator::testOutputCrsFromRasterEntries()
   tmpFile.close();
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@0\"" ), tmpName, QStringLiteral( "GTiff" ), extent, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
   //open output file and check results
   QgsRasterLayer *result = new QgsRasterLayer( tmpName, QStringLiteral( "result" ) );
   QCOMPARE( result->crs(), mpLandsatRasterLayer->crs() );
@@ -908,7 +907,6 @@ void TestQgsRasterCalculator::calcFormulasWithReprojectedLayers()
   QgsCoordinateReferenceSystem crs( QStringLiteral( "EPSG:32633" ) );
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
-
   auto _chk = [=]( const QString &formula, const std::vector<float> &values, bool useOpenCL ) {
     qDebug() << formula;
 
@@ -925,7 +923,7 @@ void TestQgsRasterCalculator::calcFormulasWithReprojectedLayers()
     QString tmpName = tmpFile.fileName();
     tmpFile.close();
     QgsRasterCalculator rc( formula, tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-    QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+    QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
     //open output file and check results
     QgsRasterLayer *result = new QgsRasterLayer( tmpName, QStringLiteral( "result" ) );
     QCOMPARE( result->width(), 2 );
@@ -991,7 +989,7 @@ void TestQgsRasterCalculator::testStatistics()
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" * 2" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, { entry1 }, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check stats are there
   auto ds = GDALOpenEx( tmpName.toUtf8().constData(), GDAL_OF_RASTER | GDAL_OF_READONLY, nullptr, nullptr, nullptr );
@@ -1051,7 +1049,7 @@ void TestQgsRasterCalculator::testFunctionTypeWithLayer()
   // Test with one raster as condition and numbers as first and second option
   // if ( landsat@1 > 124.5, 100.0 , 5.0 )
   QgsRasterCalculator rc( QStringLiteral( " if(\"landsat@1\">124.5, 100.0 , 5.0 ) " ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   auto result = std::make_unique<QgsRasterLayer>( tmpName, QStringLiteral( "result" ) );
@@ -1069,7 +1067,7 @@ void TestQgsRasterCalculator::testFunctionTypeWithLayer()
   // Test with one raster as condition, one raster first option and number as second option
   // if ( landsat@1 > 124.5, landsat@1 + landsat@2 , 5.0 )
   QgsRasterCalculator rc2( QStringLiteral( " if(\"landsat@1\">124.5, \"landsat@1\" + \"landsat@2\" , 5.0 ) " ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc2.processCalculation() ), 0 );
+  QCOMPARE( rc2.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   result = std::make_unique<QgsRasterLayer>( tmpName, QStringLiteral( "result" ) );
@@ -1086,7 +1084,7 @@ void TestQgsRasterCalculator::testFunctionTypeWithLayer()
   // Test with one raster as condition, one raster first option and number as second option
   // if ( landsat@1 > 124.5, landsat@1 + landsat@2 , landsat@3 )
   QgsRasterCalculator rc3( QStringLiteral( " if(\"landsat@1\">124.5, \"landsat@1\" + \"landsat@2\" , \"landsat@1\" - \"landsat@2\" ) " ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc3.processCalculation() ), 0 );
+  QCOMPARE( rc3.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   result = std::make_unique<QgsRasterLayer>( tmpName, QStringLiteral( "result" ) );
@@ -1103,7 +1101,7 @@ void TestQgsRasterCalculator::testFunctionTypeWithLayer()
   // Test with scalar (always true) as condition, one raster first option and number as second option
   // if ( 5 > 4, landsat@1 + landsat@2 , 0 )
   QgsRasterCalculator rc4( QStringLiteral( " if( 5>4 , \"landsat@1\" + \"landsat@2\" , 0 ) " ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc4.processCalculation() ), 0 );
+  QCOMPARE( rc4.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   result = std::make_unique<QgsRasterLayer>( tmpName, QStringLiteral( "result" ) );
@@ -1120,7 +1118,7 @@ void TestQgsRasterCalculator::testFunctionTypeWithLayer()
   // Test with scalar (always false) as condition, one raster first option and number as second option
   // if ( 4 > 5, landsat@1 + landsat@2 , 0 )
   QgsRasterCalculator rc5( QStringLiteral( " if( 4>5 , \"landsat@1\" + \"landsat@2\" , 0 ) " ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
-  QCOMPARE( static_cast<int>( rc5.processCalculation() ), 0 );
+  QCOMPARE( rc5.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   result = std::make_unique<QgsRasterLayer>( tmpName, QStringLiteral( "result" ) );
@@ -1160,7 +1158,7 @@ void TestQgsRasterCalculator::testCreationOptions()
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" + 2" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
   rc.setCreationOptions( QStringList() << "TFW=YES" );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
 
   QVERIFY( worldFile.exists() );
   worldFile.remove();
@@ -1186,14 +1184,13 @@ void TestQgsRasterCalculator::testNoDataValue()
 
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" + 2" ), tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
   rc.setNoDataValue( -5555.0 );
-  QCOMPARE( static_cast<int>( rc.processCalculation() ), 0 );
+  QCOMPARE( rc.processCalculation(), QgsRasterCalculator::Result::Success );
 
   //open output file and check results
   const std::unique_ptr<QgsRasterLayer> result = std::make_unique<QgsRasterLayer>( tmpName, QStringLiteral( "raster" ), QStringLiteral( "gdal" ) );
   QVERIFY( result->dataProvider()->sourceHasNoDataValue( 1 ) );
   QCOMPARE( result->dataProvider()->sourceNoDataValue( 1 ), -5555.0 );
 }
-
 
 QGSTEST_MAIN( TestQgsRasterCalculator )
 #include "testqgsrastercalculator.moc"


### PR DESCRIPTION
## Description

Convert enums used in raster analysis classes (`QgsInterpolator`, `QgsKernelDensityEstimation`, etc.) to enum classes.