### PR TITLE
Set project dirty when changing layer data source

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7761,6 +7761,8 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
           }
         }
       }
+
+      QgsProject::instance()->setDirty( true );
     }
   }
 }


### PR DESCRIPTION
Fixes #60925.

Probably could be backported to 3.40 and 3.42?