### PR TITLE
Fix Python conversion code for Python dict->QMap<QString, int>

### DIFF
--- a/python/PyQt6/core/conversions.sip
+++ b/python/PyQt6/core/conversions.sip
@@ -2105,7 +2105,7 @@ template<TYPE>
         int state;
 
         QString *t1 = reinterpret_cast<QString *>(sipConvertToType(t1obj, sipType_QString, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
-        int t2 = PyLong_AsLong(t1obj);
+        int t2 = PyLong_AsLong(t2obj);
 
         if (*sipIsErr)
         {

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -2155,7 +2155,7 @@ template<TYPE>
         int state;
 
         QString *t1 = reinterpret_cast<QString *>(sipConvertToType(t1obj, sipType_QString, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
-        int t2 = PyLong_AsLong(t1obj);
+        int t2 = PyLong_AsLong(t2obj);
 
         if (*sipIsErr)
         {


### PR DESCRIPTION
This isn't currently used anywhere in the bindings (only the c++ -> Python conversion for this type)

