### PR TITLE
Fix exports to Geopackage of tables with FID as NOT the first field

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -705,6 +705,13 @@ Adds a ``feature`` to the currently opened data source, using the style
 from a specified ``renderer``.
 %End
 
+    QMap<int, int> sourceFieldIndexToWriterFieldIndex() const;
+%Docstring
+Returns the map of original source field index to output file field
+index.
+
+.. versionadded:: 3.44
+%End
 
     ~QgsVectorFileWriter();
 

--- a/python/PyQt6/core/conversions.sip
+++ b/python/PyQt6/core/conversions.sip
@@ -2125,7 +2125,83 @@ template<TYPE>
 %End
 };
 
+%MappedType QMap<int, int>
+{
+  %TypeHeaderCode
+#include <QMap>
+    %End
 
+    %ConvertFromTypeCode
+    // Create the dictionary.
+    PyObject *d = PyDict_New();
+
+  if (!d)
+    return NULL;
+
+  // Set the dictionary elements.
+  QMap<int, int>::const_iterator i = sipCpp->constBegin();
+
+  while (i != sipCpp->constEnd())
+  {
+    PyObject *kobj = PyLong_FromLong(i.key());
+    PyObject *vobj = PyLong_FromLong(i.value());
+
+    if (kobj == NULL || vobj == NULL || PyDict_SetItem(d, kobj, vobj) < 0)
+    {
+      Py_DECREF(d);
+
+      if (kobj) {
+        Py_DECREF(kobj);
+      }
+      if (vobj) {
+        Py_DECREF(vobj);
+      }
+
+      return NULL;
+    }
+
+    Py_DECREF(kobj);
+    Py_DECREF(vobj);
+
+    ++i;
+  }
+
+  return d;
+  %End
+
+  %ConvertToTypeCode
+    PyObject *t1obj, *t2obj;
+  Py_ssize_t i = 0;
+
+  // Check the type if that is all that is required.
+  if (sipIsErr == NULL)
+  {
+    if (!PyDict_Check(sipPy))
+      return 0;
+
+    while (PyDict_Next(sipPy, &i, &t1obj, &t2obj))
+    {
+      if (!sipCanConvertToType(t1obj, sipType_QString, SIP_NOT_NONE))
+        return 0;
+    }
+
+    return 1;
+  }
+
+  QMap<int, int> *qm = new QMap<int, int>;
+
+  while (PyDict_Next(sipPy, &i, &t1obj, &t2obj))
+  {
+    int t1 = PyLong_AsLong(t1obj);
+    int t2 = PyLong_AsLong(t2obj);
+    qm->insert(t1, t2);
+  }
+
+  *sipCppPtr = qm;
+
+  return sipGetState(sipTransferObj);
+  %End
+};
 
 template<TYPE1, TYPE2>
 %MappedType QMap<TYPE1, TYPE2*>

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -705,6 +705,13 @@ Adds a ``feature`` to the currently opened data source, using the style
 from a specified ``renderer``.
 %End
 
+    QMap<int, int> sourceFieldIndexToWriterFieldIndex() const;
+%Docstring
+Returns the map of original source field index to output file field
+index.
+
+.. versionadded:: 3.44
+%End
 
     ~QgsVectorFileWriter();
 

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -2175,7 +2175,83 @@ template<TYPE>
 %End
 };
 
+%MappedType QMap<int, int>
+{
+  %TypeHeaderCode
+#include <QMap>
+    %End
 
+    %ConvertFromTypeCode
+    // Create the dictionary.
+    PyObject *d = PyDict_New();
+
+  if (!d)
+    return NULL;
+
+  // Set the dictionary elements.
+  QMap<int, int>::const_iterator i = sipCpp->constBegin();
+
+  while (i != sipCpp->constEnd())
+  {
+    PyObject *kobj = PyLong_FromLong(i.key());
+    PyObject *vobj = PyLong_FromLong(i.value());
+
+    if (kobj == NULL || vobj == NULL || PyDict_SetItem(d, kobj, vobj) < 0)
+    {
+      Py_DECREF(d);
+
+      if (kobj) {
+        Py_DECREF(kobj);
+      }
+      if (vobj) {
+        Py_DECREF(vobj);
+      }
+
+      return NULL;
+    }
+
+    Py_DECREF(kobj);
+    Py_DECREF(vobj);
+
+    ++i;
+  }
+
+  return d;
+  %End
+
+  %ConvertToTypeCode
+    PyObject *t1obj, *t2obj;
+  Py_ssize_t i = 0;
+
+  // Check the type if that is all that is required.
+  if (sipIsErr == NULL)
+  {
+    if (!PyDict_Check(sipPy))
+      return 0;
+
+    while (PyDict_Next(sipPy, &i, &t1obj, &t2obj))
+    {
+      if (!sipCanConvertToType(t1obj, sipType_QString, SIP_NOT_NONE))
+        return 0;
+    }
+
+    return 1;
+  }
+
+  QMap<int, int> *qm = new QMap<int, int>;
+
+  while (PyDict_Next(sipPy, &i, &t1obj, &t2obj))
+  {
+    int t1 = PyLong_AsLong(t1obj);
+    int t2 = PyLong_AsLong(t2obj);
+    qm->insert(t1, t2);
+  }
+
+  *sipCppPtr = qm;
+
+  return sipGetState(sipTransferObj);
+  %End
+};
 
 template<TYPE1, TYPE2>
 %MappedType QMap<TYPE1, TYPE2*>

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -354,7 +354,7 @@ Qgis::VectorExportResult QgsOgrProvider::createEmptyLayer( const QString &uri,
     return static_cast<Qgis::VectorExportResult>( error );
   }
 
-  QMap<int, int> attrIdxMap = writer->attrIdxToOgrIdx();
+  QMap<int, int> attrIdxMap = writer->sourceFieldIndexToWriterFieldIndex();
   writer.reset();
 
   {

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -882,8 +882,12 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      */
     bool addFeatureWithStyle( QgsFeature &feature, QgsFeatureRenderer *renderer, Qgis::DistanceUnit outputUnit = Qgis::DistanceUnit::Meters );
 
-    //! \note not available in Python bindings
-    QMap<int, int> attrIdxToOgrIdx() const SIP_SKIP { return mAttrIdxToOgrIdx; }
+    /**
+     * Returns the map of original source field index to output file field index.
+     *
+     * \since QGIS 3.44
+     */
+    QMap<int, int> sourceFieldIndexToWriterFieldIndex() const { return mAttrIdxToOgrIdx; }
 
     //! Close opened shapefile for writing
     ~QgsVectorFileWriter() override;

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -13,6 +13,7 @@ __copyright__ = "Copyright 2012, The QGIS Project"
 import os
 import tempfile
 import json
+from pathlib import Path
 
 import osgeo.gdal  # NOQA
 from osgeo import gdal, ogr
@@ -2081,6 +2082,172 @@ class TestQgsVectorFileWriter(QgisTestCase):
 
         db_conn = QgsMapLayerUtils.databaseConnection(vl)
         self.assertIsNotNone(db_conn.fieldDomain("range_domain_int"))
+
+    def test_write_gpkg_fid_first(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_file_name = Path(temp_dir) / "test_fid_first.gpkg"
+
+            source_fields = QgsFields()
+            source_fields.append(QgsField("FID", QVariant.Int))
+            source_fields.append(QgsField("text_field", QVariant.String))
+            source_fields.append(QgsField("int_field", QVariant.Int))
+
+            save_options = QgsVectorFileWriter.SaveVectorOptions()
+            writer = QgsVectorFileWriter.create(
+                dest_file_name.as_posix(),
+                source_fields,
+                Qgis.WkbType.Point,
+                QgsCoordinateReferenceSystem("EPSG:4326"),
+                QgsCoordinateTransformContext(),
+                save_options,
+                QgsFeatureSink.SinkFlags(),
+            )
+            writer_field_map = writer.sourceFieldIndexToWriterFieldIndex()
+            del writer
+            layer = QgsVectorLayer(dest_file_name.as_posix())
+            self.assertTrue(layer.isValid())
+            layer_fields = layer.fields()
+
+            self.assertEqual(
+                [f.name() for f in layer_fields], ["fid", "text_field", "int_field"]
+            )
+            self.assertEqual(
+                writer_field_map,
+                {
+                    source_fields.indexOf("text_field"): layer_fields.lookupField(
+                        "text_field"
+                    ),
+                    source_fields.indexOf("int_field"): layer_fields.lookupField(
+                        "int_field"
+                    ),
+                    source_fields.indexOf("FID"): layer_fields.lookupField("FID"),
+                },
+            )
+
+    def test_write_gpkg_fid_not_first(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_file_name = Path(temp_dir) / "test_fid_not_first.gpkg"
+
+            source_fields = QgsFields()
+            source_fields.append(QgsField("text_field", QVariant.String))
+            source_fields.append(QgsField("FID", QVariant.Int))
+            source_fields.append(QgsField("int_field", QVariant.Int))
+
+            save_options = QgsVectorFileWriter.SaveVectorOptions()
+            writer = QgsVectorFileWriter.create(
+                dest_file_name.as_posix(),
+                source_fields,
+                Qgis.WkbType.Point,
+                QgsCoordinateReferenceSystem("EPSG:4326"),
+                QgsCoordinateTransformContext(),
+                save_options,
+                QgsFeatureSink.SinkFlags(),
+            )
+            writer_field_map = writer.sourceFieldIndexToWriterFieldIndex()
+            del writer
+            layer = QgsVectorLayer(dest_file_name.as_posix())
+            self.assertTrue(layer.isValid())
+            layer_fields = layer.fields()
+
+            self.assertEqual(
+                [f.name() for f in layer_fields], ["fid", "text_field", "int_field"]
+            )
+            self.assertEqual(
+                writer_field_map,
+                {
+                    source_fields.indexOf("text_field"): layer_fields.lookupField(
+                        "text_field"
+                    ),
+                    source_fields.indexOf("int_field"): layer_fields.lookupField(
+                        "int_field"
+                    ),
+                    source_fields.indexOf("FID"): layer_fields.lookupField("FID"),
+                },
+            )
+
+    def test_write_shp_fid_first(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_file_name = Path(temp_dir) / "test_fid_first.shp"
+
+            source_fields = QgsFields()
+            source_fields.append(QgsField("FID", QVariant.Int))
+            source_fields.append(QgsField("text_field", QVariant.String))
+            source_fields.append(QgsField("int_field", QVariant.Int))
+
+            save_options = QgsVectorFileWriter.SaveVectorOptions()
+            save_options.driverName = "ESRI Shapefile"
+            writer = QgsVectorFileWriter.create(
+                dest_file_name.as_posix(),
+                source_fields,
+                Qgis.WkbType.Point,
+                QgsCoordinateReferenceSystem("EPSG:4326"),
+                QgsCoordinateTransformContext(),
+                save_options,
+                QgsFeatureSink.SinkFlags(),
+            )
+            writer_field_map = writer.sourceFieldIndexToWriterFieldIndex()
+            del writer
+            layer = QgsVectorLayer(dest_file_name.as_posix())
+            self.assertTrue(layer.isValid())
+            layer_fields = layer.fields()
+
+            self.assertEqual(
+                [f.name() for f in layer_fields], ["FID", "text_field", "int_field"]
+            )
+            self.assertEqual(
+                writer_field_map,
+                {
+                    source_fields.indexOf("text_field"): layer_fields.lookupField(
+                        "text_field"
+                    ),
+                    source_fields.indexOf("int_field"): layer_fields.lookupField(
+                        "int_field"
+                    ),
+                    source_fields.indexOf("FID"): layer_fields.lookupField("FID"),
+                },
+            )
+
+    def test_write_shp_fid_not_first(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_file_name = Path(temp_dir) / "test_fid_not_first.shp"
+
+            source_fields = QgsFields()
+            source_fields.append(QgsField("text_field", QVariant.String))
+            source_fields.append(QgsField("FID", QVariant.Int))
+            source_fields.append(QgsField("int_field", QVariant.Int))
+
+            save_options = QgsVectorFileWriter.SaveVectorOptions()
+            save_options.driverName = "ESRI Shapefile"
+            writer = QgsVectorFileWriter.create(
+                dest_file_name.as_posix(),
+                source_fields,
+                Qgis.WkbType.Point,
+                QgsCoordinateReferenceSystem("EPSG:4326"),
+                QgsCoordinateTransformContext(),
+                save_options,
+                QgsFeatureSink.SinkFlags(),
+            )
+            writer_field_map = writer.sourceFieldIndexToWriterFieldIndex()
+            del writer
+            layer = QgsVectorLayer(dest_file_name.as_posix())
+            self.assertTrue(layer.isValid())
+            layer_fields = layer.fields()
+
+            self.assertEqual(
+                [f.name() for f in layer_fields], ["text_field", "FID", "int_field"]
+            )
+            self.assertEqual(
+                writer_field_map,
+                {
+                    source_fields.indexOf("text_field"): layer_fields.lookupField(
+                        "text_field"
+                    ),
+                    source_fields.indexOf("int_field"): layer_fields.lookupField(
+                        "int_field"
+                    ),
+                    source_fields.indexOf("FID"): layer_fields.lookupField("FID"),
+                },
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When creating a GPKG with the source fields containing an explicit FID attribute which is NOT the first field, the
returned attribute mapping was not accounting for GDAL rearranging the FID field to always be the first field.

This resulted in corrupted layer imports when importing a database table with a FID as NOT the first field into a Geopackage