### PR TITLE
fix map logic

### DIFF
--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1367,7 +1367,8 @@ QPointF QgsLayoutItem::positionAtReferencePoint( const QgsLayoutItem::ReferenceP
 QgsLayoutPoint QgsLayoutItem::topLeftToReferencePoint( const QgsLayoutPoint &point ) const
 {
   const QPointF topLeft = mLayout->convertToLayoutUnits( point );
-  const QPointF refPoint = topLeft + itemPositionAtReferencePoint( mReferencePoint, rect().size() );
+  const QPointF anchorPoint = mapToScene( itemPositionAtReferencePoint( mReferencePoint, rect().size() ) );
+  const QPointF refPoint = anchorPoint - mapFromScene( topLeft );
   return mLayout->convertFromLayoutUnits( refPoint, point.units() );
 }
 


### PR DESCRIPTION
## Description

fixes #61347 

This is the solution that I found to keep the map in place when it is rotated and the anchor point is changed or the map is redrawn.

I have no clue why the `mapToScene` and `mapFromScene` are needed in this way, but removing them cause issues when changing the reference point and updating.
