### PR TITLE
testqgscoordinatereferencesystem: Don't test dynamic on ETRS89

### DIFF
--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -1768,8 +1768,24 @@ void TestQgsCoordinateReferenceSystem::isDynamic()
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
   QVERIFY( crs.isDynamic() );
 
-  // ETRS89 (generic), using datum ensemble
-  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4258" ) );
+  // Test generic geodetic CRS using datum ensemble
+  QVERIFY( crs.createFromWkt( QStringLiteral( R"""(GEOGCRS["test",
+    ENSEMBLE["test",
+             MEMBER["member1"],
+        MEMBER["member2"],
+        ELLIPSOID["GRS 1980",6378137,298.257222101,
+            LENGTHUNIT["metre",1]],
+        ENSEMBLEACCURACY[0.1]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433]],
+    CS[ellipsoidal,2],
+        AXIS["geodetic latitude (Lat)",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433]],
+        AXIS["geodetic longitude (Lon)",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433]]])""" ) ) );
+  QVERIFY( crs.isValid() );
   QVERIFY( !crs.isDynamic() );
 
   QVERIFY( crs.createFromWkt( QStringLiteral( R"""(GEOGCS["WGS 84",


### PR DESCRIPTION
## Description

ETRS89 is a CRS that does not have a "normal" datum, but rather a datum ensemble. The concept of a dynamic CRS in ISO 19111 / OGC Abstract Topic 2 is not very clear when a datum ensemble is involved. The approach used by the method QgsProjUtils::isDynamic() in QGIS (copied from OGRSpatialReference::IsDynamic() in GDAL) is to look at the first member datum of the datum ensemble, and if that datum is dynamic, then the CRS is considered dynamic.

In a recent update to the EPSG registry, the "European Terrestrial Reference Frame XXXX" datums, which are members of the "European Terrestrial Reference System 1989 ensemble", were marked as dynamic following the change request 2025.008. This update of part of PROJ 9.6.0.

To follow this update, remove this spurious test and replace it with a generic geodetic CRS using datum ensemble.

Suggested By: Even Rouault <even.rouault@spatialys.com>

Funded By: Oslandia