### PR TITLE
Use unique_ptr when class has clear ownership

### DIFF
--- a/python/PyQt6/core/auto_generated/settings/qgssettingstreenode.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingstreenode.sip.in
@@ -292,7 +292,6 @@ Constructor for QgsSettingsTreeNamedListNode.
 
 .. seealso:: :py:func:`QgsSettingsTree.createPluginTreeNode`
 %End
-    QgsSettingsTreeNamedListNode( const QgsSettingsTreeNamedListNode &other );
 };
 
 /************************************************************************

--- a/python/core/auto_generated/settings/qgssettingstreenode.sip.in
+++ b/python/core/auto_generated/settings/qgssettingstreenode.sip.in
@@ -292,7 +292,6 @@ Constructor for QgsSettingsTreeNamedListNode.
 
 .. seealso:: :py:func:`QgsSettingsTree.createPluginTreeNode`
 %End
-    QgsSettingsTreeNamedListNode( const QgsSettingsTreeNamedListNode &other );
 };
 
 /************************************************************************

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -838,8 +838,8 @@ void QgsAuthManager::setScheduledAuthDatabaseErase( bool scheduleErase )
   {
     if ( !mScheduledDbEraseTimer )
     {
-      mScheduledDbEraseTimer = new QTimer( this );
-      connect( mScheduledDbEraseTimer, &QTimer::timeout, this, &QgsAuthManager::tryToStartDbErase );
+      mScheduledDbEraseTimer = std::make_unique<QTimer>( this );
+      connect( mScheduledDbEraseTimer.get(), &QTimer::timeout, this, &QgsAuthManager::tryToStartDbErase );
       mScheduledDbEraseTimer->start( mScheduledDbEraseRequestWait * 1000 );
     }
     else if ( !mScheduledDbEraseTimer->isActive() )
@@ -3324,8 +3324,7 @@ QgsAuthManager::~QgsAuthManager()
     if ( authConn.isValid() && authConn.isOpen() )
       authConn.close();
   }
-  delete mScheduledDbEraseTimer;
-  mScheduledDbEraseTimer = nullptr;
+
   QSqlDatabase::removeDatabase( QStringLiteral( "authentication.configs" ) );
 }
 
@@ -4164,4 +4163,3 @@ QgsAuthConfigurationStorage *QgsAuthManager::firstStorageWithCapability( Qgis::A
   QgsAuthConfigurationStorageRegistry *storageRegistry = authConfigurationStorageRegistry();
   return storageRegistry->firstReadyStorageWithCapability( capability );
 }
-

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -1019,7 +1019,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
     int mPassTries = 0;
     bool mAuthDisabled = false;
     QString mAuthDisabledMessage;
-    QTimer *mScheduledDbEraseTimer = nullptr;
+    std::unique_ptr<QTimer> mScheduledDbEraseTimer;
     bool mScheduledDbErase = false;
     int mScheduledDbEraseRequestWait = 3 ; // in seconds
     bool mScheduledDbEraseRequestEmitted = false;

--- a/src/core/browser/qgsdataitem.cpp
+++ b/src/core/browser/qgsdataitem.cpp
@@ -85,7 +85,7 @@ QgsDataItem::~QgsDataItem()
     mFutureWatcher->waitForFinished();
   }
 
-  delete mFutureWatcher;
+
 }
 
 QString QgsDataItem::pathComponent( const QString &string )
@@ -204,10 +204,10 @@ void QgsDataItem::populate( bool foreground )
     // The watcher must not be created with item (in constructor) because the item may be created in thread and the watcher created in thread does not work correctly.
     if ( !mFutureWatcher )
     {
-      mFutureWatcher = new QFutureWatcher< QVector <QgsDataItem *> >( this );
+      mFutureWatcher = std::make_unique<QFutureWatcher<QVector<QgsDataItem *> >>( this );
     }
 
-    connect( mFutureWatcher, &QFutureWatcherBase::finished, this, &QgsDataItem::childrenCreated );
+    connect( mFutureWatcher.get(), &QFutureWatcherBase::finished, this, &QgsDataItem::childrenCreated );
     mFutureWatcher->setFuture( QtConcurrent::run( runCreateChildren, this ) );
   }
 }
@@ -252,7 +252,7 @@ void QgsDataItem::childrenCreated()
   {
     refresh( mFutureWatcher->result() );
   }
-  disconnect( mFutureWatcher, &QFutureWatcherBase::finished, this, &QgsDataItem::childrenCreated );
+  disconnect( mFutureWatcher.get(), &QFutureWatcherBase::finished, this, &QgsDataItem::childrenCreated );
   emit dataChanged( this ); // to replace loading icon by normal icon
 }
 
@@ -305,9 +305,9 @@ void QgsDataItem::refresh()
     setState( Qgis::BrowserItemState::Populating );
     if ( !mFutureWatcher )
     {
-      mFutureWatcher = new QFutureWatcher< QVector <QgsDataItem *> >( this );
+      mFutureWatcher = std::make_unique<QFutureWatcher<QVector<QgsDataItem *> >>( this );
     }
-    connect( mFutureWatcher, &QFutureWatcherBase::finished, this, &QgsDataItem::childrenCreated );
+    connect( mFutureWatcher.get(), &QFutureWatcherBase::finished, this, &QgsDataItem::childrenCreated );
     mFutureWatcher->setFuture( QtConcurrent::run( runCreateChildren, this ) );
   }
 }

--- a/src/core/browser/qgsdataitem.h
+++ b/src/core/browser/qgsdataitem.h
@@ -582,7 +582,7 @@ class CORE_EXPORT QgsDataItem : public QObject
 
     // Set to true if object has to be deleted when possible (nothing running in threads)
     bool mDeferredDelete = false;
-    QFutureWatcher< QVector <QgsDataItem *> > *mFutureWatcher = nullptr;
+    std::unique_ptr<QFutureWatcher<QVector<QgsDataItem *> >> mFutureWatcher;
     // number of items currently in loading (populating) state
     static QgsAnimatedIcon *sPopulatingIcon;
 };

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -596,10 +596,6 @@ QgsPalLayerSettings::~QgsPalLayerSettings()
   {
     qWarning( "stopRender was not called on QgsPalLayerSettings object!" );
   }
-
-  // pal layer is deleted internally in PAL
-
-  delete expression;
 }
 
 
@@ -613,9 +609,9 @@ QgsExpression *QgsPalLayerSettings::getLabelExpression()
 {
   if ( !expression )
   {
-    expression = new QgsExpression( fieldName );
+    expression = std::make_unique<QgsExpression>( fieldName );
   }
-  return expression;
+  return expression.get();
 }
 
 Qgis::AngleUnit QgsPalLayerSettings::rotationUnit() const

--- a/src/core/labeling/qgspallabeling.h
+++ b/src/core/labeling/qgspallabeling.h
@@ -996,7 +996,7 @@ class CORE_EXPORT QgsPalLayerSettings
     //! Property collection for data defined label settings
     QgsPropertyCollection mDataDefinedProperties;
 
-    QgsExpression *expression = nullptr;
+    std::unique_ptr<QgsExpression> expression;
 
     std::unique_ptr< QFontDatabase > mFontDB;
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1492,13 +1492,13 @@ QImage QgsWmsLegendNode::getLegendGraphicBlocking() const
 
 QgsDataDefinedSizeLegendNode::QgsDataDefinedSizeLegendNode( QgsLayerTreeLayer *nodeLayer, const QgsDataDefinedSizeLegend &settings, QObject *parent )
   : QgsLayerTreeModelLegendNode( nodeLayer, parent )
-  , mSettings( new QgsDataDefinedSizeLegend( settings ) )
+  , mSettings( std::make_unique<QgsDataDefinedSizeLegend>( settings ) )
 {
 }
 
 QgsDataDefinedSizeLegendNode::~QgsDataDefinedSizeLegendNode()
 {
-  delete mSettings;
+
 }
 
 QVariant QgsDataDefinedSizeLegendNode::data( int role ) const

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -809,7 +809,7 @@ class CORE_EXPORT QgsDataDefinedSizeLegendNode : public QgsLayerTreeModelLegendN
 
   private:
     void cacheImage() const;
-    QgsDataDefinedSizeLegend *mSettings = nullptr;
+    std::unique_ptr<QgsDataDefinedSizeLegend> mSettings;
     mutable QImage mImage;
 };
 

--- a/src/core/pal/priorityqueue.cpp
+++ b/src/core/pal/priorityqueue.cpp
@@ -50,9 +50,9 @@ PriorityQueue::PriorityQueue( int n, int maxId, bool min )
   , maxsize( n )
   , maxId( maxId )
 {
-  heap = new int[maxsize];
-  p = new double[maxsize];
-  pos = new int[maxId + 1];
+  heap = std::make_unique<int[]>( maxsize );
+  p = std::make_unique<double[]>( maxsize );
+  pos = std::make_unique<int[]>( maxId + 1 );
 
   int i;
 
@@ -68,9 +68,6 @@ PriorityQueue::PriorityQueue( int n, int maxId, bool min )
 
 PriorityQueue::~PriorityQueue()
 {
-  delete[] heap;
-  delete[] p;
-  delete[] pos;
 }
 
 int PriorityQueue::getSize() const

--- a/src/core/pal/priorityqueue.h
+++ b/src/core/pal/priorityqueue.h
@@ -93,9 +93,9 @@ namespace pal
       int size;
       int maxsize;
       int maxId;
-      int *heap = nullptr;
-      double *p = nullptr;
-      int *pos = nullptr;
+      std::unique_ptr<int[]> heap;
+      std::unique_ptr<double[]> p;
+      std::unique_ptr<int[]> pos;
 
       bool ( *greater )( double l, double r );
   };

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1000,7 +1000,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Returns pointer to the helper class that synchronizes map layer registry with layer tree
      */
-    QgsLayerTreeRegistryBridge *layerTreeRegistryBridge() const { return mLayerTreeRegistryBridge; }
+    QgsLayerTreeRegistryBridge *layerTreeRegistryBridge() const { return mLayerTreeRegistryBridge.get(); }
 
     /**
      * Returns pointer to the project's map theme collection.
@@ -2410,7 +2410,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     QString mErrorMessage;
 
-    QgsProjectBadLayerHandler *mBadLayerHandler = nullptr;
+    std::unique_ptr<QgsProjectBadLayerHandler> mBadLayerHandler;
 
     /**
      * Embedded layers which are defined in other projects. Key: layer id,
@@ -2422,7 +2422,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QgsSnappingConfig mSnappingConfig;
     Qgis::AvoidIntersectionsMode mAvoidIntersectionsMode = Qgis::AvoidIntersectionsMode::AllowIntersections;
 
-    QgsRelationManager *mRelationManager = nullptr;
+    std::unique_ptr<QgsRelationManager> mRelationManager;
 
     std::unique_ptr<QgsAnnotationManager> mAnnotationManager;
     std::unique_ptr<QgsLayoutManager> mLayoutManager;
@@ -2444,9 +2444,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     QgsProjectGpsSettings *mGpsSettings = nullptr;
 
-    QgsLayerTree *mRootGroup = nullptr;
+    std::unique_ptr<QgsLayerTree> mRootGroup;
 
-    QgsLayerTreeRegistryBridge *mLayerTreeRegistryBridge = nullptr;
+    std::unique_ptr<QgsLayerTreeRegistryBridge> mLayerTreeRegistryBridge;
 
     QgsAnnotationLayer *mMainAnnotationLayer = nullptr;
 

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -234,7 +234,7 @@ QgsMemoryProvider::QgsMemoryProvider( const QString &uri, const ProviderOptions 
 
 QgsMemoryProvider::~QgsMemoryProvider()
 {
-  delete mSpatialIndex;
+
 }
 
 QString QgsMemoryProvider::providerKey()
@@ -789,7 +789,7 @@ bool QgsMemoryProvider::createSpatialIndex()
 {
   if ( !mSpatialIndex )
   {
-    mSpatialIndex = new QgsSpatialIndex();
+    mSpatialIndex = std::make_unique<QgsSpatialIndex>();
 
     // add existing features to index
     for ( QgsFeatureMap::iterator it = mFeatures.begin(); it != mFeatures.end(); ++it )

--- a/src/core/providers/memory/qgsmemoryprovider.h
+++ b/src/core/providers/memory/qgsmemoryprovider.h
@@ -96,7 +96,7 @@ class QgsMemoryProvider final: public QgsVectorDataProvider
     QgsFeatureId mNextFeatureId;
 
     // indexing
-    QgsSpatialIndex *mSpatialIndex = nullptr;
+    std::unique_ptr<QgsSpatialIndex> mSpatialIndex;
 
     QString mSubsetString;
 

--- a/src/core/qgsfieldformatterregistry.cpp
+++ b/src/core/qgsfieldformatterregistry.cpp
@@ -41,14 +41,14 @@ QgsFieldFormatterRegistry::QgsFieldFormatterRegistry( QObject *parent )
   addFieldFormatter( new QgsRangeFieldFormatter() );
   addFieldFormatter( new QgsCheckBoxFieldFormatter() );
 
-  mFallbackFieldFormatter = new QgsFallbackFieldFormatter();
+  mFallbackFieldFormatter = std::make_unique<QgsFallbackFieldFormatter>();
 }
 
 QgsFieldFormatterRegistry::~QgsFieldFormatterRegistry()
 {
   const QgsReadWriteLocker locker( mLock, QgsReadWriteLocker::Write );
   qDeleteAll( mFieldFormatters );
-  delete mFallbackFieldFormatter;
+
 }
 
 void QgsFieldFormatterRegistry::addFieldFormatter( QgsFieldFormatter *formatter )
@@ -77,10 +77,10 @@ void QgsFieldFormatterRegistry::removeFieldFormatter( const QString &id )
 QgsFieldFormatter *QgsFieldFormatterRegistry::fieldFormatter( const QString &id ) const
 {
   const QgsReadWriteLocker locker( mLock, QgsReadWriteLocker::Read );
-  return mFieldFormatters.value( id, mFallbackFieldFormatter );
+  return mFieldFormatters.value( id, mFallbackFieldFormatter.get() );
 }
 
 QgsFieldFormatter *QgsFieldFormatterRegistry::fallbackFieldFormatter() const
 {
-  return mFallbackFieldFormatter;
+  return mFallbackFieldFormatter.get();
 }

--- a/src/core/qgsfieldformatterregistry.h
+++ b/src/core/qgsfieldformatterregistry.h
@@ -95,7 +95,7 @@ class CORE_EXPORT QgsFieldFormatterRegistry : public QObject
 
   private:
     QHash<QString, QgsFieldFormatter *> mFieldFormatters;
-    QgsFieldFormatter *mFallbackFieldFormatter = nullptr;
+    std::unique_ptr<QgsFieldFormatter> mFallbackFieldFormatter;
     mutable QReadWriteLock mLock;
 };
 

--- a/src/core/qgsrunprocess.cpp
+++ b/src/core/qgsrunprocess.cpp
@@ -46,17 +46,17 @@ QgsRunProcess::QgsRunProcess( const QString &action, bool capture )
   if ( !arguments.isEmpty() )
     arguments.removeFirst();
 
-  mProcess = new QProcess;
+  mProcess = std::make_unique<QProcess>();
 
   if ( capture )
   {
-    connect( mProcess, &QProcess::errorOccurred, this, &QgsRunProcess::processError );
-    connect( mProcess, &QProcess::readyReadStandardOutput, this, &QgsRunProcess::stdoutAvailable );
-    connect( mProcess, &QProcess::readyReadStandardError, this, &QgsRunProcess::stderrAvailable );
+    connect( mProcess.get(), &QProcess::errorOccurred, this, &QgsRunProcess::processError );
+    connect( mProcess.get(), &QProcess::readyReadStandardOutput, this, &QgsRunProcess::stdoutAvailable );
+    connect( mProcess.get(), &QProcess::readyReadStandardError, this, &QgsRunProcess::stderrAvailable );
     // We only care if the process has finished if we are capturing
     // the output from the process, hence this connect() call is
     // inside the capture if() statement.
-    connect( mProcess, static_cast < void ( QProcess::* )( int,  QProcess::ExitStatus ) >( &QProcess::finished ), this, &QgsRunProcess::processExit );
+    connect( mProcess.get(), static_cast < void ( QProcess::* )( int,  QProcess::ExitStatus ) >( &QProcess::finished ), this, &QgsRunProcess::processExit );
 
     // Use QgsMessageOutput for displaying output to user
     // It will delete itself when the dialog box is closed.
@@ -91,7 +91,7 @@ QgsRunProcess::QgsRunProcess( const QString &action, bool capture )
 
 QgsRunProcess::~QgsRunProcess()
 {
-  delete mProcess;
+
 }
 
 void QgsRunProcess::die()
@@ -151,10 +151,10 @@ void QgsRunProcess::dialogGone()
 
   mOutput = nullptr;
 
-  disconnect( mProcess, &QProcess::errorOccurred, this, &QgsRunProcess::processError );
-  disconnect( mProcess, &QProcess::readyReadStandardOutput, this, &QgsRunProcess::stdoutAvailable );
-  disconnect( mProcess, &QProcess::readyReadStandardError, this, &QgsRunProcess::stderrAvailable );
-  disconnect( mProcess, static_cast < void ( QProcess::* )( int, QProcess::ExitStatus ) >( &QProcess::finished ), this, &QgsRunProcess::processExit );
+  disconnect( mProcess.get(), &QProcess::errorOccurred, this, &QgsRunProcess::processError );
+  disconnect( mProcess.get(), &QProcess::readyReadStandardOutput, this, &QgsRunProcess::stdoutAvailable );
+  disconnect( mProcess.get(), &QProcess::readyReadStandardError, this, &QgsRunProcess::stderrAvailable );
+  disconnect( mProcess.get(), static_cast < void ( QProcess::* )( int, QProcess::ExitStatus ) >( &QProcess::finished ), this, &QgsRunProcess::processExit );
 
   die();
 }

--- a/src/core/qgsrunprocess.h
+++ b/src/core/qgsrunprocess.h
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsRunProcess: public QObject SIP_NODEFAULTCTORS
     // Deletes the instance of the class
     void die();
 
-    QProcess *mProcess = nullptr;
+    std::unique_ptr<QProcess> mProcess;
     QgsMessageOutput *mOutput = nullptr;
     QString mCommand;
 

--- a/src/core/raster/qgscontrastenhancement.cpp
+++ b/src/core/raster/qgscontrastenhancement.cpp
@@ -41,7 +41,7 @@ QgsContrastEnhancement::QgsContrastEnhancement( Qgis::DataType dataType )
   //If the data type is larger than 16-bit do not generate a lookup table
   if ( mRasterDataTypeRange <= 65535.0 )
   {
-    mLookupTable = new int[static_cast <int>( mRasterDataTypeRange + 1 )];
+    mLookupTable = std::make_unique<int[]>( static_cast <int>( mRasterDataTypeRange + 1 ) );
   }
 }
 
@@ -60,13 +60,13 @@ QgsContrastEnhancement::QgsContrastEnhancement( const QgsContrastEnhancement &ce
   //If the data type is larger than 16-bit do not generate a lookup table
   if ( mRasterDataTypeRange <= 65535.0 )
   {
-    mLookupTable = new int[static_cast <int>( mRasterDataTypeRange + 1 )];
+    mLookupTable = std::make_unique<int[]>( static_cast <int>( mRasterDataTypeRange + 1 ) );
   }
 }
 
 QgsContrastEnhancement::~QgsContrastEnhancement()
 {
-  delete [] mLookupTable;
+
 }
 
 int QgsContrastEnhancement::enhanceContrast( double value )

--- a/src/core/raster/qgscontrastenhancement.h
+++ b/src/core/raster/qgscontrastenhancement.h
@@ -244,7 +244,7 @@ class CORE_EXPORT QgsContrastEnhancement
     bool mEnhancementDirty = false;
 
     //! \brief Pointer to the lookup table
-    int *mLookupTable = nullptr;
+    std::unique_ptr<int[]> mLookupTable;
 
     //! \brief User defineable minimum value for the band, used for enhanceContrasting
     double mMinimumValue;

--- a/src/core/settings/qgssettings.cpp
+++ b/src/core/settings/qgssettings.cpp
@@ -43,7 +43,7 @@ void QgsSettings::init()
 {
   if ( ! sGlobalSettingsPath()->isEmpty() )
   {
-    mGlobalSettings = new QSettings( *sGlobalSettingsPath(), QSettings::IniFormat );
+    mGlobalSettings = std::make_unique<QSettings>( *sGlobalSettingsPath(), QSettings::IniFormat );
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     mGlobalSettings->setIniCodec( "UTF-8" );
 #endif
@@ -53,40 +53,38 @@ void QgsSettings::init()
 
 QgsSettings::QgsSettings( const QString &organization, const QString &application, QObject *parent )
 {
-  mUserSettings = new QSettings( organization, application, parent );
+  mUserSettings = std::make_unique<QSettings>( organization, application, parent );
   init();
 }
 
 QgsSettings::QgsSettings( QSettings::Scope scope, const QString &organization,
                           const QString &application, QObject *parent )
 {
-  mUserSettings = new QSettings( scope, organization, application, parent );
+  mUserSettings = std::make_unique<QSettings>( scope, organization, application, parent );
   init();
 }
 
 QgsSettings::QgsSettings( QSettings::Format format, QSettings::Scope scope,
                           const QString &organization, const QString &application, QObject *parent )
 {
-  mUserSettings = new QSettings( format, scope, organization, application, parent );
+  mUserSettings = std::make_unique<QSettings>( format, scope, organization, application, parent );
   init();
 }
 
 QgsSettings::QgsSettings( const QString &fileName, QSettings::Format format, QObject *parent )
 {
-  mUserSettings = new QSettings( fileName, format, parent );
+  mUserSettings = std::make_unique<QSettings>( fileName, format, parent );
   init();
 }
 
 QgsSettings::QgsSettings( QObject *parent )
 {
-  mUserSettings = new QSettings( parent );
+  mUserSettings = std::make_unique<QSettings>( parent );
   init();
 }
 
 QgsSettings::~QgsSettings()
 {
-  delete mUserSettings;
-  delete mGlobalSettings;
 }
 
 

--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -496,8 +496,8 @@ class CORE_EXPORT QgsSettings : public QObject
   private:
     void init();
     QString sanitizeKey( const QString &key ) const;
-    QSettings *mUserSettings = nullptr;
-    QSettings *mGlobalSettings = nullptr;
+    std::unique_ptr<QSettings> mUserSettings;
+    std::unique_ptr<QSettings> mGlobalSettings;
     bool mUsingGlobalArray = false;
     Q_DISABLE_COPY( QgsSettings )
 

--- a/src/core/settings/qgssettingstreenode.cpp
+++ b/src/core/settings/qgssettingstreenode.cpp
@@ -151,7 +151,7 @@ void QgsSettingsTreeNamedListNode::initNamedList( const Qgis::SettingsTreeNodeOp
   if ( options.testFlag( Qgis::SettingsTreeNodeOption::NamedListSelectedItemSetting ) )
   {
     // this must be done before completing the key
-    mSelectedItemSetting = new QgsSettingsEntryString( QStringLiteral( "%1/selected" ).arg( mCompleteKey ), nullptr );
+    mSelectedItemSetting = std::make_unique<QgsSettingsEntryString>( QStringLiteral( "%1/selected" ).arg( mCompleteKey ), nullptr );
   }
 
   mNamedNodesCount = mParent->namedNodesCount() + 1;
@@ -161,7 +161,7 @@ void QgsSettingsTreeNamedListNode::initNamedList( const Qgis::SettingsTreeNodeOp
 
 QgsSettingsTreeNamedListNode::~QgsSettingsTreeNamedListNode()
 {
-  delete mSelectedItemSetting;
+
 }
 
 

--- a/src/core/settings/qgssettingstreenode.cpp
+++ b/src/core/settings/qgssettingstreenode.cpp
@@ -144,6 +144,7 @@ void QgsSettingsTreeNode::init( QgsSettingsTreeNode *parent, const QString &key 
   mCompleteKey = QDir::cleanPath( QStringLiteral( "%1/%2" ).arg( parent->completeKey(), key ) ) + '/';
 }
 
+QgsSettingsTreeNamedListNode::QgsSettingsTreeNamedListNode() = default;
 
 void QgsSettingsTreeNamedListNode::initNamedList( const Qgis::SettingsTreeNodeOptions &options )
 {

--- a/src/core/settings/qgssettingstreenode.h
+++ b/src/core/settings/qgssettingstreenode.h
@@ -258,7 +258,7 @@ class CORE_EXPORT QgsSettingsTreeNamedListNode : public QgsSettingsTreeNode
      * \note This is not available in Python bindings. Use method createNamedListNode on an existing tree node.
      * \see QgsSettingsTree.createPluginTreeNode
      */
-    QgsSettingsTreeNamedListNode() = default SIP_FORCE;
+    QgsSettingsTreeNamedListNode() SIP_FORCE;
 
     QgsSettingsTreeNamedListNode( const QgsSettingsTreeNamedListNode &other ) = delete;
 

--- a/src/core/settings/qgssettingstreenode.h
+++ b/src/core/settings/qgssettingstreenode.h
@@ -243,7 +243,7 @@ class CORE_EXPORT QgsSettingsTreeNamedListNode : public QgsSettingsTreeNode
     void deleteAllItems( const QStringList &parentsNamedItems = QStringList() ) SIP_THROW( QgsSettingsException );
 
     //! Returns the setting used to store the selected item
-    const QgsSettingsEntryString *selectedItemSetting() const {return mSelectedItemSetting;}
+    const QgsSettingsEntryString *selectedItemSetting() const {return mSelectedItemSetting.get();}
 
   protected:
     //! Init the nodes with the specific \a options
@@ -260,13 +260,13 @@ class CORE_EXPORT QgsSettingsTreeNamedListNode : public QgsSettingsTreeNode
      */
     QgsSettingsTreeNamedListNode() = default SIP_FORCE;
 
-    QgsSettingsTreeNamedListNode( const QgsSettingsTreeNamedListNode &other ) = default SIP_FORCE;
+    QgsSettingsTreeNamedListNode( const QgsSettingsTreeNamedListNode &other ) = delete;
 
     //! Returns the key with named items placeholders filled with args
     QString completeKeyWithNamedItems( const QString &key, const QStringList &namedItems ) const;
 
     Qgis::SettingsTreeNodeOptions mOptions;
-    const QgsSettingsEntryString *mSelectedItemSetting = nullptr;
+    std::unique_ptr<const QgsSettingsEntryString> mSelectedItemSetting;
     QString mItemsCompleteKey;
 };
 

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -609,7 +609,7 @@ QgsGradientFillSymbolLayer::QgsGradientFillSymbolLayer( const QColor &color, con
 
 QgsGradientFillSymbolLayer::~QgsGradientFillSymbolLayer()
 {
-  delete mGradientRamp;
+
 }
 
 QgsSymbolLayer *QgsGradientFillSymbolLayer::create( const QVariantMap &props )
@@ -703,8 +703,7 @@ Qgis::SymbolLayerFlags QgsGradientFillSymbolLayer::flags() const
 
 void QgsGradientFillSymbolLayer::setColorRamp( QgsColorRamp *ramp )
 {
-  delete mGradientRamp;
-  mGradientRamp = ramp;
+  mGradientRamp.reset( ramp );
 }
 
 QString QgsGradientFillSymbolLayer::layerType() const
@@ -717,7 +716,7 @@ void QgsGradientFillSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderConte
   if ( !dataDefinedProperties().hasActiveProperties() && !mReferencePoint1IsCentroid && !mReferencePoint2IsCentroid )
   {
     //shortcut
-    applyGradient( context, mBrush, mColor, mColor2,  mGradientColorType, mGradientRamp, mGradientType, mCoordinateMode,
+    applyGradient( context, mBrush, mColor, mColor2,  mGradientColorType, mGradientRamp.get(), mGradientType, mCoordinateMode,
                    mGradientSpread, mReferencePoint1, mReferencePoint2, mAngle );
     return;
   }
@@ -874,7 +873,7 @@ void QgsGradientFillSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderConte
   }
 
   //update gradient with data defined values
-  applyGradient( context, mBrush, color, color2,  mGradientColorType, mGradientRamp, gradientType, coordinateMode,
+  applyGradient( context, mBrush, color, color2,  mGradientColorType, mGradientRamp.get(), gradientType, coordinateMode,
                  spread, QPointF( refPoint1X, refPoint1Y ), QPointF( refPoint2X, refPoint2Y ), angle );
 }
 

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -277,7 +277,7 @@ class CORE_EXPORT QgsGradientFillSymbolLayer : public QgsFillSymbolLayer
      * \see setColorRamp()
      * \see gradientColorType()
      */
-    QgsColorRamp *colorRamp() { return mGradientRamp; }
+    QgsColorRamp *colorRamp() { return mGradientRamp.get(); }
 
     /**
      * Sets the color ramp used for the gradient fill. This is only
@@ -448,7 +448,7 @@ class CORE_EXPORT QgsGradientFillSymbolLayer : public QgsFillSymbolLayer
 
     Qgis::GradientColorSource mGradientColorType;
     QColor mColor2;
-    QgsColorRamp *mGradientRamp = nullptr;
+    std::unique_ptr<QgsColorRamp> mGradientRamp;
     Qgis::GradientType mGradientType;
     Qgis::SymbolCoordinateReference mCoordinateMode;
     Qgis::GradientSpread mGradientSpread;

--- a/src/core/symbology/qgslegendsymbolitem.cpp
+++ b/src/core/symbology/qgslegendsymbolitem.cpp
@@ -18,6 +18,8 @@
 #include "qgsdatadefinedsizelegend.h"
 #include "qgssymbol.h"
 
+QgsLegendSymbolItem::QgsLegendSymbolItem() = default;
+
 QgsLegendSymbolItem::QgsLegendSymbolItem( QgsSymbol *symbol, const QString &label, const QString &ruleKey, bool checkable, int scaleMinDenom, int scaleMaxDenom, int level, const QString &parentRuleKey )
   : mSymbol( symbol ? symbol->clone() : nullptr )
   , mLabel( label )

--- a/src/core/symbology/qgslegendsymbolitem.cpp
+++ b/src/core/symbology/qgslegendsymbolitem.cpp
@@ -38,8 +38,6 @@ QgsLegendSymbolItem::QgsLegendSymbolItem( const QgsLegendSymbolItem &other )
 
 QgsLegendSymbolItem::~QgsLegendSymbolItem()
 {
-  delete mSymbol;
-  delete mDataDefinedSizeLegendSettings;
 }
 
 QgsLegendSymbolItem &QgsLegendSymbolItem::operator=( const QgsLegendSymbolItem &other )
@@ -47,13 +45,11 @@ QgsLegendSymbolItem &QgsLegendSymbolItem::operator=( const QgsLegendSymbolItem &
   if ( this == &other )
     return *this;
 
-  delete mSymbol;
-  mSymbol = other.mSymbol ? other.mSymbol->clone() : nullptr;
+  mSymbol.reset( other.mSymbol ? other.mSymbol->clone() : nullptr );
   mLabel = other.mLabel;
   mKey = other.mKey;
   mCheckable = other.mCheckable;
-  delete mDataDefinedSizeLegendSettings;
-  mDataDefinedSizeLegendSettings = other.mDataDefinedSizeLegendSettings ? new QgsDataDefinedSizeLegend( *other.mDataDefinedSizeLegendSettings ) : nullptr;
+  mDataDefinedSizeLegendSettings.reset( other.mDataDefinedSizeLegendSettings ? new QgsDataDefinedSizeLegend( *other.mDataDefinedSizeLegendSettings ) : nullptr );
   mOriginalSymbolPointer = other.mOriginalSymbolPointer;
   mScaleMinDenom = other.mScaleMinDenom;
   mScaleMaxDenom = other.mScaleMaxDenom;
@@ -79,20 +75,18 @@ bool QgsLegendSymbolItem::isScaleOK( double scale ) const
 
 void QgsLegendSymbolItem::setSymbol( QgsSymbol *s )
 {
-  delete mSymbol;
-  mSymbol = s ? s->clone() : nullptr;
+  mSymbol.reset( s ? s->clone() : nullptr );
   mOriginalSymbolPointer = s;
 }
 
 void QgsLegendSymbolItem::setDataDefinedSizeLegendSettings( QgsDataDefinedSizeLegend *settings )
 {
-  delete mDataDefinedSizeLegendSettings;
-  mDataDefinedSizeLegendSettings = settings;
+  mDataDefinedSizeLegendSettings.reset( settings );
 }
 
 QgsDataDefinedSizeLegend *QgsLegendSymbolItem::dataDefinedSizeLegendSettings() const
 {
-  return mDataDefinedSizeLegendSettings;
+  return mDataDefinedSizeLegendSettings.get();
 }
 
 void QgsLegendSymbolItem::setUserData( int key, QVariant &value )

--- a/src/core/symbology/qgslegendsymbolitem.h
+++ b/src/core/symbology/qgslegendsymbolitem.h
@@ -36,7 +36,7 @@ class CORE_EXPORT QgsLegendSymbolItem
 {
   public:
 
-    QgsLegendSymbolItem() = default;
+    QgsLegendSymbolItem();
 
     /**
      * Construct item. Does not take ownership of symbol (makes internal clone)

--- a/src/core/symbology/qgslegendsymbolitem.h
+++ b/src/core/symbology/qgslegendsymbolitem.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsLegendSymbolItem
     QgsLegendSymbolItem &operator=( const QgsLegendSymbolItem &other );
 
     //! Returns associated symbol. May be NULLPTR.
-    QgsSymbol *symbol() const { return mSymbol; }
+    QgsSymbol *symbol() const { return mSymbol.get(); }
     //! Returns text label
     QString label() const { return mLabel; }
     //! Returns unique identifier of the rule for identification of the item within renderer
@@ -123,7 +123,7 @@ class CORE_EXPORT QgsLegendSymbolItem
 
   private:
     //! Legend symbol -- may be NULLPTR.
-    QgsSymbol *mSymbol = nullptr;
+    std::unique_ptr<QgsSymbol> mSymbol;
     //! label of the item (may be empty or non-unique)
     QString mLabel;
     //! unique identifier of the symbol item (within renderer)
@@ -137,7 +137,7 @@ class CORE_EXPORT QgsLegendSymbolItem
      * optional pointer to data-defined legend size settings - if set, the output legend
      * node should be QgsDataDefinedSizeLegendNode rather than ordinary QgsSymbolLegendNode
      */
-    QgsDataDefinedSizeLegend *mDataDefinedSizeLegendSettings = nullptr;
+    std::unique_ptr<QgsDataDefinedSizeLegend> mDataDefinedSizeLegendSettings;
 
     // additional data that may be used for filtering
 


### PR DESCRIPTION
Mass refactor **on core only** using Clang LibTooling by introducing unique_ptr on "simple case" meaning when:
- Class has a raw pointer member
- We call delete on the member in destructor without any conditionnal statement
- QGIS still build without warning after the modification

It spots one issue
- QgsSettingsTreeNamedListNode copy constructor need to be deleted, it was default copying the raw pointer which could lead to double free. @3nids why do you to SIP_FORCE those ?

**Funded by [Security Project For QGIS](https://oslandia.com/en/security-project-for-qgis/)**
