### PR TITLE
[wfs] Fix fields attribute corrupted by problematic GMLAS schema read

### DIFF
--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1538,7 +1538,7 @@ bool QgsWFSProvider::readAttributesFromSchema( QDomDocument &schemaDoc, const QB
     QgsFields fieldsGMLAS;
     Qgis::WkbType geomTypeGMLAS;
     QString errorMsgGMLAS;
-    if ( readAttributesFromSchemaWithGMLAS( response, prefixedTypename, geometryAttributeGMLAS, fieldsGMLAS, geomTypeGMLAS, geometryMaybeMissing, errorMsgGMLAS ) )
+    if ( readAttributesFromSchemaWithGMLAS( response, prefixedTypename, geometryAttributeGMLAS, fieldsGMLAS, geomTypeGMLAS, geometryMaybeMissing, errorMsgGMLAS ) && ( fields.size() == 0 || fields.size() == fieldsGMLAS.size() ) )
     {
       geometryAttribute = geometryAttributeGMLAS;
       fields = fieldsGMLAS;


### PR DESCRIPTION
## Description

This PR fixes / prevents an issue introduced by https://github.com/qgis/QGIS/commit/83fe2fea87bc9ff3c45a41c5983c5746ae8e7898#diff-6e1471ae282b6cb901f1eb501b0b1ae0393a925c2b0ef13b9a56ab7b012cf597 whereas the preparation of fields of a WFS 1.1 service layer gets corrupted by problematic results from the readAttributesFromSchemaWithGMLAS function introduced in the mentioned commit.

Here's an example of a wrong fields list:
![image](https://github.com/user-attachments/assets/5ac62e20-047d-4686-8b85-88ea190442e6)

Essentially all the fields with _href, _tile, _nil, etc. name suffixes are wrong. They come from gdal miscomputing the fields.

To insure that the readAttributesFromSchemaWithGMLAS returns sound set of fields, I've added a simple non-GMLAS fields.size() == GMLAS fields.size(). If the two numbers match, we can assume the GMLAS version if valid. If they differ, we stay on the safe side of things and assume something went wrong.

As mentioned above the problem appears to lie in upstream gdal (https://github.com/OSGeo/gdal/issues/12145) but since it's unlikely we'll get a gdal fix that will be backported on all supported platforms, this is a good additional safeguard to have in place.