### PR TITLE
[Backport queued_ltr_backports] Fix duplicate layer using the shared pointer and do not update feature count

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3725,6 +3725,9 @@ bool QgsPostgresProvider::setSubsetString( const QString &theSQL, bool updateFea
   }
 #endif
 
+  // clone the share because the feature subset differs (and thus also the feature count etc)
+  mShared = mShared->clone();
+
   // Update datasource uri too
   mUri.setSql( theSQL );
   // Update yet another copy of the uri. Why are there 3 copies of the
@@ -5878,6 +5881,19 @@ void QgsPostgresSharedData::ensureFeaturesCountedAtLeast( long long fetched )
     QgsDebugMsgLevel( QStringLiteral( "feature count adjusted from %1 to %2" ).arg( mFeaturesCounted ).arg( fetched ), 2 );
     mFeaturesCounted = fetched;
   }
+}
+
+std::shared_ptr<QgsPostgresSharedData> QgsPostgresSharedData::clone() const
+{
+  QMutexLocker locker( &mMutex );
+
+  auto copy = std::make_shared<QgsPostgresSharedData>();
+  copy->mFeaturesCounted = mFeaturesCounted;
+  copy->mFidCounter = mFidCounter;
+  copy->mKeyToFid = mKeyToFid;
+  copy->mFidToKey = mFidToKey;
+  copy->mFieldSupportsEnumValues = mFieldSupportsEnumValues;
+  return copy;
 }
 
 long long QgsPostgresSharedData::featuresCounted()

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -543,6 +543,9 @@ class QgsPostgresSharedData
   public:
     QgsPostgresSharedData() = default;
 
+    //! Creates a deep copy of this shared data
+    std::shared_ptr<QgsPostgresSharedData> clone() const;
+
     long long featuresCounted();
     void setFeaturesCounted( long long count );
     void addFeaturesCounted( long long diff );
@@ -561,7 +564,7 @@ class QgsPostgresSharedData
     void setFieldSupportsEnumValues( int index, bool isSupported );
 
   protected:
-    QMutex mMutex; //!< Access to all data members is guarded by the mutex
+    mutable QMutex mMutex; //!< Access to all data members is guarded by the mutex
 
     long long mFeaturesCounted = -1; //!< Number of features in the layer
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -3260,6 +3260,44 @@ class TestPyQgsPostgresProvider(QgisTestCase, ProviderTestCase):
         vl.setSubsetString('"pk" = 3')
         self.assertGreaterEqual(vl.featureCount(), 1)
 
+    def testFeatureCountOnTable(self):
+        """
+        Test feature count on table
+        """
+        vl = QgsVectorLayer(
+            self.dbconn
+            + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=',
+            "test",
+            "postgres",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.featureCount(), 5)
+        # pk's are 1,2,3,4,5
+        vl.setSubsetString('"pk" > 3')
+        # so 4 and 5
+        self.assertEqual(vl.featureCount(), 2)
+        vl.setSubsetString('"pk" < 3')
+        # so 1 and 3
+        self.assertEqual(vl.featureCount(), 2)
+        # now dublicate it
+        dup_vl = vl.clone()
+        self.assertTrue(dup_vl.isValid())
+        # still 1 and 3
+        self.assertEqual(dup_vl.featureCount(), 2)
+        dup_vl.setSubsetString(None)
+        # so all 1,2,3,4,5
+        self.assertEqual(dup_vl.featureCount(), 5)
+        # testing regression of issue https://github.com/qgis/QGIS/issues/60926
+        # and the original layer still 1 and 3
+        self.assertEqual(vl.featureCount(), 2)
+        # and changing again vl filter
+        vl.setSubsetString('"pk" > 1')
+        # and dup_vl filter
+        dup_vl.setSubsetString('"pk" < 2')
+        # vl has 4 and dup_vl has 1
+        self.assertEqual(vl.featureCount(), 4)
+        self.assertEqual(dup_vl.featureCount(), 1)
+
     def testFeatureCountEstimatedOnView(self):
         """
         Test feature count on view when estimated data is enabled


### PR DESCRIPTION
Manual Backport of https://github.com/qgis/QGIS/pull/61444

The implementation on QgsPostgresSharedData (change on the mutex (to mutable) and the clone function) have to be made in the qgspostgresprovider-files instead of the utils (since they are only introduced to 3.42).