### PR TITLE
Fix PyQgsConsole test

### DIFF
--- a/src/gui/codeeditors/qgscodeeditordockwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditordockwidget.cpp
@@ -24,7 +24,7 @@ QgsCodeEditorDockWidget::QgsCodeEditorDockWidget( const QString &dockId, bool us
   if ( usePersistentWidget )
     options.setFlag( QgsDockableWidgetHelper::Option::PermanentWidget );
 
-  mDockableWidgetHelper = new QgsDockableWidgetHelper(
+  mDockableWidgetHelper = std::make_unique<QgsDockableWidgetHelper>(
     tr( "Code Editor" ),
     this,
     QgsDockableWidgetHelper::sOwnerWindow,
@@ -38,16 +38,15 @@ QgsCodeEditorDockWidget::QgsCodeEditorDockWidget( const QString &dockId, bool us
 
   mDockToggleButton = mDockableWidgetHelper->createDockUndockToolButton();
   mDockToggleButton->setToolTip( tr( "Dock Code Editor" ) );
-  connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::closed, this, [=]() {
+  connect( mDockableWidgetHelper.get(), &QgsDockableWidgetHelper::closed, this, [=]() {
     close();
   } );
 
-  connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::visibilityChanged, this, &QgsCodeEditorDockWidget::visibilityChanged );
+  connect( mDockableWidgetHelper.get(), &QgsDockableWidgetHelper::visibilityChanged, this, &QgsCodeEditorDockWidget::visibilityChanged );
 }
 
 QgsCodeEditorDockWidget::~QgsCodeEditorDockWidget()
 {
-  delete mDockableWidgetHelper;
 }
 
 void QgsCodeEditorDockWidget::setTitle( const QString &title )

--- a/src/gui/codeeditors/qgscodeeditordockwidget.h
+++ b/src/gui/codeeditors/qgscodeeditordockwidget.h
@@ -77,7 +77,7 @@ class GUI_EXPORT QgsCodeEditorDockWidget : public QWidget
     void visibilityChanged( bool isVisible );
 
   private:
-    QgsDockableWidgetHelper *mDockableWidgetHelper = nullptr;
+    std::unique_ptr<QgsDockableWidgetHelper> mDockableWidgetHelper;
     QToolButton *mDockToggleButton = nullptr;
 };
 

--- a/src/gui/qgsdockablewidgethelper.cpp
+++ b/src/gui/qgsdockablewidgethelper.cpp
@@ -60,18 +60,15 @@ QgsDockableWidgetHelper::~QgsDockableWidgetHelper()
 {
   if ( mDock )
   {
-    mDockGeometry = mDock->geometry();
     if ( !mSettingKeyDockId.isEmpty() )
       sSettingsDockGeometry->setValue( mDock->saveGeometry(), mSettingKeyDockId );
-    mIsDockFloating = mDock->isFloating();
-    if ( mOwnerWindow )
-      mDockArea = mOwnerWindow->dockWidgetArea( mDock );
-
-    mDock->setWidget( nullptr );
 
     if ( mOwnerWindow )
       mOwnerWindow->removeDockWidget( mDock );
-    mDock->deleteLater();
+
+    mDock->setWidget( nullptr );
+    mWidget->setParent( nullptr );
+    delete mDock.data();
     mDock = nullptr;
   }
 


### PR DESCRIPTION
- Use unique_ptr in QgsCodeEditorDockWidget to avoid double free. 
- Change widget owner in QgsDockableWidgetHelper destructor as stated
in documentation and to avoid also double free

Fix PyQgsConsole error in #61364 and #59595

**Funded by Oslandia**