### PR TITLE
fix: updateLayerSourcePath returns if layer isValid not true

### DIFF
--- a/src/core/qgsmaplayerutils.cpp
+++ b/src/core/qgsmaplayerutils.cpp
@@ -138,7 +138,7 @@ bool QgsMapLayerUtils::updateLayerSourcePath( QgsMapLayer *layer, const QString 
   parts.insert( QStringLiteral( "path" ), newPath );
   const QString newUri = QgsProviderRegistry::instance()->encodeUri( layer->providerType(), parts );
   layer->setDataSource( newUri, layer->name(), layer->providerType() );
-  return true;
+  return layer->isValid();
 }
 
 QList<QgsMapLayer *> QgsMapLayerUtils::sortLayersByType( const QList<QgsMapLayer *> &layers, const QList<Qgis::LayerType> &order )

--- a/tests/src/python/test_qgsmaplayerutils.py
+++ b/tests/src/python/test_qgsmaplayerutils.py
@@ -11,6 +11,11 @@ __date__ = "2021-05"
 __copyright__ = "Copyright 2021, The QGIS Project"
 
 
+import tempfile
+import glob
+import shutil
+from pathlib import Path
+
 from qgis.core import (
     QgsAnnotationLayer,
     QgsCoordinateReferenceSystem,
@@ -144,7 +149,7 @@ class TestQgsMapLayerUtils(QgisTestCase):
 
         ## copy files to temp directory
         tempDir = tempfile.TemporaryDirectory()
-        tempDirPath = Path(tempDir.name)
+        tempDirPath = Path(tempDir.name).as_posix()
         for file in glob.glob(unitTestDataPath() + "/points.*"):
             shutil.copy(file, tempDirPath)
         shutil.copy(unitTestDataPath() + "/mixed_layers.gpkg", tempDirPath)

--- a/tests/src/python/test_qgsprojectutils.py
+++ b/tests/src/python/test_qgsprojectutils.py
@@ -123,7 +123,7 @@ class TestQgsProjectUtils(QgisTestCase):
 
         ## copy files to temp directory
         tempDir = tempfile.TemporaryDirectory()
-        tempDirPath = Path(tempDir.name)
+        tempDirPath = Path(tempDir.name).as_posix()
         for file in glob.glob(unitTestDataPath() + "/points.*"):
             shutil.copy(file, tempDirPath)
         shutil.copy(unitTestDataPath() + "/mixed_layers.gpkg", tempDirPath)

--- a/tests/src/python/test_qgsprojectutils.py
+++ b/tests/src/python/test_qgsprojectutils.py
@@ -123,7 +123,7 @@ class TestQgsProjectUtils(QgisTestCase):
 
         ## copy files to temp directory
         tempDir = tempfile.TemporaryDirectory()
-        tempDirPath = Path(tempDir.name).as_posix()
+        tempDirPath = Path(tempDir.name)
         for file in glob.glob(unitTestDataPath() + "/points.*"):
             shutil.copy(file, tempDirPath)
         shutil.copy(unitTestDataPath() + "/mixed_layers.gpkg", tempDirPath)


### PR DESCRIPTION
updateLayerSourcePath did not check if the provider was able to load the new source. Tests was failing in silence.

Funded By Oslandia