### PR TITLE
testqgsdockwidget: Fix signal test for Qt 6.8 and above

### DIFF
--- a/tests/src/gui/testqgsdockwidget.cpp
+++ b/tests/src/gui/testqgsdockwidget.cpp
@@ -62,12 +62,24 @@ void TestQgsDockWidget::testSignals()
   QApplication::setActiveWindow( w ); //required for focus events
   QgsDockWidget *d = new QgsDockWidget( w );
 
+  // Since Qt 6.8, the `showEvent` is now correctly propagated to the dock
+  // when `w->show()` is called. Therefore, it needs to be called before
+  // the QSignalSpy are created
+#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 ) )
+  w->show();
+
+  QSignalSpy spyClosedStateChanged( d, SIGNAL( closedStateChanged( bool ) ) );
+  const QSignalSpy spyClosed( d, SIGNAL( closed() ) );
+  QSignalSpy spyOpenedStateChanged( d, SIGNAL( openedStateChanged( bool ) ) );
+  const QSignalSpy spyOpened( d, SIGNAL( opened() ) );
+#else
   QSignalSpy spyClosedStateChanged( d, SIGNAL( closedStateChanged( bool ) ) );
   const QSignalSpy spyClosed( d, SIGNAL( closed() ) );
   QSignalSpy spyOpenedStateChanged( d, SIGNAL( openedStateChanged( bool ) ) );
   const QSignalSpy spyOpened( d, SIGNAL( opened() ) );
 
   w->show();
+#endif
 
   d->show();
   QCOMPARE( spyClosedStateChanged.count(), 1 );


### PR DESCRIPTION
## Description

Since Qt 6.8, the `showEvent` is now correctly propagated to the dock when `w->show()` is called. Therefore, the first call to `spyClosedStateChanged.count()` is equal to 2 instead of 1.

By moving the `w->show()` call before the spies initialization, this ensures that the count is equal to 1 regardless of the Qt version and this also properly tests the signals emission.
