### PR TITLE
[WFS provider] in WFS-T for Insert/Update, only uses fields that are …

### DIFF
--- a/src/providers/wfs/qgsbackgroundcachedshareddata.h
+++ b/src/providers/wfs/qgsbackgroundcachedshareddata.h
@@ -194,6 +194,9 @@ class QgsBackgroundCachedSharedData
     //! Attribute fields of the layer
     QgsFields mFields;
 
+    //! Attribute fields of the layer, without using the GMLAS driver
+    QgsFields mFieldsWithoutGMLAS;
+
     //! Source CRS
     QgsCoordinateReferenceSystem mSourceCrs;
 

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -208,13 +208,13 @@ class QgsWFSProvider final : public QgsVectorDataProvider
      * The method gives back the name of
      * the geometry attribute and the thematic attributes with their types.
     */
-    bool describeFeatureType( QString &geometryAttribute, QgsFields &fields, Qgis::WkbType &geomType, bool &geometryMaybeMissing );
+    bool describeFeatureType( QString &geometryAttribute, QgsFields &fields, QgsFields &fieldsWithoutGMLAS, Qgis::WkbType &geomType, bool &geometryMaybeMissing );
 
     /**
      * For a given typename, reads the name of the geometry attribute, the
      * thematic attributes and their types from a dom document. Returns true in case of success.
     */
-    bool readAttributesFromSchema( QDomDocument &schemaDoc, const QByteArray &response, bool singleLayerContext, const QString &prefixedTypename, QString &geometryAttribute, QgsFields &fields, Qgis::WkbType &geomType, bool &geometryMaybeMissing, QString &errorMsg );
+    bool readAttributesFromSchema( QDomDocument &schemaDoc, const QByteArray &response, bool singleLayerContext, const QString &prefixedTypename, QString &geometryAttribute, QgsFields &fields, QgsFields &fieldsWithoutGMLAS, Qgis::WkbType &geomType, bool &geometryMaybeMissing, QString &errorMsg );
 
     //helper methods for WFS-T
 


### PR DESCRIPTION
…known of the QGIS XSD parser, to avoid updating inexistant remote fields

Alternative fix to #61476 . I only ran the provider_wfs.py unit tests and did not actually check the scenario of #61476. Hopefully @nirvn can give this PR a try