### PR TITLE
Remove redundant output block value setting

### DIFF
--- a/src/core/raster/qgsrasternuller.cpp
+++ b/src/core/raster/qgsrasternuller.cpp
@@ -111,7 +111,6 @@ QgsRasterBlock *QgsRasterNuller::block( int bandNo, QgsRectangle  const &extent,
       {
         isNoData = true;
       }
-      outputBlock->setValue( i, j, inputBlock->value( i, j ) );
       if ( isNoData )
       {
         outputBlock->setIsNoData( i, j );


### PR DESCRIPTION
This is always overridden by the following lines
