### PR TITLE
Expressions - Add 2 examples with @layer_cursor_point about raster maptip

### DIFF
--- a/resources/function_help/json/raster_attributes
+++ b/resources/function_help/json/raster_attributes
@@ -16,6 +16,9 @@
   "examples": [{
     "expression": "raster_attributes('vegetation', 1, raster_value('vegetation', 1, make_point(1,1)))",
     "returns": "{'class': 'Vegetated', 'subclass': 'Trees'}"
+  }, {
+    "expression": "raster_attributes('vegetation', 1, raster_value('vegetation', 1, @layer_cursor_point))",
+    "returns": "{'class': 'Vegetated', 'subclass': 'Trees'}"
   }],
   "tags": ["provider", "point", "raster", "found", "attributes"]
 }

--- a/resources/function_help/json/raster_value
+++ b/resources/function_help/json/raster_value
@@ -16,6 +16,9 @@
   "examples": [{
     "expression": "raster_value('dem', 1, make_point(1,1))",
     "returns": "25"
+  },{
+    "expression": "raster_value('ndvi', 2, @layer_cursor_point)",
+    "returns": "25"
   }],
   "tags": ["provided", "point", "raster", "found"]
 }


### PR DESCRIPTION
It's not easy to guess that we need to look for `@layer_cursor_point`. I had to look in the PR to see how to use the maptip in rasters : https://github.com/qgis/QGIS/pull/50854

In the documentation about raster maptip : 
https://docs.qgis.org/3.40/en/docs/user_manual/working_with_raster/raster_properties.html#display-properties

It's an hard-coded value `80`


Side note, does someone has help on these variables ?
I see it in the source code : https://github.com/qgis/QGIS/blob/1a803575ec5e8194df42db2ce70f12fdceb44bb3/src/core/expression/qgsexpression.cpp#L861

But I don't have help on QGIS 3.40.5