### PR TITLE
Fix anchr rotate map drift

### DIFF
--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1371,11 +1371,11 @@ QgsLayoutPoint QgsLayoutItem::topLeftToReferencePoint( const QgsLayoutPoint &poi
   QPointF refPoint;
   if ( mItemRotation != 0 && mReferencePoint != ReferencePoint::UpperLeft )
   {
-   refPoint = mapToScene( anchorPoint ) - mapFromScene( topLeft );
+    refPoint = mapToScene( anchorPoint ) - mapFromScene( topLeft );
   }
   else
     refPoint = topLeft + anchorPoint;
-return mLayout->convertFromLayoutUnits( refPoint, point.units() );
+  return mLayout->convertFromLayoutUnits( refPoint, point.units() );
 }
 
 bool QgsLayoutItem::writePropertiesToElement( QDomElement &, QDomDocument &, const QgsReadWriteContext & ) const

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1367,11 +1367,11 @@ QPointF QgsLayoutItem::positionAtReferencePoint( const QgsLayoutItem::ReferenceP
 QgsLayoutPoint QgsLayoutItem::topLeftToReferencePoint( const QgsLayoutPoint &point ) const
 {
   const QPointF topLeft = mLayout->convertToLayoutUnits( point );
-  const QPointF anchorPoint = mapToScene( itemPositionAtReferencePoint( mReferencePoint, rect().size() ) );
+  const QPointF anchorPoint = itemPositionAtReferencePoint( mReferencePoint, rect().size() );
   QPointF refPoint;
   if ( mItemRotation != 0 && mReferencePoint != ReferencePoint::UpperLeft )
   {
-   refPoint = anchorPoint - mapFromScene( topLeft );
+   refPoint = mapToScene( anchorPoint ) - mapFromScene( topLeft );
   }
   else
     refPoint = topLeft + anchorPoint;

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1368,8 +1368,14 @@ QgsLayoutPoint QgsLayoutItem::topLeftToReferencePoint( const QgsLayoutPoint &poi
 {
   const QPointF topLeft = mLayout->convertToLayoutUnits( point );
   const QPointF anchorPoint = mapToScene( itemPositionAtReferencePoint( mReferencePoint, rect().size() ) );
-  const QPointF refPoint = anchorPoint - mapFromScene( topLeft );
-  return mLayout->convertFromLayoutUnits( refPoint, point.units() );
+  QPointF refPoint;
+  if ( mItemRotation != 0 && mReferencePoint != ReferencePoint::UpperLeft )
+  {
+   refPoint = anchorPoint - mapFromScene( topLeft );
+  }
+  else
+    refPoint = topLeft + anchorPoint;
+return mLayout->convertFromLayoutUnits( refPoint, point.units() );
 }
 
 bool QgsLayoutItem::writePropertiesToElement( QDomElement &, QDomDocument &, const QgsReadWriteContext & ) const

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1367,7 +1367,8 @@ QPointF QgsLayoutItem::positionAtReferencePoint( const QgsLayoutItem::ReferenceP
 QgsLayoutPoint QgsLayoutItem::topLeftToReferencePoint( const QgsLayoutPoint &point ) const
 {
   const QPointF topLeft = mLayout->convertToLayoutUnits( point );
-  const QPointF refPoint = topLeft + itemPositionAtReferencePoint( mReferencePoint, rect().size() );
+  const QPointF anchorPoint = mapToScene( itemPositionAtReferencePoint( mReferencePoint, rect().size() ) );
+  const QPointF refPoint = anchorPoint - mapFromScene( topLeft );
   return mLayout->convertFromLayoutUnits( refPoint, point.units() );
 }
 


### PR DESCRIPTION
## Description

fixes https://github.com/qgis/QGIS/issues/61347

This is the solution that I found to keep the map in place when it is rotated and the anchor point is changed or the map is redrawn.

As the issue only occurs when the atlas forces a redraw and the issue only appears when the reference point is not in the top left and the map is rotated, the initial behaviour is fine. Conbining those two conditios lead to a drifting on the map on each redraw. The alternative calculation avoid this problem and maintains the position of the map.

Maintaining the original code path was needed to prevent issues when initialy creating the map in the test case as the new calculation method didn't play well with how the item was placed in the map. I am unsure why this was the case.

Here is a gif of the fixed behaviour.
![mapanchoringfix](https://github.com/user-attachments/assets/1dd9991b-0f9d-40be-9497-99faeb8caaf8)
