### PR TITLE
Enable multiple marker placements when loading and saving style as sld

### DIFF
--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3783,6 +3783,8 @@ empty string if the path is not associated with a vsi prefix.
  const long GEO_EPSG_CRS_ID;
 
 
+typedef QMultiMap<QString, QString> QgsStringMultimap;
+
 typedef unsigned long long qgssize;
 
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
@@ -19,8 +19,6 @@ typedef QMap<QString, QgsTextFormat > QgsTextFormatMap;
 typedef QMap<QString, QgsPalLayerSettings > QgsLabelSettingsMap;
 
 
-typedef QMultiMap<QString, QString> QgsSmartConditionMap;
-
 
 class QgsStyle : QObject
 {
@@ -1015,9 +1013,9 @@ Returns the smart groups map with id as key and name as value
 Returns the smart groups list
 %End
 
-    QgsSmartConditionMap smartgroup( int id );
+    QgsStringMultimap smartgroup( int id );
 %Docstring
-Returns the :py:class:`QgsSmartConditionMap` for the given id
+Returns the :py:class:`QgsStringMultimap` for the given id
 %End
 
     QString smartgroupOperator( int id );

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -618,7 +618,7 @@ expression
     static QgsStringMap getSvgParameterList( QDomElement &element );
 
     static QDomElement createVendorOptionElement( QDomDocument &doc, const QString &name, const QString &value );
-    static QgsStringMap getVendorOptionList( QDomElement &element );
+    static QMultiMap<QString, QString> getVendorOptionList( QDomElement &element );
 
     static QVariantMap parseProperties( const QDomElement &element );
 %Docstring

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -618,7 +618,7 @@ expression
     static QgsStringMap getSvgParameterList( QDomElement &element );
 
     static QDomElement createVendorOptionElement( QDomDocument &doc, const QString &name, const QString &value );
-    static QMultiMap<QString, QString> getVendorOptionList( QDomElement &element );
+    static QgsStringMultimap getVendorOptionList( QDomElement &element );
 
     static QVariantMap parseProperties( const QDomElement &element );
 %Docstring

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -3783,6 +3783,8 @@ empty string if the path is not associated with a vsi prefix.
  const long GEO_EPSG_CRS_ID;
 
 
+typedef QMultiMap<QString, QString> QgsStringMultimap;
+
 typedef unsigned long long qgssize;
 
 

--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -19,8 +19,6 @@ typedef QMap<QString, QgsTextFormat > QgsTextFormatMap;
 typedef QMap<QString, QgsPalLayerSettings > QgsLabelSettingsMap;
 
 
-typedef QMultiMap<QString, QString> QgsSmartConditionMap;
-
 
 class QgsStyle : QObject
 {
@@ -1015,9 +1013,9 @@ Returns the smart groups map with id as key and name as value
 Returns the smart groups list
 %End
 
-    QgsSmartConditionMap smartgroup( int id );
+    QgsStringMultimap smartgroup( int id );
 %Docstring
-Returns the :py:class:`QgsSmartConditionMap` for the given id
+Returns the :py:class:`QgsStringMultimap` for the given id
 %End
 
     QString smartgroupOperator( int id );

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -618,7 +618,7 @@ expression
     static QgsStringMap getSvgParameterList( QDomElement &element );
 
     static QDomElement createVendorOptionElement( QDomDocument &doc, const QString &name, const QString &value );
-    static QgsStringMap getVendorOptionList( QDomElement &element );
+    static QMultiMap<QString, QString> getVendorOptionList( QDomElement &element );
 
     static QVariantMap parseProperties( const QDomElement &element );
 %Docstring

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -618,7 +618,7 @@ expression
     static QgsStringMap getSvgParameterList( QDomElement &element );
 
     static QDomElement createVendorOptionElement( QDomDocument &doc, const QString &name, const QString &value );
-    static QMultiMap<QString, QString> getVendorOptionList( QDomElement &element );
+    static QgsStringMultimap getVendorOptionList( QDomElement &element );
 
     static QVariantMap parseProperties( const QDomElement &element );
 %Docstring

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -6781,6 +6781,26 @@ Q_DECL_DEPRECATED const long GEO_EPSG_CRS_ID = 4326;
 typedef QMap<QString, QString> QgsStringMap SIP_SKIP;
 
 /**
+ * \ingroup core
+ *  A multimap with a key/value pair of QStrings. When used to hold the smart group conditions,
+ *  the key is the constraint of the condition and the value is the parameter which is applied for the constraint.
+ *
+ *  The supported constraints are:
+ *  tag -> symbol has the tag matching the parameter
+ *  !tag -> symbol doesn't have the tag matching the parameter
+ *  name -> symbol has a part of its name matching the parameter
+ *  !name -> symbol doesn't have any part of the name matching the parameter
+ *
+ *  Example Usage:
+ *  QgsStringMultimap conditions;
+ *  conditions.insert( "tag", "red" ); // adds the condition: Symbol has the tag red
+ *  conditions.insert( "!name", "way" ); // add the condition: Symbol doesn't have any part of its name matching `way`
+ *
+ *  \note This is a Multimap, which means it will contain multiple values for the same key.
+ */
+typedef QMultiMap<QString, QString> QgsStringMultimap;
+
+/**
  * Qgssize is used instead of size_t, because size_t is stdlib type, unknown
  *  by SIP, and it would be hard to define size_t correctly in SIP.
  *  Currently used "unsigned long long" was introduced in C++11 (2011)

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -501,8 +501,8 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
   double widthHeightFactor = 1.0;
   Qt::PenStyle strokeStyle;
 
-  QMultiMap<QString, QString> vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
-  for ( QMultiMap<QString, QString>::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
+  QgsStringMultimap vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
+  for ( QgsStringMultimap::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
   {
     if ( it.key() == QLatin1String( "widthHeightFactor" ) )
     {

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -501,8 +501,8 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
   double widthHeightFactor = 1.0;
   Qt::PenStyle strokeStyle;
 
-  QgsStringMap vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
-  for ( QgsStringMap::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
+  QMultiMap<QString, QString> vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
+  for ( QMultiMap<QString, QString>::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
   {
     if ( it.key() == QLatin1String( "widthHeightFactor" ) )
     {

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -4632,8 +4632,8 @@ QgsSymbolLayer *QgsPointPatternFillSymbolLayer::createFromSld( QDomElement &elem
 
   // Set distance X and Y from vendor options, or from Size if no vendor options are set
   bool distanceFromVendorOption { false };
-  QMultiMap<QString, QString> vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( element );
-  for ( QMultiMap<QString, QString>::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
+  QgsStringMultimap vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( element );
+  for ( QgsStringMultimap::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
   {
     // Legacy
     if ( it.key() == QLatin1String( "distance" ) )

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -4632,8 +4632,8 @@ QgsSymbolLayer *QgsPointPatternFillSymbolLayer::createFromSld( QDomElement &elem
 
   // Set distance X and Y from vendor options, or from Size if no vendor options are set
   bool distanceFromVendorOption { false };
-  QgsStringMap vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( element );
-  for ( QgsStringMap::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
+  QMultiMap<QString, QString> vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( element );
+  for ( QMultiMap<QString, QString>::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
   {
     // Legacy
     if ( it.key() == QLatin1String( "distance" ) )

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -2598,8 +2598,8 @@ QgsSymbolLayer *QgsMarkerLineSymbolLayer::createFromSld( QDomElement &element )
   bool placeOnEveryPart = true;
   Qgis::MarkerLinePlacements placements;
 
-  QMultiMap<QString, QString> vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( element );
-  for ( QMultiMap<QString, QString>::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
+  QgsStringMultimap vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( element );
+  for ( QgsStringMultimap::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
   {
     if ( it.key() == QLatin1String( "placement" ) )
     {

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -2299,7 +2299,7 @@ QStringList QgsStyle::allNames( QgsStyle::StyleEntity type ) const
   return QStringList();
 }
 
-int QgsStyle::addSmartgroup( const QString &name, const QString &op, const QgsSmartConditionMap &conditions )
+int QgsStyle::addSmartgroup( const QString &name, const QString &op, const QgsStringMultimap &conditions )
 {
   return addSmartgroup( name, op, conditions.values( QStringLiteral( "tag" ) ),
                         conditions.values( QStringLiteral( "!tag" ) ),
@@ -2495,15 +2495,15 @@ QStringList QgsStyle::symbolsOfSmartgroup( StyleEntity type, int id )
   return unique;
 }
 
-QgsSmartConditionMap QgsStyle::smartgroup( int id )
+QgsStringMultimap QgsStyle::smartgroup( int id )
 {
   if ( !mCurrentDB )
   {
     QgsDebugError( QStringLiteral( "Cannot open database for listing groups" ) );
-    return QgsSmartConditionMap();
+    return QgsStringMultimap();
   }
 
-  QgsSmartConditionMap condition;
+  QgsStringMultimap condition;
 
   QString query = qgs_sqlite3_mprintf( "SELECT xml FROM smartgroup WHERE id=%d", id );
 

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -58,26 +58,6 @@ typedef QMap<QString, QgsPalLayerSettings > QgsLabelSettingsMap;
  */
 #define QGSCLIPBOARD_STYLE_MIME "application/qgis.style"
 
-/**
- * \ingroup core
- *  A multimap to hold the smart group conditions as constraint and parameter pairs.
- *  Both the key and the value of the map are QString. The key is the constraint of the condition and the value is the parameter which is applied for the constraint.
- *
- *  The supported constraints are:
- *  tag -> symbol has the tag matching the parameter
- *  !tag -> symbol doesn't have the tag matching the parameter
- *  name -> symbol has a part of its name matching the parameter
- *  !name -> symbol doesn't have any part of the name matching the parameter
- *
- *  Example Usage:
- *  QgsSmartConditionMap conditions;
- *  conditions.insert( "tag", "red" ); // adds the condition: Symbol has the tag red
- *  conditions.insert( "!name", "way" ); // add the condition: Symbol doesn't have any part of its name matching `way`
- *
- *  \note This is a Multimap, which means it will contain multiple values for the same key.
- */
-typedef QMultiMap<QString, QString> QgsSmartConditionMap;
-
 
 /**
  * \ingroup core
@@ -360,7 +340,7 @@ class CORE_EXPORT QgsStyle : public QObject
      *
      * \note Not available from Python bindings
      */
-    int addSmartgroup( const QString &name, const QString &op, const QgsSmartConditionMap &conditions ) SIP_SKIP;
+    int addSmartgroup( const QString &name, const QString &op, const QgsStringMultimap &conditions ) SIP_SKIP;
 
     /**
      * Adds a new smartgroup to the database and returns the id.
@@ -983,8 +963,8 @@ class CORE_EXPORT QgsStyle : public QObject
     //! Returns the smart groups list
     QStringList smartgroupNames() const;
 
-    //! Returns the QgsSmartConditionMap for the given id
-    QgsSmartConditionMap smartgroup( int id );
+    //! Returns the QgsStringMultimap for the given id
+    QgsStringMultimap smartgroup( int id );
 
     /**
      * Returns the operator for the smartgroup.

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -1905,8 +1905,8 @@ bool QgsSymbolLayerUtils::needEllipseMarker( QDomElement &element )
   if ( graphicElem.isNull() )
     return false;
 
-  QMultiMap<QString, QString> vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
-  for ( QMultiMap<QString, QString>::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
+  QgsStringMultimap vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
+  for ( QgsStringMultimap::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
   {
     if ( it.key() == QLatin1String( "widthHeightFactor" ) )
     {

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -1905,8 +1905,8 @@ bool QgsSymbolLayerUtils::needEllipseMarker( QDomElement &element )
   if ( graphicElem.isNull() )
     return false;
 
-  QgsStringMap vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
-  for ( QgsStringMap::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
+  QMultiMap<QString, QString> vendorOptions = QgsSymbolLayerUtils::getVendorOptionList( graphicElem );
+  for ( QMultiMap<QString, QString>::iterator it = vendorOptions.begin(); it != vendorOptions.end(); ++it )
   {
     if ( it.key() == QLatin1String( "widthHeightFactor" ) )
     {
@@ -3280,9 +3280,9 @@ QDomElement QgsSymbolLayerUtils::createVendorOptionElement( QDomDocument &doc, c
   return nodeElem;
 }
 
-QgsStringMap QgsSymbolLayerUtils::getVendorOptionList( QDomElement &element )
+QMultiMap<QString, QString> QgsSymbolLayerUtils::getVendorOptionList( QDomElement &element )
 {
-  QgsStringMap params;
+  QMultiMap<QString, QString> params;
 
   QDomElement paramElem = element.firstChildElement( QStringLiteral( "VendorOption" ) );
   while ( !paramElem.isNull() )
@@ -3291,7 +3291,7 @@ QgsStringMap QgsSymbolLayerUtils::getVendorOptionList( QDomElement &element )
     const QString value = paramElem.firstChild().nodeValue();
 
     if ( !name.isEmpty() && !value.isEmpty() )
-      params[ name ] = value;
+      params.insert( name, value );
 
     paramElem = paramElem.nextSiblingElement( QStringLiteral( "VendorOption" ) );
   }

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -581,7 +581,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
     static QgsStringMap getSvgParameterList( QDomElement &element );
 
     static QDomElement createVendorOptionElement( QDomDocument &doc, const QString &name, const QString &value );
-    static QMultiMap<QString, QString> getVendorOptionList( QDomElement &element );
+    static QgsStringMultimap getVendorOptionList( QDomElement &element );
 
     //! Parses the properties from XML and returns a map
     static QVariantMap parseProperties( const QDomElement &element );

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -581,7 +581,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
     static QgsStringMap getSvgParameterList( QDomElement &element );
 
     static QDomElement createVendorOptionElement( QDomDocument &doc, const QString &name, const QString &value );
-    static QgsStringMap getVendorOptionList( QDomElement &element );
+    static QMultiMap<QString, QString> getVendorOptionList( QDomElement &element );
 
     //! Parses the properties from XML and returns a map
     static QVariantMap parseProperties( const QDomElement &element );

--- a/src/gui/symbology/qgssmartgroupeditordialog.cpp
+++ b/src/gui/symbology/qgssmartgroupeditordialog.cpp
@@ -141,9 +141,9 @@ void QgsSmartGroupEditorDialog::removeCondition( int id )
   delete cond;
 }
 
-QgsSmartConditionMap QgsSmartGroupEditorDialog::conditionMap()
+QgsStringMultimap QgsSmartGroupEditorDialog::conditionMap()
 {
-  QgsSmartConditionMap conditions;
+  QgsStringMultimap conditions;
 
   const auto constMConditionMap = mConditionMap;
   for ( QgsSmartGroupCondition *condition : constMConditionMap )
@@ -159,7 +159,7 @@ QString QgsSmartGroupEditorDialog::conditionOperator()
   return mAndOrCombo->currentData().toString();
 }
 
-void QgsSmartGroupEditorDialog::setConditionMap( const QgsSmartConditionMap &map )
+void QgsSmartGroupEditorDialog::setConditionMap( const QgsStringMultimap &map )
 {
   QStringList constraints;
   constraints << QStringLiteral( "tag" ) << QStringLiteral( "name" ) << QStringLiteral( "!tag" ) << QStringLiteral( "!name" );

--- a/src/gui/symbology/qgssmartgroupeditordialog.h
+++ b/src/gui/symbology/qgssmartgroupeditordialog.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsSmartGroupCondition : public QWidget, private Ui::QgsSmartGr
 
 #include "ui_qgssmartgroupeditordialogbase.h"
 
-#include "qgsstyle.h" //for QgsSmartConditionMap
+#include "qgsstyle.h"
 
 /**
  * \ingroup gui
@@ -87,7 +87,7 @@ class GUI_EXPORT QgsSmartGroupEditorDialog : public QDialog, private Ui::QgsSmar
      * returns the condition map
      * \note not available in Python bindings
      */
-    QgsSmartConditionMap conditionMap() SIP_SKIP;
+    QgsStringMultimap conditionMap() SIP_SKIP;
 
     //! returns the AND/OR condition
     QString conditionOperator();
@@ -96,7 +96,7 @@ class GUI_EXPORT QgsSmartGroupEditorDialog : public QDialog, private Ui::QgsSmar
      * sets up the GUI for the given conditionmap
      * \note not available in Python bindings
      */
-    void setConditionMap( const QgsSmartConditionMap & ) SIP_SKIP;
+    void setConditionMap( const QgsStringMultimap & ) SIP_SKIP;
 
     //! sets the operator AND/OR
     void setOperator( const QString & );

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -2869,7 +2869,7 @@ void QgsStyleManagerDialog::editSmartgroupAction()
   QStandardItem *item = treeModel->itemFromIndex( present );
 
   QgsSmartGroupEditorDialog dlg( mStyle, this );
-  QgsSmartConditionMap map = mStyle->smartgroup( present.data( Qt::UserRole + 1 ).toInt() );
+  QgsStringMultimap map = mStyle->smartgroup( present.data( Qt::UserRole + 1 ).toInt() );
   dlg.setSmartgroupName( item->text() );
   dlg.setOperator( mStyle->smartgroupOperator( item->data().toInt() ) );
   dlg.setConditionMap( map );

--- a/tests/src/core/testqgssymbol.cpp
+++ b/tests/src/core/testqgssymbol.cpp
@@ -68,6 +68,7 @@ class TestQgsSymbol : public QgsTest
     void testParseColor();
     void testParseColorList();
     void symbolProperties();
+    void saveAndLoadMarkerLineToSld();
 
     //
     // Regression Testing
@@ -456,6 +457,36 @@ void TestQgsSymbol::symbolProperties()
 
   delete fillSymbol;
   delete fillSymbol2;
+}
+
+void TestQgsSymbol::saveAndLoadMarkerLineToSld()
+{
+  QString sldFileName( mTestDataDir + "symbol_layer/QgsMarkerLineSymbolLayerMultiplePlacements.sld" );
+
+  //create a symbol and convert it's first layer to a marker line symbol layer
+  bool defaultLoadedFlag = false;
+  QgsFeatureRenderer *renderer = mpLinesLayer->renderer();
+  QgsRenderContext renderContext;
+  QgsSymbol *symbol = renderer->symbols( renderContext ).at( 0 );
+  QgsMarkerLineSymbolLayer *symbolLayer = static_cast<QgsMarkerLineSymbolLayer *>( symbol->symbolLayer( 0 ) );
+
+  //change the placement options
+  symbolLayer->setPlaceOnEveryPart( false );
+  Qgis::MarkerLinePlacements placements;
+  placements.setFlag( Qgis::MarkerLinePlacement::Interval, true );
+  placements.setFlag( Qgis::MarkerLinePlacement::CentralPoint, true );
+  placements.setFlag( Qgis::MarkerLinePlacement::CurvePoint, true );
+  placements.setFlag( Qgis::MarkerLinePlacement::FirstVertex, true );
+
+  symbolLayer->setPlacements( placements );
+
+  //save to sld
+  mpLinesLayer->saveSldStyle( sldFileName, defaultLoadedFlag );
+
+  //load from sld
+  mpLinesLayer->loadSldStyle( sldFileName, defaultLoadedFlag );
+  QVERIFY( symbolLayer->placements() == placements );
+  QVERIFY( symbolLayer->placeOnEveryPart() == false );
 }
 
 void TestQgsSymbol::regression24954()


### PR DESCRIPTION
With these changes all marker placement options can be loaded and saved in parallel in the SLD format.
![image](https://github.com/user-attachments/assets/71be2b63-866f-4d11-8f1c-cbf8c3a9fcc8)
