### PR TITLE
Add invalidateCacheEntry() for QgsAbstractContentCache implementations

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsabstractcontentcache.py
+++ b/python/PyQt6/core/auto_additions/qgsabstractcontentcache.py
@@ -10,7 +10,7 @@ try:
     QgsAbstractContentCacheBase.parseBase64DataUrl = staticmethod(QgsAbstractContentCacheBase.parseBase64DataUrl)
     QgsAbstractContentCacheBase.parseEmbeddedStringData = staticmethod(QgsAbstractContentCacheBase.parseEmbeddedStringData)
     QgsAbstractContentCacheBase.isBase64Data = staticmethod(QgsAbstractContentCacheBase.isBase64Data)
-    QgsAbstractContentCacheBase.__virtual_methods__ = ['checkReply', 'onRemoteContentFetched']
+    QgsAbstractContentCacheBase.__virtual_methods__ = ['invalidateCacheEntry', 'checkReply', 'onRemoteContentFetched']
     QgsAbstractContentCacheBase.__signal_arguments__ = {'remoteContentFetched': ['url: str']}
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/qgsabstractcontentcache.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsabstractcontentcache.sip.in
@@ -138,6 +138,20 @@ Returns ``True`` if ``path`` represents base64 encoded data.
 .. versionadded:: 3.40
 %End
 
+    virtual bool invalidateCacheEntry( const QString &path );
+%Docstring
+Invalidates a cache entry for the specified ``path``.
+
+If an entry exists for the given ``path``, it will be removed from the
+cache.
+
+:param path: The path of the cache entry to invalidate.
+
+:return: ``True`` if an entry was invalidated, ``False`` otherwise.
+
+.. versionadded:: 3.44
+%End
+
   signals:
 
     void remoteContentFetched( const QString &url );

--- a/python/core/auto_additions/qgsabstractcontentcache.py
+++ b/python/core/auto_additions/qgsabstractcontentcache.py
@@ -10,7 +10,7 @@ try:
     QgsAbstractContentCacheBase.parseBase64DataUrl = staticmethod(QgsAbstractContentCacheBase.parseBase64DataUrl)
     QgsAbstractContentCacheBase.parseEmbeddedStringData = staticmethod(QgsAbstractContentCacheBase.parseEmbeddedStringData)
     QgsAbstractContentCacheBase.isBase64Data = staticmethod(QgsAbstractContentCacheBase.isBase64Data)
-    QgsAbstractContentCacheBase.__virtual_methods__ = ['checkReply', 'onRemoteContentFetched']
+    QgsAbstractContentCacheBase.__virtual_methods__ = ['invalidateCacheEntry', 'checkReply', 'onRemoteContentFetched']
     QgsAbstractContentCacheBase.__signal_arguments__ = {'remoteContentFetched': ['url: str']}
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/qgsabstractcontentcache.sip.in
+++ b/python/core/auto_generated/qgsabstractcontentcache.sip.in
@@ -138,6 +138,20 @@ Returns ``True`` if ``path`` represents base64 encoded data.
 .. versionadded:: 3.40
 %End
 
+    virtual bool invalidateCacheEntry( const QString &path );
+%Docstring
+Invalidates a cache entry for the specified ``path``.
+
+If an entry exists for the given ``path``, it will be removed from the
+cache.
+
+:param path: The path of the cache entry to invalidate.
+
+:return: ``True`` if an entry was invalidated, ``False`` otherwise.
+
+.. versionadded:: 3.44
+%End
+
   signals:
 
     void remoteContentFetched( const QString &url );

--- a/src/core/qgsabstractcontentcache.cpp
+++ b/src/core/qgsabstractcontentcache.cpp
@@ -37,6 +37,11 @@ QgsAbstractContentCacheBase::QgsAbstractContentCacheBase( QObject *parent )
   : QObject( parent )
 {}
 
+bool QgsAbstractContentCacheBase::invalidateCacheEntry( const QString &path )
+{
+  Q_UNUSED( path );
+  return false;
+}
 
 void QgsAbstractContentCacheBase::onRemoteContentFetched( const QString &, bool )
 {

--- a/tests/src/core/testqgsimagecache.cpp
+++ b/tests/src/core/testqgsimagecache.cpp
@@ -67,6 +67,7 @@ class TestQgsImageCache : public QgsTest
     void preseedAnimation();
     void cmykImage();
     void htmlDataUrl();
+    void invalidateCacheEntry();
 };
 
 
@@ -526,6 +527,34 @@ void TestQgsImageCache::htmlDataUrl()
   QCOMPARE( size.height(), 60 );
 }
 
+void TestQgsImageCache::invalidateCacheEntry()
+{
+  QgsImageCache cache;
+  bool inCache = false;
+
+  const QString tempImagePath = QDir::tempPath() + "/test_sample_image.png";
+  const QString originalImage = TEST_DATA_DIR + QStringLiteral( "/sample_image.png" );
+  if ( QFileInfo::exists( tempImagePath ) )
+    QFile::remove( tempImagePath );
+  QFile::copy( originalImage, tempImagePath );
+
+  bool invalidated_initial = cache.invalidateCacheEntry( tempImagePath );
+  QVERIFY( !invalidated_initial );
+
+  QImage img = cache.pathAsImage( tempImagePath, QSize( 200, 200 ), true, 1.0, inCache );
+  QVERIFY( !img.isNull() );
+  QVERIFY( inCache );
+
+  bool invalidated = cache.invalidateCacheEntry( tempImagePath );
+  QVERIFY( invalidated );
+
+  bool invalidated_twice = cache.invalidateCacheEntry( tempImagePath );
+  QVERIFY( !invalidated_twice );
+
+  img = cache.pathAsImage( tempImagePath, QSize( 200, 200 ), true, 1.0, inCache );
+  QVERIFY( !img.isNull() );
+  QVERIFY( inCache );
+}
 
 QGSTEST_MAIN( TestQgsImageCache )
 #include "testqgsimagecache.moc"


### PR DESCRIPTION
## Description

The addition of the `invalidateCacheEntry()` method provides `QgsAbstractContentCache` implementations (e.g. `QgsImageCache`) with a mechanism to invalidate individual cache entries.

This is useful when cache content is updated by a project macro or plugin, ensuring that subsequent users of the cache receive the updated data—for example, when displaying a dynamically changing .png image as an image decorator.

see also [[QGIS-Developer] Invalidating a QgsImageCache entry](https://lists.osgeo.org/pipermail/qgis-developer/2025-April/067506.html)