### PR TITLE
Typo corrected relationnal = relational

### DIFF
--- a/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
@@ -57,7 +57,7 @@ QString QgsGeometryCheckGapAlgorithm::shortHelpString() const
                       "If an allowed gaps layer is given, the gaps contained in polygons from this layer will be ignored.\n"
                       "An optional buffer can be applied to the allowed gaps.\n\n"
                       "The neighbors output layer is needed for the fix geometry (gaps) algorithm. It is a 1-N "
-                      "relationnal table for correspondance between a gap and the unique id of its neighbor features." );
+                      "relational table for correspondance between a gap and the unique id of its neighbor features." );
 }
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckGapAlgorithm::flags() const


### PR DESCRIPTION
Line 60:  relationnal --> should be relational

## Description

Corrected typo:  relationnal  should in fact be relational (removed one letter "n")
