### PR TITLE
Sort fieldsToCopy before running joinbynearest processing algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
@@ -142,23 +142,33 @@ QVariantMap QgsJoinByNearestAlgorithm::processAlgorithm( const QVariantMap &para
   }
   else
   {
-    fields2Indices.reserve( fieldsToCopy.count() );
-    for ( const QString &field : fieldsToCopy )
+    // Create a map to store the field name and its index in input2
+    QMap<int, QString> fieldIndexMap;
+  
+    // Populate the map with the index of each field in input2
+    for ( int i = 0; i < input2->fields().count(); ++i )
     {
-      const int index = input2->fields().lookupField( field );
-      if ( index >= 0 )
-      {
-        fields2Indices << index;
-        outFields2.append( input2->fields().at( index ) );
-      }
+        fieldIndexMap.insert(i, input2->fields().at(i).name());
     }
-  }
-
-  if ( !prefix.isEmpty() )
-  {
-    for ( int i = 0; i < outFields2.count(); ++i )
+  
+    // Sort the fieldsToCopy based on their position in input2
+    QStringList sortedFields = fieldsToCopy;
+    std::sort(sortedFields.begin(), sortedFields.end(), [&fieldIndexMap](const QString& a, const QString& b) {
+        int indexA = fieldIndexMap.key(a);
+        int indexB = fieldIndexMap.key(b);
+        return indexA < indexB;
+    });
+  
+    // Copy sorted field names
+    fields2Indices.reserve( sortedFields.count() );
+    for ( const QString &field : sortedFields )
     {
-      outFields2.rename( i, prefix + outFields2[i].name() );
+        const int index = input2->fields().lookupField( field );
+        if ( index >= 0 )
+        {
+            fields2Indices << index;
+            outFields2.append( input2->fields().at( index ) );
+        }
     }
   }
 

--- a/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
@@ -144,31 +144,31 @@ QVariantMap QgsJoinByNearestAlgorithm::processAlgorithm( const QVariantMap &para
   {
     // Create a map to store the field name and its index in input2
     QMap<int, QString> fieldIndexMap;
-  
+
     // Populate the map with the index of each field in input2
     for ( int i = 0; i < input2->fields().count(); ++i )
     {
-        fieldIndexMap.insert(i, input2->fields().at(i).name());
+      fieldIndexMap.insert( i, input2->fields().at( i ).name() );
     }
-  
+
     // Sort the fieldsToCopy based on their position in input2
     QStringList sortedFields = fieldsToCopy;
-    std::sort(sortedFields.begin(), sortedFields.end(), [&fieldIndexMap](const QString& a, const QString& b) {
-        int indexA = fieldIndexMap.key(a);
-        int indexB = fieldIndexMap.key(b);
-        return indexA < indexB;
-    });
-  
+    std::sort( sortedFields.begin(), sortedFields.end(), [&fieldIndexMap]( const QString &a, const QString &b ) {
+      int indexA = fieldIndexMap.key( a );
+      int indexB = fieldIndexMap.key( b );
+      return indexA < indexB;
+    } );
+
     // Copy sorted field names
     fields2Indices.reserve( sortedFields.count() );
     for ( const QString &field : sortedFields )
     {
-        const int index = input2->fields().lookupField( field );
-        if ( index >= 0 )
-        {
-            fields2Indices << index;
-            outFields2.append( input2->fields().at( index ) );
-        }
+      const int index = input2->fields().lookupField( field );
+      if ( index >= 0 )
+      {
+        fields2Indices << index;
+        outFields2.append( input2->fields().at( index ) );
+      }
     }
   }
 

--- a/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
@@ -172,6 +172,14 @@ QVariantMap QgsJoinByNearestAlgorithm::processAlgorithm( const QVariantMap &para
     }
   }
 
+  if ( !prefix.isEmpty() )
+  {
+    for ( int i = 0; i < outFields2.count(); ++i )
+    {
+      outFields2.rename( i, prefix + outFields2[i].name() );
+    }
+  }
+
   const QgsAttributeList fields2Fetch = fields2Indices;
 
   QgsFields outFields = QgsProcessingUtils::combineFields( input->fields(), outFields2 );


### PR DESCRIPTION
## Description

Fixes #61121

This bugfix was tested on the MWE provided in that issue. Note the order of `Field1_2` and `Field2_2` is now correct regardless of the order fields are listed in the `'FIELDS_TO_COPY'` parameter input.

**Original Incorrect Results:**
```
{'Input Field Order': ['Field1', 'Field2']}
        name     value
0     Field1         A
1     Field2         B
2   Field1_2         C
3   Field2_2         D
4          n         1
5   distance  1.414214
6  feature_x       0.0
7  feature_y       0.0
8  nearest_x       1.0
9  nearest_y       1.0

{'Input Field Order': ['Field2', 'Field1']}
        name     value
0     Field1         A
1     Field2         B
2   Field2_2         C
3   Field1_2         D
4          n         1
5   distance  1.414214
6  feature_x       0.0
7  feature_y       0.0
8  nearest_x       1.0
9  nearest_y       1.0
```

**New Correct Results:**
```
{'Input Field Order': ['Field1', 'Field2']}
        name     value
0     Field1         A
1     Field2         B
2   Field1_2         C
3   Field2_2         D
4          n         1
5   distance  1.414214
6  feature_x       0.0
7  feature_y       0.0
8  nearest_x       1.0
9  nearest_y       1.0

{'Input Field Order': ['Field2', 'Field1']}
        name     value
0     Field1         A
1     Field2         B
2   Field1_2         C
3   Field2_2         D
4          n         1
5   distance  1.414214
6  feature_x       0.0
7  feature_y       0.0
8  nearest_x       1.0
9  nearest_y       1.0
```


