### PR TITLE
clear features in QgsIdentifyResultsDialog::clear to avoid memory leak

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1824,6 +1824,8 @@ void QgsIdentifyResultsDialog::clear()
     delete curve;
   mPlotCurves.clear();
 
+  mFeatures.clear();
+
   mExpressionContextScope = QgsExpressionContextScope();
 
   // keep it visible but disabled, it can switch from disabled/enabled


### PR DESCRIPTION
Currently the size of QgsIdentifyResultsDialog.mFeatures increasing forever, no logic to clear it, that may cause a memory leak I think.  


This patch clear features inside the QgsIdentifyResultsDialog::clear, so at the beginning of each identify action, mFeatures gets clear.
