### PR TITLE
Fix code layout test not showing the right file

### DIFF
--- a/tests/code_layout/sipify/test_sipfiles.sh
+++ b/tests/code_layout/sipify/test_sipfiles.sh
@@ -39,7 +39,7 @@ for root_dir in python python/PyQt6; do
         if [[ -f $root_dir/${module}/auto_additions/${pyfile}.temp ]]; then
           outdiff2=$(diff $root_dir/${module}/auto_additions/${pyfile} $root_dir/${module}/auto_additions/${pyfile}.temp)
           if [[ -n "$outdiff2" ]]; then
-            echo " *** Python addition file not up to date: $root_dir/$sipfile"
+            echo " *** Python addition file not up to date: $root_dir/$pyfile"
             echo " $outdiff2 "
             code=1
           fi


### PR DESCRIPTION
## Description

The current test shows the path to the sip file when a mismatch exist for the addition file instead of the sip file.

I think the proper file should be shown to avoid confusion.