### PR TITLE
Add subtle shading of globe for better depth perception

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -62,6 +62,7 @@ set(QGIS_3D_SRCS
   lights/qgspointlightsettings.cpp
 
   materials/qgsabstractmaterialsettings.cpp
+  materials/qgsglobematerial.cpp
   materials/qgsgoochmaterialsettings.cpp
   materials/qgsmaterial.cpp
   materials/qgsmaterialregistry.cpp
@@ -177,6 +178,7 @@ set(QGIS_3D_HDRS
   lights/qgspointlightsettings.h
 
   materials/qgsabstractmaterialsettings.h
+  materials/qgsglobematerial.h
   materials/qgsgoochmaterialsettings.h
   materials/qgsmaterial.h
   materials/qgsmaterialregistry.h

--- a/src/3d/materials/qgsglobematerial.cpp
+++ b/src/3d/materials/qgsglobematerial.cpp
@@ -1,0 +1,89 @@
+/***************************************************************************
+  qgsglobematerial.cpp
+  --------------------------------------
+  Date                 : April 2025
+  Copyright            : (C) 2025 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QUrl>
+
+#include <Qt3DRender/QEffect>
+#include <Qt3DRender/QGraphicsApiFilter>
+#include <Qt3DRender/QParameter>
+#include <Qt3DRender/QRenderPass>
+#include <Qt3DRender/QShaderProgram>
+#include <Qt3DRender/QTechnique>
+#include <Qt3DRender/QTexture>
+
+#include "qgsglobematerial.h"
+#include "moc_qgsglobematerial.cpp"
+
+///@cond PRIVATE
+QgsGlobeMaterial::QgsGlobeMaterial( QNode *parent )
+  : QgsMaterial( parent )
+  , mTextureParameter( new Qt3DRender::QParameter( QStringLiteral( "diffuseTexture" ), new Qt3DRender::QTexture2D ) )
+  , mDiffuseTextureScaleParameter( new Qt3DRender::QParameter( QStringLiteral( "texCoordScale" ), 1.0f ) )
+  , mGL3Technique( new Qt3DRender::QTechnique( this ) )
+  , mGL3RenderPass( new Qt3DRender::QRenderPass( this ) )
+  , mGL3Shader( new Qt3DRender::QShaderProgram( this ) )
+  , mFilterKey( new Qt3DRender::QFilterKey( this ) )
+{
+  init();
+}
+
+QgsGlobeMaterial::~QgsGlobeMaterial() = default;
+
+
+void QgsGlobeMaterial::init()
+{
+  connect( mTextureParameter, &Qt3DRender::QParameter::valueChanged, this, &QgsGlobeMaterial::handleTextureChanged );
+
+  Qt3DRender::QEffect *effect = new Qt3DRender::QEffect();
+
+  effect->addParameter( mTextureParameter );
+  effect->addParameter( mDiffuseTextureScaleParameter );
+
+  mGL3Shader->setFragmentShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( QStringLiteral( "qrc:/shaders/globe.frag" ) ) ) );
+  mGL3Shader->setVertexShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( QStringLiteral( "qrc:/shaders/default.vert" ) ) ) );
+
+  mGL3Technique->graphicsApiFilter()->setApi( Qt3DRender::QGraphicsApiFilter::OpenGL );
+  mGL3Technique->graphicsApiFilter()->setMajorVersion( 3 );
+  mGL3Technique->graphicsApiFilter()->setMinorVersion( 1 );
+  mGL3Technique->graphicsApiFilter()->setProfile( Qt3DRender::QGraphicsApiFilter::CoreProfile );
+
+  mFilterKey->setParent( this );
+  mFilterKey->setName( QStringLiteral( "renderingStyle" ) );
+  mFilterKey->setValue( QStringLiteral( "forward" ) );
+
+  mGL3Technique->addFilterKey( mFilterKey );
+  mGL3RenderPass->setShaderProgram( mGL3Shader );
+  mGL3Technique->addRenderPass( mGL3RenderPass );
+  effect->addTechnique( mGL3Technique );
+
+  setEffect( effect );
+}
+
+void QgsGlobeMaterial::setTexture( Qt3DRender::QAbstractTexture *texture )
+{
+  mTextureParameter->setValue( QVariant::fromValue( texture ) );
+}
+
+Qt3DRender::QAbstractTexture *QgsGlobeMaterial::texture() const
+{
+  return mTextureParameter->value().value<Qt3DRender::QAbstractTexture *>();
+}
+
+void QgsGlobeMaterial::handleTextureChanged( const QVariant &var )
+{
+  emit textureChanged( var.value<Qt3DRender::QAbstractTexture *>() );
+}
+
+///@endcond PRIVATE

--- a/src/3d/materials/qgsglobematerial.h
+++ b/src/3d/materials/qgsglobematerial.h
@@ -1,0 +1,86 @@
+/***************************************************************************
+  qgsglobematerial.h
+  --------------------------------------
+  Date                 : April 2025
+  Copyright            : (C) 2025 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGLOBEMATERIAL_H
+#define QGSGLOBEMATERIAL_H
+
+#include "qgis_3d.h"
+#include "qgsmaterial.h"
+
+#include <QObject>
+
+#define SIP_NO_FILE
+
+// adapted from Qt's qtexturematerial.h
+namespace Qt3DRender
+{
+
+  class QFilterKey;
+  class QAbstractTexture;
+  class QTechnique;
+  class QParameter;
+  class QShaderProgram;
+  class QRenderPass;
+
+} // namespace Qt3DRender
+
+///@cond PRIVATE
+
+/**
+ * \ingroup qgis_3d
+ * \brief A material for globe mesh rendering - essentially an unlit texture material with some extras
+ * \since QGIS 3.44
+ */
+class _3D_EXPORT QgsGlobeMaterial : public QgsMaterial
+{
+    Q_OBJECT
+    Q_PROPERTY( Qt3DRender::QAbstractTexture *texture READ texture WRITE setTexture NOTIFY textureChanged )
+
+  public:
+    /**
+     * Constructor for QgsTextureMaterial, with the specified \a parent node.
+     */
+    explicit QgsGlobeMaterial( Qt3DCore::QNode *parent = nullptr );
+    ~QgsGlobeMaterial() override;
+
+    Qt3DRender::QAbstractTexture *texture() const;
+
+  public Q_SLOTS:
+
+    /**
+     * Sets the diffuse component of the material.
+     * Ownership is transferred to the material.
+     */
+    void setTexture( Qt3DRender::QAbstractTexture *texture );
+
+  Q_SIGNALS:
+    void textureChanged( Qt3DRender::QAbstractTexture *texture );
+
+  private:
+    void init();
+
+    void handleTextureChanged( const QVariant &var );
+
+    Qt3DRender::QParameter *mTextureParameter = nullptr;
+    Qt3DRender::QParameter *mDiffuseTextureScaleParameter = nullptr;
+    Qt3DRender::QTechnique *mGL3Technique = nullptr;
+    Qt3DRender::QRenderPass *mGL3RenderPass = nullptr;
+    Qt3DRender::QShaderProgram *mGL3Shader = nullptr;
+    Qt3DRender::QFilterKey *mFilterKey = nullptr;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSGLOBEMATERIAL_H

--- a/src/3d/qgsglobechunkedentity.cpp
+++ b/src/3d/qgsglobechunkedentity.cpp
@@ -40,7 +40,6 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include <Qt3DRender/QGeometryRenderer>
 #include <Qt3DRender/QTexture>
 #include <Qt3DRender/QTextureImage>
-#include <Qt3DExtras/QTextureMaterial>
 
 #include "qgs3dmapsettings.h"
 #include "qgs3dutils.h"
@@ -50,6 +49,7 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include "qgsdistancearea.h"
 #include "qgseventtracing.h"
 #include "qgsgeotransform.h"
+#include "qgsglobematerial.h"
 #include "qgsraycastingutils_p.h"
 #include "qgsterraintextureimage_p.h"
 #include "qgsterraintexturegenerator_p.h"
@@ -200,7 +200,7 @@ static Qt3DCore::QEntity *makeGlobeMesh( double lonMin, double lonMax, double la
   texture->setMinificationFilter( Qt3DRender::QTexture2D::Linear );
   texture->setMagnificationFilter( Qt3DRender::QTexture2D::Linear );
 
-  Qt3DExtras::QTextureMaterial *material = new Qt3DExtras::QTextureMaterial( entity );
+  QgsGlobeMaterial *material = new QgsGlobeMaterial( entity );
   material->setTexture( texture );
 
   QgsGeoTransform *geoTransform = new QgsGeoTransform( entity );
@@ -429,7 +429,7 @@ class QgsGlobeMapUpdateJob : public QgsChunkQueueJob
       , mTextureGenerator( textureGenerator )
     {
       // extract our terrain texture image from the 3D entity
-      QVector<Qt3DExtras::QTextureMaterial *> materials = node->entity()->componentsOfType<Qt3DExtras::QTextureMaterial>();
+      QVector<QgsGlobeMaterial *> materials = node->entity()->componentsOfType<QgsGlobeMaterial>();
       Q_ASSERT( materials.count() == 1 );
       QVector<Qt3DRender::QAbstractTextureImage *> texImages = materials[0]->texture()->textureImages();
       Q_ASSERT( texImages.count() == 1 );

--- a/src/3d/shaders.qrc
+++ b/src/3d/shaders.qrc
@@ -37,5 +37,6 @@
         <file>shaders/default.vert</file>
         <file>shaders/texture.frag</file>
         <file>shaders/texture.vert</file>
+        <file>shaders/globe.frag</file>
     </qresource>
 </RCC>

--- a/src/3d/shaders/globe.frag
+++ b/src/3d/shaders/globe.frag
@@ -1,0 +1,33 @@
+#version 330 core
+
+in vec3 worldPosition;
+in vec3 worldNormal;
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+uniform mat4 inverseViewMatrix;
+uniform sampler2D diffuseTexture;
+
+void main()
+{
+  // general idea of the fragment shader: for better 3d perception, we are darkening
+  // the globe's texture a bit towards the edges of the ellipsoid. We use camera's
+  // view direction and normal vector of the globe's geometry: the larger the angle
+  // between them, the darker the color should be.
+
+  vec3 cameraWorldPos = vec3(inverseViewMatrix[3]);
+  vec3 viewDir = normalize(cameraWorldPos - worldPosition);
+
+  // note: the constants below are just artistic choices to get decently looking shading
+
+  // we apply shading only when we're far from the globe, so that closer
+  // views do not get the globe's texture darkened (e.g. when looking towards horizon)
+  float distFromCamera = length(cameraWorldPos - worldPosition);
+  float shadingFactor = smoothstep(2e5, 5e5, distFromCamera);
+
+  // dot product of the normal and the view direction is the cosine of the angle between them
+  float diff = max(dot(worldNormal, viewDir), 0.0);
+
+  fragColor = texture(diffuseTexture, texCoord) * (0.3 + 0.7 * mix(1.0, diff, shadingFactor));
+}


### PR DESCRIPTION
The general idea is that for a better 3d perception, we are darkening the globe's texture a bit towards the edges of the ellipsoid, making it look like a sphere.

It helps a lot with projects where the project extent is relatively small, and when zoomed to the whole globe, we would otherwise get a white globe on white background.

We use camera's view direction and normal vector of the globe's geometry: the larger the angle between them, the darker the color should be. We don't need any special lights - camera kind of acts as a light source.

As we get closer to the globe, the shading effect disappears - it is not needed anymore and it would just unnecessarily make the globe's texture darker (currently it is starting to disappear at ~500 km from the globe, completely gone at the distance of ~200 km).

Globe with the world's countries gpkg loaded in the project:

<img src="https://github.com/user-attachments/assets/aae0c056-8c0c-4788-b99d-6b8ff04d0c32" alt="Globe with shading" width="400">
