### PR TITLE
fix for #61389

### DIFF
--- a/src/core/qgsarchive.cpp
+++ b/src/core/qgsarchive.cpp
@@ -64,10 +64,7 @@ void QgsArchive::clear()
 
 bool QgsArchive::zip( const QString &filename )
 {
-  QTemporaryFile tmpFilePath( QDir::temp().absoluteFilePath( QStringLiteral( "qgis-project-XXXXXX.zip" ) ) );
-  tmpFilePath.open();
-  tmpFilePath.close();
-  const QString tempPath = tmpFilePath.fileName();
+  const QString tempPath( QDir::temp().absoluteFilePath( QStringLiteral( "qgis-project-XXXXXX.zip" ) ) );
 
   // zip content
   if ( ! QgsZipUtils::zip( tempPath, mFiles, true ) )


### PR DESCRIPTION
QTemporaryFile apparently keeps the file open and prevents it's rename on Windows.