### PR TITLE
Fix panning in 3D globe view

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -26,6 +26,7 @@
 #include <QDomDocument>
 #include <Qt3DRender/QCamera>
 #include <Qt3DInput>
+#include <QStringLiteral>
 #include <cmath>
 
 #include "qgslogger.h"
@@ -265,6 +266,11 @@ void QgsCameraController::readXml( const QDomElement &elem )
 
 double QgsCameraController::sampleDepthBuffer( int px, int py )
 {
+  if ( !mDepthBufferIsReady )
+  {
+    QgsDebugError( QStringLiteral( "Asked to sample depth buffer, but depth buffer not ready!" ) );
+  }
+
   double depth = 1;
 
   if ( QWindow *win = window() )

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -416,6 +416,7 @@ class _3D_EXPORT QgsCameraController : public QObject
     //! click point for a rotation or a translation
     QPoint mClickPoint;
 
+    // false when no depth buffer captured or new capture requested and not yet done.
     bool mDepthBufferIsReady = false;
     QImage mDepthBufferImage;
     // -1 when unset


### PR DESCRIPTION
## Description

Since  #61404, panning (more correctly rotating the globe) in the 3D globe view has been broken. Currently, the code casts rays using the depth buffer obtained at the start of the move, moving the camera to follow the intersection. This only really works well for scenes where the "terrain height" is uniform and not for e.g. zoomed-in city buildings.  
Furthermore, the aforementioned PR completely broke this by assuming that rays are only cast using the camera used to capture the depth buffer (this was done to fix issues with varying near/far planes).

This PR fixes these issues by rewriting the logic of panning for globes. Instead of using the depth buffer for every action, we now only use it to find the grabbed point, and construct a "virtual" sphere around the origin for determining how far to move.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
