### PR TITLE
[themes] Fix ugly top padding for title-less Q*GroupBox

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -705,8 +705,11 @@ QRadioButton::indicator:hover
 /* ==================================================================================== */
 
 QGroupBox {
-    padding-top: 1.05em;
     border:1px solid rgba(0,0,0,0);
+}
+
+QGroupBox[title^=""] {
+    padding-top: 1.05em;
 }
 
 QGroupBox::title { 

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -704,8 +704,11 @@ QRadioButton::indicator:hover
 /* ==================================================================================== */
 
 QGroupBox {
-    padding-top: 1.05em;
     border:1px solid rgba(0,0,0,0);
+}
+
+QGroupBox[title^=""] {
+    padding-top: 1.05em;
 }
 
 QGroupBox::title { 


### PR DESCRIPTION
## Description

This commit gets ride of the top padding within QGroupBox/QgsCollapsibleGroupBox when no title is set. 

Before (left) vs. PR (right)

![image](https://github.com/user-attachments/assets/7546473b-ed04-4a4e-8915-a6cfb22fee07)

There's still a bit too much padding/margin below the box, but that's not something we can address in the stylesheet, and probably isn't something we'd want in most cases.