### PR TITLE
add initial center initialization methods in KMeans clustering

### DIFF
--- a/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
@@ -308,7 +308,7 @@ void QgsKMeansClusteringAlgorithm::initAdditionalCenters( std::vector<Feature> &
     distances[j] = points[j].point.sqrDist( centers[0] );
   }
 
-  for ( std::size_t j = 1; j < initializedCenters; j++ )
+  for ( int j = 1; j < initializedCenters; j++ )
   {
     distances[j] = -1;
   }

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
@@ -72,7 +72,7 @@ QString QgsKMeansClusteringAlgorithm::shortHelpString() const
 {
   return QObject::tr( "Calculates the 2D distance based k-means cluster number for each input feature.\n\n"
                       "If input geometries are lines or polygons, the clustering is based on the centroid of the feature.\n\n"
-                      "Intialization of the cluster centers can be done using either the farthest points method or the k-means++ method.");
+                      "Intialization of the cluster centers can be done using either the farthest points method or the k-means++ method." );
 }
 
 QgsKMeansClusteringAlgorithm *QgsKMeansClusteringAlgorithm::createInstance() const
@@ -286,17 +286,17 @@ void QgsKMeansClusteringAlgorithm::initCentersPlusPlus( std::vector<Feature> &po
   }
 
   // randomly select the first point
-  std::random_device rd;  
-  std::mt19937 gen(rd()); 
+  std::random_device rd;
+  std::mt19937 gen( rd() );
   // uniform distribution between 0 and n-1
-  std::uniform_int_distribution<> distrib(0, n - 1);
-  int p1 = distrib(gen);
+  std::uniform_int_distribution<> distrib( 0, n - 1 );
+  int p1 = distrib( gen );
 
   centers[0] = points[p1].point;
   initAdditionalCenters( points, centers, k, 1 );
 }
 
-void QgsKMeansClusteringAlgorithm::initAdditionalCenters( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, const int k, const int initializedCenters)
+void QgsKMeansClusteringAlgorithm::initAdditionalCenters( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, const int k, const int initializedCenters )
 {
   const std::size_t n = points.size();
   // array of minimum distance to a point from accepted cluster centers

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -57,7 +57,9 @@ class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsProcessingAlgorit
         int cluster = -1;
     };
 
-    static void initClusters( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
+    static void initCentersFarthestPoints( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
+    static void initCentersPlusPlus( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, const int k );
+    static void initAdditionalCenters( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, const int k, const int initializedCenters);
     static void calculateKMeans( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     static void findNearest( std::vector<Feature> &points, const std::vector<QgsPointXY> &centers, int k, bool &changed );
     static void updateMeans( const std::vector<Feature> &points, std::vector<QgsPointXY> &centers, std::vector<uint> &weights, int k );

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -59,7 +59,7 @@ class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsProcessingAlgorit
 
     static void initCentersFarthestPoints( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     static void initCentersPlusPlus( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, const int k );
-    static void initAdditionalCenters( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, const int k, const int initializedCenters);
+    static void initAdditionalCenters( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, const int k, const int initializedCenters );
     static void calculateKMeans( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     static void findNearest( std::vector<Feature> &points, const std::vector<QgsPointXY> &centers, int k, bool &changed );
     static void updateMeans( const std::vector<Feature> &points, std::vector<QgsPointXY> &centers, std::vector<uint> &weights, int k );

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -1016,45 +1016,85 @@ void TestQgsProcessingAlgsPt1::kmeansCluster()
 
   // no features, no crash
   int k = 2;
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  // farthest points
+  QgsKMeansClusteringAlgorithm::initCentersFarthestPoints( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  // kmeans++
+  QgsKMeansClusteringAlgorithm::initCentersPlusPlus( features, centers, k );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
 
   // features < clusters
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 1, 5 ) ) );
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  // farthest points
+  centers.clear();
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 1, 1 ) ) );
+  QgsKMeansClusteringAlgorithm::initCentersFarthestPoints( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  QCOMPARE( features[0].cluster, 0 );
+  // kmeans++
+  centers.clear();
+  QgsKMeansClusteringAlgorithm::initCentersPlusPlus( features, centers, k );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 0 );
 
   // features == clusters
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 11, 5 ) ) );
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  // farthest points
+  centers.clear();
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 3, 1 ) ) );
+  QgsKMeansClusteringAlgorithm::initCentersFarthestPoints( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 1 );
   QCOMPARE( features[1].cluster, 0 );
+  // kmeans++
+  centers.clear();
+  QgsKMeansClusteringAlgorithm::initCentersPlusPlus( features, centers, k );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  QVERIFY( features[0].cluster != features[1].cluster );
+  QVERIFY( features[0].cluster != -1 );
+  QVERIFY( features[1].cluster != -1 );
 
   // features > clusters
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 13, 3 ) ) );
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 13, 13 ) ) );
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 23, 6 ) ) );
+  // farthest points
+  centers.clear();
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 2, 7 ) ) );
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 1, 10 ) ) );
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 3, 10 ) ) );
   k = 2;
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::initCentersFarthestPoints( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 1 );
   QCOMPARE( features[1].cluster, 1 );
   QCOMPARE( features[2].cluster, 0 );
   QCOMPARE( features[3].cluster, 0 );
   QCOMPARE( features[4].cluster, 0 );
+  // kmeans++
+  centers.clear();
+  QgsKMeansClusteringAlgorithm::initCentersPlusPlus( features, centers, k );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  QCOMPARE( features[0].cluster, features[1].cluster );
+  QVERIFY( features[0].cluster != features[2].cluster );
+  QVERIFY( features[0].cluster != features[3].cluster );
+  QVERIFY( features[0].cluster != features[4].cluster );
 
   // repeat above, with 3 clusters
+  // farthest points
   k = 3;
   centers.resize( 3 );
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::initCentersFarthestPoints( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 1 );
-  QCOMPARE( features[1].cluster, 2 );
+  QCOMPARE( features[1].cluster, 1 );
   QCOMPARE( features[2].cluster, 2 );
-  QCOMPARE( features[3].cluster, 2 );
+  QCOMPARE( features[3].cluster, 0 );
   QCOMPARE( features[4].cluster, 0 );
+  // kmeans++
+  centers.clear();
+  QgsKMeansClusteringAlgorithm::initCentersPlusPlus( features, centers, k );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  QCOMPARE( features[0].cluster, features[1].cluster );
+  QVERIFY( features[0].cluster != features[3].cluster );
+  QCOMPARE( features[3].cluster, features[4].cluster );
+  QVERIFY( features[0].cluster != features[2].cluster );
+  QVERIFY( features[3].cluster != features[2].cluster );
 
   // with identical points
   features.clear();


### PR DESCRIPTION
I noticed that the number of iterations in KMeans remains the same across runs, which is due to the use of a deterministic farthest point initialization method.

This PR adds support for the KMeans++ initialization method. The key difference is that KMeans++ randomly selects the first center, while subsequent centers are chosen similarly to the farthest point method ensuring they are spread out as much as possible.

A METHOD combobox has been introduced, allowing users to choose between the two initialization strategies. The farthest point method remains the default.

![image](https://github.com/user-attachments/assets/ef0cfc58-cd98-45da-8697-79576d1b263a)

https://theory.stanford.edu/~sergei/slides/BATS-Means.pdf
https://theory.stanford.edu/~sergei/papers/kMeansPP-soda.pdf
