### PR TITLE
[vectortiles] Never try to request every tile in a zoom level

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -327,6 +327,22 @@ A null rectangle is also an empty rectangle.
 .. seealso:: :py:func:`setNull`
 %End
 
+    bool isMaximal() const;
+%Docstring
+Test if the rectangle is the maximal possible rectangle.
+
+A rectangle is considered maximal if all boundaries are either at their
+maximum possible values or are infinite values.
+
+.. seealso:: :py:func:`isFinite`
+
+.. seealso:: :py:func:`isNull`
+
+.. seealso:: :py:func:`isEmpty`
+
+.. versionadded:: 3.44
+%End
+
     QString asWktCoordinates() const;
 %Docstring
 Returns a string representation of the rectangle in WKT format.
@@ -364,6 +380,12 @@ Returns the rectangle as a polygon.
 %Docstring
 Returns ``True`` if the rectangle has finite boundaries. Will return
 ``False`` if any of the rectangle boundaries are NaN or Inf.
+
+.. seealso:: :py:func:`isMaximal`
+
+.. seealso:: :py:func:`isNull`
+
+.. seealso:: :py:func:`isEmpty`
 %End
 
     void invert();

--- a/python/PyQt6/core/auto_generated/qgstiles.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstiles.sip.in
@@ -103,6 +103,13 @@ Returns index of the first row in the range
 Returns index of the last row in the range
 %End
 
+    int count() const;
+%Docstring
+Returns the total number of tiles in the range.
+
+.. versionadded:: 3.44
+%End
+
 };
 
 

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -327,6 +327,22 @@ A null rectangle is also an empty rectangle.
 .. seealso:: :py:func:`setNull`
 %End
 
+    bool isMaximal() const;
+%Docstring
+Test if the rectangle is the maximal possible rectangle.
+
+A rectangle is considered maximal if all boundaries are either at their
+maximum possible values or are infinite values.
+
+.. seealso:: :py:func:`isFinite`
+
+.. seealso:: :py:func:`isNull`
+
+.. seealso:: :py:func:`isEmpty`
+
+.. versionadded:: 3.44
+%End
+
     QString asWktCoordinates() const;
 %Docstring
 Returns a string representation of the rectangle in WKT format.
@@ -364,6 +380,12 @@ Returns the rectangle as a polygon.
 %Docstring
 Returns ``True`` if the rectangle has finite boundaries. Will return
 ``False`` if any of the rectangle boundaries are NaN or Inf.
+
+.. seealso:: :py:func:`isMaximal`
+
+.. seealso:: :py:func:`isNull`
+
+.. seealso:: :py:func:`isEmpty`
 %End
 
     void invert();

--- a/python/core/auto_generated/qgstiles.sip.in
+++ b/python/core/auto_generated/qgstiles.sip.in
@@ -103,6 +103,13 @@ Returns index of the first row in the range
 Returns index of the last row in the range
 %End
 
+    int count() const;
+%Docstring
+Returns the total number of tiles in the range.
+
+.. versionadded:: 3.44
+%End
+
 };
 
 

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -532,6 +532,26 @@ class CORE_EXPORT QgsRectangle
     }
 
     /**
+     * Test if the rectangle is the maximal possible rectangle.
+     *
+     * A rectangle is considered maximal if all boundaries
+     * are either at their maximum possible values or are infinite values.
+     *
+     * \see isFinite()
+     * \see isNull()
+     * \see isEmpty()
+     *
+     * \since QGIS 3.44
+     */
+    bool isMaximal() const
+    {
+      return ( std::isinf( mXmin ) || mXmin == std::numeric_limits<double>::lowest() )
+             && ( std::isinf( mYmin ) || mYmin == std::numeric_limits<double>::lowest() )
+             && ( std::isinf( mXmax ) || mXmax == std::numeric_limits<double>::max() )
+             && ( std::isinf( mYmax ) || mYmax == std::numeric_limits<double>::max() );
+    }
+
+    /**
      * Returns a string representation of the rectangle in WKT format.
      */
     Q_INVOKABLE QString asWktCoordinates() const;
@@ -592,6 +612,10 @@ class CORE_EXPORT QgsRectangle
     /**
      * Returns TRUE if the rectangle has finite boundaries. Will
      * return FALSE if any of the rectangle boundaries are NaN or Inf.
+     *
+     * \see isMaximal()
+     * \see isNull()
+     * \see isEmpty()
      */
     bool isFinite() const
     {

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -113,6 +113,13 @@ class CORE_EXPORT QgsTileRange
     //! Returns index of the last row in the range
     int endRow() const { return mEndRow; }
 
+    /**
+     * Returns the total number of tiles in the range.
+     *
+     * \since QGIS 3.44
+     */
+    int count() const { return isValid() ? ( mEndRow - mStartRow + 1 ) * ( mEndColumn - mStartColumn + 1 ) : 0; }
+
   private:
     int mStartColumn = -1;
     int mEndColumn = -1;

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -108,7 +108,34 @@ bool QgsVectorTileLayerRenderer::render()
   tTotal.start();
 
   const double tileRenderScale = mTileMatrixSet.scaleForRenderContext( ctx );
-  QgsDebugMsgLevel( QStringLiteral( "Vector tiles rendering extent: " ) + ctx.extent().toString( -1 ), 2 );
+
+  QgsRectangle extent = ctx.extent();
+  if ( extent.isMaximal() )
+  {
+    // invalid extent. We don't want to fetch ALL tiles at the zoom level!
+    // This has occurred because the map renderer is being pessimistic and thinks a worst-case
+    // scenario is acceptable when it failed to transform the map extent to the layer's crs.
+    // But while that's permissible eg for a local raster layer, it's entirely inappropriate
+    // for vector tiles!
+    // So let's try and determine a MINIMAL extent for the layer, avoiding the pessimism used
+    // in the generic map renderer code
+    QgsCoordinateTransform layerToMapTransform = ctx.coordinateTransform();
+    layerToMapTransform.setAllowFallbackTransforms( true );
+    layerToMapTransform.setBallparkTransformsAreAppropriate( true );
+
+    QgsRectangle extentInMapCrs = ctx.mapExtent();
+    try
+    {
+      extent = layerToMapTransform.transformBoundingBox( extentInMapCrs, Qgis::TransformDirection::Reverse );
+    }
+    catch ( QgsCsException &cs )
+    {
+      QgsDebugError( QStringLiteral( "Could not transform map extent to layer extent -- cannot calculate valid extent for vector tiles, aborting: %1" ).arg( cs.what() ) );
+      return false;
+    }
+  }
+
+  QgsDebugMsgLevel( QStringLiteral( "Vector tiles rendering extent: " ) + extent.toString( -1 ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "Vector tiles map scale 1 : %1" ).arg( tileRenderScale ), 2 );
 
   mTileZoomToFetch = mTileMatrixSet.scaleToZoomLevel( tileRenderScale );
@@ -118,13 +145,13 @@ bool QgsVectorTileLayerRenderer::render()
 
   mTileMatrix = mTileMatrixSet.tileMatrix( mTileZoomToFetch );
 
-  mTileRange = mTileMatrix.tileRangeFromExtent( ctx.extent() );
-  QgsDebugMsgLevel( QStringLiteral( "Vector tiles range X: %1 - %2  Y: %3 - %4" )
+  mTileRange = mTileMatrix.tileRangeFromExtent( extent );
+  QgsDebugMsgLevel( QStringLiteral( "Vector tiles range X: %1 - %2  Y: %3 - %4 (%5 tiles total)" )
                     .arg( mTileRange.startColumn() ).arg( mTileRange.endColumn() )
-                    .arg( mTileRange.startRow() ).arg( mTileRange.endRow() ), 2 );
+                    .arg( mTileRange.startRow() ).arg( mTileRange.endRow() ).arg( mTileRange.count() ), 2 );
 
   // view center is used to sort the order of tiles for fetching and rendering
-  const QPointF viewCenter = mTileMatrix.mapToTileCoordinates( ctx.extent().center() );
+  const QPointF viewCenter = mTileMatrix.mapToTileCoordinates( extent.center() );
 
   if ( !mTileRange.isValid() )
   {

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -43,6 +43,7 @@ class TestQgsRectangle : public QObject
     void include();
     void buffered();
     void isFinite();
+    void maximal();
     void combine();
     void dataStream();
     void scale();
@@ -529,6 +530,21 @@ void TestQgsRectangle::isFinite()
   QVERIFY( !QgsRectangle( 1, std::numeric_limits<double>::quiet_NaN(), 3, 4 ).isFinite() );
   QVERIFY( !QgsRectangle( 1, 2, std::numeric_limits<double>::quiet_NaN(), 4 ).isFinite() );
   QVERIFY( !QgsRectangle( 1, 2, 3, std::numeric_limits<double>::quiet_NaN() ).isFinite() );
+}
+
+void TestQgsRectangle::maximal()
+{
+  QVERIFY( !QgsRectangle( 1, 2, 3, 4 ).isMaximal() );
+  QVERIFY( !QgsRectangle( std::numeric_limits<double>::infinity(), 2, 3, 4 ).isMaximal() );
+  QVERIFY( !QgsRectangle( 1, std::numeric_limits<double>::infinity(), 3, 4 ).isMaximal() );
+  QVERIFY( !QgsRectangle( 1, 2, std::numeric_limits<double>::infinity(), 4 ).isMaximal() );
+  QVERIFY( !QgsRectangle( 1, 2, 3, std::numeric_limits<double>::infinity() ).isMaximal() );
+  QVERIFY( QgsRectangle( std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity() ).isMaximal() );
+  QVERIFY( !QgsRectangle( std::numeric_limits<double>::lowest(), 2, 3, 4 ).isMaximal() );
+  QVERIFY( !QgsRectangle( 1, std::numeric_limits<double>::lowest(), 3, 4 ).isMaximal() );
+  QVERIFY( !QgsRectangle( 1, 2, std::numeric_limits<double>::max(), 4 ).isMaximal() );
+  QVERIFY( !QgsRectangle( 1, 2, 3, std::numeric_limits<double>::max() ).isMaximal() );
+  QVERIFY( QgsRectangle( std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max() ).isMaximal() );
 }
 
 void TestQgsRectangle::combine()

--- a/tests/src/python/test_qgstiles.py
+++ b/tests/src/python/test_qgstiles.py
@@ -60,10 +60,14 @@ class TestQgsTiles(QgisTestCase):
         self.assertEqual(range.startRow(), 3)
         self.assertEqual(range.endRow(), 4)
         self.assertTrue(range.isValid())
+        self.assertEqual(range.count(), 4)
+        range = QgsTileRange(1, 10, 3, 6)
+        self.assertEqual(range.count(), 40)
 
         # invalid range
         range = QgsTileRange()
         self.assertFalse(range.isValid())
+        self.assertEqual(range.count(), 0)
 
     def testQgsTileMatrix(self):
         matrix = QgsTileMatrix.fromCustomDef(


### PR DESCRIPTION
In certain circumstances (eg map in geographic CRS, including +/-180 long or +/- 90 lat within map bounds), the extent
passed to the map layer renderers is a maximal extent indicating that the generic map renderer code could not successfully
reproject the map extent to the layer's crs.

This is BAD for vector tiles, as it results in us trying to fetch EVERY SINGLE TILE IN THE WORLD for a given zoom level!!!1!

Add special logic to the vector tile renderer to catch this situation is attempt to determine a minimal extent to fetch, or
fail gracefully.

This is especially relevant when vector tiles are used in a 3d globe, as this will hit the +/-180 +/- 90 trigger.