### PR TITLE
Fix saving/loading globe 3D view

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -244,12 +244,17 @@ QDomElement QgsCameraController::writeXml( QDomDocument &doc ) const
 {
   QDomElement elemCamera = doc.createElement( QStringLiteral( "camera" ) );
   QgsVector3D centerPoint;
-  if ( mScene->mapSettings()->sceneMode() == Qgis::SceneMode::Local )
-    centerPoint = mCameraPose.centerPoint();
-  else if ( mScene->mapSettings()->sceneMode() == Qgis::SceneMode::Globe )
-    // Save center point in map coordinates, since our world origin won't be
-    // the same on loading
-    centerPoint = mCameraPose.centerPoint() + mOrigin;
+  switch ( mScene->mapSettings()->sceneMode() )
+  {
+    case Qgis::SceneMode::Local:
+      centerPoint = mCameraPose.centerPoint();
+      break;
+    case Qgis::SceneMode::Globe:
+      // Save center point in map coordinates, since our world origin won't be
+      // the same on loading
+      centerPoint = mCameraPose.centerPoint() + mOrigin;
+      break;
+  }
   elemCamera.setAttribute( QStringLiteral( "x" ), centerPoint.x() );
   elemCamera.setAttribute( QStringLiteral( "y" ), centerPoint.z() );
   elemCamera.setAttribute( QStringLiteral( "elev" ), centerPoint.y() );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -243,9 +243,16 @@ void QgsCameraController::setCameraPose( const QgsCameraPose &camPose, bool forc
 QDomElement QgsCameraController::writeXml( QDomDocument &doc ) const
 {
   QDomElement elemCamera = doc.createElement( QStringLiteral( "camera" ) );
-  elemCamera.setAttribute( QStringLiteral( "x" ), mCameraPose.centerPoint().x() );
-  elemCamera.setAttribute( QStringLiteral( "y" ), mCameraPose.centerPoint().z() );
-  elemCamera.setAttribute( QStringLiteral( "elev" ), mCameraPose.centerPoint().y() );
+  QgsVector3D centerPoint;
+  if ( mScene->mapSettings()->sceneMode() == Qgis::SceneMode::Local )
+    centerPoint = mCameraPose.centerPoint();
+  else if ( mScene->mapSettings()->sceneMode() == Qgis::SceneMode::Globe )
+    // Save center point in map coordinates, since our world origin won't be
+    // the same on loading
+    centerPoint = mCameraPose.centerPoint() + mOrigin;
+  elemCamera.setAttribute( QStringLiteral( "x" ), centerPoint.x() );
+  elemCamera.setAttribute( QStringLiteral( "y" ), centerPoint.z() );
+  elemCamera.setAttribute( QStringLiteral( "elev" ), centerPoint.y() );
   elemCamera.setAttribute( QStringLiteral( "dist" ), mCameraPose.distanceFromCenterPoint() );
   elemCamera.setAttribute( QStringLiteral( "pitch" ), mCameraPose.pitchAngle() );
   elemCamera.setAttribute( QStringLiteral( "yaw" ), mCameraPose.headingAngle() );
@@ -260,7 +267,10 @@ void QgsCameraController::readXml( const QDomElement &elem )
   const float dist = elem.attribute( QStringLiteral( "dist" ) ).toFloat();
   const float pitch = elem.attribute( QStringLiteral( "pitch" ) ).toFloat();
   const float yaw = elem.attribute( QStringLiteral( "yaw" ) ).toFloat();
-  setLookingAtPoint( QgsVector3D( x, elev, y ), dist, pitch, yaw );
+  QgsVector3D centerPoint( x, elev, y );
+  if ( mScene->mapSettings()->sceneMode() == Qgis::SceneMode::Globe )
+    centerPoint = centerPoint - mOrigin;
+  setLookingAtPoint( centerPoint, dist, pitch, yaw );
 }
 
 double QgsCameraController::sampleDepthBuffer( int px, int py )


### PR DESCRIPTION
## Description

Currently the XML saving/loading code in `QgsCameraController` doesn't handle the globe mode as a special case. This leads to it saving the camera center point's coordinates verbatim, but these coordinates are relative to `mOrigin` ("in world coordinates"), which will likely be different when the 3D view is loaded anew.

This PR fixes the issue by saving the center point "in map coordinates" instead.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
