### PR TITLE
fix interpolation and heatmap algs qt6

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -11,7 +11,6 @@ on:
       - release-**
       - queued_ltr_backports
   pull_request:
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -11,6 +11,7 @@ on:
       - release-**
       - queued_ltr_backports
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -166,7 +166,7 @@ class IdwInterpolation(QgisAlgorithm):
             data.transformContext = context.transformContext()
             layers.append(layer)
 
-            data.valueSource = int(v[1])
+            data.valueSource = QgsInterpolator.ValueSource(int(v[1]))
             data.interpolationAttribute = int(v[2])
             if (
                 data.valueSource == QgsInterpolator.ValueSource.ValueAttribute

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -180,7 +180,7 @@ class TinInterpolation(QgisAlgorithm):
             if not crs.isValid():
                 crs = layer.sourceCrs()
 
-            data.valueSource = int(v[1])
+            data.valueSource = QgsInterpolator.ValueSource(int(v[1]))
             data.interpolationAttribute = int(v[2])
             if (
                 data.valueSource == QgsInterpolator.ValueSource.ValueAttribute

--- a/python/plugins/processing/algs/qgis/ui/HeatmapWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/HeatmapWidgets.py
@@ -190,13 +190,13 @@ class HeatmapPixelSizeWidgetWrapper(WidgetWrapper):
             return
 
         for wrapper in wrappers:
-            if wrapper.parameterDefinition().name() == self.param.parent_layer:
+            if wrapper.parameterDefinition().name() == self.parameterDefinition().parent_layer:
                 self.setSource(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.parentLayerChanged)
-            elif wrapper.parameterDefinition().name() == self.param.radius_param:
+            elif wrapper.parameterDefinition().name() == self.parameterDefinition().radius_param:
                 self.setRadius(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.radiusChanged)
-            elif wrapper.parameterDefinition().name() == self.param.radius_field_param:
+            elif wrapper.parameterDefinition().name() == self.parameterDefinition().radius_field_param:
                 self.setSource(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.radiusFieldChanged)
 

--- a/python/plugins/processing/algs/qgis/ui/HeatmapWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/HeatmapWidgets.py
@@ -190,13 +190,22 @@ class HeatmapPixelSizeWidgetWrapper(WidgetWrapper):
             return
 
         for wrapper in wrappers:
-            if wrapper.parameterDefinition().name() == self.parameterDefinition().parent_layer:
+            if (
+                wrapper.parameterDefinition().name()
+                == self.parameterDefinition().parent_layer
+            ):
                 self.setSource(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.parentLayerChanged)
-            elif wrapper.parameterDefinition().name() == self.parameterDefinition().radius_param:
+            elif (
+                wrapper.parameterDefinition().name()
+                == self.parameterDefinition().radius_param
+            ):
                 self.setRadius(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.radiusChanged)
-            elif wrapper.parameterDefinition().name() == self.parameterDefinition().radius_field_param:
+            elif (
+                wrapper.parameterDefinition().name()
+                == self.parameterDefinition().radius_field_param
+            ):
                 self.setSource(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.radiusFieldChanged)
 

--- a/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
@@ -425,10 +425,10 @@ class PixelSizeWidgetWrapper(WidgetWrapper):
             return
 
         for wrapper in wrappers:
-            if wrapper.parameterDefinition().name() == self.param.layersData:
+            if wrapper.parameterDefinition().name() == self.parameterDefinition().layersData:
                 self.setLayers(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.layersChanged)
-            elif wrapper.parameterDefinition().name() == self.param.extent:
+            elif wrapper.parameterDefinition().name() == self.parameterDefinition().extent:
                 self.setExtent(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.extentChanged)
 

--- a/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
@@ -425,10 +425,16 @@ class PixelSizeWidgetWrapper(WidgetWrapper):
             return
 
         for wrapper in wrappers:
-            if wrapper.parameterDefinition().name() == self.parameterDefinition().layersData:
+            if (
+                wrapper.parameterDefinition().name()
+                == self.parameterDefinition().layersData
+            ):
                 self.setLayers(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.layersChanged)
-            elif wrapper.parameterDefinition().name() == self.parameterDefinition().extent:
+            elif (
+                wrapper.parameterDefinition().name()
+                == self.parameterDefinition().extent
+            ):
                 self.setExtent(wrapper.parameterValue())
                 wrapper.widgetValueHasChanged.connect(self.extentChanged)
 


### PR DESCRIPTION
fix: #61615 

Fixes opening of TIN and IDW interpolation and Heatmap alg dialogs on Qt6 builds (replacing self.param which is not accessible in the Qt6 build with self.parameterDefinition()), as well as actually running TIN and IDW algs.

In TIN and IDW algs, valueSource requires QgsInterpolator.ValueSource and not int as per the error: 

`TypeError: a member of enum 'ValueSource' is expected not 'int'`

when running the algs, but those are enums with no defined values, so can be accessed with indexes.

It does not break the Qt5 build (tested with the newest version).