### PR TITLE
[SERVER] Fix conditional short circuit statement

### DIFF
--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -484,14 +484,16 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
         // TODO: QGIS 4 fix the OWS services and treat them as APIs
         if ( !response.feedback() || !response.feedback()->isCanceled() )
         {
-          if ( params.service().isEmpty() ) 
+          if ( params.service().isEmpty() )
           {
             QgsServerApi *api = sServiceRegistry->apiForRequest( request );
-            if ( api ) 
+            if ( api )
             {
-                const QgsServerApiContext context { api->rootPath(), &request, &responseDecorator, project, sServerInterface };
-                api->executeRequest( context );
-            } else {
+              const QgsServerApiContext context { api->rootPath(), &request, &responseDecorator, project, sServerInterface };
+              api->executeRequest( context );
+            }
+            else
+            {
               throw QgsOgcServiceException(
                 QStringLiteral( "Service configuration error" ),
                 QStringLiteral( "Service unknown or unsupported. Current supported services "

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -482,14 +482,23 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
 
         // Dispatcher: if SERVICE is set, we assume a OWS service, if not, let's try an API
         // TODO: QGIS 4 fix the OWS services and treat them as APIs
-        QgsServerApi *api = nullptr;
-
         if ( !response.feedback() || !response.feedback()->isCanceled() )
         {
-          if ( params.service().isEmpty() && ( api = sServiceRegistry->apiForRequest( request ) ) )
+          if ( params.service().isEmpty() ) 
           {
-            const QgsServerApiContext context { api->rootPath(), &request, &responseDecorator, project, sServerInterface };
-            api->executeRequest( context );
+            QgsServerApi *api = sServiceRegistry->apiForRequest( request );
+            if ( api ) 
+            {
+                const QgsServerApiContext context { api->rootPath(), &request, &responseDecorator, project, sServerInterface };
+                api->executeRequest( context );
+            } else {
+              throw QgsOgcServiceException(
+                QStringLiteral( "Service configuration error" ),
+                QStringLiteral( "Service unknown or unsupported. Current supported services "
+                                "(case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 "
+                                "(OGC API Features) endpoint" )
+              );
+            }
           }
           else
           {

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -525,12 +525,13 @@ class TestQgsServer(QgsServerTestBase):
         self.assertEqual(
             self.strip_version_xmlns(bytes(response.body())),
             self.strip_version_xmlns(
-                b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n'
+            ),
         )
         self.assertEqual(
             response.headers(),
             {"Content-Length": "365", "Content-Type": "text/xml; charset=utf-8"},
-            )
+        )
         self.assertEqual(response.statusCode(), 200)
 
     def test_requestHandlerProject(self):
@@ -544,7 +545,8 @@ class TestQgsServer(QgsServerTestBase):
         self.assertEqual(
             self.strip_version_xmlns(bytes(response.body())),
             self.strip_version_xmlns(
-                b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n'
+            ),
         )
         self.assertEqual(
             response.headers(),

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -523,14 +523,15 @@ class TestQgsServer(QgsServerTestBase):
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response)
         self.assertEqual(
-            bytes(response.body()),
-            b'<?xml version="1.0" encoding="UTF-8"?>\n<ServerException>Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file</ServerException>\n',
+            self.strip_version_xmlns(bytes(response.body())),
+            self.strip_version_xmlns(
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
         )
         self.assertEqual(
             response.headers(),
-            {"Content-Length": "195", "Content-Type": "text/xml; charset=utf-8"},
-        )
-        self.assertEqual(response.statusCode(), 500)
+            {"Content-Length": "365", "Content-Type": "text/xml; charset=utf-8"},
+            )
+        self.assertEqual(response.statusCode(), 200)
 
     def test_requestHandlerProject(self):
         """Test request handler with none project"""
@@ -541,14 +542,15 @@ class TestQgsServer(QgsServerTestBase):
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response, None)
         self.assertEqual(
-            bytes(response.body()),
-            b'<?xml version="1.0" encoding="UTF-8"?>\n<ServerException>Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file</ServerException>\n',
+            self.strip_version_xmlns(bytes(response.body())),
+            self.strip_version_xmlns(
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
         )
         self.assertEqual(
             response.headers(),
-            {"Content-Length": "195", "Content-Type": "text/xml; charset=utf-8"},
+            {"Content-Length": "365", "Content-Type": "text/xml; charset=utf-8"},
         )
-        self.assertEqual(response.statusCode(), 500)
+        self.assertEqual(response.statusCode(), 200)
 
     def test_api(self):
         """Using an empty query string (returns an XML exception)
@@ -557,10 +559,10 @@ class TestQgsServer(QgsServerTestBase):
         header, body = self._execute_request("")
         response = self.strip_version_xmlns(header + body)
         expected = self.strip_version_xmlns(
-            b'Content-Length: 195\nContent-Type: text/xml; charset=utf-8\n\n<?xml version="1.0" encoding="UTF-8"?>\n<ServerException>Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file</ServerException>\n'
+            b'Content-Length: 365\nContent-Type: text/xml; charset=utf-8\n\n<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n'
         )
         self.assertEqual(response, expected)
-        expected = b"Content-Length: 195\nContent-Type: text/xml; charset=utf-8\n\n"
+        expected = b"Content-Length: 365\nContent-Type: text/xml; charset=utf-8\n\n"
         self.assertEqual(header, expected)
 
         # Test response when project is specified but without service

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -209,7 +209,8 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
             self.assertEqual(
                 self.strip_version_xmlns(bytes(response.body())),
                 self.strip_version_xmlns(
-                    b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
+                    b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n'
+                ),
             )
 
         _test_error("http://server.qgis.org/index.json")

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -207,8 +207,9 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
             response = QgsBufferServerResponse()
             self.server.handleRequest(request, response)
             self.assertEqual(
-                bytes(response.body()),
-                b'<?xml version="1.0" encoding="UTF-8"?>\n<ServerException>Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file</ServerException>\n',
+                self.strip_version_xmlns(bytes(response.body())),
+                self.strip_version_xmlns(
+                    b'<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
             )
 
         _test_error("http://server.qgis.org/index.json")


### PR DESCRIPTION
## Description

The following conditional statement prevent lazy (short circuit) evaluation because of the assignement to `api`: 
```
if ( params.service().isEmpty() && ( api = sServiceRegistry->apiForRequest( request ) ) )
{
   ...
```
Thus, even if the `service` parameter is not set the `apiForRequest` method is still executed for nothing (and maybe unwanted side effects).

This PR ensure that if service is set then no matching api search is done. 