### PR TITLE
feat(3d/renderview): extract ambient occlusion renderview

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -81,6 +81,7 @@ set(QGIS_3D_SRCS
   framegraph/qgsabstractrenderview.cpp
   framegraph/qgs3daxisrenderview.cpp
   framegraph/qgsambientocclusionrenderentity.cpp
+  framegraph/qgsambientocclusionrenderview.cpp
   framegraph/qgsambientocclusionblurentity.cpp
   framegraph/qgsdebugtextureentity.cpp
   framegraph/qgsdebugtexturerenderview.cpp
@@ -195,6 +196,7 @@ set(QGIS_3D_HDRS
   framegraph/qgsabstractrenderview.h
   framegraph/qgs3daxisrenderview.h
   framegraph/qgsambientocclusionrenderentity.h
+  framegraph/qgsambientocclusionrenderview.h
   framegraph/qgsambientocclusionblurentity.h
   framegraph/qgsdebugtextureentity.h
   framegraph/qgsdebugtexturerenderview.h

--- a/src/3d/framegraph/qgsambientocclusionrenderview.cpp
+++ b/src/3d/framegraph/qgsambientocclusionrenderview.cpp
@@ -1,0 +1,183 @@
+/***************************************************************************
+  qgsambientocclusionrenderview.cpp
+  --------------------------------------
+  Date                 : June 2024
+  Copyright            : (C) 2024 by Benoit De Mezzo and (C) 2020 by Belgacem Nedjima
+  Email                : benoit dot de dot mezzo at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsambientocclusionrenderview.h"
+#include <Qt3DRender/QCamera>
+#include <Qt3DRender/QLayerFilter>
+#include <Qt3DRender/QLayer>
+#include <Qt3DRender/QRenderTargetSelector>
+#include <Qt3DRender/QRenderTarget>
+#include <Qt3DRender/QTexture>
+#include <Qt3DRender/QClearBuffers>
+#include <Qt3DRender/qsubtreeenabler.h>
+#include <Qt3DRender/QCameraSelector>
+#include <Qt3DRender/QRenderStateSet>
+#include <Qt3DRender/QDepthTest>
+#include <Qt3DRender/QCullFace>
+
+
+QgsAmbientOcclusionRenderView::QgsAmbientOcclusionRenderView( const QString &viewName, Qt3DRender::QCamera *mainCamera, QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity )
+  : QgsAbstractRenderView( viewName )
+  , mMainCamera( mainCamera )
+{
+  mAOPassLayer = new Qt3DRender::QLayer;
+  mAOPassLayer->setRecursive( true );
+  mAOPassLayer->setObjectName( mViewName + "::Layer(AO)" );
+
+  mBlurPassLayer = new Qt3DRender::QLayer;
+  mBlurPassLayer->setRecursive( true );
+  mBlurPassLayer->setObjectName( mViewName + "::Layer(Blur)" );
+
+  // ambient occlusion rendering pass
+  buildRenderPass( mSize, forwardDepthTexture, rootSceneEntity );
+}
+
+void QgsAmbientOcclusionRenderView::updateWindowResize( int width, int height )
+{
+  mAOPassTexture->setSize( width, height );
+  mBlurPassTexture->setSize( width, height );
+}
+
+void QgsAmbientOcclusionRenderView::setEnabled( bool enable )
+{
+  QgsAbstractRenderView::setEnabled( enable );
+  if ( mAmbientOcclusionRenderEntity != nullptr )
+    mAmbientOcclusionRenderEntity->setEnabled( enable );
+  if ( mAmbientOcclusionBlurEntity != nullptr )
+    mAmbientOcclusionBlurEntity->setEnabled( enable );
+}
+
+Qt3DRender::QRenderTarget *QgsAmbientOcclusionRenderView::buildTextures( QSize mSize )
+{
+  // Create a texture to render into.
+  Qt3DRender::QRenderTargetOutput *colorTargetOutput = new Qt3DRender::QRenderTargetOutput;
+  colorTargetOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
+
+  mBlurPassTexture = new Qt3DRender::QTexture2D( colorTargetOutput );
+  mBlurPassTexture->setSize( mSize.width(), mSize.height() );
+  mBlurPassTexture->setFormat( Qt3DRender::QAbstractTexture::R32F );
+  mBlurPassTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mBlurPassTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mBlurPassTexture->setObjectName( mViewName + "::ColorTarget" );
+  colorTargetOutput->setTexture( mBlurPassTexture );
+
+  Qt3DRender::QRenderTarget *renderTarget = new Qt3DRender::QRenderTarget;
+  renderTarget->addOutput( colorTargetOutput );
+
+  return renderTarget;
+}
+
+void QgsAmbientOcclusionRenderView::buildRenderPass( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity )
+{
+  // AO pass
+  {
+    Qt3DRender::QCameraSelector *cameraSelector = new Qt3DRender::QCameraSelector( mRendererEnabler );
+    cameraSelector->setObjectName( mViewName + "::CameraSelector(AO)" );
+    cameraSelector->setCamera( mMainCamera );
+
+    Qt3DRender::QRenderStateSet *renderStateSet = new Qt3DRender::QRenderStateSet( cameraSelector );
+
+    Qt3DRender::QDepthTest *depthRenderDepthTest = new Qt3DRender::QDepthTest;
+    depthRenderDepthTest->setDepthFunction( Qt3DRender::QDepthTest::Always );
+    Qt3DRender::QCullFace *depthRenderCullFace = new Qt3DRender::QCullFace;
+    depthRenderCullFace->setMode( Qt3DRender::QCullFace::NoCulling );
+
+    renderStateSet->addRenderState( depthRenderDepthTest );
+    renderStateSet->addRenderState( depthRenderCullFace );
+
+    Qt3DRender::QLayerFilter *layerFilter = new Qt3DRender::QLayerFilter( renderStateSet );
+    layerFilter->addLayer( mAOPassLayer );
+
+    Qt3DRender::QRenderTargetSelector *renderTargetSelector = new Qt3DRender::QRenderTargetSelector( layerFilter );
+    renderTargetSelector->setObjectName( mViewName + "::RenderTargetSelector(AO)" );
+
+    // create intermediate texture
+    Qt3DRender::QRenderTargetOutput *colorTargetOutput = new Qt3DRender::QRenderTargetOutput;
+    colorTargetOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
+
+    mAOPassTexture = new Qt3DRender::QTexture2D( colorTargetOutput );
+    mAOPassTexture->setSize( mSize.width(), mSize.height() );
+    mAOPassTexture->setFormat( Qt3DRender::QAbstractTexture::R32F );
+    mAOPassTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+    mAOPassTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+    mAOPassTexture->setObjectName( mViewName + "::ColorTarget(AO)" );
+    colorTargetOutput->setTexture( mAOPassTexture );
+
+    Qt3DRender::QRenderTarget *renderTarget = new Qt3DRender::QRenderTarget;
+    renderTarget->setObjectName( mViewName + "::Target(AO)" );
+    renderTarget->addOutput( colorTargetOutput );
+
+    renderTargetSelector->setTarget( renderTarget );
+
+    mAmbientOcclusionRenderEntity = new QgsAmbientOcclusionRenderEntity( forwardDepthTexture, mAOPassLayer, mMainCamera, rootSceneEntity );
+  }
+
+  // blur pass
+  {
+    Qt3DRender::QCameraSelector *cameraSelector = new Qt3DRender::QCameraSelector( mRendererEnabler );
+    cameraSelector->setObjectName( mViewName + "::CameraSelector(Blur)" );
+    cameraSelector->setCamera( mMainCamera );
+
+    Qt3DRender::QRenderStateSet *renderStateSet = new Qt3DRender::QRenderStateSet( cameraSelector );
+
+    Qt3DRender::QDepthTest *depthRenderDepthTest = new Qt3DRender::QDepthTest;
+    depthRenderDepthTest->setDepthFunction( Qt3DRender::QDepthTest::Always );
+    Qt3DRender::QCullFace *depthRenderCullFace = new Qt3DRender::QCullFace;
+    depthRenderCullFace->setMode( Qt3DRender::QCullFace::NoCulling );
+
+    renderStateSet->addRenderState( depthRenderDepthTest );
+    renderStateSet->addRenderState( depthRenderCullFace );
+
+    Qt3DRender::QLayerFilter *layerFilter = new Qt3DRender::QLayerFilter( renderStateSet );
+    layerFilter->addLayer( mBlurPassLayer );
+
+    Qt3DRender::QRenderTarget *renderTarget = buildTextures( mSize );
+
+    mRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( layerFilter );
+    mRenderTargetSelector->setObjectName( mViewName + "::RenderTargetSelector(Blur)" );
+    mRenderTargetSelector->setTarget( renderTarget );
+
+    mAmbientOcclusionBlurEntity = new QgsAmbientOcclusionBlurEntity( mAOPassTexture, mBlurPassLayer, rootSceneEntity );
+  }
+}
+
+void QgsAmbientOcclusionRenderView::setIntensity( float intensity )
+{
+  if ( mAmbientOcclusionRenderEntity != nullptr )
+  {
+    mAmbientOcclusionRenderEntity->setIntensity( intensity );
+  }
+}
+
+void QgsAmbientOcclusionRenderView::setRadius( float radius )
+{
+  if ( mAmbientOcclusionRenderEntity != nullptr )
+  {
+    mAmbientOcclusionRenderEntity->setRadius( radius );
+  }
+}
+
+void QgsAmbientOcclusionRenderView::setThreshold( float threshold )
+{
+  if ( mAmbientOcclusionRenderEntity != nullptr )
+  {
+    mAmbientOcclusionRenderEntity->setThreshold( threshold );
+  }
+}
+
+Qt3DRender::QTexture2D *QgsAmbientOcclusionRenderView::blurredFactorMapTexture() const
+{
+  return mBlurPassTexture;
+}

--- a/src/3d/framegraph/qgsambientocclusionrenderview.cpp
+++ b/src/3d/framegraph/qgsambientocclusionrenderview.cpp
@@ -32,7 +32,6 @@
 
 QgsAmbientOcclusionRenderView::QgsAmbientOcclusionRenderView( const QString &viewName, Qt3DRender::QCamera *mainCamera, QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity )
   : QgsAbstractRenderView( viewName )
-  , mMainCamera( mainCamera )
 {
   mAOPassLayer = new Qt3DRender::QLayer;
   mAOPassLayer->setRecursive( true );
@@ -43,7 +42,7 @@ QgsAmbientOcclusionRenderView::QgsAmbientOcclusionRenderView( const QString &vie
   mBlurPassLayer->setObjectName( mViewName + "::Layer(Blur)" );
 
   // ambient occlusion rendering pass
-  buildRenderPasses( mSize, forwardDepthTexture, rootSceneEntity );
+  buildRenderPasses( mSize, forwardDepthTexture, rootSceneEntity, mainCamera );
 }
 
 void QgsAmbientOcclusionRenderView::updateWindowResize( int width, int height )
@@ -99,7 +98,7 @@ Qt3DRender::QRenderTarget *QgsAmbientOcclusionRenderView::buildBlurTexture( QSiz
   return renderTarget;
 }
 
-void QgsAmbientOcclusionRenderView::buildRenderPasses( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity )
+void QgsAmbientOcclusionRenderView::buildRenderPasses( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity, Qt3DRender::QCamera *mainCamera )
 {
   // AO pass
   {
@@ -122,7 +121,7 @@ void QgsAmbientOcclusionRenderView::buildRenderPasses( QSize mSize, Qt3DRender::
     renderTargetSelector->setObjectName( mViewName + "::RenderTargetSelector(AO)" );
     renderTargetSelector->setTarget( renderTarget );
 
-    mAmbientOcclusionRenderEntity = new QgsAmbientOcclusionRenderEntity( forwardDepthTexture, mAOPassLayer, mMainCamera, rootSceneEntity );
+    mAmbientOcclusionRenderEntity = new QgsAmbientOcclusionRenderEntity( forwardDepthTexture, mAOPassLayer, mainCamera, rootSceneEntity );
   }
 
   // blur pass

--- a/src/3d/framegraph/qgsambientocclusionrenderview.h
+++ b/src/3d/framegraph/qgsambientocclusionrenderview.h
@@ -1,0 +1,90 @@
+/***************************************************************************
+  qgsambientocclusionrenderview.h
+  --------------------------------------
+  Date                 : June 2024
+  Copyright            : (C) 2024 by Benoit De Mezzo and (C) 2020 by Belgacem Nedjima
+  Email                : benoit dot de dot mezzo at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAMBIENTOCCLUSIONRENDERVIEW_H
+#define QGSAMBIENTOCCLUSIONRENDERVIEW_H
+
+#include "qgsabstractrenderview.h"
+#include "qgsambientocclusionrenderentity.h"
+#include "qgsambientocclusionblurentity.h"
+
+namespace Qt3DRender
+{
+  class QRenderSettings;
+  class QLayer;
+  class QSubtreeEnabler;
+  class QTexture2D;
+  class QCamera;
+  class QCameraSelector;
+  class QLayerFilter;
+  class QRenderTargetSelector;
+  class QRenderTarget;
+} //namespace Qt3DRender
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup qgis_3d
+ * \brief Container class that holds different objects related to depth rendering
+ *
+ * \note Not available in Python bindings
+ *
+ * The depth buffer render pass is made to copy the depth buffer into
+ * an RGB texture that can be captured into a QImage and sent to the CPU for
+ * calculating real 3D points from mouse coordinates (for zoom, rotation, drag..)
+ *
+ * \since QGIS 3.44
+ */
+class QgsAmbientOcclusionRenderView : public QgsAbstractRenderView
+{
+  public:
+    QgsAmbientOcclusionRenderView( const QString &viewName, Qt3DRender::QCamera *mainCamera, QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity );
+
+    //! Delegates to QgsAmbientOcclusionRenderEntity::setIntensity
+    void setIntensity( float intensity );
+
+    //! Delegates to QgsAmbientOcclusionRenderEntity::setRadius
+    void setRadius( float radius );
+
+    //! Delegates to QgsAmbientOcclusionRenderEntity::setThreshold
+    void setThreshold( float threshold );
+
+    //! Returns blur pass texture
+    Qt3DRender::QTexture2D *blurredFactorMapTexture() const;
+
+    virtual void updateWindowResize( int width, int height ) override;
+    virtual void setEnabled( bool enable ) override;
+
+  private:
+    Qt3DRender::QCamera *mMainCamera = nullptr;
+
+    Qt3DRender::QLayer *mAOPassLayer = nullptr;
+    Qt3DRender::QTexture2D *mAOPassTexture = nullptr;
+    Qt3DRender::QTexture2D *mBlurPassTexture = nullptr;
+    Qt3DRender::QLayer *mBlurPassLayer = nullptr;
+    Qt3DRender::QRenderTargetSelector *mRenderTargetSelector = nullptr;
+
+    QgsAmbientOcclusionRenderEntity *mAmbientOcclusionRenderEntity = nullptr;
+    QgsAmbientOcclusionBlurEntity *mAmbientOcclusionBlurEntity = nullptr;
+
+    void buildRenderPass( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity );
+
+    /**
+     * Build AO and blur textures and add then to a new rendertarget
+     */
+    Qt3DRender::QRenderTarget *buildTextures( QSize mSize );
+};
+
+#endif // QGSAMBIENTOCCLUSIONRENDERVIEW_H

--- a/src/3d/framegraph/qgsambientocclusionrenderview.h
+++ b/src/3d/framegraph/qgsambientocclusionrenderview.h
@@ -17,8 +17,8 @@
 #define QGSAMBIENTOCCLUSIONRENDERVIEW_H
 
 #include "qgsabstractrenderview.h"
-#include "qgsambientocclusionrenderentity.h"
-#include "qgsambientocclusionblurentity.h"
+
+#define SIP_NO_FILE
 
 namespace Qt3DRender
 {
@@ -33,18 +33,19 @@ namespace Qt3DRender
   class QRenderTarget;
 } //namespace Qt3DRender
 
-#define SIP_NO_FILE
+class QgsAmbientOcclusionRenderEntity;
+class QgsAmbientOcclusionBlurEntity;
 
 /**
  * \ingroup qgis_3d
- * \brief Container class that holds different objects related to depth rendering
+ * \brief Container class that holds different objects related to ambient occlusion rendering
  *
  * \note Not available in Python bindings
  *
- * The depth buffer render pass is made to copy the depth buffer into
- * an RGB texture that can be captured into a QImage and sent to the CPU for
- * calculating real 3D points from mouse coordinates (for zoom, rotation, drag..)
- *
+ * This renderview create 2 passes with their own entity: 
+ *  - the first pass computes the ambient occlusion (creates a QgsAmbientOcclusionRenderEntity)
+ *  - the second generates a blur (creates a QgsAmbientOcclusionBlurEntity)
+ * 
  * \since QGIS 3.44
  */
 class QgsAmbientOcclusionRenderView : public QgsAbstractRenderView
@@ -75,17 +76,21 @@ class QgsAmbientOcclusionRenderView : public QgsAbstractRenderView
     Qt3DRender::QTexture2D *mAOPassTexture = nullptr;
     Qt3DRender::QTexture2D *mBlurPassTexture = nullptr;
     Qt3DRender::QLayer *mBlurPassLayer = nullptr;
-    Qt3DRender::QRenderTargetSelector *mRenderTargetSelector = nullptr;
 
     QgsAmbientOcclusionRenderEntity *mAmbientOcclusionRenderEntity = nullptr;
     QgsAmbientOcclusionBlurEntity *mAmbientOcclusionBlurEntity = nullptr;
 
-    void buildRenderPass( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity );
+    void buildRenderPasses( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity );
 
     /**
-     * Build AO and blur textures and add then to a new rendertarget
+     * Build AO texture and add it to a new rendertarget
      */
-    Qt3DRender::QRenderTarget *buildTextures( QSize mSize );
+    Qt3DRender::QRenderTarget *buildAOTexture( QSize mSize );
+
+    /**
+     * Build blur texture and add it to a new rendertarget
+     */
+    Qt3DRender::QRenderTarget *buildBlurTexture( QSize mSize );
 };
 
 #endif // QGSAMBIENTOCCLUSIONRENDERVIEW_H

--- a/src/3d/framegraph/qgsambientocclusionrenderview.h
+++ b/src/3d/framegraph/qgsambientocclusionrenderview.h
@@ -33,6 +33,11 @@ namespace Qt3DRender
   class QRenderTarget;
 } //namespace Qt3DRender
 
+namespace Qt3DCore
+{
+  class QEntity;
+} //namespace Qt3DCore
+
 class QgsAmbientOcclusionRenderEntity;
 class QgsAmbientOcclusionBlurEntity;
 
@@ -70,8 +75,6 @@ class QgsAmbientOcclusionRenderView : public QgsAbstractRenderView
     virtual void setEnabled( bool enable ) override;
 
   private:
-    Qt3DRender::QCamera *mMainCamera = nullptr;
-
     Qt3DRender::QLayer *mAOPassLayer = nullptr;
     Qt3DRender::QTexture2D *mAOPassTexture = nullptr;
     Qt3DRender::QTexture2D *mBlurPassTexture = nullptr;
@@ -80,7 +83,7 @@ class QgsAmbientOcclusionRenderView : public QgsAbstractRenderView
     QgsAmbientOcclusionRenderEntity *mAmbientOcclusionRenderEntity = nullptr;
     QgsAmbientOcclusionBlurEntity *mAmbientOcclusionBlurEntity = nullptr;
 
-    void buildRenderPasses( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity );
+    void buildRenderPasses( QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity, Qt3DRender::QCamera *mainCamera );
 
     /**
      * Build AO texture and add it to a new rendertarget

--- a/src/3d/framegraph/qgsambientocclusionrenderview.h
+++ b/src/3d/framegraph/qgsambientocclusionrenderview.h
@@ -50,6 +50,7 @@ namespace Qt3DRender
 class QgsAmbientOcclusionRenderView : public QgsAbstractRenderView
 {
   public:
+    //! Default constructor
     QgsAmbientOcclusionRenderView( const QString &viewName, Qt3DRender::QCamera *mainCamera, QSize mSize, Qt3DRender::QTexture2D *forwardDepthTexture, Qt3DCore::QEntity *rootSceneEntity );
 
     //! Delegates to QgsAmbientOcclusionRenderEntity::setIntensity

--- a/src/3d/framegraph/qgsframegraph.cpp
+++ b/src/3d/framegraph/qgsframegraph.cpp
@@ -22,8 +22,6 @@
 #include "qgsabstractrenderview.h"
 #include "qgsshadowrenderview.h"
 
-#include "qgsambientocclusionrenderentity.h"
-#include "qgsambientocclusionblurentity.h"
 
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
 #include <Qt3DRender/QAttribute>
@@ -59,12 +57,14 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include "qgsdepthentity.h"
 #include "qgsdebugtexturerenderview.h"
 #include "qgsdebugtextureentity.h"
+#include "qgsambientocclusionrenderview.h"
 
 const QString QgsFrameGraph::FORWARD_RENDERVIEW = "forward";
 const QString QgsFrameGraph::SHADOW_RENDERVIEW = "shadow";
 const QString QgsFrameGraph::AXIS3D_RENDERVIEW = "3daxis";
 const QString QgsFrameGraph::DEPTH_RENDERVIEW = "depth";
 const QString QgsFrameGraph::DEBUG_RENDERVIEW = "debug_texture";
+const QString QgsFrameGraph::AO_RENDERVIEW = "ambient_occlusion";
 
 void QgsFrameGraph::constructForwardRenderPass()
 {
@@ -162,105 +162,13 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructPostprocessingPass()
   return mRenderCaptureTargetSelector;
 }
 
-Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructAmbientOcclusionRenderPass()
+void QgsFrameGraph::constructAmbientOcclusionRenderPass()
 {
-  mAmbientOcclusionRenderCameraSelector = new Qt3DRender::QCameraSelector;
-  mAmbientOcclusionRenderCameraSelector->setObjectName( "AmbientOcclusion render pass CameraSelector" );
-  mAmbientOcclusionRenderCameraSelector->setCamera( mMainCamera );
-
-  mAmbientOcclusionRenderStateSet = new Qt3DRender::QRenderStateSet( mAmbientOcclusionRenderCameraSelector );
-
-  Qt3DRender::QDepthTest *depthRenderDepthTest = new Qt3DRender::QDepthTest;
-  depthRenderDepthTest->setDepthFunction( Qt3DRender::QDepthTest::Always );
-  ;
-  Qt3DRender::QCullFace *depthRenderCullFace = new Qt3DRender::QCullFace;
-  depthRenderCullFace->setMode( Qt3DRender::QCullFace::NoCulling );
-
-  mAmbientOcclusionRenderStateSet->addRenderState( depthRenderDepthTest );
-  mAmbientOcclusionRenderStateSet->addRenderState( depthRenderCullFace );
-
-  mAmbientOcclusionRenderLayerFilter = new Qt3DRender::QLayerFilter( mAmbientOcclusionRenderStateSet );
-
-  mAmbientOcclusionRenderCaptureTargetSelector = new Qt3DRender::QRenderTargetSelector( mAmbientOcclusionRenderLayerFilter );
-  Qt3DRender::QRenderTarget *colorRenderTarget = new Qt3DRender::QRenderTarget( mAmbientOcclusionRenderCaptureTargetSelector );
-
-  // The lifetime of the objects created here is managed
-  // automatically, as they become children of this object.
-
-  // Create a render target output for rendering color.
-  Qt3DRender::QRenderTargetOutput *colorOutput = new Qt3DRender::QRenderTargetOutput( colorRenderTarget );
-  colorOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
-
-  // Create a texture to render into.
-  mAmbientOcclusionRenderTexture = new Qt3DRender::QTexture2D( colorOutput );
-  mAmbientOcclusionRenderTexture->setSize( mSize.width(), mSize.height() );
-  mAmbientOcclusionRenderTexture->setFormat( Qt3DRender::QAbstractTexture::R32F );
-  mAmbientOcclusionRenderTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
-  mAmbientOcclusionRenderTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
-
-  // Hook the texture up to our output, and the output up to this object.
-  colorOutput->setTexture( mAmbientOcclusionRenderTexture );
-  colorRenderTarget->addOutput( colorOutput );
-
-  mAmbientOcclusionRenderCaptureTargetSelector->setTarget( colorRenderTarget );
-
-  Qt3DRender::QLayer *ambientOcclusionRenderLayer = new Qt3DRender::QLayer();
   Qt3DRender::QTexture2D *forwardDepthTexture = forwardRenderView().depthTexture();
-  mAmbientOcclusionRenderEntity = new QgsAmbientOcclusionRenderEntity( forwardDepthTexture, ambientOcclusionRenderLayer, mMainCamera, mRootEntity );
-  mAmbientOcclusionRenderLayerFilter->addLayer( ambientOcclusionRenderLayer );
 
-  return mAmbientOcclusionRenderCameraSelector;
+  QgsAmbientOcclusionRenderView *aorv = new QgsAmbientOcclusionRenderView( AO_RENDERVIEW, mMainCamera, mSize, forwardDepthTexture, mRootEntity );
+  registerRenderView( std::unique_ptr<QgsAmbientOcclusionRenderView>( aorv ), AO_RENDERVIEW );
 }
-
-Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructAmbientOcclusionBlurPass()
-{
-  mAmbientOcclusionBlurCameraSelector = new Qt3DRender::QCameraSelector;
-  mAmbientOcclusionBlurCameraSelector->setObjectName( "AmbientOcclusion blur pass CameraSelector" );
-  mAmbientOcclusionBlurCameraSelector->setCamera( mMainCamera );
-
-  mAmbientOcclusionBlurStateSet = new Qt3DRender::QRenderStateSet( mAmbientOcclusionBlurCameraSelector );
-
-  Qt3DRender::QDepthTest *depthRenderDepthTest = new Qt3DRender::QDepthTest;
-  depthRenderDepthTest->setDepthFunction( Qt3DRender::QDepthTest::Always );
-  ;
-  Qt3DRender::QCullFace *depthRenderCullFace = new Qt3DRender::QCullFace;
-  depthRenderCullFace->setMode( Qt3DRender::QCullFace::NoCulling );
-
-  mAmbientOcclusionBlurStateSet->addRenderState( depthRenderDepthTest );
-  mAmbientOcclusionBlurStateSet->addRenderState( depthRenderCullFace );
-
-  mAmbientOcclusionBlurLayerFilter = new Qt3DRender::QLayerFilter( mAmbientOcclusionBlurStateSet );
-
-  mAmbientOcclusionBlurRenderCaptureTargetSelector = new Qt3DRender::QRenderTargetSelector( mAmbientOcclusionBlurLayerFilter );
-  Qt3DRender::QRenderTarget *depthRenderTarget = new Qt3DRender::QRenderTarget( mAmbientOcclusionBlurRenderCaptureTargetSelector );
-
-  // The lifetime of the objects created here is managed
-  // automatically, as they become children of this object.
-
-  // Create a render target output for rendering color.
-  Qt3DRender::QRenderTargetOutput *colorOutput = new Qt3DRender::QRenderTargetOutput( depthRenderTarget );
-  colorOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
-
-  // Create a texture to render into.
-  mAmbientOcclusionBlurTexture = new Qt3DRender::QTexture2D( colorOutput );
-  mAmbientOcclusionBlurTexture->setSize( mSize.width(), mSize.height() );
-  mAmbientOcclusionBlurTexture->setFormat( Qt3DRender::QAbstractTexture::R32F );
-  mAmbientOcclusionBlurTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
-  mAmbientOcclusionBlurTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
-
-  // Hook the texture up to our output, and the output up to this object.
-  colorOutput->setTexture( mAmbientOcclusionBlurTexture );
-  depthRenderTarget->addOutput( colorOutput );
-
-  mAmbientOcclusionBlurRenderCaptureTargetSelector->setTarget( depthRenderTarget );
-
-  Qt3DRender::QLayer *ambientOcclusionBlurLayer = new Qt3DRender::QLayer();
-  mAmbientOcclusionBlurEntity = new QgsAmbientOcclusionBlurEntity( mAmbientOcclusionRenderTexture, ambientOcclusionBlurLayer, mRootEntity );
-  mAmbientOcclusionBlurLayerFilter->addLayer( ambientOcclusionBlurLayer );
-
-  return mAmbientOcclusionBlurCameraSelector;
-}
-
 
 Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructRubberBandsPass()
 {
@@ -373,11 +281,7 @@ QgsFrameGraph::QgsFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *m
   constructDepthRenderPass();
 
   // Ambient occlusion factor render pass
-  Qt3DRender::QFrameGraphNode *ambientOcclusionFactorRender = constructAmbientOcclusionRenderPass();
-  ambientOcclusionFactorRender->setParent( mMainViewPort );
-
-  Qt3DRender::QFrameGraphNode *ambientOcclusionBlurPass = constructAmbientOcclusionBlurPass();
-  ambientOcclusionBlurPass->setParent( mMainViewPort );
+  constructAmbientOcclusionRenderPass();
 
   // post process
   Qt3DRender::QFrameGraphNode *postprocessingPass = constructPostprocessingPass();
@@ -540,31 +444,6 @@ void QgsFrameGraph::setClearColor( const QColor &clearColor )
   forwardRenderView().setClearColor( clearColor );
 }
 
-void QgsFrameGraph::setAmbientOcclusionEnabled( bool enabled )
-{
-  mAmbientOcclusionEnabled = enabled;
-  mAmbientOcclusionRenderEntity->setEnabled( enabled );
-  mPostprocessingEntity->setAmbientOcclusionEnabled( enabled );
-}
-
-void QgsFrameGraph::setAmbientOcclusionIntensity( float intensity )
-{
-  mAmbientOcclusionIntensity = intensity;
-  mAmbientOcclusionRenderEntity->setIntensity( intensity );
-}
-
-void QgsFrameGraph::setAmbientOcclusionRadius( float radius )
-{
-  mAmbientOcclusionRadius = radius;
-  mAmbientOcclusionRenderEntity->setRadius( radius );
-}
-
-void QgsFrameGraph::setAmbientOcclusionThreshold( float threshold )
-{
-  mAmbientOcclusionThreshold = threshold;
-  mAmbientOcclusionRenderEntity->setThreshold( threshold );
-}
-
 void QgsFrameGraph::setFrustumCullingEnabled( bool enabled )
 {
   forwardRenderView().setFrustumCullingEnabled( enabled );
@@ -572,9 +451,6 @@ void QgsFrameGraph::setFrustumCullingEnabled( bool enabled )
 
 void QgsFrameGraph::setupEyeDomeLighting( bool enabled, double strength, int distance )
 {
-  mEyeDomeLightingEnabled = enabled;
-  mEyeDomeLightingStrength = strength;
-  mEyeDomeLightingDistance = distance;
   mPostprocessingEntity->setEyeDomeLightingEnabled( enabled );
   mPostprocessingEntity->setEyeDomeLightingStrength( strength );
   mPostprocessingEntity->setEyeDomeLightingDistance( distance );
@@ -592,9 +468,6 @@ void QgsFrameGraph::setSize( QSize s )
   mRenderCaptureColorTexture->setSize( mSize.width(), mSize.height() );
   mRenderCaptureDepthTexture->setSize( mSize.width(), mSize.height() );
   mRenderSurfaceSelector->setExternalRenderTargetSize( mSize );
-
-  mAmbientOcclusionRenderTexture->setSize( mSize.width(), mSize.height() );
-  mAmbientOcclusionBlurTexture->setSize( mSize.width(), mSize.height() );
 }
 
 void QgsFrameGraph::setRenderCaptureEnabled( bool enabled )

--- a/src/3d/framegraph/qgsframegraph.cpp
+++ b/src/3d/framegraph/qgsframegraph.cpp
@@ -64,7 +64,7 @@ const QString QgsFrameGraph::SHADOW_RENDERVIEW = "shadow";
 const QString QgsFrameGraph::AXIS3D_RENDERVIEW = "3daxis";
 const QString QgsFrameGraph::DEPTH_RENDERVIEW = "depth";
 const QString QgsFrameGraph::DEBUG_RENDERVIEW = "debug_texture";
-const QString QgsFrameGraph::AO_RENDERVIEW = "ambient_occlusion";
+const QString QgsFrameGraph::AMBIENT_OCCLUSION_RENDERVIEW = "ambient_occlusion";
 
 void QgsFrameGraph::constructForwardRenderPass()
 {
@@ -166,8 +166,8 @@ void QgsFrameGraph::constructAmbientOcclusionRenderPass()
 {
   Qt3DRender::QTexture2D *forwardDepthTexture = forwardRenderView().depthTexture();
 
-  QgsAmbientOcclusionRenderView *aorv = new QgsAmbientOcclusionRenderView( AO_RENDERVIEW, mMainCamera, mSize, forwardDepthTexture, mRootEntity );
-  registerRenderView( std::unique_ptr<QgsAmbientOcclusionRenderView>( aorv ), AO_RENDERVIEW );
+  QgsAmbientOcclusionRenderView *aorv = new QgsAmbientOcclusionRenderView( AMBIENT_OCCLUSION_RENDERVIEW, mMainCamera, mSize, forwardDepthTexture, mRootEntity );
+  registerRenderView( std::unique_ptr<QgsAmbientOcclusionRenderView>( aorv ), AMBIENT_OCCLUSION_RENDERVIEW );
 }
 
 Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructRubberBandsPass()
@@ -509,4 +509,10 @@ QgsDepthRenderView &QgsFrameGraph::depthRenderView()
 {
   QgsAbstractRenderView *rv = mRenderViewMap[QgsFrameGraph::DEPTH_RENDERVIEW].get();
   return *( dynamic_cast<QgsDepthRenderView *>( rv ) );
+}
+
+QgsAmbientOcclusionRenderView &QgsFrameGraph::ambientOcclusionRenderView()
+{
+  QgsAbstractRenderView *rv = mRenderViewMap[QgsFrameGraph::AMBIENT_OCCLUSION_RENDERVIEW].get();
+  return *( dynamic_cast<QgsAmbientOcclusionRenderView *>( rv ) );
 }

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -38,7 +38,6 @@
 #include <Qt3DRender/QDebugOverlay>
 
 #include "qgspointlightsettings.h"
-#include "qgsambientocclusionrenderentity.h"
 
 class QgsDirectionalLightSettings;
 class QgsCameraController;
@@ -50,6 +49,7 @@ class QgsShadowRenderView;
 class QgsDepthRenderView;
 class QgsShadowSettings;
 class QgsDebugTextureEntity;
+class QgsAmbientOcclusionRenderView;
 
 #define SIP_NO_FILE
 
@@ -193,6 +193,12 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     QgsDepthRenderView &depthRenderView();
 
     /**
+     * Returns ambient occlusion renderview
+     * \since QGIS 3.44
+     */
+    QgsAmbientOcclusionRenderView &ambientOcclusionRenderView();
+
+    /**
      * Updates shadow bias, light and texture size according to \a shadowSettings and \a lightSources
      * \since QGIS 3.44
      */
@@ -216,7 +222,7 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     static const QString DEPTH_RENDERVIEW;
     static const QString DEBUG_RENDERVIEW;
     //! Ambient occlusion render view name
-    static const QString AO_RENDERVIEW;
+    static const QString AMBIENT_OCCLUSION_RENDERVIEW;
 
   private:
     Qt3DRender::QRenderSurfaceSelector *mRenderSurfaceSelector = nullptr;

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -38,13 +38,12 @@
 #include <Qt3DRender/QDebugOverlay>
 
 #include "qgspointlightsettings.h"
+#include "qgsambientocclusionrenderentity.h"
 
 class QgsDirectionalLightSettings;
 class QgsCameraController;
 class QgsRectangle;
 class QgsPostprocessingEntity;
-class QgsAmbientOcclusionRenderEntity;
-class QgsAmbientOcclusionBlurEntity;
 class QgsAbstractRenderView;
 class QgsForwardRenderView;
 class QgsShadowRenderView;
@@ -75,12 +74,6 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     //! Returns the root of the frame graph object
     Qt3DRender::QFrameGraphNode *frameGraphRoot() { return mRenderSurfaceSelector; }
 
-    /**
-     * Returns blurred ambient occlusion factor values texture
-     * \since QGIS 3.28
-     */
-    Qt3DRender::QTexture2D *blurredAmbientOcclusionFactorMap() { return mAmbientOcclusionBlurTexture; }
-
     //! Returns the main camera
     Qt3DRender::QCamera *mainCamera() { return mMainCamera; }
 
@@ -98,54 +91,6 @@ class QgsFrameGraph : public Qt3DCore::QEntity
 
     //! Sets whether frustum culling is enabled
     void setFrustumCullingEnabled( bool enabled );
-
-    /**
-     * Sets whether Screen Space Ambient Occlusion will be enabled
-     * \since QGIS 3.28
-     */
-    void setAmbientOcclusionEnabled( bool enabled );
-
-    /**
-     * Returns whether Screen Space Ambient Occlusion is enabled
-     * \since QGIS 3.28
-     */
-    bool ambientOcclusionEnabled() const { return mAmbientOcclusionEnabled; }
-
-    /**
-     * Sets the ambient occlusion intensity
-     * \since QGIS 3.28
-     */
-    void setAmbientOcclusionIntensity( float intensity );
-
-    /**
-     * Returns the ambient occlusion intensity
-     * \since QGIS 3.28
-     */
-    float ambientOcclusionIntensity() const { return mAmbientOcclusionIntensity; }
-
-    /**
-     * Sets the ambient occlusion radius
-     * \since QGIS 3.28
-     */
-    void setAmbientOcclusionRadius( float radius );
-
-    /**
-     * Returns the ambient occlusion radius
-     * \since QGIS 3.28
-     */
-    float ambientOcclusionRadius() const { return mAmbientOcclusionRadius; }
-
-    /**
-     * Sets the ambient occlusion threshold
-     * \since QGIS 3.28
-     */
-    void setAmbientOcclusionThreshold( float threshold );
-
-    /**
-     * Returns the ambient occlusion threshold
-     * \since QGIS 3.28
-     */
-    float ambientOcclusionThreshold() const { return mAmbientOcclusionThreshold; }
 
     //! Sets the clear color of the scene (background color)
     void setClearColor( const QColor &clearColor );
@@ -270,6 +215,8 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     static const QString AXIS3D_RENDERVIEW;
     static const QString DEPTH_RENDERVIEW;
     static const QString DEBUG_RENDERVIEW;
+    //! Ambient occlusion render view name
+    static const QString AO_RENDERVIEW;
 
   private:
     Qt3DRender::QRenderSurfaceSelector *mRenderSurfaceSelector = nullptr;
@@ -284,39 +231,13 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QTexture2D *mRenderCaptureColorTexture = nullptr;
     Qt3DRender::QTexture2D *mRenderCaptureDepthTexture = nullptr;
 
-    // Ambient occlusion factor generation pass
-    Qt3DRender::QCameraSelector *mAmbientOcclusionRenderCameraSelector = nullptr;
-    Qt3DRender::QRenderStateSet *mAmbientOcclusionRenderStateSet = nullptr;
-    Qt3DRender::QLayerFilter *mAmbientOcclusionRenderLayerFilter = nullptr;
-    Qt3DRender::QRenderTargetSelector *mAmbientOcclusionRenderCaptureTargetSelector = nullptr;
-    // Ambient occlusion factor generation pass texture related objects:
-    Qt3DRender::QTexture2D *mAmbientOcclusionRenderTexture = nullptr;
-
-    // Ambient occlusion factor blur pass
-    Qt3DRender::QCameraSelector *mAmbientOcclusionBlurCameraSelector = nullptr;
-    Qt3DRender::QRenderStateSet *mAmbientOcclusionBlurStateSet = nullptr;
-    Qt3DRender::QLayerFilter *mAmbientOcclusionBlurLayerFilter = nullptr;
-    Qt3DRender::QRenderTargetSelector *mAmbientOcclusionBlurRenderCaptureTargetSelector = nullptr;
-    // Ambient occlusion factor blur pass texture related objects:
-    Qt3DRender::QTexture2D *mAmbientOcclusionBlurTexture = nullptr;
-
     // Rubber bands pass
     Qt3DRender::QCameraSelector *mRubberBandsCameraSelector = nullptr;
     Qt3DRender::QLayerFilter *mRubberBandsLayerFilter = nullptr;
     Qt3DRender::QRenderStateSet *mRubberBandsStateSet = nullptr;
     Qt3DRender::QRenderTargetSelector *mRubberBandsRenderTargetSelector = nullptr;
 
-    // Ambient occlusion related settings
-    bool mAmbientOcclusionEnabled = false;
-    float mAmbientOcclusionIntensity = 0.5f;
-    float mAmbientOcclusionRadius = 25.f;
-    float mAmbientOcclusionThreshold = 0.5f;
-
     QSize mSize = QSize( 1024, 768 );
-
-    bool mEyeDomeLightingEnabled = false;
-    double mEyeDomeLightingStrength = 1000.0;
-    int mEyeDomeLightingDistance = 1;
 
     QVector3D mLightDirection = QVector3D( 0.0, -1.0f, 0.0f );
 
@@ -325,8 +246,6 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QLayer *mRubberBandsLayer = nullptr;
 
     QgsPostprocessingEntity *mPostprocessingEntity = nullptr;
-    QgsAmbientOcclusionRenderEntity *mAmbientOcclusionRenderEntity = nullptr;
-    QgsAmbientOcclusionBlurEntity *mAmbientOcclusionBlurEntity = nullptr;
 
     Qt3DCore::QEntity *mRubberBandsRootEntity = nullptr;
 
@@ -340,13 +259,11 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     void constructDebugTexturePass( Qt3DRender::QFrameGraphNode *topNode = nullptr );
     Qt3DRender::QFrameGraphNode *constructPostprocessingPass();
     void constructDepthRenderPass();
-    Qt3DRender::QFrameGraphNode *constructAmbientOcclusionRenderPass();
-    Qt3DRender::QFrameGraphNode *constructAmbientOcclusionBlurPass();
+    void constructAmbientOcclusionRenderPass();
     Qt3DRender::QFrameGraphNode *constructRubberBandsPass();
 
     Qt3DRender::QFrameGraphNode *constructSubPostPassForProcessing();
     Qt3DRender::QFrameGraphNode *constructSubPostPassForRenderCapture();
-    Qt3DRender::QFrameGraphNode *constructSubPostPassForTexturesPreview();
 
     bool mRenderCaptureEnabled = false;
 

--- a/src/3d/framegraph/qgspostprocessingentity.cpp
+++ b/src/3d/framegraph/qgspostprocessingentity.cpp
@@ -46,16 +46,19 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include "qgsframegraph.h"
 #include "qgsshadowrenderview.h"
 #include "qgsforwardrenderview.h"
+#include "qgsambientocclusionrenderview.h"
 
 QgsPostprocessingEntity::QgsPostprocessingEntity( QgsFrameGraph *frameGraph, Qt3DRender::QLayer *layer, QNode *parent )
   : QgsRenderPassQuad( layer, parent )
 {
   QgsShadowRenderView &shadowRenderView = frameGraph->shadowRenderView();
   QgsForwardRenderView &forwardRenderView = frameGraph->forwardRenderView();
+  QgsAmbientOcclusionRenderView *aoRenderView = dynamic_cast<QgsAmbientOcclusionRenderView *>( frameGraph->renderView( QgsFrameGraph::AO_RENDERVIEW ) );
+
   mColorTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "colorTexture" ), forwardRenderView.colorTexture() );
   mDepthTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "depthTexture" ), forwardRenderView.depthTexture() );
   mShadowMapParameter = new Qt3DRender::QParameter( QStringLiteral( "shadowTexture" ), shadowRenderView.mapTexture() );
-  mAmbientOcclusionTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "ssaoTexture" ), frameGraph->blurredAmbientOcclusionFactorMap() );
+  mAmbientOcclusionTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "ssaoTexture" ), aoRenderView->blurredFactorMapTexture() );
   mMaterial->addParameter( mColorTextureParameter );
   mMaterial->addParameter( mDepthTextureParameter );
   mMaterial->addParameter( mShadowMapParameter );

--- a/src/3d/framegraph/qgspostprocessingentity.cpp
+++ b/src/3d/framegraph/qgspostprocessingentity.cpp
@@ -53,12 +53,12 @@ QgsPostprocessingEntity::QgsPostprocessingEntity( QgsFrameGraph *frameGraph, Qt3
 {
   QgsShadowRenderView &shadowRenderView = frameGraph->shadowRenderView();
   QgsForwardRenderView &forwardRenderView = frameGraph->forwardRenderView();
-  QgsAmbientOcclusionRenderView *aoRenderView = dynamic_cast<QgsAmbientOcclusionRenderView *>( frameGraph->renderView( QgsFrameGraph::AO_RENDERVIEW ) );
+  QgsAmbientOcclusionRenderView &aoRenderView = frameGraph->ambientOcclusionRenderView();
 
   mColorTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "colorTexture" ), forwardRenderView.colorTexture() );
   mDepthTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "depthTexture" ), forwardRenderView.depthTexture() );
   mShadowMapParameter = new Qt3DRender::QParameter( QStringLiteral( "shadowTexture" ), shadowRenderView.mapTexture() );
-  mAmbientOcclusionTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "ssaoTexture" ), aoRenderView->blurredFactorMapTexture() );
+  mAmbientOcclusionTextureParameter = new Qt3DRender::QParameter( QStringLiteral( "ssaoTexture" ), aoRenderView.blurredFactorMapTexture() );
   mMaterial->addParameter( mColorTextureParameter );
   mMaterial->addParameter( mDepthTextureParameter );
   mMaterial->addParameter( mShadowMapParameter );

--- a/src/3d/framegraph/qgsshadowrenderview.cpp
+++ b/src/3d/framegraph/qgsshadowrenderview.cpp
@@ -120,6 +120,7 @@ Qt3DRender::QLayer *QgsShadowRenderView::entityCastingShadowsLayer() const
   return mEntityCastingShadowsLayer;
 }
 
+
 void QgsShadowRenderView::setMapSize( int width, int height )
 {
   mMapTexture->setSize( width, height );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -87,6 +87,8 @@
 #include "qgspointcloudlayer.h"
 #include "qgsshadowrenderview.h"
 #include "qgsforwardrenderview.h"
+#include "qgsambientocclusionrenderview.h"
+#include "qgspostprocessingentity.h"
 
 std::function<QMap<QString, Qgs3DMapScene *>()> Qgs3DMapScene::sOpenScenesFunction = [] { return QMap<QString, Qgs3DMapScene *>(); };
 
@@ -1011,12 +1013,20 @@ void Qgs3DMapScene::onShadowSettingsChanged()
 
 void Qgs3DMapScene::onAmbientOcclusionSettingsChanged()
 {
-  QgsFrameGraph *frameGraph = mEngine->frameGraph();
   QgsAmbientOcclusionSettings ambientOcclusionSettings = mMap.ambientOcclusionSettings();
-  frameGraph->setAmbientOcclusionEnabled( ambientOcclusionSettings.isEnabled() );
-  frameGraph->setAmbientOcclusionRadius( ambientOcclusionSettings.radius() );
-  frameGraph->setAmbientOcclusionIntensity( ambientOcclusionSettings.intensity() );
-  frameGraph->setAmbientOcclusionThreshold( ambientOcclusionSettings.threshold() );
+
+  QgsAbstractRenderView *renderView = mEngine->frameGraph()->renderView( QgsFrameGraph::AO_RENDERVIEW );
+  QgsAmbientOcclusionRenderView *aoRenderView = dynamic_cast<QgsAmbientOcclusionRenderView *>( renderView );
+
+  if ( aoRenderView )
+  {
+    aoRenderView->setRadius( ambientOcclusionSettings.radius() );
+    aoRenderView->setIntensity( ambientOcclusionSettings.intensity() );
+    aoRenderView->setThreshold( ambientOcclusionSettings.threshold() );
+    aoRenderView->setEnabled( ambientOcclusionSettings.isEnabled() );
+  }
+
+  mEngine->frameGraph()->postprocessingEntity()->setAmbientOcclusionEnabled( ambientOcclusionSettings.isEnabled() );
 }
 
 void Qgs3DMapScene::onDebugShadowMapSettingsChanged()

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1015,16 +1015,12 @@ void Qgs3DMapScene::onAmbientOcclusionSettingsChanged()
 {
   QgsAmbientOcclusionSettings ambientOcclusionSettings = mMap.ambientOcclusionSettings();
 
-  QgsAbstractRenderView *renderView = mEngine->frameGraph()->renderView( QgsFrameGraph::AO_RENDERVIEW );
-  QgsAmbientOcclusionRenderView *aoRenderView = dynamic_cast<QgsAmbientOcclusionRenderView *>( renderView );
+  QgsAmbientOcclusionRenderView &aoRenderView = mEngine->frameGraph()->ambientOcclusionRenderView();
 
-  if ( aoRenderView )
-  {
-    aoRenderView->setRadius( ambientOcclusionSettings.radius() );
-    aoRenderView->setIntensity( ambientOcclusionSettings.intensity() );
-    aoRenderView->setThreshold( ambientOcclusionSettings.threshold() );
-    aoRenderView->setEnabled( ambientOcclusionSettings.isEnabled() );
-  }
+  aoRenderView.setRadius( ambientOcclusionSettings.radius() );
+  aoRenderView.setIntensity( ambientOcclusionSettings.intensity() );
+  aoRenderView.setThreshold( ambientOcclusionSettings.threshold() );
+  aoRenderView.setEnabled( ambientOcclusionSettings.isEnabled() );
 
   mEngine->frameGraph()->postprocessingEntity()->setAmbientOcclusionEnabled( ambientOcclusionSettings.isEnabled() );
 }

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -2157,6 +2157,7 @@ void TestQgs3DRendering::testAmbientOcclusion()
   // =========== set camera position
   scene->cameraController()->setLookingAtPoint( QVector3D( 0, 0, 0 ), 400, 50, 10 );
 
+  // =========== set AO to OFF
   QgsAmbientOcclusionSettings aoSettings = mapSettings.ambientOcclusionSettings();
   aoSettings.setEnabled( false );
   mapSettings.setAmbientOcclusionSettings( aoSettings );
@@ -2166,6 +2167,7 @@ void TestQgs3DRendering::testAmbientOcclusion()
   QGSCOMPARELONGSTR( "ambient_occlusion_1", "framegraph.txt", actualFG.toUtf8() );
   QGSVERIFYIMAGECHECK( "ambient_occlusion_1", "ambient_occlusion_1", img, QString(), 40, QSize( 0, 0 ), 15 );
 
+  // =========== set AO to ON
   aoSettings.setEnabled( true );
   mapSettings.setAmbientOcclusionSettings( aoSettings );
 

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
@@ -31,21 +31,23 @@
         (Qt3DRender::QLayerFilter{69/<no_name>}) [ (AcceptAnyMatchingLayers:[ {68/depth::Layer} ]) ]
           (Qt3DRender::QRenderTargetSelector{70/<no_name>}) [ (outputs:[ (Color0:{72[RGB8_UNorm]/depth::mColorTexture) ]) ]
             (Qt3DRender::QRenderCapture{74/<no_name>})
-    (Qt3DRender::QCameraSelector{87/AmbientOcclusion render pass CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-      (Qt3DRender::QRenderStateSet{88/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-        (Qt3DRender::QLayerFilter{91/<no_name>}) [ (AcceptAnyMatchingLayers:[ {96/<no_name>} ]) ]
-          (Qt3DRender::QRenderTargetSelector{92/<no_name>}) [ (outputs:[ (Color0:{95[R32F]/<no_name>) ]) ]
-    (Qt3DRender::QCameraSelector{119/AmbientOcclusion blur pass CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-      (Qt3DRender::QRenderStateSet{120/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-        (Qt3DRender::QLayerFilter{123/<no_name>}) [ (AcceptAnyMatchingLayers:[ {128/<no_name>} ]) ]
-          (Qt3DRender::QRenderTargetSelector{124/<no_name>}) [ (outputs:[ (Color0:{127[R32F]/<no_name>) ]) ]
-    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{149/<no_name>})
-      (Qt3DRender::QNoDraw{184/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{185/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{187/<no_name>}) [ (AcceptAnyMatchingLayers:[ {186/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-      (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{192/<no_name>})
+    (Qt3DRender::QNoDraw{87/ambient_occlusion::NoDraw})
+      (Qt3DRender::QSubtreeEnabler{88/ambient_occlusion::SubtreeEnabler}) [D]
+        (Qt3DRender::QCameraSelector{91/ambient_occlusion::CameraSelector(AO)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+          (Qt3DRender::QRenderStateSet{92/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{95/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{96/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{98[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QCameraSelector{122/ambient_occlusion::CameraSelector(Blur)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+          (Qt3DRender::QRenderStateSet{123/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{126/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{130/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{128[R32F]/ambient_occlusion::ColorTarget) ]) ]
+    (Qt3DRender::QRenderTargetSelector{143/PostProcessingPass}) [ (outputs:[ (Color0:{146[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{148[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{149/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{150/<no_name>}) [ (AcceptAnyMatchingLayers:[ {152/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{151/<no_name>})
+      (Qt3DRender::QNoDraw{186/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{187/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{189/<no_name>}) [ (AcceptAnyMatchingLayers:[ {188/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{190/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QNoDraw{193/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{194/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
@@ -33,21 +33,19 @@
             (Qt3DRender::QRenderCapture{74/<no_name>})
     (Qt3DRender::QNoDraw{87/ambient_occlusion::NoDraw})
       (Qt3DRender::QSubtreeEnabler{88/ambient_occlusion::SubtreeEnabler}) [D]
-        (Qt3DRender::QCameraSelector{91/ambient_occlusion::CameraSelector(AO)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-          (Qt3DRender::QRenderStateSet{92/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{95/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{96/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{98[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-        (Qt3DRender::QCameraSelector{122/ambient_occlusion::CameraSelector(Blur)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-          (Qt3DRender::QRenderStateSet{123/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{126/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{130/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{128[R32F]/ambient_occlusion::ColorTarget) ]) ]
-    (Qt3DRender::QRenderTargetSelector{143/PostProcessingPass}) [ (outputs:[ (Color0:{146[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{148[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{149/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{150/<no_name>}) [ (AcceptAnyMatchingLayers:[ {152/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{151/<no_name>})
-      (Qt3DRender::QNoDraw{186/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{187/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{189/<no_name>}) [ (AcceptAnyMatchingLayers:[ {188/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{190/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-      (Qt3DRender::QNoDraw{193/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{194/<no_name>})
+        (Qt3DRender::QRenderStateSet{91/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{94/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{98/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{96[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QRenderStateSet{121/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{124/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{128/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{126[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{149/<no_name>})
+      (Qt3DRender::QNoDraw{184/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{185/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{187/<no_name>}) [ (AcceptAnyMatchingLayers:[ {186/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{192/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
@@ -33,21 +33,19 @@
             (Qt3DRender::QRenderCapture{74/<no_name>})
     (Qt3DRender::QNoDraw{87/ambient_occlusion::NoDraw}) [D]
       (Qt3DRender::QSubtreeEnabler{88/ambient_occlusion::SubtreeEnabler})
-        (Qt3DRender::QCameraSelector{91/ambient_occlusion::CameraSelector(AO)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-          (Qt3DRender::QRenderStateSet{92/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{95/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{96/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{98[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-        (Qt3DRender::QCameraSelector{122/ambient_occlusion::CameraSelector(Blur)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-          (Qt3DRender::QRenderStateSet{123/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{126/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{130/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{128[R32F]/ambient_occlusion::ColorTarget) ]) ]
-    (Qt3DRender::QRenderTargetSelector{143/PostProcessingPass}) [ (outputs:[ (Color0:{146[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{148[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{149/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{150/<no_name>}) [ (AcceptAnyMatchingLayers:[ {152/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{151/<no_name>})
-      (Qt3DRender::QNoDraw{186/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{187/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{189/<no_name>}) [ (AcceptAnyMatchingLayers:[ {188/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{190/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-      (Qt3DRender::QNoDraw{193/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{194/<no_name>})
+        (Qt3DRender::QRenderStateSet{91/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{94/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{98/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{96[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QRenderStateSet{121/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{124/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{128/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{126[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{149/<no_name>})
+      (Qt3DRender::QNoDraw{184/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{185/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{187/<no_name>}) [ (AcceptAnyMatchingLayers:[ {186/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{192/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
@@ -31,21 +31,23 @@
         (Qt3DRender::QLayerFilter{69/<no_name>}) [ (AcceptAnyMatchingLayers:[ {68/depth::Layer} ]) ]
           (Qt3DRender::QRenderTargetSelector{70/<no_name>}) [ (outputs:[ (Color0:{72[RGB8_UNorm]/depth::mColorTexture) ]) ]
             (Qt3DRender::QRenderCapture{74/<no_name>})
-    (Qt3DRender::QCameraSelector{87/AmbientOcclusion render pass CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-      (Qt3DRender::QRenderStateSet{88/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-        (Qt3DRender::QLayerFilter{91/<no_name>}) [ (AcceptAnyMatchingLayers:[ {96/<no_name>} ]) ]
-          (Qt3DRender::QRenderTargetSelector{92/<no_name>}) [ (outputs:[ (Color0:{95[R32F]/<no_name>) ]) ]
-    (Qt3DRender::QCameraSelector{119/AmbientOcclusion blur pass CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-      (Qt3DRender::QRenderStateSet{120/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-        (Qt3DRender::QLayerFilter{123/<no_name>}) [ (AcceptAnyMatchingLayers:[ {128/<no_name>} ]) ]
-          (Qt3DRender::QRenderTargetSelector{124/<no_name>}) [ (outputs:[ (Color0:{127[R32F]/<no_name>) ]) ]
-    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{149/<no_name>})
-      (Qt3DRender::QNoDraw{184/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{185/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{187/<no_name>}) [ (AcceptAnyMatchingLayers:[ {186/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-      (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{192/<no_name>})
+    (Qt3DRender::QNoDraw{87/ambient_occlusion::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{88/ambient_occlusion::SubtreeEnabler})
+        (Qt3DRender::QCameraSelector{91/ambient_occlusion::CameraSelector(AO)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+          (Qt3DRender::QRenderStateSet{92/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{95/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{96/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{98[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QCameraSelector{122/ambient_occlusion::CameraSelector(Blur)}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+          (Qt3DRender::QRenderStateSet{123/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{126/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{130/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{128[R32F]/ambient_occlusion::ColorTarget) ]) ]
+    (Qt3DRender::QRenderTargetSelector{143/PostProcessingPass}) [ (outputs:[ (Color0:{146[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{148[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{149/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{150/<no_name>}) [ (AcceptAnyMatchingLayers:[ {152/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{151/<no_name>})
+      (Qt3DRender::QNoDraw{186/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{187/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{189/<no_name>}) [ (AcceptAnyMatchingLayers:[ {188/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{190/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QNoDraw{193/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{194/<no_name>})


### PR DESCRIPTION
This PR is part of https://github.com/qgis/QGIS-Enhancement-Proposals/issues/259 QEP (relates to https://github.com/qgis/QGIS-Enhancement-Proposals/issues/252) and follows #60159.

It extracts the ambient occlusion render view into a dedicated class.

More PR will follow with the others renderviews.

cc @ptitjano @mkrus 

Funded by CEA/DAM @renardf