### PR TITLE
[themes] Revert the ugly top padding for title-less Q*GroupBox fix

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -705,11 +705,8 @@ QRadioButton::indicator:hover
 /* ==================================================================================== */
 
 QGroupBox {
-    border:1px solid rgba(0,0,0,0);
-}
-
-QGroupBox[title^=""] {
     padding-top: 1.05em;
+    border:1px solid rgba(0,0,0,0);
 }
 
 QGroupBox::title { 

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -704,11 +704,8 @@ QRadioButton::indicator:hover
 /* ==================================================================================== */
 
 QGroupBox {
-    border:1px solid rgba(0,0,0,0);
-}
-
-QGroupBox[title^=""] {
     padding-top: 1.05em;
+    border:1px solid rgba(0,0,0,0);
 }
 
 QGroupBox::title { 


### PR DESCRIPTION
## Description

The PR reverts commit 95a2acb910b4de26933f516bcce5ca80f2155ce0 , turns out Qt is doing a really poor job at handling properties selector within stylesheet, which is a shame.
