### PR TITLE
Checkbox for replacing null value: fix #45088

### DIFF
--- a/src/core/qgsdefaultvalue.cpp
+++ b/src/core/qgsdefaultvalue.cpp
@@ -16,9 +16,10 @@
 #include "qgsdefaultvalue.h"
 #include "moc_qgsdefaultvalue.cpp"
 
-QgsDefaultValue::QgsDefaultValue( const QString &expression, bool applyOnUpdate )
+QgsDefaultValue::QgsDefaultValue( const QString &expression, bool applyOnUpdate, bool replaceNullValue )
   : mExpression( expression )
   , mApplyOnUpdate( applyOnUpdate )
+  , mReplaceNullValue( replaceNullValue )
 {
 
 }
@@ -47,6 +48,16 @@ bool QgsDefaultValue::applyOnUpdate() const
 void QgsDefaultValue::setApplyOnUpdate( bool applyOnUpdate )
 {
   mApplyOnUpdate = applyOnUpdate;
+}
+
+bool QgsDefaultValue::replaceNullValue() const
+{
+  return mReplaceNullValue;
+}
+
+void QgsDefaultValue::setReplaceNullValue( bool replaceNullValue )
+{
+  mReplaceNullValue = replaceNullValue;
 }
 
 bool QgsDefaultValue::isValid() const

--- a/src/core/qgsdefaultvalue.h
+++ b/src/core/qgsdefaultvalue.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsDefaultValue
      * Create a new default value with the given \a expression and \a applyOnUpdate flag.
      * \see QgsVectorLayer::setDefaultValueDefinition
      */
-    explicit QgsDefaultValue( const QString &expression = QString(), bool applyOnUpdate = false );
+    explicit QgsDefaultValue( const QString &expression = QString(), bool applyOnUpdate = false, bool replaceNullValue = false );
 
     // TODO c++20 - replace with = default
     bool operator==( const QgsDefaultValue &other ) const;
@@ -97,6 +97,14 @@ class CORE_EXPORT QgsDefaultValue
     void setApplyOnUpdate( bool applyOnUpdate );
 
     /**
+     * The replaceNullValue flag determines if this expression should replace
+     * the NULL value inserted by default, or if it should be added to it.
+     */
+    bool replaceNullValue() const;
+
+    void setReplaceNullValue( bool applyOnUpdate );
+
+    /**
      * Returns if this default value should be applied.
      * \returns FALSE if the expression is a null string.
      */
@@ -111,6 +119,7 @@ class CORE_EXPORT QgsDefaultValue
   private:
     QString mExpression;
     bool mApplyOnUpdate = false;
+    bool mReplaceNullValue = false;
 };
 
 Q_DECLARE_METATYPE( QgsDefaultValue )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2615,10 +2615,11 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
         QString field = defaultElem.attribute( QStringLiteral( "field" ), QString() );
         QString expression = defaultElem.attribute( QStringLiteral( "expression" ), QString() );
         bool applyOnUpdate = defaultElem.attribute( QStringLiteral( "applyOnUpdate" ), QStringLiteral( "0" ) ) == QLatin1String( "1" );
+        bool replaceNullValue = defaultElem.attribute( QStringLiteral( "replaceNullValue" ), QStringLiteral( "0" ) ) == QLatin1String( "1" );
         if ( field.isEmpty() || expression.isEmpty() )
           continue;
 
-        mDefaultExpressionMap.insert( field, QgsDefaultValue( expression, applyOnUpdate ) );
+        mDefaultExpressionMap.insert( field, QgsDefaultValue( expression, applyOnUpdate, replaceNullValue ) );
       }
     }
 
@@ -3192,6 +3193,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
       defaultElem.setAttribute( QStringLiteral( "field" ), field.name() );
       defaultElem.setAttribute( QStringLiteral( "expression" ), field.defaultValueDefinition().expression() );
       defaultElem.setAttribute( QStringLiteral( "applyOnUpdate" ), field.defaultValueDefinition().applyOnUpdate() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+      defaultElem.setAttribute( QStringLiteral( "replaceNullValue" ), field.defaultValueDefinition().replaceNullValue() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
       defaultsElem.appendChild( defaultElem );
     }
     node.appendChild( defaultsElem );

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -546,7 +546,6 @@ void QgsAttributeTypeDialog::defaultExpressionChanged()
   mDefaultPreviewLabel->setText( "<i>" + previewText + "</i>" );
 
   mReplaceNullValueCheckBox->setEnabled( true );
-
 }
 
 void QgsAttributeTypeDialog::updateSplitPolicyLabel()

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -98,6 +98,8 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   mWarnDefaultValueHasFieldsWidget->setVisible( false );
   connect( mApplyDefaultValueOnUpdateCheckBox, &QCheckBox::stateChanged, this, &QgsAttributeTypeDialog::defaultExpressionChanged );
 
+  connect( mReplaceNullValueCheckBox, &QCheckBox::stateChanged, this, &QgsAttributeTypeDialog::defaultExpressionChanged );
+
   constraintExpressionWidget->setAllowEmptyFieldName( true );
   constraintExpressionWidget->setLayer( vl );
 
@@ -406,6 +408,16 @@ void QgsAttributeTypeDialog::setApplyDefaultValueOnUpdate( bool applyDefaultValu
   mApplyDefaultValueOnUpdateCheckBox->setChecked( applyDefaultValueOnUpdate );
 }
 
+bool QgsAttributeTypeDialog::replaceNullWithDefaultValue() const
+{
+  return mReplaceNullValueCheckBox->isChecked();
+}
+
+void QgsAttributeTypeDialog::setReplaceNullWithDefaultValue( bool replaceNullWithDefaultValue )
+{
+  mReplaceNullValueCheckBox->setChecked( replaceNullWithDefaultValue );
+}
+
 Qgis::FieldDomainSplitPolicy QgsAttributeTypeDialog::splitPolicy() const
 {
   return mSplitPolicyComboBox->currentData().value<Qgis::FieldDomainSplitPolicy>();
@@ -490,6 +502,8 @@ void QgsAttributeTypeDialog::defaultExpressionChanged()
   if ( expression.isEmpty() )
   {
     mDefaultPreviewLabel->setText( QString() );
+    mReplaceNullValueCheckBox->setDisabled( true );
+    mReplaceNullValueCheckBox->setChecked( false );
     return;
   }
 
@@ -530,6 +544,9 @@ void QgsAttributeTypeDialog::defaultExpressionChanged()
   const QString previewText = fieldFormatter->representValue( mLayer, mFieldIdx, editorWidgetConfig(), QVariant(), val );
 
   mDefaultPreviewLabel->setText( "<i>" + previewText + "</i>" );
+
+  mReplaceNullValueCheckBox->setEnabled( true );
+
 }
 
 void QgsAttributeTypeDialog::updateSplitPolicyLabel()

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -235,6 +235,9 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
     bool applyDefaultValueOnUpdate() const;
     void setApplyDefaultValueOnUpdate( bool applyDefaultValueOnUpdate );
 
+    bool replaceNullWithDefaultValue() const;
+    void setReplaceNullWithDefaultValue( bool replaceNullWithDefaultValue );
+
     /**
      * Returns the field's split policy.
      *

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -42,7 +42,6 @@ QgsValueMapConfigDlg::QgsValueMapConfigDlg( QgsVectorLayer *vl, int fieldIdx, QW
   tableWidget->horizontalHeader()->setSectionsClickable( true );
   tableWidget->setSortingEnabled( true );
 
-  connect( addNullButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::addNullButtonPushed );
   connect( removeSelectedButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::removeSelectedButtonPushed );
   connect( loadFromLayerButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::loadFromLayerButtonPushed );
   connect( loadFromCSVButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::loadFromCSVButtonPushed );

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -41,9 +41,9 @@ QVariant QgsValueMapWidgetWrapper::value() const
     v = QgsVariantUtils::createNullVariant( field().type() );
 
   //to avoid non-displayed null value when table has value(s), but no null/default
-  if( mComboBox )
-    if (mComboBox->currentIndex() == -1 && mComboBox->count() > 0)
-       mComboBox->setCurrentIndex( 0 );
+  if ( mComboBox )
+    if ( mComboBox->currentIndex() == -1 && mComboBox->count() > 0 )
+      mComboBox->setCurrentIndex( 0 );
 
   return v;
 }
@@ -101,12 +101,12 @@ void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QVaria
       QMap constraintAndStrength = layer()->fieldConstraintsAndStrength( fieldIdx() );
       auto notNullIt = constraintAndStrength.find( QgsFieldConstraints::ConstraintNotNull );
       bool notNullHard = false;
-      if( notNullIt != constraintAndStrength.end() )
+      if ( notNullIt != constraintAndStrength.end() )
         notNullHard = ( notNullIt.value() == QgsFieldConstraints::ConstraintStrengthHard );
       if ( QgsVariantUtils::isNull( value ) && !notNullHard )
       {
         //add null value option if value is null
-        if( mComboBox->findText( QgsApplication::nullRepresentation().prepend( '(' ).append( ')')) == -1 )
+        if ( mComboBox->findText( QgsApplication::nullRepresentation().prepend( '(' ).append( ')' ) ) == -1 )
         {
           mComboBox->addItem( QgsApplication::nullRepresentation().prepend( '(' ).append( ')' ), v );
         }
@@ -121,7 +121,7 @@ void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QVaria
         //add additional null value option
         if ( !layer()->defaultValueDefinition( fieldIdx() ).replaceNullValue() && !notNullHard )
         {
-          if( mComboBox->findText( QgsApplication::nullRepresentation().prepend( '(' ).append( ')')) == -1 )
+          if ( mComboBox->findText( QgsApplication::nullRepresentation().prepend( '(' ).append( ')' ) ) == -1 )
           {
             mComboBox->addItem( QgsApplication::nullRepresentation().prepend( '(' ).append( ')' ), QgsValueMapFieldFormatter::NULL_VALUE );
           }

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
@@ -56,6 +56,7 @@ class GUI_EXPORT QgsValueMapWidgetWrapper : public QgsEditorWidgetWrapper
   public:
     QVariant value() const override;
     void showIndeterminateState() override;
+    QComboBox *comboBox();
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -57,6 +57,7 @@
 #include "qgstexteditwrapper.h"
 #include "qgsfieldmodel.h"
 #include "qgscollapsiblegroupbox.h"
+#include "qgsvaluemapwidgetwrapper.h"
 
 #include <QDir>
 #include <QTextStream>
@@ -1568,7 +1569,36 @@ void QgsAttributeForm::synchronizeState()
   for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
   {
     QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
-    if ( eww )
+    QgsValueMapWidgetWrapper *vmww = qobject_cast<QgsValueMapWidgetWrapper *>( eww );
+    if ( vmww )
+    {
+      if ( vmww->comboBox()->count() == 0 ) //comboBox()->currentIndex() == -1
+      {
+        ww->setEnabled( false );
+        vmww->comboBox()->setToolTip( tr( "No value set in value map configuration" ) );
+        if ( vmww->constraintResult() == QgsEditorWidgetWrapper::ConstraintResultFailSoft )
+          vmww->comboBox()->setStyleSheet("QComboBox { background-color: rgba(255, 200, 45, 0.3); }");
+        isEditable = false;
+      }
+      // else if ( vmww->comboBox()->currentIndex() == -1 )
+      //   vmww->comboBox()->setCurrentIndex( 0 );
+      else if ( vmww->comboBox()->count() == 1 )
+      {
+        ww->setEnabled( false );
+        vmww->comboBox()->setToolTip( tr( "No other value set in value map configuration" ) );
+        if ( vmww->constraintResult() == QgsEditorWidgetWrapper::ConstraintResultFailSoft )
+          vmww->comboBox()->setStyleSheet("QComboBox { background-color: rgba(255, 200, 45, 0.3); }");
+        isEditable = true;
+      }
+      else
+      {
+        vmww->comboBox()->setToolTip( QString() );
+        ww->setEnabled( true );
+        if ( vmww->constraintResult() == QgsEditorWidgetWrapper::ConstraintResultFailSoft )
+          vmww->comboBox()->setStyleSheet("QComboBox { background-color: rgba(255, 200, 45, 0.3); }");
+      }
+    }
+    else if ( eww )
     {
       const QList<QgsAttributeFormEditorWidget *> formWidgets = mFormEditorWidgets.values( eww->fieldIdx() );
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1577,7 +1577,7 @@ void QgsAttributeForm::synchronizeState()
         ww->setEnabled( false );
         vmww->comboBox()->setToolTip( tr( "No value set in value map configuration" ) );
         if ( vmww->constraintResult() == QgsEditorWidgetWrapper::ConstraintResultFailSoft )
-          vmww->comboBox()->setStyleSheet("QComboBox { background-color: rgba(255, 200, 45, 0.3); }");
+          vmww->comboBox()->setStyleSheet( "QComboBox { background-color: rgba(255, 200, 45, 0.3); }" );
         isEditable = false;
       }
       // else if ( vmww->comboBox()->currentIndex() == -1 )
@@ -1587,7 +1587,7 @@ void QgsAttributeForm::synchronizeState()
         ww->setEnabled( false );
         vmww->comboBox()->setToolTip( tr( "No other value set in value map configuration" ) );
         if ( vmww->constraintResult() == QgsEditorWidgetWrapper::ConstraintResultFailSoft )
-          vmww->comboBox()->setStyleSheet("QComboBox { background-color: rgba(255, 200, 45, 0.3); }");
+          vmww->comboBox()->setStyleSheet( "QComboBox { background-color: rgba(255, 200, 45, 0.3); }" );
         isEditable = true;
       }
       else
@@ -1595,7 +1595,7 @@ void QgsAttributeForm::synchronizeState()
         vmww->comboBox()->setToolTip( QString() );
         ww->setEnabled( true );
         if ( vmww->constraintResult() == QgsEditorWidgetWrapper::ConstraintResultFailSoft )
-          vmww->comboBox()->setStyleSheet("QComboBox { background-color: rgba(255, 200, 45, 0.3); }");
+          vmww->comboBox()->setStyleSheet( "QComboBox { background-color: rgba(255, 200, 45, 0.3); }" );
       }
     }
     else if ( eww )

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -320,6 +320,7 @@ void QgsAttributesFormProperties::loadAttributeTypeDialog()
 
   mAttributeTypeDialog->setDefaultValueExpression( mLayer->defaultValueDefinition( index ).expression() );
   mAttributeTypeDialog->setApplyDefaultValueOnUpdate( mLayer->defaultValueDefinition( index ).applyOnUpdate() );
+  mAttributeTypeDialog->setReplaceNullWithDefaultValue( mLayer->defaultValueDefinition( index ).replaceNullValue() );
 
   mAttributeTypeDialog->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributeTypeFrame->layout()->setContentsMargins( 0, 0, 0, 0 );
@@ -421,7 +422,7 @@ void QgsAttributesFormProperties::storeAttributeTypeDialog()
   cfg.mMergePolicy = mAttributeTypeDialog->mergePolicy();
 
   const int fieldIndex = mAttributeTypeDialog->fieldIdx();
-  mLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( mAttributeTypeDialog->defaultValueExpression(), mAttributeTypeDialog->applyDefaultValueOnUpdate() ) );
+  mLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( mAttributeTypeDialog->defaultValueExpression(), mAttributeTypeDialog->applyDefaultValueOnUpdate(), mAttributeTypeDialog->replaceNullWithDefaultValue() ) );
 
   const QString fieldName = mLayer->fields().at( fieldIndex ).name();
 

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -265,13 +265,23 @@
         </layout>
        </widget>
       </item>
-      <item row="8" column="0" colspan="2">
+      <item row="8" column="0">
        <widget class="QCheckBox" name="mApplyDefaultValueOnUpdateCheckBox">
         <property name="toolTip">
          <string>&lt;p&gt;With this option checked, the default value will not only be used when the feature is first created, but also whenever a feature's attribute or geometry is changed.&lt;/p&gt;&lt;p&gt;This is often useful for a last_modified timestamp or to record the username that last modified the feature.&lt;/p&gt;</string>
         </property>
         <property name="text">
          <string>Apply default value on update</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QCheckBox" name="mReplaceNullValueCheckBox">
+        <property name="toolTip">
+         <string>&amp;lt;p&amp;gt;Use the default value to replace the &quot;NULL&quot; value which is always available when no default  value is defined.&amp;lt;/p&amp;gt;</string>
+        </property>
+        <property name="text">
+         <string>Replace &quot;NULL&quot; value</string>
         </property>
        </widget>
       </item>

--- a/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
@@ -91,13 +91,6 @@
    <item row="3" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="addNullButton">
-       <property name="text">
-        <string>Add &quot;NULL&quot; value</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="removeSelectedButton">
        <property name="text">
         <string>Remove Selected</string>
@@ -125,7 +118,6 @@
   <tabstop>loadFromLayerButton</tabstop>
   <tabstop>loadFromCSVButton</tabstop>
   <tabstop>tableWidget</tabstop>
-  <tabstop>addNullButton</tabstop>
   <tabstop>removeSelectedButton</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Removal of button add null value under table, introduction of checkbox replace null value. Changes to the behaviour of the combobox for choosing a value. Fixes qgis#45088 and qgis#59387