### PR TITLE
replace pre-commit.ci by a local workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,9 +5,7 @@ on: [pull_request, push]
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,15 +1,20 @@
 name: Pre-commit checks
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+  issue_comment:
+    types: [created]
 
 jobs:
   pre-commit:
+    if: github.event_name != 'issue_comment' || github.event.comment.body == '/fix-precommit'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'pre-commit open PR') && '0' || '100' }}
+          fetch-depth: 200
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -29,7 +34,7 @@ jobs:
             fi
 
       - name: Auto-commit fixes
-        if: failure() && github.event.pull_request.head.repo.full_name == github.repository
+        if: failure() && github.event.pull_request.head.repo.full_name == github.repository && github.event_name != 'issue_comment'
         run: |
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -38,7 +43,7 @@ jobs:
             git push
 
       - name: Create a new branch for pre-commit fixes
-        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'pre-commit open PR')
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -47,8 +52,40 @@ jobs:
             git commit -m "auto-fix pre-commit issues"
             git push -f --set-upstream origin fix/pre-commit-fixes-${{ github.event.pull_request.number }}
 
+      - name: Listen for `/fix-precommit` comment
+        if: failure() && github.event_name == 'issue_comment' && github.event.comment.body == '/fix-precommit' && github.event.issue.pull_request
+        uses: actions/github-script@v7
+        with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+                const pullRequest = await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: context.issue.number
+                });
+
+                const branchName = `fix/pre-commit-fixes-${context.issue.number}`;
+                await github.rest.git.createRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `refs/heads/${branchName}`,
+                    sha: pullRequest.data.head.sha
+                });
+
+                const { data: pr } = await github.rest.pulls.create({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    head: branchName,
+                    base: pullRequest.data.base.ref,
+                    title: 'Auto-fix pre-commit issues',
+                    body: 'This PR fixes pre-commit errors automatically.',
+                    maintainer_can_modify: true
+                });
+
+                console.log(`Created PR: ${pr.html_url}`);
+
       - name: Comment on PR if pre-commit failed
-        if: failure() && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'pre-commit open PR')
+        if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,21 +94,5 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "⚠️ Pre-commit checks failed. You can fix issues locally by running `pre-commit run --all-files`. Alternatively, add the label `pre-commit open PR` to this pull request, and I will attempt to auto-fix and open a new pull request for you."
-                })
-
-      - name: Open PR
-        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'pre-commit open PR')
-        uses: actions/github-script@v7
-        with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            script: |
-                const { data: pr } = await github.rest.pulls.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                head: 'fix/pre-commit-fixes-${{ github.event.pull_request.number }}',
-                base: '${{ github.event.pull_request.base.ref }}',
-                title: 'Auto-fix pre-commit issues',
-                body: 'This PR fixes pre-commit errors automatically.',
-                maintainer_can_modify: true
+                body: "⚠️ Pre-commit checks failed. You can fix issues locally by running `pre-commit run --all-files`. Alternatively, comment `/fix-precommit` on this pull request, and I will attempt to auto-fix and open a new pull request for you."
                 });

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-            python-version: '3.x'
+            python-version: '3.13'
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'pre-commit open PR') && '0' || '1' }}
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'pre-commit open PR') && '0' || '100' }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,79 @@
+name: Pre-commit checks
+
+on: [pull_request, push]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'pre-commit open PR') && '0' || '1' }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+            python-version: '3.x'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit checks
+        id: pre-commit
+        run: |
+            MODIFIED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | tr '\n' ' ')
+            if [ -n "$MODIFIED_FILES" ]; then
+                pre-commit run --files $MODIFIED_FILES || (echo "pre-commit failed. Attempting to auto-fix..." && exit 1)
+            else
+                pre-commit run --all-files
+            fi
+
+      - name: Auto-commit fixes
+        if: failure() && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add .
+            git commit -m "auto-fix pre-commit issues" || echo "No changes to commit"
+            git push
+
+      - name: Create a new branch for pre-commit fixes
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'pre-commit open PR')
+        run: |
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout -b fix/pre-commit-fixes-${{ github.event.pull_request.number }}
+            git add .
+            git commit -m "auto-fix pre-commit issues"
+            git push -f --set-upstream origin fix/pre-commit-fixes-${{ github.event.pull_request.number }}
+
+      - name: Comment on PR if pre-commit failed
+        if: failure() && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'pre-commit open PR')
+        uses: actions/github-script@v7
+        with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+                github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "⚠️ Pre-commit checks failed. You can fix issues locally by running `pre-commit run --all-files`. Alternatively, add the label `pre-commit open PR` to this pull request, and I will attempt to auto-fix and open a new pull request for you."
+                })
+
+      - name: Open PR
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'pre-commit open PR')
+        uses: actions/github-script@v7
+        with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+                const { data: pr } = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: 'fix/pre-commit-fixes-${{ github.event.pull_request.number }}',
+                base: '${{ github.event.pull_request.base.ref }}',
+                title: 'Auto-fix pre-commit issues',
+                body: 'This PR fixes pre-commit errors automatically.',
+                maintainer_can_modify: true
+                });

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,3 @@ repos:
         always_run: true
         pass_filenames: false
 
-ci:
-  autofix_prs: true
-  autoupdate_schedule: quarterly


### PR DESCRIPTION
This is removing the pre-commit.ci integration following pre-commit.ci request (see https://github.com/qgis/QGIS/issues/61566)

Basically this means that we cannot have anymore autofix of PRs from forks which is the most frequent scenario.

In the new workflow, there will be a comment and if the user adds the label `pre-commit open PR` a PR will be created on his fork to fix the given branch.

This is not tested yet. I would like to hear feedback first on the approach before spending more time.

