### PR TITLE
[afs] Fix compatibility with 3rd party (non-esri) servers

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -107,9 +107,12 @@ QVariantMap QgsArcGisRestQueryUtils::getObjects( const QString &layerurl, const 
   QUrlQuery query( queryUrl );
   query.addQueryItem( QStringLiteral( "f" ), QStringLiteral( "json" ) );
   query.addQueryItem( QStringLiteral( "objectIds" ), ids.join( QLatin1Char( ',' ) ) );
-  const QString wkid = crs.indexOf( QLatin1Char( ':' ) ) >= 0 ? crs.split( ':' )[1] : QString();
-  query.addQueryItem( QStringLiteral( "inSR" ), wkid );
-  query.addQueryItem( QStringLiteral( "outSR" ), wkid );
+  if ( !crs.isEmpty() && crs.contains( ':' ) )
+  {
+    const QString wkid = crs.indexOf( QLatin1Char( ':' ) ) >= 0 ? crs.split( ':' )[1] : QString();
+    query.addQueryItem( QStringLiteral( "inSR" ), wkid );
+    query.addQueryItem( QStringLiteral( "outSR" ), wkid );
+  }
 
   query.addQueryItem( QStringLiteral( "returnGeometry" ), fetchGeometry ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
 

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -75,6 +75,25 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
 
     /**
      * Retrieves all matching objects from the specified layer URL.
+     *
+     * \param layerurl
+     * \param authcfg
+     * \param objectIds
+     * \param crs override CRS for retrieved features. If empty, features will be retrieved in their original CRS (i.e. the original representation from the
+     * service). If set, then the service will be asked to transform the features from their original representation to the matching CRS. Since the exact transformation
+     * which will be used by the service is unknown, is it highly recommended to leave this argument empty and handle any transformations on the client (QGIS) side instead.
+     * The string must be value of the form "auth:code". Only the code portion will be used, and passed to the service as a integer only. It is assumed that the backend
+     * has the same CRS definition for the code as the proj database, and if this is not the case then an unexpected transformation will occur.
+     * \param fetchGeometry
+     * \param fetchAttributes
+     * \param fetchM
+     * \param fetchZ
+     * \param filterRect
+     * \param errorTitle
+     * \param errorText
+     * \param requestHeaders
+     * \param feedback
+     * \param urlPrefix
      */
     static QVariantMap getObjects( const QString &layerurl, const QString &authcfg, const QList<quint32> &objectIds, const QString &crs,
                                    bool fetchGeometry, const QStringList &fetchAttributes, bool fetchM, bool fetchZ,


### PR DESCRIPTION
Don't add empty inSR/outSR arguments to the query, as these cause errors with third-party servers which implement the FeatureServer API (e.g. Earthsoft EQuIS)

Funded by North Road, thanks to SLYR

