### PR TITLE
[processing][api] Add API for an algorithm to auto-set parameter values

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6672,6 +6672,25 @@ Qgis.ProcessingLogLevel.__doc__ = """Logging level for algorithms to use when pu
 """
 # --
 Qgis.ProcessingLogLevel.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.ProcessingMode.Standard.__doc__ = "Standard (single-run) algorithm mode"
+Qgis.ProcessingMode.Batch.__doc__ = "Batch processing mode"
+Qgis.ProcessingMode.Modeler.__doc__ = "Modeler mode"
+Qgis.ProcessingMode.__doc__ = """Types of modes which Processing widgets can be created for.
+
+.. note::
+
+   Prior to QGIS 3.44 this was available as :py:class:`QgsProcessingGui`.WidgetType
+
+.. versionadded:: 3.44
+
+* ``Standard``: Standard (single-run) algorithm mode
+* ``Batch``: Batch processing mode
+* ``Modeler``: Modeler mode
+
+"""
+# --
+Qgis.ProcessingMode.baseClass = Qgis
 QgsProcessingFeatureSourceDefinition.Flag = Qgis.ProcessingFeatureSourceDefinitionFlag
 # monkey patching scoped based enum
 QgsProcessingFeatureSourceDefinition.FlagOverrideDefaultGeometryCheck = Qgis.ProcessingFeatureSourceDefinitionFlag.OverrideDefaultGeometryCheck

--- a/python/PyQt6/core/auto_additions/qgsprocessingalgorithm.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingalgorithm.py
@@ -14,7 +14,7 @@ try:
     QgsProcessingAlgorithm.invalidSinkError = staticmethod(QgsProcessingAlgorithm.invalidSinkError)
     QgsProcessingAlgorithm.invalidPointCloudError = staticmethod(QgsProcessingAlgorithm.invalidPointCloudError)
     QgsProcessingAlgorithm.writeFeatureError = staticmethod(QgsProcessingAlgorithm.writeFeatureError)
-    QgsProcessingAlgorithm.__virtual_methods__ = ['shortDescription', 'tags', 'shortHelpString', 'helpString', 'helpUrl', 'documentationFlags', 'icon', 'svgIconPath', 'group', 'groupId', 'flags', 'canExecute', 'checkParameterValues', 'preprocessParameters', 'sinkProperties', 'createCustomParametersWidget', 'createExpressionContext', 'validateInputCrs', 'asPythonCommand', 'asQgisProcessCommand', 'asMap', 'supportInPlaceEdit', 'prepareAlgorithm', 'postProcessAlgorithm']
+    QgsProcessingAlgorithm.__virtual_methods__ = ['shortDescription', 'tags', 'shortHelpString', 'helpString', 'helpUrl', 'documentationFlags', 'icon', 'svgIconPath', 'group', 'groupId', 'flags', 'canExecute', 'checkParameterValues', 'preprocessParameters', 'autogenerateParameterValues', 'sinkProperties', 'createCustomParametersWidget', 'createExpressionContext', 'validateInputCrs', 'asPythonCommand', 'asQgisProcessCommand', 'asMap', 'supportInPlaceEdit', 'prepareAlgorithm', 'postProcessAlgorithm']
     QgsProcessingAlgorithm.__abstract_methods__ = ['name', 'displayName', 'createInstance', 'initAlgorithm', 'processAlgorithm']
     QgsProcessingAlgorithm.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -243,6 +243,34 @@ via the algorithm dialog. This method should NOT be called manually by
 algorithms.
 %End
 
+    virtual QVariantMap autogenerateParameterValues( const QVariantMap &existingParameters, const QString &changedParameter, Qgis::ProcessingMode mode ) const;
+%Docstring
+Returns a map of default auto-generated parameters to fill in, based on
+existing parameters.
+
+This method is used to automatically fill parameter values when a row is
+added or modified in the batch processing interface, or automatically
+update other parameter values when parameters are modified in the
+toolbox mode.
+
+:param existingParameters: map of current parameter values
+:param changedParameter: name of parameter which has just been changed,
+                         triggering the update of default parameter
+                         values
+:param mode: current Processing mode. Allows different autogenerate
+             behavior for batch mode, modeler or toolbox.
+
+:return: map of default parameter values to use for the algorithm. Any
+         matching parameters included in the map will be automatically
+         overridden with the value from the returned map. Parameter
+         names not included in the returned map will remain unchanged.
+
+The default behavior is to return an empty map, indicating that no
+parameters should be automatically generated.
+
+.. versionadded:: 3.44
+%End
+
     QgsProcessingProvider *provider() const /HoldGIL/;
 %Docstring
 Returns the provider to which this algorithm belongs.

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2032,6 +2032,13 @@ The development version
       ModelDebug,
     };
 
+    enum class ProcessingMode
+    {
+      Standard,
+      Batch,
+      Modeler,
+    };
+
     enum class ProcessingFeatureSourceDefinitionFlag /BaseType=IntFlag/
     {
       OverrideDefaultGeometryCheck,

--- a/python/PyQt6/gui/__init__.py.in
+++ b/python/PyQt6/gui/__init__.py.in
@@ -78,5 +78,17 @@ QgsMapLayerAction.EnabledOnlyWhenEditable.is_monkey_patched = True
 QgsMapLayerAction.EnabledOnlyWhenEditable.__doc__ = "Action should be shown only for editable layers"
 QgsMapLayerAction.Flags = _Qgis.MapLayerActionFlags
 
+QgsProcessingGui.WidgetType = _Qgis.ProcessingMode
+# monkey patching scoped based enum
+QgsProcessingGui.Standard = _Qgis.ProcessingMode.Standard
+QgsProcessingGui.Standard.is_monkey_patched = True
+QgsProcessingGui.Standard.__doc__ = "Standard (single-run) algorithm mode"
+QgsProcessingGui.Batch = _Qgis.ProcessingMode.Batch
+QgsProcessingGui.Batch.is_monkey_patched = True
+QgsProcessingGui.Batch.__doc__ = "Batch processing mode"
+QgsProcessingGui.Modeler = _Qgis.ProcessingMode.Modeler
+QgsProcessingGui.Modeler.is_monkey_patched = True
+QgsProcessingGui.Modeler.__doc__ = "Modeler mode"
+
 # Classes patched
 QgsSettingsEnumEditorWidgetWrapper = PyQgsSettingsEnumEditorWidgetWrapper

--- a/python/PyQt6/gui/auto_additions/qgsprocessinggui.py
+++ b/python/PyQt6/gui/auto_additions/qgsprocessinggui.py
@@ -1,8 +1,0 @@
-# The following has been generated automatically from src/gui/processing/qgsprocessinggui.h
-QgsProcessingGui.Standard = QgsProcessingGui.WidgetType.Standard
-QgsProcessingGui.Batch = QgsProcessingGui.WidgetType.Batch
-QgsProcessingGui.Modeler = QgsProcessingGui.WidgetType.Modeler
-try:
-    QgsProcessingGui.__group__ = ['processing']
-except (NameError, AttributeError):
-    pass

--- a/python/PyQt6/gui/auto_additions/qgsprocessingwidgetwrapper.py
+++ b/python/PyQt6/gui/auto_additions/qgsprocessingwidgetwrapper.py
@@ -1,11 +1,16 @@
 # The following has been generated automatically from src/gui/processing/qgsprocessingwidgetwrapper.h
 # monkey patching scoped based enum
 QgsProcessingParametersGenerator.Flag.SkipDefaultValueParameters.__doc__ = "Parameters which are unchanged from their default values should not be included"
+QgsProcessingParametersGenerator.Flag.SkipValidation.__doc__ = "Skip validation of parameters. \n.. versionadded:: 3.44"
 QgsProcessingParametersGenerator.Flag.__doc__ = """Flags controlling parameter generation.
 
 .. versionadded:: 3.24
 
 * ``SkipDefaultValueParameters``: Parameters which are unchanged from their default values should not be included
+* ``SkipValidation``: Skip validation of parameters.
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessinggui.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessinggui.sip.in
@@ -10,25 +10,15 @@
 
 
 
-class QgsProcessingGui
-{
-%Docstring(signature="appended")
+class QgsProcessingGui {
+%Docstring
 Contains general functions and values related to Processing GUI
 components.
 
 .. versionadded:: 3.4
 %End
-
-%TypeHeaderCode
-#include "qgsprocessinggui.h"
-%End
   public:
-    enum WidgetType /BaseType=IntEnum/
-    {
-      Standard,
-      Batch,
-      Modeler,
-    };
+
 };
 
 /************************************************************************

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingguiregistry.sip.in
@@ -92,7 +92,7 @@ will be deleted.
 .. versionadded:: 3.4
 %End
 
-    QgsAbstractProcessingParameterWidgetWrapper *createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) /Factory/;
+    QgsAbstractProcessingParameterWidgetWrapper *createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) /Factory/;
 %Docstring
 Creates a new parameter widget wrapper for the given ``parameter``. The
 ``type`` argument dictates the type of dialog the wrapper should be

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingmaplayercombobox.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingmaplayercombobox.sip.in
@@ -26,7 +26,7 @@ Processing map layer combo box.
 #include "qgsprocessingmaplayercombobox.h"
 %End
   public:
-    QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = 0 );
+    QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = 0 );
 %Docstring
 Constructor for QgsProcessingMapLayerComboBox, with the specified
 ``parameter`` definition.

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -246,13 +246,13 @@ they are constructed through the central registry, via calls to
 #include "qgsprocessingwidgetwrapper.h"
 %End
   public:
-    QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QObject *parent /TransferThis/ = 0 );
+    QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QObject *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsAbstractProcessingParameterWidgetWrapper, for the
 specified ``parameter`` definition and dialog ``type``.
 %End
 
-    QgsProcessingGui::WidgetType type() const;
+    Qgis::ProcessingMode type() const;
 %Docstring
 Returns the dialog type for which widgets and labels will be created by
 this wrapper.
@@ -491,7 +491,7 @@ Returns the type string for the parameter type the factory is associated
 with.
 %End
 
-    virtual QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) = 0 /Factory/;
+    virtual QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) = 0 /Factory/;
 %Docstring
 Creates a new widget wrapper for the specified ``parameter`` definition.
 
@@ -647,7 +647,7 @@ does not provide a graphical widget, yet still implements the
 #include "qgsprocessingwidgetwrapper.h"
 %End
   public:
-    QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QObject *parent /TransferThis/ = 0 );
+    QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QObject *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsProcessingHiddenWidgetWrapper, for the specified
 ``parameter`` definition and dialog ``type``.

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -51,6 +51,7 @@ processing algorithms.
     enum class Flag /BaseType=IntFlag/
     {
       SkipDefaultValueParameters,
+      SkipValidation,
     };
     typedef QFlags<QgsProcessingParametersGenerator::Flag> Flags;
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6610,6 +6610,25 @@ Qgis.ProcessingLogLevel.__doc__ = """Logging level for algorithms to use when pu
 """
 # --
 Qgis.ProcessingLogLevel.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.ProcessingMode.Standard.__doc__ = "Standard (single-run) algorithm mode"
+Qgis.ProcessingMode.Batch.__doc__ = "Batch processing mode"
+Qgis.ProcessingMode.Modeler.__doc__ = "Modeler mode"
+Qgis.ProcessingMode.__doc__ = """Types of modes which Processing widgets can be created for.
+
+.. note::
+
+   Prior to QGIS 3.44 this was available as :py:class:`QgsProcessingGui`.WidgetType
+
+.. versionadded:: 3.44
+
+* ``Standard``: Standard (single-run) algorithm mode
+* ``Batch``: Batch processing mode
+* ``Modeler``: Modeler mode
+
+"""
+# --
+Qgis.ProcessingMode.baseClass = Qgis
 QgsProcessingFeatureSourceDefinition.Flag = Qgis.ProcessingFeatureSourceDefinitionFlag
 # monkey patching scoped based enum
 QgsProcessingFeatureSourceDefinition.FlagOverrideDefaultGeometryCheck = Qgis.ProcessingFeatureSourceDefinitionFlag.OverrideDefaultGeometryCheck

--- a/python/core/auto_additions/qgsprocessingalgorithm.py
+++ b/python/core/auto_additions/qgsprocessingalgorithm.py
@@ -14,7 +14,7 @@ try:
     QgsProcessingAlgorithm.invalidSinkError = staticmethod(QgsProcessingAlgorithm.invalidSinkError)
     QgsProcessingAlgorithm.invalidPointCloudError = staticmethod(QgsProcessingAlgorithm.invalidPointCloudError)
     QgsProcessingAlgorithm.writeFeatureError = staticmethod(QgsProcessingAlgorithm.writeFeatureError)
-    QgsProcessingAlgorithm.__virtual_methods__ = ['shortDescription', 'tags', 'shortHelpString', 'helpString', 'helpUrl', 'documentationFlags', 'icon', 'svgIconPath', 'group', 'groupId', 'flags', 'canExecute', 'checkParameterValues', 'preprocessParameters', 'sinkProperties', 'createCustomParametersWidget', 'createExpressionContext', 'validateInputCrs', 'asPythonCommand', 'asQgisProcessCommand', 'asMap', 'supportInPlaceEdit', 'prepareAlgorithm', 'postProcessAlgorithm']
+    QgsProcessingAlgorithm.__virtual_methods__ = ['shortDescription', 'tags', 'shortHelpString', 'helpString', 'helpUrl', 'documentationFlags', 'icon', 'svgIconPath', 'group', 'groupId', 'flags', 'canExecute', 'checkParameterValues', 'preprocessParameters', 'autogenerateParameterValues', 'sinkProperties', 'createCustomParametersWidget', 'createExpressionContext', 'validateInputCrs', 'asPythonCommand', 'asQgisProcessCommand', 'asMap', 'supportInPlaceEdit', 'prepareAlgorithm', 'postProcessAlgorithm']
     QgsProcessingAlgorithm.__abstract_methods__ = ['name', 'displayName', 'createInstance', 'initAlgorithm', 'processAlgorithm']
     QgsProcessingAlgorithm.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -243,6 +243,34 @@ via the algorithm dialog. This method should NOT be called manually by
 algorithms.
 %End
 
+    virtual QVariantMap autogenerateParameterValues( const QVariantMap &existingParameters, const QString &changedParameter, Qgis::ProcessingMode mode ) const;
+%Docstring
+Returns a map of default auto-generated parameters to fill in, based on
+existing parameters.
+
+This method is used to automatically fill parameter values when a row is
+added or modified in the batch processing interface, or automatically
+update other parameter values when parameters are modified in the
+toolbox mode.
+
+:param existingParameters: map of current parameter values
+:param changedParameter: name of parameter which has just been changed,
+                         triggering the update of default parameter
+                         values
+:param mode: current Processing mode. Allows different autogenerate
+             behavior for batch mode, modeler or toolbox.
+
+:return: map of default parameter values to use for the algorithm. Any
+         matching parameters included in the map will be automatically
+         overridden with the value from the returned map. Parameter
+         names not included in the returned map will remain unchanged.
+
+The default behavior is to return an empty map, indicating that no
+parameters should be automatically generated.
+
+.. versionadded:: 3.44
+%End
+
     QgsProcessingProvider *provider() const /HoldGIL/;
 %Docstring
 Returns the provider to which this algorithm belongs.

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2032,6 +2032,13 @@ The development version
       ModelDebug,
     };
 
+    enum class ProcessingMode
+    {
+      Standard,
+      Batch,
+      Modeler,
+    };
+
     enum class ProcessingFeatureSourceDefinitionFlag
     {
       OverrideDefaultGeometryCheck,

--- a/python/gui/__init__.py.in
+++ b/python/gui/__init__.py.in
@@ -78,6 +78,19 @@ QgsMapLayerAction.EnabledOnlyWhenEditable.is_monkey_patched = True
 QgsMapLayerAction.EnabledOnlyWhenEditable.__doc__ = "Action should be shown only for editable layers"
 QgsMapLayerAction.Flags = _Qgis.MapLayerActionFlags
 
+QgsProcessingGui.WidgetType = _Qgis.ProcessingMode
+# monkey patching scoped based enum
+QgsProcessingGui.Standard = _Qgis.ProcessingMode.Standard
+QgsProcessingGui.Standard.is_monkey_patched = True
+QgsProcessingGui.Standard.__doc__ = "Standard (single-run) algorithm mode"
+QgsProcessingGui.Batch = _Qgis.ProcessingMode.Batch
+QgsProcessingGui.Batch.is_monkey_patched = True
+QgsProcessingGui.Batch.__doc__ = "Batch processing mode"
+QgsProcessingGui.Modeler = _Qgis.ProcessingMode.Modeler
+QgsProcessingGui.Modeler.is_monkey_patched = True
+QgsProcessingGui.Modeler.__doc__ = "Modeler mode"
+
+
 # monkey patch old settings wrappers
 QgsSettingsStringEditorWidgetWrapper = QgsSettingsStringLineEditWrapper
 QgsSettingsBoolEditorWidgetWrapper = QgsSettingsBoolCheckBoxWrapper

--- a/python/gui/auto_additions/qgsprocessinggui.py
+++ b/python/gui/auto_additions/qgsprocessinggui.py
@@ -1,5 +1,0 @@
-# The following has been generated automatically from src/gui/processing/qgsprocessinggui.h
-try:
-    QgsProcessingGui.__group__ = ['processing']
-except (NameError, AttributeError):
-    pass

--- a/python/gui/auto_additions/qgsprocessingwidgetwrapper.py
+++ b/python/gui/auto_additions/qgsprocessingwidgetwrapper.py
@@ -1,11 +1,16 @@
 # The following has been generated automatically from src/gui/processing/qgsprocessingwidgetwrapper.h
 # monkey patching scoped based enum
 QgsProcessingParametersGenerator.Flag.SkipDefaultValueParameters.__doc__ = "Parameters which are unchanged from their default values should not be included"
+QgsProcessingParametersGenerator.Flag.SkipValidation.__doc__ = "Skip validation of parameters. \n.. versionadded:: 3.44"
 QgsProcessingParametersGenerator.Flag.__doc__ = """Flags controlling parameter generation.
 
 .. versionadded:: 3.24
 
 * ``SkipDefaultValueParameters``: Parameters which are unchanged from their default values should not be included
+* ``SkipValidation``: Skip validation of parameters.
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/gui/auto_generated/processing/qgsprocessinggui.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessinggui.sip.in
@@ -10,25 +10,15 @@
 
 
 
-class QgsProcessingGui
-{
-%Docstring(signature="appended")
+class QgsProcessingGui {
+%Docstring
 Contains general functions and values related to Processing GUI
 components.
 
 .. versionadded:: 3.4
 %End
-
-%TypeHeaderCode
-#include "qgsprocessinggui.h"
-%End
   public:
-    enum WidgetType
-    {
-      Standard,
-      Batch,
-      Modeler,
-    };
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/processing/qgsprocessingguiregistry.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingguiregistry.sip.in
@@ -92,7 +92,7 @@ will be deleted.
 .. versionadded:: 3.4
 %End
 
-    QgsAbstractProcessingParameterWidgetWrapper *createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) /Factory/;
+    QgsAbstractProcessingParameterWidgetWrapper *createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) /Factory/;
 %Docstring
 Creates a new parameter widget wrapper for the given ``parameter``. The
 ``type`` argument dictates the type of dialog the wrapper should be

--- a/python/gui/auto_generated/processing/qgsprocessingmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmaplayercombobox.sip.in
@@ -26,7 +26,7 @@ Processing map layer combo box.
 #include "qgsprocessingmaplayercombobox.h"
 %End
   public:
-    QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = 0 );
+    QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = 0 );
 %Docstring
 Constructor for QgsProcessingMapLayerComboBox, with the specified
 ``parameter`` definition.

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -51,6 +51,7 @@ processing algorithms.
     enum class Flag
     {
       SkipDefaultValueParameters,
+      SkipValidation,
     };
     typedef QFlags<QgsProcessingParametersGenerator::Flag> Flags;
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -246,13 +246,13 @@ they are constructed through the central registry, via calls to
 #include "qgsprocessingwidgetwrapper.h"
 %End
   public:
-    QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QObject *parent /TransferThis/ = 0 );
+    QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QObject *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsAbstractProcessingParameterWidgetWrapper, for the
 specified ``parameter`` definition and dialog ``type``.
 %End
 
-    QgsProcessingGui::WidgetType type() const;
+    Qgis::ProcessingMode type() const;
 %Docstring
 Returns the dialog type for which widgets and labels will be created by
 this wrapper.
@@ -491,7 +491,7 @@ Returns the type string for the parameter type the factory is associated
 with.
 %End
 
-    virtual QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) = 0 /Factory/;
+    virtual QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) = 0 /Factory/;
 %Docstring
 Creates a new widget wrapper for the specified ``parameter`` definition.
 
@@ -647,7 +647,7 @@ does not provide a graphical widget, yet still implements the
 #include "qgsprocessingwidgetwrapper.h"
 %End
   public:
-    QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QObject *parent /TransferThis/ = 0 );
+    QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter = 0, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QObject *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsProcessingHiddenWidgetWrapper, for the specified
 ``parameter`` definition and dialog ``type``.

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -219,6 +219,7 @@ class ParametersPanel(QgsProcessingParametersWidget):
         include_default = not (
             flags & QgsProcessingParametersGenerator.Flag.SkipDefaultValueParameters
         )
+        validate = not (flags & QgsProcessingParametersGenerator.Flag.SkipValidation)
         parameters = {}
         for p, v in self.extra_parameters.items():
             parameters[p] = v
@@ -251,7 +252,7 @@ class ParametersPanel(QgsProcessingParametersWidget):
                 if param.defaultValue() != value or include_default:
                     parameters[param.name()] = value
 
-                if not param.checkValueIsAcceptable(value):
+                if validate and not param.checkValueIsAcceptable(value):
                     raise AlgorithmDialogBase.InvalidParameterValue(param, widget)
             else:
                 if self.in_place and param.name() == "OUTPUT":
@@ -276,9 +277,12 @@ class ParametersPanel(QgsProcessingParametersWidget):
                     parameters[param.name()] = value
 
                     context = createContext()
-                    ok, error = param.isSupportedOutputValue(value, context)
-                    if not ok:
-                        raise AlgorithmDialogBase.InvalidOutputExtension(widget, error)
+                    if validate:
+                        ok, error = param.isSupportedOutputValue(value, context)
+                        if not ok:
+                            raise AlgorithmDialogBase.InvalidOutputExtension(
+                                widget, error
+                            )
 
         return self.algorithm().preprocessParameters(parameters)
 

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -134,6 +134,11 @@ QVariantMap QgsProcessingAlgorithm::preprocessParameters( const QVariantMap &par
   return parameters;
 }
 
+QVariantMap QgsProcessingAlgorithm::autogenerateParameterValues( const QVariantMap &, const QString &, Qgis::ProcessingMode ) const
+{
+  return {};
+}
+
 QgsProcessingProvider *QgsProcessingAlgorithm::provider() const
 {
   return mProvider;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -253,6 +253,26 @@ class CORE_EXPORT QgsProcessingAlgorithm
     virtual QVariantMap preprocessParameters( const QVariantMap &parameters );
 
     /**
+     * Returns a map of default auto-generated parameters to fill in, based on existing parameters.
+     *
+     * This method is used to automatically fill parameter values when a row is added or modified
+     * in the batch processing interface, or automatically update other parameter values when
+     * parameters are modified in the toolbox mode.
+     *
+     * \param existingParameters map of current parameter values
+     * \param changedParameter name of parameter which has just been changed, triggering the update of default parameter values
+     * \param mode current Processing mode. Allows different autogenerate behavior for batch mode, modeler or toolbox.
+     *
+     * \returns map of default parameter values to use for the algorithm. Any matching parameters included in the map will be automatically
+     * overridden with the value from the returned map. Parameter names not included in the returned map will remain unchanged.
+     *
+     * The default behavior is to return an empty map, indicating that no parameters should be automatically generated.
+     *
+     * \since QGIS 3.44
+     */
+    virtual QVariantMap autogenerateParameterValues( const QVariantMap &existingParameters, const QString &changedParameter, Qgis::ProcessingMode mode ) const;
+
+    /**
      * Returns the provider to which this algorithm belongs.
      */
     QgsProcessingProvider *provider() const SIP_HOLDGIL;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3527,6 +3527,21 @@ class CORE_EXPORT Qgis
     Q_ENUM( ProcessingLogLevel )
 
     /**
+     * Types of modes which Processing widgets can be created for.
+     *
+     * \note Prior to QGIS 3.44 this was available as QgsProcessingGui::WidgetType
+     *
+     * \since QGIS 3.44
+     */
+    enum class ProcessingMode
+    {
+      Standard, //!< Standard (single-run) algorithm mode
+      Batch, //!< Batch processing mode
+      Modeler, //!< Modeler mode
+    };
+    Q_ENUM( ProcessingMode )
+
+    /**
      * Flags which control behavior for a Processing feature source.
      *
      * \note Prior to QGIS 3.36 this was available as QgsProcessingFeatureSourceDefinition::Flag

--- a/src/gui/processing/qgsprocessingaggregatewidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingaggregatewidgetwrapper.cpp
@@ -252,7 +252,7 @@ QgsProcessingParameterDefinition *QgsProcessingAggregateParameterDefinitionWidge
 // QgsProcessingAggregateWidgetWrapper
 //
 
-QgsProcessingAggregateWidgetWrapper::QgsProcessingAggregateWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingAggregateWidgetWrapper::QgsProcessingAggregateWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -262,7 +262,7 @@ QString QgsProcessingAggregateWidgetWrapper::parameterType() const
   return QgsProcessingParameterAggregate::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAggregateWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAggregateWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingAggregateWidgetWrapper( parameter, type );
 }
@@ -290,8 +290,8 @@ void QgsProcessingAggregateWidgetWrapper::postInitialize( const QList<QgsAbstrac
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -307,7 +307,7 @@ void QgsProcessingAggregateWidgetWrapper::postInitialize( const QList<QgsAbstrac
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }

--- a/src/gui/processing/qgsprocessingaggregatewidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingaggregatewidgetwrapper.h
@@ -80,11 +80,11 @@ class GUI_EXPORT QgsProcessingAggregateWidgetWrapper : public QgsAbstractProcess
     Q_OBJECT
 
   public:
-    QgsProcessingAggregateWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingAggregateWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override SIP_FACTORY;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override SIP_FACTORY;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingalignrasterlayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingalignrasterlayerswidgetwrapper.cpp
@@ -272,7 +272,7 @@ void QgsProcessingAlignRasterLayersWidget::updateSummaryText()
 // QgsProcessingAlignRasterLayersWidgetWrapper
 //
 
-QgsProcessingAlignRasterLayersWidgetWrapper::QgsProcessingAlignRasterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingAlignRasterLayersWidgetWrapper::QgsProcessingAlignRasterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -282,7 +282,7 @@ QString QgsProcessingAlignRasterLayersWidgetWrapper::parameterType() const
   return QgsProcessingParameterAlignRasterLayers::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAlignRasterLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAlignRasterLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingAlignRasterLayersWidgetWrapper( parameter, type );
 }

--- a/src/gui/processing/qgsprocessingalignrasterlayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingalignrasterlayerswidgetwrapper.h
@@ -112,11 +112,11 @@ class GUI_EXPORT QgsProcessingAlignRasterLayersWidgetWrapper : public QgsAbstrac
     Q_OBJECT
 
   public:
-    QgsProcessingAlignRasterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingAlignRasterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -287,7 +287,7 @@ void QgsProcessingDxfLayersWidget::updateSummaryText()
 // QgsProcessingDxfLayersWidgetWrapper
 //
 
-QgsProcessingDxfLayersWidgetWrapper::QgsProcessingDxfLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingDxfLayersWidgetWrapper::QgsProcessingDxfLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -297,7 +297,7 @@ QString QgsProcessingDxfLayersWidgetWrapper::parameterType() const
   return QgsProcessingParameterDxfLayers::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDxfLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDxfLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingDxfLayersWidgetWrapper( parameter, type );
 }

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
@@ -112,11 +112,11 @@ class GUI_EXPORT QgsProcessingDxfLayersWidgetWrapper : public QgsAbstractProcess
     Q_OBJECT
 
   public:
-    QgsProcessingDxfLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingDxfLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
@@ -270,7 +270,7 @@ QgsProcessingParameterDefinition *QgsProcessingFieldMapParameterDefinitionWidget
 // QgsProcessingFieldMapWidgetWrapper
 //
 
-QgsProcessingFieldMapWidgetWrapper::QgsProcessingFieldMapWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingFieldMapWidgetWrapper::QgsProcessingFieldMapWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -280,7 +280,7 @@ QString QgsProcessingFieldMapWidgetWrapper::parameterType() const
   return QgsProcessingParameterFieldMapping::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFieldMapWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFieldMapWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingFieldMapWidgetWrapper( parameter, type );
 }
@@ -308,8 +308,8 @@ void QgsProcessingFieldMapWidgetWrapper::postInitialize( const QList<QgsAbstract
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -325,7 +325,7 @@ void QgsProcessingFieldMapWidgetWrapper::postInitialize( const QList<QgsAbstract
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }

--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.h
@@ -81,11 +81,11 @@ class GUI_EXPORT QgsProcessingFieldMapWidgetWrapper : public QgsAbstractProcessi
     Q_OBJECT
 
   public:
-    QgsProcessingFieldMapWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingFieldMapWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override SIP_FACTORY;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override SIP_FACTORY;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessinggui.h
+++ b/src/gui/processing/qgsprocessinggui.h
@@ -29,16 +29,9 @@
  *
  * \since QGIS 3.4
  */
-class GUI_EXPORT QgsProcessingGui
-{
+class GUI_EXPORT QgsProcessingGui {
   public:
-    //! Types of dialogs which Processing widgets can be created for
-    enum WidgetType
-    {
-      Standard, //!< Standard algorithm dialog
-      Batch,    //!< Batch processing dialog
-      Modeler,  //!< Modeler dialog
-    };
+
 };
 
 #endif // QGSPROCESSINGGUI_H

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -153,7 +153,7 @@ void QgsProcessingGuiRegistry::removeParameterWidgetFactory( QgsProcessingParame
   delete factory;
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingGuiRegistry::createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingGuiRegistry::createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   if ( !parameter )
     return nullptr;

--- a/src/gui/processing/qgsprocessingguiregistry.h
+++ b/src/gui/processing/qgsprocessingguiregistry.h
@@ -20,7 +20,6 @@
 
 #include "qgis_gui.h"
 #include "qgis_sip.h"
-#include "qgsprocessinggui.h"
 #include "qgsprocessingwidgetwrapper.h"
 #include <QList>
 #include <QMap>
@@ -114,7 +113,7 @@ class GUI_EXPORT QgsProcessingGuiRegistry
      *
      * \since QGIS 3.4
      */
-    QgsAbstractProcessingParameterWidgetWrapper *createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) SIP_FACTORY;
+    QgsAbstractProcessingParameterWidgetWrapper *createParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) SIP_FACTORY;
 
     /**
      * Creates a new modeler parameter widget for the given \a parameter. This widget allows

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -40,7 +40,7 @@
 
 ///@cond PRIVATE
 
-QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QWidget( parent )
   , mParameter( parameter->clone() )
 {
@@ -53,7 +53,7 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   layout->setAlignment( mCombo, Qt::AlignTop );
 
   int iconSize = QgsGuiUtils::scaleIconSize( 24 );
-  if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() && type == QgsProcessingGui::Standard )
+  if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() && type == Qgis::ProcessingMode::Standard )
   {
     mIterateButton = new QToolButton();
     mIterateButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mIconIterate.svg" ) ) );
@@ -114,7 +114,7 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
 
   Qgis::LayerFilters filters = Qgis::LayerFilters();
 
-  if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() && type == QgsProcessingGui::Standard )
+  if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() && type == Qgis::ProcessingMode::Standard )
   {
     mUseSelectionCheckBox = new QCheckBox( tr( "Selected features only" ) );
     mUseSelectionCheckBox->setChecked( false );

--- a/src/gui/processing/qgsprocessingmaplayercombobox.h
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.h
@@ -47,7 +47,7 @@ class GUI_EXPORT QgsProcessingMapLayerComboBox : public QWidget
     /**
      * Constructor for QgsProcessingMapLayerComboBox, with the specified \a parameter definition.
      */
-    QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMapLayerComboBox( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     ~QgsProcessingMapLayerComboBox() override;
 

--- a/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
+++ b/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
@@ -193,7 +193,7 @@ void QgsProcessingMeshDatasetGroupsWidget::selectCurrentActiveDatasetGroup()
   setValue( options );
 }
 
-QgsProcessingMeshDatasetGroupsWidgetWrapper::QgsProcessingMeshDatasetGroupsWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMeshDatasetGroupsWidgetWrapper::QgsProcessingMeshDatasetGroupsWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {}
 
@@ -202,7 +202,7 @@ QString QgsProcessingMeshDatasetGroupsWidgetWrapper::parameterType() const
   return QgsProcessingParameterMeshDatasetGroups::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMeshDatasetGroupsWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMeshDatasetGroupsWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingMeshDatasetGroupsWidgetWrapper( parameter, type );
 }
@@ -217,8 +217,8 @@ void QgsProcessingMeshDatasetGroupsWidgetWrapper::postInitialize( const QList<Qg
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers ); //necessary here?
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -233,7 +233,7 @@ void QgsProcessingMeshDatasetGroupsWidgetWrapper::postInitialize( const QList<Qg
       }
     }
     break;
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -310,7 +310,7 @@ void QgsProcessingMeshDatasetGroupsWidget::updateSummaryText()
   mLineEdit->setText( tr( "%n option(s) selected", nullptr, mValue.count() ) );
 }
 
-QgsProcessingMeshDatasetTimeWidgetWrapper::QgsProcessingMeshDatasetTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMeshDatasetTimeWidgetWrapper::QgsProcessingMeshDatasetTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -320,7 +320,7 @@ QString QgsProcessingMeshDatasetTimeWidgetWrapper::parameterType() const
   return QgsProcessingParameterMeshDatasetTime::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMeshDatasetTimeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMeshDatasetTimeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingMeshDatasetTimeWidgetWrapper( parameter, type );
 }
@@ -330,8 +330,8 @@ void QgsProcessingMeshDatasetTimeWidgetWrapper::postInitialize( const QList<QgsA
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers ); //necessary here?
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       const QgsAbstractProcessingParameterWidgetWrapper *layerParameterWrapper = nullptr;
       const QgsAbstractProcessingParameterWidgetWrapper *datasetGroupsParameterWrapper = nullptr;
@@ -353,7 +353,7 @@ void QgsProcessingMeshDatasetTimeWidgetWrapper::postInitialize( const QList<QgsA
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }

--- a/src/gui/processing/qgsprocessingmeshdatasetwidget.h
+++ b/src/gui/processing/qgsprocessingmeshdatasetwidget.h
@@ -73,10 +73,10 @@ class GUI_EXPORT QgsProcessingMeshDatasetGroupsWidgetWrapper : public QgsAbstrac
     Q_OBJECT
 
   public:
-    QgsProcessingMeshDatasetGroupsWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMeshDatasetGroupsWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -166,10 +166,10 @@ class GUI_EXPORT QgsProcessingMeshDatasetTimeWidgetWrapper : public QgsAbstractP
     Q_OBJECT
 
   public:
-    QgsProcessingMeshDatasetTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMeshDatasetTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     void postInitialize( const QList<QgsAbstractProcessingParameterWidgetWrapper *> &wrappers ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -76,7 +76,7 @@ QgsProcessingModelerParameterWidget::QgsProcessingModelerParameterWidget( QgsPro
 
   mStackedWidget = new QStackedWidget();
 
-  mStaticWidgetWrapper.reset( QgsGui::processingGuiRegistry()->createParameterWidgetWrapper( mParameterDefinition, QgsProcessingGui::Modeler ) );
+  mStaticWidgetWrapper.reset( QgsGui::processingGuiRegistry()->createParameterWidgetWrapper( mParameterDefinition, Qgis::ProcessingMode::Modeler ) );
   if ( mStaticWidgetWrapper )
   {
     QWidget *widget = mStaticWidgetWrapper->createWrappedWidget( context );

--- a/src/gui/processing/qgsprocessingrasteroptionswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingrasteroptionswidgetwrapper.cpp
@@ -26,7 +26,7 @@
 
 /// @cond private
 
-QgsProcessingRasterOptionsWidgetWrapper::QgsProcessingRasterOptionsWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingRasterOptionsWidgetWrapper::QgsProcessingRasterOptionsWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -36,7 +36,7 @@ QString QgsProcessingRasterOptionsWidgetWrapper::parameterType() const
   return QStringLiteral( "rasteroptions" );
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRasterOptionsWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRasterOptionsWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingRasterOptionsWidgetWrapper( parameter, type );
 }
@@ -45,7 +45,7 @@ QWidget *QgsProcessingRasterOptionsWidgetWrapper::createWidget()
 {
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       mOptionsWidget = new QgsRasterFormatSaveOptionsWidget();
       mOptionsWidget->setToolTip( parameterDefinition()->toolTip() );
@@ -54,8 +54,8 @@ QWidget *QgsProcessingRasterOptionsWidgetWrapper::createWidget()
       } );
       return mOptionsWidget;
     }
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       mLineEdit = new QLineEdit();
       mLineEdit->setToolTip( parameterDefinition()->toolTip() );

--- a/src/gui/processing/qgsprocessingrasteroptionswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingrasteroptionswidgetwrapper.h
@@ -42,11 +42,11 @@ class GUI_EXPORT QgsProcessingRasterOptionsWidgetWrapper : public QgsAbstractPro
     Q_OBJECT
 
   public:
-    QgsProcessingRasterOptionsWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingRasterOptionsWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingtininputlayerswidget.cpp
+++ b/src/gui/processing/qgsprocessingtininputlayerswidget.cpp
@@ -340,7 +340,7 @@ void QgsProcessingTinInputLayersDelegate::setModelData( QWidget *editor, QAbstra
   model->setData( index, comboType->currentData(), Qt::EditRole );
 }
 
-QgsProcessingTinInputLayersWidgetWrapper::QgsProcessingTinInputLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingTinInputLayersWidgetWrapper::QgsProcessingTinInputLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {}
 
@@ -349,7 +349,7 @@ QString QgsProcessingTinInputLayersWidgetWrapper::parameterType() const
   return QStringLiteral( "tininputlayers" );
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingTinInputLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingTinInputLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingTinInputLayersWidgetWrapper( parameter, type );
 }

--- a/src/gui/processing/qgsprocessingtininputlayerswidget.h
+++ b/src/gui/processing/qgsprocessingtininputlayerswidget.h
@@ -99,10 +99,10 @@ class GUI_EXPORT QgsProcessingTinInputLayersWidgetWrapper : public QgsAbstractPr
     Q_OBJECT
 
   public:
-    QgsProcessingTinInputLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingTinInputLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.cpp
@@ -295,7 +295,7 @@ void QgsProcessingVectorTileWriterLayersWidget::updateSummaryText()
 // QgsProcessingVectorTileWriterLayersWidgetWrapper
 //
 
-QgsProcessingVectorTileWriterLayersWidgetWrapper::QgsProcessingVectorTileWriterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingVectorTileWriterLayersWidgetWrapper::QgsProcessingVectorTileWriterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -305,7 +305,7 @@ QString QgsProcessingVectorTileWriterLayersWidgetWrapper::parameterType() const
   return QgsProcessingParameterVectorTileWriterLayers::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorTileWriterLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorTileWriterLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingVectorTileWriterLayersWidgetWrapper( parameter, type );
 }

--- a/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.h
@@ -114,11 +114,11 @@ class QgsProcessingVectorTileWriterLayersWidgetWrapper : public QgsAbstractProce
     Q_OBJECT
 
   public:
-    QgsProcessingVectorTileWriterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingVectorTileWriterLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -109,14 +109,14 @@ void QgsProcessingParameterWidgetContext::setModel( QgsProcessingModelAlgorithm 
 // QgsAbstractProcessingParameterWidgetWrapper
 //
 
-QgsAbstractProcessingParameterWidgetWrapper::QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QObject *parent )
+QgsAbstractProcessingParameterWidgetWrapper::QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QObject *parent )
   : QObject( parent )
   , mType( type )
   , mParameterDefinition( parameter )
 {
 }
 
-QgsProcessingGui::WidgetType QgsAbstractProcessingParameterWidgetWrapper::type() const
+Qgis::ProcessingMode QgsAbstractProcessingParameterWidgetWrapper::type() const
 {
   return mType;
 }
@@ -228,11 +228,11 @@ QLabel *QgsAbstractProcessingParameterWidgetWrapper::createLabel()
 {
   switch ( mType )
   {
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Batch:
       return nullptr;
 
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
     {
       QString description = mParameterDefinition->description();
       if ( parameterDefinition()->flags() & Qgis::ProcessingParameterFlag::Optional )
@@ -257,8 +257,8 @@ void QgsAbstractProcessingParameterWidgetWrapper::postInitialize( const QList<Qg
 {
   switch ( mType )
   {
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Standard:
     {
       if ( parameterDefinition()->isDynamic() )
       {
@@ -275,7 +275,7 @@ void QgsAbstractProcessingParameterWidgetWrapper::postInitialize( const QList<Qg
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -474,7 +474,7 @@ QgsExpressionContext QgsProcessingGuiUtils::createExpressionContext( QgsProcessi
 }
 ///@endcond
 
-QgsProcessingHiddenWidgetWrapper::QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QObject *parent )
+QgsProcessingHiddenWidgetWrapper::QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QObject *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -274,12 +274,12 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, p
      * Constructor for QgsAbstractProcessingParameterWidgetWrapper, for the specified
      * \a parameter definition and dialog \a type.
      */
-    QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * Returns the dialog type for which widgets and labels will be created by this wrapper.
      */
-    QgsProcessingGui::WidgetType type() const;
+    Qgis::ProcessingMode type() const;
 
     /**
      * Sets the \a context in which the Processing parameter widget is shown, e.g., the
@@ -482,7 +482,7 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, p
     void parentLayerChanged( QgsAbstractProcessingParameterWidgetWrapper *wrapper );
 
   private:
-    QgsProcessingGui::WidgetType mType = QgsProcessingGui::Standard;
+    Qgis::ProcessingMode mType = Qgis::ProcessingMode::Standard;
     const QgsProcessingParameterDefinition *mParameterDefinition = nullptr;
 
     void setDynamicParentLayerParameter( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper );
@@ -526,7 +526,7 @@ class GUI_EXPORT QgsProcessingParameterWidgetFactoryInterface
      *
      * \see createModelerWidgetWrapper()
      */
-    virtual QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) = 0 SIP_FACTORY;
+    virtual QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) = 0 SIP_FACTORY;
 
     /**
      * Creates a new modeler parameter widget for the given \a parameter. This widget allows
@@ -664,7 +664,7 @@ class GUI_EXPORT QgsProcessingHiddenWidgetWrapper : public QgsAbstractProcessing
      * Constructor for QgsProcessingHiddenWidgetWrapper, for the specified
      * \a parameter definition and dialog \a type.
      */
-    QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    QgsProcessingHiddenWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
     QVariant widgetValue() const override;

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -82,6 +82,7 @@ class GUI_EXPORT QgsProcessingParametersGenerator
     enum class Flag : int SIP_ENUM_BASETYPE( IntFlag )
     {
       SkipDefaultValueParameters = 1 << 0, //!< Parameters which are unchanged from their default values should not be included
+      SkipValidation = 1 << 1,             //!< Skip validation of parameters. \since QGIS 3.44
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -114,7 +114,7 @@ QgsProcessingParameterDefinition *QgsProcessingBooleanParameterDefinitionWidget:
 }
 
 
-QgsProcessingBooleanWidgetWrapper::QgsProcessingBooleanWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingBooleanWidgetWrapper::QgsProcessingBooleanWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -123,7 +123,7 @@ QWidget *QgsProcessingBooleanWidgetWrapper::createWidget()
 {
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       QString description = parameterDefinition()->description();
       if ( parameterDefinition()->flags() & Qgis::ProcessingParameterFlag::Optional )
@@ -138,8 +138,8 @@ QWidget *QgsProcessingBooleanWidgetWrapper::createWidget()
       return mCheckBox;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       mComboBox = new QComboBox();
       mComboBox->addItem( tr( "Yes" ), true );
@@ -159,7 +159,7 @@ QWidget *QgsProcessingBooleanWidgetWrapper::createWidget()
 QLabel *QgsProcessingBooleanWidgetWrapper::createLabel()
 {
   // avoid creating labels in standard dialogs
-  if ( type() == QgsProcessingGui::Standard )
+  if ( type() == Qgis::ProcessingMode::Standard )
     return nullptr;
   else
     return QgsAbstractProcessingParameterWidgetWrapper::createLabel();
@@ -169,15 +169,15 @@ void QgsProcessingBooleanWidgetWrapper::setWidgetValue( const QVariant &value, Q
 {
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       const bool v = QgsProcessingParameters::parameterAsBool( parameterDefinition(), value, context );
       mCheckBox->setChecked( v );
       break;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       const bool v = QgsProcessingParameters::parameterAsBool( parameterDefinition(), value, context );
       mComboBox->setCurrentIndex( mComboBox->findData( v ) );
@@ -190,11 +190,11 @@ QVariant QgsProcessingBooleanWidgetWrapper::widgetValue() const
 {
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
       return mCheckBox->isChecked();
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       return mComboBox->currentData();
   }
   return QVariant();
@@ -205,7 +205,7 @@ QString QgsProcessingBooleanWidgetWrapper::parameterType() const
   return QgsProcessingParameterBoolean::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingBooleanWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingBooleanWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingBooleanWidgetWrapper( parameter, type );
 }
@@ -249,7 +249,7 @@ QgsProcessingParameterDefinition *QgsProcessingCrsParameterDefinitionWidget::cre
   return param.release();
 }
 
-QgsProcessingCrsWidgetWrapper::QgsProcessingCrsWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingCrsWidgetWrapper::QgsProcessingCrsWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -271,13 +271,13 @@ QWidget *QgsProcessingCrsWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       return mProjectionSelectionWidget;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
     {
       QWidget *w = new QWidget();
       w->setToolTip( parameterDefinition()->toolTip() );
@@ -342,7 +342,7 @@ QString QgsProcessingCrsWidgetWrapper::parameterType() const
   return QgsProcessingParameterCrs::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingCrsWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingCrsWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingCrsWidgetWrapper( parameter, type );
 }
@@ -387,7 +387,7 @@ QgsProcessingParameterDefinition *QgsProcessingStringParameterDefinitionWidget::
 }
 
 
-QgsProcessingStringWidgetWrapper::QgsProcessingStringWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingStringWidgetWrapper::QgsProcessingStringWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -422,8 +422,8 @@ QWidget *QgsProcessingStringWidgetWrapper::createWidget()
   {
     switch ( type() )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Modeler:
       {
         if ( static_cast<const QgsProcessingParameterString *>( parameterDefinition() )->multiLine() )
         {
@@ -447,7 +447,7 @@ QWidget *QgsProcessingStringWidgetWrapper::createWidget()
         }
       }
 
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Batch:
       {
         mLineEdit = new QLineEdit();
         mLineEdit->setToolTip( parameterDefinition()->toolTip() );
@@ -502,7 +502,7 @@ QString QgsProcessingStringWidgetWrapper::parameterType() const
   return QgsProcessingParameterString::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingStringWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingStringWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingStringWidgetWrapper( parameter, type );
 }
@@ -517,7 +517,7 @@ QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingStringWidgetWrapper
 // QgsProcessingAuthConfigWidgetWrapper
 //
 
-QgsProcessingAuthConfigWidgetWrapper::QgsProcessingAuthConfigWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingAuthConfigWidgetWrapper::QgsProcessingAuthConfigWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -526,9 +526,9 @@ QWidget *QgsProcessingAuthConfigWidgetWrapper::createWidget()
 {
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
+    case Qgis::ProcessingMode::Batch:
     {
       mAuthConfigSelect = new QgsAuthConfigSelect();
       mAuthConfigSelect->setToolTip( parameterDefinition()->toolTip() );
@@ -562,7 +562,7 @@ QString QgsProcessingAuthConfigWidgetWrapper::parameterType() const
   return QgsProcessingParameterAuthConfig::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAuthConfigWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAuthConfigWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingAuthConfigWidgetWrapper( parameter, type );
 }
@@ -654,7 +654,7 @@ QgsProcessingParameterDefinition *QgsProcessingNumberParameterDefinitionWidget::
   return param.release();
 }
 
-QgsProcessingNumericWidgetWrapper::QgsProcessingNumericWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingNumericWidgetWrapper::QgsProcessingNumericWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -666,9 +666,9 @@ QWidget *QgsProcessingNumericWidgetWrapper::createWidget()
   const int decimals = metadata.value( QStringLiteral( "widget_wrapper" ) ).toMap().value( QStringLiteral( "decimals" ), 6 ).toInt();
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
+    case Qgis::ProcessingMode::Batch:
     {
       // lots of duplicate code here -- but there's no common interface between QSpinBox/QDoubleSpinBox which would allow us to avoid this
       QAbstractSpinBox *spinBox = nullptr;
@@ -856,7 +856,7 @@ QString QgsProcessingNumericWidgetWrapper::parameterType() const
   return QgsProcessingParameterNumber::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingNumericWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingNumericWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingNumericWidgetWrapper( parameter, type );
 }
@@ -979,7 +979,7 @@ QgsProcessingParameterDefinition *QgsProcessingDistanceParameterDefinitionWidget
   return param.release();
 }
 
-QgsProcessingDistanceWidgetWrapper::QgsProcessingDistanceWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingDistanceWidgetWrapper::QgsProcessingDistanceWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingNumericWidgetWrapper( parameter, type, parent )
 {
 }
@@ -989,7 +989,7 @@ QString QgsProcessingDistanceWidgetWrapper::parameterType() const
   return QgsProcessingParameterDistance::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDistanceWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDistanceWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingDistanceWidgetWrapper( parameter, type );
 }
@@ -1001,7 +1001,7 @@ QWidget *QgsProcessingDistanceWidgetWrapper::createWidget()
   QWidget *spin = QgsProcessingNumericWidgetWrapper::createWidget();
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       mLabel = new QLabel();
       mUnitsCombo = new QComboBox();
@@ -1048,8 +1048,8 @@ QWidget *QgsProcessingDistanceWidgetWrapper::createWidget()
       return w;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       return spin;
   }
   return nullptr;
@@ -1060,7 +1060,7 @@ void QgsProcessingDistanceWidgetWrapper::postInitialize( const QList<QgsAbstract
   QgsProcessingNumericWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -1076,8 +1076,8 @@ void QgsProcessingDistanceWidgetWrapper::postInitialize( const QList<QgsAbstract
       break;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -1265,7 +1265,7 @@ QgsProcessingParameterDefinition *QgsProcessingAreaParameterDefinitionWidget::cr
 // QgsProcessingAreaWidgetWrapper
 //
 
-QgsProcessingAreaWidgetWrapper::QgsProcessingAreaWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingAreaWidgetWrapper::QgsProcessingAreaWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingNumericWidgetWrapper( parameter, type, parent )
 {
 }
@@ -1275,7 +1275,7 @@ QString QgsProcessingAreaWidgetWrapper::parameterType() const
   return QgsProcessingParameterArea::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAreaWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAreaWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingAreaWidgetWrapper( parameter, type );
 }
@@ -1287,7 +1287,7 @@ QWidget *QgsProcessingAreaWidgetWrapper::createWidget()
   QWidget *spin = QgsProcessingNumericWidgetWrapper::createWidget();
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       mLabel = new QLabel();
       mUnitsCombo = new QComboBox();
@@ -1337,8 +1337,8 @@ QWidget *QgsProcessingAreaWidgetWrapper::createWidget()
       return w;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       return spin;
   }
   return nullptr;
@@ -1349,7 +1349,7 @@ void QgsProcessingAreaWidgetWrapper::postInitialize( const QList<QgsAbstractProc
   QgsProcessingNumericWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -1365,8 +1365,8 @@ void QgsProcessingAreaWidgetWrapper::postInitialize( const QList<QgsAbstractProc
       break;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -1554,7 +1554,7 @@ QgsProcessingParameterDefinition *QgsProcessingVolumeParameterDefinitionWidget::
 // QgsProcessingVolumeWidgetWrapper
 //
 
-QgsProcessingVolumeWidgetWrapper::QgsProcessingVolumeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingVolumeWidgetWrapper::QgsProcessingVolumeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingNumericWidgetWrapper( parameter, type, parent )
 {
 }
@@ -1564,7 +1564,7 @@ QString QgsProcessingVolumeWidgetWrapper::parameterType() const
   return QgsProcessingParameterVolume::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVolumeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVolumeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingVolumeWidgetWrapper( parameter, type );
 }
@@ -1576,7 +1576,7 @@ QWidget *QgsProcessingVolumeWidgetWrapper::createWidget()
   QWidget *spin = QgsProcessingNumericWidgetWrapper::createWidget();
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       mLabel = new QLabel();
       mUnitsCombo = new QComboBox();
@@ -1624,8 +1624,8 @@ QWidget *QgsProcessingVolumeWidgetWrapper::createWidget()
       return w;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       return spin;
   }
   return nullptr;
@@ -1636,7 +1636,7 @@ void QgsProcessingVolumeWidgetWrapper::postInitialize( const QList<QgsAbstractPr
   QgsProcessingNumericWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -1652,8 +1652,8 @@ void QgsProcessingVolumeWidgetWrapper::postInitialize( const QList<QgsAbstractPr
       break;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -1795,7 +1795,7 @@ QgsProcessingParameterDefinition *QgsProcessingDurationParameterDefinitionWidget
   return param.release();
 }
 
-QgsProcessingDurationWidgetWrapper::QgsProcessingDurationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingDurationWidgetWrapper::QgsProcessingDurationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingNumericWidgetWrapper( parameter, type, parent )
 {
 }
@@ -1805,7 +1805,7 @@ QString QgsProcessingDurationWidgetWrapper::parameterType() const
   return QgsProcessingParameterDuration::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDurationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDurationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingDurationWidgetWrapper( parameter, type );
 }
@@ -1817,7 +1817,7 @@ QWidget *QgsProcessingDurationWidgetWrapper::createWidget()
   QWidget *spin = QgsProcessingNumericWidgetWrapper::createWidget();
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       mUnitsCombo = new QComboBox();
 
@@ -1845,8 +1845,8 @@ QWidget *QgsProcessingDurationWidgetWrapper::createWidget()
       return w;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
       return spin;
   }
   return nullptr;
@@ -1856,7 +1856,7 @@ QLabel *QgsProcessingDurationWidgetWrapper::createLabel()
 {
   QLabel *label = QgsAbstractProcessingParameterWidgetWrapper::createLabel();
 
-  if ( type() == QgsProcessingGui::Modeler )
+  if ( type() == Qgis::ProcessingMode::Modeler )
   {
     label->setText( QStringLiteral( "%1 [%2]" ).arg( label->text(), QgsUnitTypes::toString( mBaseUnit ) ) );
   }
@@ -1930,7 +1930,7 @@ QgsProcessingParameterDefinition *QgsProcessingScaleParameterDefinitionWidget::c
   return param.release();
 }
 
-QgsProcessingScaleWidgetWrapper::QgsProcessingScaleWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingScaleWidgetWrapper::QgsProcessingScaleWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingNumericWidgetWrapper( parameter, type, parent )
 {
 }
@@ -1940,7 +1940,7 @@ QString QgsProcessingScaleWidgetWrapper::parameterType() const
   return QgsProcessingParameterScale::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingScaleWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingScaleWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingScaleWidgetWrapper( parameter, type );
 }
@@ -1951,9 +1951,9 @@ QWidget *QgsProcessingScaleWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       mScaleWidget = new QgsScaleWidget( nullptr );
       if ( scaleDef->flags() & Qgis::ProcessingParameterFlag::Optional )
@@ -2076,7 +2076,7 @@ QgsProcessingParameterDefinition *QgsProcessingRangeParameterDefinitionWidget::c
 }
 
 
-QgsProcessingRangeWidgetWrapper::QgsProcessingRangeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingRangeWidgetWrapper::QgsProcessingRangeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -2086,9 +2086,9 @@ QWidget *QgsProcessingRangeWidgetWrapper::createWidget()
   const QgsProcessingParameterRange *rangeDef = static_cast<const QgsProcessingParameterRange *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
+    case Qgis::ProcessingMode::Batch:
     {
       QHBoxLayout *layout = new QHBoxLayout();
 
@@ -2246,7 +2246,7 @@ QString QgsProcessingRangeWidgetWrapper::parameterType() const
   return QgsProcessingParameterRange::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRangeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRangeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingRangeWidgetWrapper( parameter, type );
 }
@@ -2285,7 +2285,7 @@ QgsProcessingParameterDefinition *QgsProcessingMatrixParameterDefinitionWidget::
 }
 
 
-QgsProcessingMatrixWidgetWrapper::QgsProcessingMatrixWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMatrixWidgetWrapper::QgsProcessingMatrixWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -2301,9 +2301,9 @@ QWidget *QgsProcessingMatrixWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       return mMatrixWidget;
     }
@@ -2336,7 +2336,7 @@ QString QgsProcessingMatrixWidgetWrapper::parameterType() const
   return QgsProcessingParameterMatrix::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMatrixWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMatrixWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingMatrixWidgetWrapper( parameter, type );
 }
@@ -2421,7 +2421,7 @@ QgsProcessingParameterDefinition *QgsProcessingFileParameterDefinitionWidget::cr
 }
 
 
-QgsProcessingFileWidgetWrapper::QgsProcessingFileWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingFileWidgetWrapper::QgsProcessingFileWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -2431,9 +2431,9 @@ QWidget *QgsProcessingFileWidgetWrapper::createWidget()
   const QgsProcessingParameterFile *fileParam = dynamic_cast<const QgsProcessingParameterFile *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
+    case Qgis::ProcessingMode::Batch:
     {
       mFileWidget = new QgsFileWidget();
       mFileWidget->setToolTip( parameterDefinition()->toolTip() );
@@ -2491,7 +2491,7 @@ QString QgsProcessingFileWidgetWrapper::parameterType() const
   return QgsProcessingParameterFile::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFileWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFileWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingFileWidgetWrapper( parameter, type );
 }
@@ -2649,7 +2649,7 @@ QgsProcessingParameterDefinition *QgsProcessingExpressionParameterDefinitionWidg
   return param.release();
 }
 
-QgsProcessingExpressionWidgetWrapper::QgsProcessingExpressionWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingExpressionWidgetWrapper::QgsProcessingExpressionWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -2659,9 +2659,9 @@ QWidget *QgsProcessingExpressionWidgetWrapper::createWidget()
   const QgsProcessingParameterExpression *expParam = dynamic_cast<const QgsProcessingParameterExpression *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
+    case Qgis::ProcessingMode::Batch:
     {
       if ( expParam->parentLayerParameterName().isEmpty() )
       {
@@ -2690,7 +2690,7 @@ QWidget *QgsProcessingExpressionWidgetWrapper::createWidget()
         {
           mRasterCalculatorExpLineEdit = new QgsProcessingRasterCalculatorExpressionLineEdit();
           mRasterCalculatorExpLineEdit->setToolTip( parameterDefinition()->toolTip() );
-          if ( type() == QgsProcessingGui::Modeler )
+          if ( type() == Qgis::ProcessingMode::Modeler )
           {
             mRasterCalculatorExpLineEdit->setLayers( QVariantList() << "A" << "B" << "C" << "D" << "E" << "F" << "G" );
           }
@@ -2737,8 +2737,8 @@ void QgsProcessingExpressionWidgetWrapper::postInitialize( const QList<QgsAbstra
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -2754,7 +2754,7 @@ void QgsProcessingExpressionWidgetWrapper::postInitialize( const QList<QgsAbstra
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -2938,7 +2938,7 @@ QString QgsProcessingExpressionWidgetWrapper::parameterType() const
   return QgsProcessingParameterExpression::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingExpressionWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingExpressionWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingExpressionWidgetWrapper( parameter, type );
 }
@@ -3249,7 +3249,7 @@ QgsProcessingParameterDefinition *QgsProcessingEnumParameterDefinitionWidget::cr
 }
 
 
-QgsProcessingEnumWidgetWrapper::QgsProcessingEnumWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingEnumWidgetWrapper::QgsProcessingEnumWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -3259,7 +3259,7 @@ QWidget *QgsProcessingEnumWidgetWrapper::createWidget()
   const QgsProcessingParameterEnum *expParam = dynamic_cast<const QgsProcessingParameterEnum *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       // checkbox panel only for use outside in standard gui!
       if ( expParam->metadata().value( QStringLiteral( "widget_wrapper" ) ).toMap().value( QStringLiteral( "useCheckBoxes" ), false ).toBool() )
@@ -3274,8 +3274,8 @@ QWidget *QgsProcessingEnumWidgetWrapper::createWidget()
       }
     }
       [[fallthrough]];
-    case QgsProcessingGui::Modeler:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Modeler:
+    case Qgis::ProcessingMode::Batch:
     {
       if ( expParam->allowMultiple() )
       {
@@ -3387,7 +3387,7 @@ QString QgsProcessingEnumWidgetWrapper::parameterType() const
   return QgsProcessingParameterEnum::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingEnumWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingEnumWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingEnumWidgetWrapper( parameter, type );
 }
@@ -3401,7 +3401,7 @@ QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingEnumWidgetWrapper::
 // QgsProcessingLayoutWidgetWrapper
 //
 
-QgsProcessingLayoutWidgetWrapper::QgsProcessingLayoutWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingLayoutWidgetWrapper::QgsProcessingLayoutWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -3411,8 +3411,8 @@ QWidget *QgsProcessingLayoutWidgetWrapper::createWidget()
   const QgsProcessingParameterLayout *layoutParam = dynamic_cast<const QgsProcessingParameterLayout *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       // combobox only for use outside modeler!
       mComboBox = new QgsLayoutComboBox( nullptr, widgetContext().project() ? widgetContext().project()->layoutManager() : nullptr );
@@ -3427,7 +3427,7 @@ QWidget *QgsProcessingLayoutWidgetWrapper::createWidget()
       return mComboBox;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
     {
       mPlainComboBox = new QComboBox();
       mPlainComboBox->setEditable( true );
@@ -3503,7 +3503,7 @@ QString QgsProcessingLayoutWidgetWrapper::parameterType() const
   return QgsProcessingParameterLayout::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingLayoutWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingLayoutWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingLayoutWidgetWrapper( parameter, type );
 }
@@ -3562,7 +3562,7 @@ QgsProcessingParameterDefinition *QgsProcessingLayoutItemParameterDefinitionWidg
 }
 
 
-QgsProcessingLayoutItemWidgetWrapper::QgsProcessingLayoutItemWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingLayoutItemWidgetWrapper::QgsProcessingLayoutItemWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -3572,8 +3572,8 @@ QWidget *QgsProcessingLayoutItemWidgetWrapper::createWidget()
   const QgsProcessingParameterLayoutItem *layoutParam = dynamic_cast<const QgsProcessingParameterLayoutItem *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       // combobox only for use outside modeler!
       mComboBox = new QgsLayoutItemComboBox( nullptr, nullptr );
@@ -3589,7 +3589,7 @@ QWidget *QgsProcessingLayoutItemWidgetWrapper::createWidget()
       return mComboBox;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
     {
       mLineEdit = new QLineEdit();
       mLineEdit->setToolTip( tr( "UUID or ID of an existing print layout item" ) );
@@ -3607,8 +3607,8 @@ void QgsProcessingLayoutItemWidgetWrapper::postInitialize( const QList<QgsAbstra
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -3624,7 +3624,7 @@ void QgsProcessingLayoutItemWidgetWrapper::postInitialize( const QList<QgsAbstra
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -3698,7 +3698,7 @@ QString QgsProcessingLayoutItemWidgetWrapper::parameterType() const
   return QgsProcessingParameterLayoutItem::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingLayoutItemWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingLayoutItemWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingLayoutItemWidgetWrapper( parameter, type );
 }
@@ -3978,7 +3978,7 @@ QgsProcessingParameterDefinition *QgsProcessingPointParameterDefinitionWidget::c
   return param.release();
 }
 
-QgsProcessingPointWidgetWrapper::QgsProcessingPointWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingPointWidgetWrapper::QgsProcessingPointWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -3988,8 +3988,8 @@ QWidget *QgsProcessingPointWidgetWrapper::createWidget()
   const QgsProcessingParameterPoint *pointParam = dynamic_cast<const QgsProcessingParameterPoint *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       mPanel = new QgsProcessingPointPanel( nullptr );
       if ( widgetContext().mapCanvas() )
@@ -3998,7 +3998,7 @@ QWidget *QgsProcessingPointWidgetWrapper::createWidget()
       if ( pointParam->flags() & Qgis::ProcessingParameterFlag::Optional )
         mPanel->setAllowNull( true );
 
-      if ( type() == QgsProcessingGui::Standard )
+      if ( type() == Qgis::ProcessingMode::Standard )
         mPanel->setShowPointOnCanvas( true );
 
       mPanel->setToolTip( parameterDefinition()->toolTip() );
@@ -4012,7 +4012,7 @@ QWidget *QgsProcessingPointWidgetWrapper::createWidget()
       return mPanel;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
     {
       mLineEdit = new QLineEdit();
       mLineEdit->setToolTip( tr( "Point as 'x,y'" ) );
@@ -4093,7 +4093,7 @@ QString QgsProcessingPointWidgetWrapper::parameterType() const
   return QgsProcessingParameterPoint::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingPointWidgetWrapper( parameter, type );
 }
@@ -4139,7 +4139,7 @@ QgsProcessingParameterDefinition *QgsProcessingGeometryParameterDefinitionWidget
   return param.release();
 }
 
-QgsProcessingGeometryWidgetWrapper::QgsProcessingGeometryWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingGeometryWidgetWrapper::QgsProcessingGeometryWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -4148,9 +4148,9 @@ QWidget *QgsProcessingGeometryWidgetWrapper::createWidget()
 {
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
+    case Qgis::ProcessingMode::Batch:
     {
       mGeometryWidget = new QgsGeometryWidget();
       mGeometryWidget->setToolTip( parameterDefinition()->toolTip() );
@@ -4202,7 +4202,7 @@ QString QgsProcessingGeometryWidgetWrapper::parameterType() const
   return QgsProcessingParameterGeometry::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingGeometryWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingGeometryWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingGeometryWidgetWrapper( parameter, type );
 }
@@ -4257,7 +4257,7 @@ QgsProcessingParameterDefinition *QgsProcessingColorParameterDefinitionWidget::c
   return param.release();
 }
 
-QgsProcessingColorWidgetWrapper::QgsProcessingColorWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingColorWidgetWrapper::QgsProcessingColorWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -4267,9 +4267,9 @@ QWidget *QgsProcessingColorWidgetWrapper::createWidget()
   const QgsProcessingParameterColor *colorParam = dynamic_cast<const QgsProcessingParameterColor *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       mColorButton = new QgsColorButton( nullptr );
       mColorButton->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
@@ -4331,7 +4331,7 @@ QString QgsProcessingColorWidgetWrapper::parameterType() const
   return QgsProcessingParameterColor::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingColorWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingColorWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingColorWidgetWrapper( parameter, type );
 }
@@ -4438,7 +4438,7 @@ QgsProcessingParameterDefinition *QgsProcessingCoordinateOperationParameterDefin
   return param.release();
 }
 
-QgsProcessingCoordinateOperationWidgetWrapper::QgsProcessingCoordinateOperationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingCoordinateOperationWidgetWrapper::QgsProcessingCoordinateOperationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -4451,7 +4451,7 @@ QWidget *QgsProcessingCoordinateOperationWidgetWrapper::createWidget()
   mDestCrs = QgsProcessingUtils::variantToCrs( coordParam->destinationCrs(), c );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
+    case Qgis::ProcessingMode::Standard:
     {
       mOperationWidget = new QgsCoordinateOperationWidget( nullptr );
       mOperationWidget->setShowMakeDefault( false );
@@ -4474,8 +4474,8 @@ QWidget *QgsProcessingCoordinateOperationWidgetWrapper::createWidget()
       return mOperationWidget;
     }
 
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       mLineEdit = new QLineEdit();
       QHBoxLayout *layout = new QHBoxLayout();
@@ -4510,8 +4510,8 @@ void QgsProcessingCoordinateOperationWidgetWrapper::postInitialize( const QList<
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -4533,7 +4533,7 @@ void QgsProcessingCoordinateOperationWidgetWrapper::postInitialize( const QList<
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -4627,7 +4627,7 @@ QString QgsProcessingCoordinateOperationWidgetWrapper::parameterType() const
   return QgsProcessingParameterCoordinateOperation::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingCoordinateOperationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingCoordinateOperationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingCoordinateOperationWidgetWrapper( parameter, type );
 }
@@ -4869,7 +4869,7 @@ QgsProcessingParameterDefinition *QgsProcessingFieldParameterDefinitionWidget::c
   return param.release();
 }
 
-QgsProcessingFieldWidgetWrapper::QgsProcessingFieldWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingFieldWidgetWrapper::QgsProcessingFieldWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -4879,8 +4879,8 @@ QWidget *QgsProcessingFieldWidgetWrapper::createWidget()
   const QgsProcessingParameterField *fieldParam = dynamic_cast<const QgsProcessingParameterField *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       if ( fieldParam->allowMultiple() )
       {
@@ -4915,7 +4915,7 @@ QWidget *QgsProcessingFieldWidgetWrapper::createWidget()
       }
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
     {
       mLineEdit = new QLineEdit();
       mLineEdit->setToolTip( QObject::tr( "Name of field (separate field names with ; for multiple field parameters)" ) );
@@ -4933,8 +4933,8 @@ void QgsProcessingFieldWidgetWrapper::postInitialize( const QList<QgsAbstractPro
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -4950,7 +4950,7 @@ void QgsProcessingFieldWidgetWrapper::postInitialize( const QList<QgsAbstractPro
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -5206,7 +5206,7 @@ QString QgsProcessingFieldWidgetWrapper::parameterType() const
   return QgsProcessingParameterField::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFieldWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFieldWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingFieldWidgetWrapper( parameter, type );
 }
@@ -5267,7 +5267,7 @@ QgsProcessingParameterDefinition *QgsProcessingMapThemeParameterDefinitionWidget
 }
 
 
-QgsProcessingMapThemeWidgetWrapper::QgsProcessingMapThemeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMapThemeWidgetWrapper::QgsProcessingMapThemeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -5289,11 +5289,11 @@ QWidget *QgsProcessingMapThemeWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
       break;
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       mComboBox->setEditable( true );
       break;
   }
@@ -5345,7 +5345,7 @@ QString QgsProcessingMapThemeWidgetWrapper::parameterType() const
   return QgsProcessingParameterMapTheme::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMapThemeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMapThemeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingMapThemeWidgetWrapper( parameter, type );
 }
@@ -5391,7 +5391,7 @@ QgsProcessingParameterDefinition *QgsProcessingDateTimeParameterDefinitionWidget
 }
 
 
-QgsProcessingDateTimeWidgetWrapper::QgsProcessingDateTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingDateTimeWidgetWrapper::QgsProcessingDateTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -5510,7 +5510,7 @@ QString QgsProcessingDateTimeWidgetWrapper::parameterType() const
   return QgsProcessingParameterDateTime::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDateTimeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDateTimeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingDateTimeWidgetWrapper( parameter, type );
 }
@@ -5562,7 +5562,7 @@ QgsProcessingParameterDefinition *QgsProcessingProviderConnectionParameterDefini
 }
 
 
-QgsProcessingProviderConnectionWidgetWrapper::QgsProcessingProviderConnectionWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingProviderConnectionWidgetWrapper::QgsProcessingProviderConnectionWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -5577,10 +5577,10 @@ QWidget *QgsProcessingProviderConnectionWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
       break;
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       mProviderComboBox->setEditable( true );
       break;
   }
@@ -5646,7 +5646,7 @@ QString QgsProcessingProviderConnectionWidgetWrapper::parameterType() const
   return QgsProcessingParameterProviderConnection::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingProviderConnectionWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingProviderConnectionWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingProviderConnectionWidgetWrapper( parameter, type );
 }
@@ -5726,7 +5726,7 @@ QgsProcessingParameterDefinition *QgsProcessingDatabaseSchemaParameterDefinition
 }
 
 
-QgsProcessingDatabaseSchemaWidgetWrapper::QgsProcessingDatabaseSchemaWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingDatabaseSchemaWidgetWrapper::QgsProcessingDatabaseSchemaWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -5741,10 +5741,10 @@ QWidget *QgsProcessingDatabaseSchemaWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
       break;
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       mSchemaComboBox->comboBox()->setEditable( true );
       break;
   }
@@ -5835,7 +5835,7 @@ QString QgsProcessingDatabaseSchemaWidgetWrapper::parameterType() const
   return QgsProcessingParameterDatabaseSchema::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDatabaseSchemaWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDatabaseSchemaWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingDatabaseSchemaWidgetWrapper( parameter, type );
 }
@@ -5845,8 +5845,8 @@ void QgsProcessingDatabaseSchemaWidgetWrapper::postInitialize( const QList<QgsAb
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -5862,7 +5862,7 @@ void QgsProcessingDatabaseSchemaWidgetWrapper::postInitialize( const QList<QgsAb
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -5963,7 +5963,7 @@ QgsProcessingParameterDefinition *QgsProcessingDatabaseTableParameterDefinitionW
 }
 
 
-QgsProcessingDatabaseTableWidgetWrapper::QgsProcessingDatabaseTableWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingDatabaseTableWidgetWrapper::QgsProcessingDatabaseTableWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -5976,7 +5976,7 @@ QWidget *QgsProcessingDatabaseTableWidgetWrapper::createWidget()
   if ( tableParam->flags() & Qgis::ProcessingParameterFlag::Optional )
     mTableComboBox->setAllowEmptyTable( true );
 
-  if ( type() == QgsProcessingGui::Modeler || tableParam->allowNewTableNames() )
+  if ( type() == Qgis::ProcessingMode::Modeler || tableParam->allowNewTableNames() )
     mTableComboBox->comboBox()->setEditable( true );
 
   mTableComboBox->setToolTip( parameterDefinition()->toolTip() );
@@ -6096,7 +6096,7 @@ QString QgsProcessingDatabaseTableWidgetWrapper::parameterType() const
   return QgsProcessingParameterDatabaseTable::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDatabaseTableWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDatabaseTableWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingDatabaseTableWidgetWrapper( parameter, type );
 }
@@ -6106,8 +6106,8 @@ void QgsProcessingDatabaseTableWidgetWrapper::postInitialize( const QList<QgsAbs
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -6129,7 +6129,7 @@ void QgsProcessingDatabaseTableWidgetWrapper::postInitialize( const QList<QgsAbs
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -6177,7 +6177,7 @@ QgsProcessingParameterDefinition *QgsProcessingExtentParameterDefinitionWidget::
 }
 
 
-QgsProcessingExtentWidgetWrapper::QgsProcessingExtentWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingExtentWidgetWrapper::QgsProcessingExtentWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -6187,9 +6187,9 @@ QWidget *QgsProcessingExtentWidgetWrapper::createWidget()
   const QgsProcessingParameterExtent *extentParam = dynamic_cast<const QgsProcessingParameterExtent *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
+    case Qgis::ProcessingMode::Modeler:
     {
       mExtentWidget = new QgsExtentWidget( nullptr );
       if ( widgetContext().mapCanvas() )
@@ -6204,7 +6204,7 @@ QWidget *QgsProcessingExtentWidgetWrapper::createWidget()
         emit widgetValueHasChanged( this );
       } );
 
-      if ( mDialog && type() != QgsProcessingGui::Modeler )
+      if ( mDialog && type() != Qgis::ProcessingMode::Modeler )
         setDialog( mDialog ); // setup connections to panel - dialog was previously set before the widget was created
 
       return mExtentWidget;
@@ -6216,14 +6216,14 @@ QWidget *QgsProcessingExtentWidgetWrapper::createWidget()
 void QgsProcessingExtentWidgetWrapper::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
 {
   QgsAbstractProcessingParameterWidgetWrapper::setWidgetContext( context );
-  if ( mExtentWidget && context.mapCanvas() && type() != QgsProcessingGui::Modeler )
+  if ( mExtentWidget && context.mapCanvas() && type() != Qgis::ProcessingMode::Modeler )
     mExtentWidget->setMapCanvas( context.mapCanvas() );
 }
 
 void QgsProcessingExtentWidgetWrapper::setDialog( QDialog *dialog )
 {
   mDialog = dialog;
-  if ( mExtentWidget && mDialog && type() != QgsProcessingGui::Modeler )
+  if ( mExtentWidget && mDialog && type() != Qgis::ProcessingMode::Modeler )
   {
     connect( mExtentWidget, &QgsExtentWidget::toggleDialogVisibility, mDialog, [=]( bool visible ) {
       if ( !visible )
@@ -6277,7 +6277,7 @@ QString QgsProcessingExtentWidgetWrapper::parameterType() const
   return QgsProcessingParameterExtent::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingExtentWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingExtentWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingExtentWidgetWrapper( parameter, type );
 }
@@ -6337,7 +6337,7 @@ QgsProcessingParameterDefinition *QgsProcessingMapLayerParameterDefinitionWidget
   return param.release();
 }
 
-QgsProcessingMapLayerWidgetWrapper::QgsProcessingMapLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMapLayerWidgetWrapper::QgsProcessingMapLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -6348,10 +6348,10 @@ QWidget *QgsProcessingMapLayerWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
       break;
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       mComboBox->setEditable( true );
       break;
   }
@@ -6420,7 +6420,7 @@ QString QgsProcessingMapLayerWidgetWrapper::parameterType() const
   return QgsProcessingParameterMapLayer::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMapLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMapLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingMapLayerWidgetWrapper( parameter, type );
 }
@@ -6435,7 +6435,7 @@ QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingMapLayerWidgetWrapp
 // QgsProcessingRasterLayerWidgetWrapper
 //
 
-QgsProcessingRasterLayerWidgetWrapper::QgsProcessingRasterLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingRasterLayerWidgetWrapper::QgsProcessingRasterLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingMapLayerWidgetWrapper( parameter, type, parent )
 {
 }
@@ -6450,7 +6450,7 @@ QString QgsProcessingRasterLayerWidgetWrapper::parameterType() const
   return QgsProcessingParameterRasterLayer::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRasterLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRasterLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingRasterLayerWidgetWrapper( parameter, type );
 }
@@ -6509,7 +6509,7 @@ QgsProcessingParameterDefinition *QgsProcessingVectorLayerParameterDefinitionWid
 }
 
 
-QgsProcessingVectorLayerWidgetWrapper::QgsProcessingVectorLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingVectorLayerWidgetWrapper::QgsProcessingVectorLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingMapLayerWidgetWrapper( parameter, type, parent )
 {
 }
@@ -6524,7 +6524,7 @@ QString QgsProcessingVectorLayerWidgetWrapper::parameterType() const
   return QgsProcessingParameterVectorLayer::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingVectorLayerWidgetWrapper( parameter, type );
 }
@@ -6581,7 +6581,7 @@ QgsProcessingParameterDefinition *QgsProcessingFeatureSourceParameterDefinitionW
   return param.release();
 }
 
-QgsProcessingFeatureSourceWidgetWrapper::QgsProcessingFeatureSourceWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingFeatureSourceWidgetWrapper::QgsProcessingFeatureSourceWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingMapLayerWidgetWrapper( parameter, type, parent )
 {
 }
@@ -6596,7 +6596,7 @@ QString QgsProcessingFeatureSourceWidgetWrapper::parameterType() const
   return QgsProcessingParameterFeatureSource::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFeatureSourceWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFeatureSourceWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingFeatureSourceWidgetWrapper( parameter, type );
 }
@@ -6610,7 +6610,7 @@ QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingFeatureSourceWidget
 // QgsProcessingMeshLayerWidgetWrapper
 //
 
-QgsProcessingMeshLayerWidgetWrapper::QgsProcessingMeshLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMeshLayerWidgetWrapper::QgsProcessingMeshLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingMapLayerWidgetWrapper( parameter, type, parent )
 {
 }
@@ -6625,7 +6625,7 @@ QString QgsProcessingMeshLayerWidgetWrapper::parameterType() const
   return QgsProcessingParameterMeshLayer::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMeshLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMeshLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingMeshLayerWidgetWrapper( parameter, type );
 }
@@ -6814,7 +6814,7 @@ QgsProcessingParameterDefinition *QgsProcessingBandParameterDefinitionWidget::cr
   return param.release();
 }
 
-QgsProcessingBandWidgetWrapper::QgsProcessingBandWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingBandWidgetWrapper::QgsProcessingBandWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -6824,8 +6824,8 @@ QWidget *QgsProcessingBandWidgetWrapper::createWidget()
   const QgsProcessingParameterBand *bandParam = dynamic_cast<const QgsProcessingParameterBand *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       if ( bandParam->allowMultiple() )
       {
@@ -6849,7 +6849,7 @@ QWidget *QgsProcessingBandWidgetWrapper::createWidget()
       }
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
     {
       mLineEdit = new QLineEdit();
       mLineEdit->setToolTip( QObject::tr( "Band number (separate bands with ; for multiple band parameters)" ) );
@@ -6867,8 +6867,8 @@ void QgsProcessingBandWidgetWrapper::postInitialize( const QList<QgsAbstractProc
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -6884,7 +6884,7 @@ void QgsProcessingBandWidgetWrapper::postInitialize( const QList<QgsAbstractProc
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -7049,7 +7049,7 @@ QString QgsProcessingBandWidgetWrapper::parameterType() const
   return QgsProcessingParameterBand::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingBandWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingBandWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingBandWidgetWrapper( parameter, type );
 }
@@ -7323,7 +7323,7 @@ QgsProcessingParameterDefinition *QgsProcessingMultipleLayerParameterDefinitionW
   return param.release();
 }
 
-QgsProcessingMultipleLayerWidgetWrapper::QgsProcessingMultipleLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingMultipleLayerWidgetWrapper::QgsProcessingMultipleLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -7335,7 +7335,7 @@ QWidget *QgsProcessingMultipleLayerWidgetWrapper::createWidget()
   mPanel = new QgsProcessingMultipleLayerPanelWidget( nullptr, layerParam );
   mPanel->setToolTip( parameterDefinition()->toolTip() );
   mPanel->setProject( widgetContext().project() );
-  if ( type() == QgsProcessingGui::Modeler )
+  if ( type() == Qgis::ProcessingMode::Modeler )
     mPanel->setModel( widgetContext().model(), widgetContext().modelChildAlgorithmId() );
   connect( mPanel, &QgsProcessingMultipleLayerPanelWidget::changed, this, [=] {
     emit widgetValueHasChanged( this );
@@ -7349,7 +7349,7 @@ void QgsProcessingMultipleLayerWidgetWrapper::setWidgetContext( const QgsProcess
   if ( mPanel )
   {
     mPanel->setProject( context.project() );
-    if ( type() == QgsProcessingGui::Modeler )
+    if ( type() == Qgis::ProcessingMode::Modeler )
       mPanel->setModel( widgetContext().model(), widgetContext().modelChildAlgorithmId() );
   }
 }
@@ -7399,7 +7399,7 @@ QString QgsProcessingMultipleLayerWidgetWrapper::parameterType() const
   return QgsProcessingParameterMultipleLayers::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMultipleLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMultipleLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingMultipleLayerWidgetWrapper( parameter, type );
 }
@@ -7414,7 +7414,7 @@ QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingMultipleLayerWidget
 // QgsProcessingPointCloudLayerWidgetWrapper
 //
 
-QgsProcessingPointCloudLayerWidgetWrapper::QgsProcessingPointCloudLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingPointCloudLayerWidgetWrapper::QgsProcessingPointCloudLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingMapLayerWidgetWrapper( parameter, type, parent )
 {
 }
@@ -7429,7 +7429,7 @@ QString QgsProcessingPointCloudLayerWidgetWrapper::parameterType() const
   return QgsProcessingParameterPointCloudLayer::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointCloudLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointCloudLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingPointCloudLayerWidgetWrapper( parameter, type );
 }
@@ -7449,7 +7449,7 @@ QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingPointCloudLayerWidg
 // QgsProcessingAnnotationLayerWidgetWrapper
 //
 
-QgsProcessingAnnotationLayerWidgetWrapper::QgsProcessingAnnotationLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingAnnotationLayerWidgetWrapper::QgsProcessingAnnotationLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -7464,7 +7464,7 @@ QString QgsProcessingAnnotationLayerWidgetWrapper::parameterType() const
   return QgsProcessingParameterAnnotationLayer::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAnnotationLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingAnnotationLayerWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingAnnotationLayerWidgetWrapper( parameter, type );
 }
@@ -7496,10 +7496,10 @@ QWidget *QgsProcessingAnnotationLayerWidgetWrapper::createWidget()
 
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
       break;
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       mComboBox->setEditable( true );
       break;
   }
@@ -7764,7 +7764,7 @@ QgsProcessingParameterDefinition *QgsProcessingPointCloudAttributeParameterDefin
   return param.release();
 }
 
-QgsProcessingPointCloudAttributeWidgetWrapper::QgsProcessingPointCloudAttributeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingPointCloudAttributeWidgetWrapper::QgsProcessingPointCloudAttributeWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -7774,8 +7774,8 @@ QWidget *QgsProcessingPointCloudAttributeWidgetWrapper::createWidget()
   const QgsProcessingParameterPointCloudAttribute *attrParam = dynamic_cast<const QgsProcessingParameterPointCloudAttribute *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       if ( attrParam->allowMultiple() )
       {
@@ -7798,7 +7798,7 @@ QWidget *QgsProcessingPointCloudAttributeWidgetWrapper::createWidget()
       }
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
     {
       mLineEdit = new QLineEdit();
       mLineEdit->setToolTip( QObject::tr( "Name of attribute (separate attribute names with ; for multiple attribute parameters)" ) );
@@ -7816,8 +7816,8 @@ void QgsProcessingPointCloudAttributeWidgetWrapper::postInitialize( const QList<
   QgsAbstractProcessingParameterWidgetWrapper::postInitialize( wrappers );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Batch:
     {
       for ( const QgsAbstractProcessingParameterWidgetWrapper *wrapper : wrappers )
       {
@@ -7833,7 +7833,7 @@ void QgsProcessingPointCloudAttributeWidgetWrapper::postInitialize( const QList<
       break;
     }
 
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Modeler:
       break;
   }
 }
@@ -7976,7 +7976,7 @@ QString QgsProcessingPointCloudAttributeWidgetWrapper::parameterType() const
   return QgsProcessingParameterPointCloudAttribute::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointCloudAttributeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointCloudAttributeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingPointCloudAttributeWidgetWrapper( parameter, type );
 }
@@ -7991,7 +7991,7 @@ QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingPointCloudAttribute
 // QgsProcessingOutputWidgetWrapper
 //
 
-QgsProcessingOutputWidgetWrapper::QgsProcessingOutputWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingOutputWidgetWrapper::QgsProcessingOutputWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8001,8 +8001,8 @@ QWidget *QgsProcessingOutputWidgetWrapper::createWidget()
   const QgsProcessingDestinationParameter *destParam = dynamic_cast<const QgsProcessingDestinationParameter *>( parameterDefinition() );
   switch ( type() )
   {
-    case QgsProcessingGui::Standard:
-    case QgsProcessingGui::Modeler:
+    case Qgis::ProcessingMode::Standard:
+    case Qgis::ProcessingMode::Modeler:
     {
       mOutputWidget = new QgsProcessingLayerOutputDestinationWidget( destParam, false );
       if ( mProcessingContextGenerator )
@@ -8018,13 +8018,13 @@ QWidget *QgsProcessingOutputWidgetWrapper::createWidget()
         emit widgetValueHasChanged( this );
       } );
 
-      if ( type() == QgsProcessingGui::Standard
+      if ( type() == Qgis::ProcessingMode::Standard
            && ( destParam->type() == QgsProcessingParameterRasterDestination::typeName() || destParam->type() == QgsProcessingParameterFeatureSink::typeName() || destParam->type() == QgsProcessingParameterVectorDestination::typeName() || destParam->type() == QgsProcessingParameterPointCloudDestination::typeName() || destParam->type() == QgsProcessingParameterVectorTileDestination::typeName() ) )
         mOutputWidget->addOpenAfterRunningOption();
 
       return mOutputWidget;
     }
-    case QgsProcessingGui::Batch:
+    case Qgis::ProcessingMode::Batch:
       break;
   }
 
@@ -8058,7 +8058,7 @@ QVariantMap QgsProcessingOutputWidgetWrapper::customProperties() const
 // QgsProcessingFeatureSinkWidgetWrapper
 //
 
-QgsProcessingFeatureSinkWidgetWrapper::QgsProcessingFeatureSinkWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingFeatureSinkWidgetWrapper::QgsProcessingFeatureSinkWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingOutputWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8068,7 +8068,7 @@ QString QgsProcessingFeatureSinkWidgetWrapper::parameterType() const
   return QgsProcessingParameterFeatureSink::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFeatureSinkWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFeatureSinkWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingFeatureSinkWidgetWrapper( parameter, type );
 }
@@ -8082,7 +8082,7 @@ QString QgsProcessingFeatureSinkWidgetWrapper::modelerExpressionFormatString() c
 // QgsProcessingFeatureSinkWidgetWrapper
 //
 
-QgsProcessingVectorDestinationWidgetWrapper::QgsProcessingVectorDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingVectorDestinationWidgetWrapper::QgsProcessingVectorDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingOutputWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8092,7 +8092,7 @@ QString QgsProcessingVectorDestinationWidgetWrapper::parameterType() const
   return QgsProcessingParameterVectorDestination::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingVectorDestinationWidgetWrapper( parameter, type );
 }
@@ -8106,7 +8106,7 @@ QString QgsProcessingVectorDestinationWidgetWrapper::modelerExpressionFormatStri
 // QgsProcessingRasterDestinationWidgetWrapper
 //
 
-QgsProcessingRasterDestinationWidgetWrapper::QgsProcessingRasterDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingRasterDestinationWidgetWrapper::QgsProcessingRasterDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingOutputWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8116,7 +8116,7 @@ QString QgsProcessingRasterDestinationWidgetWrapper::parameterType() const
   return QgsProcessingParameterRasterDestination::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRasterDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRasterDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingRasterDestinationWidgetWrapper( parameter, type );
 }
@@ -8130,7 +8130,7 @@ QString QgsProcessingRasterDestinationWidgetWrapper::modelerExpressionFormatStri
 // QgsProcessingPointCloudDestinationWidgetWrapper
 //
 
-QgsProcessingPointCloudDestinationWidgetWrapper::QgsProcessingPointCloudDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingPointCloudDestinationWidgetWrapper::QgsProcessingPointCloudDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingOutputWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8140,7 +8140,7 @@ QString QgsProcessingPointCloudDestinationWidgetWrapper::parameterType() const
   return QgsProcessingParameterPointCloudDestination::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointCloudDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingPointCloudDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingPointCloudDestinationWidgetWrapper( parameter, type );
 }
@@ -8154,7 +8154,7 @@ QString QgsProcessingPointCloudDestinationWidgetWrapper::modelerExpressionFormat
 // QgsProcessingFileDestinationWidgetWrapper
 //
 
-QgsProcessingFileDestinationWidgetWrapper::QgsProcessingFileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingFileDestinationWidgetWrapper::QgsProcessingFileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingOutputWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8164,7 +8164,7 @@ QString QgsProcessingFileDestinationWidgetWrapper::parameterType() const
   return QgsProcessingParameterFileDestination::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFileDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFileDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingFileDestinationWidgetWrapper( parameter, type );
 }
@@ -8179,7 +8179,7 @@ QString QgsProcessingFileDestinationWidgetWrapper::modelerExpressionFormatString
 // QgsProcessingFolderDestinationWidgetWrapper
 //
 
-QgsProcessingFolderDestinationWidgetWrapper::QgsProcessingFolderDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingFolderDestinationWidgetWrapper::QgsProcessingFolderDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingOutputWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8189,7 +8189,7 @@ QString QgsProcessingFolderDestinationWidgetWrapper::parameterType() const
   return QgsProcessingParameterFolderDestination::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFolderDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingFolderDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingFolderDestinationWidgetWrapper( parameter, type );
 }
@@ -8204,7 +8204,7 @@ QString QgsProcessingFolderDestinationWidgetWrapper::modelerExpressionFormatStri
 // QgsProcessingVectorTileDestinationWidgetWrapper
 //
 
-QgsProcessingVectorTileDestinationWidgetWrapper::QgsProcessingVectorTileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+QgsProcessingVectorTileDestinationWidgetWrapper::QgsProcessingVectorTileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type, QWidget *parent )
   : QgsProcessingOutputWidgetWrapper( parameter, type, parent )
 {
 }
@@ -8214,7 +8214,7 @@ QString QgsProcessingVectorTileDestinationWidgetWrapper::parameterType() const
   return QgsProcessingParameterVectorTileDestination::typeName();
 }
 
-QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorTileDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingVectorTileDestinationWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type )
 {
   return new QgsProcessingPointCloudDestinationWidgetWrapper( parameter, type );
 }

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -95,11 +95,11 @@ class GUI_EXPORT QgsProcessingBooleanWidgetWrapper : public QgsAbstractProcessin
     Q_OBJECT
 
   public:
-    QgsProcessingBooleanWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingBooleanWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -139,11 +139,11 @@ class GUI_EXPORT QgsProcessingCrsWidgetWrapper : public QgsAbstractProcessingPar
     Q_OBJECT
 
   public:
-    QgsProcessingCrsWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingCrsWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -185,11 +185,11 @@ class GUI_EXPORT QgsProcessingStringWidgetWrapper : public QgsAbstractProcessing
     Q_OBJECT
 
   public:
-    QgsProcessingStringWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingStringWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -218,11 +218,11 @@ class GUI_EXPORT QgsProcessingAuthConfigWidgetWrapper : public QgsAbstractProces
     Q_OBJECT
 
   public:
-    QgsProcessingAuthConfigWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingAuthConfigWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;
@@ -258,11 +258,11 @@ class GUI_EXPORT QgsProcessingNumericWidgetWrapper : public QgsAbstractProcessin
     Q_OBJECT
 
   public:
-    QgsProcessingNumericWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingNumericWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -309,11 +309,11 @@ class GUI_EXPORT QgsProcessingDistanceWidgetWrapper : public QgsProcessingNumeri
     Q_OBJECT
 
   public:
-    QgsProcessingDistanceWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingDistanceWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -360,11 +360,11 @@ class GUI_EXPORT QgsProcessingAreaWidgetWrapper : public QgsProcessingNumericWid
     Q_OBJECT
 
   public:
-    QgsProcessingAreaWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingAreaWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -412,11 +412,11 @@ class GUI_EXPORT QgsProcessingVolumeWidgetWrapper : public QgsProcessingNumericW
     Q_OBJECT
 
   public:
-    QgsProcessingVolumeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingVolumeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -464,11 +464,11 @@ class GUI_EXPORT QgsProcessingDurationWidgetWrapper : public QgsProcessingNumeri
     Q_OBJECT
 
   public:
-    QgsProcessingDurationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingDurationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -507,11 +507,11 @@ class GUI_EXPORT QgsProcessingScaleWidgetWrapper : public QgsProcessingNumericWi
     Q_OBJECT
 
   public:
-    QgsProcessingScaleWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingScaleWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -552,11 +552,11 @@ class GUI_EXPORT QgsProcessingRangeWidgetWrapper : public QgsAbstractProcessingP
     Q_OBJECT
 
   public:
-    QgsProcessingRangeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingRangeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -599,11 +599,11 @@ class GUI_EXPORT QgsProcessingMatrixWidgetWrapper : public QgsAbstractProcessing
     Q_OBJECT
 
   public:
-    QgsProcessingMatrixWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMatrixWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -644,11 +644,11 @@ class GUI_EXPORT QgsProcessingFileWidgetWrapper : public QgsAbstractProcessingPa
     Q_OBJECT
 
   public:
-    QgsProcessingFileWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingFileWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -692,11 +692,11 @@ class GUI_EXPORT QgsProcessingExpressionWidgetWrapper : public QgsAbstractProces
     Q_OBJECT
 
   public:
-    QgsProcessingExpressionWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingExpressionWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -805,11 +805,11 @@ class GUI_EXPORT QgsProcessingEnumWidgetWrapper : public QgsAbstractProcessingPa
     Q_OBJECT
 
   public:
-    QgsProcessingEnumWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingEnumWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -840,11 +840,11 @@ class GUI_EXPORT QgsProcessingLayoutWidgetWrapper : public QgsAbstractProcessing
     Q_OBJECT
 
   public:
-    QgsProcessingLayoutWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingLayoutWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;
@@ -880,11 +880,11 @@ class GUI_EXPORT QgsProcessingLayoutItemWidgetWrapper : public QgsAbstractProces
     Q_OBJECT
 
   public:
-    QgsProcessingLayoutItemWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingLayoutItemWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -997,11 +997,11 @@ class GUI_EXPORT QgsProcessingPointWidgetWrapper : public QgsAbstractProcessingP
     Q_OBJECT
 
   public:
-    QgsProcessingPointWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingPointWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1044,11 +1044,11 @@ class GUI_EXPORT QgsProcessingGeometryWidgetWrapper : public QgsAbstractProcessi
     Q_OBJECT
 
   public:
-    QgsProcessingGeometryWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingGeometryWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1087,11 +1087,11 @@ class GUI_EXPORT QgsProcessingExtentWidgetWrapper : public QgsAbstractProcessing
     Q_OBJECT
 
   public:
-    QgsProcessingExtentWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingExtentWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1134,11 +1134,11 @@ class GUI_EXPORT QgsProcessingColorWidgetWrapper : public QgsAbstractProcessingP
     Q_OBJECT
 
   public:
-    QgsProcessingColorWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingColorWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1183,11 +1183,11 @@ class GUI_EXPORT QgsProcessingCoordinateOperationWidgetWrapper : public QgsAbstr
     Q_OBJECT
 
   public:
-    QgsProcessingCoordinateOperationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingCoordinateOperationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1274,11 +1274,11 @@ class GUI_EXPORT QgsProcessingFieldWidgetWrapper : public QgsAbstractProcessingP
     Q_OBJECT
 
   public:
-    QgsProcessingFieldWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingFieldWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1329,11 +1329,11 @@ class GUI_EXPORT QgsProcessingMapThemeWidgetWrapper : public QgsAbstractProcessi
     Q_OBJECT
 
   public:
-    QgsProcessingMapThemeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMapThemeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1373,11 +1373,11 @@ class GUI_EXPORT QgsProcessingDateTimeWidgetWrapper : public QgsAbstractProcessi
     Q_OBJECT
 
   public:
-    QgsProcessingDateTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingDateTimeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;
@@ -1424,11 +1424,11 @@ class GUI_EXPORT QgsProcessingProviderConnectionWidgetWrapper : public QgsAbstra
     Q_OBJECT
 
   public:
-    QgsProcessingProviderConnectionWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingProviderConnectionWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
 
     // QgsProcessingParameterWidgetWrapper interface
@@ -1471,11 +1471,11 @@ class GUI_EXPORT QgsProcessingDatabaseSchemaWidgetWrapper : public QgsAbstractPr
     Q_OBJECT
 
   public:
-    QgsProcessingDatabaseSchemaWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingDatabaseSchemaWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     void postInitialize( const QList<QgsAbstractProcessingParameterWidgetWrapper *> &wrappers ) override;
 
 
@@ -1523,11 +1523,11 @@ class GUI_EXPORT QgsProcessingDatabaseTableWidgetWrapper : public QgsAbstractPro
     Q_OBJECT
 
   public:
-    QgsProcessingDatabaseTableWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingDatabaseTableWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     void postInitialize( const QList<QgsAbstractProcessingParameterWidgetWrapper *> &wrappers ) override;
 
 
@@ -1576,11 +1576,11 @@ class GUI_EXPORT QgsProcessingMapLayerWidgetWrapper : public QgsAbstractProcessi
     Q_OBJECT
 
   public:
-    QgsProcessingMapLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMapLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1612,11 +1612,11 @@ class GUI_EXPORT QgsProcessingRasterLayerWidgetWrapper : public QgsProcessingMap
     Q_OBJECT
 
   public:
-    QgsProcessingRasterLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingRasterLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1645,11 +1645,11 @@ class GUI_EXPORT QgsProcessingVectorLayerWidgetWrapper : public QgsProcessingMap
     Q_OBJECT
 
   public:
-    QgsProcessingVectorLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingVectorLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1678,11 +1678,11 @@ class GUI_EXPORT QgsProcessingFeatureSourceWidgetWrapper : public QgsProcessingM
     Q_OBJECT
 
   public:
-    QgsProcessingFeatureSourceWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingFeatureSourceWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1700,11 +1700,11 @@ class GUI_EXPORT QgsProcessingMeshLayerWidgetWrapper : public QgsProcessingMapLa
     Q_OBJECT
 
   public:
-    QgsProcessingMeshLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMeshLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1772,11 +1772,11 @@ class GUI_EXPORT QgsProcessingBandWidgetWrapper : public QgsAbstractProcessingPa
     Q_OBJECT
 
   public:
-    QgsProcessingBandWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingBandWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1879,11 +1879,11 @@ class GUI_EXPORT QgsProcessingMultipleLayerWidgetWrapper : public QgsAbstractPro
     Q_OBJECT
 
   public:
-    QgsProcessingMultipleLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingMultipleLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -1913,7 +1913,7 @@ class GUI_EXPORT QgsProcessingOutputWidgetWrapper : public QgsAbstractProcessing
     Q_OBJECT
 
   public:
-    QgsProcessingOutputWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingOutputWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;
@@ -1936,11 +1936,11 @@ class GUI_EXPORT QgsProcessingFeatureSinkWidgetWrapper : public QgsProcessingOut
     Q_OBJECT
 
   public:
-    QgsProcessingFeatureSinkWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingFeatureSinkWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QString modelerExpressionFormatString() const override;
@@ -1954,11 +1954,11 @@ class GUI_EXPORT QgsProcessingVectorDestinationWidgetWrapper : public QgsProcess
     Q_OBJECT
 
   public:
-    QgsProcessingVectorDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingVectorDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QString modelerExpressionFormatString() const override;
@@ -1969,11 +1969,11 @@ class GUI_EXPORT QgsProcessingRasterDestinationWidgetWrapper : public QgsProcess
     Q_OBJECT
 
   public:
-    QgsProcessingRasterDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingRasterDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QString modelerExpressionFormatString() const override;
@@ -1984,11 +1984,11 @@ class GUI_EXPORT QgsProcessingPointCloudDestinationWidgetWrapper : public QgsPro
     Q_OBJECT
 
   public:
-    QgsProcessingPointCloudDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingPointCloudDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QString modelerExpressionFormatString() const override;
@@ -1999,11 +1999,11 @@ class GUI_EXPORT QgsProcessingFileDestinationWidgetWrapper : public QgsProcessin
     Q_OBJECT
 
   public:
-    QgsProcessingFileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingFileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QString modelerExpressionFormatString() const override;
@@ -2014,11 +2014,11 @@ class GUI_EXPORT QgsProcessingFolderDestinationWidgetWrapper : public QgsProcess
     Q_OBJECT
 
   public:
-    QgsProcessingFolderDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingFolderDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QString modelerExpressionFormatString() const override;
@@ -2029,11 +2029,11 @@ class GUI_EXPORT QgsProcessingPointCloudLayerWidgetWrapper : public QgsProcessin
     Q_OBJECT
 
   public:
-    QgsProcessingPointCloudLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingPointCloudLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -2051,11 +2051,11 @@ class GUI_EXPORT QgsProcessingAnnotationLayerWidgetWrapper : public QgsAbstractP
     Q_OBJECT
 
   public:
-    QgsProcessingAnnotationLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingAnnotationLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -2135,11 +2135,11 @@ class GUI_EXPORT QgsProcessingPointCloudAttributeWidgetWrapper : public QgsAbstr
     Q_OBJECT
 
   public:
-    QgsProcessingPointCloudAttributeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingPointCloudAttributeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
     QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
       QgsProcessingContext &context,
       const QgsProcessingParameterWidgetContext &widgetContext,
@@ -2175,11 +2175,11 @@ class GUI_EXPORT QgsProcessingVectorTileDestinationWidgetWrapper : public QgsPro
     Q_OBJECT
 
   public:
-    QgsProcessingVectorTileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+    QgsProcessingVectorTileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard, QWidget *parent = nullptr );
 
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override;
 
   protected:
     QString modelerExpressionFormatString() const override;

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -886,7 +886,7 @@ void QgsGraduatedSymbolRendererWidget::updateMethodParameters()
 
   for ( const QgsProcessingParameterDefinition *def : mClassificationMethod->parameterDefinitions() )
   {
-    QgsAbstractProcessingParameterWidgetWrapper *ppww = QgsGui::processingGuiRegistry()->createParameterWidgetWrapper( def, QgsProcessingGui::Standard );
+    QgsAbstractProcessingParameterWidgetWrapper *ppww = QgsGui::processingGuiRegistry()->createParameterWidgetWrapper( def, Qgis::ProcessingMode::Standard );
     mParametersLayout->addRow( ppww->createWrappedLabel(), ppww->createWrappedWidget( context ) );
 
     QVariant value = mClassificationMethod->parameterValues().value( def->name(), def->defaultValueForGui() );

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -171,7 +171,7 @@ class TestParameterType : public QgsProcessingParameterType
 class TestWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper // clazy:exclude=missing-qobject-macro
 {
   public:
-    TestWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard )
+    TestWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr, Qgis::ProcessingMode type = Qgis::ProcessingMode::Standard )
       : QgsAbstractProcessingParameterWidgetWrapper( parameter, type )
     {}
 
@@ -209,7 +209,7 @@ class TestWidgetFactory : public QgsProcessingParameterWidgetFactoryInterface
       return type;
     }
 
-    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, Qgis::ProcessingMode type ) override
     {
       return new TestWidgetWrapper( parameter, type );
     }
@@ -528,7 +528,7 @@ void TestProcessingGui::testWrapperFactoryRegistry()
   TestParameterType *numParamType = new TestParameterType( QStringLiteral( "num" ) );
   TestParameterType *stringParamType = new TestParameterType( QStringLiteral( "str" ) );
 
-  QVERIFY( !guiRegistry.createParameterWidgetWrapper( &numParam, QgsProcessingGui::Standard ) );
+  QVERIFY( !guiRegistry.createParameterWidgetWrapper( &numParam, Qgis::ProcessingMode::Standard ) );
 
   TestWidgetFactory *factory = new TestWidgetFactory( QStringLiteral( "str" ) );
   QVERIFY( guiRegistry.addParameterWidgetFactory( factory ) );
@@ -542,9 +542,9 @@ void TestProcessingGui::testWrapperFactoryRegistry()
   QVERIFY( QgsApplication::processingRegistry()->addParameterType( numParamType ) );
   QVERIFY( QgsApplication::processingRegistry()->addParameterType( stringParamType ) );
 
-  QgsAbstractProcessingParameterWidgetWrapper *wrapper = guiRegistry.createParameterWidgetWrapper( &numParam, QgsProcessingGui::Standard );
+  QgsAbstractProcessingParameterWidgetWrapper *wrapper = guiRegistry.createParameterWidgetWrapper( &numParam, Qgis::ProcessingMode::Standard );
   QVERIFY( !wrapper );
-  wrapper = guiRegistry.createParameterWidgetWrapper( &stringParam, QgsProcessingGui::Standard );
+  wrapper = guiRegistry.createParameterWidgetWrapper( &stringParam, Qgis::ProcessingMode::Standard );
   QVERIFY( wrapper );
   QCOMPARE( wrapper->parameterDefinition()->type(), QStringLiteral( "str" ) );
   delete wrapper;
@@ -552,18 +552,18 @@ void TestProcessingGui::testWrapperFactoryRegistry()
   TestWidgetFactory *factory3 = new TestWidgetFactory( QStringLiteral( "num" ) );
   QVERIFY( guiRegistry.addParameterWidgetFactory( factory3 ) );
 
-  wrapper = guiRegistry.createParameterWidgetWrapper( &numParam, QgsProcessingGui::Standard );
+  wrapper = guiRegistry.createParameterWidgetWrapper( &numParam, Qgis::ProcessingMode::Standard );
   QVERIFY( wrapper );
   QCOMPARE( wrapper->parameterDefinition()->type(), QStringLiteral( "num" ) );
   delete wrapper;
 
   // creating wrapper using metadata
   TestParamDefinition customParam( QStringLiteral( "custom" ), QStringLiteral( "custom" ) );
-  wrapper = guiRegistry.createParameterWidgetWrapper( &customParam, QgsProcessingGui::Standard );
+  wrapper = guiRegistry.createParameterWidgetWrapper( &customParam, Qgis::ProcessingMode::Standard );
   QVERIFY( !wrapper );
   customParam.setMetadata( { { QStringLiteral( "widget_wrapper" ), QVariantMap( { { QStringLiteral( "widget_type" ), QStringLiteral( "str" ) } } ) }
   } );
-  wrapper = guiRegistry.createParameterWidgetWrapper( &customParam, QgsProcessingGui::Standard );
+  wrapper = guiRegistry.createParameterWidgetWrapper( &customParam, Qgis::ProcessingMode::Standard );
   QVERIFY( wrapper );
   QCOMPARE( wrapper->parameterDefinition()->type(), QStringLiteral( "custom" ) );
   delete wrapper;
@@ -576,10 +576,10 @@ void TestProcessingGui::testWrapperFactoryRegistry()
   QgsApplication::processingRegistry()->removeParameterType( numParamType );
   QgsApplication::processingRegistry()->removeParameterType( stringParamType );
 
-  wrapper = guiRegistry.createParameterWidgetWrapper( &stringParam, QgsProcessingGui::Standard );
+  wrapper = guiRegistry.createParameterWidgetWrapper( &stringParam, Qgis::ProcessingMode::Standard );
   QVERIFY( !wrapper );
 
-  wrapper = guiRegistry.createParameterWidgetWrapper( &numParam, QgsProcessingGui::Standard );
+  wrapper = guiRegistry.createParameterWidgetWrapper( &numParam, Qgis::ProcessingMode::Standard );
   QVERIFY( wrapper );
   QCOMPARE( wrapper->parameterDefinition()->type(), QStringLiteral( "num" ) );
   delete wrapper;
@@ -590,19 +590,19 @@ void TestProcessingGui::testWrapperGeneral()
   TestParamDefinition param( QStringLiteral( "boolean" ), QStringLiteral( "bool" ) );
   param.setAdditionalExpressionContextVariables( QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
   QgsProcessingBooleanWidgetWrapper wrapper( &param );
-  QCOMPARE( wrapper.type(), QgsProcessingGui::Standard );
+  QCOMPARE( wrapper.type(), Qgis::ProcessingMode::Standard );
 
   QgsExpressionContext expContext = wrapper.createExpressionContext();
   QVERIFY( expContext.hasVariable( QStringLiteral( "a" ) ) );
   QVERIFY( expContext.hasVariable( QStringLiteral( "b" ) ) );
   QCOMPARE( expContext.highlightedVariables(), QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
 
-  QgsProcessingBooleanWidgetWrapper wrapper2( &param, QgsProcessingGui::Batch );
-  QCOMPARE( wrapper2.type(), QgsProcessingGui::Batch );
+  QgsProcessingBooleanWidgetWrapper wrapper2( &param, Qgis::ProcessingMode::Batch );
+  QCOMPARE( wrapper2.type(), Qgis::ProcessingMode::Batch );
   QCOMPARE( wrapper2.parameterDefinition()->name(), QStringLiteral( "bool" ) );
 
-  QgsProcessingBooleanWidgetWrapper wrapperModeler( &param, QgsProcessingGui::Modeler );
-  QCOMPARE( wrapperModeler.type(), QgsProcessingGui::Modeler );
+  QgsProcessingBooleanWidgetWrapper wrapperModeler( &param, Qgis::ProcessingMode::Modeler );
+  QCOMPARE( wrapperModeler.type(), Qgis::ProcessingMode::Modeler );
 
   QgsProcessingContext context;
   QVERIFY( !wrapper2.wrappedWidget() );
@@ -690,8 +690,8 @@ void TestProcessingGui::testWrapperDynamic()
   const QgsProcessingParameterDefinition *layerDef = centroidAlg->parameterDefinition( QStringLiteral( "INPUT" ) );
   const QgsProcessingParameterDefinition *allPartsDef = centroidAlg->parameterDefinition( QStringLiteral( "ALL_PARTS" ) );
 
-  QgsProcessingBooleanWidgetWrapper inputWrapper( layerDef, QgsProcessingGui::Standard );
-  QgsProcessingBooleanWidgetWrapper allPartsWrapper( allPartsDef, QgsProcessingGui::Standard );
+  QgsProcessingBooleanWidgetWrapper inputWrapper( layerDef, Qgis::ProcessingMode::Standard );
+  QgsProcessingBooleanWidgetWrapper allPartsWrapper( allPartsDef, Qgis::ProcessingMode::Standard );
 
   QgsProcessingContext context;
 
@@ -981,7 +981,7 @@ void TestProcessingGui::testBooleanWrapper()
   delete w;
 
   // batch wrapper
-  QgsProcessingBooleanWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingBooleanWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingBooleanWidgetWrapper::widgetValueHasChanged );
@@ -1005,7 +1005,7 @@ void TestProcessingGui::testBooleanWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingBooleanWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingBooleanWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingBooleanWidgetWrapper::widgetValueHasChanged );
@@ -1095,7 +1095,7 @@ void TestProcessingGui::testStringWrapper()
   delete w;
 
   // batch wrapper
-  QgsProcessingStringWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingStringWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingStringWidgetWrapper::widgetValueHasChanged );
@@ -1119,7 +1119,7 @@ void TestProcessingGui::testStringWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingStringWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingStringWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingStringWidgetWrapper::widgetValueHasChanged );
@@ -1181,7 +1181,7 @@ void TestProcessingGui::testStringWrapper()
   delete w;
 
   // batch wrapper - should still be a line edit
-  QgsProcessingStringWidgetWrapper wrapperMultiLineB( &param, QgsProcessingGui::Batch );
+  QgsProcessingStringWidgetWrapper wrapperMultiLineB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperMultiLineB.createWrappedWidget( context );
   QSignalSpy spy5( &wrapperMultiLineB, &QgsProcessingStringWidgetWrapper::widgetValueHasChanged );
@@ -1205,7 +1205,7 @@ void TestProcessingGui::testStringWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingStringWidgetWrapper wrapperMultiLineM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingStringWidgetWrapper wrapperMultiLineM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperMultiLineM.createWrappedWidget( context );
   QSignalSpy spy6( &wrapperMultiLineM, &QgsProcessingStringWidgetWrapper::widgetValueHasChanged );
@@ -1352,7 +1352,7 @@ void TestProcessingGui::testStringWrapper()
 
 void TestProcessingGui::testFileWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingParameterFile param( QStringLiteral( "file" ), QStringLiteral( "file" ) );
 
     QgsProcessingFileWidgetWrapper wrapper( &param, type );
@@ -1373,7 +1373,7 @@ void TestProcessingGui::testFileWrapper()
     QVERIFY( static_cast<QgsFileWidget *>( wrapper.wrappedWidget() )->filePath().isEmpty() );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "file" ) );
@@ -1416,13 +1416,13 @@ void TestProcessingGui::testFileWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
 
   // config widget
@@ -1537,7 +1537,7 @@ void TestProcessingGui::testAuthCfgWrapper()
   delete w;
 
   // batch wrapper
-  QgsProcessingAuthConfigWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingAuthConfigWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingAuthConfigWidgetWrapper::widgetValueHasChanged );
@@ -1559,7 +1559,7 @@ void TestProcessingGui::testAuthCfgWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingAuthConfigWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingAuthConfigWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingAuthConfigWidgetWrapper::widgetValueHasChanged );
@@ -1624,7 +1624,7 @@ void TestProcessingGui::testCrsWrapper()
   delete w;
 
   // batch wrapper
-  QgsProcessingCrsWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingCrsWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingCrsWidgetWrapper::widgetValueHasChanged );
@@ -1648,7 +1648,7 @@ void TestProcessingGui::testCrsWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingCrsWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingCrsWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingCrsWidgetWrapper::widgetValueHasChanged );
@@ -1713,7 +1713,7 @@ void TestProcessingGui::testCrsWrapper()
 
 void TestProcessingGui::testNumericWrapperDouble()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingContext context;
 
     QgsProcessingParameterNumber param( QStringLiteral( "num" ), QStringLiteral( "num" ), Qgis::ProcessingNumberParameterType::Double );
@@ -1742,7 +1742,7 @@ void TestProcessingGui::testNumericWrapperDouble()
     QCOMPARE( static_cast<QgsDoubleSpinBox *>( wrapper.wrappedWidget() )->value(), 0.0 );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "num" ) );
@@ -1870,13 +1870,13 @@ void TestProcessingGui::testNumericWrapperDouble()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -1920,7 +1920,7 @@ void TestProcessingGui::testNumericWrapperDouble()
 
 void TestProcessingGui::testNumericWrapperInt()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingContext context;
 
     QgsProcessingParameterNumber param( QStringLiteral( "num" ), QStringLiteral( "num" ), Qgis::ProcessingNumberParameterType::Integer );
@@ -1947,7 +1947,7 @@ void TestProcessingGui::testNumericWrapperInt()
     QCOMPARE( static_cast<QgsSpinBox *>( wrapper.wrappedWidget() )->value(), 0 );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "num" ) );
@@ -2059,13 +2059,13 @@ void TestProcessingGui::testNumericWrapperInt()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -2250,7 +2250,7 @@ void TestProcessingGui::testDistanceWrapper()
   // with default unit
   QgsProcessingParameterDistance paramDefaultUnit( QStringLiteral( "num" ), QStringLiteral( "num" ) );
   paramDefaultUnit.setDefaultUnit( Qgis::DistanceUnit::Feet );
-  QgsProcessingDistanceWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, QgsProcessingGui::Standard );
+  QgsProcessingDistanceWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, Qgis::ProcessingMode::Standard );
   w = wrapperDefaultUnit.createWrappedWidget( context );
   w->show();
   QCOMPARE( wrapperDefaultUnit.mLabel->text(), QStringLiteral( "feet" ) );
@@ -2263,14 +2263,14 @@ void TestProcessingGui::testDistanceWrapper()
   wrapperMetadata.insert( QStringLiteral( "decimals" ), 2 );
   metadata.insert( QStringLiteral( "widget_wrapper" ), wrapperMetadata );
   paramDecimals.setMetadata( metadata );
-  QgsProcessingDistanceWidgetWrapper wrapperDecimals( &paramDecimals, QgsProcessingGui::Standard );
+  QgsProcessingDistanceWidgetWrapper wrapperDecimals( &paramDecimals, Qgis::ProcessingMode::Standard );
   w = wrapperDecimals.createWrappedWidget( context );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->decimals(), 2 );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->singleStep(), 0.01 ); // single step should never be less than set number of decimals
   delete w;
 
   // batch wrapper
-  QgsProcessingDistanceWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingDistanceWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingDistanceWidgetWrapper::widgetValueHasChanged );
@@ -2292,7 +2292,7 @@ void TestProcessingGui::testDistanceWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingDistanceWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingDistanceWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingDistanceWidgetWrapper::widgetValueHasChanged );
@@ -2473,7 +2473,7 @@ void TestProcessingGui::testAreaWrapper()
   // with default unit
   QgsProcessingParameterArea paramDefaultUnit( QStringLiteral( "num" ), QStringLiteral( "num" ) );
   paramDefaultUnit.setDefaultUnit( Qgis::AreaUnit::SquareFeet );
-  QgsProcessingAreaWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, QgsProcessingGui::Standard );
+  QgsProcessingAreaWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, Qgis::ProcessingMode::Standard );
   w = wrapperDefaultUnit.createWrappedWidget( context );
   w->show();
   QCOMPARE( wrapperDefaultUnit.mLabel->text(), QStringLiteral( "square feet" ) );
@@ -2486,14 +2486,14 @@ void TestProcessingGui::testAreaWrapper()
   wrapperMetadata.insert( QStringLiteral( "decimals" ), 2 );
   metadata.insert( QStringLiteral( "widget_wrapper" ), wrapperMetadata );
   paramDecimals.setMetadata( metadata );
-  QgsProcessingAreaWidgetWrapper wrapperDecimals( &paramDecimals, QgsProcessingGui::Standard );
+  QgsProcessingAreaWidgetWrapper wrapperDecimals( &paramDecimals, Qgis::ProcessingMode::Standard );
   w = wrapperDecimals.createWrappedWidget( context );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->decimals(), 2 );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->singleStep(), 0.01 ); // single step should never be less than set number of decimals
   delete w;
 
   // batch wrapper
-  QgsProcessingAreaWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingAreaWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingAreaWidgetWrapper::widgetValueHasChanged );
@@ -2515,7 +2515,7 @@ void TestProcessingGui::testAreaWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingAreaWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingAreaWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingAreaWidgetWrapper::widgetValueHasChanged );
@@ -2696,7 +2696,7 @@ void TestProcessingGui::testVolumeWrapper()
   // with default unit
   QgsProcessingParameterVolume paramDefaultUnit( QStringLiteral( "num" ), QStringLiteral( "num" ) );
   paramDefaultUnit.setDefaultUnit( Qgis::VolumeUnit::CubicFeet );
-  QgsProcessingVolumeWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, QgsProcessingGui::Standard );
+  QgsProcessingVolumeWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, Qgis::ProcessingMode::Standard );
   w = wrapperDefaultUnit.createWrappedWidget( context );
   w->show();
   QCOMPARE( wrapperDefaultUnit.mLabel->text(), QStringLiteral( "cubic feet" ) );
@@ -2709,14 +2709,14 @@ void TestProcessingGui::testVolumeWrapper()
   wrapperMetadata.insert( QStringLiteral( "decimals" ), 2 );
   metadata.insert( QStringLiteral( "widget_wrapper" ), wrapperMetadata );
   paramDecimals.setMetadata( metadata );
-  QgsProcessingVolumeWidgetWrapper wrapperDecimals( &paramDecimals, QgsProcessingGui::Standard );
+  QgsProcessingVolumeWidgetWrapper wrapperDecimals( &paramDecimals, Qgis::ProcessingMode::Standard );
   w = wrapperDecimals.createWrappedWidget( context );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->decimals(), 2 );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->singleStep(), 0.01 ); // single step should never be less than set number of decimals
   delete w;
 
   // batch wrapper
-  QgsProcessingVolumeWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingVolumeWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingVolumeWidgetWrapper::widgetValueHasChanged );
@@ -2738,7 +2738,7 @@ void TestProcessingGui::testVolumeWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingVolumeWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingVolumeWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingVolumeWidgetWrapper::widgetValueHasChanged );
@@ -2835,7 +2835,7 @@ void TestProcessingGui::testDurationWrapper()
   // with default unit
   QgsProcessingParameterDuration paramDefaultUnit( QStringLiteral( "dur" ), QStringLiteral( "dur" ) );
   paramDefaultUnit.setDefaultUnit( Qgis::TemporalUnit::Days );
-  QgsProcessingDurationWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, QgsProcessingGui::Standard );
+  QgsProcessingDurationWidgetWrapper wrapperDefaultUnit( &paramDefaultUnit, Qgis::ProcessingMode::Standard );
   w = wrapperDefaultUnit.createWrappedWidget( context );
   w->show();
   QCOMPARE( wrapperDefaultUnit.mUnitsCombo->currentText(), QgsUnitTypes::toString( Qgis::TemporalUnit::Days ) );
@@ -2848,14 +2848,14 @@ void TestProcessingGui::testDurationWrapper()
   wrapperMetadata.insert( QStringLiteral( "decimals" ), 2 );
   metadata.insert( QStringLiteral( "widget_wrapper" ), wrapperMetadata );
   paramDecimals.setMetadata( metadata );
-  QgsProcessingDurationWidgetWrapper wrapperDecimals( &paramDecimals, QgsProcessingGui::Standard );
+  QgsProcessingDurationWidgetWrapper wrapperDecimals( &paramDecimals, Qgis::ProcessingMode::Standard );
   w = wrapperDecimals.createWrappedWidget( context );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->decimals(), 2 );
   QCOMPARE( wrapperDecimals.mDoubleSpinBox->singleStep(), 0.01 ); // single step should never be less than set number of decimals
   delete w;
 
   // batch wrapper
-  QgsProcessingDurationWidgetWrapper wrapperB( &param, QgsProcessingGui::Batch );
+  QgsProcessingDurationWidgetWrapper wrapperB( &param, Qgis::ProcessingMode::Batch );
 
   w = wrapperB.createWrappedWidget( context );
   QSignalSpy spy2( &wrapperB, &QgsProcessingDurationWidgetWrapper::widgetValueHasChanged );
@@ -2877,7 +2877,7 @@ void TestProcessingGui::testDurationWrapper()
   delete w;
 
   // modeler wrapper
-  QgsProcessingDurationWidgetWrapper wrapperM( &param, QgsProcessingGui::Modeler );
+  QgsProcessingDurationWidgetWrapper wrapperM( &param, Qgis::ProcessingMode::Modeler );
 
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingDurationWidgetWrapper::widgetValueHasChanged );
@@ -2940,7 +2940,7 @@ void TestProcessingGui::testDurationWrapper()
 
 void TestProcessingGui::testScaleWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingContext context;
 
     QgsProcessingParameterScale param( QStringLiteral( "num" ), QStringLiteral( "num" ) );
@@ -2962,7 +2962,7 @@ void TestProcessingGui::testScaleWrapper()
     QCOMPARE( static_cast<QgsScaleWidget *>( wrapper.wrappedWidget() )->scale(), 0.0 );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "num" ) );
@@ -3017,13 +3017,13 @@ void TestProcessingGui::testScaleWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -3056,7 +3056,7 @@ void TestProcessingGui::testScaleWrapper()
 
 void TestProcessingGui::testRangeWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingContext context;
 
     QgsProcessingParameterRange param( QStringLiteral( "range" ), QStringLiteral( "range" ), Qgis::ProcessingNumberParameterType::Double );
@@ -3091,7 +3091,7 @@ void TestProcessingGui::testRangeWrapper()
     QCOMPARE( wrapper.mMaxSpinBox->value(), 36.5 );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "range" ) );
@@ -3177,13 +3177,13 @@ void TestProcessingGui::testRangeWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -3244,7 +3244,7 @@ void TestProcessingGui::testMatrixDialog()
 
 void TestProcessingGui::testMatrixWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingContext context;
 
     QgsProcessingParameterMatrix param( QStringLiteral( "matrix" ), QStringLiteral( "matrix" ), 3, false, QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
@@ -3268,7 +3268,7 @@ void TestProcessingGui::testMatrixWrapper()
     QCOMPARE( wrapper.mMatrixWidget->value(), QVariantList() << QStringLiteral( "28.1" ) << QStringLiteral( "36.5" ) << QStringLiteral( "5.5" ) << QStringLiteral( "8.9" ) );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "matrix" ) );
@@ -3289,13 +3289,13 @@ void TestProcessingGui::testMatrixWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -3337,7 +3337,7 @@ void TestProcessingGui::testExpressionWrapper()
   const QgsProcessingParameterDefinition *vLayerDef = centroidAlg->parameterDefinition( QStringLiteral( "INPUT" ) );
   const QgsProcessingParameterDefinition *pcLayerDef = new QgsProcessingParameterPointCloudLayer( "INPUT", QStringLiteral( "input" ), QVariant(), false );
 
-  auto testWrapper = [vLayerDef, pcLayerDef]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [vLayerDef, pcLayerDef]( Qgis::ProcessingMode type ) {
     QgsProcessingParameterExpression param( QStringLiteral( "expression" ), QStringLiteral( "expression" ) );
 
     QgsProcessingExpressionWidgetWrapper wrapper( &param, type );
@@ -3356,7 +3356,7 @@ void TestProcessingGui::testExpressionWrapper()
     QVERIFY( static_cast<QgsExpressionLineEdit *>( wrapper.wrappedWidget() )->expression().isEmpty() );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "expression" ) );
@@ -3515,13 +3515,13 @@ void TestProcessingGui::testExpressionWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -3584,7 +3584,7 @@ void TestProcessingGui::testFieldWrapper()
   const QgsProcessingAlgorithm *centroidAlg = QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "native:centroids" ) );
   const QgsProcessingParameterDefinition *layerDef = centroidAlg->parameterDefinition( QStringLiteral( "INPUT" ) );
 
-  auto testWrapper = [layerDef]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [layerDef]( Qgis::ProcessingMode type ) {
     TestLayerWrapper layerWrapper( layerDef );
     QgsProject p;
     QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "LineString?field=aaa:int&field=bbb:string" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
@@ -3608,12 +3608,12 @@ void TestProcessingGui::testFieldWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsFieldComboBox *>( wrapper.wrappedWidget() )->currentField(), QStringLiteral( "bbb" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QLineEdit *>( wrapper.wrappedWidget() )->text(), QStringLiteral( "bbb" ) );
         break;
     }
@@ -3643,18 +3643,18 @@ void TestProcessingGui::testFieldWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsFieldComboBox *>( wrapper2.wrappedWidget() )->currentField(), QString() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->text(), QString() );
         break;
     }
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "field [optional]" ) );
@@ -3669,12 +3669,12 @@ void TestProcessingGui::testFieldWrapper()
     // check signal
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         static_cast<QgsFieldComboBox *>( wrapper2.wrappedWidget() )->setField( QStringLiteral( "bbb" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->setText( QStringLiteral( "bbb" ) );
         break;
     }
@@ -3683,12 +3683,12 @@ void TestProcessingGui::testFieldWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer(), vl );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -3699,12 +3699,12 @@ void TestProcessingGui::testFieldWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QVERIFY( !wrapper2.mComboBox->layer() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -3712,12 +3712,12 @@ void TestProcessingGui::testFieldWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QVERIFY( !wrapper2.mComboBox->layer() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     QVERIFY( !wrapper2.mParentLayer.get() );
@@ -3731,12 +3731,12 @@ void TestProcessingGui::testFieldWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer(), vl );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     QVERIFY( !wrapper2.mParentLayer.get() );
@@ -3747,12 +3747,12 @@ void TestProcessingGui::testFieldWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer()->publicSource(), pointFileName );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -3804,12 +3804,12 @@ void TestProcessingGui::testFieldWrapper()
     w = wrapper4.createWrappedWidget( context );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsFieldComboBox *>( wrapper4.wrappedWidget() )->filters(), QgsFieldProxyModel::String );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     f2 = wrapper4.filterFields( f );
@@ -3824,13 +3824,13 @@ void TestProcessingGui::testFieldWrapper()
     wrapper4a.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper4a.mPanel->fields().count(), 1 );
         QCOMPARE( wrapper4a.mPanel->fields().at( 0 ).name(), QStringLiteral( "bbb" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     delete w;
@@ -3841,12 +3841,12 @@ void TestProcessingGui::testFieldWrapper()
     w = wrapper5.createWrappedWidget( context );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsFieldComboBox *>( wrapper5.wrappedWidget() )->filters(), QgsFieldProxyModel::Numeric );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     f2 = wrapper5.filterFields( f );
@@ -3863,13 +3863,13 @@ void TestProcessingGui::testFieldWrapper()
     wrapper5a.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper5a.mPanel->fields().count(), 1 );
         QCOMPARE( wrapper5a.mPanel->fields().at( 0 ).name(), QStringLiteral( "aaa" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     delete w;
@@ -3880,12 +3880,12 @@ void TestProcessingGui::testFieldWrapper()
     w = wrapper6.createWrappedWidget( context );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsFieldComboBox *>( wrapper6.wrappedWidget() )->filters(), QgsFieldProxyModel::Date | QgsFieldProxyModel::Time | QgsFieldProxyModel::DateTime );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     f2 = wrapper6.filterFields( f );
@@ -3900,12 +3900,12 @@ void TestProcessingGui::testFieldWrapper()
     w = wrapper7.createWrappedWidget( context );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsFieldComboBox *>( wrapper7.wrappedWidget() )->filters(), QgsFieldProxyModel::Binary );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     f2 = wrapper7.filterFields( f );
@@ -3919,12 +3919,12 @@ void TestProcessingGui::testFieldWrapper()
     w = wrapper8.createWrappedWidget( context );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsFieldComboBox *>( wrapper8.wrappedWidget() )->filters(), QgsFieldProxyModel::Boolean );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     f2 = wrapper8.filterFields( f );
@@ -3940,12 +3940,12 @@ void TestProcessingGui::testFieldWrapper()
     wrapper9.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper9.widgetValue().toList(), QVariantList() << QStringLiteral( "aaa" ) << QStringLiteral( "bbb" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     delete w;
@@ -3962,25 +3962,25 @@ void TestProcessingGui::testFieldWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper10.widgetValue().toList(), QVariantList() << QStringLiteral( "bbb" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     delete w;
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -4349,7 +4349,7 @@ void TestProcessingGui::testBandWrapper()
   const QgsProcessingAlgorithm *statsAlg = QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "native:rasterlayerstatistics" ) );
   const QgsProcessingParameterDefinition *layerDef = statsAlg->parameterDefinition( QStringLiteral( "INPUT" ) );
 
-  auto testWrapper = [layerDef]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [layerDef]( Qgis::ProcessingMode type ) {
     TestLayerWrapper layerWrapper( layerDef );
     QgsProject p;
     QgsRasterLayer *rl = new QgsRasterLayer( TEST_DATA_DIR + QStringLiteral( "/landsat.tif" ), QStringLiteral( "x" ), QStringLiteral( "gdal" ) );
@@ -4373,12 +4373,12 @@ void TestProcessingGui::testBandWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsRasterBandComboBox *>( wrapper.wrappedWidget() )->currentBand(), 3 );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QLineEdit *>( wrapper.wrappedWidget() )->text(), QStringLiteral( "3" ) );
         break;
     }
@@ -4389,12 +4389,12 @@ void TestProcessingGui::testBandWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsRasterBandComboBox *>( wrapper.wrappedWidget() )->currentBand(), 1 );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QLineEdit *>( wrapper.wrappedWidget() )->text(), QStringLiteral( "1" ) );
         break;
     }
@@ -4420,18 +4420,18 @@ void TestProcessingGui::testBandWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsRasterBandComboBox *>( wrapper2.wrappedWidget() )->currentBand(), -1 );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->text(), QString() );
         break;
     }
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "band [optional]" ) );
@@ -4446,12 +4446,12 @@ void TestProcessingGui::testBandWrapper()
     // check signal
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         static_cast<QgsRasterBandComboBox *>( wrapper2.wrappedWidget() )->setBand( 6 );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->setText( QStringLiteral( "6" ) );
         break;
     }
@@ -4460,12 +4460,12 @@ void TestProcessingGui::testBandWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer(), rl );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -4476,12 +4476,12 @@ void TestProcessingGui::testBandWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QVERIFY( !wrapper2.mComboBox->layer() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -4489,12 +4489,12 @@ void TestProcessingGui::testBandWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QVERIFY( !wrapper2.mComboBox->layer() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     QVERIFY( !wrapper2.mParentLayer.get() );
@@ -4508,12 +4508,12 @@ void TestProcessingGui::testBandWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer(), rl );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     QVERIFY( !wrapper2.mParentLayer.get() );
@@ -4524,12 +4524,12 @@ void TestProcessingGui::testBandWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer()->publicSource(), rasterFileName );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -4597,13 +4597,13 @@ void TestProcessingGui::testBandWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -4645,7 +4645,7 @@ void TestProcessingGui::testMultipleInputWrapper()
   QString path1 = TEST_DATA_DIR + QStringLiteral( "/landsat-f32-b1.tif" );
   QString path2 = TEST_DATA_DIR + QStringLiteral( "/landsat.tif" );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     QgsProcessingParameterMultipleLayers param( QStringLiteral( "multi" ), QStringLiteral( "multi" ), Qgis::ProcessingSourceType::Vector, QVariant(), false );
 
     QgsProcessingMultipleLayerWidgetWrapper wrapper( &param, type );
@@ -4684,7 +4684,7 @@ void TestProcessingGui::testMultipleInputWrapper()
     QVERIFY( static_cast<QgsProcessingMultipleLayerPanelWidget *>( wrapper2.wrappedWidget() )->value().toList().isEmpty() );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "multi [optional]" ) );
@@ -4701,7 +4701,7 @@ void TestProcessingGui::testMultipleInputWrapper()
     QCOMPARE( spy2.count(), 3 );
 
 
-    if ( wrapper.type() == QgsProcessingGui::Modeler )
+    if ( wrapper.type() == Qgis::ProcessingMode::Modeler )
     {
       // different mix of sources
 
@@ -4721,13 +4721,13 @@ void TestProcessingGui::testMultipleInputWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -5015,7 +5015,7 @@ void TestProcessingGui::testEnumCheckboxPanel()
 
 void TestProcessingGui::testEnumWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type, bool checkboxStyle = false ) {
+  auto testWrapper = []( Qgis::ProcessingMode type, bool checkboxStyle = false ) {
     // non optional, single value
     QgsProcessingParameterEnum param( QStringLiteral( "enum" ), QStringLiteral( "enum" ), QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) << QStringLiteral( "c" ), false );
     QVariantMap metadata;
@@ -5057,7 +5057,7 @@ void TestProcessingGui::testEnumWrapper()
     }
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "enum" ) );
@@ -5464,16 +5464,16 @@ void TestProcessingGui::testEnumWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // checkbox style (not for batch or model mode!)
-  testWrapper( QgsProcessingGui::Standard, true );
+  testWrapper( Qgis::ProcessingMode::Standard, true );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -5519,7 +5519,7 @@ void TestProcessingGui::testLayoutWrapper()
   l2->setName( "l2" );
   p.layoutManager()->addLayout( l2 );
 
-  auto testWrapper = [&p]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [&p]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterLayout param( QStringLiteral( "layout" ), QStringLiteral( "layout" ), false );
 
@@ -5536,7 +5536,7 @@ void TestProcessingGui::testLayoutWrapper()
     wrapper.setWidgetValue( "l2", context );
     QCOMPARE( spy.count(), 1 );
     QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "l2" ) );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper.wrappedWidget() )->currentIndex(), 1 );
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "l2" ) );
@@ -5548,7 +5548,7 @@ void TestProcessingGui::testLayoutWrapper()
     wrapper.setWidgetValue( "l1", context );
     QCOMPARE( spy.count(), 2 );
     QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "l1" ) );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper.wrappedWidget() )->currentIndex(), 0 );
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "l1" ) );
@@ -5559,7 +5559,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "layout" ) );
@@ -5572,7 +5572,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
 
     // check signal
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       static_cast<QComboBox *>( wrapper.wrappedWidget() )->setCurrentIndex( 1 );
     }
@@ -5596,7 +5596,7 @@ void TestProcessingGui::testLayoutWrapper()
     wrapper2.setWidgetValue( "l2", context );
     QCOMPARE( spy2.count(), 1 );
     QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "l2" ) );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper2.wrappedWidget() )->currentIndex(), 2 );
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l2" ) );
@@ -5608,7 +5608,7 @@ void TestProcessingGui::testLayoutWrapper()
     wrapper2.setWidgetValue( "l1", context );
     QCOMPARE( spy2.count(), 2 );
     QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "l1" ) );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper2.wrappedWidget() )->currentIndex(), 1 );
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1" ) );
@@ -5620,7 +5620,7 @@ void TestProcessingGui::testLayoutWrapper()
     wrapper2.setWidgetValue( QVariant(), context );
     QCOMPARE( spy2.count(), 3 );
     QVERIFY( !wrapper2.widgetValue().isValid() );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( static_cast<QgsLayoutComboBox *>( wrapper2.wrappedWidget() )->currentIndex(), 0 );
       QVERIFY( static_cast<QgsLayoutComboBox *>( wrapper2.wrappedWidget() )->currentText().isEmpty() );
@@ -5631,7 +5631,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
 
     // check signal
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
       static_cast<QComboBox *>( wrapper2.wrappedWidget() )->setCurrentIndex( 2 );
     else
       static_cast<QComboBox *>( wrapper2.wrappedWidget() )->setCurrentText( QStringLiteral( "aaa" ) );
@@ -5641,13 +5641,13 @@ void TestProcessingGui::testLayoutWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testLayoutItemWrapper()
@@ -5663,7 +5663,7 @@ void TestProcessingGui::testLayoutItemWrapper()
   label2->setId( "b" );
   l1->addLayoutItem( label2 );
 
-  auto testWrapper = [&p, l1, label1, label2]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [&p, l1, label1, label2]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterLayoutItem param( QStringLiteral( "layout" ), QStringLiteral( "layout" ), false );
 
@@ -5681,7 +5681,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     QSignalSpy spy( &wrapper, &QgsProcessingLayoutItemWidgetWrapper::widgetValueHasChanged );
     wrapper.setWidgetValue( "b", context );
     QCOMPARE( spy.count(), 1 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( wrapper.widgetValue().toString(), label2->uuid() );
       QCOMPARE( static_cast<QgsLayoutItemComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "b" ) );
@@ -5693,7 +5693,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     }
     wrapper.setWidgetValue( "a", context );
     QCOMPARE( spy.count(), 2 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( wrapper.widgetValue().toString(), label1->uuid() );
       QCOMPARE( static_cast<QgsLayoutItemComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "a" ) );
@@ -5705,7 +5705,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     }
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "layout" ) );
@@ -5718,7 +5718,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     }
 
     // check signal
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       static_cast<QComboBox *>( wrapper.wrappedWidget() )->setCurrentIndex( 1 );
     }
@@ -5742,7 +5742,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     QSignalSpy spy2( &wrapper2, &QgsProcessingLayoutItemWidgetWrapper::widgetValueHasChanged );
     wrapper2.setWidgetValue( "b", context );
     QCOMPARE( spy2.count(), 1 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( wrapper2.widgetValue().toString(), label2->uuid() );
       QCOMPARE( static_cast<QgsLayoutItemComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "b" ) );
@@ -5754,7 +5754,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     }
     wrapper2.setWidgetValue( "a", context );
     QCOMPARE( spy2.count(), 2 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( wrapper2.widgetValue().toString(), label1->uuid() );
       QCOMPARE( static_cast<QgsLayoutItemComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "a" ) );
@@ -5767,7 +5767,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     wrapper2.setWidgetValue( QVariant(), context );
     QCOMPARE( spy2.count(), 3 );
     QVERIFY( !wrapper2.widgetValue().isValid() );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QVERIFY( static_cast<QgsLayoutItemComboBox *>( wrapper2.wrappedWidget() )->currentText().isEmpty() );
     }
@@ -5777,7 +5777,7 @@ void TestProcessingGui::testLayoutItemWrapper()
     }
 
     // check signal
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
       static_cast<QgsLayoutItemComboBox *>( wrapper2.wrappedWidget() )->setCurrentIndex( 1 );
     else
       static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->setText( QStringLiteral( "aaa" ) );
@@ -5787,13 +5787,13 @@ void TestProcessingGui::testLayoutItemWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
 
   // config widget
@@ -5862,7 +5862,7 @@ void TestProcessingGui::testPointPanel()
 
 void TestProcessingGui::testPointWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterPoint param( QStringLiteral( "point" ), QStringLiteral( "point" ), false );
 
@@ -5874,7 +5874,7 @@ void TestProcessingGui::testPointWrapper()
     QSignalSpy spy( &wrapper, &QgsProcessingLayoutItemWidgetWrapper::widgetValueHasChanged );
     wrapper.setWidgetValue( "1,2", context );
     QCOMPARE( spy.count(), 1 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "1.000000,2.000000" ) );
       QCOMPARE( static_cast<QgsProcessingPointPanel *>( wrapper.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000" ) );
@@ -5886,7 +5886,7 @@ void TestProcessingGui::testPointWrapper()
     }
     wrapper.setWidgetValue( "1,2 [EPSG:3111]", context );
     QCOMPARE( spy.count(), 2 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
       QCOMPARE( static_cast<QgsProcessingPointPanel *>( wrapper.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
@@ -5898,7 +5898,7 @@ void TestProcessingGui::testPointWrapper()
     }
 
     // check signal
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       static_cast<QgsProcessingPointPanel *>( wrapper.wrappedWidget() )->mLineEdit->setText( QStringLiteral( "b" ) );
     }
@@ -5910,7 +5910,7 @@ void TestProcessingGui::testPointWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "point" ) );
@@ -5934,7 +5934,7 @@ void TestProcessingGui::testPointWrapper()
     QSignalSpy spy2( &wrapper2, &QgsProcessingLayoutItemWidgetWrapper::widgetValueHasChanged );
     wrapper2.setWidgetValue( "1,2", context );
     QCOMPARE( spy2.count(), 1 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( static_cast<QgsProcessingPointPanel *>( wrapper2.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000" ) );
       QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "1.000000,2.000000" ) );
@@ -5947,7 +5947,7 @@ void TestProcessingGui::testPointWrapper()
 
     wrapper2.setWidgetValue( "1,2 [EPSG:3111]", context );
     QCOMPARE( spy2.count(), 2 );
-    if ( type != QgsProcessingGui::Modeler )
+    if ( type != Qgis::ProcessingMode::Modeler )
     {
       QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
       QCOMPARE( static_cast<QgsProcessingPointPanel *>( wrapper2.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
@@ -5960,7 +5960,7 @@ void TestProcessingGui::testPointWrapper()
     wrapper2.setWidgetValue( QVariant(), context );
     QCOMPARE( spy2.count(), 3 );
     QVERIFY( !wrapper2.widgetValue().isValid() );
-    if ( type == QgsProcessingGui::Modeler )
+    if ( type == Qgis::ProcessingMode::Modeler )
     {
       QVERIFY( static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->text().isEmpty() );
     }
@@ -5973,7 +5973,7 @@ void TestProcessingGui::testPointWrapper()
     wrapper2.setWidgetValue( "", context );
     QCOMPARE( spy2.count(), 5 );
     QVERIFY( !wrapper2.widgetValue().isValid() );
-    if ( type == QgsProcessingGui::Modeler )
+    if ( type == Qgis::ProcessingMode::Modeler )
     {
       QVERIFY( static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->text().isEmpty() );
     }
@@ -5985,7 +5985,7 @@ void TestProcessingGui::testPointWrapper()
     // check signals
     wrapper2.setWidgetValue( "1,3", context );
     QCOMPARE( spy2.count(), 6 );
-    if ( type == QgsProcessingGui::Modeler )
+    if ( type == Qgis::ProcessingMode::Modeler )
     {
       static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->clear();
     }
@@ -5999,13 +5999,13 @@ void TestProcessingGui::testPointWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingContext context;
@@ -6039,7 +6039,7 @@ void TestProcessingGui::testPointWrapper()
 
 void TestProcessingGui::testGeometryWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterGeometry param( QStringLiteral( "geometry" ), QStringLiteral( "geometry" ), false );
 
@@ -6059,7 +6059,7 @@ void TestProcessingGui::testGeometryWrapper()
     QVERIFY( static_cast<QgsGeometryWidget *>( wrapper.wrappedWidget() )->geometryValue().asWkt().isEmpty() );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "geometry" ) );
@@ -6109,14 +6109,14 @@ void TestProcessingGui::testGeometryWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
 
   // config widget
@@ -6153,7 +6153,7 @@ void TestProcessingGui::testGeometryWrapper()
 
 void TestProcessingGui::testExtentWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterExtent param( QStringLiteral( "extent" ), QStringLiteral( "extent" ), false );
 
@@ -6179,7 +6179,7 @@ void TestProcessingGui::testExtentWrapper()
     QCOMPARE( spy.count(), 3 );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "extent" ) );
@@ -6239,13 +6239,13 @@ void TestProcessingGui::testExtentWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingContext context;
@@ -6278,7 +6278,7 @@ void TestProcessingGui::testExtentWrapper()
 
 void TestProcessingGui::testColorWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingParameterColor param( QStringLiteral( "color" ), QStringLiteral( "color" ) );
 
     QgsProcessingColorWidgetWrapper wrapper( &param, type );
@@ -6299,7 +6299,7 @@ void TestProcessingGui::testColorWrapper()
     QVERIFY( !static_cast<QgsColorButton *>( wrapper.wrappedWidget() )->color().isValid() );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "color" ) );
@@ -6343,13 +6343,13 @@ void TestProcessingGui::testColorWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -6385,7 +6385,7 @@ void TestProcessingGui::testColorWrapper()
 
 void TestProcessingGui::testCoordinateOperationWrapper()
 {
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingParameterCoordinateOperation param( QStringLiteral( "op" ), QStringLiteral( "op" ) );
 
     QgsProcessingCoordinateOperationWidgetWrapper wrapper( &param, type );
@@ -6401,7 +6401,7 @@ void TestProcessingGui::testCoordinateOperationWrapper()
     QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84" ) );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
+      case Qgis::ProcessingMode::Standard:
       {
         QCOMPARE( static_cast<QgsCoordinateOperationWidget *>( wrapper.wrappedWidget() )->selectedOperation().proj, QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84" ) );
         wrapper.setWidgetValue( QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=159 +z=175 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84" ), context );
@@ -6416,8 +6416,8 @@ void TestProcessingGui::testCoordinateOperationWrapper()
         break;
       }
 
-      case QgsProcessingGui::Modeler:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Modeler:
+      case Qgis::ProcessingMode::Batch:
       {
         QCOMPARE( wrapper.mLineEdit->text(), QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84" ) );
         wrapper.setWidgetValue( QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=159 +z=175 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84" ), context );
@@ -6432,7 +6432,7 @@ void TestProcessingGui::testCoordinateOperationWrapper()
     }
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "op" ) );
@@ -6448,13 +6448,13 @@ void TestProcessingGui::testCoordinateOperationWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -7072,7 +7072,7 @@ void TestProcessingGui::testMapLayerWrapper()
   QgsRasterLayer *raster = new QgsRasterLayer( QStringLiteral( TEST_DATA_DIR ) + "/raster/band1_byte_ct_epsg4326.tif", QStringLiteral( "band1_byte" ) );
   QgsProject::instance()->addMapLayer( raster );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterMapLayer param( QStringLiteral( "layer" ), QStringLiteral( "layer" ), false );
 
@@ -7086,9 +7086,9 @@ void TestProcessingGui::testMapLayerWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "bb" ) );
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "bb" ) );
@@ -7120,11 +7120,11 @@ void TestProcessingGui::testMapLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), raster->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte" ) );
         break;
     }
@@ -7137,12 +7137,12 @@ void TestProcessingGui::testMapLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), polygon->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1 [EPSG:4326]" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1" ) );
         break;
     }
@@ -7166,11 +7166,11 @@ void TestProcessingGui::testMapLayerWrapper()
     QCOMPARE( wrapper3.widgetValue().toString(), raster->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte" ) );
         break;
     }
@@ -7181,7 +7181,7 @@ void TestProcessingGui::testMapLayerWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "layer" ) );
@@ -7195,13 +7195,13 @@ void TestProcessingGui::testMapLayerWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -7241,7 +7241,7 @@ void TestProcessingGui::testRasterLayerWrapper()
   QgsRasterLayer *raster2 = new QgsRasterLayer( QStringLiteral( TEST_DATA_DIR ) + "/raster/band1_byte_ct_epsg4326.tif", QStringLiteral( "band1_byte2" ) );
   QgsProject::instance()->addMapLayer( raster2 );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterRasterLayer param( QStringLiteral( "raster" ), QStringLiteral( "raster" ), false );
 
@@ -7255,9 +7255,9 @@ void TestProcessingGui::testRasterLayerWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "bb" ) );
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "bb" ) );
@@ -7289,11 +7289,11 @@ void TestProcessingGui::testRasterLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), raster->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte" ) );
         break;
     }
@@ -7306,12 +7306,12 @@ void TestProcessingGui::testRasterLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), raster2->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte2 [EPSG:4326]" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte2" ) );
         break;
     }
@@ -7335,11 +7335,11 @@ void TestProcessingGui::testRasterLayerWrapper()
     QCOMPARE( wrapper3.widgetValue().toString(), raster->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "band1_byte" ) );
         break;
     }
@@ -7350,7 +7350,7 @@ void TestProcessingGui::testRasterLayerWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "raster" ) );
@@ -7364,13 +7364,13 @@ void TestProcessingGui::testRasterLayerWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testVectorLayerWrapper()
@@ -7386,7 +7386,7 @@ void TestProcessingGui::testVectorLayerWrapper()
   QgsVectorLayer *noGeom = new QgsVectorLayer( QStringLiteral( "None" ), QStringLiteral( "l1" ), QStringLiteral( "memory" ) );
   QgsProject::instance()->addMapLayer( noGeom );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterVectorLayer param( QStringLiteral( "vector" ), QStringLiteral( "vector" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::Vector ), false );
 
@@ -7400,9 +7400,9 @@ void TestProcessingGui::testVectorLayerWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "bb" ) );
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "bb" ) );
@@ -7434,11 +7434,11 @@ void TestProcessingGui::testVectorLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), point->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "point [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "point" ) );
         break;
     }
@@ -7451,12 +7451,12 @@ void TestProcessingGui::testVectorLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), polygon->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1 [EPSG:4326]" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1" ) );
         break;
     }
@@ -7480,11 +7480,11 @@ void TestProcessingGui::testVectorLayerWrapper()
     QCOMPARE( wrapper3.widgetValue().toString(), point->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "point [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "point" ) );
         break;
     }
@@ -7495,7 +7495,7 @@ void TestProcessingGui::testVectorLayerWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "vector" ) );
@@ -7509,13 +7509,13 @@ void TestProcessingGui::testVectorLayerWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -7559,7 +7559,7 @@ void TestProcessingGui::testFeatureSourceWrapper()
   QgsVectorLayer *noGeom = new QgsVectorLayer( QStringLiteral( "None" ), QStringLiteral( "l1" ), QStringLiteral( "memory" ) );
   QgsProject::instance()->addMapLayer( noGeom );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterFeatureSource param( QStringLiteral( "source" ), QStringLiteral( "source" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::Vector ), false );
 
@@ -7573,9 +7573,9 @@ void TestProcessingGui::testFeatureSourceWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "bb" ) );
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "bb" ) );
@@ -7607,11 +7607,11 @@ void TestProcessingGui::testFeatureSourceWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), point->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "point [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "point" ) );
         break;
     }
@@ -7624,12 +7624,12 @@ void TestProcessingGui::testFeatureSourceWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), polygon->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1 [EPSG:4326]" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1" ) );
         break;
     }
@@ -7653,11 +7653,11 @@ void TestProcessingGui::testFeatureSourceWrapper()
     QCOMPARE( wrapper3.widgetValue().toString(), point->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "point [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "point" ) );
         break;
     }
@@ -7668,7 +7668,7 @@ void TestProcessingGui::testFeatureSourceWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "source" ) );
@@ -7682,13 +7682,13 @@ void TestProcessingGui::testFeatureSourceWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -7734,7 +7734,7 @@ void TestProcessingGui::testMeshLayerWrapper()
   mesh2->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
   QgsProject::instance()->addMapLayer( mesh2 );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterMeshLayer param( QStringLiteral( "mesh" ), QStringLiteral( "mesh" ), false );
 
@@ -7748,9 +7748,9 @@ void TestProcessingGui::testMeshLayerWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "bb" ) );
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "bb" ) );
@@ -7782,11 +7782,11 @@ void TestProcessingGui::testMeshLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), mesh2->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "mesh2 [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "mesh2" ) );
         break;
     }
@@ -7799,12 +7799,12 @@ void TestProcessingGui::testMeshLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), mesh->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "mesh1 [EPSG:4326]" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "mesh1" ) );
         break;
     }
@@ -7828,11 +7828,11 @@ void TestProcessingGui::testMeshLayerWrapper()
     QCOMPARE( wrapper3.widgetValue().toString(), mesh2->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "mesh2 [EPSG:4326]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "mesh2" ) );
         break;
     }
@@ -7843,7 +7843,7 @@ void TestProcessingGui::testMeshLayerWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "mesh" ) );
@@ -7857,13 +7857,13 @@ void TestProcessingGui::testMeshLayerWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::paramConfigWidget()
@@ -7903,7 +7903,7 @@ void TestProcessingGui::testMapThemeWrapper()
 
   QCOMPARE( p.mapThemeCollection()->mapThemes(), QStringList() << QStringLiteral( "aa" ) << QStringLiteral( "bb" ) );
 
-  auto testWrapper = [&p]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [&p]( Qgis::ProcessingMode type ) {
     // non optional, no existing themes
     QgsProcessingParameterMapTheme param( QStringLiteral( "theme" ), QStringLiteral( "theme" ), false );
 
@@ -7917,8 +7917,8 @@ void TestProcessingGui::testMapThemeWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         // batch or standard mode, only valid themes can be set!
         QCOMPARE( spy.count(), 0 );
         QVERIFY( !wrapper.widgetValue().isValid() );
@@ -7929,7 +7929,7 @@ void TestProcessingGui::testMapThemeWrapper()
         QCOMPARE( static_cast<QComboBox *>( wrapper.wrappedWidget() )->currentIndex(), -1 );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "bb" ) );
         QCOMPARE( static_cast<QComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "bb" ) );
@@ -7988,7 +7988,7 @@ void TestProcessingGui::testMapThemeWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "theme" ) );
@@ -8002,13 +8002,13 @@ void TestProcessingGui::testMapThemeWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
 
   // config widget
@@ -8048,7 +8048,7 @@ void TestProcessingGui::testMapThemeWrapper()
 
 void TestProcessingGui::testDateTimeWrapper()
 {
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional, no existing themes
     QgsProcessingParameterDateTime param( QStringLiteral( "datetime" ), QStringLiteral( "datetime" ), Qgis::ProcessingDateTimeParameterDataType::DateTime, QVariant(), false );
 
@@ -8143,7 +8143,7 @@ void TestProcessingGui::testDateTimeWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "datetime" ) );
@@ -8157,13 +8157,13 @@ void TestProcessingGui::testDateTimeWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -8203,7 +8203,7 @@ void TestProcessingGui::testProviderConnectionWrapper()
   md->saveConnection( conn, QStringLiteral( "aa" ) );
   md->saveConnection( conn, QStringLiteral( "bb" ) );
 
-  auto testWrapper = []( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = []( Qgis::ProcessingMode type ) {
     QgsProcessingParameterProviderConnection param( QStringLiteral( "conn" ), QStringLiteral( "connection" ), QStringLiteral( "ogr" ), false );
 
     QgsProcessingProviderConnectionWidgetWrapper wrapper( &param, type );
@@ -8224,8 +8224,8 @@ void TestProcessingGui::testProviderConnectionWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
       {
         // batch or standard mode, only valid connections can be set!
         // not valid
@@ -8235,7 +8235,7 @@ void TestProcessingGui::testProviderConnectionWrapper()
         QCOMPARE( static_cast<QComboBox *>( wrapper.wrappedWidget() )->currentIndex(), -1 );
         break;
       }
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         // invalid connections permitted
         wrapper.setWidgetValue( QStringLiteral( "cc" ), context );
         QCOMPARE( spy.count(), 3 );
@@ -8268,7 +8268,7 @@ void TestProcessingGui::testProviderConnectionWrapper()
     QVERIFY( !wrapper3.widgetValue().isValid() );
     delete w;
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "connection" ) );
@@ -8282,13 +8282,13 @@ void TestProcessingGui::testProviderConnectionWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -8342,7 +8342,7 @@ void TestProcessingGui::testDatabaseSchemaWrapper()
   const QStringList schemas = dynamic_cast<QgsAbstractDatabaseProviderConnection *>( conn )->schemas();
   QVERIFY( !schemas.isEmpty() );
 
-  auto testWrapper = [&schemas]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [&schemas]( Qgis::ProcessingMode type ) {
     QgsProcessingParameterProviderConnection connParam( QStringLiteral( "conn" ), QStringLiteral( "connection" ), QStringLiteral( "postgres" ), QVariant(), true );
     TestLayerWrapper connWrapper( &connParam );
 
@@ -8376,8 +8376,8 @@ void TestProcessingGui::testDatabaseSchemaWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
       {
         // batch or standard mode, only valid schemas can be set!
         // not valid
@@ -8387,7 +8387,7 @@ void TestProcessingGui::testDatabaseSchemaWrapper()
         QCOMPARE( static_cast<QgsDatabaseSchemaComboBox *>( wrapper.wrappedWidget() )->comboBox()->currentIndex(), -1 );
         break;
       }
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         // invalid schemas permitted
         wrapper.setWidgetValue( QStringLiteral( "cc" ), context );
         QCOMPARE( spy.count(), 3 );
@@ -8407,14 +8407,14 @@ void TestProcessingGui::testDatabaseSchemaWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
       {
         QCOMPARE( spy.count(), 3 );
         break;
       }
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 5 );
         break;
     }
@@ -8423,14 +8423,14 @@ void TestProcessingGui::testDatabaseSchemaWrapper()
     wrapper.setWidgetValue( QStringLiteral( "qgis_test" ), context );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
       {
         QVERIFY( !wrapper.widgetValue().isValid() );
         break;
       }
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         // invalid schemas permitted
         QCOMPARE( spy.count(), 6 );
         QCOMPARE( static_cast<QgsDatabaseSchemaComboBox *>( wrapper.wrappedWidget() )->comboBox()->currentText(), QStringLiteral( "qgis_test" ) );
@@ -8464,7 +8464,7 @@ void TestProcessingGui::testDatabaseSchemaWrapper()
 
     delete w;
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "schema" ) );
@@ -8478,13 +8478,13 @@ void TestProcessingGui::testDatabaseSchemaWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -8543,7 +8543,7 @@ void TestProcessingGui::testDatabaseTableWrapper()
 
   QVERIFY( !tableNames.isEmpty() );
 
-  auto testWrapper = [&tableNames]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [&tableNames]( Qgis::ProcessingMode type ) {
     QgsProcessingParameterProviderConnection connParam( QStringLiteral( "conn" ), QStringLiteral( "connection" ), QStringLiteral( "postgres" ), QVariant(), true );
     TestLayerWrapper connWrapper( &connParam );
     QgsProcessingParameterDatabaseSchema schemaParam( QStringLiteral( "schema" ), QStringLiteral( "schema" ), QStringLiteral( "connection" ), QVariant(), true );
@@ -8581,8 +8581,8 @@ void TestProcessingGui::testDatabaseTableWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
       {
         // batch or standard mode, only valid tables can be set!
         // not valid
@@ -8592,7 +8592,7 @@ void TestProcessingGui::testDatabaseTableWrapper()
         QCOMPARE( static_cast<QgsDatabaseTableComboBox *>( wrapper.wrappedWidget() )->comboBox()->currentIndex(), -1 );
         break;
       }
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         // invalid tables permitted
         wrapper.setWidgetValue( QStringLiteral( "cc" ), context );
         QCOMPARE( spy.count(), 3 );
@@ -8612,14 +8612,14 @@ void TestProcessingGui::testDatabaseTableWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
       {
         QCOMPARE( spy.count(), 3 );
         break;
       }
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 5 );
         break;
     }
@@ -8628,14 +8628,14 @@ void TestProcessingGui::testDatabaseTableWrapper()
     wrapper.setWidgetValue( QStringLiteral( "some_poly_data" ), context );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
       {
         QVERIFY( !wrapper.widgetValue().isValid() );
         break;
       }
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         // invalid tables permitted
         QCOMPARE( spy.count(), 6 );
         QCOMPARE( static_cast<QgsDatabaseTableComboBox *>( wrapper.wrappedWidget() )->comboBox()->currentText(), QStringLiteral( "some_poly_data" ) );
@@ -8701,7 +8701,7 @@ void TestProcessingGui::testDatabaseTableWrapper()
 
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "table" ) );
@@ -8715,13 +8715,13 @@ void TestProcessingGui::testDatabaseTableWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -8798,7 +8798,7 @@ void TestProcessingGui::testFieldMapWrapper()
   const QgsProcessingAlgorithm *centroidAlg = QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "native:centroids" ) );
   const QgsProcessingParameterDefinition *layerDef = centroidAlg->parameterDefinition( QStringLiteral( "INPUT" ) );
 
-  auto testWrapper = [layerDef]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [layerDef]( Qgis::ProcessingMode type ) {
     QgsProcessingParameterFieldMapping param( QStringLiteral( "mapping" ), QStringLiteral( "mapping" ) );
 
     QgsProcessingFieldMapWidgetWrapper wrapper( &param, type );
@@ -8841,7 +8841,7 @@ void TestProcessingGui::testFieldMapWrapper()
     QCOMPARE( static_cast<QgsProcessingFieldMapPanelWidget *>( wrapper.wrappedWidget() )->value().toList().size(), 1 );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "mapping" ) );
@@ -8921,13 +8921,13 @@ void TestProcessingGui::testFieldMapWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -8998,7 +8998,7 @@ void TestProcessingGui::testAggregateWrapper()
   const QgsProcessingAlgorithm *centroidAlg = QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "native:centroids" ) );
   const QgsProcessingParameterDefinition *layerDef = centroidAlg->parameterDefinition( QStringLiteral( "INPUT" ) );
 
-  auto testWrapper = [layerDef]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [layerDef]( Qgis::ProcessingMode type ) {
     QgsProcessingParameterAggregate param( QStringLiteral( "mapping" ), QStringLiteral( "mapping" ) );
 
     QgsProcessingAggregateWidgetWrapper wrapper( &param, type );
@@ -9043,7 +9043,7 @@ void TestProcessingGui::testAggregateWrapper()
     QCOMPARE( static_cast<QgsProcessingAggregatePanelWidget *>( wrapper.wrappedWidget() )->value().toList().size(), 1 );
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "mapping" ) );
@@ -9124,13 +9124,13 @@ void TestProcessingGui::testAggregateWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;
@@ -9979,7 +9979,7 @@ void TestProcessingGui::testFeatureSourceOptionsWidget()
 
 void TestProcessingGui::testVectorOutWrapper()
 {
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterVectorDestination param( QStringLiteral( "vector" ), QStringLiteral( "vector" ) );
 
@@ -9993,9 +9993,9 @@ void TestProcessingGui::testVectorOutWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().value<QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/bb.shp" ) );
         QCOMPARE( static_cast<QgsProcessingLayerOutputDestinationWidget *>( wrapper.wrappedWidget() )->value().value<QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/bb.shp" ) );
@@ -10028,7 +10028,7 @@ void TestProcessingGui::testVectorOutWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "vector" ) );
@@ -10042,18 +10042,18 @@ void TestProcessingGui::testVectorOutWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  // testWrapper( QgsProcessingGui::Batch );
+  // testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testSinkWrapper()
 {
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterFeatureSink param( QStringLiteral( "sink" ), QStringLiteral( "sink" ) );
 
@@ -10067,9 +10067,9 @@ void TestProcessingGui::testSinkWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().value<QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/bb.shp" ) );
         QCOMPARE( static_cast<QgsProcessingLayerOutputDestinationWidget *>( wrapper.wrappedWidget() )->value().value<QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/bb.shp" ) );
@@ -10102,7 +10102,7 @@ void TestProcessingGui::testSinkWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "sink" ) );
@@ -10116,18 +10116,18 @@ void TestProcessingGui::testSinkWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  // testWrapper( QgsProcessingGui::Batch );
+  // testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testRasterOutWrapper()
 {
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterRasterDestination param( QStringLiteral( "raster" ), QStringLiteral( "raster" ) );
 
@@ -10141,9 +10141,9 @@ void TestProcessingGui::testRasterOutWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().value<QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/bb.tif" ) );
         QCOMPARE( static_cast<QgsProcessingLayerOutputDestinationWidget *>( wrapper.wrappedWidget() )->value().value<QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/bb.tif" ) );
@@ -10176,7 +10176,7 @@ void TestProcessingGui::testRasterOutWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "raster" ) );
@@ -10190,18 +10190,18 @@ void TestProcessingGui::testRasterOutWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  // testWrapper( QgsProcessingGui::Batch );
+  // testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testFileOutWrapper()
 {
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterFileDestination param( QStringLiteral( "file" ), QStringLiteral( "file" ) );
 
@@ -10215,9 +10215,9 @@ void TestProcessingGui::testFileOutWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "/bb.tif" ) );
         QCOMPARE( static_cast<QgsProcessingLayerOutputDestinationWidget *>( wrapper.wrappedWidget() )->value().toString(), QStringLiteral( "/bb.tif" ) );
@@ -10250,7 +10250,7 @@ void TestProcessingGui::testFileOutWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "file" ) );
@@ -10264,18 +10264,18 @@ void TestProcessingGui::testFileOutWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  // testWrapper( QgsProcessingGui::Batch );
+  // testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testFolderOutWrapper()
 {
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterFolderDestination param( QStringLiteral( "folder" ), QStringLiteral( "folder" ) );
 
@@ -10289,9 +10289,9 @@ void TestProcessingGui::testFolderOutWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "/bb" ) );
         QCOMPARE( static_cast<QgsProcessingLayerOutputDestinationWidget *>( wrapper.wrappedWidget() )->value().toString(), QStringLiteral( "/bb" ) );
@@ -10324,7 +10324,7 @@ void TestProcessingGui::testFolderOutWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "folder" ) );
@@ -10338,13 +10338,13 @@ void TestProcessingGui::testFolderOutWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  // testWrapper( QgsProcessingGui::Batch );
+  // testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testTinInputLayerWrapper()
@@ -10817,7 +10817,7 @@ void TestProcessingGui::testPointCloudLayerWrapper()
   QVERIFY( cloud2->isValid() );
   QgsProject::instance()->addMapLayer( cloud2 );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterPointCloudLayer param( QStringLiteral( "cloud" ), QStringLiteral( "cloud" ), false );
 
@@ -10831,9 +10831,9 @@ void TestProcessingGui::testPointCloudLayerWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( spy.count(), 1 );
         QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "bb" ) );
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "bb" ) );
@@ -10865,11 +10865,11 @@ void TestProcessingGui::testPointCloudLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), cloud2->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "cloud2 [EPSG:28356]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "cloud2" ) );
         break;
     }
@@ -10882,12 +10882,12 @@ void TestProcessingGui::testPointCloudLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), cloud1->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "cloud1 [EPSG:28356]" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "cloud1" ) );
         break;
     }
@@ -10911,11 +10911,11 @@ void TestProcessingGui::testPointCloudLayerWrapper()
     QCOMPARE( wrapper3.widgetValue().toString(), cloud2->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "cloud2 [EPSG:28356]" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QgsProcessingMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "cloud2" ) );
         break;
     }
@@ -10925,7 +10925,7 @@ void TestProcessingGui::testPointCloudLayerWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "cloud" ) );
@@ -10939,13 +10939,13 @@ void TestProcessingGui::testPointCloudLayerWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testAnnotationLayerWrapper()
@@ -10956,7 +10956,7 @@ void TestProcessingGui::testAnnotationLayerWrapper()
   QVERIFY( layer1->isValid() );
   QgsProject::instance()->addMapLayer( layer1 );
 
-  auto testWrapper = [=]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [=]( Qgis::ProcessingMode type ) {
     // non optional
     QgsProcessingParameterAnnotationLayer param( QStringLiteral( "annotation" ), QStringLiteral( "annotation" ), false );
 
@@ -10983,11 +10983,11 @@ void TestProcessingGui::testAnnotationLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), layer1->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( qgis::down_cast<QgsMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "secondary annotations" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( qgis::down_cast<QgsMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "secondary annotations" ) );
         break;
     }
@@ -11000,12 +11000,12 @@ void TestProcessingGui::testAnnotationLayerWrapper()
     QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "main" ) );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( qgis::down_cast<QgsMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "Annotations" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( qgis::down_cast<QgsMapLayerComboBox *>( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "Annotations" ) );
         break;
     }
@@ -11029,11 +11029,11 @@ void TestProcessingGui::testAnnotationLayerWrapper()
     QCOMPARE( wrapper3.widgetValue().toString(), layer1->id() );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( qgis::down_cast<QgsMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "secondary annotations" ) );
         break;
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( qgis::down_cast<QgsMapLayerComboBox *>( wrapper3.wrappedWidget() )->currentText(), QStringLiteral( "secondary annotations" ) );
         break;
     }
@@ -11043,7 +11043,7 @@ void TestProcessingGui::testAnnotationLayerWrapper()
     delete w;
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "annotation" ) );
@@ -11057,20 +11057,20 @@ void TestProcessingGui::testAnnotationLayerWrapper()
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 }
 
 void TestProcessingGui::testPointCloudAttributeWrapper()
 {
   const QgsProcessingParameterDefinition *layerDef = new QgsProcessingParameterPointCloudLayer( "INPUT", QStringLiteral( "input" ), QVariant(), false );
 
-  auto testWrapper = [layerDef]( QgsProcessingGui::WidgetType type ) {
+  auto testWrapper = [layerDef]( Qgis::ProcessingMode type ) {
     TestLayerWrapper layerWrapper( layerDef );
     QgsProject p;
     QgsPointCloudLayer *pcl = new QgsPointCloudLayer( QStringLiteral( TEST_DATA_DIR ) + "/point_clouds/copc/rgb.copc.laz", QStringLiteral( "x" ), QStringLiteral( "copc" ) );
@@ -11094,12 +11094,12 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsPointCloudAttributeComboBox *>( wrapper.wrappedWidget() )->currentAttribute(), QStringLiteral( "Red" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QLineEdit *>( wrapper.wrappedWidget() )->text(), QStringLiteral( "Red" ) );
         break;
     }
@@ -11129,18 +11129,18 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( static_cast<QgsPointCloudAttributeComboBox *>( wrapper2.wrappedWidget() )->currentAttribute(), QString() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         QCOMPARE( static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->text(), QString() );
         break;
     }
 
     QLabel *l = wrapper.createWrappedLabel();
-    if ( wrapper.type() != QgsProcessingGui::Batch )
+    if ( wrapper.type() != Qgis::ProcessingMode::Batch )
     {
       QVERIFY( l );
       QCOMPARE( l->text(), QStringLiteral( "attribute [optional]" ) );
@@ -11155,12 +11155,12 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
     // check signal
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         static_cast<QgsPointCloudAttributeComboBox *>( wrapper2.wrappedWidget() )->setAttribute( QStringLiteral( "Red" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         static_cast<QLineEdit *>( wrapper2.wrappedWidget() )->setText( QStringLiteral( "Red" ) );
         break;
     }
@@ -11169,12 +11169,12 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer(), pcl );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -11185,12 +11185,12 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
 
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QVERIFY( !wrapper2.mComboBox->layer() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -11198,12 +11198,12 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QVERIFY( !wrapper2.mComboBox->layer() );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     QVERIFY( !wrapper2.mParentLayer.get() );
@@ -11217,12 +11217,12 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer(), pcl );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     QVERIFY( !wrapper2.mParentLayer.get() );
@@ -11233,12 +11233,12 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
     wrapper2.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper2.mComboBox->layer()->publicSource(), pointCloudFileName );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
 
@@ -11278,25 +11278,25 @@ void TestProcessingGui::testPointCloudAttributeWrapper()
     wrapper4.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
-      case QgsProcessingGui::Standard:
-      case QgsProcessingGui::Batch:
+      case Qgis::ProcessingMode::Standard:
+      case Qgis::ProcessingMode::Batch:
         QCOMPARE( wrapper4.widgetValue().toList(), QVariantList() << QStringLiteral( "X" ) << QStringLiteral( "Y" ) << QStringLiteral( "Z" ) << QStringLiteral( "Intensity" ) << QStringLiteral( "ReturnNumber" ) << QStringLiteral( "NumberOfReturns" ) << QStringLiteral( "ScanDirectionFlag" ) << QStringLiteral( "EdgeOfFlightLine" ) << QStringLiteral( "Classification" ) << QStringLiteral( "ScanAngleRank" ) << QStringLiteral( "UserData" ) << QStringLiteral( "PointSourceId" ) << QStringLiteral( "Synthetic" ) << QStringLiteral( "KeyPoint" ) << QStringLiteral( "Withheld" ) << QStringLiteral( "Overlap" ) << QStringLiteral( "ScannerChannel" ) << QStringLiteral( "GpsTime" ) << QStringLiteral( "Red" ) << QStringLiteral( "Green" ) << QStringLiteral( "Blue" ) );
         break;
 
-      case QgsProcessingGui::Modeler:
+      case Qgis::ProcessingMode::Modeler:
         break;
     }
     delete w;
   };
 
   // standard wrapper
-  testWrapper( QgsProcessingGui::Standard );
+  testWrapper( Qgis::ProcessingMode::Standard );
 
   // batch wrapper
-  testWrapper( QgsProcessingGui::Batch );
+  testWrapper( Qgis::ProcessingMode::Batch );
 
   // modeler wrapper
-  testWrapper( QgsProcessingGui::Modeler );
+  testWrapper( Qgis::ProcessingMode::Modeler );
 
   // config widget
   QgsProcessingParameterWidgetContext widgetContext;


### PR DESCRIPTION
Adds an API which an algorithm can implement to support auto-setting
parameter values. This is designed to handle the case
of eg an algorithm which does a file format translation, where
it's desirable to default the output parameter value to an input
parameter value with a different extension.

This can now be done by implementing autogenerateParameterValues
in the algorithm, eg:

    def autogenerateParameterValues(self, existingParameters, changedParameter, mode):
        if changedParameter == self.INPUT:
            input_file = existingParameters.get(self.INPUT)
            if input_file:
                input_path = Path(input_file)
                if input_path.exists():
                    # auto set output parameter to same as input but with 'qgs' extension
                    return {self.OUTPUT: input_path.with_suffix('.qgs').as_posix()}

        return {}


Funded by North Road, thanks to SLYR

![Peek 2025-04-29 14-15](https://github.com/user-attachments/assets/48711790-a04b-4e31-a90c-21511f12ea06)


![Peek 2025-04-29 11-31](https://github.com/user-attachments/assets/02a47716-b2ac-4fe3-a5f2-8c0ef3c789ff)
