### PR TITLE
test_qgscodeeditor: Correctly check that a font is monospace

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -35,7 +35,6 @@ PyQgsStyleStorageMssql
 # To be fixed
 PyQgsAnnotation
 PyQgsAuthenticationSystem
-PyQgsCodeEditor
 PyQgsDelimitedTextProvider
 PyQgsEditWidgets
 PyQgsElevationProfileCanvas

--- a/tests/src/python/test_qgscodeeditor.py
+++ b/tests/src/python/test_qgscodeeditor.py
@@ -12,8 +12,8 @@ __copyright__ = "Copyright 2020, The QGIS Project"
 
 import sys
 
-from qgis.PyQt.QtCore import QCoreApplication
-from qgis.PyQt.QtGui import QColor, QFont
+from qgis.PyQt.QtCore import QT_VERSION_STR, QCoreApplication
+from qgis.PyQt.QtGui import QColor, QFontDatabase
 from qgis.core import QgsApplication, QgsSettings
 from qgis.gui import QgsCodeEditor, QgsCodeEditorColorScheme
 import unittest
@@ -128,8 +128,14 @@ class TestQgsCodeEditor(QgisTestCase):
         )
 
     def testFontFamily(self):
-        f = QgsCodeEditor().getMonospaceFont()
-        self.assertTrue(f.styleHint() & QFont.StyleHint.Monospace)
+        # check that the font is monospace
+        font = QgsCodeEditor().getMonospaceFont()
+        if int(QT_VERSION_STR.split(".")[0]) >= 6:
+            font_db = QFontDatabase
+        else:
+            font_db = QFontDatabase()
+
+        self.assertTrue(font_db.isFixedPitch(font.family(), font_db.styleString(font)))
 
         QgsSettings().setValue(
             "codeEditor/fontfamily", getTestFont().family(), QgsSettings.Section.Gui


### PR DESCRIPTION
## Description

`QgsCodeEditor::getMonospaceFont` is supposed to return a monospace font. The test checks that the returned font is monospace by calling QFont::styleHint` method and comparing it to
`QFont.StyleHint.Monospace`. However `QFont::StyleHint` matches the font family. A font does not need to belong to the "Monospace" family in order to be monospace.

This issue is fixed by using `QFontDatabase::isFixedPitch` to check if the font is monospace. This also make the test work on Qt6.
