### PR TITLE
Add info about properly setting a map theme via API

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmapcanvas.sip.in
@@ -595,6 +595,9 @@ string to clear the theme association and allow map updates with
 If an empty string is passed then the current theme association will be
 cleared.
 
+To set a theme and simultaneously update the layer tree, use
+:py:func:`QgsMapThemeCollection.applyTheme()`.
+
 .. seealso:: :py:func:`theme`
 %End
 

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -595,6 +595,9 @@ string to clear the theme association and allow map updates with
 If an empty string is passed then the current theme association will be
 cleared.
 
+To set a theme and simultaneously update the layer tree, use
+:py:func:`QgsMapThemeCollection.applyTheme()`.
+
 .. seealso:: :py:func:`theme`
 %End
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -603,6 +603,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
      *
      * If an empty string is passed then the current theme association will be
      * cleared.
+     *
+     * To set a theme and simultaneously update the layer tree, use
+     * QgsMapThemeCollection.applyTheme().
      * \see theme()
      */
     void setTheme( const QString &theme );

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -605,7 +605,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
      * cleared.
      *
      * To set a theme and simultaneously update the layer tree, use
-     * QgsMapThemeCollection.applyTheme().
+     * QgsMapThemeCollection::applyTheme().
      * \see theme()
      */
     void setTheme( const QString &theme );


### PR DESCRIPTION
A quick documentation improvement. Shout if this is the wrong place, formatting or tone or anything. :)

https://qgis.org/pyqgis/master/gui/QgsMapCanvas.html#qgis.gui.QgsMapCanvas.setTheme is a promising candidate to set a map theme programmatically. But this method does only set the map canvas' theme, it does not update layer tree. As a result the GUI is in a bad state.

For most API users the https://qgis.org/pyqgis/3.40/core/QgsMapThemeCollection.html#qgis.core.QgsMapThemeCollection.applyTheme method is more useful. This one actually does update the layer tree too and from my tests, the GUI is in a correct state.

This PR simply adds a hint to the QgsMapCanvas' method to consider using the QgsMapThemeCollection's method.