### PR TITLE
fix map export qt6

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7062,14 +7062,14 @@ void QgisApp::saveMapAsImage()
 {
   QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorations(), QgsProject::instance()->annotationManager()->annotations() );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
-  dlg->show();
+  dlg->exec();
 } // saveMapAsImage
 
 void QgisApp::saveMapAsPdf()
 {
   QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorations(), QgsProject::instance()->annotationManager()->annotations(), QgsMapSaveDialog::Pdf );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
-  dlg->show();
+  dlg->exec();
 } // saveMapAsPdf
 
 //overloaded version of the above function

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7062,14 +7062,14 @@ void QgisApp::saveMapAsImage()
 {
   QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorations(), QgsProject::instance()->annotationManager()->annotations() );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
-  dlg->exec();
+  dlg->show();
 } // saveMapAsImage
 
 void QgisApp::saveMapAsPdf()
 {
   QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorations(), QgsProject::instance()->annotationManager()->annotations(), QgsMapSaveDialog::Pdf );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
-  dlg->exec();
+  dlg->show();
 } // saveMapAsPdf
 
 //overloaded version of the above function

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -150,7 +150,6 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
     }
   }
 
-  connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsMapSaveDialog::onAccepted );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsMapSaveDialog::showHelp );
 }
 

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -449,13 +449,20 @@ void QgsMapSaveDialog::copyToClipboard()
   QgsApplication::taskManager()->addTask( mapRendererTask );
 }
 
+void QgsMapSaveDialog::accept()
+{
+  // prevent the dialog from closing before saving the image/pdf
+  QgsMapSaveDialog::onAccepted();
+  QDialog::accept();
+}
+
 void QgsMapSaveDialog::onAccepted()
 {
   switch ( mDialogType )
   {
     case Image:
     {
-      const QPair<QString, QString> fileNameAndFilter = QgsGuiUtils::getSaveAsImageName( QgisApp::instance(), tr( "Choose a file name to save the map image as" ) );
+      const QPair<QString, QString> fileNameAndFilter = QgsGuiUtils::getSaveAsImageName( this, tr( "Choose a file name to save the map image as" ) );
       if ( !fileNameAndFilter.first.isEmpty() )
       {
         QgsMapSettings ms = QgsMapSettings();
@@ -503,7 +510,7 @@ void QgsMapSaveDialog::onAccepted()
     {
       QgsSettings settings;
       const QString lastUsedDir = settings.value( QStringLiteral( "UI/lastSaveAsImageDir" ), QDir::homePath() ).toString();
-      QString fileName = QFileDialog::getSaveFileName( QgisApp::instance(), tr( "Save Map As" ), lastUsedDir, tr( "PDF Format" ) + " (*.pdf *.PDF)" );
+      QString fileName = QFileDialog::getSaveFileName( this, tr( "Save Map As" ), lastUsedDir, tr( "PDF Format" ) + " (*.pdf *.PDF)" );
       // return dialog focus on Mac
       activateWindow();
       raise();

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -78,6 +78,8 @@ class APP_EXPORT QgsMapSaveDialog : public QDialog, private Ui::QgsMapSaveDialog
     //! configure a map settings object
     void applyMapSettings( QgsMapSettings &mapSettings );
 
+    void accept() override;
+
   private slots:
     void onAccepted();
 


### PR DESCRIPTION
fix: #61607 
fix: #60755 
fix: #60415 

This was an interesting one and potentially happens in other parts of QGIS.

The problem was within the /src/app/qgsmapsavedialog.cpp at the line where it calls the qgsguiutils::getSaveAsImage (and getSaveFileName) where the function was passed the instance of QgisApp as the parent of the file dialog it opens. 
Qt6 would cause memory corruption by placing the file dialog at the location of the (now closed, but still executing a function) QgsMapSaveDialog.
The variables in QgsSaveMapDialog would contain garbage values after qgsguiutils function would init a save dialog.

With show() to exec(), the stack is now safe, file dialog can be shown, its result properly returned without breaking the QgsMapSaveDialog and maps can be exported.
Does not break the Qt5 build. 