### PR TITLE
Use unique_ptr when class has clear ownership V2

### DIFF
--- a/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
@@ -313,6 +313,7 @@ Constructor
 %End
         ~NodeUnaryOperator();
 
+
         QgsSQLStatement::UnaryOperator op() const;
 %Docstring
 Operator
@@ -331,6 +332,8 @@ Operand
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeUnaryOperator( const NodeUnaryOperator &other );
       protected:
     };
 
@@ -349,6 +352,7 @@ Binary logical/arithmetical operator (AND, OR, =, +, ...).
 Constructor
 %End
         ~NodeBinaryOperator();
+
 
         QgsSQLStatement::BinaryOperator op() const;
 %Docstring
@@ -383,6 +387,8 @@ Precedence
 Is left associative ?
 %End
 
+      private:
+        NodeBinaryOperator( const NodeBinaryOperator &other );
       protected:
 
     };
@@ -402,6 +408,7 @@ An 'x IN (y, z)' operator.
 Constructor
 %End
         ~NodeInOperator();
+
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -426,6 +433,8 @@ Values list
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeInOperator( const NodeInOperator &other );
       protected:
     };
 
@@ -443,6 +452,7 @@ An 'X BETWEEN y and z' operator.
 %Docstring
 Constructor
 %End
+
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -472,6 +482,8 @@ Maximum bound
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeBetweenOperator( const NodeBetweenOperator &other );
       protected:
     };
 
@@ -491,6 +503,7 @@ Constructor
 %End
         ~NodeFunction();
 
+
         QString name() const;
 %Docstring
 Returns function name
@@ -509,6 +522,8 @@ Returns arguments
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeFunction( const NodeFunction &other );
       protected:
 
     };
@@ -619,6 +634,7 @@ Constructor
 %End
         ~NodeSelectedColumn();
 
+
         void setAlias( const QString &alias );
 %Docstring
 Sets alias name
@@ -646,6 +662,8 @@ Alias name
 Clone with same type return
 %End
 
+      private:
+        NodeSelectedColumn( const NodeSelectedColumn &other );
       protected:
     };
 
@@ -665,6 +683,7 @@ Constructor
 %End
         ~NodeCast();
 
+
         QgsSQLStatement::Node *node() const;
 %Docstring
 Node that is referred to
@@ -683,6 +702,8 @@ Type
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeCast( const NodeCast &other );
       protected:
     };
 
@@ -764,6 +785,7 @@ Constructor with table definition and USING columns
 %End
         ~NodeJoin();
 
+
         QgsSQLStatement::NodeTableDef *tableDef() const;
 %Docstring
 Table definition
@@ -797,6 +819,8 @@ Join type
 Clone with same type return
 %End
 
+      private:
+        NodeJoin( const NodeJoin &other );
       protected:
     };
 
@@ -815,6 +839,7 @@ Column in a ORDER BY.
 Constructor
 %End
         ~NodeColumnSorted();
+
 
         QgsSQLStatement::NodeColumnRef *column() const;
 %Docstring
@@ -838,6 +863,8 @@ Whether the column is sorted in ascending order
 Clone with same type return
 %End
 
+      private:
+        NodeColumnSorted( const NodeColumnSorted &other );
       protected:
     };
 
@@ -856,6 +883,7 @@ SELECT node.
 Constructor
 %End
         ~NodeSelect();
+
 
         void setJoins( const QList<QgsSQLStatement::NodeJoin *> &joins /Transfer/ );
 %Docstring
@@ -907,6 +935,8 @@ Returns the list of order by columns
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeSelect( const NodeSelect &other );
       protected:
     };
 

--- a/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
@@ -311,7 +311,6 @@ Unary logical/arithmetical operator ( NOT, - ).
 %Docstring
 Constructor
 %End
-        ~NodeUnaryOperator();
 
 
         QgsSQLStatement::UnaryOperator op() const;
@@ -351,7 +350,6 @@ Binary logical/arithmetical operator (AND, OR, =, +, ...).
 %Docstring
 Constructor
 %End
-        ~NodeBinaryOperator();
 
 
         QgsSQLStatement::BinaryOperator op() const;
@@ -407,7 +405,6 @@ An 'x IN (y, z)' operator.
 %Docstring
 Constructor
 %End
-        ~NodeInOperator();
 
 
         QgsSQLStatement::Node *node() const;
@@ -452,7 +449,6 @@ An 'X BETWEEN y and z' operator.
 %Docstring
 Constructor
 %End
-
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -501,7 +497,6 @@ Function with a name and arguments node.
 %Docstring
 Constructor
 %End
-        ~NodeFunction();
 
 
         QString name() const;
@@ -632,7 +627,6 @@ Selected column.
 %Docstring
 Constructor
 %End
-        ~NodeSelectedColumn();
 
 
         void setAlias( const QString &alias );
@@ -681,7 +675,6 @@ CAST operator.
 %Docstring
 Constructor
 %End
-        ~NodeCast();
 
 
         QgsSQLStatement::Node *node() const;
@@ -783,7 +776,6 @@ Constructor with table definition, ON expression
 %Docstring
 Constructor with table definition and USING columns
 %End
-        ~NodeJoin();
 
 
         QgsSQLStatement::NodeTableDef *tableDef() const;
@@ -838,7 +830,6 @@ Column in a ORDER BY.
 %Docstring
 Constructor
 %End
-        ~NodeColumnSorted();
 
 
         QgsSQLStatement::NodeColumnRef *column() const;

--- a/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
@@ -312,7 +312,6 @@ Unary logical/arithmetical operator ( NOT, - ).
 Constructor
 %End
 
-
         QgsSQLStatement::UnaryOperator op() const;
 %Docstring
 Operator
@@ -350,7 +349,6 @@ Binary logical/arithmetical operator (AND, OR, =, +, ...).
 %Docstring
 Constructor
 %End
-
 
         QgsSQLStatement::BinaryOperator op() const;
 %Docstring
@@ -406,7 +404,6 @@ An 'x IN (y, z)' operator.
 Constructor
 %End
 
-
         QgsSQLStatement::Node *node() const;
 %Docstring
 Variable at the left of IN
@@ -449,7 +446,6 @@ An 'X BETWEEN y and z' operator.
 %Docstring
 Constructor
 %End
-
         QgsSQLStatement::Node *node() const;
 %Docstring
 Variable at the left of BETWEEN
@@ -497,7 +493,6 @@ Function with a name and arguments node.
 %Docstring
 Constructor
 %End
-
 
         QString name() const;
 %Docstring
@@ -628,7 +623,6 @@ Selected column.
 Constructor
 %End
 
-
         void setAlias( const QString &alias );
 %Docstring
 Sets alias name
@@ -675,7 +669,6 @@ CAST operator.
 %Docstring
 Constructor
 %End
-
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -777,7 +770,6 @@ Constructor with table definition, ON expression
 Constructor with table definition and USING columns
 %End
 
-
         QgsSQLStatement::NodeTableDef *tableDef() const;
 %Docstring
 Table definition
@@ -831,7 +823,6 @@ Column in a ORDER BY.
 Constructor
 %End
 
-
         QgsSQLStatement::NodeColumnRef *column() const;
 %Docstring
 The name of the column.
@@ -874,7 +865,6 @@ SELECT node.
 Constructor
 %End
         ~NodeSelect();
-
 
         void setJoins( const QList<QgsSQLStatement::NodeJoin *> &joins /Transfer/ );
 %Docstring

--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -313,6 +313,7 @@ Constructor
 %End
         ~NodeUnaryOperator();
 
+
         QgsSQLStatement::UnaryOperator op() const;
 %Docstring
 Operator
@@ -331,6 +332,8 @@ Operand
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeUnaryOperator( const NodeUnaryOperator &other );
       protected:
     };
 
@@ -349,6 +352,7 @@ Binary logical/arithmetical operator (AND, OR, =, +, ...).
 Constructor
 %End
         ~NodeBinaryOperator();
+
 
         QgsSQLStatement::BinaryOperator op() const;
 %Docstring
@@ -383,6 +387,8 @@ Precedence
 Is left associative ?
 %End
 
+      private:
+        NodeBinaryOperator( const NodeBinaryOperator &other );
       protected:
 
     };
@@ -402,6 +408,7 @@ An 'x IN (y, z)' operator.
 Constructor
 %End
         ~NodeInOperator();
+
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -426,6 +433,8 @@ Values list
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeInOperator( const NodeInOperator &other );
       protected:
     };
 
@@ -443,6 +452,7 @@ An 'X BETWEEN y and z' operator.
 %Docstring
 Constructor
 %End
+
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -472,6 +482,8 @@ Maximum bound
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeBetweenOperator( const NodeBetweenOperator &other );
       protected:
     };
 
@@ -491,6 +503,7 @@ Constructor
 %End
         ~NodeFunction();
 
+
         QString name() const;
 %Docstring
 Returns function name
@@ -509,6 +522,8 @@ Returns arguments
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeFunction( const NodeFunction &other );
       protected:
 
     };
@@ -619,6 +634,7 @@ Constructor
 %End
         ~NodeSelectedColumn();
 
+
         void setAlias( const QString &alias );
 %Docstring
 Sets alias name
@@ -646,6 +662,8 @@ Alias name
 Clone with same type return
 %End
 
+      private:
+        NodeSelectedColumn( const NodeSelectedColumn &other );
       protected:
     };
 
@@ -665,6 +683,7 @@ Constructor
 %End
         ~NodeCast();
 
+
         QgsSQLStatement::Node *node() const;
 %Docstring
 Node that is referred to
@@ -683,6 +702,8 @@ Type
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeCast( const NodeCast &other );
       protected:
     };
 
@@ -764,6 +785,7 @@ Constructor with table definition and USING columns
 %End
         ~NodeJoin();
 
+
         QgsSQLStatement::NodeTableDef *tableDef() const;
 %Docstring
 Table definition
@@ -797,6 +819,8 @@ Join type
 Clone with same type return
 %End
 
+      private:
+        NodeJoin( const NodeJoin &other );
       protected:
     };
 
@@ -815,6 +839,7 @@ Column in a ORDER BY.
 Constructor
 %End
         ~NodeColumnSorted();
+
 
         QgsSQLStatement::NodeColumnRef *column() const;
 %Docstring
@@ -838,6 +863,8 @@ Whether the column is sorted in ascending order
 Clone with same type return
 %End
 
+      private:
+        NodeColumnSorted( const NodeColumnSorted &other );
       protected:
     };
 
@@ -856,6 +883,7 @@ SELECT node.
 Constructor
 %End
         ~NodeSelect();
+
 
         void setJoins( const QList<QgsSQLStatement::NodeJoin *> &joins /Transfer/ );
 %Docstring
@@ -907,6 +935,8 @@ Returns the list of order by columns
         virtual QgsSQLStatement::Node *clone() const /Factory/;
 
 
+      private:
+        NodeSelect( const NodeSelect &other );
       protected:
     };
 

--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -311,7 +311,6 @@ Unary logical/arithmetical operator ( NOT, - ).
 %Docstring
 Constructor
 %End
-        ~NodeUnaryOperator();
 
 
         QgsSQLStatement::UnaryOperator op() const;
@@ -351,7 +350,6 @@ Binary logical/arithmetical operator (AND, OR, =, +, ...).
 %Docstring
 Constructor
 %End
-        ~NodeBinaryOperator();
 
 
         QgsSQLStatement::BinaryOperator op() const;
@@ -407,7 +405,6 @@ An 'x IN (y, z)' operator.
 %Docstring
 Constructor
 %End
-        ~NodeInOperator();
 
 
         QgsSQLStatement::Node *node() const;
@@ -452,7 +449,6 @@ An 'X BETWEEN y and z' operator.
 %Docstring
 Constructor
 %End
-
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -501,7 +497,6 @@ Function with a name and arguments node.
 %Docstring
 Constructor
 %End
-        ~NodeFunction();
 
 
         QString name() const;
@@ -632,7 +627,6 @@ Selected column.
 %Docstring
 Constructor
 %End
-        ~NodeSelectedColumn();
 
 
         void setAlias( const QString &alias );
@@ -681,7 +675,6 @@ CAST operator.
 %Docstring
 Constructor
 %End
-        ~NodeCast();
 
 
         QgsSQLStatement::Node *node() const;
@@ -783,7 +776,6 @@ Constructor with table definition, ON expression
 %Docstring
 Constructor with table definition and USING columns
 %End
-        ~NodeJoin();
 
 
         QgsSQLStatement::NodeTableDef *tableDef() const;
@@ -838,7 +830,6 @@ Column in a ORDER BY.
 %Docstring
 Constructor
 %End
-        ~NodeColumnSorted();
 
 
         QgsSQLStatement::NodeColumnRef *column() const;

--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -312,7 +312,6 @@ Unary logical/arithmetical operator ( NOT, - ).
 Constructor
 %End
 
-
         QgsSQLStatement::UnaryOperator op() const;
 %Docstring
 Operator
@@ -350,7 +349,6 @@ Binary logical/arithmetical operator (AND, OR, =, +, ...).
 %Docstring
 Constructor
 %End
-
 
         QgsSQLStatement::BinaryOperator op() const;
 %Docstring
@@ -406,7 +404,6 @@ An 'x IN (y, z)' operator.
 Constructor
 %End
 
-
         QgsSQLStatement::Node *node() const;
 %Docstring
 Variable at the left of IN
@@ -449,7 +446,6 @@ An 'X BETWEEN y and z' operator.
 %Docstring
 Constructor
 %End
-
         QgsSQLStatement::Node *node() const;
 %Docstring
 Variable at the left of BETWEEN
@@ -497,7 +493,6 @@ Function with a name and arguments node.
 %Docstring
 Constructor
 %End
-
 
         QString name() const;
 %Docstring
@@ -628,7 +623,6 @@ Selected column.
 Constructor
 %End
 
-
         void setAlias( const QString &alias );
 %Docstring
 Sets alias name
@@ -675,7 +669,6 @@ CAST operator.
 %Docstring
 Constructor
 %End
-
 
         QgsSQLStatement::Node *node() const;
 %Docstring
@@ -777,7 +770,6 @@ Constructor with table definition, ON expression
 Constructor with table definition and USING columns
 %End
 
-
         QgsSQLStatement::NodeTableDef *tableDef() const;
 %Docstring
 Table definition
@@ -831,7 +823,6 @@ Column in a ORDER BY.
 Constructor
 %End
 
-
         QgsSQLStatement::NodeColumnRef *column() const;
 %Docstring
 The name of the column.
@@ -874,7 +865,6 @@ SELECT node.
 Constructor
 %End
         ~NodeSelect();
-
 
         void setJoins( const QList<QgsSQLStatement::NodeJoin *> &joins /Transfer/ );
 %Docstring

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -122,7 +122,7 @@ QgsAnnotationLayer::QgsAnnotationLayer( const QString &name, const LayerOptions 
 
   QgsDataProvider::ProviderOptions providerOptions;
   providerOptions.transformContext = options.transformContext;
-  mDataProvider = new QgsAnnotationLayerDataProvider( providerOptions, Qgis::DataProviderReadFlags() );
+  mDataProvider = std::make_unique<QgsAnnotationLayerDataProvider>( providerOptions, Qgis::DataProviderReadFlags() );
 
   mPaintEffect.reset( QgsPaintEffectRegistry::defaultStack() );
   mPaintEffect->setEnabled( false );
@@ -132,7 +132,7 @@ QgsAnnotationLayer::~QgsAnnotationLayer()
 {
   emit willBeDeleted();
   qDeleteAll( mItems );
-  delete mDataProvider;
+
 }
 
 void QgsAnnotationLayer::reset()
@@ -609,14 +609,14 @@ QgsDataProvider *QgsAnnotationLayer::dataProvider()
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return mDataProvider;
+  return mDataProvider.get();
 }
 
 const QgsDataProvider *QgsAnnotationLayer::dataProvider() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return mDataProvider;
+  return mDataProvider.get();
 }
 
 QString QgsAnnotationLayer::htmlMetadata() const

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -234,7 +234,7 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     std::unique_ptr< QgsAnnotationLayerSpatialIndex > mSpatialIndex;
     QSet< QString > mNonIndexedItems;
 
-    QgsDataProvider *mDataProvider = nullptr;
+    std::unique_ptr<QgsDataProvider> mDataProvider;
 
     std::unique_ptr< QgsPaintEffect > mPaintEffect;
 

--- a/src/core/dxf/qgsdxfpaintdevice.cpp
+++ b/src/core/dxf/qgsdxfpaintdevice.cpp
@@ -21,17 +21,17 @@
 
 QgsDxfPaintDevice::QgsDxfPaintDevice( QgsDxfExport *dxf )
 {
-  mPaintEngine = new QgsDxfPaintEngine( this, dxf );
+  mPaintEngine = std::make_unique<QgsDxfPaintEngine>( this, dxf );
 }
 
 QgsDxfPaintDevice::~QgsDxfPaintDevice()
 {
-  delete mPaintEngine;
+
 }
 
 QPaintEngine *QgsDxfPaintDevice::paintEngine() const
 {
-  return mPaintEngine;
+  return mPaintEngine.get();
 }
 
 int QgsDxfPaintDevice::metric( PaintDeviceMetric metric ) const

--- a/src/core/dxf/qgsdxfpaintdevice.h
+++ b/src/core/dxf/qgsdxfpaintdevice.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsDxfPaintDevice: public QPaintDevice
 
 
   private:
-    QgsDxfPaintEngine *mPaintEngine = nullptr;
+    std::unique_ptr<QgsDxfPaintEngine> mPaintEngine;
 
     QSizeF mDrawingSize; //size (in source coordinates)
     QRectF mRectangle; //size (in dxf coordinates)

--- a/src/core/network/qgsnetworkcontentfetcher.cpp
+++ b/src/core/network/qgsnetworkcontentfetcher.cpp
@@ -34,7 +34,7 @@ QgsNetworkContentFetcher::~QgsNetworkContentFetcher()
     //cancel running request
     mReply->abort();
   }
-  delete mReply;
+
 }
 
 void QgsNetworkContentFetcher::fetchContent( const QUrl &url, const QString &authcfg )
@@ -63,18 +63,18 @@ void QgsNetworkContentFetcher::fetchContent( const QNetworkRequest &r, const QSt
   {
     //cancel any in progress requests
     mReply->abort();
-    mReply->deleteLater();
+    mReply.release()->deleteLater();
     mReply = nullptr;
   }
 
-  mReply = QgsNetworkAccessManager::instance()->get( request );
+  mReply.reset( QgsNetworkAccessManager::instance()->get( request ) );
   if ( !mAuthCfg.isEmpty() )
   {
-    QgsApplication::authManager()->updateNetworkReply( mReply, mAuthCfg );
+    QgsApplication::authManager()->updateNetworkReply( mReply.get(), mAuthCfg );
   }
   mReply->setParent( nullptr ); // we don't want thread locale QgsNetworkAccessManagers to delete the reply - we want ownership of it to belong to this object
-  connect( mReply, &QNetworkReply::finished, this, [this] { contentLoaded(); } );
-  connect( mReply, &QNetworkReply::downloadProgress, this, &QgsNetworkContentFetcher::downloadProgress );
+  connect( mReply.get(), &QNetworkReply::finished, this, [this] { contentLoaded(); } );
+  connect( mReply.get(), &QNetworkReply::downloadProgress, this, &QgsNetworkContentFetcher::downloadProgress );
 
   auto onError = [this]( QNetworkReply::NetworkError code )
   {
@@ -83,7 +83,7 @@ void QgsNetworkContentFetcher::fetchContent( const QNetworkRequest &r, const QSt
       emit errorOccurred( code, mReply->errorString() );
   };
 
-  connect( mReply, &QNetworkReply::errorOccurred, this, onError );
+  connect( mReply.get(), &QNetworkReply::errorOccurred, this, onError );
 }
 
 QNetworkReply *QgsNetworkContentFetcher::reply()
@@ -93,12 +93,12 @@ QNetworkReply *QgsNetworkContentFetcher::reply()
     return nullptr;
   }
 
-  return mReply;
+  return mReply.get();
 }
 
 QString QgsNetworkContentFetcher::contentDispositionFilename() const
 {
-  return mReply ? QgsNetworkReplyContent::extractFilenameFromContentDispositionHeader( mReply ) : QString();
+  return mReply ? QgsNetworkReplyContent::extractFilenameFromContentDispositionHeader( mReply.get() ) : QString();
 }
 
 QString QgsNetworkContentFetcher::contentAsString() const
@@ -123,7 +123,7 @@ void QgsNetworkContentFetcher::cancel()
   {
     //cancel any in progress requests
     mReply->abort();
-    mReply->deleteLater();
+    mReply.release()->deleteLater();
     mReply = nullptr;
   }
 }
@@ -205,6 +205,6 @@ void QgsNetworkContentFetcher::contentLoaded( bool ok )
   }
 
   //redirect, so fetch redirect target
-  mReply->deleteLater();
+  mReply.release()->deleteLater();
   fetchContent( redirect.toUrl(), mAuthCfg );
 }

--- a/src/core/network/qgsnetworkcontentfetcher.h
+++ b/src/core/network/qgsnetworkcontentfetcher.h
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsNetworkContentFetcher : public QObject
   private:
 
     QString mAuthCfg;
-    QNetworkReply *mReply = nullptr;
+    std::unique_ptr<QNetworkReply> mReply;
 
     bool mContentLoaded = false;
 

--- a/src/core/qgsgrouplayer.cpp
+++ b/src/core/qgsgrouplayer.cpp
@@ -40,13 +40,13 @@ QgsGroupLayer::QgsGroupLayer( const QString &name, const LayerOptions &options )
 
   QgsDataProvider::ProviderOptions providerOptions;
   providerOptions.transformContext = options.transformContext;
-  mDataProvider = new QgsGroupLayerDataProvider( providerOptions, Qgis::DataProviderReadFlags() );
+  mDataProvider = std::make_unique<QgsGroupLayerDataProvider>( providerOptions, Qgis::DataProviderReadFlags() );
 }
 
 QgsGroupLayer::~QgsGroupLayer()
 {
   emit willBeDeleted();
-  delete mDataProvider;
+
 }
 
 QgsGroupLayer *QgsGroupLayer::clone() const
@@ -226,14 +226,14 @@ QgsDataProvider *QgsGroupLayer::dataProvider()
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return mDataProvider;
+  return mDataProvider.get();
 }
 
 const QgsDataProvider *QgsGroupLayer::dataProvider() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return mDataProvider;
+  return mDataProvider.get();
 }
 
 QString QgsGroupLayer::htmlMetadata() const

--- a/src/core/qgsgrouplayer.h
+++ b/src/core/qgsgrouplayer.h
@@ -139,7 +139,7 @@ class CORE_EXPORT QgsGroupLayer : public QgsMapLayer
 
   private:
 
-    QgsGroupLayerDataProvider *mDataProvider = nullptr;
+    std::unique_ptr<QgsGroupLayerDataProvider> mDataProvider;
     QgsCoordinateTransformContext mTransformContext;
 
     QList< QgsMapLayerRef > mChildren;

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -151,11 +151,10 @@ QgsSQLStatement &QgsSQLStatement::operator=( const QgsSQLStatement &other )
 {
   if ( &other != this )
   {
-    mRootNode.reset( ::parse( mStatement, mParserErrorString, mAllowFragments ) );
     mParserErrorString.clear();
     mStatement = other.mStatement;
     mAllowFragments = other.mAllowFragments;
-
+    mRootNode.reset( ::parse( mStatement, mParserErrorString, mAllowFragments ) );
   }
   return *this;
 }

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -136,7 +136,7 @@ QgsSQLStatement::QgsSQLStatement( const QString &expr )
 QgsSQLStatement::QgsSQLStatement( const QString &expr, bool allowFragments )
   : mAllowFragments( allowFragments )
 {
-  mRootNode = ::parse( expr, mParserErrorString, mAllowFragments );
+  mRootNode.reset( ::parse( expr, mParserErrorString, mAllowFragments ) );
   mStatement = expr;
 }
 
@@ -144,25 +144,25 @@ QgsSQLStatement::QgsSQLStatement( const QgsSQLStatement &other )
   : mAllowFragments( other.mAllowFragments )
   , mStatement( other.mStatement )
 {
-  mRootNode = ::parse( mStatement, mParserErrorString, mAllowFragments );
+  mRootNode.reset( ::parse( mStatement, mParserErrorString, mAllowFragments ) );
 }
 
 QgsSQLStatement &QgsSQLStatement::operator=( const QgsSQLStatement &other )
 {
   if ( &other != this )
   {
-    delete mRootNode;
+    mRootNode.reset( ::parse( mStatement, mParserErrorString, mAllowFragments ) );
     mParserErrorString.clear();
     mStatement = other.mStatement;
     mAllowFragments = other.mAllowFragments;
-    mRootNode = ::parse( mStatement, mParserErrorString, mAllowFragments );
+
   }
   return *this;
 }
 
 QgsSQLStatement::~QgsSQLStatement()
 {
-  delete mRootNode;
+
 }
 
 bool QgsSQLStatement::hasParserError() const { return !mParserErrorString.isNull() || ( !mRootNode && !mAllowFragments ); }
@@ -177,7 +177,7 @@ void QgsSQLStatement::acceptVisitor( QgsSQLStatement::Visitor &v ) const
 
 const QgsSQLStatement::Node *QgsSQLStatement::rootNode() const
 {
-  return mRootNode;
+  return mRootNode.get();
 }
 
 void QgsSQLStatement::RecursiveVisitor::visit( const QgsSQLStatement::NodeSelect &n )
@@ -408,9 +408,9 @@ bool QgsSQLStatement::NodeBinaryOperator::leftAssociative() const
 
 QString QgsSQLStatement::NodeBinaryOperator::dump() const
 {
-  QgsSQLStatement::NodeBinaryOperator *lOp = dynamic_cast<QgsSQLStatement::NodeBinaryOperator *>( mOpLeft );
-  QgsSQLStatement::NodeBinaryOperator *rOp = dynamic_cast<QgsSQLStatement::NodeBinaryOperator *>( mOpRight );
-  QgsSQLStatement::NodeUnaryOperator *ruOp = dynamic_cast<QgsSQLStatement::NodeUnaryOperator *>( mOpRight );
+  QgsSQLStatement::NodeBinaryOperator *lOp = dynamic_cast<QgsSQLStatement::NodeBinaryOperator *>( mOpLeft.get() );
+  QgsSQLStatement::NodeBinaryOperator *rOp = dynamic_cast<QgsSQLStatement::NodeBinaryOperator *>( mOpRight.get() );
+  QgsSQLStatement::NodeUnaryOperator *ruOp = dynamic_cast<QgsSQLStatement::NodeUnaryOperator *>( mOpRight.get() );
 
   QString rdump( mOpRight->dump() );
 
@@ -594,7 +594,7 @@ QgsSQLStatement::NodeSelect::~NodeSelect()
   qDeleteAll( mTableList );
   qDeleteAll( mColumns );
   qDeleteAll( mJoins );
-  delete mWhere;
+
   qDeleteAll( mOrderBy );
 }
 

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -594,7 +594,6 @@ QgsSQLStatement::NodeSelect::~NodeSelect()
   qDeleteAll( mTableList );
   qDeleteAll( mColumns );
   qDeleteAll( mJoins );
-
   qDeleteAll( mOrderBy );
 }
 

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -327,7 +327,6 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeUnaryOperator( QgsSQLStatement::UnaryOperator op, QgsSQLStatement::Node *operand SIP_TRANSFER ) : mOp( op ), mOperand( operand ) {}
-        ~NodeUnaryOperator() override {  }
 
         NodeUnaryOperator( const NodeUnaryOperator &other ) = delete;
         NodeUnaryOperator &operator=( const NodeUnaryOperator &other ) = delete;
@@ -367,7 +366,6 @@ class CORE_EXPORT QgsSQLStatement
           , mOpLeft( opLeft )
           , mOpRight( opRight )
         {}
-        ~NodeBinaryOperator() override {   }
 
         NodeBinaryOperator( const NodeBinaryOperator &other ) = delete;
         NodeBinaryOperator &operator=( const NodeBinaryOperator &other ) = delete;
@@ -414,7 +412,6 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeInOperator( QgsSQLStatement::Node *node SIP_TRANSFER, QgsSQLStatement::NodeList *list SIP_TRANSFER, bool notin = false ) : mNode( node ), mList( list ), mNotIn( notin ) {}
-        ~NodeInOperator() override {   }
 
         NodeInOperator( const NodeInOperator &other ) = delete;
         NodeInOperator &operator=( const NodeInOperator &other ) = delete;
@@ -455,7 +452,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeBetweenOperator( QgsSQLStatement::Node *node SIP_TRANSFER, QgsSQLStatement::Node *minVal SIP_TRANSFER, QgsSQLStatement::Node *maxVal SIP_TRANSFER, bool notBetween = false )
           : mNode( node ), mMinVal( minVal ), mMaxVal( maxVal ), mNotBetween( notBetween ) {}
-        ~NodeBetweenOperator() override {    }
 
         NodeBetweenOperator( const NodeBetweenOperator &other ) = delete;
         NodeBetweenOperator &operator=( const NodeBetweenOperator &other ) = delete;
@@ -499,7 +495,6 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeFunction( const QString &name, QgsSQLStatement::NodeList *args  SIP_TRANSFER ) : mName( name ), mArgs( args ) {}
-        ~NodeFunction() override {  }
 
         NodeFunction( const NodeFunction &other ) = delete;
         NodeFunction &operator=( const NodeFunction &other ) = delete;
@@ -601,7 +596,6 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeSelectedColumn( QgsSQLStatement::Node *node SIP_TRANSFER ) : mColumnNode( node ) {}
-        ~NodeSelectedColumn() override {  }
 
         NodeSelectedColumn( const NodeSelectedColumn &other ) = delete;
         NodeSelectedColumn &operator=( const NodeSelectedColumn &other ) = delete;
@@ -642,7 +636,6 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeCast( QgsSQLStatement::Node *node SIP_TRANSFER, const QString &type ) : mNode( node ), mType( type ) {}
-        ~NodeCast() override {  }
 
         NodeCast( const NodeCast &other ) = delete;
         NodeCast &operator=( const NodeCast &other ) = delete;
@@ -726,7 +719,6 @@ class CORE_EXPORT QgsSQLStatement
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef SIP_TRANSFER, QgsSQLStatement::Node *onExpr SIP_TRANSFER, QgsSQLStatement::JoinType type ) : mTableDef( tabledef ), mOnExpr( onExpr ), mType( type ) {}
         //! Constructor with table definition and USING columns
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef SIP_TRANSFER, const QList<QString> &usingColumns, QgsSQLStatement::JoinType type ) : mTableDef( tabledef ), mUsingColumns( usingColumns ), mType( type ) {}
-        ~NodeJoin() override {   }
 
         NodeJoin( const NodeJoin &other ) = delete;
         NodeJoin &operator=( const NodeJoin &other ) = delete;
@@ -772,7 +764,6 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeColumnSorted( QgsSQLStatement::NodeColumnRef *column SIP_TRANSFER, bool asc ) : mColumn( column ), mAsc( asc ) {}
-        ~NodeColumnSorted() override {  }
 
         NodeColumnSorted( const NodeColumnSorted &other ) = delete;
         NodeColumnSorted &operator=( const NodeColumnSorted &other ) = delete;

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -329,6 +329,9 @@ class CORE_EXPORT QgsSQLStatement
         NodeUnaryOperator( QgsSQLStatement::UnaryOperator op, QgsSQLStatement::Node *operand SIP_TRANSFER ) : mOp( op ), mOperand( operand ) {}
         ~NodeUnaryOperator() override {  }
 
+        NodeUnaryOperator( const NodeUnaryOperator &other ) = delete;
+        NodeUnaryOperator &operator=( const NodeUnaryOperator &other ) = delete;
+
         //! Operator
         QgsSQLStatement::UnaryOperator op() const { return mOp; }
 
@@ -340,6 +343,11 @@ class CORE_EXPORT QgsSQLStatement
 
         void accept( QgsSQLStatement::Visitor &v ) const override { v.visit( *this ); }
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
+
+      private:
+#ifdef SIP_RUN
+        NodeUnaryOperator( const NodeUnaryOperator &other );
+#endif
 
       protected:
         UnaryOperator mOp;
@@ -360,6 +368,9 @@ class CORE_EXPORT QgsSQLStatement
           , mOpRight( opRight )
         {}
         ~NodeBinaryOperator() override {   }
+
+        NodeBinaryOperator( const NodeBinaryOperator &other ) = delete;
+        NodeBinaryOperator &operator=( const NodeBinaryOperator &other ) = delete;
 
         //! Operator
         QgsSQLStatement::BinaryOperator op() const { return mOp; }
@@ -382,6 +393,11 @@ class CORE_EXPORT QgsSQLStatement
         //! Is left associative ?
         bool leftAssociative() const;
 
+      private:
+#ifdef SIP_RUN
+        NodeBinaryOperator( const NodeBinaryOperator &other );
+#endif
+
       protected:
 
         BinaryOperator mOp;
@@ -400,6 +416,9 @@ class CORE_EXPORT QgsSQLStatement
         NodeInOperator( QgsSQLStatement::Node *node SIP_TRANSFER, QgsSQLStatement::NodeList *list SIP_TRANSFER, bool notin = false ) : mNode( node ), mList( list ), mNotIn( notin ) {}
         ~NodeInOperator() override {   }
 
+        NodeInOperator( const NodeInOperator &other ) = delete;
+        NodeInOperator &operator=( const NodeInOperator &other ) = delete;
+
         //! Variable at the left of IN
         QgsSQLStatement::Node *node() const { return mNode.get(); }
 
@@ -414,6 +433,11 @@ class CORE_EXPORT QgsSQLStatement
 
         void accept( QgsSQLStatement::Visitor &v ) const override { v.visit( *this ); }
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
+
+      private:
+#ifdef SIP_RUN
+        NodeInOperator( const NodeInOperator &other );
+#endif
 
       protected:
         std::unique_ptr<Node> mNode;
@@ -433,6 +457,9 @@ class CORE_EXPORT QgsSQLStatement
           : mNode( node ), mMinVal( minVal ), mMaxVal( maxVal ), mNotBetween( notBetween ) {}
         ~NodeBetweenOperator() override {    }
 
+        NodeBetweenOperator( const NodeBetweenOperator &other ) = delete;
+        NodeBetweenOperator &operator=( const NodeBetweenOperator &other ) = delete;
+
         //! Variable at the left of BETWEEN
         QgsSQLStatement::Node *node() const { return mNode.get(); }
 
@@ -450,6 +477,11 @@ class CORE_EXPORT QgsSQLStatement
 
         void accept( QgsSQLStatement::Visitor &v ) const override { v.visit( *this ); }
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
+
+      private:
+#ifdef SIP_RUN
+        NodeBetweenOperator( const NodeBetweenOperator &other );
+#endif
 
       protected:
         std::unique_ptr<Node> mNode;
@@ -469,6 +501,9 @@ class CORE_EXPORT QgsSQLStatement
         NodeFunction( const QString &name, QgsSQLStatement::NodeList *args  SIP_TRANSFER ) : mName( name ), mArgs( args ) {}
         ~NodeFunction() override {  }
 
+        NodeFunction( const NodeFunction &other ) = delete;
+        NodeFunction &operator=( const NodeFunction &other ) = delete;
+
         //! Returns function name
         QString name() const { return mName; }
 
@@ -480,6 +515,11 @@ class CORE_EXPORT QgsSQLStatement
 
         void accept( QgsSQLStatement::Visitor &v ) const override { v.visit( *this ); }
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
+
+      private:
+#ifdef SIP_RUN
+        NodeFunction( const NodeFunction &other );
+#endif
 
       protected:
         QString mName;
@@ -563,6 +603,9 @@ class CORE_EXPORT QgsSQLStatement
         NodeSelectedColumn( QgsSQLStatement::Node *node SIP_TRANSFER ) : mColumnNode( node ) {}
         ~NodeSelectedColumn() override {  }
 
+        NodeSelectedColumn( const NodeSelectedColumn &other ) = delete;
+        NodeSelectedColumn &operator=( const NodeSelectedColumn &other ) = delete;
+
         //! Sets alias name
         void setAlias( const QString &alias ) { mAlias = alias; }
 
@@ -580,6 +623,11 @@ class CORE_EXPORT QgsSQLStatement
         //! Clone with same type return
         QgsSQLStatement::NodeSelectedColumn *cloneThis() const SIP_FACTORY;
 
+      private:
+#ifdef SIP_RUN
+        NodeSelectedColumn( const NodeSelectedColumn &other );
+#endif
+
       protected:
         std::unique_ptr<Node> mColumnNode;
         QString mAlias;
@@ -596,6 +644,9 @@ class CORE_EXPORT QgsSQLStatement
         NodeCast( QgsSQLStatement::Node *node SIP_TRANSFER, const QString &type ) : mNode( node ), mType( type ) {}
         ~NodeCast() override {  }
 
+        NodeCast( const NodeCast &other ) = delete;
+        NodeCast &operator=( const NodeCast &other ) = delete;
+
         //! Node that is referred to
         QgsSQLStatement::Node *node() const { return mNode.get(); }
 
@@ -607,6 +658,12 @@ class CORE_EXPORT QgsSQLStatement
 
         void accept( QgsSQLStatement::Visitor &v ) const override { v.visit( *this ); }
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
+
+      private:
+
+#ifdef SIP_RUN
+        NodeCast( const NodeCast &other );
+#endif
 
       protected:
         std::unique_ptr<Node> mNode;
@@ -671,6 +728,9 @@ class CORE_EXPORT QgsSQLStatement
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef SIP_TRANSFER, const QList<QString> &usingColumns, QgsSQLStatement::JoinType type ) : mTableDef( tabledef ), mUsingColumns( usingColumns ), mType( type ) {}
         ~NodeJoin() override {   }
 
+        NodeJoin( const NodeJoin &other ) = delete;
+        NodeJoin &operator=( const NodeJoin &other ) = delete;
+
         //! Table definition
         QgsSQLStatement::NodeTableDef *tableDef() const { return mTableDef.get(); }
 
@@ -691,6 +751,11 @@ class CORE_EXPORT QgsSQLStatement
         //! Clone with same type return
         QgsSQLStatement::NodeJoin *cloneThis() const SIP_FACTORY;
 
+      private:
+#ifdef SIP_RUN
+        NodeJoin( const NodeJoin &other );
+#endif
+
       protected:
         std::unique_ptr<NodeTableDef> mTableDef;
         std::unique_ptr<Node> mOnExpr;
@@ -709,6 +774,9 @@ class CORE_EXPORT QgsSQLStatement
         NodeColumnSorted( QgsSQLStatement::NodeColumnRef *column SIP_TRANSFER, bool asc ) : mColumn( column ), mAsc( asc ) {}
         ~NodeColumnSorted() override {  }
 
+        NodeColumnSorted( const NodeColumnSorted &other ) = delete;
+        NodeColumnSorted &operator=( const NodeColumnSorted &other ) = delete;
+
         //! The name of the column.
         QgsSQLStatement::NodeColumnRef *column() const { return mColumn.get(); }
 
@@ -722,6 +790,11 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
         //! Clone with same type return
         QgsSQLStatement::NodeColumnSorted *cloneThis() const SIP_FACTORY;
+
+      private:
+#ifdef SIP_RUN
+        NodeColumnSorted( const NodeColumnSorted &other );
+#endif
 
       protected:
         std::unique_ptr<NodeColumnRef> mColumn;
@@ -738,6 +811,9 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeSelect( const QList<QgsSQLStatement::NodeTableDef *> &tableList SIP_TRANSFER, const QList<QgsSQLStatement::NodeSelectedColumn *> &columns SIP_TRANSFER, bool distinct ) : mTableList( tableList ), mColumns( columns ), mDistinct( distinct ) {}
         ~NodeSelect() override;
+
+        NodeSelect( const NodeSelect &other ) = delete;
+        NodeSelect &operator=( const NodeSelect &other ) = delete;
 
         //! Sets joins
         void setJoins( const QList<QgsSQLStatement::NodeJoin *> &joins SIP_TRANSFER ) { qDeleteAll( mJoins ); mJoins = joins; }
@@ -766,6 +842,12 @@ class CORE_EXPORT QgsSQLStatement
 
         void accept( QgsSQLStatement::Visitor &v ) const override { v.visit( *this ); }
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
+
+      private:
+
+#ifdef SIP_RUN
+        NodeSelect( const NodeSelect &other );
+#endif
 
       protected:
         QList<NodeTableDef *> mTableList;

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -327,13 +327,13 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeUnaryOperator( QgsSQLStatement::UnaryOperator op, QgsSQLStatement::Node *operand SIP_TRANSFER ) : mOp( op ), mOperand( operand ) {}
-        ~NodeUnaryOperator() override { delete mOperand; }
+        ~NodeUnaryOperator() override {  }
 
         //! Operator
         QgsSQLStatement::UnaryOperator op() const { return mOp; }
 
         //! Operand
-        QgsSQLStatement::Node *operand() const { return mOperand; }
+        QgsSQLStatement::Node *operand() const { return mOperand.get(); }
 
         QgsSQLStatement::NodeType nodeType() const override { return ntUnaryOperator; }
         QString dump() const override;
@@ -343,7 +343,7 @@ class CORE_EXPORT QgsSQLStatement
 
       protected:
         UnaryOperator mOp;
-        Node *mOperand = nullptr;
+        std::unique_ptr<Node> mOperand;
     };
 
     /**
@@ -359,16 +359,16 @@ class CORE_EXPORT QgsSQLStatement
           , mOpLeft( opLeft )
           , mOpRight( opRight )
         {}
-        ~NodeBinaryOperator() override { delete mOpLeft; delete mOpRight; }
+        ~NodeBinaryOperator() override {   }
 
         //! Operator
         QgsSQLStatement::BinaryOperator op() const { return mOp; }
 
         //! Left operand
-        QgsSQLStatement::Node *opLeft() const { return mOpLeft; }
+        QgsSQLStatement::Node *opLeft() const { return mOpLeft.get(); }
 
         //! Right operand
-        QgsSQLStatement::Node *opRight() const { return mOpRight; }
+        QgsSQLStatement::Node *opRight() const { return mOpRight.get(); }
 
         QgsSQLStatement::NodeType nodeType() const override { return ntBinaryOperator; }
         QString dump() const override;
@@ -385,8 +385,8 @@ class CORE_EXPORT QgsSQLStatement
       protected:
 
         BinaryOperator mOp;
-        Node *mOpLeft = nullptr;
-        Node *mOpRight = nullptr;
+        std::unique_ptr<Node> mOpLeft;
+        std::unique_ptr<Node> mOpRight;
     };
 
     /**
@@ -398,16 +398,16 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeInOperator( QgsSQLStatement::Node *node SIP_TRANSFER, QgsSQLStatement::NodeList *list SIP_TRANSFER, bool notin = false ) : mNode( node ), mList( list ), mNotIn( notin ) {}
-        ~NodeInOperator() override { delete mNode; delete mList; }
+        ~NodeInOperator() override {   }
 
         //! Variable at the left of IN
-        QgsSQLStatement::Node *node() const { return mNode; }
+        QgsSQLStatement::Node *node() const { return mNode.get(); }
 
         //! Whether this is a NOT IN operator
         bool isNotIn() const { return mNotIn; }
 
         //! Values list
-        QgsSQLStatement::NodeList *list() const { return mList; }
+        QgsSQLStatement::NodeList *list() const { return mList.get(); }
 
         QgsSQLStatement::NodeType nodeType() const override { return ntInOperator; }
         QString dump() const override;
@@ -416,8 +416,8 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       protected:
-        Node *mNode = nullptr;
-        NodeList *mList = nullptr;
+        std::unique_ptr<Node> mNode;
+        std::unique_ptr<NodeList> mList;
         bool mNotIn;
     };
 
@@ -431,19 +431,19 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeBetweenOperator( QgsSQLStatement::Node *node SIP_TRANSFER, QgsSQLStatement::Node *minVal SIP_TRANSFER, QgsSQLStatement::Node *maxVal SIP_TRANSFER, bool notBetween = false )
           : mNode( node ), mMinVal( minVal ), mMaxVal( maxVal ), mNotBetween( notBetween ) {}
-        ~NodeBetweenOperator() override { delete mNode; delete mMinVal; delete mMaxVal; }
+        ~NodeBetweenOperator() override {    }
 
         //! Variable at the left of BETWEEN
-        QgsSQLStatement::Node *node() const { return mNode; }
+        QgsSQLStatement::Node *node() const { return mNode.get(); }
 
         //! Whether this is a NOT BETWEEN operator
         bool isNotBetween() const { return mNotBetween; }
 
         //! Minimum bound
-        QgsSQLStatement::Node *minVal() const { return mMinVal; }
+        QgsSQLStatement::Node *minVal() const { return mMinVal.get(); }
 
         //! Maximum bound
-        QgsSQLStatement::Node *maxVal() const { return mMaxVal; }
+        QgsSQLStatement::Node *maxVal() const { return mMaxVal.get(); }
 
         QgsSQLStatement::NodeType nodeType() const override { return ntBetweenOperator; }
         QString dump() const override;
@@ -452,9 +452,9 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       protected:
-        Node *mNode = nullptr;
-        Node *mMinVal = nullptr;
-        Node *mMaxVal = nullptr;
+        std::unique_ptr<Node> mNode;
+        std::unique_ptr<Node> mMinVal;
+        std::unique_ptr<Node> mMaxVal;
         bool mNotBetween;
     };
 
@@ -467,13 +467,13 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeFunction( const QString &name, QgsSQLStatement::NodeList *args  SIP_TRANSFER ) : mName( name ), mArgs( args ) {}
-        ~NodeFunction() override { delete mArgs; }
+        ~NodeFunction() override {  }
 
         //! Returns function name
         QString name() const { return mName; }
 
         //! Returns arguments
-        QgsSQLStatement::NodeList *args() const { return mArgs; }
+        QgsSQLStatement::NodeList *args() const { return mArgs.get(); }
 
         QgsSQLStatement::NodeType nodeType() const override { return ntFunction; }
         QString dump() const override;
@@ -483,7 +483,7 @@ class CORE_EXPORT QgsSQLStatement
 
       protected:
         QString mName;
-        NodeList *mArgs = nullptr;
+        std::unique_ptr<NodeList> mArgs;
 
     };
 
@@ -561,13 +561,13 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeSelectedColumn( QgsSQLStatement::Node *node SIP_TRANSFER ) : mColumnNode( node ) {}
-        ~NodeSelectedColumn() override { delete mColumnNode; }
+        ~NodeSelectedColumn() override {  }
 
         //! Sets alias name
         void setAlias( const QString &alias ) { mAlias = alias; }
 
         //! Column that is referred to
-        QgsSQLStatement::Node *column() const { return mColumnNode; }
+        QgsSQLStatement::Node *column() const { return mColumnNode.get(); }
 
         //! Alias name
         QString alias() const { return mAlias; }
@@ -581,7 +581,7 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::NodeSelectedColumn *cloneThis() const SIP_FACTORY;
 
       protected:
-        Node *mColumnNode = nullptr;
+        std::unique_ptr<Node> mColumnNode;
         QString mAlias;
     };
 
@@ -594,10 +594,10 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeCast( QgsSQLStatement::Node *node SIP_TRANSFER, const QString &type ) : mNode( node ), mType( type ) {}
-        ~NodeCast() override { delete mNode; }
+        ~NodeCast() override {  }
 
         //! Node that is referred to
-        QgsSQLStatement::Node *node() const { return mNode; }
+        QgsSQLStatement::Node *node() const { return mNode.get(); }
 
         //! Type
         QString type() const { return mType; }
@@ -609,7 +609,7 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       protected:
-        Node *mNode = nullptr;
+        std::unique_ptr<Node> mNode;
         QString mType;
     };
 
@@ -669,13 +669,13 @@ class CORE_EXPORT QgsSQLStatement
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef SIP_TRANSFER, QgsSQLStatement::Node *onExpr SIP_TRANSFER, QgsSQLStatement::JoinType type ) : mTableDef( tabledef ), mOnExpr( onExpr ), mType( type ) {}
         //! Constructor with table definition and USING columns
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef SIP_TRANSFER, const QList<QString> &usingColumns, QgsSQLStatement::JoinType type ) : mTableDef( tabledef ), mUsingColumns( usingColumns ), mType( type ) {}
-        ~NodeJoin() override { delete mTableDef; delete mOnExpr; }
+        ~NodeJoin() override {   }
 
         //! Table definition
-        QgsSQLStatement::NodeTableDef *tableDef() const { return mTableDef; }
+        QgsSQLStatement::NodeTableDef *tableDef() const { return mTableDef.get(); }
 
         //! On expression. Will be NULLPTR if usingColumns() is not empty
-        QgsSQLStatement::Node *onExpr() const { return mOnExpr; }
+        QgsSQLStatement::Node *onExpr() const { return mOnExpr.get(); }
 
         //! Columns referenced by USING
         QList<QString> usingColumns() const { return mUsingColumns; }
@@ -692,8 +692,8 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::NodeJoin *cloneThis() const SIP_FACTORY;
 
       protected:
-        NodeTableDef *mTableDef = nullptr;
-        Node *mOnExpr = nullptr;
+        std::unique_ptr<NodeTableDef> mTableDef;
+        std::unique_ptr<Node> mOnExpr;
         QList<QString> mUsingColumns;
         JoinType mType;
     };
@@ -707,10 +707,10 @@ class CORE_EXPORT QgsSQLStatement
       public:
         //! Constructor
         NodeColumnSorted( QgsSQLStatement::NodeColumnRef *column SIP_TRANSFER, bool asc ) : mColumn( column ), mAsc( asc ) {}
-        ~NodeColumnSorted() override { delete mColumn; }
+        ~NodeColumnSorted() override {  }
 
         //! The name of the column.
-        QgsSQLStatement::NodeColumnRef *column() const { return mColumn; }
+        QgsSQLStatement::NodeColumnRef *column() const { return mColumn.get(); }
 
         //! Whether the column is sorted in ascending order
         bool ascending() const { return mAsc; }
@@ -724,7 +724,7 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::NodeColumnSorted *cloneThis() const SIP_FACTORY;
 
       protected:
-        NodeColumnRef *mColumn = nullptr;
+        std::unique_ptr<NodeColumnRef> mColumn;
         bool mAsc;
     };
 
@@ -744,7 +744,7 @@ class CORE_EXPORT QgsSQLStatement
         //! Append a join
         void appendJoin( QgsSQLStatement::NodeJoin *join SIP_TRANSFER ) { mJoins.append( join ); }
         //! Sets where clause
-        void setWhere( QgsSQLStatement::Node *where SIP_TRANSFER ) { delete mWhere; mWhere = where; }
+        void setWhere( QgsSQLStatement::Node *where SIP_TRANSFER ) { mWhere.reset( where );  }
         //! Sets order by columns
         void setOrderBy( const QList<QgsSQLStatement::NodeColumnSorted *> &orderBy SIP_TRANSFER ) { qDeleteAll( mOrderBy ); mOrderBy = orderBy; }
 
@@ -757,7 +757,7 @@ class CORE_EXPORT QgsSQLStatement
         //! Returns the list of joins
         QList<QgsSQLStatement::NodeJoin *> joins() const { return mJoins; }
         //! Returns the where clause
-        QgsSQLStatement::Node *where() const { return mWhere; }
+        QgsSQLStatement::Node *where() const { return mWhere.get(); }
         //! Returns the list of order by columns
         QList<QgsSQLStatement::NodeColumnSorted *> orderBy() const { return mOrderBy; }
 
@@ -772,7 +772,7 @@ class CORE_EXPORT QgsSQLStatement
         QList<NodeSelectedColumn *> mColumns;
         bool mDistinct;
         QList<NodeJoin *> mJoins;
-        Node *mWhere = nullptr;
+        std::unique_ptr<Node> mWhere;
         QList<NodeColumnSorted *> mOrderBy;
     };
 
@@ -844,7 +844,7 @@ class CORE_EXPORT QgsSQLStatement
     void acceptVisitor( QgsSQLStatement::Visitor &v ) const;
 
   protected:
-    QgsSQLStatement::Node *mRootNode = nullptr;
+    std::unique_ptr<QgsSQLStatement::Node> mRootNode;
     bool mAllowFragments = false;
     QString mStatement;
     QString mParserErrorString;

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -328,9 +328,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeUnaryOperator( QgsSQLStatement::UnaryOperator op, QgsSQLStatement::Node *operand SIP_TRANSFER ) : mOp( op ), mOperand( operand ) {}
 
-        NodeUnaryOperator( const NodeUnaryOperator &other ) = delete;
-        NodeUnaryOperator &operator=( const NodeUnaryOperator &other ) = delete;
-
         //! Operator
         QgsSQLStatement::UnaryOperator op() const { return mOp; }
 
@@ -344,6 +341,10 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       private:
+
+        NodeUnaryOperator( const NodeUnaryOperator &other ) = delete;
+        NodeUnaryOperator &operator=( const NodeUnaryOperator &other ) = delete;
+
 #ifdef SIP_RUN
         NodeUnaryOperator( const NodeUnaryOperator &other );
 #endif
@@ -367,9 +368,6 @@ class CORE_EXPORT QgsSQLStatement
           , mOpRight( opRight )
         {}
 
-        NodeBinaryOperator( const NodeBinaryOperator &other ) = delete;
-        NodeBinaryOperator &operator=( const NodeBinaryOperator &other ) = delete;
-
         //! Operator
         QgsSQLStatement::BinaryOperator op() const { return mOp; }
 
@@ -392,6 +390,10 @@ class CORE_EXPORT QgsSQLStatement
         bool leftAssociative() const;
 
       private:
+
+        NodeBinaryOperator( const NodeBinaryOperator &other ) = delete;
+        NodeBinaryOperator &operator=( const NodeBinaryOperator &other ) = delete;
+
 #ifdef SIP_RUN
         NodeBinaryOperator( const NodeBinaryOperator &other );
 #endif
@@ -413,9 +415,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeInOperator( QgsSQLStatement::Node *node SIP_TRANSFER, QgsSQLStatement::NodeList *list SIP_TRANSFER, bool notin = false ) : mNode( node ), mList( list ), mNotIn( notin ) {}
 
-        NodeInOperator( const NodeInOperator &other ) = delete;
-        NodeInOperator &operator=( const NodeInOperator &other ) = delete;
-
         //! Variable at the left of IN
         QgsSQLStatement::Node *node() const { return mNode.get(); }
 
@@ -432,6 +431,10 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       private:
+
+        NodeInOperator( const NodeInOperator &other ) = delete;
+        NodeInOperator &operator=( const NodeInOperator &other ) = delete;
+
 #ifdef SIP_RUN
         NodeInOperator( const NodeInOperator &other );
 #endif
@@ -453,9 +456,6 @@ class CORE_EXPORT QgsSQLStatement
         NodeBetweenOperator( QgsSQLStatement::Node *node SIP_TRANSFER, QgsSQLStatement::Node *minVal SIP_TRANSFER, QgsSQLStatement::Node *maxVal SIP_TRANSFER, bool notBetween = false )
           : mNode( node ), mMinVal( minVal ), mMaxVal( maxVal ), mNotBetween( notBetween ) {}
 
-        NodeBetweenOperator( const NodeBetweenOperator &other ) = delete;
-        NodeBetweenOperator &operator=( const NodeBetweenOperator &other ) = delete;
-
         //! Variable at the left of BETWEEN
         QgsSQLStatement::Node *node() const { return mNode.get(); }
 
@@ -475,6 +475,10 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       private:
+
+        NodeBetweenOperator( const NodeBetweenOperator &other ) = delete;
+        NodeBetweenOperator &operator=( const NodeBetweenOperator &other ) = delete;
+
 #ifdef SIP_RUN
         NodeBetweenOperator( const NodeBetweenOperator &other );
 #endif
@@ -496,9 +500,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeFunction( const QString &name, QgsSQLStatement::NodeList *args  SIP_TRANSFER ) : mName( name ), mArgs( args ) {}
 
-        NodeFunction( const NodeFunction &other ) = delete;
-        NodeFunction &operator=( const NodeFunction &other ) = delete;
-
         //! Returns function name
         QString name() const { return mName; }
 
@@ -512,6 +513,10 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       private:
+
+        NodeFunction( const NodeFunction &other ) = delete;
+        NodeFunction &operator=( const NodeFunction &other ) = delete;
+
 #ifdef SIP_RUN
         NodeFunction( const NodeFunction &other );
 #endif
@@ -597,9 +602,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeSelectedColumn( QgsSQLStatement::Node *node SIP_TRANSFER ) : mColumnNode( node ) {}
 
-        NodeSelectedColumn( const NodeSelectedColumn &other ) = delete;
-        NodeSelectedColumn &operator=( const NodeSelectedColumn &other ) = delete;
-
         //! Sets alias name
         void setAlias( const QString &alias ) { mAlias = alias; }
 
@@ -618,6 +620,10 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::NodeSelectedColumn *cloneThis() const SIP_FACTORY;
 
       private:
+
+        NodeSelectedColumn( const NodeSelectedColumn &other ) = delete;
+        NodeSelectedColumn &operator=( const NodeSelectedColumn &other ) = delete;
+
 #ifdef SIP_RUN
         NodeSelectedColumn( const NodeSelectedColumn &other );
 #endif
@@ -637,9 +643,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeCast( QgsSQLStatement::Node *node SIP_TRANSFER, const QString &type ) : mNode( node ), mType( type ) {}
 
-        NodeCast( const NodeCast &other ) = delete;
-        NodeCast &operator=( const NodeCast &other ) = delete;
-
         //! Node that is referred to
         QgsSQLStatement::Node *node() const { return mNode.get(); }
 
@@ -653,6 +656,9 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       private:
+
+        NodeCast( const NodeCast &other ) = delete;
+        NodeCast &operator=( const NodeCast &other ) = delete;
 
 #ifdef SIP_RUN
         NodeCast( const NodeCast &other );
@@ -720,9 +726,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor with table definition and USING columns
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef SIP_TRANSFER, const QList<QString> &usingColumns, QgsSQLStatement::JoinType type ) : mTableDef( tabledef ), mUsingColumns( usingColumns ), mType( type ) {}
 
-        NodeJoin( const NodeJoin &other ) = delete;
-        NodeJoin &operator=( const NodeJoin &other ) = delete;
-
         //! Table definition
         QgsSQLStatement::NodeTableDef *tableDef() const { return mTableDef.get(); }
 
@@ -744,6 +747,10 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::NodeJoin *cloneThis() const SIP_FACTORY;
 
       private:
+
+        NodeJoin( const NodeJoin &other ) = delete;
+        NodeJoin &operator=( const NodeJoin &other ) = delete;
+
 #ifdef SIP_RUN
         NodeJoin( const NodeJoin &other );
 #endif
@@ -765,9 +772,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeColumnSorted( QgsSQLStatement::NodeColumnRef *column SIP_TRANSFER, bool asc ) : mColumn( column ), mAsc( asc ) {}
 
-        NodeColumnSorted( const NodeColumnSorted &other ) = delete;
-        NodeColumnSorted &operator=( const NodeColumnSorted &other ) = delete;
-
         //! The name of the column.
         QgsSQLStatement::NodeColumnRef *column() const { return mColumn.get(); }
 
@@ -783,6 +787,10 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::NodeColumnSorted *cloneThis() const SIP_FACTORY;
 
       private:
+
+        NodeColumnSorted( const NodeColumnSorted &other ) = delete;
+        NodeColumnSorted &operator=( const NodeColumnSorted &other ) = delete;
+
 #ifdef SIP_RUN
         NodeColumnSorted( const NodeColumnSorted &other );
 #endif
@@ -802,9 +810,6 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor
         NodeSelect( const QList<QgsSQLStatement::NodeTableDef *> &tableList SIP_TRANSFER, const QList<QgsSQLStatement::NodeSelectedColumn *> &columns SIP_TRANSFER, bool distinct ) : mTableList( tableList ), mColumns( columns ), mDistinct( distinct ) {}
         ~NodeSelect() override;
-
-        NodeSelect( const NodeSelect &other ) = delete;
-        NodeSelect &operator=( const NodeSelect &other ) = delete;
 
         //! Sets joins
         void setJoins( const QList<QgsSQLStatement::NodeJoin *> &joins SIP_TRANSFER ) { qDeleteAll( mJoins ); mJoins = joins; }
@@ -835,6 +840,9 @@ class CORE_EXPORT QgsSQLStatement
         QgsSQLStatement::Node *clone() const override SIP_FACTORY;
 
       private:
+
+        NodeSelect( const NodeSelect &other ) = delete;
+        NodeSelect &operator=( const NodeSelect &other ) = delete;
 
 #ifdef SIP_RUN
         NodeSelect( const NodeSelect &other );

--- a/src/core/raster/qgsrasterrenderer.cpp
+++ b/src/core/raster/qgsrasterrenderer.cpp
@@ -39,7 +39,7 @@ QgsRasterRenderer::QgsRasterRenderer( QgsRasterInterface *input, const QString &
 
 QgsRasterRenderer::~QgsRasterRenderer()
 {
-  delete mRasterTransparency;
+
 }
 
 int QgsRasterRenderer::bandCount() const
@@ -119,8 +119,8 @@ bool QgsRasterRenderer::usesTransparency() const
 
 void QgsRasterRenderer::setRasterTransparency( QgsRasterTransparency *t )
 {
-  delete mRasterTransparency;
-  mRasterTransparency = t;
+  mRasterTransparency.reset( t );
+
 }
 
 QList< QPair< QString, QColor > > QgsRasterRenderer::legendSymbologyItems() const
@@ -202,8 +202,8 @@ void QgsRasterRenderer::readXml( const QDomElement &rendererElem )
   const QDomElement rasterTransparencyElem = rendererElem.firstChildElement( QStringLiteral( "rasterTransparency" ) );
   if ( !rasterTransparencyElem.isNull() )
   {
-    delete mRasterTransparency;
-    mRasterTransparency = new QgsRasterTransparency();
+    mRasterTransparency.reset( new QgsRasterTransparency() );
+
     mRasterTransparency->readXml( rasterTransparencyElem );
   }
 

--- a/src/core/raster/qgsrasterrenderer.h
+++ b/src/core/raster/qgsrasterrenderer.h
@@ -160,7 +160,7 @@ class CORE_EXPORT QgsRasterRenderer : public QgsRasterInterface
     void setNodataColor( const QColor &color ) { mNodataColor = color; }
 
     void setRasterTransparency( QgsRasterTransparency *t SIP_TRANSFER );
-    const QgsRasterTransparency *rasterTransparency() const { return mRasterTransparency; }
+    const QgsRasterTransparency *rasterTransparency() const { return mRasterTransparency.get(); }
 
     void setAlphaBand( int band ) { mAlphaBand = band; }
     int alphaBand() const { return mAlphaBand; }
@@ -257,7 +257,7 @@ class CORE_EXPORT QgsRasterRenderer : public QgsRasterInterface
     //! Global alpha value (0-1)
     double mOpacity = 1.0;
     //! Raster transparency per color or value. Overwrites global alpha value
-    QgsRasterTransparency *mRasterTransparency = nullptr;
+    std::unique_ptr<QgsRasterTransparency> mRasterTransparency;
 
     /**
      * Read alpha value from band. Is combined with value from raster transparency / global alpha value.

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -67,13 +67,13 @@ void QgsFeatureRenderer::copyRendererData( QgsFeatureRenderer *destRenderer ) co
 QgsFeatureRenderer::QgsFeatureRenderer( const QString &type )
   : mType( type )
 {
-  mPaintEffect = QgsPaintEffectRegistry::defaultStack();
+  mPaintEffect.reset( QgsPaintEffectRegistry::defaultStack() );
   mPaintEffect->setEnabled( false );
 }
 
 QgsFeatureRenderer::~QgsFeatureRenderer()
 {
-  delete mPaintEffect;
+
 }
 
 const QgsPropertiesDefinition &QgsFeatureRenderer::propertyDefinitions()
@@ -233,7 +233,7 @@ void QgsFeatureRenderer::saveRendererData( QDomDocument &doc, QDomElement &rende
   mDataDefinedProperties.writeXml( elemDataDefinedProperties, propertyDefinitions() );
   rendererElem.appendChild( elemDataDefinedProperties );
 
-  if ( mPaintEffect && !QgsPaintEffectRegistry::isDefaultStack( mPaintEffect ) )
+  if ( mPaintEffect && !QgsPaintEffectRegistry::isDefaultStack( mPaintEffect.get() ) )
     mPaintEffect->saveProperties( doc, rendererElem );
 
   if ( !mOrderBy.isEmpty() )
@@ -572,13 +572,13 @@ QgsSymbolList QgsFeatureRenderer::originalSymbolsForFeature( const QgsFeature &f
 
 QgsPaintEffect *QgsFeatureRenderer::paintEffect() const
 {
-  return mPaintEffect;
+  return mPaintEffect.get();
 }
 
 void QgsFeatureRenderer::setPaintEffect( QgsPaintEffect *effect )
 {
-  delete mPaintEffect;
-  mPaintEffect = effect;
+  mPaintEffect.reset( effect );
+
 }
 
 void QgsFeatureRenderer::setDataDefinedProperty( Property key, const QgsProperty &property )

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -716,7 +716,7 @@ class CORE_EXPORT QgsFeatureRenderer
     //! The current size of editing marker
     double mCurrentVertexMarkerSize = 2;
 
-    QgsPaintEffect *mPaintEffect = nullptr;
+    std::unique_ptr<QgsPaintEffect> mPaintEffect;
 
     bool mForceRaster = false;
 

--- a/src/core/vector/qgsvectorlayercache.h
+++ b/src/core/vector/qgsvectorlayercache.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
           , mAllAttributesFetched( allAttributesFetched )
           , mGeometryFetched( geometryFetched )
         {
-          mFeature = new QgsFeature( feat );
+          mFeature = std::make_unique<QgsFeature>( feat );
         }
 
         ~QgsCachedFeature()
@@ -78,17 +78,17 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
           // That's the reason we need this wrapper:
           // Inform the cache that this feature has been removed
           mCache->featureRemoved( mFeature->id() );
-          delete mFeature;
+
         }
 
-        inline const QgsFeature *feature() { return mFeature; }
+        inline const QgsFeature *feature() { return mFeature.get(); }
 
         bool allAttributesFetched() const;
 
         bool geometryFetched() const;
 
       private:
-        QgsFeature *mFeature = nullptr;
+        std::unique_ptr<QgsFeature> mFeature;
         QgsVectorLayerCache *mCache = nullptr;
         bool mAllAttributesFetched = true;
         bool mGeometryFetched = false;


### PR DESCRIPTION
Following #61465

Another round of unique_ptr adding when ownership is clear.

To be noted:
- release unique_ptr before calling deleteLater
- I add to manually [fix Sip](503a3d77b691a0ad2c2d915f75e9d450235fd402) 

**Funded by [Security Project For QGIS](https://oslandia.com/en/security-project-for-qgis/)**