### PR TITLE
[bug] lazy vector extent not stored in the project

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -761,7 +761,7 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
     const QgsRectangle extent2D { mExtent2D.isNull() ? extent() : mExtent2D };
     if ( !extent2D.isNull() )
     {
-      layerElement.appendChild( QgsXmlUtils::writeRectangle( mExtent2D, document ) );
+      layerElement.appendChild( QgsXmlUtils::writeRectangle( extent2D, document ) );
     }
   }
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -755,8 +755,15 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 
   if ( !mExtent3D.isNull() && dataProvider() && dataProvider()->elevationProperties() && dataProvider()->elevationProperties()->containsElevationData() )
     layerElement.appendChild( QgsXmlUtils::writeBox3D( mExtent3D, document ) );
-  else if ( !mExtent2D.isNull() )
-    layerElement.appendChild( QgsXmlUtils::writeRectangle( mExtent2D, document ) );
+  else
+  {
+    // Extent might be null because lazily set
+    const QgsRectangle extent2D { mExtent2D.isNull() ? extent() : mExtent2D };
+    if ( !extent2D.isNull() )
+    {
+      layerElement.appendChild( QgsXmlUtils::writeRectangle( mExtent2D, document ) );
+    }
+  }
 
   if ( const QgsRectangle lWgs84Extent = wgs84Extent( true ); !lWgs84Extent.isNull() )
   {


### PR DESCRIPTION
Fix #61181

When lazily set, if the project was stored without any call to QgsVectorLayer::extent() the QgsMapLayer::mExtent2D was null and not stored in the project.
