### PR TITLE
Fix crash and visual artefacts when using linking components

### DIFF
--- a/src/gui/processing/models/qgsmodelviewtoollink.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoollink.cpp
@@ -58,12 +58,13 @@ void QgsModelViewToolLink::modelMoveEvent( QgsModelViewMouseEvent *event )
     }
   }
 
-  if ( !socket && mLastHoveredSocket && socket != mLastHoveredSocket )
+  if ( mLastHoveredSocket && socket != mLastHoveredSocket )
   {
     mLastHoveredSocket->modelHoverLeaveEvent( event );
     mLastHoveredSocket = nullptr;
   }
-  else
+
+  if ( socket && socket != mLastHoveredSocket )
   {
     mLastHoveredSocket = socket;
   }
@@ -75,8 +76,14 @@ void QgsModelViewToolLink::modelReleaseEvent( QgsModelViewMouseEvent *event )
   {
     return;
   }
-  view()->setTool( mPreviousViewTool );
   mBezierRubberBand->finish( event->modelPoint() );
+  if ( mLastHoveredSocket )
+  {
+    mLastHoveredSocket->modelHoverLeaveEvent( nullptr );
+    mLastHoveredSocket = nullptr;
+  }
+
+  view()->setTool( mPreviousViewTool );
 
   // we need to manually pass this event down to items we want it to go to -- QGraphicsScene doesn't propagate
   QList<QGraphicsItem *> items = scene()->items( event->modelPoint() );


### PR DESCRIPTION
## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
