### PR TITLE
inja: remove warning deprecated-literal-operator when using clang >v20

### DIFF
--- a/external/inja/inja.hpp
+++ b/external/inja/inja.hpp
@@ -205,22 +205,22 @@ using namespace std::literals::string_view_literals;
 inline namespace literals {
 inline namespace string_view_literals {
 
-constexpr std::string_view operator"" _sv(const char *str, size_t len) noexcept // (1)
+constexpr std::string_view operator""_sv(const char *str, size_t len) noexcept // (1)
 {
   return std::string_view {str, len};
 }
 
-constexpr std::u16string_view operator"" _sv(const char16_t *str, size_t len) noexcept // (2)
+constexpr std::u16string_view operator""_sv(const char16_t *str, size_t len) noexcept // (2)
 {
   return std::u16string_view {str, len};
 }
 
-constexpr std::u32string_view operator"" _sv(const char32_t *str, size_t len) noexcept // (3)
+constexpr std::u32string_view operator""_sv(const char32_t *str, size_t len) noexcept // (3)
 {
   return std::u32string_view {str, len};
 }
 
-constexpr std::wstring_view operator"" _sv(const wchar_t *str, size_t len) noexcept // (4)
+constexpr std::wstring_view operator""_sv(const wchar_t *str, size_t len) noexcept // (4)
 {
   return std::wstring_view {str, len};
 }
@@ -1302,22 +1302,22 @@ nssv_inline_ns namespace literals {
 
 #if nssv_CONFIG_STD_SV_OPERATOR && nssv_HAVE_STD_DEFINED_LITERALS
 
-    nssv_constexpr nonstd::sv_lite::string_view operator"" sv(const char *str, size_t len) nssv_noexcept // (1)
+    nssv_constexpr nonstd::sv_lite::string_view operator""sv(const char *str, size_t len) nssv_noexcept // (1)
     {
       return nonstd::sv_lite::string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::u16string_view operator"" sv(const char16_t *str, size_t len) nssv_noexcept // (2)
+    nssv_constexpr nonstd::sv_lite::u16string_view operator""sv(const char16_t *str, size_t len) nssv_noexcept // (2)
     {
       return nonstd::sv_lite::u16string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::u32string_view operator"" sv(const char32_t *str, size_t len) nssv_noexcept // (3)
+    nssv_constexpr nonstd::sv_lite::u32string_view operator""sv(const char32_t *str, size_t len) nssv_noexcept // (3)
     {
       return nonstd::sv_lite::u32string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::wstring_view operator"" sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
+    nssv_constexpr nonstd::sv_lite::wstring_view operator""sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
     {
       return nonstd::sv_lite::wstring_view {str, len};
     }
@@ -1326,22 +1326,22 @@ nssv_inline_ns namespace literals {
 
 #if nssv_CONFIG_USR_SV_OPERATOR
 
-    nssv_constexpr nonstd::sv_lite::string_view operator"" _sv(const char *str, size_t len) nssv_noexcept // (1)
+    nssv_constexpr nonstd::sv_lite::string_view operator""_sv(const char *str, size_t len) nssv_noexcept // (1)
     {
       return nonstd::sv_lite::string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::u16string_view operator"" _sv(const char16_t *str, size_t len) nssv_noexcept // (2)
+    nssv_constexpr nonstd::sv_lite::u16string_view operator""_sv(const char16_t *str, size_t len) nssv_noexcept // (2)
     {
       return nonstd::sv_lite::u16string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::u32string_view operator"" _sv(const char32_t *str, size_t len) nssv_noexcept // (3)
+    nssv_constexpr nonstd::sv_lite::u32string_view operator""_sv(const char32_t *str, size_t len) nssv_noexcept // (3)
     {
       return nonstd::sv_lite::u32string_view {str, len};
     }
 
-    nssv_constexpr nonstd::sv_lite::wstring_view operator"" _sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
+    nssv_constexpr nonstd::sv_lite::wstring_view operator""_sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
     {
       return nonstd::sv_lite::wstring_view {str, len};
     }

--- a/external/inja/inja.hpp
+++ b/external/inja/inja.hpp
@@ -1,30 +1,61 @@
-#ifndef PANTOR_INJA_HPP
-#define PANTOR_INJA_HPP
+/*
+  ___        _          Version 3.3
+ |_ _|_ __  (_) __ _    https://github.com/pantor/inja
+  | || '_ \ | |/ _` |   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  | || | | || | (_| |
+ |___|_| |_|/ |\__,_|   Copyright (c) 2018-2021 Lars Berscheid
+          |__/
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 
-#include <functional>
-#include <iostream>
-#include <map>
-#include <memory>
-#include <sstream>
-#include <string>
-#include <vector>
+#ifndef INCLUDE_INJA_INJA_HPP_
+#define INCLUDE_INJA_INJA_HPP_
 
 #include <nlohmann/json.hpp>
 
-// #include "environment.hpp"
-#ifndef PANTOR_INJA_ENVIRONMENT_HPP
-#define PANTOR_INJA_ENVIRONMENT_HPP
+#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(INJA_NOEXCEPTION)
+  #ifndef INJA_THROW
+    #define INJA_THROW(exception) throw exception
+  #endif
+#else
+  #include <cstdlib>
+  #ifndef INJA_THROW
+    #define INJA_THROW(exception) std::abort(); std::ignore = exception
+  #endif
+  #ifndef INJA_NOEXCEPTION
+    #define INJA_NOEXCEPTION
+  #endif
+#endif
 
-#include <memory>
+// #include "environment.hpp"
+#ifndef INCLUDE_INJA_ENVIRONMENT_HPP_
+#define INCLUDE_INJA_ENVIRONMENT_HPP_
+
 #include <fstream>
+#include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 
 #include <nlohmann/json.hpp>
 
 // #include "config.hpp"
-#ifndef PANTOR_INJA_CONFIG_HPP
-#define PANTOR_INJA_CONFIG_HPP
+#ifndef INCLUDE_INJA_CONFIG_HPP_
+#define INCLUDE_INJA_CONFIG_HPP_
 
 #include <functional>
 #include <string>
@@ -43,94 +74,98 @@
 #ifndef NONSTD_SV_LITE_H_INCLUDED
 #define NONSTD_SV_LITE_H_INCLUDED
 
-#define string_view_lite_MAJOR  1
-#define string_view_lite_MINOR  1
-#define string_view_lite_PATCH  0
+#define string_view_lite_MAJOR 1
+#define string_view_lite_MINOR 4
+#define string_view_lite_PATCH 0
 
-#define string_view_lite_VERSION  nssv_STRINGIFY(string_view_lite_MAJOR) "." nssv_STRINGIFY(string_view_lite_MINOR) "." nssv_STRINGIFY(string_view_lite_PATCH)
+#define string_view_lite_VERSION                                                                                       \
+  nssv_STRINGIFY(string_view_lite_MAJOR) "." nssv_STRINGIFY(string_view_lite_MINOR) "." nssv_STRINGIFY(                \
+      string_view_lite_PATCH)
 
-#define nssv_STRINGIFY(  x )  nssv_STRINGIFY_( x )
-#define nssv_STRINGIFY_( x )  #x
+#define nssv_STRINGIFY(x) nssv_STRINGIFY_(x)
+#define nssv_STRINGIFY_(x) #x
 
 // string-view lite configuration:
 
-#define nssv_STRING_VIEW_DEFAULT  0
-#define nssv_STRING_VIEW_NONSTD   1
-#define nssv_STRING_VIEW_STD      2
+#define nssv_STRING_VIEW_DEFAULT 0
+#define nssv_STRING_VIEW_NONSTD 1
+#define nssv_STRING_VIEW_STD 2
 
-#if !defined( nssv_CONFIG_SELECT_STRING_VIEW )
-# define nssv_CONFIG_SELECT_STRING_VIEW  ( nssv_HAVE_STD_STRING_VIEW ? nssv_STRING_VIEW_STD : nssv_STRING_VIEW_NONSTD )
+#if !defined(nssv_CONFIG_SELECT_STRING_VIEW)
+#define nssv_CONFIG_SELECT_STRING_VIEW (nssv_HAVE_STD_STRING_VIEW ? nssv_STRING_VIEW_STD : nssv_STRING_VIEW_NONSTD)
 #endif
 
-#if defined( nssv_CONFIG_SELECT_STD_STRING_VIEW ) || defined( nssv_CONFIG_SELECT_NONSTD_STRING_VIEW )
-# error nssv_CONFIG_SELECT_STD_STRING_VIEW and nssv_CONFIG_SELECT_NONSTD_STRING_VIEW are deprecated and removed, please use nssv_CONFIG_SELECT_STRING_VIEW=nssv_STRING_VIEW_...
+#if defined(nssv_CONFIG_SELECT_STD_STRING_VIEW) || defined(nssv_CONFIG_SELECT_NONSTD_STRING_VIEW)
+#error nssv_CONFIG_SELECT_STD_STRING_VIEW and nssv_CONFIG_SELECT_NONSTD_STRING_VIEW are deprecated and removed, please use nssv_CONFIG_SELECT_STRING_VIEW=nssv_STRING_VIEW_...
 #endif
 
-#ifndef  nssv_CONFIG_STD_SV_OPERATOR
-# define nssv_CONFIG_STD_SV_OPERATOR  0
+#ifndef nssv_CONFIG_STD_SV_OPERATOR
+#define nssv_CONFIG_STD_SV_OPERATOR 0
 #endif
 
-#ifndef  nssv_CONFIG_USR_SV_OPERATOR
-# define nssv_CONFIG_USR_SV_OPERATOR  1
+#ifndef nssv_CONFIG_USR_SV_OPERATOR
+#define nssv_CONFIG_USR_SV_OPERATOR 1
 #endif
 
-#ifdef   nssv_CONFIG_CONVERSION_STD_STRING
-# define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS   nssv_CONFIG_CONVERSION_STD_STRING
-# define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS  nssv_CONFIG_CONVERSION_STD_STRING
+#ifdef nssv_CONFIG_CONVERSION_STD_STRING
+#define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS nssv_CONFIG_CONVERSION_STD_STRING
+#define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS nssv_CONFIG_CONVERSION_STD_STRING
 #endif
 
-#ifndef  nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
-# define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS  1
+#ifndef nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
+#define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS 1
 #endif
 
-#ifndef  nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
-# define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS  1
+#ifndef nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+#define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS 1
 #endif
 
 // Control presence of exception handling (try and auto discover):
 
 #ifndef nssv_CONFIG_NO_EXCEPTIONS
-# if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
-#  define nssv_CONFIG_NO_EXCEPTIONS  0
-# else
-#  define nssv_CONFIG_NO_EXCEPTIONS  1
-# endif
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#define nssv_CONFIG_NO_EXCEPTIONS 0
+#else
+#define nssv_CONFIG_NO_EXCEPTIONS 1
+#endif
 #endif
 
 // C++ language version detection (C++20 is speculative):
 // Note: VC14.0/1900 (VS2015) lacks too much from C++14.
 
-#ifndef   nssv_CPLUSPLUS
-# if defined(_MSVC_LANG ) && !defined(__clang__)
-#  define nssv_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
-# else
-#  define nssv_CPLUSPLUS  __cplusplus
-# endif
+#ifndef nssv_CPLUSPLUS
+#if defined(_MSVC_LANG) && !defined(__clang__)
+#define nssv_CPLUSPLUS (_MSC_VER == 1900 ? 201103L : _MSVC_LANG)
+#else
+#define nssv_CPLUSPLUS __cplusplus
+#endif
 #endif
 
-#define nssv_CPP98_OR_GREATER  ( nssv_CPLUSPLUS >= 199711L )
-#define nssv_CPP11_OR_GREATER  ( nssv_CPLUSPLUS >= 201103L )
-#define nssv_CPP11_OR_GREATER_ ( nssv_CPLUSPLUS >= 201103L )
-#define nssv_CPP14_OR_GREATER  ( nssv_CPLUSPLUS >= 201402L )
-#define nssv_CPP17_OR_GREATER  ( nssv_CPLUSPLUS >= 201703L )
-#define nssv_CPP20_OR_GREATER  ( nssv_CPLUSPLUS >= 202000L )
+#define nssv_CPP98_OR_GREATER (nssv_CPLUSPLUS >= 199711L)
+#define nssv_CPP11_OR_GREATER (nssv_CPLUSPLUS >= 201103L)
+#define nssv_CPP11_OR_GREATER_ (nssv_CPLUSPLUS >= 201103L)
+#define nssv_CPP14_OR_GREATER (nssv_CPLUSPLUS >= 201402L)
+#define nssv_CPP17_OR_GREATER (nssv_CPLUSPLUS >= 201703L)
+#define nssv_CPP20_OR_GREATER (nssv_CPLUSPLUS >= 202000L)
 
 // use C++17 std::string_view if available and requested:
 
-#if nssv_CPP17_OR_GREATER && defined(__has_include )
-# if __has_include( <string_view> )
-#  define nssv_HAVE_STD_STRING_VIEW  1
-# else
-#  define nssv_HAVE_STD_STRING_VIEW  0
-# endif
+#if nssv_CPP17_OR_GREATER && defined(__has_include)
+#if __has_include(<string_view> )
+#define nssv_HAVE_STD_STRING_VIEW 1
 #else
-# define  nssv_HAVE_STD_STRING_VIEW  0
+#define nssv_HAVE_STD_STRING_VIEW 0
+#endif
+#else
+#define nssv_HAVE_STD_STRING_VIEW 0
 #endif
 
-#define  nssv_USES_STD_STRING_VIEW  ( (nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_STD) || ((nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_DEFAULT) && nssv_HAVE_STD_STRING_VIEW) )
+#define nssv_USES_STD_STRING_VIEW                                                                                      \
+  ((nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_STD) ||                                                         \
+   ((nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_DEFAULT) && nssv_HAVE_STD_STRING_VIEW))
 
-#define nssv_HAVE_STARTS_WITH ( nssv_CPP20_OR_GREATER || !nssv_USES_STD_STRING_VIEW )
-#define nssv_HAVE_ENDS_WITH     nssv_HAVE_STARTS_WITH
+#define nssv_HAVE_STARTS_WITH (nssv_CPP20_OR_GREATER || !nssv_USES_STD_STRING_VIEW)
+#define nssv_HAVE_ENDS_WITH nssv_HAVE_STARTS_WITH
 
 //
 // Use C++17 std::string_view:
@@ -146,18 +181,15 @@
 
 namespace nonstd {
 
-template< class CharT, class Traits, class Allocator = std::allocator<CharT> >
-std::basic_string<CharT, Traits, Allocator>
-to_string( std::basic_string_view<CharT, Traits> v, Allocator const & a = Allocator() )
-{
-    return std::basic_string<CharT,Traits, Allocator>( v.begin(), v.end(), a );
+template <class CharT, class Traits, class Allocator = std::allocator<CharT>>
+std::basic_string<CharT, Traits, Allocator> to_string(std::basic_string_view<CharT, Traits> v,
+                                                      Allocator const &a = Allocator()) {
+  return std::basic_string<CharT, Traits, Allocator>(v.begin(), v.end(), a);
 }
 
-template< class CharT, class Traits, class Allocator >
-std::basic_string_view<CharT, Traits>
-to_string_view( std::basic_string<CharT, Traits, Allocator> const & s )
-{
-    return std::basic_string_view<CharT, Traits>( s.data(), s.size() );
+template <class CharT, class Traits, class Allocator>
+std::basic_string_view<CharT, Traits> to_string_view(std::basic_string<CharT, Traits, Allocator> const &s) {
+  return std::basic_string_view<CharT, Traits>(s.data(), s.size());
 }
 
 // Literal operators sv and _sv:
@@ -173,28 +205,28 @@ using namespace std::literals::string_view_literals;
 inline namespace literals {
 inline namespace string_view_literals {
 
-
-constexpr std::string_view operator "" _sv( const char* str, size_t len ) noexcept  // (1)
+constexpr std::string_view operator"" _sv(const char *str, size_t len) noexcept // (1)
 {
-    return std::string_view{ str, len };
+  return std::string_view {str, len};
 }
 
-constexpr std::u16string_view operator "" _sv( const char16_t* str, size_t len ) noexcept  // (2)
+constexpr std::u16string_view operator"" _sv(const char16_t *str, size_t len) noexcept // (2)
 {
-    return std::u16string_view{ str, len };
+  return std::u16string_view {str, len};
 }
 
-constexpr std::u32string_view operator "" _sv( const char32_t* str, size_t len ) noexcept  // (3)
+constexpr std::u32string_view operator"" _sv(const char32_t *str, size_t len) noexcept // (3)
 {
-    return std::u32string_view{ str, len };
+  return std::u32string_view {str, len};
 }
 
-constexpr std::wstring_view operator "" _sv( const wchar_t* str, size_t len ) noexcept  // (4)
+constexpr std::wstring_view operator"" _sv(const wchar_t *str, size_t len) noexcept // (4)
 {
-    return std::wstring_view{ str, len };
+  return std::wstring_view {str, len};
 }
 
-}} // namespace literals::string_view_literals
+} // namespace string_view_literals
+} // namespace literals
 
 #endif // nssv_CONFIG_USR_SV_OPERATOR
 
@@ -204,11 +236,11 @@ constexpr std::wstring_view operator "" _sv( const wchar_t* str, size_t len ) no
 
 namespace nonstd {
 
+using std::basic_string_view;
 using std::string_view;
-using std::wstring_view;
 using std::u16string_view;
 using std::u32string_view;
-using std::basic_string_view;
+using std::wstring_view;
 
 // literal "sv" and "_sv", see above
 
@@ -242,115 +274,117 @@ using std::operator<<;
 // MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
 // MSVC++ 14.1 _MSC_VER >= 1910 (Visual Studio 2017)
 
-#if defined(_MSC_VER ) && !defined(__clang__)
-# define nssv_COMPILER_MSVC_VER      (_MSC_VER )
-# define nssv_COMPILER_MSVC_VERSION  (_MSC_VER / 10 - 10 * ( 5 + (_MSC_VER < 1900 ) ) )
+#if defined(_MSC_VER) && !defined(__clang__)
+#define nssv_COMPILER_MSVC_VER (_MSC_VER)
+#define nssv_COMPILER_MSVC_VERSION (_MSC_VER / 10 - 10 * (5 + (_MSC_VER < 1900)))
 #else
-# define nssv_COMPILER_MSVC_VER      0
-# define nssv_COMPILER_MSVC_VERSION  0
+#define nssv_COMPILER_MSVC_VER 0
+#define nssv_COMPILER_MSVC_VERSION 0
 #endif
 
-#define nssv_COMPILER_VERSION( major, minor, patch )  (10 * ( 10 * major + minor) + patch)
+#define nssv_COMPILER_VERSION(major, minor, patch) (10 * (10 * (major) + (minor)) + (patch))
 
 #if defined(__clang__)
-# define nssv_COMPILER_CLANG_VERSION  nssv_COMPILER_VERSION(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#define nssv_COMPILER_CLANG_VERSION nssv_COMPILER_VERSION(__clang_major__, __clang_minor__, __clang_patchlevel__)
 #else
-# define nssv_COMPILER_CLANG_VERSION    0
+#define nssv_COMPILER_CLANG_VERSION 0
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)
-# define nssv_COMPILER_GNUC_VERSION  nssv_COMPILER_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#define nssv_COMPILER_GNUC_VERSION nssv_COMPILER_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #else
-# define nssv_COMPILER_GNUC_VERSION    0
+#define nssv_COMPILER_GNUC_VERSION 0
 #endif
 
 // half-open range [lo..hi):
-#define nssv_BETWEEN( v, lo, hi ) ( (lo) <= (v) && (v) < (hi) )
+#define nssv_BETWEEN(v, lo, hi) ((lo) <= (v) && (v) < (hi))
 
 // Presence of language and library features:
 
 #ifdef _HAS_CPP0X
-# define nssv_HAS_CPP0X  _HAS_CPP0X
+#define nssv_HAS_CPP0X _HAS_CPP0X
 #else
-# define nssv_HAS_CPP0X  0
+#define nssv_HAS_CPP0X 0
 #endif
 
 // Unless defined otherwise below, consider VC14 as C++11 for variant-lite:
 
 #if nssv_COMPILER_MSVC_VER >= 1900
-# undef  nssv_CPP11_OR_GREATER
-# define nssv_CPP11_OR_GREATER  1
+#undef nssv_CPP11_OR_GREATER
+#define nssv_CPP11_OR_GREATER 1
 #endif
 
-#define nssv_CPP11_90   (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1500)
-#define nssv_CPP11_100  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1600)
-#define nssv_CPP11_110  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1700)
-#define nssv_CPP11_120  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1800)
-#define nssv_CPP11_140  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1900)
-#define nssv_CPP11_141  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1910)
+#define nssv_CPP11_90 (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1500)
+#define nssv_CPP11_100 (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1600)
+#define nssv_CPP11_110 (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1700)
+#define nssv_CPP11_120 (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1800)
+#define nssv_CPP11_140 (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1900)
+#define nssv_CPP11_141 (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1910)
 
-#define nssv_CPP14_000  (nssv_CPP14_OR_GREATER)
-#define nssv_CPP17_000  (nssv_CPP17_OR_GREATER)
+#define nssv_CPP14_000 (nssv_CPP14_OR_GREATER)
+#define nssv_CPP17_000 (nssv_CPP17_OR_GREATER)
 
 // Presence of C++11 language features:
 
-#define nssv_HAVE_CONSTEXPR_11          nssv_CPP11_140
-#define nssv_HAVE_EXPLICIT_CONVERSION   nssv_CPP11_140
-#define nssv_HAVE_INLINE_NAMESPACE      nssv_CPP11_140
-#define nssv_HAVE_NOEXCEPT              nssv_CPP11_140
-#define nssv_HAVE_NULLPTR               nssv_CPP11_100
-#define nssv_HAVE_REF_QUALIFIER         nssv_CPP11_140
-#define nssv_HAVE_UNICODE_LITERALS      nssv_CPP11_140
+#define nssv_HAVE_CONSTEXPR_11 nssv_CPP11_140
+#define nssv_HAVE_EXPLICIT_CONVERSION nssv_CPP11_140
+#define nssv_HAVE_INLINE_NAMESPACE nssv_CPP11_140
+#define nssv_HAVE_NOEXCEPT nssv_CPP11_140
+#define nssv_HAVE_NULLPTR nssv_CPP11_100
+#define nssv_HAVE_REF_QUALIFIER nssv_CPP11_140
+#define nssv_HAVE_UNICODE_LITERALS nssv_CPP11_140
 #define nssv_HAVE_USER_DEFINED_LITERALS nssv_CPP11_140
-#define nssv_HAVE_WCHAR16_T             nssv_CPP11_100
-#define nssv_HAVE_WCHAR32_T             nssv_CPP11_100
+#define nssv_HAVE_WCHAR16_T nssv_CPP11_100
+#define nssv_HAVE_WCHAR32_T nssv_CPP11_100
 
-#if ! ( ( nssv_CPP11 && nssv_COMPILER_CLANG_VERSION ) || nssv_BETWEEN( nssv_COMPILER_CLANG_VERSION, 300, 400 ) )
-# define nssv_HAVE_STD_DEFINED_LITERALS  nssv_CPP11_140
+#if !((nssv_CPP11_OR_GREATER && nssv_COMPILER_CLANG_VERSION) || nssv_BETWEEN(nssv_COMPILER_CLANG_VERSION, 300, 400))
+#define nssv_HAVE_STD_DEFINED_LITERALS nssv_CPP11_140
+#else
+#define nssv_HAVE_STD_DEFINED_LITERALS 0
 #endif
 
 // Presence of C++14 language features:
 
-#define nssv_HAVE_CONSTEXPR_14          nssv_CPP14_000
+#define nssv_HAVE_CONSTEXPR_14 nssv_CPP14_000
 
 // Presence of C++17 language features:
 
-#define nssv_HAVE_NODISCARD             nssv_CPP17_000
+#define nssv_HAVE_NODISCARD nssv_CPP17_000
 
 // Presence of C++ library features:
 
-#define nssv_HAVE_STD_HASH              nssv_CPP11_120
+#define nssv_HAVE_STD_HASH nssv_CPP11_120
 
 // C++ feature usage:
 
 #if nssv_HAVE_CONSTEXPR_11
-# define nssv_constexpr  constexpr
+#define nssv_constexpr constexpr
 #else
-# define nssv_constexpr  /*constexpr*/
+#define nssv_constexpr /*constexpr*/
 #endif
 
-#if  nssv_HAVE_CONSTEXPR_14
-# define nssv_constexpr14  constexpr
+#if nssv_HAVE_CONSTEXPR_14
+#define nssv_constexpr14 constexpr
 #else
-# define nssv_constexpr14  /*constexpr*/
+#define nssv_constexpr14 /*constexpr*/
 #endif
 
 #if nssv_HAVE_EXPLICIT_CONVERSION
-# define nssv_explicit  explicit
+#define nssv_explicit explicit
 #else
-# define nssv_explicit  /*explicit*/
+#define nssv_explicit /*explicit*/
 #endif
 
 #if nssv_HAVE_INLINE_NAMESPACE
-# define nssv_inline_ns  inline
+#define nssv_inline_ns inline
 #else
-# define nssv_inline_ns  /*inline*/
+#define nssv_inline_ns /*inline*/
 #endif
 
 #if nssv_HAVE_NOEXCEPT
-# define nssv_noexcept  noexcept
+#define nssv_noexcept noexcept
 #else
-# define nssv_noexcept  /*noexcept*/
+#define nssv_noexcept /*noexcept*/
 #endif
 
 //#if nssv_HAVE_REF_QUALIFIER
@@ -362,15 +396,15 @@ using std::operator<<;
 //#endif
 
 #if nssv_HAVE_NULLPTR
-# define nssv_nullptr  nullptr
+#define nssv_nullptr nullptr
 #else
-# define nssv_nullptr  NULL
+#define nssv_nullptr NULL
 #endif
 
 #if nssv_HAVE_NODISCARD
-# define nssv_nodiscard  [[nodiscard]]
+#define nssv_nodiscard [[nodiscard]]
 #else
-# define nssv_nodiscard  /*[[nodiscard]]*/
+#define nssv_nodiscard /*[[nodiscard]]*/
 #endif
 
 // Additional includes:
@@ -380,45 +414,45 @@ using std::operator<<;
 #include <iterator>
 #include <limits>
 #include <ostream>
-#include <string>   // std::char_traits<>
+#include <string> // std::char_traits<>
 
-#if ! nssv_CONFIG_NO_EXCEPTIONS
-# include <stdexcept>
+#if !nssv_CONFIG_NO_EXCEPTIONS
+#include <stdexcept>
 #endif
 
 #if nssv_CPP11_OR_GREATER
-# include <type_traits>
+#include <type_traits>
 #endif
 
 // Clang, GNUC, MSVC warning suppression macros:
 
 #if defined(__clang__)
-# pragma clang diagnostic ignored "-Wreserved-user-defined-literal"
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wuser-defined-literals"
+#pragma clang diagnostic ignored "-Wreserved-user-defined-literal"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuser-defined-literals"
 #elif defined(__GNUC__)
-# pragma  GCC  diagnostic push
-# pragma  GCC  diagnostic ignored "-Wliteral-suffix"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wliteral-suffix"
 #endif // __clang__
 
 #if nssv_COMPILER_MSVC_VERSION >= 140
-# define nssv_SUPPRESS_MSGSL_WARNING(expr)        [[gsl::suppress(expr)]]
-# define nssv_SUPPRESS_MSVC_WARNING(code, descr)  __pragma(warning(suppress: code) )
-# define nssv_DISABLE_MSVC_WARNINGS(codes)        __pragma(warning(push))  __pragma(warning(disable: codes))
+#define nssv_SUPPRESS_MSGSL_WARNING(expr) [[gsl::suppress(expr)]]
+#define nssv_SUPPRESS_MSVC_WARNING(code, descr) __pragma(warning(suppress : code))
+#define nssv_DISABLE_MSVC_WARNINGS(codes) __pragma(warning(push)) __pragma(warning(disable : codes))
 #else
-# define nssv_SUPPRESS_MSGSL_WARNING(expr)
-# define nssv_SUPPRESS_MSVC_WARNING(code, descr)
-# define nssv_DISABLE_MSVC_WARNINGS(codes)
+#define nssv_SUPPRESS_MSGSL_WARNING(expr)
+#define nssv_SUPPRESS_MSVC_WARNING(code, descr)
+#define nssv_DISABLE_MSVC_WARNINGS(codes)
 #endif
 
 #if defined(__clang__)
-# define nssv_RESTORE_WARNINGS()  _Pragma("clang diagnostic pop")
+#define nssv_RESTORE_WARNINGS() _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__)
-# define nssv_RESTORE_WARNINGS()  _Pragma("GCC diagnostic pop")
+#define nssv_RESTORE_WARNINGS() _Pragma("GCC diagnostic pop")
 #elif nssv_COMPILER_MSVC_VERSION >= 140
-# define nssv_RESTORE_WARNINGS()  __pragma(warning(pop ))
+#define nssv_RESTORE_WARNINGS() __pragma(warning(pop))
 #else
-# define nssv_RESTORE_WARNINGS()
+#define nssv_RESTORE_WARNINGS()
 #endif
 
 // Suppress the following MSVC (GSL) warnings:
@@ -428,418 +462,409 @@ using std::operator<<;
 //                      use brace initialization, gsl::narrow_cast or gsl::narow
 // - C26481: gsl::b.1 : don't use pointer arithmetic. Use span instead
 
-nssv_DISABLE_MSVC_WARNINGS( 4455 26481 26472 )
-//nssv_DISABLE_CLANG_WARNINGS( "-Wuser-defined-literals" )
-//nssv_DISABLE_GNUC_WARNINGS( -Wliteral-suffix )
+nssv_DISABLE_MSVC_WARNINGS(4455 26481 26472)
+    // nssv_DISABLE_CLANG_WARNINGS( "-Wuser-defined-literals" )
+    // nssv_DISABLE_GNUC_WARNINGS( -Wliteral-suffix )
 
-namespace nonstd { namespace sv_lite {
+    namespace nonstd {
+  namespace sv_lite {
 
-template
-<
-    class CharT,
-    class Traits = std::char_traits<CharT>
->
-class basic_string_view;
+#if nssv_CPP11_OR_GREATER
 
-//
-// basic_string_view:
-//
+  namespace detail {
 
-template
-<
-    class CharT,
-    class Traits /* = std::char_traits<CharT> */
->
-class basic_string_view
-{
-public:
+  // Expect tail call optimization to make length() non-recursive:
+
+  template <typename CharT> inline constexpr std::size_t length(CharT *s, std::size_t result = 0) {
+    return *s == '\0' ? result : length(s + 1, result + 1);
+  }
+
+  } // namespace detail
+
+#endif // nssv_CPP11_OR_GREATER
+
+  template <class CharT, class Traits = std::char_traits<CharT>> class basic_string_view;
+
+  //
+  // basic_string_view:
+  //
+
+  template <class CharT, class Traits /* = std::char_traits<CharT> */
+            >
+  class basic_string_view {
+  public:
     // Member types:
 
     typedef Traits traits_type;
-    typedef CharT  value_type;
+    typedef CharT value_type;
 
-    typedef CharT       * pointer;
-    typedef CharT const * const_pointer;
-    typedef CharT       & reference;
-    typedef CharT const & const_reference;
+    typedef CharT *pointer;
+    typedef CharT const *const_pointer;
+    typedef CharT &reference;
+    typedef CharT const &const_reference;
 
     typedef const_pointer iterator;
     typedef const_pointer const_iterator;
-    typedef std::reverse_iterator< const_iterator > reverse_iterator;
-    typedef	std::reverse_iterator< const_iterator > const_reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
-    typedef std::size_t     size_type;
-    typedef std::ptrdiff_t  difference_type;
+    typedef std::size_t size_type;
+    typedef std::ptrdiff_t difference_type;
 
     // 24.4.2.1 Construction and assignment:
 
-    nssv_constexpr basic_string_view() nssv_noexcept
-        : data_( nssv_nullptr )
-        , size_( 0 )
-    {}
+    nssv_constexpr basic_string_view() nssv_noexcept : data_(nssv_nullptr), size_(0) {}
 
 #if nssv_CPP11_OR_GREATER
-    nssv_constexpr basic_string_view( basic_string_view const & other ) nssv_noexcept = default;
+    nssv_constexpr basic_string_view(basic_string_view const &other) nssv_noexcept = default;
 #else
-    nssv_constexpr basic_string_view( basic_string_view const & other ) nssv_noexcept
-        : data_( other.data_)
-        , size_( other.size_)
-    {}
+    nssv_constexpr basic_string_view(basic_string_view const &other) nssv_noexcept : data_(other.data_),
+                                                                                     size_(other.size_) {}
 #endif
 
-    nssv_constexpr basic_string_view( CharT const * s, size_type count )
-        : data_( s )
-        , size_( count )
-    {}
+    nssv_constexpr basic_string_view(CharT const *s, size_type count) nssv_noexcept // non-standard noexcept
+        : data_(s),
+          size_(count) {}
 
-    nssv_constexpr basic_string_view( CharT const * s)
-        : data_( s )
-        , size_( Traits::length(s) )
-    {}
+    nssv_constexpr basic_string_view(CharT const *s) nssv_noexcept // non-standard noexcept
+        : data_(s)
+#if nssv_CPP17_OR_GREATER
+        ,
+          size_(Traits::length(s))
+#elif nssv_CPP11_OR_GREATER
+        ,
+          size_(detail::length(s))
+#else
+        ,
+          size_(Traits::length(s))
+#endif
+    {
+    }
 
     // Assignment:
 
 #if nssv_CPP11_OR_GREATER
-    nssv_constexpr14 basic_string_view & operator=( basic_string_view const & other ) nssv_noexcept = default;
+    nssv_constexpr14 basic_string_view &operator=(basic_string_view const &other) nssv_noexcept = default;
 #else
-    nssv_constexpr14 basic_string_view & operator=( basic_string_view const & other ) nssv_noexcept
-    {
-        data_ = other.data_;
-        size_ = other.size_;
-        return *this;
+    nssv_constexpr14 basic_string_view &operator=(basic_string_view const &other) nssv_noexcept {
+      data_ = other.data_;
+      size_ = other.size_;
+      return *this;
     }
 #endif
 
     // 24.4.2.2 Iterator support:
 
-    nssv_constexpr const_iterator begin()  const nssv_noexcept { return data_;         }
-    nssv_constexpr const_iterator end()    const nssv_noexcept { return data_ + size_; }
+    nssv_constexpr const_iterator begin() const nssv_noexcept { return data_; }
+    nssv_constexpr const_iterator end() const nssv_noexcept { return data_ + size_; }
 
     nssv_constexpr const_iterator cbegin() const nssv_noexcept { return begin(); }
-    nssv_constexpr const_iterator cend()   const nssv_noexcept { return end();   }
+    nssv_constexpr const_iterator cend() const nssv_noexcept { return end(); }
 
-    nssv_constexpr const_reverse_iterator rbegin()  const nssv_noexcept { return const_reverse_iterator( end() );   }
-    nssv_constexpr const_reverse_iterator rend()    const nssv_noexcept { return const_reverse_iterator( begin() ); }
+    nssv_constexpr const_reverse_iterator rbegin() const nssv_noexcept { return const_reverse_iterator(end()); }
+    nssv_constexpr const_reverse_iterator rend() const nssv_noexcept { return const_reverse_iterator(begin()); }
 
     nssv_constexpr const_reverse_iterator crbegin() const nssv_noexcept { return rbegin(); }
-    nssv_constexpr const_reverse_iterator crend()   const nssv_noexcept { return rend();   }
+    nssv_constexpr const_reverse_iterator crend() const nssv_noexcept { return rend(); }
 
     // 24.4.2.3 Capacity:
 
-    nssv_constexpr size_type size()     const nssv_noexcept { return size_; }
-    nssv_constexpr size_type length()   const nssv_noexcept { return size_; }
-    nssv_constexpr size_type max_size() const nssv_noexcept { return (std::numeric_limits< size_type >::max)(); }
+    nssv_constexpr size_type size() const nssv_noexcept { return size_; }
+    nssv_constexpr size_type length() const nssv_noexcept { return size_; }
+    nssv_constexpr size_type max_size() const nssv_noexcept { return (std::numeric_limits<size_type>::max)(); }
 
     // since C++20
-    nssv_nodiscard nssv_constexpr bool empty() const nssv_noexcept
-    {
-        return 0 == size_;
-    }
+    nssv_nodiscard nssv_constexpr bool empty() const nssv_noexcept { return 0 == size_; }
 
     // 24.4.2.4 Element access:
 
-    nssv_constexpr const_reference operator[]( size_type pos ) const
-    {
-        return data_at( pos );
-    }
+    nssv_constexpr const_reference operator[](size_type pos) const { return data_at(pos); }
 
-    nssv_constexpr14 const_reference at( size_type pos ) const
-    {
+    nssv_constexpr14 const_reference at(size_type pos) const {
 #if nssv_CONFIG_NO_EXCEPTIONS
-        assert( pos < size() );
+      assert(pos < size());
 #else
-        if ( pos >= size() )
-        {
-            throw std::out_of_range("nonst::string_view::at()");
-        }
+      if (pos >= size()) {
+        throw std::out_of_range("nonstd::string_view::at()");
+      }
 #endif
-        return data_at( pos );
+      return data_at(pos);
     }
 
-    nssv_constexpr const_reference front() const { return data_at( 0 );          }
-    nssv_constexpr const_reference back()  const { return data_at( size() - 1 ); }
+    nssv_constexpr const_reference front() const { return data_at(0); }
+    nssv_constexpr const_reference back() const { return data_at(size() - 1); }
 
-    nssv_constexpr const_pointer   data()  const nssv_noexcept { return data_; }
+    nssv_constexpr const_pointer data() const nssv_noexcept { return data_; }
 
     // 24.4.2.5 Modifiers:
 
-    nssv_constexpr14 void remove_prefix( size_type n )
-    {
-        assert( n <= size() );
-        data_ += n;
-        size_ -= n;
+    nssv_constexpr14 void remove_prefix(size_type n) {
+      assert(n <= size());
+      data_ += n;
+      size_ -= n;
     }
 
-    nssv_constexpr14 void remove_suffix( size_type n )
-    {
-        assert( n <= size() );
-        size_ -= n;
+    nssv_constexpr14 void remove_suffix(size_type n) {
+      assert(n <= size());
+      size_ -= n;
     }
 
-    nssv_constexpr14 void swap( basic_string_view & other ) nssv_noexcept
-    {
-        using std::swap;
-        swap( data_, other.data_ );
-        swap( size_, other.size_ );
+    nssv_constexpr14 void swap(basic_string_view &other) nssv_noexcept {
+      using std::swap;
+      swap(data_, other.data_);
+      swap(size_, other.size_);
     }
 
     // 24.4.2.6 String operations:
 
-    size_type copy( CharT * dest, size_type n, size_type pos = 0 ) const
-    {
+    size_type copy(CharT *dest, size_type n, size_type pos = 0) const {
 #if nssv_CONFIG_NO_EXCEPTIONS
-        assert( pos <= size() );
+      assert(pos <= size());
 #else
-        if ( pos > size() )
-        {
-            throw std::out_of_range("nonst::string_view::copy()");
-        }
+      if (pos > size()) {
+        throw std::out_of_range("nonstd::string_view::copy()");
+      }
 #endif
-        const size_type rlen = (std::min)( n, size() - pos );
+      const size_type rlen = (std::min)(n, size() - pos);
 
-        (void) Traits::copy( dest, data() + pos, rlen );
+      (void)Traits::copy(dest, data() + pos, rlen);
 
-        return rlen;
+      return rlen;
     }
 
-    nssv_constexpr14 basic_string_view substr( size_type pos = 0, size_type n = npos ) const
-    {
+    nssv_constexpr14 basic_string_view substr(size_type pos = 0, size_type n = npos) const {
 #if nssv_CONFIG_NO_EXCEPTIONS
-        assert( pos <= size() );
+      assert(pos <= size());
 #else
-        if ( pos > size() )
-        {
-            throw std::out_of_range("nonst::string_view::substr()");
-        }
+      if (pos > size()) {
+        throw std::out_of_range("nonstd::string_view::substr()");
+      }
 #endif
-        return basic_string_view( data() + pos, (std::min)( n, size() - pos ) );
+      return basic_string_view(data() + pos, (std::min)(n, size() - pos));
     }
 
     // compare(), 6x:
 
-    nssv_constexpr14 int compare( basic_string_view other ) const nssv_noexcept // (1)
+    nssv_constexpr14 int compare(basic_string_view other) const nssv_noexcept // (1)
     {
-        if ( const int result = Traits::compare( data(), other.data(), (std::min)( size(), other.size() ) ) )
-            return result;
+      if (const int result = Traits::compare(data(), other.data(), (std::min)(size(), other.size()))) {
+        return result;
+      }
 
-        return size() == other.size() ? 0 : size() < other.size() ? -1 : 1;
+      return size() == other.size() ? 0 : size() < other.size() ? -1 : 1;
     }
 
-    nssv_constexpr int compare( size_type pos1, size_type n1, basic_string_view other ) const // (2)
+    nssv_constexpr int compare(size_type pos1, size_type n1, basic_string_view other) const // (2)
     {
-        return substr( pos1, n1 ).compare( other );
+      return substr(pos1, n1).compare(other);
     }
 
-    nssv_constexpr int compare( size_type pos1, size_type n1, basic_string_view other, size_type pos2, size_type n2 ) const // (3)
+    nssv_constexpr int compare(size_type pos1, size_type n1, basic_string_view other, size_type pos2,
+                               size_type n2) const // (3)
     {
-        return substr( pos1, n1 ).compare( other.substr( pos2, n2 ) );
+      return substr(pos1, n1).compare(other.substr(pos2, n2));
     }
 
-    nssv_constexpr int compare( CharT const * s ) const // (4)
+    nssv_constexpr int compare(CharT const *s) const // (4)
     {
-        return compare( basic_string_view( s ) );
+      return compare(basic_string_view(s));
     }
 
-    nssv_constexpr int compare( size_type pos1, size_type n1, CharT const * s ) const // (5)
+    nssv_constexpr int compare(size_type pos1, size_type n1, CharT const *s) const // (5)
     {
-        return substr( pos1, n1 ).compare( basic_string_view( s ) );
+      return substr(pos1, n1).compare(basic_string_view(s));
     }
 
-    nssv_constexpr int compare( size_type pos1, size_type n1, CharT const * s, size_type n2 ) const // (6)
+    nssv_constexpr int compare(size_type pos1, size_type n1, CharT const *s, size_type n2) const // (6)
     {
-        return substr( pos1, n1 ).compare( basic_string_view( s, n2 ) );
+      return substr(pos1, n1).compare(basic_string_view(s, n2));
     }
 
     // 24.4.2.7 Searching:
 
     // starts_with(), 3x, since C++20:
 
-    nssv_constexpr bool starts_with( basic_string_view v ) const nssv_noexcept  // (1)
+    nssv_constexpr bool starts_with(basic_string_view v) const nssv_noexcept // (1)
     {
-        return size() >= v.size() && compare( 0, v.size(), v ) == 0;
+      return size() >= v.size() && compare(0, v.size(), v) == 0;
     }
 
-    nssv_constexpr bool starts_with( CharT c ) const nssv_noexcept  // (2)
+    nssv_constexpr bool starts_with(CharT c) const nssv_noexcept // (2)
     {
-        return starts_with( basic_string_view( &c, 1 ) );
+      return starts_with(basic_string_view(&c, 1));
     }
 
-    nssv_constexpr bool starts_with( CharT const * s ) const  // (3)
+    nssv_constexpr bool starts_with(CharT const *s) const // (3)
     {
-        return starts_with( basic_string_view( s ) );
+      return starts_with(basic_string_view(s));
     }
 
     // ends_with(), 3x, since C++20:
 
-    nssv_constexpr bool ends_with( basic_string_view v ) const nssv_noexcept  // (1)
+    nssv_constexpr bool ends_with(basic_string_view v) const nssv_noexcept // (1)
     {
-        return size() >= v.size() && compare( size() - v.size(), npos, v ) == 0;
+      return size() >= v.size() && compare(size() - v.size(), npos, v) == 0;
     }
 
-    nssv_constexpr bool ends_with( CharT c ) const nssv_noexcept  // (2)
+    nssv_constexpr bool ends_with(CharT c) const nssv_noexcept // (2)
     {
-        return ends_with( basic_string_view( &c, 1 ) );
+      return ends_with(basic_string_view(&c, 1));
     }
 
-    nssv_constexpr bool ends_with( CharT const * s ) const  // (3)
+    nssv_constexpr bool ends_with(CharT const *s) const // (3)
     {
-        return ends_with( basic_string_view( s ) );
+      return ends_with(basic_string_view(s));
     }
 
     // find(), 4x:
 
-    nssv_constexpr14 size_type find( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    nssv_constexpr14 size_type find(basic_string_view v, size_type pos = 0) const nssv_noexcept // (1)
     {
-        return assert( v.size() == 0 || v.data() != nssv_nullptr )
-            , pos >= size()
-            ? npos
-            : to_pos( std::search( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq ) );
+      return assert(v.size() == 0 || v.data() != nssv_nullptr),
+             pos >= size() ? npos : to_pos(std::search(cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq));
     }
 
-    nssv_constexpr14 size_type find( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    nssv_constexpr14 size_type find(CharT c, size_type pos = 0) const nssv_noexcept // (2)
     {
-        return find( basic_string_view( &c, 1 ), pos );
+      return find(basic_string_view(&c, 1), pos);
     }
 
-    nssv_constexpr14 size_type find( CharT const * s, size_type pos, size_type n ) const  // (3)
+    nssv_constexpr14 size_type find(CharT const *s, size_type pos, size_type n) const // (3)
     {
-        return find( basic_string_view( s, n ), pos );
+      return find(basic_string_view(s, n), pos);
     }
 
-    nssv_constexpr14 size_type find( CharT const * s, size_type pos = 0 ) const  // (4)
+    nssv_constexpr14 size_type find(CharT const *s, size_type pos = 0) const // (4)
     {
-        return find( basic_string_view( s ), pos );
+      return find(basic_string_view(s), pos);
     }
 
     // rfind(), 4x:
 
-    nssv_constexpr14 size_type rfind( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    nssv_constexpr14 size_type rfind(basic_string_view v, size_type pos = npos) const nssv_noexcept // (1)
     {
-        if ( size() < v.size() )
-            return npos;
+      if (size() < v.size()) {
+        return npos;
+      }
 
-        if ( v.empty() )
-            return (std::min)( size(), pos );
+      if (v.empty()) {
+        return (std::min)(size(), pos);
+      }
 
-        const_iterator last   = cbegin() + (std::min)( size() - v.size(), pos ) + v.size();
-        const_iterator result = std::find_end( cbegin(), last, v.cbegin(), v.cend(), Traits::eq );
+      const_iterator last = cbegin() + (std::min)(size() - v.size(), pos) + v.size();
+      const_iterator result = std::find_end(cbegin(), last, v.cbegin(), v.cend(), Traits::eq);
 
-        return result != last ? size_type( result - cbegin() ) : npos;
+      return result != last ? size_type(result - cbegin()) : npos;
     }
 
-    nssv_constexpr14 size_type rfind( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    nssv_constexpr14 size_type rfind(CharT c, size_type pos = npos) const nssv_noexcept // (2)
     {
-        return rfind( basic_string_view( &c, 1 ), pos );
+      return rfind(basic_string_view(&c, 1), pos);
     }
 
-    nssv_constexpr14 size_type rfind( CharT const * s, size_type pos, size_type n ) const  // (3)
+    nssv_constexpr14 size_type rfind(CharT const *s, size_type pos, size_type n) const // (3)
     {
-        return rfind( basic_string_view( s, n ), pos );
+      return rfind(basic_string_view(s, n), pos);
     }
 
-    nssv_constexpr14 size_type rfind( CharT const * s, size_type pos = npos ) const  // (4)
+    nssv_constexpr14 size_type rfind(CharT const *s, size_type pos = npos) const // (4)
     {
-        return rfind( basic_string_view( s ), pos );
+      return rfind(basic_string_view(s), pos);
     }
 
     // find_first_of(), 4x:
 
-    nssv_constexpr size_type find_first_of( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    nssv_constexpr size_type find_first_of(basic_string_view v, size_type pos = 0) const nssv_noexcept // (1)
     {
-        return pos >= size()
-            ? npos
-            : to_pos( std::find_first_of( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq ) );
+      return pos >= size() ? npos
+                           : to_pos(std::find_first_of(cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq));
     }
 
-    nssv_constexpr size_type find_first_of( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    nssv_constexpr size_type find_first_of(CharT c, size_type pos = 0) const nssv_noexcept // (2)
     {
-        return find_first_of( basic_string_view( &c, 1 ), pos );
+      return find_first_of(basic_string_view(&c, 1), pos);
     }
 
-    nssv_constexpr size_type find_first_of( CharT const * s, size_type pos, size_type n ) const  // (3)
+    nssv_constexpr size_type find_first_of(CharT const *s, size_type pos, size_type n) const // (3)
     {
-        return find_first_of( basic_string_view( s, n ), pos );
+      return find_first_of(basic_string_view(s, n), pos);
     }
 
-    nssv_constexpr size_type find_first_of(  CharT const * s, size_type pos = 0 ) const  // (4)
+    nssv_constexpr size_type find_first_of(CharT const *s, size_type pos = 0) const // (4)
     {
-        return find_first_of( basic_string_view( s ), pos );
+      return find_first_of(basic_string_view(s), pos);
     }
 
     // find_last_of(), 4x:
 
-    nssv_constexpr size_type find_last_of( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    nssv_constexpr size_type find_last_of(basic_string_view v, size_type pos = npos) const nssv_noexcept // (1)
     {
-        return empty()
-            ? npos
-            : pos >= size()
-            ? find_last_of( v, size() - 1 )
-            : to_pos( std::find_first_of( const_reverse_iterator( cbegin() + pos + 1 ), crend(), v.cbegin(), v.cend(), Traits::eq ) );
+      return empty() ? npos
+                     : pos >= size() ? find_last_of(v, size() - 1)
+                                     : to_pos(std::find_first_of(const_reverse_iterator(cbegin() + pos + 1), crend(),
+                                                                 v.cbegin(), v.cend(), Traits::eq));
     }
 
-    nssv_constexpr size_type find_last_of( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    nssv_constexpr size_type find_last_of(CharT c, size_type pos = npos) const nssv_noexcept // (2)
     {
-        return find_last_of( basic_string_view( &c, 1 ), pos );
+      return find_last_of(basic_string_view(&c, 1), pos);
     }
 
-    nssv_constexpr size_type find_last_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    nssv_constexpr size_type find_last_of(CharT const *s, size_type pos, size_type count) const // (3)
     {
-        return find_last_of( basic_string_view( s, count ), pos );
+      return find_last_of(basic_string_view(s, count), pos);
     }
 
-    nssv_constexpr size_type find_last_of( CharT const * s, size_type pos = npos ) const  // (4)
+    nssv_constexpr size_type find_last_of(CharT const *s, size_type pos = npos) const // (4)
     {
-        return find_last_of( basic_string_view( s ), pos );
+      return find_last_of(basic_string_view(s), pos);
     }
 
     // find_first_not_of(), 4x:
 
-    nssv_constexpr size_type find_first_not_of( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    nssv_constexpr size_type find_first_not_of(basic_string_view v, size_type pos = 0) const nssv_noexcept // (1)
     {
-        return pos >= size()
-            ? npos
-            : to_pos( std::find_if( cbegin() + pos, cend(), not_in_view( v ) ) );
+      return pos >= size() ? npos : to_pos(std::find_if(cbegin() + pos, cend(), not_in_view(v)));
     }
 
-    nssv_constexpr size_type find_first_not_of( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    nssv_constexpr size_type find_first_not_of(CharT c, size_type pos = 0) const nssv_noexcept // (2)
     {
-        return find_first_not_of( basic_string_view( &c, 1 ), pos );
+      return find_first_not_of(basic_string_view(&c, 1), pos);
     }
 
-    nssv_constexpr size_type find_first_not_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    nssv_constexpr size_type find_first_not_of(CharT const *s, size_type pos, size_type count) const // (3)
     {
-        return find_first_not_of( basic_string_view( s, count ), pos );
+      return find_first_not_of(basic_string_view(s, count), pos);
     }
 
-    nssv_constexpr size_type find_first_not_of( CharT const * s, size_type pos = 0 ) const  // (4)
+    nssv_constexpr size_type find_first_not_of(CharT const *s, size_type pos = 0) const // (4)
     {
-        return find_first_not_of( basic_string_view( s ), pos );
+      return find_first_not_of(basic_string_view(s), pos);
     }
 
     // find_last_not_of(), 4x:
 
-    nssv_constexpr size_type find_last_not_of( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    nssv_constexpr size_type find_last_not_of(basic_string_view v, size_type pos = npos) const nssv_noexcept // (1)
     {
-        return empty()
-            ? npos
-            : pos >= size()
-            ? find_last_not_of( v, size() - 1 )
-            : to_pos( std::find_if( const_reverse_iterator( cbegin() + pos + 1 ), crend(), not_in_view( v ) ) );
+      return empty() ? npos
+                     : pos >= size()
+                           ? find_last_not_of(v, size() - 1)
+                           : to_pos(std::find_if(const_reverse_iterator(cbegin() + pos + 1), crend(), not_in_view(v)));
     }
 
-    nssv_constexpr size_type find_last_not_of( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    nssv_constexpr size_type find_last_not_of(CharT c, size_type pos = npos) const nssv_noexcept // (2)
     {
-        return find_last_not_of( basic_string_view( &c, 1 ), pos );
+      return find_last_not_of(basic_string_view(&c, 1), pos);
     }
 
-    nssv_constexpr size_type find_last_not_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    nssv_constexpr size_type find_last_not_of(CharT const *s, size_type pos, size_type count) const // (3)
     {
-        return find_last_not_of( basic_string_view( s, count ), pos );
+      return find_last_not_of(basic_string_view(s, count), pos);
     }
 
-    nssv_constexpr size_type find_last_not_of( CharT const * s, size_type pos = npos ) const  // (4)
+    nssv_constexpr size_type find_last_not_of(CharT const *s, size_type pos = npos) const // (4)
     {
-        return find_last_not_of( basic_string_view( s ), pos );
+      return find_last_not_of(basic_string_view(s), pos);
     }
 
     // Constants:
@@ -852,298 +877,418 @@ public:
     enum { npos = size_type(-1) };
 #endif
 
-private:
-    struct not_in_view
-    {
-        const basic_string_view v;
+  private:
+    struct not_in_view {
+      const basic_string_view v;
 
-        nssv_constexpr not_in_view( basic_string_view v ) : v( v ) {}
+      nssv_constexpr explicit not_in_view(basic_string_view v) : v(v) {}
 
-        nssv_constexpr bool operator()( CharT c ) const
-        {
-            return npos == v.find_first_of( c );
-        }
+      nssv_constexpr bool operator()(CharT c) const { return npos == v.find_first_of(c); }
     };
 
-    nssv_constexpr size_type to_pos( const_iterator it ) const
-    {
-        return it == cend() ? npos : size_type( it - cbegin() );
+    nssv_constexpr size_type to_pos(const_iterator it) const { return it == cend() ? npos : size_type(it - cbegin()); }
+
+    nssv_constexpr size_type to_pos(const_reverse_iterator it) const {
+      return it == crend() ? npos : size_type(crend() - it - 1);
     }
 
-    nssv_constexpr size_type to_pos( const_reverse_iterator it ) const
-    {
-        return it == crend() ? npos : size_type( crend() - it - 1 );
-    }
-
-    nssv_constexpr const_reference data_at( size_type pos ) const
-    {
-#if nssv_BETWEEN( nssv_COMPILER_GNUC_VERSION, 1, 500 )
-        return data_[pos];
+    nssv_constexpr const_reference data_at(size_type pos) const {
+#if nssv_BETWEEN(nssv_COMPILER_GNUC_VERSION, 1, 500)
+      return data_[pos];
 #else
-        return assert( pos < size() ), data_[pos];
+      return assert(pos < size()), data_[pos];
 #endif
     }
 
-private:
+  private:
     const_pointer data_;
-    size_type     size_;
+    size_type size_;
 
-public:
+  public:
 #if nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
 
-    template< class Allocator >
-    basic_string_view( std::basic_string<CharT, Traits, Allocator> const & s ) nssv_noexcept
-        : data_( s.data() )
-        , size_( s.size() )
-    {}
+    template <class Allocator>
+    basic_string_view(std::basic_string<CharT, Traits, Allocator> const &s) nssv_noexcept : data_(s.data()),
+                                                                                            size_(s.size()) {}
 
 #if nssv_HAVE_EXPLICIT_CONVERSION
 
-    template< class Allocator >
-    explicit operator std::basic_string<CharT, Traits, Allocator>() const
-    {
-        return to_string( Allocator() );
+    template <class Allocator> explicit operator std::basic_string<CharT, Traits, Allocator>() const {
+      return to_string(Allocator());
     }
 
 #endif // nssv_HAVE_EXPLICIT_CONVERSION
 
 #if nssv_CPP11_OR_GREATER
 
-    template< class Allocator = std::allocator<CharT> >
-    std::basic_string<CharT, Traits, Allocator>
-    to_string( Allocator const & a = Allocator() ) const
-    {
-        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    template <class Allocator = std::allocator<CharT>>
+    std::basic_string<CharT, Traits, Allocator> to_string(Allocator const &a = Allocator()) const {
+      return std::basic_string<CharT, Traits, Allocator>(begin(), end(), a);
     }
 
 #else
 
-    std::basic_string<CharT, Traits>
-    to_string() const
-    {
-        return std::basic_string<CharT, Traits>( begin(), end() );
-    }
+    std::basic_string<CharT, Traits> to_string() const { return std::basic_string<CharT, Traits>(begin(), end()); }
 
-    template< class Allocator >
-    std::basic_string<CharT, Traits, Allocator>
-    to_string( Allocator const & a ) const
-    {
-        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    template <class Allocator> std::basic_string<CharT, Traits, Allocator> to_string(Allocator const &a) const {
+      return std::basic_string<CharT, Traits, Allocator>(begin(), end(), a);
     }
 
 #endif // nssv_CPP11_OR_GREATER
 
 #endif // nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
-};
+  };
 
-//
-// Non-member functions:
-//
+  //
+  // Non-member functions:
+  //
 
-// 24.4.3 Non-member comparison functions:
-// lexicographically compare two string views (function template):
+  // 24.4.3 Non-member comparison functions:
+  // lexicographically compare two string views (function template):
 
-template< class CharT, class Traits >
-nssv_constexpr bool operator== (
-    basic_string_view <CharT, Traits> lhs,
-    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) == 0 ; }
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator==(basic_string_view<CharT, Traits> lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) == 0;
+  }
 
-template< class CharT, class Traits >
-nssv_constexpr bool operator!= (
-    basic_string_view <CharT, Traits> lhs,
-    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) != 0 ; }
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator!=(basic_string_view<CharT, Traits> lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) != 0;
+  }
 
-template< class CharT, class Traits >
-nssv_constexpr bool operator< (
-    basic_string_view <CharT, Traits> lhs,
-    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) < 0 ; }
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<(basic_string_view<CharT, Traits> lhs,
+                                basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) < 0;
+  }
 
-template< class CharT, class Traits >
-nssv_constexpr bool operator<= (
-    basic_string_view <CharT, Traits> lhs,
-    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) <= 0 ; }
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<=(basic_string_view<CharT, Traits> lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) <= 0;
+  }
 
-template< class CharT, class Traits >
-nssv_constexpr bool operator> (
-    basic_string_view <CharT, Traits> lhs,
-    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) > 0 ; }
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>(basic_string_view<CharT, Traits> lhs,
+                                basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) > 0;
+  }
 
-template< class CharT, class Traits >
-nssv_constexpr bool operator>= (
-    basic_string_view <CharT, Traits> lhs,
-    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) >= 0 ; }
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>=(basic_string_view<CharT, Traits> lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) >= 0;
+  }
 
-// Let S be basic_string_view<CharT, Traits>, and sv be an instance of S.
-// Implementations shall provide sufficient additional overloads marked
-// constexpr and noexcept so that an object t with an implicit conversion
-// to S can be compared according to Table 67.
+  // Let S be basic_string_view<CharT, Traits>, and sv be an instance of S.
+  // Implementations shall provide sufficient additional overloads marked
+  // constexpr and noexcept so that an object t with an implicit conversion
+  // to S can be compared according to Table 67.
 
-#if nssv_CPP11_OR_GREATER && ! nssv_BETWEEN( nssv_COMPILER_MSVC_VERSION, 100, 141 )
+#if !nssv_CPP11_OR_GREATER || nssv_BETWEEN(nssv_COMPILER_MSVC_VERSION, 100, 141)
 
-#define nssv_BASIC_STRING_VIEW_I(T,U)  typename std::decay< basic_string_view<T,U> >::type
+  // accomodate for older compilers:
 
-#if nssv_BETWEEN( nssv_COMPILER_MSVC_VERSION, 140, 150 )
-# define nssv_MSVC_ORDER(x)  , int=x
+  // ==
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator==(basic_string_view<CharT, Traits> lhs, char const *rhs) nssv_noexcept {
+    return lhs.compare(rhs) == 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator==(char const *lhs, basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return rhs.compare(lhs) == 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator==(basic_string_view<CharT, Traits> lhs,
+                                 std::basic_string<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator==(std::basic_string<CharT, Traits> rhs,
+                                 basic_string_view<CharT, Traits> lhs) nssv_noexcept {
+    return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
+  }
+
+  // !=
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator!=(basic_string_view<CharT, Traits> lhs, char const *rhs) nssv_noexcept {
+    return lhs.compare(rhs) != 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator!=(char const *lhs, basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return rhs.compare(lhs) != 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator!=(basic_string_view<CharT, Traits> lhs,
+                                 std::basic_string<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.size() != rhs.size() && lhs.compare(rhs) != 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator!=(std::basic_string<CharT, Traits> rhs,
+                                 basic_string_view<CharT, Traits> lhs) nssv_noexcept {
+    return lhs.size() != rhs.size() || rhs.compare(lhs) != 0;
+  }
+
+  // <
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<(basic_string_view<CharT, Traits> lhs, char const *rhs) nssv_noexcept {
+    return lhs.compare(rhs) < 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<(char const *lhs, basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return rhs.compare(lhs) > 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<(basic_string_view<CharT, Traits> lhs,
+                                std::basic_string<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) < 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<(std::basic_string<CharT, Traits> rhs,
+                                basic_string_view<CharT, Traits> lhs) nssv_noexcept {
+    return rhs.compare(lhs) > 0;
+  }
+
+  // <=
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<=(basic_string_view<CharT, Traits> lhs, char const *rhs) nssv_noexcept {
+    return lhs.compare(rhs) <= 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<=(char const *lhs, basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return rhs.compare(lhs) >= 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<=(basic_string_view<CharT, Traits> lhs,
+                                 std::basic_string<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) <= 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator<=(std::basic_string<CharT, Traits> rhs,
+                                 basic_string_view<CharT, Traits> lhs) nssv_noexcept {
+    return rhs.compare(lhs) >= 0;
+  }
+
+  // >
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>(basic_string_view<CharT, Traits> lhs, char const *rhs) nssv_noexcept {
+    return lhs.compare(rhs) > 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>(char const *lhs, basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return rhs.compare(lhs) < 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>(basic_string_view<CharT, Traits> lhs,
+                                std::basic_string<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) > 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>(std::basic_string<CharT, Traits> rhs,
+                                basic_string_view<CharT, Traits> lhs) nssv_noexcept {
+    return rhs.compare(lhs) < 0;
+  }
+
+  // >=
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>=(basic_string_view<CharT, Traits> lhs, char const *rhs) nssv_noexcept {
+    return lhs.compare(rhs) >= 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>=(char const *lhs, basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return rhs.compare(lhs) <= 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>=(basic_string_view<CharT, Traits> lhs,
+                                 std::basic_string<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) >= 0;
+  }
+
+  template <class CharT, class Traits>
+  nssv_constexpr bool operator>=(std::basic_string<CharT, Traits> rhs,
+                                 basic_string_view<CharT, Traits> lhs) nssv_noexcept {
+    return rhs.compare(lhs) <= 0;
+  }
+
+#else // newer compilers:
+
+#define nssv_BASIC_STRING_VIEW_I(T, U) typename std::decay<basic_string_view<T, U>>::type
+
+#if nssv_BETWEEN(nssv_COMPILER_MSVC_VERSION, 140, 150)
+#define nssv_MSVC_ORDER(x) , int = x
 #else
-# define nssv_MSVC_ORDER(x)  /*, int=x*/
+#define nssv_MSVC_ORDER(x) /*, int=x*/
 #endif
 
-// ==
+  // ==
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
-nssv_constexpr bool operator==(
-         basic_string_view  <CharT, Traits> lhs,
-    nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) == 0; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(1)>
+  nssv_constexpr bool operator==(basic_string_view<CharT, Traits> lhs,
+                                 nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs) nssv_noexcept {
+    return lhs.compare(rhs) == 0;
+  }
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
-nssv_constexpr bool operator==(
-    nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
-         basic_string_view  <CharT, Traits> rhs ) nssv_noexcept
-{ return lhs.size() == rhs.size() && lhs.compare( rhs ) == 0; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(2)>
+  nssv_constexpr bool operator==(nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
+  }
 
-// !=
+  // !=
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
-nssv_constexpr bool operator!= (
-         basic_string_view  < CharT, Traits > lhs,
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
-{ return lhs.size() != rhs.size() || lhs.compare( rhs ) != 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(1)>
+  nssv_constexpr bool operator!=(basic_string_view<CharT, Traits> lhs,
+                                 nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs) nssv_noexcept {
+    return lhs.size() != rhs.size() || lhs.compare(rhs) != 0;
+  }
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
-nssv_constexpr bool operator!= (
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
-         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) != 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(2)>
+  nssv_constexpr bool operator!=(nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) != 0;
+  }
 
-// <
+  // <
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
-nssv_constexpr bool operator< (
-         basic_string_view  < CharT, Traits > lhs,
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) < 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(1)>
+  nssv_constexpr bool operator<(basic_string_view<CharT, Traits> lhs,
+                                nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs) nssv_noexcept {
+    return lhs.compare(rhs) < 0;
+  }
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
-nssv_constexpr bool operator< (
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
-         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) < 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(2)>
+  nssv_constexpr bool operator<(nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+                                basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) < 0;
+  }
 
-// <=
+  // <=
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
-nssv_constexpr bool operator<= (
-         basic_string_view  < CharT, Traits > lhs,
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) <= 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(1)>
+  nssv_constexpr bool operator<=(basic_string_view<CharT, Traits> lhs,
+                                 nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs) nssv_noexcept {
+    return lhs.compare(rhs) <= 0;
+  }
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
-nssv_constexpr bool operator<= (
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
-         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) <= 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(2)>
+  nssv_constexpr bool operator<=(nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) <= 0;
+  }
 
-// >
+  // >
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
-nssv_constexpr bool operator> (
-         basic_string_view  < CharT, Traits > lhs,
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) > 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(1)>
+  nssv_constexpr bool operator>(basic_string_view<CharT, Traits> lhs,
+                                nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs) nssv_noexcept {
+    return lhs.compare(rhs) > 0;
+  }
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
-nssv_constexpr bool operator> (
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
-         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) > 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(2)>
+  nssv_constexpr bool operator>(nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+                                basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) > 0;
+  }
 
-// >=
+  // >=
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
-nssv_constexpr bool operator>= (
-         basic_string_view  < CharT, Traits > lhs,
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) >= 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(1)>
+  nssv_constexpr bool operator>=(basic_string_view<CharT, Traits> lhs,
+                                 nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs) nssv_noexcept {
+    return lhs.compare(rhs) >= 0;
+  }
 
-template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
-nssv_constexpr bool operator>= (
-    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
-         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
-{ return lhs.compare( rhs ) >= 0 ; }
+  template <class CharT, class Traits nssv_MSVC_ORDER(2)>
+  nssv_constexpr bool operator>=(nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+                                 basic_string_view<CharT, Traits> rhs) nssv_noexcept {
+    return lhs.compare(rhs) >= 0;
+  }
 
 #undef nssv_MSVC_ORDER
 #undef nssv_BASIC_STRING_VIEW_I
 
-#endif // nssv_CPP11_OR_GREATER
+#endif // compiler-dependent approach to comparisons
 
-// 24.4.4 Inserters and extractors:
+  // 24.4.4 Inserters and extractors:
 
-namespace detail {
+  namespace detail {
 
-template< class Stream >
-void write_padding( Stream & os, std::streamsize n )
-{
-    for ( std::streamsize i = 0; i < n; ++i )
-        os.rdbuf()->sputc( os.fill() );
-}
+  template <class Stream> void write_padding(Stream &os, std::streamsize n) {
+    for (std::streamsize i = 0; i < n; ++i)
+      os.rdbuf()->sputc(os.fill());
+  }
 
-template< class Stream, class View >
-Stream & write_to_stream( Stream & os, View const & sv )
-{
-    typename Stream::sentry sentry( os );
+  template <class Stream, class View> Stream &write_to_stream(Stream &os, View const &sv) {
+    typename Stream::sentry sentry(os);
 
-    if ( !os )
-        return os;
+    if (!os)
+      return os;
 
-    const std::streamsize length = static_cast<std::streamsize>( sv.length() );
+    const std::streamsize length = static_cast<std::streamsize>(sv.length());
 
     // Whether, and how, to pad:
-    const bool      pad = ( length < os.width() );
-    const bool left_pad = pad && ( os.flags() & std::ios_base::adjustfield ) == std::ios_base::right;
+    const bool pad = (length < os.width());
+    const bool left_pad = pad && (os.flags() & std::ios_base::adjustfield) == std::ios_base::right;
 
-    if ( left_pad )
-        write_padding( os, os.width() - length );
+    if (left_pad)
+      write_padding(os, os.width() - length);
 
     // Write span characters:
-    os.rdbuf()->sputn( sv.begin(), length );
+    os.rdbuf()->sputn(sv.begin(), length);
 
-    if ( pad && !left_pad )
-        write_padding( os, os.width() - length );
+    if (pad && !left_pad)
+      write_padding(os, os.width() - length);
 
     // Reset output stream width:
-    os.width( 0 );
+    os.width(0);
 
     return os;
-}
+  }
 
-} // namespace detail
+  } // namespace detail
 
-template< class CharT, class Traits >
-std::basic_ostream<CharT, Traits> &
-operator<<(
-    std::basic_ostream<CharT, Traits>& os,
-    basic_string_view <CharT, Traits> sv )
-{
-    return detail::write_to_stream( os, sv );
-}
+  template <class CharT, class Traits>
+  std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
+                                                basic_string_view<CharT, Traits> sv) {
+    return detail::write_to_stream(os, sv);
+  }
 
-// Several typedefs for common character types are provided:
+  // Several typedefs for common character types are provided:
 
-typedef basic_string_view<char>      string_view;
-typedef basic_string_view<wchar_t>   wstring_view;
+  typedef basic_string_view<char> string_view;
+  typedef basic_string_view<wchar_t> wstring_view;
 #if nssv_HAVE_WCHAR16_T
-typedef basic_string_view<char16_t>  u16string_view;
-typedef basic_string_view<char32_t>  u32string_view;
+  typedef basic_string_view<char16_t> u16string_view;
+  typedef basic_string_view<char32_t> u32string_view;
 #endif
 
-}} // namespace nonstd::sv_lite
+  } // namespace sv_lite
+} // namespace nonstd::sv_lite
 
 //
 // 24.4.6 Suffix for basic_string_view literals:
@@ -1153,57 +1298,58 @@ typedef basic_string_view<char32_t>  u32string_view;
 
 namespace nonstd {
 nssv_inline_ns namespace literals {
-nssv_inline_ns namespace string_view_literals {
+  nssv_inline_ns namespace string_view_literals {
 
 #if nssv_CONFIG_STD_SV_OPERATOR && nssv_HAVE_STD_DEFINED_LITERALS
 
-nssv_constexpr nonstd::sv_lite::string_view operator "" sv( const char* str, size_t len ) nssv_noexcept  // (1)
-{
-    return nonstd::sv_lite::string_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::string_view operator"" sv(const char *str, size_t len) nssv_noexcept // (1)
+    {
+      return nonstd::sv_lite::string_view {str, len};
+    }
 
-nssv_constexpr nonstd::sv_lite::u16string_view operator "" sv( const char16_t* str, size_t len ) nssv_noexcept  // (2)
-{
-    return nonstd::sv_lite::u16string_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::u16string_view operator"" sv(const char16_t *str, size_t len) nssv_noexcept // (2)
+    {
+      return nonstd::sv_lite::u16string_view {str, len};
+    }
 
-nssv_constexpr nonstd::sv_lite::u32string_view operator "" sv( const char32_t* str, size_t len ) nssv_noexcept  // (3)
-{
-    return nonstd::sv_lite::u32string_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::u32string_view operator"" sv(const char32_t *str, size_t len) nssv_noexcept // (3)
+    {
+      return nonstd::sv_lite::u32string_view {str, len};
+    }
 
-nssv_constexpr nonstd::sv_lite::wstring_view operator "" sv( const wchar_t* str, size_t len ) nssv_noexcept  // (4)
-{
-    return nonstd::sv_lite::wstring_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::wstring_view operator"" sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
+    {
+      return nonstd::sv_lite::wstring_view {str, len};
+    }
 
 #endif // nssv_CONFIG_STD_SV_OPERATOR && nssv_HAVE_STD_DEFINED_LITERALS
 
 #if nssv_CONFIG_USR_SV_OPERATOR
 
-nssv_constexpr nonstd::sv_lite::string_view operator "" _sv( const char* str, size_t len ) nssv_noexcept  // (1)
-{
-    return nonstd::sv_lite::string_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::string_view operator"" _sv(const char *str, size_t len) nssv_noexcept // (1)
+    {
+      return nonstd::sv_lite::string_view {str, len};
+    }
 
-nssv_constexpr nonstd::sv_lite::u16string_view operator "" _sv( const char16_t* str, size_t len ) nssv_noexcept  // (2)
-{
-    return nonstd::sv_lite::u16string_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::u16string_view operator"" _sv(const char16_t *str, size_t len) nssv_noexcept // (2)
+    {
+      return nonstd::sv_lite::u16string_view {str, len};
+    }
 
-nssv_constexpr nonstd::sv_lite::u32string_view operator "" _sv( const char32_t* str, size_t len ) nssv_noexcept  // (3)
-{
-    return nonstd::sv_lite::u32string_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::u32string_view operator"" _sv(const char32_t *str, size_t len) nssv_noexcept // (3)
+    {
+      return nonstd::sv_lite::u32string_view {str, len};
+    }
 
-nssv_constexpr nonstd::sv_lite::wstring_view operator "" _sv( const wchar_t* str, size_t len ) nssv_noexcept  // (4)
-{
-    return nonstd::sv_lite::wstring_view{ str, len };
-}
+    nssv_constexpr nonstd::sv_lite::wstring_view operator"" _sv(const wchar_t *str, size_t len) nssv_noexcept // (4)
+    {
+      return nonstd::sv_lite::wstring_view {str, len};
+    }
 
 #endif // nssv_CONFIG_USR_SV_OPERATOR
-
-}}} // namespace nonstd::literals::string_view_literals
+  }
+}
+} // namespace nonstd
 
 #endif
 
@@ -1220,39 +1366,32 @@ namespace sv_lite {
 
 #if nssv_CPP11_OR_GREATER && nssv_COMPILER_MSVC_VERSION != 140
 
-template< class CharT, class Traits, class Allocator = std::allocator<CharT> >
-std::basic_string<CharT, Traits, Allocator>
-to_string( basic_string_view<CharT, Traits> v, Allocator const & a = Allocator() )
-{
-    return std::basic_string<CharT,Traits, Allocator>( v.begin(), v.end(), a );
+template <class CharT, class Traits, class Allocator = std::allocator<CharT>>
+std::basic_string<CharT, Traits, Allocator> to_string(basic_string_view<CharT, Traits> v,
+                                                      Allocator const &a = Allocator()) {
+  return std::basic_string<CharT, Traits, Allocator>(v.begin(), v.end(), a);
 }
 
 #else
 
-template< class CharT, class Traits >
-std::basic_string<CharT, Traits>
-to_string( basic_string_view<CharT, Traits> v )
-{
-    return std::basic_string<CharT, Traits>( v.begin(), v.end() );
+template <class CharT, class Traits> std::basic_string<CharT, Traits> to_string(basic_string_view<CharT, Traits> v) {
+  return std::basic_string<CharT, Traits>(v.begin(), v.end());
 }
 
-template< class CharT, class Traits, class Allocator >
-std::basic_string<CharT, Traits, Allocator>
-to_string( basic_string_view<CharT, Traits> v, Allocator const & a )
-{
-    return std::basic_string<CharT, Traits, Allocator>( v.begin(), v.end(), a );
+template <class CharT, class Traits, class Allocator>
+std::basic_string<CharT, Traits, Allocator> to_string(basic_string_view<CharT, Traits> v, Allocator const &a) {
+  return std::basic_string<CharT, Traits, Allocator>(v.begin(), v.end(), a);
 }
 
 #endif // nssv_CPP11_OR_GREATER
 
-template< class CharT, class Traits, class Allocator >
-basic_string_view<CharT, Traits>
-to_string_view( std::basic_string<CharT, Traits, Allocator> const & s )
-{
-    return basic_string_view<CharT, Traits>( s.data(), s.size() );
+template <class CharT, class Traits, class Allocator>
+basic_string_view<CharT, Traits> to_string_view(std::basic_string<CharT, Traits, Allocator> const &s) {
+  return basic_string_view<CharT, Traits>(s.data(), s.size());
 }
 
-}} // namespace nonstd::sv_lite
+} // namespace sv_lite
+} // namespace nonstd
 
 #endif // nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
 
@@ -1302,44 +1441,32 @@ using sv_lite::to_string_view;
 
 namespace std {
 
-template<>
-struct hash< nonstd::string_view >
-{
+template <> struct hash<nonstd::string_view> {
 public:
-    std::size_t operator()( nonstd::string_view v ) const nssv_noexcept
-    {
-        return std::hash<std::string>()( std::string( v.data(), v.size() ) );
-    }
+  std::size_t operator()(nonstd::string_view v) const nssv_noexcept {
+    return std::hash<std::string>()(std::string(v.data(), v.size()));
+  }
 };
 
-template<>
-struct hash< nonstd::wstring_view >
-{
+template <> struct hash<nonstd::wstring_view> {
 public:
-    std::size_t operator()( nonstd::wstring_view v ) const nssv_noexcept
-    {
-        return std::hash<std::wstring>()( std::wstring( v.data(), v.size() ) );
-    }
+  std::size_t operator()(nonstd::wstring_view v) const nssv_noexcept {
+    return std::hash<std::wstring>()(std::wstring(v.data(), v.size()));
+  }
 };
 
-template<>
-struct hash< nonstd::u16string_view >
-{
+template <> struct hash<nonstd::u16string_view> {
 public:
-    std::size_t operator()( nonstd::u16string_view v ) const nssv_noexcept
-    {
-        return std::hash<std::u16string>()( std::u16string( v.data(), v.size() ) );
-    }
+  std::size_t operator()(nonstd::u16string_view v) const nssv_noexcept {
+    return std::hash<std::u16string>()(std::u16string(v.data(), v.size()));
+  }
 };
 
-template<>
-struct hash< nonstd::u32string_view >
-{
+template <> struct hash<nonstd::u32string_view> {
 public:
-    std::size_t operator()( nonstd::u32string_view v ) const nssv_noexcept
-    {
-        return std::hash<std::u32string>()( std::u32string( v.data(), v.size() ) );
-    }
+  std::size_t operator()(nonstd::u32string_view v) const nssv_noexcept {
+    return std::hash<std::u32string>()(std::u32string(v.data(), v.size()));
+  }
 };
 
 } // namespace std
@@ -1352,23 +1479,30 @@ nssv_RESTORE_WARNINGS()
 #endif // NONSTD_SV_LITE_H_INCLUDED
 
 
-
 namespace inja {
 
-enum class ElementNotation {
-  Dot,
-  Pointer
-};
-
+/*!
+ * \brief Class for lexer configuration.
+ */
 struct LexerConfig {
   std::string statement_open {"{%"};
+  std::string statement_open_no_lstrip {"{%+"};
+  std::string statement_open_force_lstrip {"{%-"};
   std::string statement_close {"%}"};
+  std::string statement_close_force_rstrip {"-%}"};
   std::string line_statement {"##"};
   std::string expression_open {"{{"};
+  std::string expression_open_force_lstrip {"{{-"};
   std::string expression_close {"}}"};
+  std::string expression_close_force_rstrip {"-}}"};
   std::string comment_open {"{#"};
+  std::string comment_open_force_lstrip {"{#-"};
   std::string comment_close {"#}"};
+  std::string comment_close_force_rstrip {"-#}"};
   std::string open_chars {"#{"};
+
+  bool trim_blocks {false};
+  bool lstrip_blocks {false};
 
   void update_open_chars() {
     open_chars = "";
@@ -1378,76 +1512,101 @@ struct LexerConfig {
     if (open_chars.find(statement_open[0]) == std::string::npos) {
       open_chars += statement_open[0];
     }
+    if (open_chars.find(statement_open_no_lstrip[0]) == std::string::npos) {
+      open_chars += statement_open_no_lstrip[0];
+    }
+    if (open_chars.find(statement_open_force_lstrip[0]) == std::string::npos) {
+      open_chars += statement_open_force_lstrip[0];
+    }
     if (open_chars.find(expression_open[0]) == std::string::npos) {
       open_chars += expression_open[0];
+    }
+    if (open_chars.find(expression_open_force_lstrip[0]) == std::string::npos) {
+      open_chars += expression_open_force_lstrip[0];
     }
     if (open_chars.find(comment_open[0]) == std::string::npos) {
       open_chars += comment_open[0];
     }
+    if (open_chars.find(comment_open_force_lstrip[0]) == std::string::npos) {
+      open_chars += comment_open_force_lstrip[0];
+    }
   }
 };
 
+/*!
+ * \brief Class for parser configuration.
+ */
 struct ParserConfig {
-  ElementNotation notation {ElementNotation::Dot};
+  bool search_included_templates_in_files {true};
 };
 
-}
+/*!
+ * \brief Class for render configuration.
+ */
+struct RenderConfig {
+  bool throw_at_missing_includes {true};
+};
 
-#endif // PANTOR_INJA_CONFIG_HPP
+} // namespace inja
+
+#endif // INCLUDE_INJA_CONFIG_HPP_
 
 // #include "function_storage.hpp"
-#ifndef PANTOR_INJA_FUNCTION_STORAGE_HPP
-#define PANTOR_INJA_FUNCTION_STORAGE_HPP
+#ifndef INCLUDE_INJA_FUNCTION_STORAGE_HPP_
+#define INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 
-// #include "bytecode.hpp"
-#ifndef PANTOR_INJA_BYTECODE_HPP
-#define PANTOR_INJA_BYTECODE_HPP
-
-#include <utility>
-
-#include <nlohmann/json.hpp>
+#include <vector>
 
 // #include "string_view.hpp"
 
 
-
 namespace inja {
 
-using namespace nlohmann;
+using json = nlohmann::json;
 
+using Arguments = std::vector<const json *>;
+using CallbackFunction = std::function<json(Arguments &args)>;
+using VoidCallbackFunction = std::function<void(Arguments &args)>;
 
-struct Bytecode {
-  enum class Op : uint8_t {
-    Nop,
-    // print StringRef (always immediate)
-    PrintText,
-    // print value
-    PrintValue,
-    // push value onto stack (always immediate)
-    Push,
-
-    // builtin functions
-    // result is pushed to stack
-    // args specify number of arguments
-    // all functions can take their "last" argument either immediate
-    // or popped off stack (e.g. if immediate, it's like the immediate was
-    // just pushed to the stack)
+/*!
+ * \brief Class for builtin functions and user-defined callbacks.
+ */
+class FunctionStorage {
+public:
+  enum class Operation {
     Not,
     And,
     Or,
     In,
     Equal,
+    NotEqual,
     Greater,
     GreaterEqual,
     Less,
     LessEqual,
+    Add,
+    Subtract,
+    Multiplication,
+    Division,
+    Power,
+    Modulo,
+    AtId,
     At,
-    Different,
+    Default,
     DivisibleBy,
     Even,
+    Exists,
+    ExistsInObject,
     First,
     Float,
     Int,
+    IsArray,
+    IsBoolean,
+    IsFloat,
+    IsInteger,
+    IsNumber,
+    IsObject,
+    IsString,
     Last,
     Length,
     Lower,
@@ -1455,169 +1614,156 @@ struct Bytecode {
     Min,
     Odd,
     Range,
-    Result,
     Round,
     Sort,
     Upper,
-    Exists,
-    ExistsInObject,
-    IsBoolean,
-    IsNumber,
-    IsInteger,
-    IsFloat,
-    IsObject,
-    IsArray,
-    IsString,
-    Default,
-
-    // include another template
-    // value is the template name
-    Include,
-
-    // callback function
-    // str is the function name (this means it cannot be a lookup)
-    // args specify number of arguments
-    // as with builtin functions, "last" argument can be immediate
+    Super,
+    Join,
     Callback,
-
-    // unconditional jump
-    // args is the index of the bytecode to jump to.
-    Jump,
-
-    // conditional jump
-    // value popped off stack is checked for truthyness
-    // if false, args is the index of the bytecode to jump to.
-    // if true, no action is taken (falls through)
-    ConditionalJump,
-
-    // start loop
-    // value popped off stack is what is iterated over
-    // args is index of bytecode after end loop (jumped to if iterable is
-    // empty)
-    // immediate value is key name (for maps)
-    // str is value name
-    StartLoop,
-
-    // end a loop
-    // args is index of the first bytecode in the loop body
-    EndLoop,
+    ParenLeft,
+    ParenRight,
+    None,
   };
 
-  enum Flag {
-    // location of value for value-taking ops (mask)
-    ValueMask = 0x03,
-    // pop value off stack
-    ValuePop = 0x00,
-    // value is immediate rather than on stack
-    ValueImmediate = 0x01,
-    // lookup immediate str (dot notation)
-    ValueLookupDot = 0x02,
-    // lookup immediate str (json pointer notation)
-    ValueLookupPointer = 0x03,
+  struct FunctionData {
+    explicit FunctionData(const Operation &op, const CallbackFunction &cb = CallbackFunction{}) : operation(op), callback(cb) {}
+    const Operation operation;
+    const CallbackFunction callback;
   };
 
-  Op op {Op::Nop};
-  uint32_t args: 30;
-  uint32_t flags: 2;
+private:
+  const int VARIADIC {-1};
 
-  json value;
-  std::string str;
+  std::map<std::pair<std::string, int>, FunctionData> function_storage = {
+    {std::make_pair("at", 2), FunctionData { Operation::At }},
+    {std::make_pair("default", 2), FunctionData { Operation::Default }},
+    {std::make_pair("divisibleBy", 2), FunctionData { Operation::DivisibleBy }},
+    {std::make_pair("even", 1), FunctionData { Operation::Even }},
+    {std::make_pair("exists", 1), FunctionData { Operation::Exists }},
+    {std::make_pair("existsIn", 2), FunctionData { Operation::ExistsInObject }},
+    {std::make_pair("first", 1), FunctionData { Operation::First }},
+    {std::make_pair("float", 1), FunctionData { Operation::Float }},
+    {std::make_pair("int", 1), FunctionData { Operation::Int }},
+    {std::make_pair("isArray", 1), FunctionData { Operation::IsArray }},
+    {std::make_pair("isBoolean", 1), FunctionData { Operation::IsBoolean }},
+    {std::make_pair("isFloat", 1), FunctionData { Operation::IsFloat }},
+    {std::make_pair("isInteger", 1), FunctionData { Operation::IsInteger }},
+    {std::make_pair("isNumber", 1), FunctionData { Operation::IsNumber }},
+    {std::make_pair("isObject", 1), FunctionData { Operation::IsObject }},
+    {std::make_pair("isString", 1), FunctionData { Operation::IsString }},
+    {std::make_pair("last", 1), FunctionData { Operation::Last }},
+    {std::make_pair("length", 1), FunctionData { Operation::Length }},
+    {std::make_pair("lower", 1), FunctionData { Operation::Lower }},
+    {std::make_pair("max", 1), FunctionData { Operation::Max }},
+    {std::make_pair("min", 1), FunctionData { Operation::Min }},
+    {std::make_pair("odd", 1), FunctionData { Operation::Odd }},
+    {std::make_pair("range", 1), FunctionData { Operation::Range }},
+    {std::make_pair("round", 2), FunctionData { Operation::Round }},
+    {std::make_pair("sort", 1), FunctionData { Operation::Sort }},
+    {std::make_pair("upper", 1), FunctionData { Operation::Upper }},
+    {std::make_pair("super", 0), FunctionData { Operation::Super }},
+    {std::make_pair("super", 1), FunctionData { Operation::Super }},
+    {std::make_pair("join", 2), FunctionData { Operation::Join }},
+  };
 
-  Bytecode(): args(0), flags(0) {}
-  explicit Bytecode(Op op, unsigned int args = 0): op(op), args(args), flags(0) {}
-  explicit Bytecode(Op op, nonstd::string_view str, unsigned int flags): op(op), args(0), flags(flags), str(str) {}
-  explicit Bytecode(Op op, json&& value, unsigned int flags): op(op), args(0), flags(flags), value(std::move(value)) {}
+public:
+  void add_builtin(nonstd::string_view name, int num_args, Operation op) {
+    function_storage.emplace(std::make_pair(static_cast<std::string>(name), num_args), FunctionData { op });
+  }
+
+  void add_callback(nonstd::string_view name, int num_args, const CallbackFunction &callback) {
+    function_storage.emplace(std::make_pair(static_cast<std::string>(name), num_args), FunctionData { Operation::Callback, callback });
+  }
+
+  FunctionData find_function(nonstd::string_view name, int num_args) const {
+    auto it = function_storage.find(std::make_pair(static_cast<std::string>(name), num_args));
+    if (it != function_storage.end()) {
+      return it->second;
+
+    // Find variadic function
+    } else if (num_args > 0) {
+      it = function_storage.find(std::make_pair(static_cast<std::string>(name), VARIADIC));
+      if (it != function_storage.end()) {
+        return it->second;
+      }
+    }
+
+    return FunctionData { Operation::None };
+  }
 };
 
-}  // namespace inja
+} // namespace inja
 
-#endif  // PANTOR_INJA_BYTECODE_HPP
+#endif // INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 
-// #include "string_view.hpp"
+// #include "parser.hpp"
+#ifndef INCLUDE_INJA_PARSER_HPP_
+#define INCLUDE_INJA_PARSER_HPP_
 
+#include <limits>
+#include <stack>
+#include <string>
+#include <utility>
+#include <queue>
+#include <vector>
 
+// #include "config.hpp"
+
+// #include "exceptions.hpp"
+#ifndef INCLUDE_INJA_EXCEPTIONS_HPP_
+#define INCLUDE_INJA_EXCEPTIONS_HPP_
+
+#include <stdexcept>
+#include <string>
 
 namespace inja {
 
-using namespace nlohmann;
-
-using Arguments = std::vector<const json*>;
-using CallbackFunction = std::function<json(Arguments& args)>;
-
-class FunctionStorage {
- public:
-  void add_builtin(nonstd::string_view name, unsigned int num_args, Bytecode::Op op) {
-    auto& data = get_or_new(name, num_args);
-    data.op = op;
-  }
-
-  void add_callback(nonstd::string_view name, unsigned int num_args, const CallbackFunction& function) {
-    auto& data = get_or_new(name, num_args);
-    data.function = function;
-  }
-
-  Bytecode::Op find_builtin(nonstd::string_view name, unsigned int num_args) const {
-    if (auto ptr = get(name, num_args)) {
-      return ptr->op;
-    }
-    return Bytecode::Op::Nop;
-  }
-
-  CallbackFunction find_callback(nonstd::string_view name, unsigned int num_args) const {
-    if (auto ptr = get(name, num_args)) {
-      return ptr->function;
-    }
-    return nullptr;
-  }
-
- private:
-  struct FunctionData {
-    unsigned int num_args {0};
-    Bytecode::Op op {Bytecode::Op::Nop}; // for builtins
-    CallbackFunction function; // for callbacks
-  };
-
-  FunctionData& get_or_new(nonstd::string_view name, unsigned int num_args) {
-    auto &vec = m_map[static_cast<std::string>(name)];
-    for (auto &i: vec) {
-      if (i.num_args == num_args) return i;
-    }
-    vec.emplace_back();
-    vec.back().num_args = num_args;
-    return vec.back();
-  }
-
-  const FunctionData* get(nonstd::string_view name, unsigned int num_args) const {
-    auto it = m_map.find(static_cast<std::string>(name));
-    if (it == m_map.end()) return nullptr;
-    for (auto &&i: it->second) {
-      if (i.num_args == num_args) return &i;
-    }
-    return nullptr;
-  }
-
-  std::map<std::string, std::vector<FunctionData>> m_map;
+struct SourceLocation {
+  size_t line;
+  size_t column;
 };
 
-}
+struct InjaError : public std::runtime_error {
+  const std::string type;
+  const std::string message;
 
-#endif // PANTOR_INJA_FUNCTION_STORAGE_HPP
+  const SourceLocation location;
 
-// #include "parser.hpp"
-#ifndef PANTOR_INJA_PARSER_HPP
-#define PANTOR_INJA_PARSER_HPP
+  explicit InjaError(const std::string &type, const std::string &message)
+      : std::runtime_error("[inja.exception." + type + "] " + message), type(type), message(message), location({0, 0}) {}
 
-#include <limits>
+  explicit InjaError(const std::string &type, const std::string &message, SourceLocation location)
+      : std::runtime_error("[inja.exception." + type + "] (at " + std::to_string(location.line) + ":" +
+                           std::to_string(location.column) + ") " + message),
+        type(type), message(message), location(location) {}
+};
 
-// #include "bytecode.hpp"
+struct ParserError : public InjaError {
+  explicit ParserError(const std::string &message, SourceLocation location) : InjaError("parser_error", message, location) {}
+};
 
-// #include "config.hpp"
+struct RenderError : public InjaError {
+  explicit RenderError(const std::string &message, SourceLocation location) : InjaError("render_error", message, location) {}
+};
+
+struct FileError : public InjaError {
+  explicit FileError(const std::string &message) : InjaError("file_error", message) {}
+  explicit FileError(const std::string &message, SourceLocation location) : InjaError("file_error", message, location) {}
+};
+
+struct JsonError : public InjaError {
+  explicit JsonError(const std::string &message, SourceLocation location) : InjaError("json_error", message, location) {}
+};
+
+} // namespace inja
+
+#endif // INCLUDE_INJA_EXCEPTIONS_HPP_
 
 // #include "function_storage.hpp"
 
 // #include "lexer.hpp"
-#ifndef PANTOR_INJA_LEXER_HPP
-#define PANTOR_INJA_LEXER_HPP
+#ifndef INCLUDE_INJA_LEXER_HPP_
+#define INCLUDE_INJA_LEXER_HPP_
 
 #include <cctype>
 #include <locale>
@@ -1625,334 +1771,364 @@ class FunctionStorage {
 // #include "config.hpp"
 
 // #include "token.hpp"
-#ifndef PANTOR_INJA_TOKEN_HPP
-#define PANTOR_INJA_TOKEN_HPP
+#ifndef INCLUDE_INJA_TOKEN_HPP_
+#define INCLUDE_INJA_TOKEN_HPP_
+
+#include <string>
 
 // #include "string_view.hpp"
 
 
-
 namespace inja {
 
+/*!
+ * \brief Helper-class for the inja Lexer.
+ */
 struct Token {
   enum class Kind {
     Text,
-    ExpressionOpen,      // {{
-    ExpressionClose,     // }}
-    LineStatementOpen,   // ##
-    LineStatementClose,  // \n
-    StatementOpen,       // {%
-    StatementClose,      // %}
-    CommentOpen,         // {#
-    CommentClose,        // #}
-    Id,                  // this, this.foo
-    Number,              // 1, 2, -1, 5.2, -5.3
-    String,              // "this"
-    Comma,               // ,
-    Colon,               // :
-    LeftParen,           // (
-    RightParen,          // )
-    LeftBracket,         // [
-    RightBracket,        // ]
-    LeftBrace,           // {
-    RightBrace,          // }
-    Equal,               // ==
-    GreaterThan,         // >
-    GreaterEqual,        // >=
-    LessThan,            // <
-    LessEqual,           // <=
-    NotEqual,            // !=
+    ExpressionOpen,     // {{
+    ExpressionClose,    // }}
+    LineStatementOpen,  // ##
+    LineStatementClose, // \n
+    StatementOpen,      // {%
+    StatementClose,     // %}
+    CommentOpen,        // {#
+    CommentClose,       // #}
+    Id,                 // this, this.foo
+    Number,             // 1, 2, -1, 5.2, -5.3
+    String,             // "this"
+    Plus,               // +
+    Minus,              // -
+    Times,              // *
+    Slash,              // /
+    Percent,            // %
+    Power,              // ^
+    Comma,              // ,
+    Dot,                // .
+    Colon,              // :
+    LeftParen,          // (
+    RightParen,         // )
+    LeftBracket,        // [
+    RightBracket,       // ]
+    LeftBrace,          // {
+    RightBrace,         // }
+    Equal,              // ==
+    NotEqual,           // !=
+    GreaterThan,        // >
+    GreaterEqual,       // >=
+    LessThan,           // <
+    LessEqual,          // <=
     Unknown,
-    Eof
-  } kind {Kind::Unknown};
+    Eof,
+  };
 
+  Kind kind {Kind::Unknown};
   nonstd::string_view text;
 
-  constexpr Token() = default;
-  constexpr Token(Kind kind, nonstd::string_view text): kind(kind), text(text) {}
+  explicit constexpr Token() = default;
+  explicit constexpr Token(Kind kind, nonstd::string_view text) : kind(kind), text(text) {}
 
   std::string describe() const {
     switch (kind) {
-      case Kind::Text:
-        return "<text>";
-      case Kind::LineStatementClose:
-        return "<eol>";
-      case Kind::Eof:
-        return "<eof>";
-      default:
-        return static_cast<std::string>(text);
+    case Kind::Text:
+      return "<text>";
+    case Kind::LineStatementClose:
+      return "<eol>";
+    case Kind::Eof:
+      return "<eof>";
+    default:
+      return static_cast<std::string>(text);
     }
   }
 };
 
-}
+} // namespace inja
 
-#endif // PANTOR_INJA_TOKEN_HPP
+#endif // INCLUDE_INJA_TOKEN_HPP_
 
 // #include "utils.hpp"
-#ifndef PANTOR_INJA_UTILS_HPP
-#define PANTOR_INJA_UTILS_HPP
+#ifndef INCLUDE_INJA_UTILS_HPP_
+#define INCLUDE_INJA_UTILS_HPP_
 
-#include <stdexcept>
+#include <algorithm>
+#include <fstream>
+#include <string>
+#include <utility>
+
+// #include "exceptions.hpp"
 
 // #include "string_view.hpp"
 
 
-
 namespace inja {
 
-inline void inja_throw(const std::string& type, const std::string& message) {
-  throw std::runtime_error("[inja.exception." + type + "] " + message);
+inline void open_file_or_throw(const std::string &path, std::ifstream &file) {
+  file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+#ifndef INJA_NOEXCEPTION
+  try {
+    file.open(path);
+  } catch (const std::ios_base::failure & /*e*/) {
+    INJA_THROW(FileError("failed accessing file at '" + path + "'"));
+  }
+#else
+  file.open(path);
+#endif
 }
 
 namespace string_view {
-  inline nonstd::string_view slice(nonstd::string_view view, size_t start, size_t end) {
-    start = std::min(start, view.size());
-    end = std::min(std::max(start, end), view.size());
-    return view.substr(start, end - start); // StringRef(Data + Start, End - Start);
+inline nonstd::string_view slice(nonstd::string_view view, size_t start, size_t end) {
+  start = std::min(start, view.size());
+  end = std::min(std::max(start, end), view.size());
+  return view.substr(start, end - start);
+}
+
+inline std::pair<nonstd::string_view, nonstd::string_view> split(nonstd::string_view view, char Separator) {
+  size_t idx = view.find(Separator);
+  if (idx == nonstd::string_view::npos) {
+    return std::make_pair(view, nonstd::string_view());
+  }
+  return std::make_pair(slice(view, 0, idx), slice(view, idx + 1, nonstd::string_view::npos));
+}
+
+inline bool starts_with(nonstd::string_view view, nonstd::string_view prefix) {
+  return (view.size() >= prefix.size() && view.compare(0, prefix.size(), prefix) == 0);
+}
+} // namespace string_view
+
+inline SourceLocation get_source_location(nonstd::string_view content, size_t pos) {
+  // Get line and offset position (starts at 1:1)
+  auto sliced = string_view::slice(content, 0, pos);
+  std::size_t last_newline = sliced.rfind("\n");
+
+  if (last_newline == nonstd::string_view::npos) {
+    return {1, sliced.length() + 1};
   }
 
-  inline std::pair<nonstd::string_view, nonstd::string_view> split(nonstd::string_view view, char Separator) {
-    size_t idx = view.find(Separator);
-    if (idx == nonstd::string_view::npos) {
-      return std::make_pair(view, nonstd::string_view());
+  // Count newlines
+  size_t count_lines = 0;
+  size_t search_start = 0;
+  while (search_start <= sliced.size()) {
+    search_start = sliced.find("\n", search_start) + 1;
+    if (search_start == 0) {
+      break;
     }
-    return std::make_pair(slice(view, 0, idx), slice(view, idx + 1, nonstd::string_view::npos));
+    count_lines += 1;
   }
 
-  inline bool starts_with(nonstd::string_view view, nonstd::string_view prefix) {
-    return (view.size() >= prefix.size() && view.compare(0, prefix.size(), prefix) == 0);
-  }
-}  // namespace string
+  return {count_lines + 1, sliced.length() - last_newline};
+}
 
-}  // namespace inja
+inline void replace_substring(std::string& s, const std::string& f,
+                              const std::string& t)
+{
+  if (f.empty()) return;
+  for (auto pos = s.find(f);                  // find first occurrence of f
+            pos != std::string::npos;         // make sure f was found
+            s.replace(pos, f.size(), t),      // replace with t, and
+            pos = s.find(f, pos + t.size()))  // find next occurrence of f
+  {}
+}
 
-#endif  // PANTOR_INJA_UTILS_HPP
+} // namespace inja
 
+#endif // INCLUDE_INJA_UTILS_HPP_
 
 
 namespace inja {
 
+/*!
+ * \brief Class for lexing an inja Template.
+ */
 class Lexer {
   enum class State {
     Text,
     ExpressionStart,
+    ExpressionStartForceLstrip,
     ExpressionBody,
     LineStart,
     LineBody,
     StatementStart,
+    StatementStartNoLstrip,
+    StatementStartForceLstrip,
     StatementBody,
     CommentStart,
-    CommentBody
-  } m_state;
+    CommentStartForceLstrip,
+    CommentBody,
+  };
 
-  const LexerConfig& m_config;
+  enum class MinusState {
+    Operator,
+    Number,
+  };
+
+  const LexerConfig &config;
+
+  State state;
+  MinusState minus_state;
   nonstd::string_view m_in;
-  size_t m_tok_start;
-  size_t m_pos;
+  size_t tok_start;
+  size_t pos;
 
- public:
-  explicit Lexer(const LexerConfig& config) : m_config(config) {}
 
-  void start(nonstd::string_view in) {
-    m_in = in;
-    m_tok_start = 0;
-    m_pos = 0;
-    m_state = State::Text;
-  }
-
-  Token scan() {
-    m_tok_start = m_pos;
-
-  again:
-    if (m_tok_start >= m_in.size()) return make_token(Token::Kind::Eof);
-
-    switch (m_state) {
-      default:
-      case State::Text: {
-        // fast-scan to first open character
-        size_t open_start = m_in.substr(m_pos).find_first_of(m_config.open_chars);
-        if (open_start == nonstd::string_view::npos) {
-          // didn't find open, return remaining text as text token
-          m_pos = m_in.size();
-          return make_token(Token::Kind::Text);
-        }
-        m_pos += open_start;
-
-        // try to match one of the opening sequences, and get the close
-        nonstd::string_view open_str = m_in.substr(m_pos);
-        if (inja::string_view::starts_with(open_str, m_config.expression_open)) {
-          m_state = State::ExpressionStart;
-        } else if (inja::string_view::starts_with(open_str, m_config.statement_open)) {
-          m_state = State::StatementStart;
-        } else if (inja::string_view::starts_with(open_str, m_config.comment_open)) {
-          m_state = State::CommentStart;
-        } else if ((m_pos == 0 || m_in[m_pos - 1] == '\n') &&
-                   inja::string_view::starts_with(open_str, m_config.line_statement)) {
-          m_state = State::LineStart;
-        } else {
-          m_pos += 1; // wasn't actually an opening sequence
-          goto again;
-        }
-        if (m_pos == m_tok_start) goto again;  // don't generate empty token
-        return make_token(Token::Kind::Text);
-      }
-      case State::ExpressionStart: {
-        m_state = State::ExpressionBody;
-        m_pos += m_config.expression_open.size();
-        return make_token(Token::Kind::ExpressionOpen);
-      }
-      case State::LineStart: {
-        m_state = State::LineBody;
-        m_pos += m_config.line_statement.size();
-        return make_token(Token::Kind::LineStatementOpen);
-      }
-      case State::StatementStart: {
-        m_state = State::StatementBody;
-        m_pos += m_config.statement_open.size();
-        return make_token(Token::Kind::StatementOpen);
-      }
-      case State::CommentStart: {
-        m_state = State::CommentBody;
-        m_pos += m_config.comment_open.size();
-        return make_token(Token::Kind::CommentOpen);
-      }
-      case State::ExpressionBody:
-        return scan_body(m_config.expression_close, Token::Kind::ExpressionClose);
-      case State::LineBody:
-        return scan_body("\n", Token::Kind::LineStatementClose);
-      case State::StatementBody:
-        return scan_body(m_config.statement_close, Token::Kind::StatementClose);
-      case State::CommentBody: {
-        // fast-scan to comment close
-        size_t end = m_in.substr(m_pos).find(m_config.comment_close);
-        if (end == nonstd::string_view::npos) {
-          m_pos = m_in.size();
-          return make_token(Token::Kind::Eof);
-        }
-        // return the entire comment in the close token
-        m_state = State::Text;
-        m_pos += end + m_config.comment_close.size();
-        return make_token(Token::Kind::CommentClose);
-      }
-    }
-  }
-
-  const LexerConfig& get_config() const { return m_config; }
-
- private:
-  Token scan_body(nonstd::string_view close, Token::Kind closeKind) {
+  Token scan_body(nonstd::string_view close, Token::Kind closeKind, nonstd::string_view close_trim = nonstd::string_view(), bool trim = false) {
   again:
     // skip whitespace (except for \n as it might be a close)
-    if (m_tok_start >= m_in.size()) return make_token(Token::Kind::Eof);
-    char ch = m_in[m_tok_start];
+    if (tok_start >= m_in.size()) {
+      return make_token(Token::Kind::Eof);
+    }
+    const char ch = m_in[tok_start];
     if (ch == ' ' || ch == '\t' || ch == '\r') {
-      m_tok_start += 1;
+      tok_start += 1;
       goto again;
     }
 
     // check for close
-    if (inja::string_view::starts_with(m_in.substr(m_tok_start), close)) {
-      m_state = State::Text;
-      m_pos = m_tok_start + close.size();
-      return make_token(closeKind);
+    if (!close_trim.empty() && inja::string_view::starts_with(m_in.substr(tok_start), close_trim)) {
+      state = State::Text;
+      pos = tok_start + close_trim.size();
+      const Token tok = make_token(closeKind);
+      skip_whitespaces_and_newlines();
+      return tok;
+    }
+
+    if (inja::string_view::starts_with(m_in.substr(tok_start), close)) {
+      state = State::Text;
+      pos = tok_start + close.size();
+      const Token tok = make_token(closeKind);
+      if (trim) {
+        skip_whitespaces_and_first_newline();
+      }
+      return tok;
     }
 
     // skip \n
     if (ch == '\n') {
-      m_tok_start += 1;
+      tok_start += 1;
       goto again;
     }
 
-    m_pos = m_tok_start + 1;
-    if (std::isalpha(ch)) return scan_id();
+    pos = tok_start + 1;
+    if (std::isalpha(ch)) {
+      minus_state = MinusState::Operator;
+      return scan_id();
+    }
+
+    const MinusState current_minus_state = minus_state;
+    if (minus_state == MinusState::Operator) {
+      minus_state = MinusState::Number;
+    }
+
     switch (ch) {
-      case ',':
-        return make_token(Token::Kind::Comma);
-      case ':':
-        return make_token(Token::Kind::Colon);
-      case '(':
-        return make_token(Token::Kind::LeftParen);
-      case ')':
-        return make_token(Token::Kind::RightParen);
-      case '[':
-        return make_token(Token::Kind::LeftBracket);
-      case ']':
-        return make_token(Token::Kind::RightBracket);
-      case '{':
-        return make_token(Token::Kind::LeftBrace);
-      case '}':
-        return make_token(Token::Kind::RightBrace);
-      case '>':
-        if (m_pos < m_in.size() && m_in[m_pos] == '=') {
-          m_pos += 1;
-          return make_token(Token::Kind::GreaterEqual);
-        }
-        return make_token(Token::Kind::GreaterThan);
-      case '<':
-        if (m_pos < m_in.size() && m_in[m_pos] == '=') {
-          m_pos += 1;
-          return make_token(Token::Kind::LessEqual);
-        }
-        return make_token(Token::Kind::LessThan);
-      case '=':
-        if (m_pos < m_in.size() && m_in[m_pos] == '=') {
-          m_pos += 1;
-          return make_token(Token::Kind::Equal);
-        }
-        return make_token(Token::Kind::Unknown);
-      case '!':
-        if (m_pos < m_in.size() && m_in[m_pos] == '=') {
-          m_pos += 1;
-          return make_token(Token::Kind::NotEqual);
-        }
-        return make_token(Token::Kind::Unknown);
-      case '\"':
-        return scan_string();
-      case '0':
-      case '1':
-      case '2':
-      case '3':
-      case '4':
-      case '5':
-      case '6':
-      case '7':
-      case '8':
-      case '9':
-      case '-':
-        return scan_number();
-      case '_':
-        return scan_id();
-      default:
-        return make_token(Token::Kind::Unknown);
+    case '+':
+      return make_token(Token::Kind::Plus);
+    case '-':
+      if (current_minus_state == MinusState::Operator) {
+        return make_token(Token::Kind::Minus);
+      }
+      return scan_number();
+    case '*':
+      return make_token(Token::Kind::Times);
+    case '/':
+      return make_token(Token::Kind::Slash);
+    case '^':
+      return make_token(Token::Kind::Power);
+    case '%':
+      return make_token(Token::Kind::Percent);
+    case '.':
+      return make_token(Token::Kind::Dot);
+    case ',':
+      return make_token(Token::Kind::Comma);
+    case ':':
+      return make_token(Token::Kind::Colon);
+    case '(':
+      return make_token(Token::Kind::LeftParen);
+    case ')':
+      minus_state = MinusState::Operator;
+      return make_token(Token::Kind::RightParen);
+    case '[':
+      return make_token(Token::Kind::LeftBracket);
+    case ']':
+      minus_state = MinusState::Operator;
+      return make_token(Token::Kind::RightBracket);
+    case '{':
+      return make_token(Token::Kind::LeftBrace);
+    case '}':
+      minus_state = MinusState::Operator;
+      return make_token(Token::Kind::RightBrace);
+    case '>':
+      if (pos < m_in.size() && m_in[pos] == '=') {
+        pos += 1;
+        return make_token(Token::Kind::GreaterEqual);
+      }
+      return make_token(Token::Kind::GreaterThan);
+    case '<':
+      if (pos < m_in.size() && m_in[pos] == '=') {
+        pos += 1;
+        return make_token(Token::Kind::LessEqual);
+      }
+      return make_token(Token::Kind::LessThan);
+    case '=':
+      if (pos < m_in.size() && m_in[pos] == '=') {
+        pos += 1;
+        return make_token(Token::Kind::Equal);
+      }
+      return make_token(Token::Kind::Unknown);
+    case '!':
+      if (pos < m_in.size() && m_in[pos] == '=') {
+        pos += 1;
+        return make_token(Token::Kind::NotEqual);
+      }
+      return make_token(Token::Kind::Unknown);
+    case '\"':
+      return scan_string();
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      minus_state = MinusState::Operator;
+      return scan_number();
+    case '_':
+    case '@':
+    case '$':
+      minus_state = MinusState::Operator;
+      return scan_id();
+    default:
+      return make_token(Token::Kind::Unknown);
     }
   }
 
   Token scan_id() {
     for (;;) {
-      if (m_pos >= m_in.size()) {
+      if (pos >= m_in.size()) {
         break;
       }
-      char ch = m_in[m_pos];
+      const char ch = m_in[pos];
       if (!std::isalnum(ch) && ch != '.' && ch != '/' && ch != '_' && ch != '-') {
         break;
       }
-      m_pos += 1;
+      pos += 1;
     }
     return make_token(Token::Kind::Id);
   }
 
   Token scan_number() {
     for (;;) {
-      if (m_pos >= m_in.size()) {
+      if (pos >= m_in.size()) {
         break;
       }
-      char ch = m_in[m_pos];
+      const char ch = m_in[pos];
       // be very permissive in lexer (we'll catch errors when conversion happens)
       if (!std::isdigit(ch) && ch != '.' && ch != 'e' && ch != 'E' && ch != '+' && ch != '-') {
         break;
       }
-      m_pos += 1;
+      pos += 1;
     }
     return make_token(Token::Kind::Number);
   }
@@ -1960,11 +2136,13 @@ class Lexer {
   Token scan_string() {
     bool escape {false};
     for (;;) {
-      if (m_pos >= m_in.size()) break;
-      char ch = m_in[m_pos++];
+      if (pos >= m_in.size()) {
+        break;
+      }
+      const char ch = m_in[pos++];
       if (ch == '\\') {
         escape = true;
-      } else if (!escape && ch == m_in[m_tok_start]) {
+      } else if (!escape && ch == m_in[tok_start]) {
         break;
       } else {
         escape = false;
@@ -1973,38 +2151,709 @@ class Lexer {
     return make_token(Token::Kind::String);
   }
 
-  Token make_token(Token::Kind kind) const {
-    return Token(kind, string_view::slice(m_in, m_tok_start, m_pos));
+  Token make_token(Token::Kind kind) const { return Token(kind, string_view::slice(m_in, tok_start, pos)); }
+
+  void skip_whitespaces_and_newlines() {
+    if (pos < m_in.size()) {
+      while (pos < m_in.size() && (m_in[pos] == ' ' || m_in[pos] == '\t' || m_in[pos] == '\n' || m_in[pos] == '\r')) {
+        pos += 1;
+      }
+    }
+  }
+
+  void skip_whitespaces_and_first_newline() {
+    if (pos < m_in.size()) {
+      while (pos < m_in.size() && (m_in[pos] == ' ' || m_in[pos] == '\t')) {
+        pos += 1;
+      }
+    }
+
+    if (pos < m_in.size()) {
+      const char ch = m_in[pos];
+      if (ch == '\n') {
+        pos += 1;
+      } else if (ch == '\r') {
+        pos += 1;
+        if (pos < m_in.size() && m_in[pos] == '\n') {
+          pos += 1;
+        }
+      }
+    }
+  }
+
+  static nonstd::string_view clear_final_line_if_whitespace(nonstd::string_view text) {
+    nonstd::string_view result = text;
+    while (!result.empty()) {
+      const char ch = result.back();
+      if (ch == ' ' || ch == '\t') {
+        result.remove_suffix(1);
+      } else if (ch == '\n' || ch == '\r') {
+        break;
+      } else {
+        return text;
+      }
+    }
+    return result;
+  }
+
+public:
+  explicit Lexer(const LexerConfig &config) : config(config), state(State::Text), minus_state(MinusState::Number) {}
+
+  SourceLocation current_position() const {
+    return get_source_location(m_in, tok_start);
+  }
+
+  void start(nonstd::string_view input) {
+    m_in = input;
+    tok_start = 0;
+    pos = 0;
+    state = State::Text;
+    minus_state = MinusState::Number;
+
+    // Consume byte order mark (BOM) for UTF-8
+    if (inja::string_view::starts_with(m_in, "\xEF\xBB\xBF")) {
+      m_in = m_in.substr(3);
+    }
+  }
+
+  Token scan() {
+    tok_start = pos;
+
+  again:
+    if (tok_start >= m_in.size()) {
+      return make_token(Token::Kind::Eof);
+    }
+
+    switch (state) {
+    default:
+    case State::Text: {
+      // fast-scan to first open character
+      const size_t open_start = m_in.substr(pos).find_first_of(config.open_chars);
+      if (open_start == nonstd::string_view::npos) {
+        // didn't find open, return remaining text as text token
+        pos = m_in.size();
+        return make_token(Token::Kind::Text);
+      }
+      pos += open_start;
+
+      // try to match one of the opening sequences, and get the close
+      nonstd::string_view open_str = m_in.substr(pos);
+      bool must_lstrip = false;
+      if (inja::string_view::starts_with(open_str, config.expression_open)) {
+        if (inja::string_view::starts_with(open_str, config.expression_open_force_lstrip)) {
+          state = State::ExpressionStartForceLstrip;
+          must_lstrip = true;
+        } else {
+          state = State::ExpressionStart;
+        }
+      } else if (inja::string_view::starts_with(open_str, config.statement_open)) {
+        if (inja::string_view::starts_with(open_str, config.statement_open_no_lstrip)) {
+          state = State::StatementStartNoLstrip;
+        } else if (inja::string_view::starts_with(open_str, config.statement_open_force_lstrip )) {
+          state = State::StatementStartForceLstrip;
+          must_lstrip = true;
+        } else {
+          state = State::StatementStart;
+          must_lstrip = config.lstrip_blocks;
+        }
+      } else if (inja::string_view::starts_with(open_str, config.comment_open)) {
+        if (inja::string_view::starts_with(open_str, config.comment_open_force_lstrip)) {
+          state = State::CommentStartForceLstrip;
+          must_lstrip = true;
+        } else {
+          state = State::CommentStart;
+          must_lstrip = config.lstrip_blocks;
+        }
+      } else if ((pos == 0 || m_in[pos - 1] == '\n') && inja::string_view::starts_with(open_str, config.line_statement)) {
+        state = State::LineStart;
+      } else {
+        pos += 1; // wasn't actually an opening sequence
+        goto again;
+      }
+
+      nonstd::string_view text = string_view::slice(m_in, tok_start, pos);
+      if (must_lstrip) {
+        text = clear_final_line_if_whitespace(text);
+      }
+
+      if (text.empty()) {
+        goto again; // don't generate empty token
+      }
+      return Token(Token::Kind::Text, text);
+    }
+    case State::ExpressionStart: {
+      state = State::ExpressionBody;
+      pos += config.expression_open.size();
+      return make_token(Token::Kind::ExpressionOpen);
+    }
+    case State::ExpressionStartForceLstrip: {
+      state = State::ExpressionBody;
+      pos += config.expression_open_force_lstrip.size();
+      return make_token(Token::Kind::ExpressionOpen);
+    }
+    case State::LineStart: {
+      state = State::LineBody;
+      pos += config.line_statement.size();
+      return make_token(Token::Kind::LineStatementOpen);
+    }
+    case State::StatementStart: {
+      state = State::StatementBody;
+      pos += config.statement_open.size();
+      return make_token(Token::Kind::StatementOpen);
+    }
+    case State::StatementStartNoLstrip: {
+      state = State::StatementBody;
+      pos += config.statement_open_no_lstrip.size();
+      return make_token(Token::Kind::StatementOpen);
+    }
+    case State::StatementStartForceLstrip: {
+      state = State::StatementBody;
+      pos += config.statement_open_force_lstrip.size();
+      return make_token(Token::Kind::StatementOpen);
+    }
+    case State::CommentStart: {
+      state = State::CommentBody;
+      pos += config.comment_open.size();
+      return make_token(Token::Kind::CommentOpen);
+    }
+    case State::CommentStartForceLstrip: {
+      state = State::CommentBody;
+      pos += config.comment_open_force_lstrip.size();
+      return make_token(Token::Kind::CommentOpen);
+    }
+    case State::ExpressionBody:
+      return scan_body(config.expression_close, Token::Kind::ExpressionClose, config.expression_close_force_rstrip);
+    case State::LineBody:
+      return scan_body("\n", Token::Kind::LineStatementClose);
+    case State::StatementBody:
+      return scan_body(config.statement_close, Token::Kind::StatementClose, config.statement_close_force_rstrip, config.trim_blocks);
+    case State::CommentBody: {
+      // fast-scan to comment close
+      const size_t end = m_in.substr(pos).find(config.comment_close);
+      if (end == nonstd::string_view::npos) {
+        pos = m_in.size();
+        return make_token(Token::Kind::Eof);
+      }
+
+      // Check for trim pattern
+      const bool must_rstrip = inja::string_view::starts_with(m_in.substr(pos + end - 1), config.comment_close_force_rstrip);
+
+      // return the entire comment in the close token
+      state = State::Text;
+      pos += end + config.comment_close.size();
+      Token tok = make_token(Token::Kind::CommentClose);
+
+      if (must_rstrip || config.trim_blocks) {
+        skip_whitespaces_and_first_newline();
+      }
+      return tok;
+    }
+    }
+  }
+
+  const LexerConfig &get_config() const {
+    return config;
   }
 };
 
-}
+} // namespace inja
 
-#endif // PANTOR_INJA_LEXER_HPP
+#endif // INCLUDE_INJA_LEXER_HPP_
 
-// #include "template.hpp"
-#ifndef PANTOR_INJA_TEMPLATE_HPP
-#define PANTOR_INJA_TEMPLATE_HPP
+// #include "node.hpp"
+#ifndef INCLUDE_INJA_NODE_HPP_
+#define INCLUDE_INJA_NODE_HPP_
 
 #include <string>
-#include <vector>
+#include <utility>
 
-// #include "bytecode.hpp"
+#include <nlohmann/json.hpp>
+
+// #include "function_storage.hpp"
+
+// #include "string_view.hpp"
 
 
 
 namespace inja {
 
+class NodeVisitor;
+class BlockNode;
+class TextNode;
+class ExpressionNode;
+class LiteralNode;
+class JsonNode;
+class FunctionNode;
+class ExpressionListNode;
+class StatementNode;
+class ForStatementNode;
+class ForArrayStatementNode;
+class ForObjectStatementNode;
+class IfStatementNode;
+class IncludeStatementNode;
+class ExtendsStatementNode;
+class BlockStatementNode;
+class SetStatementNode;
+
+
+class NodeVisitor {
+public:
+  virtual ~NodeVisitor() = default;
+
+  virtual void visit(const BlockNode& node) = 0;
+  virtual void visit(const TextNode& node) = 0;
+  virtual void visit(const ExpressionNode& node) = 0;
+  virtual void visit(const LiteralNode& node) = 0;
+  virtual void visit(const JsonNode& node) = 0;
+  virtual void visit(const FunctionNode& node) = 0;
+  virtual void visit(const ExpressionListNode& node) = 0;
+  virtual void visit(const StatementNode& node) = 0;
+  virtual void visit(const ForStatementNode& node) = 0;
+  virtual void visit(const ForArrayStatementNode& node) = 0;
+  virtual void visit(const ForObjectStatementNode& node) = 0;
+  virtual void visit(const IfStatementNode& node) = 0;
+  virtual void visit(const IncludeStatementNode& node) = 0;
+  virtual void visit(const ExtendsStatementNode& node) = 0;
+  virtual void visit(const BlockStatementNode& node) = 0;
+  virtual void visit(const SetStatementNode& node) = 0;
+};
+
+/*!
+ * \brief Base node class for the abstract syntax tree (AST).
+ */
+class AstNode {
+public:
+  virtual void accept(NodeVisitor& v) const = 0;
+
+  size_t pos;
+
+  AstNode(size_t pos) : pos(pos) { }
+  virtual ~AstNode() { }
+};
+
+
+class BlockNode : public AstNode {
+public:
+  std::vector<std::shared_ptr<AstNode>> nodes;
+
+  explicit BlockNode() : AstNode(0) {}
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class TextNode : public AstNode {
+public:
+  const size_t length;
+
+  explicit TextNode(size_t pos, size_t length): AstNode(pos), length(length) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class ExpressionNode : public AstNode {
+public:
+  explicit ExpressionNode(size_t pos) : AstNode(pos) {}
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class LiteralNode : public ExpressionNode {
+public:
+  const nlohmann::json value;
+
+  explicit LiteralNode(const nlohmann::json& value, size_t pos) : ExpressionNode(pos), value(value) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class JsonNode : public ExpressionNode {
+public:
+  const std::string name;
+  const json::json_pointer ptr;
+
+  static std::string convert_dot_to_json_ptr(nonstd::string_view ptr_name) {
+    std::string result;
+    do {
+      nonstd::string_view part;
+      std::tie(part, ptr_name) = string_view::split(ptr_name, '.');
+      result.push_back('/');
+      result.append(part.begin(), part.end());
+    } while (!ptr_name.empty());
+    return result;
+  }
+
+  explicit JsonNode(nonstd::string_view ptr_name, size_t pos) : ExpressionNode(pos), name(ptr_name), ptr(json::json_pointer(convert_dot_to_json_ptr(ptr_name))) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class FunctionNode : public ExpressionNode {
+  using Op = FunctionStorage::Operation;
+
+public:
+  enum class Associativity {
+    Left,
+    Right,
+  };
+
+  unsigned int precedence;
+  Associativity associativity;
+
+  Op operation;
+
+  std::string name;
+  int number_args; // Should also be negative -> -1 for unknown number
+  std::vector<std::shared_ptr<ExpressionNode>> arguments;
+  CallbackFunction callback;
+
+  explicit FunctionNode(nonstd::string_view name, size_t pos) : ExpressionNode(pos), precedence(8), associativity(Associativity::Left), operation(Op::Callback), name(name), number_args(1) { }
+  explicit FunctionNode(Op operation, size_t pos) : ExpressionNode(pos), operation(operation), number_args(1) {
+    switch (operation) {
+      case Op::Not: {
+        number_args = 1;
+        precedence = 4;
+        associativity = Associativity::Left;
+      } break;
+      case Op::And: {
+        number_args = 2;
+        precedence = 1;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Or: {
+        number_args = 2;
+        precedence = 1;
+        associativity = Associativity::Left;
+      } break;
+      case Op::In: {
+        number_args = 2;
+        precedence = 2;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Equal: {
+        number_args = 2;
+        precedence = 2;
+        associativity = Associativity::Left;
+      } break;
+      case Op::NotEqual: {
+        number_args = 2;
+        precedence = 2;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Greater: {
+        number_args = 2;
+        precedence = 2;
+        associativity = Associativity::Left;
+      } break;
+      case Op::GreaterEqual: {
+        number_args = 2;
+        precedence = 2;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Less: {
+        number_args = 2;
+        precedence = 2;
+        associativity = Associativity::Left;
+      } break;
+      case Op::LessEqual: {
+        number_args = 2;
+        precedence = 2;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Add: {
+        number_args = 2;
+        precedence = 3;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Subtract: {
+        number_args = 2;
+        precedence = 3;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Multiplication: {
+        number_args = 2;
+        precedence = 4;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Division: {
+        number_args = 2;
+        precedence = 4;
+        associativity = Associativity::Left;
+      } break;
+      case Op::Power: {
+        number_args = 2;
+        precedence = 5;
+        associativity = Associativity::Right;
+      } break;
+      case Op::Modulo: {
+        number_args = 2;
+        precedence = 4;
+        associativity = Associativity::Left;
+      } break;
+      case Op::AtId: {
+        number_args = 2;
+        precedence = 8;
+        associativity = Associativity::Left;
+      } break;
+      default: {
+        precedence = 1;
+        associativity = Associativity::Left;
+      }
+    }
+  }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class ExpressionListNode : public AstNode {
+public:
+  std::shared_ptr<ExpressionNode> root;
+
+  explicit ExpressionListNode() : AstNode(0) { }
+  explicit ExpressionListNode(size_t pos) : AstNode(pos) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class StatementNode : public AstNode {
+public:
+  StatementNode(size_t pos) : AstNode(pos) { }
+
+  virtual void accept(NodeVisitor& v) const = 0;
+};
+
+class ForStatementNode : public StatementNode {
+public:
+  ExpressionListNode condition;
+  BlockNode body;
+  BlockNode *const parent;
+
+  ForStatementNode(BlockNode *const parent, size_t pos) : StatementNode(pos), parent(parent) { }
+
+  virtual void accept(NodeVisitor& v) const = 0;
+};
+
+class ForArrayStatementNode : public ForStatementNode {
+public:
+  const std::string value;
+
+  explicit ForArrayStatementNode(const std::string& value, BlockNode *const parent, size_t pos) : ForStatementNode(parent, pos), value(value) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class ForObjectStatementNode : public ForStatementNode {
+public:
+  const std::string key;
+  const std::string value;
+
+  explicit ForObjectStatementNode(const std::string& key, const std::string& value, BlockNode *const parent, size_t pos) : ForStatementNode(parent, pos), key(key), value(value) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class IfStatementNode : public StatementNode {
+public:
+  ExpressionListNode condition;
+  BlockNode true_statement;
+  BlockNode false_statement;
+  BlockNode *const parent;
+
+  const bool is_nested;
+  bool has_false_statement {false};
+
+  explicit IfStatementNode(BlockNode *const parent, size_t pos) : StatementNode(pos), parent(parent), is_nested(false) { }
+  explicit IfStatementNode(bool is_nested, BlockNode *const parent, size_t pos) : StatementNode(pos), parent(parent), is_nested(is_nested) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class IncludeStatementNode : public StatementNode {
+public:
+  const std::string file;
+
+  explicit IncludeStatementNode(const std::string& file, size_t pos) : StatementNode(pos), file(file) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+class ExtendsStatementNode : public StatementNode {
+public:
+  const std::string file;
+
+  explicit ExtendsStatementNode(const std::string& file, size_t pos) : StatementNode(pos), file(file) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  };
+};
+
+class BlockStatementNode : public StatementNode {
+public:
+  const std::string name;
+  BlockNode block;
+  BlockNode *const parent;
+
+  explicit BlockStatementNode(BlockNode *const parent, const std::string& name, size_t pos) : StatementNode(pos), name(name), parent(parent) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  };
+};
+
+class SetStatementNode : public StatementNode {
+public:
+  const std::string key;
+  ExpressionListNode expression;
+
+  explicit SetStatementNode(const std::string& key, size_t pos) : StatementNode(pos), key(key) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  }
+};
+
+} // namespace inja
+
+#endif // INCLUDE_INJA_NODE_HPP_
+
+// #include "template.hpp"
+#ifndef INCLUDE_INJA_TEMPLATE_HPP_
+#define INCLUDE_INJA_TEMPLATE_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+// #include "node.hpp"
+
+// #include "statistics.hpp"
+#ifndef INCLUDE_INJA_STATISTICS_HPP_
+#define INCLUDE_INJA_STATISTICS_HPP_
+
+// #include "node.hpp"
+
+
+
+namespace inja {
+
+/*!
+ * \brief A class for counting statistics on a Template.
+ */
+class StatisticsVisitor : public NodeVisitor {
+  void visit(const BlockNode& node) {
+    for (auto& n : node.nodes) {
+      n->accept(*this);
+    }
+  }
+
+  void visit(const TextNode&) { }
+  void visit(const ExpressionNode&) { }
+  void visit(const LiteralNode&) { }
+
+  void visit(const JsonNode&) {
+    variable_counter += 1;
+  }
+
+  void visit(const FunctionNode& node) {
+    for (auto& n : node.arguments) {
+      n->accept(*this);
+    }
+  }
+
+  void visit(const ExpressionListNode& node) {
+    node.root->accept(*this);
+  }
+
+  void visit(const StatementNode&) { }
+  void visit(const ForStatementNode&) { }
+
+  void visit(const ForArrayStatementNode& node) {
+    node.condition.accept(*this);
+    node.body.accept(*this);
+  }
+
+  void visit(const ForObjectStatementNode& node) {
+    node.condition.accept(*this);
+    node.body.accept(*this);
+  }
+
+  void visit(const IfStatementNode& node) {
+    node.condition.accept(*this);
+    node.true_statement.accept(*this);
+    node.false_statement.accept(*this);
+  }
+
+  void visit(const IncludeStatementNode&) { }
+
+  void visit(const ExtendsStatementNode&) { }
+
+  void visit(const BlockStatementNode& node) {
+    node.block.accept(*this);
+  }
+
+  void visit(const SetStatementNode&) { }
+
+public:
+  unsigned int variable_counter;
+
+  explicit StatisticsVisitor() : variable_counter(0) { }
+};
+
+} // namespace inja
+
+#endif // INCLUDE_INJA_STATISTICS_HPP_
+
+
+
+namespace inja {
+
+/*!
+ * \brief The main inja Template.
+ */
 struct Template {
-  std::vector<Bytecode> bytecodes;
+  BlockNode root;
   std::string content;
+  std::map<std::string, std::shared_ptr<BlockStatementNode>> block_storage;
+
+  explicit Template() { }
+  explicit Template(const std::string& content): content(content) { }
+
+  /// Return number of variables (total number, not distinct ones) in the template
+  int count_variables() {
+    auto statistic_visitor = StatisticsVisitor();
+    root.accept(statistic_visitor);
+    return statistic_visitor.variable_counter;
+  }
 };
 
 using TemplateStorage = std::map<std::string, Template>;
 
-}
+} // namespace inja
 
-#endif // PANTOR_INJA_TEMPLATE_HPP
+#endif // INCLUDE_INJA_TEMPLATE_HPP_
 
 // #include "token.hpp"
 
@@ -2013,479 +2862,604 @@ using TemplateStorage = std::map<std::string, Template>;
 
 #include <nlohmann/json.hpp>
 
-
 namespace inja {
 
-class ParserStatic {
-  ParserStatic() {
-    functions.add_builtin("at", 2, Bytecode::Op::At);
-    functions.add_builtin("default", 2, Bytecode::Op::Default);
-    functions.add_builtin("divisibleBy", 2, Bytecode::Op::DivisibleBy);
-    functions.add_builtin("even", 1, Bytecode::Op::Even);
-    functions.add_builtin("first", 1, Bytecode::Op::First);
-    functions.add_builtin("float", 1, Bytecode::Op::Float);
-    functions.add_builtin("int", 1, Bytecode::Op::Int);
-    functions.add_builtin("last", 1, Bytecode::Op::Last);
-    functions.add_builtin("length", 1, Bytecode::Op::Length);
-    functions.add_builtin("lower", 1, Bytecode::Op::Lower);
-    functions.add_builtin("max", 1, Bytecode::Op::Max);
-    functions.add_builtin("min", 1, Bytecode::Op::Min);
-    functions.add_builtin("odd", 1, Bytecode::Op::Odd);
-    functions.add_builtin("range", 1, Bytecode::Op::Range);
-    functions.add_builtin("round", 2, Bytecode::Op::Round);
-    functions.add_builtin("sort", 1, Bytecode::Op::Sort);
-    functions.add_builtin("upper", 1, Bytecode::Op::Upper);
-    functions.add_builtin("exists", 1, Bytecode::Op::Exists);
-    functions.add_builtin("existsIn", 2, Bytecode::Op::ExistsInObject);
-    functions.add_builtin("isBoolean", 1, Bytecode::Op::IsBoolean);
-    functions.add_builtin("isNumber", 1, Bytecode::Op::IsNumber);
-    functions.add_builtin("isInteger", 1, Bytecode::Op::IsInteger);
-    functions.add_builtin("isFloat", 1, Bytecode::Op::IsFloat);
-    functions.add_builtin("isObject", 1, Bytecode::Op::IsObject);
-    functions.add_builtin("isArray", 1, Bytecode::Op::IsArray);
-    functions.add_builtin("isString", 1, Bytecode::Op::IsString);
-  }
-
- public:
-  ParserStatic(const ParserStatic&) = delete;
-  ParserStatic& operator=(const ParserStatic&) = delete;
-
-  static const ParserStatic& get_instance() {
-    static ParserStatic inst;
-    return inst;
-  }
-
-  FunctionStorage functions;
-};
-
+/*!
+ * \brief Class for parsing an inja Template.
+ */
 class Parser {
- public:
-  explicit Parser(const ParserConfig& parser_config, const LexerConfig& lexer_config, TemplateStorage& included_templates): m_config(parser_config), m_lexer(lexer_config), m_included_templates(included_templates), m_static(ParserStatic::get_instance()) { }
+  const ParserConfig &config;
 
-  bool parse_expression(Template& tmpl) {
-    if (!parse_expression_and(tmpl)) return false;
-    if (m_tok.kind != Token::Kind::Id || m_tok.text != static_cast<decltype(m_tok.text)>("or")) return true;
-    get_next_token();
-    if (!parse_expression_and(tmpl)) return false;
-    append_function(tmpl, Bytecode::Op::Or, 2);
-    return true;
+  Lexer lexer;
+  TemplateStorage &template_storage;
+  const FunctionStorage &function_storage;
+
+  Token tok, peek_tok;
+  bool have_peek_tok {false};
+
+  size_t current_paren_level {0};
+  size_t current_bracket_level {0};
+  size_t current_brace_level {0};
+
+  nonstd::string_view json_literal_start;
+
+  BlockNode *current_block {nullptr};
+  ExpressionListNode *current_expression_list {nullptr};
+  std::stack<std::pair<FunctionNode*, size_t>> function_stack;
+  std::vector<std::shared_ptr<ExpressionNode>> arguments;
+
+  std::stack<std::shared_ptr<FunctionNode>> operator_stack;
+  std::stack<IfStatementNode*> if_statement_stack;
+  std::stack<ForStatementNode*> for_statement_stack;
+  std::stack<BlockStatementNode*> block_statement_stack;
+
+  inline void throw_parser_error(const std::string &message) {
+    INJA_THROW(ParserError(message, lexer.current_position()));
   }
 
-  bool parse_expression_and(Template& tmpl) {
-    if (!parse_expression_not(tmpl)) return false;
-    if (m_tok.kind != Token::Kind::Id || m_tok.text != static_cast<decltype(m_tok.text)>("and")) return true;
-    get_next_token();
-    if (!parse_expression_not(tmpl)) return false;
-    append_function(tmpl, Bytecode::Op::And, 2);
-    return true;
-  }
-
-  bool parse_expression_not(Template& tmpl) {
-    if (m_tok.kind == Token::Kind::Id && m_tok.text == static_cast<decltype(m_tok.text)>("not")) {
-      get_next_token();
-      if (!parse_expression_not(tmpl)) return false;
-      append_function(tmpl, Bytecode::Op::Not, 1);
-      return true;
+  inline void get_next_token() {
+    if (have_peek_tok) {
+      tok = peek_tok;
+      have_peek_tok = false;
     } else {
-      return parse_expression_comparison(tmpl);
+      tok = lexer.scan();
     }
   }
 
-  bool parse_expression_comparison(Template& tmpl) {
-    if (!parse_expression_datum(tmpl)) return false;
-    Bytecode::Op op;
-    switch (m_tok.kind) {
-      case Token::Kind::Id:
-        if (m_tok.text == static_cast<decltype(m_tok.text)>("in"))
-          op = Bytecode::Op::In;
-        else
-          return true;
-        break;
-      case Token::Kind::Equal:
-        op = Bytecode::Op::Equal;
-        break;
-      case Token::Kind::GreaterThan:
-        op = Bytecode::Op::Greater;
-        break;
-      case Token::Kind::LessThan:
-        op = Bytecode::Op::Less;
-        break;
-      case Token::Kind::LessEqual:
-        op = Bytecode::Op::LessEqual;
-        break;
-      case Token::Kind::GreaterEqual:
-        op = Bytecode::Op::GreaterEqual;
-        break;
-      case Token::Kind::NotEqual:
-        op = Bytecode::Op::Different;
-        break;
-      default:
-        return true;
+  inline void get_peek_token() {
+    if (!have_peek_tok) {
+      peek_tok = lexer.scan();
+      have_peek_tok = true;
     }
-    get_next_token();
-    if (!parse_expression_datum(tmpl)) return false;
-    append_function(tmpl, op, 2);
-    return true;
   }
 
-  bool parse_expression_datum(Template& tmpl) {
-    nonstd::string_view json_first;
-    size_t bracket_level = 0;
-    size_t brace_level = 0;
+  inline void add_json_literal(const char* content_ptr) {
+    nonstd::string_view json_text(json_literal_start.data(), tok.text.data() - json_literal_start.data() + tok.text.size());
+    arguments.emplace_back(std::make_shared<LiteralNode>(json::parse(json_text), json_text.data() - content_ptr));
+  }
 
-    for (;;) {
-      switch (m_tok.kind) {
-        case Token::Kind::LeftParen: {
-          get_next_token();
-          if (!parse_expression(tmpl)) return false;
-          if (m_tok.kind != Token::Kind::RightParen) {
-            inja_throw("parser_error", "unmatched '('");
-          }
-          get_next_token();
-          return true;
+  inline void add_operator() {
+    auto function = operator_stack.top();
+    operator_stack.pop();
+
+    for (int i = 0; i < function->number_args; ++i) {
+      function->arguments.insert(function->arguments.begin(), arguments.back());
+      arguments.pop_back();
+    }
+    arguments.emplace_back(function);
+  }
+
+  void add_to_template_storage(nonstd::string_view path, std::string& template_name) {
+    if (config.search_included_templates_in_files && template_storage.find(template_name) == template_storage.end()) {
+      // Build the relative path
+      template_name = static_cast<std::string>(path) + template_name;
+      if (template_name.compare(0, 2, "./") == 0) {
+        template_name.erase(0, 2);
+      }
+
+      if (template_storage.find(template_name) == template_storage.end()) {
+        auto include_template = Template(load_file(template_name));
+        template_storage.emplace(template_name, include_template);
+        parse_into_template(template_storage[template_name], template_name);
+      }
+    }
+  }
+
+  bool parse_expression(Template &tmpl, Token::Kind closing) {
+    while (tok.kind != closing && tok.kind != Token::Kind::Eof) {
+      // Literals
+      switch (tok.kind) {
+      case Token::Kind::String: {
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          json_literal_start = tok.text;
+          add_json_literal(tmpl.content.c_str());
         }
-        case Token::Kind::Id:
-          get_peek_token();
-          if (m_peek_tok.kind == Token::Kind::LeftParen) {
-            // function call, parse arguments
-            Token func_token = m_tok;
-            get_next_token();  // id
-            get_next_token();  // leftParen
-            unsigned int num_args = 0;
-            if (m_tok.kind == Token::Kind::RightParen) {
-              // no args
-              get_next_token();
-            } else {
-              for (;;) {
-                if (!parse_expression(tmpl)) {
-                  inja_throw("parser_error", "expected expression, got '" + m_tok.describe() + "'");
-                }
-                num_args += 1;
-                if (m_tok.kind == Token::Kind::RightParen) {
-                  get_next_token();
-                  break;
-                }
-                if (m_tok.kind != Token::Kind::Comma) {
-                  inja_throw("parser_error", "expected ')' or ',', got '" + m_tok.describe() + "'");
-                }
-                get_next_token();
-              }
-            }
 
-            auto op = m_static.functions.find_builtin(func_token.text, num_args);
+      } break;
+      case Token::Kind::Number: {
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          json_literal_start = tok.text;
+          add_json_literal(tmpl.content.c_str());
+        }
 
-            if (op != Bytecode::Op::Nop) {
-              // swap arguments for default(); see comment in RenderTo()
-              if (op == Bytecode::Op::Default)
-                std::swap(tmpl.bytecodes.back(), *(tmpl.bytecodes.rbegin() + 1));
-              append_function(tmpl, op, num_args);
-              return true;
-            } else {
-              append_callback(tmpl, func_token.text, num_args);
-              return true;
-            }
-          } else if (m_tok.text == static_cast<decltype(m_tok.text)>("true") ||
-              m_tok.text == static_cast<decltype(m_tok.text)>("false") ||
-              m_tok.text == static_cast<decltype(m_tok.text)>("null")) {
-            // true, false, null are json literals
-            if (brace_level == 0 && bracket_level == 0) {
-              json_first = m_tok.text;
-              goto returnJson;
-            }
-            break;
+      } break;
+      case Token::Kind::LeftBracket: {
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          json_literal_start = tok.text;
+        }
+        current_bracket_level += 1;
+
+      } break;
+      case Token::Kind::LeftBrace: {
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          json_literal_start = tok.text;
+        }
+        current_brace_level += 1;
+
+      } break;
+      case Token::Kind::RightBracket: {
+        if (current_bracket_level == 0) {
+          throw_parser_error("unexpected ']'");
+        }
+
+        current_bracket_level -= 1;
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          add_json_literal(tmpl.content.c_str());
+        }
+
+      } break;
+      case Token::Kind::RightBrace: {
+        if (current_brace_level == 0) {
+          throw_parser_error("unexpected '}'");
+        }
+
+        current_brace_level -= 1;
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          add_json_literal(tmpl.content.c_str());
+        }
+
+      } break;
+      case Token::Kind::Id: {
+        get_peek_token();
+
+        // Json Literal
+        if (tok.text == static_cast<decltype(tok.text)>("true") || tok.text == static_cast<decltype(tok.text)>("false") || tok.text == static_cast<decltype(tok.text)>("null")) {
+          if (current_brace_level == 0 && current_bracket_level == 0) {
+            json_literal_start = tok.text;
+            add_json_literal(tmpl.content.c_str());
+          }
+
+	      // Operator
+        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
+          goto parse_operator;
+
+        // Functions
+        } else if (peek_tok.kind == Token::Kind::LeftParen) {
+          operator_stack.emplace(std::make_shared<FunctionNode>(static_cast<std::string>(tok.text), tok.text.data() - tmpl.content.c_str()));
+          function_stack.emplace(operator_stack.top().get(), current_paren_level);
+
+        // Variables
+        } else {
+          arguments.emplace_back(std::make_shared<JsonNode>(static_cast<std::string>(tok.text), tok.text.data() - tmpl.content.c_str()));
+        }
+
+      // Operators
+      } break;
+      case Token::Kind::Equal:
+      case Token::Kind::NotEqual:
+      case Token::Kind::GreaterThan:
+      case Token::Kind::GreaterEqual:
+      case Token::Kind::LessThan:
+      case Token::Kind::LessEqual:
+      case Token::Kind::Plus:
+      case Token::Kind::Minus:
+      case Token::Kind::Times:
+      case Token::Kind::Slash:
+      case Token::Kind::Power:
+      case Token::Kind::Percent:
+      case Token::Kind::Dot: {
+
+  parse_operator:
+        FunctionStorage::Operation operation;
+        switch (tok.kind) {
+        case Token::Kind::Id: {
+          if (tok.text == "and") {
+            operation = FunctionStorage::Operation::And;
+          } else if (tok.text == "or") {
+            operation = FunctionStorage::Operation::Or;
+          } else if (tok.text == "in") {
+            operation = FunctionStorage::Operation::In;
+          } else if (tok.text == "not") {
+            operation = FunctionStorage::Operation::Not;
           } else {
-            // normal literal (json read)
-            tmpl.bytecodes.emplace_back(
-                Bytecode::Op::Push, m_tok.text,
-                m_config.notation == ElementNotation::Pointer ? Bytecode::Flag::ValueLookupPointer : Bytecode::Flag::ValueLookupDot);
-            get_next_token();
-            return true;
+            throw_parser_error("unknown operator in parser.");
           }
-        // json passthrough
-        case Token::Kind::Number:
-        case Token::Kind::String:
-          if (brace_level == 0 && bracket_level == 0) {
-            json_first = m_tok.text;
-            goto returnJson;
+        } break;
+        case Token::Kind::Equal: {
+          operation = FunctionStorage::Operation::Equal;
+        } break;
+        case Token::Kind::NotEqual: {
+          operation = FunctionStorage::Operation::NotEqual;
+        } break;
+        case Token::Kind::GreaterThan: {
+          operation = FunctionStorage::Operation::Greater;
+        } break;
+        case Token::Kind::GreaterEqual: {
+          operation = FunctionStorage::Operation::GreaterEqual;
+        } break;
+        case Token::Kind::LessThan: {
+          operation = FunctionStorage::Operation::Less;
+        } break;
+        case Token::Kind::LessEqual: {
+          operation = FunctionStorage::Operation::LessEqual;
+        } break;
+        case Token::Kind::Plus: {
+          operation = FunctionStorage::Operation::Add;
+        } break;
+        case Token::Kind::Minus: {
+          operation = FunctionStorage::Operation::Subtract;
+        } break;
+        case Token::Kind::Times: {
+          operation = FunctionStorage::Operation::Multiplication;
+        } break;
+        case Token::Kind::Slash: {
+          operation = FunctionStorage::Operation::Division;
+        } break;
+        case Token::Kind::Power: {
+          operation = FunctionStorage::Operation::Power;
+        } break;
+        case Token::Kind::Percent: {
+          operation = FunctionStorage::Operation::Modulo;
+        } break;
+        case Token::Kind::Dot: {
+          operation = FunctionStorage::Operation::AtId;
+        } break;
+        default: {
+          throw_parser_error("unknown operator in parser.");
+        }
+        }
+        auto function_node = std::make_shared<FunctionNode>(operation, tok.text.data() - tmpl.content.c_str());
+
+        while (!operator_stack.empty() && ((operator_stack.top()->precedence > function_node->precedence) || (operator_stack.top()->precedence == function_node->precedence && function_node->associativity == FunctionNode::Associativity::Left)) && (operator_stack.top()->operation != FunctionStorage::Operation::ParenLeft)) {
+          add_operator();
+        }
+
+        operator_stack.emplace(function_node);
+
+      } break;
+      case Token::Kind::Comma: {
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          if (function_stack.empty()) {
+            throw_parser_error("unexpected ','");
           }
-          break;
-        case Token::Kind::Comma:
-        case Token::Kind::Colon:
-          if (brace_level == 0 && bracket_level == 0) {
-            inja_throw("parser_error", "unexpected token '" + m_tok.describe() + "'");
+
+          function_stack.top().first->number_args += 1;
+        }
+
+      } break;
+      case Token::Kind::Colon: {
+        if (current_brace_level == 0 && current_bracket_level == 0) {
+          throw_parser_error("unexpected ':'");
+        }
+
+      } break;
+      case Token::Kind::LeftParen: {
+        current_paren_level += 1;
+        operator_stack.emplace(std::make_shared<FunctionNode>(FunctionStorage::Operation::ParenLeft, tok.text.data() - tmpl.content.c_str()));
+
+        get_peek_token();
+        if (peek_tok.kind == Token::Kind::RightParen) {
+          if (!function_stack.empty() && function_stack.top().second == current_paren_level - 1) {
+            function_stack.top().first->number_args = 0;
           }
-          break;
-        case Token::Kind::LeftBracket:
-          if (brace_level == 0 && bracket_level == 0) {
-            json_first = m_tok.text;
+        }
+
+      } break;
+      case Token::Kind::RightParen: {
+        current_paren_level -= 1;
+        while (!operator_stack.empty() && operator_stack.top()->operation != FunctionStorage::Operation::ParenLeft) {
+          add_operator();
+        }
+
+        if (!operator_stack.empty() && operator_stack.top()->operation == FunctionStorage::Operation::ParenLeft) {
+          operator_stack.pop();
+        }
+
+        if (!function_stack.empty() && function_stack.top().second == current_paren_level) {
+          auto func = function_stack.top().first;
+          auto function_data = function_storage.find_function(func->name, func->number_args);
+          if (function_data.operation == FunctionStorage::Operation::None) {
+            throw_parser_error("unknown function " + func->name);
           }
-          bracket_level += 1;
-          break;
-        case Token::Kind::LeftBrace:
-          if (brace_level == 0 && bracket_level == 0) {
-            json_first = m_tok.text;
+          func->operation = function_data.operation;
+          if (function_data.operation == FunctionStorage::Operation::Callback) {
+            func->callback = function_data.callback;
           }
-          brace_level += 1;
-          break;
-        case Token::Kind::RightBracket:
-          if (bracket_level == 0) {
-            inja_throw("parser_error", "unexpected ']'");
+
+          if (operator_stack.empty()) {
+            throw_parser_error("internal error at function " + func->name);
           }
-          --bracket_level;
-          if (brace_level == 0 && bracket_level == 0) goto returnJson;
-          break;
-        case Token::Kind::RightBrace:
-          if (brace_level == 0) {
-            inja_throw("parser_error", "unexpected '}'");
-          }
-          --brace_level;
-          if (brace_level == 0 && bracket_level == 0) goto returnJson;
-          break;
-        default:
-          if (brace_level != 0) {
-            inja_throw("parser_error", "unmatched '{'");
-          }
-          if (bracket_level != 0) {
-            inja_throw("parser_error", "unmatched '['");
-          }
-          return false;
+
+          add_operator();
+          function_stack.pop();
+        }
+      } break;
+      default:
+        break;
       }
 
       get_next_token();
     }
 
-  returnJson:
-    // bridge across all intermediate tokens
-    nonstd::string_view json_text(json_first.data(), m_tok.text.data() - json_first.data() + m_tok.text.size());
-    tmpl.bytecodes.emplace_back(Bytecode::Op::Push, json::parse(json_text), Bytecode::Flag::ValueImmediate);
-    get_next_token();
+    while (!operator_stack.empty()) {
+      add_operator();
+    }
+
+    if (arguments.size() == 1) {
+      current_expression_list->root = arguments[0];
+      arguments = {};
+
+    } else if (arguments.size() > 1) {
+      throw_parser_error("malformed expression");
+    }
+
     return true;
   }
 
-  bool parse_statement(Template& tmpl, nonstd::string_view path) {
-    if (m_tok.kind != Token::Kind::Id) return false;
+  bool parse_statement(Template &tmpl, Token::Kind closing, nonstd::string_view path) {
+    if (tok.kind != Token::Kind::Id) {
+      return false;
+    }
 
-    if (m_tok.text == static_cast<decltype(m_tok.text)>("if")) {
+    if (tok.text == static_cast<decltype(tok.text)>("if")) {
       get_next_token();
 
-      // evaluate expression
-      if (!parse_expression(tmpl)) return false;
+      auto if_statement_node = std::make_shared<IfStatementNode>(current_block, tok.text.data() - tmpl.content.c_str());
+      current_block->nodes.emplace_back(if_statement_node);
+      if_statement_stack.emplace(if_statement_node.get());
+      current_block = &if_statement_node->true_statement;
+      current_expression_list = &if_statement_node->condition;
 
-      // start a new if block on if stack
-      m_if_stack.emplace_back(tmpl.bytecodes.size());
-
-      // conditional jump; destination will be filled in by else or endif
-      tmpl.bytecodes.emplace_back(Bytecode::Op::ConditionalJump);
-    } else if (m_tok.text == static_cast<decltype(m_tok.text)>("endif")) {
-      if (m_if_stack.empty()) {
-        inja_throw("parser_error", "endif without matching if");
+      if (!parse_expression(tmpl, closing)) {
+        return false;
       }
-      auto& if_data = m_if_stack.back();
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("else")) {
+      if (if_statement_stack.empty()) {
+        throw_parser_error("else without matching if");
+      }
+      auto &if_statement_data = if_statement_stack.top();
       get_next_token();
 
-      // previous conditional jump jumps here
-      if (if_data.prev_cond_jump != std::numeric_limits<unsigned int>::max()) {
-        tmpl.bytecodes[if_data.prev_cond_jump].args = tmpl.bytecodes.size();
-      }
+      if_statement_data->has_false_statement = true;
+      current_block = &if_statement_data->false_statement;
 
-      // update all previous unconditional jumps to here
-      for (unsigned int i: if_data.uncond_jumps) {
-        tmpl.bytecodes[i].args = tmpl.bytecodes.size();
-      }
-
-      // pop if stack
-      m_if_stack.pop_back();
-    } else if (m_tok.text == static_cast<decltype(m_tok.text)>("else")) {
-      if (m_if_stack.empty())
-        inja_throw("parser_error", "else without matching if");
-      auto& if_data = m_if_stack.back();
-      get_next_token();
-
-      // end previous block with unconditional jump to endif; destination will be
-      // filled in by endif
-      if_data.uncond_jumps.push_back(tmpl.bytecodes.size());
-      tmpl.bytecodes.emplace_back(Bytecode::Op::Jump);
-
-      // previous conditional jump jumps here
-      tmpl.bytecodes[if_data.prev_cond_jump].args = tmpl.bytecodes.size();
-      if_data.prev_cond_jump = std::numeric_limits<unsigned int>::max();
-
-      // chained else if
-      if (m_tok.kind == Token::Kind::Id && m_tok.text == static_cast<decltype(m_tok.text)>("if")) {
+      // Chained else if
+      if (tok.kind == Token::Kind::Id && tok.text == static_cast<decltype(tok.text)>("if")) {
         get_next_token();
 
-        // evaluate expression
-        if (!parse_expression(tmpl)) return false;
+        auto if_statement_node = std::make_shared<IfStatementNode>(true, current_block, tok.text.data() - tmpl.content.c_str());
+        current_block->nodes.emplace_back(if_statement_node);
+        if_statement_stack.emplace(if_statement_node.get());
+        current_block = &if_statement_node->true_statement;
+        current_expression_list = &if_statement_node->condition;
 
-        // update "previous jump"
-        if_data.prev_cond_jump = tmpl.bytecodes.size();
-
-        // conditional jump; destination will be filled in by else or endif
-        tmpl.bytecodes.emplace_back(Bytecode::Op::ConditionalJump);
+        if (!parse_expression(tmpl, closing)) {
+          return false;
+        }
       }
-    } else if (m_tok.text == static_cast<decltype(m_tok.text)>("for")) {
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("endif")) {
+      if (if_statement_stack.empty()) {
+        throw_parser_error("endif without matching if");
+      }
+
+      // Nested if statements
+      while (if_statement_stack.top()->is_nested) {
+        if_statement_stack.pop();
+      }
+
+      auto &if_statement_data = if_statement_stack.top();
+      get_next_token();
+
+      current_block = if_statement_data->parent;
+      if_statement_stack.pop();
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("block")) {
+      get_next_token();
+
+      if (tok.kind != Token::Kind::Id) {
+        throw_parser_error("expected block name, got '" + tok.describe() + "'");
+      }
+
+      const std::string block_name = static_cast<std::string>(tok.text);
+
+      auto block_statement_node = std::make_shared<BlockStatementNode>(current_block, block_name, tok.text.data() - tmpl.content.c_str());
+      current_block->nodes.emplace_back(block_statement_node);
+      block_statement_stack.emplace(block_statement_node.get());
+      current_block = &block_statement_node->block;
+      auto success = tmpl.block_storage.emplace(block_name, block_statement_node);
+      if (!success.second) {
+        throw_parser_error("block with the name '" + block_name + "' does already exist");
+      }
+
+      get_next_token();
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("endblock")) {
+      if (block_statement_stack.empty()) {
+        throw_parser_error("endblock without matching block");
+      }
+
+      auto &block_statement_data = block_statement_stack.top();
+      get_next_token();
+
+      current_block = block_statement_data->parent;
+      block_statement_stack.pop();
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("for")) {
       get_next_token();
 
       // options: for a in arr; for a, b in obj
-      if (m_tok.kind != Token::Kind::Id)
-        inja_throw("parser_error", "expected id, got '" + m_tok.describe() + "'");
-      Token value_token = m_tok;
+      if (tok.kind != Token::Kind::Id) {
+        throw_parser_error("expected id, got '" + tok.describe() + "'");
+      }
+
+      Token value_token = tok;
       get_next_token();
 
-      Token key_token;
-      if (m_tok.kind == Token::Kind::Comma) {
+      // Object type
+      std::shared_ptr<ForStatementNode> for_statement_node;
+      if (tok.kind == Token::Kind::Comma) {
         get_next_token();
-        if (m_tok.kind != Token::Kind::Id)
-          inja_throw("parser_error", "expected id, got '" + m_tok.describe() + "'");
-        key_token = std::move(value_token);
-        value_token = m_tok;
+        if (tok.kind != Token::Kind::Id) {
+          throw_parser_error("expected id, got '" + tok.describe() + "'");
+        }
+
+        Token key_token = std::move(value_token);
+        value_token = tok;
         get_next_token();
+
+        for_statement_node = std::make_shared<ForObjectStatementNode>(static_cast<std::string>(key_token.text), static_cast<std::string>(value_token.text), current_block, tok.text.data() - tmpl.content.c_str());
+
+      // Array type
+      } else {
+        for_statement_node = std::make_shared<ForArrayStatementNode>(static_cast<std::string>(value_token.text), current_block, tok.text.data() - tmpl.content.c_str());
       }
 
-      if (m_tok.kind != Token::Kind::Id || m_tok.text != static_cast<decltype(m_tok.text)>("in"))
-        inja_throw("parser_error",
-                   "expected 'in', got '" + m_tok.describe() + "'");
+      current_block->nodes.emplace_back(for_statement_node);
+      for_statement_stack.emplace(for_statement_node.get());
+      current_block = &for_statement_node->body;
+      current_expression_list = &for_statement_node->condition;
+
+      if (tok.kind != Token::Kind::Id || tok.text != static_cast<decltype(tok.text)>("in")) {
+        throw_parser_error("expected 'in', got '" + tok.describe() + "'");
+      }
       get_next_token();
 
-      if (!parse_expression(tmpl)) return false;
-
-      m_loop_stack.push_back(tmpl.bytecodes.size());
-
-      tmpl.bytecodes.emplace_back(Bytecode::Op::StartLoop);
-      if (!key_token.text.empty()) {
-        tmpl.bytecodes.back().value = key_token.text;
-      }
-      tmpl.bytecodes.back().str = static_cast<std::string>(value_token.text);
-    } else if (m_tok.text == static_cast<decltype(m_tok.text)>("endfor")) {
-      get_next_token();
-      if (m_loop_stack.empty()) {
-        inja_throw("parser_error", "endfor without matching for");
+      if (!parse_expression(tmpl, closing)) {
+        return false;
       }
 
-      // update loop with EndLoop index (for empty case)
-      tmpl.bytecodes[m_loop_stack.back()].args = tmpl.bytecodes.size();
+    } else if (tok.text == static_cast<decltype(tok.text)>("endfor")) {
+      if (for_statement_stack.empty()) {
+        throw_parser_error("endfor without matching for");
+      }
 
-      tmpl.bytecodes.emplace_back(Bytecode::Op::EndLoop);
-      tmpl.bytecodes.back().args = m_loop_stack.back() + 1;  // loop body
-      m_loop_stack.pop_back();
-    } else if (m_tok.text == static_cast<decltype(m_tok.text)>("include")) {
+      auto &for_statement_data = for_statement_stack.top();
       get_next_token();
 
-      if (m_tok.kind != Token::Kind::String) {
-        inja_throw("parser_error", "expected string, got '" + m_tok.describe() + "'");
+      current_block = for_statement_data->parent;
+      for_statement_stack.pop();
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("include")) {
+      get_next_token();
+
+      if (tok.kind != Token::Kind::String) {
+        throw_parser_error("expected string, got '" + tok.describe() + "'");
       }
 
-      // build the relative path
-      json json_name = json::parse(m_tok.text);
-      std::string pathname = static_cast<std::string>(path);
-      pathname += json_name.get_ref<const std::string&>();
-      if (pathname.compare(0, 2, "./") == 0) {
-        pathname.erase(0, 2);
-      }
-      // sys::path::remove_dots(pathname, true, sys::path::Style::posix);
+      std::string template_name = json::parse(tok.text).get_ref<const std::string &>();
+      add_to_template_storage(path, template_name);
 
-      Template include_template = parse_template(pathname);
-      m_included_templates.emplace(pathname, include_template);
-
-      // generate a reference bytecode
-      tmpl.bytecodes.emplace_back(Bytecode::Op::Include, json(pathname), Bytecode::Flag::ValueImmediate);
+      current_block->nodes.emplace_back(std::make_shared<IncludeStatementNode>(template_name, tok.text.data() - tmpl.content.c_str()));
 
       get_next_token();
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("extends")) {
+      get_next_token();
+
+      if (tok.kind != Token::Kind::String) {
+        throw_parser_error("expected string, got '" + tok.describe() + "'");
+      }
+
+      std::string template_name = json::parse(tok.text).get_ref<const std::string &>();
+      add_to_template_storage(path, template_name);
+
+      current_block->nodes.emplace_back(std::make_shared<ExtendsStatementNode>(template_name, tok.text.data() - tmpl.content.c_str()));
+
+      get_next_token();
+
+    } else if (tok.text == static_cast<decltype(tok.text)>("set")) {
+      get_next_token();
+
+      if (tok.kind != Token::Kind::Id) {
+        throw_parser_error("expected variable name, got '" + tok.describe() + "'");
+      }
+
+      std::string key = static_cast<std::string>(tok.text);
+      get_next_token();
+
+      auto set_statement_node = std::make_shared<SetStatementNode>(key, tok.text.data() - tmpl.content.c_str());
+      current_block->nodes.emplace_back(set_statement_node);
+      current_expression_list = &set_statement_node->expression;
+
+      if (tok.text != static_cast<decltype(tok.text)>("=")) {
+        throw_parser_error("expected '=', got '" + tok.describe() + "'");
+      }
+      get_next_token();
+
+      if (!parse_expression(tmpl, closing)) {
+        return false;
+      }
+
     } else {
       return false;
     }
     return true;
   }
 
-  void append_function(Template& tmpl, Bytecode::Op op, unsigned int num_args) {
-    // we can merge with back-to-back push
-    if (!tmpl.bytecodes.empty()) {
-      Bytecode& last = tmpl.bytecodes.back();
-      if (last.op == Bytecode::Op::Push) {
-        last.op = op;
-        last.args = num_args;
-        return;
-      }
-    }
-
-    // otherwise just add it to the end
-    tmpl.bytecodes.emplace_back(op, num_args);
-  }
-
-  void append_callback(Template& tmpl, nonstd::string_view name, unsigned int num_args) {
-    // we can merge with back-to-back push value (not lookup)
-    if (!tmpl.bytecodes.empty()) {
-      Bytecode& last = tmpl.bytecodes.back();
-      if (last.op == Bytecode::Op::Push &&
-          (last.flags & Bytecode::Flag::ValueMask) == Bytecode::Flag::ValueImmediate) {
-        last.op = Bytecode::Op::Callback;
-        last.args = num_args;
-        last.str = static_cast<std::string>(name);
-        return;
-      }
-    }
-
-    // otherwise just add it to the end
-    tmpl.bytecodes.emplace_back(Bytecode::Op::Callback, num_args);
-    tmpl.bytecodes.back().str = static_cast<std::string>(name);
-  }
-
-  void parse_into(Template& tmpl, nonstd::string_view path) {
-    m_lexer.start(tmpl.content);
+  void parse_into(Template &tmpl, nonstd::string_view path) {
+    lexer.start(tmpl.content);
+    current_block = &tmpl.root;
 
     for (;;) {
       get_next_token();
-      switch (m_tok.kind) {
-        case Token::Kind::Eof:
-          if (!m_if_stack.empty()) inja_throw("parser_error", "unmatched if");
-          if (!m_loop_stack.empty()) inja_throw("parser_error", "unmatched for");
-          return;
-        case Token::Kind::Text:
-          tmpl.bytecodes.emplace_back(Bytecode::Op::PrintText, m_tok.text, 0u);
-          break;
-        case Token::Kind::StatementOpen:
-          get_next_token();
-          if (!parse_statement(tmpl, path)) {
-            inja_throw("parser_error", "expected statement, got '" + m_tok.describe() + "'");
-          }
-          if (m_tok.kind != Token::Kind::StatementClose) {
-            inja_throw("parser_error", "expected statement close, got '" + m_tok.describe() + "'");
-          }
-          break;
-        case Token::Kind::LineStatementOpen:
-          get_next_token();
-          parse_statement(tmpl, path);
-          if (m_tok.kind != Token::Kind::LineStatementClose &&
-              m_tok.kind != Token::Kind::Eof) {
-            inja_throw("parser_error", "expected line statement close, got '" + m_tok.describe() + "'");
-          }
-          break;
-        case Token::Kind::ExpressionOpen:
-          get_next_token();
-          if (!parse_expression(tmpl)) {
-            inja_throw("parser_error", "expected expression, got '" + m_tok.describe() + "'");
-          }
-          append_function(tmpl, Bytecode::Op::PrintValue, 1);
-          if (m_tok.kind != Token::Kind::ExpressionClose) {
-            inja_throw("parser_error", "expected expression close, got '" + m_tok.describe() + "'");
-          }
-          break;
-        case Token::Kind::CommentOpen:
-          get_next_token();
-          if (m_tok.kind != Token::Kind::CommentClose) {
-            inja_throw("parser_error", "expected comment close, got '" + m_tok.describe() + "'");
-          }
-          break;
-        default:
-          inja_throw("parser_error", "unexpected token '" + m_tok.describe() + "'");
-          break;
+      switch (tok.kind) {
+      case Token::Kind::Eof: {
+        if (!if_statement_stack.empty()) {
+          throw_parser_error("unmatched if");
+        }
+        if (!for_statement_stack.empty()) {
+          throw_parser_error("unmatched for");
+        }
+      } return;
+      case Token::Kind::Text: {
+        current_block->nodes.emplace_back(std::make_shared<TextNode>(tok.text.data() - tmpl.content.c_str(), tok.text.size()));
+      } break;
+      case Token::Kind::StatementOpen: {
+        get_next_token();
+        if (!parse_statement(tmpl, Token::Kind::StatementClose, path)) {
+          throw_parser_error("expected statement, got '" + tok.describe() + "'");
+        }
+        if (tok.kind != Token::Kind::StatementClose) {
+          throw_parser_error("expected statement close, got '" + tok.describe() + "'");
+        }
+      } break;
+      case Token::Kind::LineStatementOpen: {
+        get_next_token();
+        if (!parse_statement(tmpl, Token::Kind::LineStatementClose, path)) {
+          throw_parser_error("expected statement, got '" + tok.describe() + "'");
+        }
+        if (tok.kind != Token::Kind::LineStatementClose && tok.kind != Token::Kind::Eof) {
+          throw_parser_error("expected line statement close, got '" + tok.describe() + "'");
+        }
+      } break;
+      case Token::Kind::ExpressionOpen: {
+        get_next_token();
+
+        auto expression_list_node = std::make_shared<ExpressionListNode>(tok.text.data() - tmpl.content.c_str());
+        current_block->nodes.emplace_back(expression_list_node);
+        current_expression_list = expression_list_node.get();
+
+        if (!parse_expression(tmpl, Token::Kind::ExpressionClose)) {
+          throw_parser_error("expected expression, got '" + tok.describe() + "'");
+        }
+
+        if (tok.kind != Token::Kind::ExpressionClose) {
+          throw_parser_error("expected expression close, got '" + tok.describe() + "'");
+        }
+      } break;
+      case Token::Kind::CommentOpen: {
+        get_next_token();
+        if (tok.kind != Token::Kind::CommentClose) {
+          throw_parser_error("expected comment close, got '" + tok.describe() + "'");
+        }
+      } break;
+      default: {
+        throw_parser_error("unexpected token '" + tok.describe() + "'");
+      } break;
       }
     }
   }
 
+
+public:
+  explicit Parser(const ParserConfig &parser_config, const LexerConfig &lexer_config,
+                  TemplateStorage &template_storage, const FunctionStorage &function_storage)
+      : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) { }
+
   Template parse(nonstd::string_view input, nonstd::string_view path) {
-    Template result;
-    result.content = static_cast<std::string>(input);
+    auto result = Template(static_cast<std::string>(input));
     parse_into(result, path);
     return result;
   }
@@ -2494,871 +3468,976 @@ class Parser {
     return parse(input, "./");
   }
 
-  Template parse_template(nonstd::string_view filename) {
-    Template result;
-    result.content = load_file(filename);
-
+  void parse_into_template(Template& tmpl, nonstd::string_view filename) {
     nonstd::string_view path = filename.substr(0, filename.find_last_of("/\\") + 1);
-      // StringRef path = sys::path::parent_path(filename);
-    Parser(m_config, m_lexer.get_config(), m_included_templates).parse_into(result, path);
-    return result;
+
+    // StringRef path = sys::path::parent_path(filename);
+    auto sub_parser = Parser(config, lexer.get_config(), template_storage, function_storage);
+    sub_parser.parse_into(tmpl, path);
   }
 
   std::string load_file(nonstd::string_view filename) {
-		std::ifstream file(static_cast<std::string>(filename));
-		std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-		return text;
-	}
-
- private:
-  const ParserConfig& m_config;
-  Lexer m_lexer;
-  Token m_tok;
-  Token m_peek_tok;
-  bool m_have_peek_tok {false};
-  TemplateStorage& m_included_templates;
-  const ParserStatic& m_static;
-
-  struct IfData {
-    unsigned int prev_cond_jump;
-    std::vector<unsigned int> uncond_jumps;
-
-    explicit IfData(unsigned int condJump): prev_cond_jump(condJump) {}
-  };
-
-  std::vector<IfData> m_if_stack;
-  std::vector<unsigned int> m_loop_stack;
-
-  void get_next_token() {
-    if (m_have_peek_tok) {
-      m_tok = m_peek_tok;
-      m_have_peek_tok = false;
-    } else {
-      m_tok = m_lexer.scan();
-    }
-  }
-
-  void get_peek_token() {
-    if (!m_have_peek_tok) {
-      m_peek_tok = m_lexer.scan();
-      m_have_peek_tok = true;
-    }
+    std::ifstream file;
+    open_file_or_throw(static_cast<std::string>(filename), file);
+    std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    return text;
   }
 };
 
-}  // namespace inja
+} // namespace inja
 
-#endif  // PANTOR_INJA_PARSER_HPP
-
-// #include "polyfill.hpp"
-#ifndef PANTOR_INJA_POLYFILL_HPP
-#define PANTOR_INJA_POLYFILL_HPP
-
-
-#if __cplusplus < 201402L
-
-#include <cstddef>
-#include <type_traits>
-#include <utility>
-
-
-namespace stdinja {
-  template<class T> struct _Unique_if {
-    typedef std::unique_ptr<T> _Single_object;
-  };
-
-  template<class T> struct _Unique_if<T[]> {
-    typedef std::unique_ptr<T[]> _Unknown_bound;
-  };
-
-  template<class T, size_t N> struct _Unique_if<T[N]> {
-    typedef void _Known_bound;
-  };
-
-  template<class T, class... Args>
-  typename _Unique_if<T>::_Single_object
-  make_unique(Args&&... args) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-  }
-
-  template<class T>
-  typename _Unique_if<T>::_Unknown_bound
-  make_unique(size_t n) {
-    typedef typename std::remove_extent<T>::type U;
-    return std::unique_ptr<T>(new U[n]());
-  }
-
-  template<class T, class... Args>
-  typename _Unique_if<T>::_Known_bound
-  make_unique(Args&&...) = delete;
-}
-
-#else
-
-namespace stdinja = std;
-
-#endif // memory */
-
-
-#endif // PANTOR_INJA_POLYFILL_HPP
+#endif // INCLUDE_INJA_PARSER_HPP_
 
 // #include "renderer.hpp"
-#ifndef PANTOR_INJA_RENDERER_HPP
-#define PANTOR_INJA_RENDERER_HPP
+#ifndef INCLUDE_INJA_RENDERER_HPP_
+#define INCLUDE_INJA_RENDERER_HPP_
 
 #include <algorithm>
 #include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
-// #include "bytecode.hpp"
+// #include "config.hpp"
+
+// #include "exceptions.hpp"
+
+// #include "node.hpp"
 
 // #include "template.hpp"
 
 // #include "utils.hpp"
 
 
-
 namespace inja {
 
-inline nonstd::string_view convert_dot_to_json_pointer(nonstd::string_view dot, std::string& out) {
-  out.clear();
-  do {
-    nonstd::string_view part;
-    std::tie(part, dot) = string_view::split(dot, '.');
-    out.push_back('/');
-    out.append(part.begin(), part.end());
-  } while (!dot.empty());
-  return nonstd::string_view(out.data(), out.size());
-}
+/*!
+ * \brief Class for rendering a Template with data.
+ */
+class Renderer : public NodeVisitor  {
+  using Op = FunctionStorage::Operation;
 
-class Renderer {
-  std::vector<const json*>& get_args(const Bytecode& bc) {
-    m_tmp_args.clear();
+  const RenderConfig config;
+  const TemplateStorage &template_storage;
+  const FunctionStorage &function_storage;
 
-    bool has_imm = ((bc.flags & Bytecode::Flag::ValueMask) != Bytecode::Flag::ValuePop);
+  const Template *current_template;
+  size_t current_level {0};
+  std::vector<const Template*> template_stack;
+  std::vector<const BlockStatementNode*> block_statement_stack;
 
-    // get args from stack
-    unsigned int pop_args = bc.args;
-    if (has_imm) {
-      pop_args -= 1;
-    }
+  const json *json_input;
+  std::ostream *output_stream;
 
-    for (auto i = std::prev(m_stack.end(), pop_args); i != m_stack.end(); i++) {
-      m_tmp_args.push_back(&(*i));
-    }
+  json json_additional_data;
+  json* current_loop_data = &json_additional_data["loop"];
 
-    // get immediate arg
-    if (has_imm) {
-      m_tmp_args.push_back(get_imm(bc));
-    }
+  std::vector<std::shared_ptr<json>> json_tmp_stack;
+  std::stack<const json*> json_eval_stack;
+  std::stack<const JsonNode*> not_found_stack;
 
-    return m_tmp_args;
-  }
+  bool break_rendering {false};
 
-  void pop_args(const Bytecode& bc) {
-    unsigned int popArgs = bc.args;
-    if ((bc.flags & Bytecode::Flag::ValueMask) != Bytecode::Flag::ValuePop) {
-      popArgs -= 1;
-    }
-    for (unsigned int i = 0; i < popArgs; ++i) {
-      m_stack.pop_back();
-    }
-  }
-
-  const json* get_imm(const Bytecode& bc) {
-    std::string ptr_buffer;
-    nonstd::string_view ptr;
-    switch (bc.flags & Bytecode::Flag::ValueMask) {
-      case Bytecode::Flag::ValuePop:
-        return nullptr;
-      case Bytecode::Flag::ValueImmediate:
-        return &bc.value;
-      case Bytecode::Flag::ValueLookupDot:
-        ptr = convert_dot_to_json_pointer(bc.str, ptr_buffer);
-        break;
-      case Bytecode::Flag::ValueLookupPointer:
-        ptr_buffer += '/';
-        ptr_buffer += bc.str;
-        ptr = ptr_buffer;
-        break;
-    }
-    try {
-      return &m_data->at(json::json_pointer(ptr.data()));
-    } catch (std::exception&) {
-      // try to evaluate as a no-argument callback
-      if (auto callback = m_callbacks.find_callback(bc.str, 0)) {
-        std::vector<const json*> arguments {};
-        m_tmp_val = callback(arguments);
-        return &m_tmp_val;
-      }
-      inja_throw("render_error", "variable '" + static_cast<std::string>(bc.str) + "' not found");
-      return nullptr;
-    }
-  }
-
-  bool truthy(const json& var) const {
-    if (var.empty()) {
+  bool truthy(const json* data) const {
+    if (data->is_boolean()) {
+      return data->get<bool>();
+    } else if (data->is_number()) {
+      return (*data != 0);
+    } else if (data->is_null()) {
       return false;
-    } else if (var.is_number()) {
-      return (var != 0);
-    } else if (var.is_string()) {
-      return !var.empty();
     }
-
-    try {
-      return var.get<bool>();
-    } catch (json::type_error& e) {
-      inja_throw("json_error", e.what());
-      throw;
-    }
+    return !data->empty();
   }
 
-  void update_loop_data()  {
-    LoopLevel& level = m_loop_stack.back();
-
-    if (level.loop_type == LoopLevel::Type::Array) {
-      level.data[static_cast<std::string>(level.value_name)] = level.values.at(level.index); // *level.it;
-      auto& loopData = level.data["loop"];
-      loopData["index"] = level.index;
-      loopData["index1"] = level.index + 1;
-      loopData["is_first"] = (level.index == 0);
-      loopData["is_last"] = (level.index == level.size - 1);
+  void print_json(const std::shared_ptr<json> value) {
+    if (value->is_string()) {
+      *output_stream << value->get_ref<const json::string_t&>();
+    } else if (value->is_number_integer()) {
+      *output_stream << value->get<const json::number_integer_t>();
+    } else if (value->is_null()) {
     } else {
-      level.data[static_cast<std::string>(level.key_name)] = level.map_it->first;
-      level.data[static_cast<std::string>(level.value_name)] = *level.map_it->second;
+      *output_stream << value->dump();
     }
   }
 
-  const TemplateStorage& m_included_templates;
-  const FunctionStorage& m_callbacks;
+  const std::shared_ptr<json> eval_expression_list(const ExpressionListNode& expression_list) {
+    if (!expression_list.root) {
+      throw_renderer_error("empty expression", expression_list);
+    }
 
-  std::vector<json> m_stack;
+    expression_list.root->accept(*this);
 
+    if (json_eval_stack.empty()) {
+      throw_renderer_error("empty expression", expression_list);
+    } else if (json_eval_stack.size() != 1) {
+      throw_renderer_error("malformed expression", expression_list);
+    }
 
-  struct LoopLevel {
-    enum class Type { Map, Array };
+    const auto result = json_eval_stack.top();
+    json_eval_stack.pop();
 
-    Type loop_type;
-    nonstd::string_view key_name;   // variable name for keys
-    nonstd::string_view value_name; // variable name for values
-    json data;                      // data with loop info added
+    if (!result) {
+      if (not_found_stack.empty()) {
+        throw_renderer_error("expression could not be evaluated", expression_list);
+      }
 
-    json values;                    // values to iterate over
+      auto node = not_found_stack.top();
+      not_found_stack.pop();
 
-    // loop over list
-    size_t index;                   // current list index
-    size_t size;                    // length of list
-
-    // loop over map
-    using KeyValue = std::pair<nonstd::string_view, json*>;
-    using MapValues = std::vector<KeyValue>;
-    MapValues map_values;           // values to iterate over
-    MapValues::iterator map_it;     // iterator over values
-
-  };
-
-  std::vector<LoopLevel> m_loop_stack;
-  const json* m_data;
-
-  std::vector<const json*> m_tmp_args;
-  json m_tmp_val;
-
-
- public:
-  Renderer(const TemplateStorage& included_templates, const FunctionStorage& callbacks): m_included_templates(included_templates), m_callbacks(callbacks) {
-    m_stack.reserve(16);
-    m_tmp_args.reserve(4);
-    m_loop_stack.reserve(16);
+      throw_renderer_error("variable '" + static_cast<std::string>(node->name) + "' not found", *node);
+    }
+    return std::make_shared<json>(*result);
   }
 
-  void render_to(std::ostream& os, const Template& tmpl, const json& data) {
-    m_data = &data;
+  void throw_renderer_error(const std::string &message, const AstNode& node) {
+    SourceLocation loc = get_source_location(current_template->content, node.pos);
+    INJA_THROW(RenderError(message, loc));
+  }
 
-    for (size_t i = 0; i < tmpl.bytecodes.size(); ++i) {
-      const auto& bc = tmpl.bytecodes[i];
+  template<size_t N, size_t N_start = 0, bool throw_not_found=true>
+  std::array<const json*, N> get_arguments(const FunctionNode& node) {
+    if (node.arguments.size() < N_start + N) {
+      throw_renderer_error("function needs " + std::to_string(N_start + N) + " variables, but has only found " + std::to_string(node.arguments.size()), node);
+    }
 
-      switch (bc.op) {
-        case Bytecode::Op::Nop: {
-          break;
-        }
-        case Bytecode::Op::PrintText: {
-          os << bc.str;
-          break;
-        }
-        case Bytecode::Op::PrintValue: {
-          const json& val = *get_args(bc)[0];
-          if (val.is_string()) {
-            os << val.get_ref<const std::string&>();
-          } else {
-            os << val.dump();
-          }
-          pop_args(bc);
-          break;
-        }
-        case Bytecode::Op::Push: {
-          m_stack.emplace_back(*get_imm(bc));
-          break;
-        }
-        case Bytecode::Op::Upper: {
-          auto result = get_args(bc)[0]->get<std::string>();
-          std::transform(result.begin(), result.end(), result.begin(), ::toupper);
-          pop_args(bc);
-          m_stack.emplace_back(std::move(result));
-          break;
-        }
-        case Bytecode::Op::Lower: {
-          auto result = get_args(bc)[0]->get<std::string>();
-          std::transform(result.begin(), result.end(), result.begin(), ::tolower);
-          pop_args(bc);
-          m_stack.emplace_back(std::move(result));
-          break;
-        }
-        case Bytecode::Op::Range: {
-          int number = get_args(bc)[0]->get<int>();
-          std::vector<int> result(number);
-          std::iota(std::begin(result), std::end(result), 0);
-          pop_args(bc);
-          m_stack.emplace_back(std::move(result));
-          break;
-        }
-        case Bytecode::Op::Length: {
-          const json& val = *get_args(bc)[0];
+    for (size_t i = N_start; i < N_start + N; i += 1) {
+      node.arguments[i]->accept(*this);
+    }
 
-          int result;
-          if (val.is_string()) {
-            result = val.get_ref<const std::string&>().length();
-          } else {
-            result = val.size();
-          }
+    if (json_eval_stack.size() < N) {
+      throw_renderer_error("function needs " + std::to_string(N) + " variables, but has only found " + std::to_string(json_eval_stack.size()), node);
+    }
 
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Sort: {
-          auto result = get_args(bc)[0]->get<std::vector<json>>();
-          std::sort(result.begin(), result.end());
-          pop_args(bc);
-          m_stack.emplace_back(std::move(result));
-          break;
-        }
-        case Bytecode::Op::At: {
-          auto args = get_args(bc);
-          auto result = args[0]->at(args[1]->get<int>());
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::First: {
-          auto result = get_args(bc)[0]->front();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Last: {
-          auto result = get_args(bc)[0]->back();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Round: {
-          auto args = get_args(bc);
-          double number = args[0]->get<double>();
-          int precision = args[1]->get<int>();
-          pop_args(bc);
-          m_stack.emplace_back(std::round(number * std::pow(10.0, precision)) / std::pow(10.0, precision));
-          break;
-        }
-        case Bytecode::Op::DivisibleBy: {
-          auto args = get_args(bc);
-          int number = args[0]->get<int>();
-          int divisor = args[1]->get<int>();
-          pop_args(bc);
-          m_stack.emplace_back((divisor != 0) && (number % divisor == 0));
-          break;
-        }
-        case Bytecode::Op::Odd: {
-          int number = get_args(bc)[0]->get<int>();
-          pop_args(bc);
-          m_stack.emplace_back(number % 2 != 0);
-          break;
-        }
-        case Bytecode::Op::Even: {
-          int number = get_args(bc)[0]->get<int>();
-          pop_args(bc);
-          m_stack.emplace_back(number % 2 == 0);
-          break;
-        }
-        case Bytecode::Op::Max: {
-          auto args = get_args(bc);
-          auto result = *std::max_element(args[0]->begin(), args[0]->end());
-          pop_args(bc);
-          m_stack.emplace_back(std::move(result));
-          break;
-        }
-        case Bytecode::Op::Min: {
-          auto args = get_args(bc);
-          auto result = *std::min_element(args[0]->begin(), args[0]->end());
-          pop_args(bc);
-          m_stack.emplace_back(std::move(result));
-          break;
-        }
-        case Bytecode::Op::Not: {
-          bool result = !truthy(*get_args(bc)[0]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::And: {
-          auto args = get_args(bc);
-          bool result = truthy(*args[0]) && truthy(*args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Or: {
-          auto args = get_args(bc);
-          bool result = truthy(*args[0]) || truthy(*args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::In: {
-          auto args = get_args(bc);
-          bool result = std::find(args[1]->begin(), args[1]->end(), *args[0]) !=
-                        args[1]->end();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Equal: {
-          auto args = get_args(bc);
-          bool result = (*args[0] == *args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Greater: {
-          auto args = get_args(bc);
-          bool result = (*args[0] > *args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Less: {
-          auto args = get_args(bc);
-          bool result = (*args[0] < *args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::GreaterEqual: {
-          auto args = get_args(bc);
-          bool result = (*args[0] >= *args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::LessEqual: {
-          auto args = get_args(bc);
-          bool result = (*args[0] <= *args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Different: {
-          auto args = get_args(bc);
-          bool result = (*args[0] != *args[1]);
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Float: {
-          double result =
-              std::stod(get_args(bc)[0]->get_ref<const std::string&>());
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Int: {
-          int result = std::stoi(get_args(bc)[0]->get_ref<const std::string&>());
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Exists: {
-          auto&& name = get_args(bc)[0]->get_ref<const std::string&>();
-          bool result = (data.find(name) != data.end());
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::ExistsInObject: {
-          auto args = get_args(bc);
-          auto&& name = args[1]->get_ref<const std::string&>();
-          bool result = (args[0]->find(name) != args[0]->end());
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::IsBoolean: {
-          bool result = get_args(bc)[0]->is_boolean();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::IsNumber: {
-          bool result = get_args(bc)[0]->is_number();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::IsInteger: {
-          bool result = get_args(bc)[0]->is_number_integer();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::IsFloat: {
-          bool result = get_args(bc)[0]->is_number_float();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::IsObject: {
-          bool result = get_args(bc)[0]->is_object();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::IsArray: {
-          bool result = get_args(bc)[0]->is_array();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::IsString: {
-          bool result = get_args(bc)[0]->is_string();
-          pop_args(bc);
-          m_stack.emplace_back(result);
-          break;
-        }
-        case Bytecode::Op::Default: {
-          // default needs to be a bit "magic"; we can't evaluate the first
-          // argument during the push operation, so we swap the arguments during
-          // the parse phase so the second argument is pushed on the stack and
-          // the first argument is in the immediate
-          try {
-            const json* imm = get_imm(bc);
-            // if no exception was raised, replace the stack value with it
-            m_stack.back() = *imm;
-          } catch (std::exception&) {
-            // couldn't read immediate, just leave the stack as is
-          }
-          break;
-        }
-        case Bytecode::Op::Include:
-          Renderer(m_included_templates, m_callbacks).render_to(os, m_included_templates.find(get_imm(bc)->get_ref<const std::string&>())->second, data);
-          break;
-        case Bytecode::Op::Callback: {
-          auto callback = m_callbacks.find_callback(bc.str, bc.args);
-          if (!callback) {
-            inja_throw("render_error", "function '" + static_cast<std::string>(bc.str) + "' (" + std::to_string(static_cast<unsigned int>(bc.args)) + ") not found");
-          }
-          json result = callback(get_args(bc));
-          pop_args(bc);
-          m_stack.emplace_back(std::move(result));
-          break;
-        }
-        case Bytecode::Op::Jump: {
-          i = bc.args - 1;  // -1 due to ++i in loop
-          break;
-        }
-        case Bytecode::Op::ConditionalJump: {
-          if (!truthy(m_stack.back())) {
-            i = bc.args - 1;  // -1 due to ++i in loop
-          }
-          m_stack.pop_back();
-          break;
-        }
-        case Bytecode::Op::StartLoop: {
-          // jump past loop body if empty
-          if (m_stack.back().empty()) {
-            m_stack.pop_back();
-            i = bc.args;  // ++i in loop will take it past EndLoop
-            break;
-          }
+    std::array<const json*, N> result;
+    for (size_t i = 0; i < N; i += 1) {
+      result[N - i - 1] = json_eval_stack.top();
+      json_eval_stack.pop();
 
-          m_loop_stack.emplace_back();
-          LoopLevel& level = m_loop_stack.back();
-          level.value_name = bc.str;
-          level.values = std::move(m_stack.back());
-          level.data = (*m_data);
-          m_stack.pop_back();
+      if (!result[N - i - 1]) {
+        const auto json_node = not_found_stack.top();
+        not_found_stack.pop();
 
-          if (bc.value.is_string()) {
-            // map iterator
-            if (!level.values.is_object()) {
-              m_loop_stack.pop_back();
-              inja_throw("render_error", "for key, value requires object");
-            }
-            level.loop_type = LoopLevel::Type::Map;
-            level.key_name = bc.value.get_ref<const std::string&>();
-
-            // sort by key
-            for (auto it = level.values.begin(), end = level.values.end(); it != end; ++it) {
-              level.map_values.emplace_back(it.key(), &it.value());
-            }
-            std::sort(level.map_values.begin(), level.map_values.end(), [](const LoopLevel::KeyValue& a, const LoopLevel::KeyValue& b) { return a.first < b.first; });
-            level.map_it = level.map_values.begin();
-          } else {
-            if (!level.values.is_array()) {
-              m_loop_stack.pop_back();
-              inja_throw("render_error", "type must be array");
-            }
-
-            // list iterator
-            level.loop_type = LoopLevel::Type::Array;
-            level.index = 0;
-            level.size = level.values.size();
-          }
-
-          // provide parent access in nested loop
-          auto parent_loop_it = level.data.find("loop");
-          if (parent_loop_it != level.data.end()) {
-            json loop_copy = *parent_loop_it;
-            (*parent_loop_it)["parent"] = std::move(loop_copy);
-          }
-
-          // set "current" data to loop data
-          m_data = &level.data;
-          update_loop_data();
-          break;
-        }
-        case Bytecode::Op::EndLoop: {
-          if (m_loop_stack.empty()) {
-            inja_throw("render_error", "unexpected state in renderer");
-          }
-          LoopLevel& level = m_loop_stack.back();
-
-          bool done;
-          if (level.loop_type == LoopLevel::Type::Array) {
-            level.index += 1;
-            done = (level.index == level.values.size());
-          } else {
-            level.map_it += 1;
-            done = (level.map_it == level.map_values.end());
-          }
-
-          if (done) {
-            m_loop_stack.pop_back();
-            // set "current" data to outer loop data or main data as appropriate
-            if (!m_loop_stack.empty()) {
-              m_data = &m_loop_stack.back().data;
-            } else {
-              m_data = &data;
-            }
-            break;
-          }
-
-          update_loop_data();
-
-          // jump back to start of loop
-          i = bc.args - 1;  // -1 due to ++i in loop
-          break;
-        }
-        default: {
-          inja_throw("render_error", "unknown op in renderer: " + std::to_string(static_cast<unsigned int>(bc.op)));
+        if (throw_not_found) {
+          throw_renderer_error("variable '" + static_cast<std::string>(json_node->name) + "' not found", *json_node);
         }
       }
     }
+    return result;
+  }
+
+  template<bool throw_not_found=true>
+  Arguments get_argument_vector(const FunctionNode& node) {
+    const size_t N = node.arguments.size();
+    for (auto a: node.arguments) {
+      a->accept(*this);
+    }
+
+    if (json_eval_stack.size() < N) {
+      throw_renderer_error("function needs " + std::to_string(N) + " variables, but has only found " + std::to_string(json_eval_stack.size()), node);
+    }
+
+    Arguments result {N};
+    for (size_t i = 0; i < N; i += 1) {
+      result[N - i - 1] = json_eval_stack.top();
+      json_eval_stack.pop();
+
+      if (!result[N - i - 1]) {
+        const auto json_node = not_found_stack.top();
+        not_found_stack.pop();
+
+        if (throw_not_found) {
+          throw_renderer_error("variable '" + static_cast<std::string>(json_node->name) + "' not found", *json_node);
+        }
+      }
+    }
+    return result;
+  }
+
+  void visit(const BlockNode& node) {
+    for (auto& n : node.nodes) {
+      n->accept(*this);
+
+      if (break_rendering) {
+        break;
+      }
+    }
+  }
+
+  void visit(const TextNode& node) {
+    output_stream->write(current_template->content.c_str() + node.pos, node.length);
+  }
+
+  void visit(const ExpressionNode&) { }
+
+  void visit(const LiteralNode& node) {
+    json_eval_stack.push(&node.value);
+  }
+
+  void visit(const JsonNode& node) {
+    if (json_additional_data.contains(node.ptr)) {
+      json_eval_stack.push(&(json_additional_data[node.ptr]));
+
+    } else if (json_input->contains(node.ptr)) {
+      json_eval_stack.push(&(*json_input)[node.ptr]);
+
+    } else {
+      // Try to evaluate as a no-argument callback
+      const auto function_data = function_storage.find_function(node.name, 0);
+      if (function_data.operation == FunctionStorage::Operation::Callback) {
+        Arguments empty_args {};
+        const auto value = std::make_shared<json>(function_data.callback(empty_args));
+        json_tmp_stack.push_back(value);
+        json_eval_stack.push(value.get());
+
+      } else {
+        json_eval_stack.push(nullptr);
+        not_found_stack.emplace(&node);
+      }
+    }
+  }
+
+  void visit(const FunctionNode& node) {
+    std::shared_ptr<json> result_ptr;
+
+    switch (node.operation) {
+    case Op::Not: {
+      const auto args = get_arguments<1>(node);
+      result_ptr = std::make_shared<json>(!truthy(args[0]));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::And: {
+      result_ptr = std::make_shared<json>(truthy(get_arguments<1, 0>(node)[0]) && truthy(get_arguments<1, 1>(node)[0]));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Or: {
+      result_ptr = std::make_shared<json>(truthy(get_arguments<1, 0>(node)[0]) || truthy(get_arguments<1, 1>(node)[0]));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::In: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(std::find(args[1]->begin(), args[1]->end(), *args[0]) != args[1]->end());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Equal: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(*args[0] == *args[1]);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::NotEqual: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(*args[0] != *args[1]);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Greater: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(*args[0] > *args[1]);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::GreaterEqual: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(*args[0] >= *args[1]);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Less: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(*args[0] < *args[1]);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::LessEqual: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(*args[0] <= *args[1]);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Add: {
+      const auto args = get_arguments<2>(node);
+      if (args[0]->is_string() && args[1]->is_string()) {
+        result_ptr = std::make_shared<json>(args[0]->get_ref<const std::string&>() + args[1]->get_ref<const std::string&>());
+        json_tmp_stack.push_back(result_ptr);
+      } else if (args[0]->is_number_integer() && args[1]->is_number_integer()) {
+        result_ptr = std::make_shared<json>(args[0]->get<int>() + args[1]->get<int>());
+        json_tmp_stack.push_back(result_ptr);
+      } else {
+        result_ptr = std::make_shared<json>(args[0]->get<double>() + args[1]->get<double>());
+        json_tmp_stack.push_back(result_ptr);
+      }
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Subtract: {
+      const auto args = get_arguments<2>(node);
+      if (args[0]->is_number_integer() && args[1]->is_number_integer()) {
+        result_ptr = std::make_shared<json>(args[0]->get<int>() - args[1]->get<int>());
+        json_tmp_stack.push_back(result_ptr);
+      } else {
+        result_ptr = std::make_shared<json>(args[0]->get<double>() - args[1]->get<double>());
+        json_tmp_stack.push_back(result_ptr);
+      }
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Multiplication: {
+      const auto args = get_arguments<2>(node);
+      if (args[0]->is_number_integer() && args[1]->is_number_integer()) {
+        result_ptr = std::make_shared<json>(args[0]->get<int>() * args[1]->get<int>());
+        json_tmp_stack.push_back(result_ptr);
+      } else {
+        result_ptr = std::make_shared<json>(args[0]->get<double>() * args[1]->get<double>());
+        json_tmp_stack.push_back(result_ptr);
+      }
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Division: {
+      const auto args = get_arguments<2>(node);
+      if (args[1]->get<double>() == 0) {
+        throw_renderer_error("division by zero", node);
+      }
+      result_ptr = std::make_shared<json>(args[0]->get<double>() / args[1]->get<double>());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Power: {
+      const auto args = get_arguments<2>(node);
+      if (args[0]->is_number_integer() && args[1]->get<int>() >= 0) {
+        int result = static_cast<int>(std::pow(args[0]->get<int>(), args[1]->get<int>()));
+        result_ptr = std::make_shared<json>(std::move(result));
+        json_tmp_stack.push_back(result_ptr);
+      } else {
+        double result = std::pow(args[0]->get<double>(), args[1]->get<int>());
+        result_ptr = std::make_shared<json>(std::move(result));
+        json_tmp_stack.push_back(result_ptr);
+      }
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Modulo: {
+      const auto args = get_arguments<2>(node);
+      result_ptr = std::make_shared<json>(args[0]->get<int>() % args[1]->get<int>());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::AtId: {
+      const auto container = get_arguments<1, 0, false>(node)[0];
+      node.arguments[1]->accept(*this);
+      if (not_found_stack.empty()) {
+        throw_renderer_error("could not find element with given name", node);
+      }
+      const auto id_node = not_found_stack.top();
+      not_found_stack.pop();
+      json_eval_stack.pop();
+      json_eval_stack.push(&container->at(id_node->name));
+    } break;
+    case Op::At: {
+      const auto args = get_arguments<2>(node);
+      if (args[0]->is_object()) {
+        json_eval_stack.push(&args[0]->at(args[1]->get<std::string>()));
+      } else {
+        json_eval_stack.push(&args[0]->at(args[1]->get<int>()));
+      }
+    } break;
+    case Op::Default: {
+      const auto test_arg = get_arguments<1, 0, false>(node)[0];
+      json_eval_stack.push(test_arg ? test_arg : get_arguments<1, 1>(node)[0]);
+    } break;
+    case Op::DivisibleBy: {
+      const auto args = get_arguments<2>(node);
+      const int divisor = args[1]->get<int>();
+      result_ptr = std::make_shared<json>((divisor != 0) && (args[0]->get<int>() % divisor == 0));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Even: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->get<int>() % 2 == 0);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Exists: {
+      auto &&name = get_arguments<1>(node)[0]->get_ref<const std::string &>();
+      result_ptr = std::make_shared<json>(json_input->contains(json::json_pointer(JsonNode::convert_dot_to_json_ptr(name))));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::ExistsInObject: {
+      const auto args = get_arguments<2>(node);
+      auto &&name = args[1]->get_ref<const std::string &>();
+      result_ptr = std::make_shared<json>(args[0]->find(name) != args[0]->end());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::First: {
+      const auto result = &get_arguments<1>(node)[0]->front();
+      json_eval_stack.push(result);
+    } break;
+    case Op::Float: {
+      result_ptr = std::make_shared<json>(std::stod(get_arguments<1>(node)[0]->get_ref<const std::string &>()));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Int: {
+      result_ptr = std::make_shared<json>(std::stoi(get_arguments<1>(node)[0]->get_ref<const std::string &>()));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Last: {
+      const auto result = &get_arguments<1>(node)[0]->back();
+      json_eval_stack.push(result);
+    } break;
+    case Op::Length: {
+      const auto val = get_arguments<1>(node)[0];
+      if (val->is_string()) {
+        result_ptr = std::make_shared<json>(val->get_ref<const std::string &>().length());
+      } else {
+        result_ptr = std::make_shared<json>(val->size());
+      }
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Lower: {
+      std::string result = get_arguments<1>(node)[0]->get<std::string>();
+      std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+      result_ptr = std::make_shared<json>(std::move(result));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Max: {
+      const auto args = get_arguments<1>(node);
+      const auto result = std::max_element(args[0]->begin(), args[0]->end());
+      json_eval_stack.push(&(*result));
+    } break;
+    case Op::Min: {
+      const auto args = get_arguments<1>(node);
+      const auto result = std::min_element(args[0]->begin(), args[0]->end());
+      json_eval_stack.push(&(*result));
+    } break;
+    case Op::Odd: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->get<int>() % 2 != 0);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Range: {
+      std::vector<int> result(get_arguments<1>(node)[0]->get<int>());
+      std::iota(result.begin(), result.end(), 0);
+      result_ptr = std::make_shared<json>(std::move(result));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Round: {
+      const auto args = get_arguments<2>(node);
+      const int precision = args[1]->get<int>();
+      const double result = std::round(args[0]->get<double>() * std::pow(10.0, precision)) / std::pow(10.0, precision);
+      if(0==precision){
+        result_ptr = std::make_shared<json>(int(result));
+      }else{
+        result_ptr = std::make_shared<json>(std::move(result));
+      }
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Sort: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->get<std::vector<json>>());
+      std::sort(result_ptr->begin(), result_ptr->end());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Upper: {
+      std::string result = get_arguments<1>(node)[0]->get<std::string>();
+      std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+      result_ptr = std::make_shared<json>(std::move(result));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::IsBoolean: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->is_boolean());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::IsNumber: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->is_number());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::IsInteger: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->is_number_integer());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::IsFloat: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->is_number_float());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::IsObject: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->is_object());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::IsArray: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->is_array());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::IsString: {
+      result_ptr = std::make_shared<json>(get_arguments<1>(node)[0]->is_string());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Callback: {
+      auto args = get_argument_vector(node);
+      result_ptr = std::make_shared<json>(node.callback(args));
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Super: {
+      const auto args = get_argument_vector(node);
+      const size_t old_level = current_level;
+      const size_t level_diff = (args.size() == 1) ? args[0]->get<int>() : 1;
+      const size_t level = current_level + level_diff;
+
+      if (block_statement_stack.empty()) {
+        throw_renderer_error("super() call is not within a block", node);
+      }
+
+      if (level < 1 || level > template_stack.size() - 1) {
+        throw_renderer_error("level of super() call does not match parent templates (between 1 and " + std::to_string(template_stack.size() - 1) + ")", node);
+      }
+
+      const auto current_block_statement = block_statement_stack.back();
+      const Template *new_template = template_stack.at(level);
+      const Template *old_template = current_template;
+      const auto block_it = new_template->block_storage.find(current_block_statement->name);
+      if (block_it != new_template->block_storage.end()) {
+        current_template = new_template;
+        current_level = level;
+        block_it->second->block.accept(*this);
+        current_level = old_level;
+        current_template = old_template;
+      } else {
+        throw_renderer_error("could not find block with name '" + current_block_statement->name + "'", node);
+      }
+      result_ptr = std::make_shared<json>(nullptr);
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::Join: {
+      const auto args = get_arguments<2>(node);
+      const auto separator = args[1]->get<std::string>();
+      std::ostringstream os;
+      std::string sep;
+      for (const auto& value : *args[0]) {
+        os << sep;
+        if (value.is_string()) {
+          os << value.get<std::string>(); // otherwise the value is surrounded with ""
+        } else {
+          os << value;
+        }
+        sep = separator;
+      }
+      result_ptr = std::make_shared<json>(os.str());
+      json_tmp_stack.push_back(result_ptr);
+      json_eval_stack.push(result_ptr.get());
+    } break;
+    case Op::ParenLeft:
+    case Op::ParenRight:
+    case Op::None:
+      break;
+    }
+  }
+
+  void visit(const ExpressionListNode& node) {
+    print_json(eval_expression_list(node));
+  }
+
+  void visit(const StatementNode&) { }
+
+  void visit(const ForStatementNode&) { }
+
+  void visit(const ForArrayStatementNode& node) {
+    const auto result = eval_expression_list(node.condition);
+    if (!result->is_array()) {
+      throw_renderer_error("object must be an array", node);
+    }
+
+    if (!current_loop_data->empty()) {
+      auto tmp = *current_loop_data; // Because of clang-3
+      (*current_loop_data)["parent"] = std::move(tmp);
+    }
+
+    size_t index = 0;
+    (*current_loop_data)["is_first"] = true;
+    (*current_loop_data)["is_last"] = (result->size() <= 1);
+    for (auto it = result->begin(); it != result->end(); ++it) {
+      json_additional_data[static_cast<std::string>(node.value)] = *it;
+
+      (*current_loop_data)["index"] = index;
+      (*current_loop_data)["index1"] = index + 1;
+      if (index == 1) {
+        (*current_loop_data)["is_first"] = false;
+      }
+      if (index == result->size() - 1) {
+        (*current_loop_data)["is_last"] = true;
+      }
+
+      node.body.accept(*this);
+      ++index;
+    }
+
+    json_additional_data[static_cast<std::string>(node.value)].clear();
+    if (!(*current_loop_data)["parent"].empty()) {
+      const auto tmp = (*current_loop_data)["parent"];
+      *current_loop_data = std::move(tmp);
+    } else {
+      current_loop_data = &json_additional_data["loop"];
+    }
+  }
+
+  void visit(const ForObjectStatementNode& node) {
+    const auto result = eval_expression_list(node.condition);
+    if (!result->is_object()) {
+      throw_renderer_error("object must be an object", node);
+    }
+
+    if (!current_loop_data->empty()) {
+      (*current_loop_data)["parent"] = std::move(*current_loop_data);
+    }
+
+    size_t index = 0;
+    (*current_loop_data)["is_first"] = true;
+    (*current_loop_data)["is_last"] = (result->size() <= 1);
+    for (auto it = result->begin(); it != result->end(); ++it) {
+      json_additional_data[static_cast<std::string>(node.key)] = it.key();
+      json_additional_data[static_cast<std::string>(node.value)] = it.value();
+
+      (*current_loop_data)["index"] = index;
+      (*current_loop_data)["index1"] = index + 1;
+      if (index == 1) {
+        (*current_loop_data)["is_first"] = false;
+      }
+      if (index == result->size() - 1) {
+        (*current_loop_data)["is_last"] = true;
+      }
+
+      node.body.accept(*this);
+      ++index;
+    }
+
+    json_additional_data[static_cast<std::string>(node.key)].clear();
+    json_additional_data[static_cast<std::string>(node.value)].clear();
+    if (!(*current_loop_data)["parent"].empty()) {
+      *current_loop_data = std::move((*current_loop_data)["parent"]);
+    } else {
+      current_loop_data = &json_additional_data["loop"];
+    }
+  }
+
+  void visit(const IfStatementNode& node) {
+    const auto result = eval_expression_list(node.condition);
+    if (truthy(result.get())) {
+      node.true_statement.accept(*this);
+    } else if (node.has_false_statement) {
+      node.false_statement.accept(*this);
+    }
+  }
+
+  void visit(const IncludeStatementNode& node) {
+    auto sub_renderer = Renderer(config, template_storage, function_storage);
+    const auto included_template_it = template_storage.find(node.file);
+    if (included_template_it != template_storage.end()) {
+      sub_renderer.render_to(*output_stream, included_template_it->second, *json_input, &json_additional_data);
+    } else if (config.throw_at_missing_includes) {
+      throw_renderer_error("include '" + node.file + "' not found", node);
+    }
+  }
+
+  void visit(const ExtendsStatementNode& node) {
+    const auto included_template_it = template_storage.find(node.file);
+    if (included_template_it != template_storage.end()) {
+      const Template *parent_template = &included_template_it->second;
+      render_to(*output_stream, *parent_template, *json_input, &json_additional_data);
+      break_rendering = true;
+    } else if (config.throw_at_missing_includes) {
+      throw_renderer_error("extends '" + node.file + "' not found", node);
+    }
+  }
+
+  void visit(const BlockStatementNode& node) {
+    const size_t old_level = current_level;
+    current_level = 0;
+    current_template = template_stack.front();
+    const auto block_it = current_template->block_storage.find(node.name);
+    if (block_it != current_template->block_storage.end()) {
+      block_statement_stack.emplace_back(&node);
+      block_it->second->block.accept(*this);
+      block_statement_stack.pop_back();
+    }
+    current_level = old_level;
+    current_template = template_stack.back();
+  }
+
+  void visit(const SetStatementNode& node) {
+    std::string ptr = node.key;
+    replace_substring(ptr, ".", "/");
+    ptr = "/" + ptr;
+    json_additional_data[nlohmann::json::json_pointer(ptr)] = *eval_expression_list(node.expression);
+  }
+
+public:
+  Renderer(const RenderConfig& config, const TemplateStorage &template_storage, const FunctionStorage &function_storage)
+      : config(config), template_storage(template_storage), function_storage(function_storage) { }
+
+  void render_to(std::ostream &os, const Template &tmpl, const json &data, json *loop_data = nullptr) {
+    output_stream = &os;
+    current_template = &tmpl;
+    json_input = &data;
+    if (loop_data) {
+      json_additional_data = *loop_data;
+      current_loop_data = &json_additional_data["loop"];
+    }
+
+    template_stack.emplace_back(current_template);
+    current_template->root.accept(*this);
+
+    json_tmp_stack.clear();
   }
 };
 
-}  // namespace inja
+} // namespace inja
 
-#endif  // PANTOR_INJA_RENDERER_HPP
+#endif // INCLUDE_INJA_RENDERER_HPP_
 
 // #include "string_view.hpp"
 
 // #include "template.hpp"
 
+// #include "utils.hpp"
 
 
 namespace inja {
 
-using namespace nlohmann;
+using json = nlohmann::json;
 
+/*!
+ * \brief Class for changing the configuration.
+ */
 class Environment {
-  class Impl {
-   public:
-    std::string input_path;
-    std::string output_path;
+  std::string input_path;
+  std::string output_path;
 
-    LexerConfig lexer_config;
-    ParserConfig parser_config;
+  LexerConfig lexer_config;
+  ParserConfig parser_config;
+  RenderConfig render_config;
 
-    FunctionStorage callbacks;
-    TemplateStorage included_templates;
-  };
+  FunctionStorage function_storage;
+  TemplateStorage template_storage;
 
-  std::unique_ptr<Impl> m_impl;
+public:
+  Environment() : Environment("") {}
 
- public:
-  Environment(): Environment("") { }
+  explicit Environment(const std::string &global_path) : input_path(global_path), output_path(global_path) {}
 
-  explicit Environment(const std::string& global_path): m_impl(stdinja::make_unique<Impl>()) {
-    m_impl->input_path = global_path;
-    m_impl->output_path = global_path;
-  }
-
-  explicit Environment(const std::string& input_path, const std::string& output_path): m_impl(stdinja::make_unique<Impl>()) {
-    m_impl->input_path = input_path;
-    m_impl->output_path = output_path;
-  }
+  Environment(const std::string &input_path, const std::string &output_path)
+      : input_path(input_path), output_path(output_path) {}
 
   /// Sets the opener and closer for template statements
-  void set_statement(const std::string& open, const std::string& close) {
-    m_impl->lexer_config.statement_open = open;
-    m_impl->lexer_config.statement_close = close;
-    m_impl->lexer_config.update_open_chars();
+  void set_statement(const std::string &open, const std::string &close) {
+    lexer_config.statement_open = open;
+    lexer_config.statement_open_no_lstrip = open + "+";
+    lexer_config.statement_open_force_lstrip = open + "-";
+    lexer_config.statement_close = close;
+    lexer_config.statement_close_force_rstrip = "-" + close;
+    lexer_config.update_open_chars();
   }
 
   /// Sets the opener for template line statements
-  void set_line_statement(const std::string& open) {
-    m_impl->lexer_config.line_statement = open;
-    m_impl->lexer_config.update_open_chars();
+  void set_line_statement(const std::string &open) {
+    lexer_config.line_statement = open;
+    lexer_config.update_open_chars();
   }
 
   /// Sets the opener and closer for template expressions
-  void set_expression(const std::string& open, const std::string& close) {
-    m_impl->lexer_config.expression_open = open;
-    m_impl->lexer_config.expression_close = close;
-    m_impl->lexer_config.update_open_chars();
+  void set_expression(const std::string &open, const std::string &close) {
+    lexer_config.expression_open = open;
+    lexer_config.expression_open_force_lstrip = open + "-";
+    lexer_config.expression_close = close;
+    lexer_config.expression_close_force_rstrip = "-" + close;
+    lexer_config.update_open_chars();
   }
 
   /// Sets the opener and closer for template comments
-  void set_comment(const std::string& open, const std::string& close) {
-    m_impl->lexer_config.comment_open = open;
-    m_impl->lexer_config.comment_close = close;
-    m_impl->lexer_config.update_open_chars();
+  void set_comment(const std::string &open, const std::string &close) {
+    lexer_config.comment_open = open;
+    lexer_config.comment_open_force_lstrip = open + "-";
+    lexer_config.comment_close = close;
+    lexer_config.comment_close_force_rstrip = "-" + close;
+    lexer_config.update_open_chars();
+  }
+
+  /// Sets whether to remove the first newline after a block
+  void set_trim_blocks(bool trim_blocks) {
+    lexer_config.trim_blocks = trim_blocks;
+  }
+
+  /// Sets whether to strip the spaces and tabs from the start of a line to a block
+  void set_lstrip_blocks(bool lstrip_blocks) {
+    lexer_config.lstrip_blocks = lstrip_blocks;
   }
 
   /// Sets the element notation syntax
-  void set_element_notation(ElementNotation notation) {
-    m_impl->parser_config.notation = notation;
+  void set_search_included_templates_in_files(bool search_in_files) {
+    parser_config.search_included_templates_in_files = search_in_files;
   }
 
+  /// Sets whether a missing include will throw an error
+  void set_throw_at_missing_includes(bool will_throw) {
+    render_config.throw_at_missing_includes = will_throw;
+  }
 
   Template parse(nonstd::string_view input) {
-    Parser parser(m_impl->parser_config, m_impl->lexer_config, m_impl->included_templates);
+    Parser parser(parser_config, lexer_config, template_storage, function_storage);
     return parser.parse(input);
   }
 
-  Template parse_template(const std::string& filename) {
-    Parser parser(m_impl->parser_config, m_impl->lexer_config, m_impl->included_templates);
-		return parser.parse_template(m_impl->input_path + static_cast<std::string>(filename));
-	}
-
-  std::string render(nonstd::string_view input, const json& data) {
-    return render(parse(input), data);
+  Template parse_template(const std::string &filename) {
+    Parser parser(parser_config, lexer_config, template_storage, function_storage);
+    auto result = Template(parser.load_file(input_path + static_cast<std::string>(filename)));
+    parser.parse_into_template(result, input_path + static_cast<std::string>(filename));
+    return result;
   }
 
-  std::string render(const Template& tmpl, const json& data) {
+  Template parse_file(const std::string &filename) {
+    return parse_template(filename);
+  }
+
+  std::string render(nonstd::string_view input, const json &data) { return render(parse(input), data); }
+
+  std::string render(const Template &tmpl, const json &data) {
     std::stringstream os;
     render_to(os, tmpl, data);
     return os.str();
   }
 
-  std::string render_file(const std::string& filename, const json& data) {
-		return render(parse_template(filename), data);
-	}
+  std::string render_file(const std::string &filename, const json &data) {
+    return render(parse_template(filename), data);
+  }
 
-  std::string render_file_with_json_file(const std::string& filename, const std::string& filename_data) {
-		const json data = load_json(filename_data);
-		return render_file(filename, data);
-	}
+  std::string render_file_with_json_file(const std::string &filename, const std::string &filename_data) {
+    const json data = load_json(filename_data);
+    return render_file(filename, data);
+  }
 
-  void write(const std::string& filename, const json& data, const std::string& filename_out) {
-		std::ofstream file(m_impl->output_path + filename_out);
-		file << render_file(filename, data);
-		file.close();
-	}
+  void write(const std::string &filename, const json &data, const std::string &filename_out) {
+    std::ofstream file(output_path + filename_out);
+    file << render_file(filename, data);
+    file.close();
+  }
 
-  void write(const Template& temp, const json& data, const std::string& filename_out) {
-		std::ofstream file(m_impl->output_path + filename_out);
-		file << render(temp, data);
-		file.close();
-	}
+  void write(const Template &temp, const json &data, const std::string &filename_out) {
+    std::ofstream file(output_path + filename_out);
+    file << render(temp, data);
+    file.close();
+  }
 
-	void write_with_json_file(const std::string& filename, const std::string& filename_data, const std::string& filename_out) {
-		const json data = load_json(filename_data);
-		write(filename, data, filename_out);
-	}
+  void write_with_json_file(const std::string &filename, const std::string &filename_data,
+                            const std::string &filename_out) {
+    const json data = load_json(filename_data);
+    write(filename, data, filename_out);
+  }
 
-	void write_with_json_file(const Template& temp, const std::string& filename_data, const std::string& filename_out) {
-		const json data = load_json(filename_data);
-		write(temp, data, filename_out);
-	}
+  void write_with_json_file(const Template &temp, const std::string &filename_data, const std::string &filename_out) {
+    const json data = load_json(filename_data);
+    write(temp, data, filename_out);
+  }
 
-  std::ostream& render_to(std::ostream& os, const Template& tmpl, const json& data) {
-    Renderer(m_impl->included_templates, m_impl->callbacks).render_to(os, tmpl, data);
+  std::ostream &render_to(std::ostream &os, const Template &tmpl, const json &data) {
+    Renderer(render_config, template_storage, function_storage).render_to(os, tmpl, data);
     return os;
   }
 
-  std::string load_file(const std::string& filename) {
-    Parser parser(m_impl->parser_config, m_impl->lexer_config, m_impl->included_templates);
-		return parser.load_file(m_impl->input_path + filename);
-	}
+  std::string load_file(const std::string &filename) {
+    Parser parser(parser_config, lexer_config, template_storage, function_storage);
+    return parser.load_file(input_path + filename);
+  }
 
-  json load_json(const std::string& filename) {
-		std::ifstream file(m_impl->input_path + filename);
-		json j;
-		file >> j;
-		return j;
-	}
+  json load_json(const std::string &filename) {
+    std::ifstream file;
+    open_file_or_throw(input_path + filename, file);
+    json j;
+    file >> j;
+    return j;
+  }
 
-  void add_callback(const std::string& name, unsigned int numArgs, const CallbackFunction& callback) {
-    m_impl->callbacks.add_callback(name, numArgs, callback);
+  /*!
+  @brief Adds a variadic callback
+  */
+  void add_callback(const std::string &name, const CallbackFunction &callback) {
+    add_callback(name, -1, callback);
+  }
+
+  /*!
+  @brief Adds a variadic void callback
+  */
+  void add_void_callback(const std::string &name, const VoidCallbackFunction &callback) {
+    add_void_callback(name, -1, callback);
+  }
+
+  /*!
+  @brief Adds a callback with given number or arguments
+  */
+  void add_callback(const std::string &name, int num_args, const CallbackFunction &callback) {
+    function_storage.add_callback(name, num_args, callback);
+  }
+
+  /*!
+  @brief Adds a void callback with given number or arguments
+  */
+  void add_void_callback(const std::string &name, int num_args, const VoidCallbackFunction &callback) {
+    function_storage.add_callback(name, num_args, [callback](Arguments& args) { callback(args); return json(); });
   }
 
   /** Includes a template with a given name into the environment.
    * Then, a template can be rendered in another template using the
    * include "<name>" syntax.
    */
-  void include_template(const std::string& name, const Template& tmpl) {
-    m_impl->included_templates[name] = tmpl;
+  void include_template(const std::string &name, const Template &tmpl) {
+    template_storage[name] = tmpl;
   }
 };
 
 /*!
 @brief render with default settings to a string
 */
-inline std::string render(nonstd::string_view input, const json& data) {
+inline std::string render(nonstd::string_view input, const json &data) {
   return Environment().render(input, data);
 }
 
 /*!
 @brief render with default settings to the given output stream
 */
-inline void render_to(std::ostream& os, nonstd::string_view input, const json& data) {
+inline void render_to(std::ostream &os, nonstd::string_view input, const json &data) {
   Environment env;
   env.render_to(os, env.parse(input), data);
 }
 
-}
+} // namespace inja
 
-#endif // PANTOR_INJA_ENVIRONMENT_HPP
+#endif // INCLUDE_INJA_ENVIRONMENT_HPP_
 
-// #include "string_view.hpp"
-
-// #include "template.hpp"
+// #include "exceptions.hpp"
 
 // #include "parser.hpp"
 
 // #include "renderer.hpp"
 
+// #include "string_view.hpp"
+
+// #include "template.hpp"
 
 
-#endif  // PANTOR_INJA_HPP
+#endif // INCLUDE_INJA_INJA_HPP_

--- a/resources/server/api/ogc/templates/wfs3/getFeatures.html
+++ b/resources/server/api/ogc/templates/wfs3/getFeatures.html
@@ -54,7 +54,7 @@
                 <dl class="row">
                 {% for name, value in feature.properties %}
                     <dt class="col-sm-12">{{ name }}</dt>
-                    <dd class="col-sm-12">{{ value }}</dd>
+                    <dd class="col-sm-12">{{ if_nullptr_null_str(value) }}</dd>
                 {% endfor %}
                 </dl>
             {% endfor %}


### PR DESCRIPTION
Appear when using recent (>v20) clang 