### PR TITLE
QgsDbImportVectorLayerDialog add option to only include selected features when importing

### DIFF
--- a/src/gui/qgsdbimportvectorlayerdialog.cpp
+++ b/src/gui/qgsdbimportvectorlayerdialog.cpp
@@ -234,6 +234,9 @@ void QgsDbImportVectorLayerDialog::setSourceLayer( QgsVectorLayer *layer )
   mFieldsView->setSourceLayer( mSourceLayer );
   mFieldsView->setSourceFields( mSourceLayer->fields() );
   mFieldsView->setDestinationFields( mSourceLayer->fields() );
+
+  const bool selectedFeatures = mSourceLayer->selectedFeatureCount() > 0;
+  mSourceLayerOnlySelected->setEnabled( selectedFeatures );
 }
 
 void QgsDbImportVectorLayerDialog::loadFieldsFromLayer()
@@ -350,6 +353,11 @@ std::unique_ptr<QgsVectorLayerExporterTask> QgsDbImportVectorLayerDialog::create
   if ( mExtentGroupBox->isEnabled() && mExtentGroupBox->isChecked() )
   {
     exportOptions.setExtent( QgsReferencedRectangle( mExtentGroupBox->outputExtent(), mExtentGroupBox->outputCrs() ) );
+  }
+
+  if ( mSourceLayerOnlySelected->isEnabled() && mSourceLayerOnlySelected->isChecked() )
+  {
+    exportOptions.setSelectedOnly( true );
   }
 
   const QList<QgsFieldMappingModel::Field> fieldMapping = mFieldsView->mapping();

--- a/src/ui/qgsdbimportvectorlayerdialog.ui
+++ b/src/ui/qgsdbimportvectorlayerdialog.ui
@@ -41,6 +41,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="mSourceLayerOnlySelected">
+        <property name="text">
+         <string>Selected features only</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
## Description

Add option to QgsDbImportVectorLayerDialog to only export selected features. The button is only active if there is a selection on selected layer.

![selected_features](https://github.com/user-attachments/assets/3f73adbb-38b4-4f6e-aef0-faed2a7cc581)

Funded by Ocean Winds
