### PR TITLE
add kmeans++

### DIFF
--- a/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
@@ -264,7 +264,7 @@ void QgsKMeansClusteringAlgorithm::initClustersFarthestPoints( std::vector<Featu
 
   if ( feedback && duplicateCount > 1 )
   {
-    feedback->pushInfo( QObject::tr( "There are at least %n duplicate input(s), the number of output clusters may be less than was requested", nullptr, duplicateCount ) );
+    feedback->pushWarning( QObject::tr( "There are at least %n duplicate input(s), the number of output clusters may be less than was requested", nullptr, duplicateCount ) );
   }
 
   // By now two points should be found and be not the same
@@ -359,7 +359,7 @@ void QgsKMeansClusteringAlgorithm::initClustersPlusPlus( std::vector<Feature> &p
   }
   if ( feedback && duplicateCount > 1 )
   {
-    feedback->pushInfo( QObject::tr( "There are at least %n duplicate input(s), the number of output clusters may be less than was requested", nullptr, duplicateCount ) );
+    feedback->pushWarning( QObject::tr( "There are at least %n duplicate input(s), the number of output clusters may be less than was requested", nullptr, duplicateCount ) );
   }
 
   // greedy kmeans++

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
@@ -422,7 +422,7 @@ void QgsKMeansClusteringAlgorithm::initClustersPlusPlus( std::vector<Feature> &p
     // store distances between previous and new candidate center, error and best candidate index
     double currentError = 0;
     double lowestError = std::numeric_limits<double>::max();
-    size_t bestCandidateIndex;
+    unsigned int bestCandidateIndex = 0;
     for ( unsigned int j = 0; j < numCandidateCenters; j++ )
     {
       for ( size_t z = 0; z < n; z++ )

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -58,7 +58,8 @@ class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsProcessingAlgorit
         int cluster = -1;
     };
 
-    static void initClusters( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
+    static void initClustersFarthestPoints( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
+    static void initClustersPlusPlus( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     static void calculateKMeans( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     static void findNearest( std::vector<Feature> &points, const std::vector<QgsPointXY> &centers, int k, bool &changed );
     static void updateMeans( const std::vector<Feature> &points, std::vector<QgsPointXY> &centers, std::vector<uint> &weights, int k );

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -1016,44 +1016,65 @@ void TestQgsProcessingAlgsPt1::kmeansCluster()
 
   // no features, no crash
   int k = 2;
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  // farthest points
+  QgsKMeansClusteringAlgorithm::initClustersFarthestPoints( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  // kmeans++
+  QgsKMeansClusteringAlgorithm::initClustersPlusPlus( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
 
   // features < clusters
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 1, 5 ) ) );
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  // farthest points
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 1, 1 ) ) );
+  QgsKMeansClusteringAlgorithm::initClustersFarthestPoints( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  QCOMPARE( features[0].cluster, 0 );
+  // kmeans++
+  QgsKMeansClusteringAlgorithm::initClustersPlusPlus( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 0 );
 
   // features == clusters
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 11, 5 ) ) );
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 3, 1 ) ) );
+  // farthest points
+  QgsKMeansClusteringAlgorithm::initClustersFarthestPoints( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 1 );
   QCOMPARE( features[1].cluster, 0 );
+  // kmeans++
+  QgsKMeansClusteringAlgorithm::initClustersPlusPlus( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  QVERIFY( features[0].cluster != features[1].cluster );
 
   // features > clusters
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 13, 3 ) ) );
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 13, 13 ) ) );
-  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 23, 6 ) ) );
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 2, 8 ) ) );
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 1, 10 ) ) );
+  features.emplace_back( QgsKMeansClusteringAlgorithm::Feature( QgsPointXY( 3, 10 ) ) );
   k = 2;
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  // farthest points
+  QgsKMeansClusteringAlgorithm::initClustersFarthestPoints( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 1 );
   QCOMPARE( features[1].cluster, 1 );
   QCOMPARE( features[2].cluster, 0 );
   QCOMPARE( features[3].cluster, 0 );
   QCOMPARE( features[4].cluster, 0 );
+  // kmeans++
+  QgsKMeansClusteringAlgorithm::initClustersPlusPlus( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
+  QCOMPARE( features[0].cluster, features[1].cluster );
+  QCOMPARE( features[2].cluster, features[3].cluster );
+  QCOMPARE( features[4].cluster, features[3].cluster );
 
   // repeat above, with 3 clusters
   k = 3;
   centers.resize( 3 );
-  QgsKMeansClusteringAlgorithm::initClusters( features, centers, k, nullptr );
+  QgsKMeansClusteringAlgorithm::initClustersFarthestPoints( features, centers, k, nullptr );
   QgsKMeansClusteringAlgorithm::calculateKMeans( features, centers, k, nullptr );
   QCOMPARE( features[0].cluster, 1 );
-  QCOMPARE( features[1].cluster, 2 );
+  QCOMPARE( features[1].cluster, 1 );
   QCOMPARE( features[2].cluster, 2 );
-  QCOMPARE( features[3].cluster, 2 );
+  QCOMPARE( features[3].cluster, 0 );
   QCOMPARE( features[4].cluster, 0 );
 
   // with identical points


### PR DESCRIPTION
Original paper: https://theory.stanford.edu/~sergei/papers/kMeansPP-soda.pdf
Original author presentation (with pictures and graphs): https://theory.stanford.edu/~sergei/slides/BATS-Means.pdf
Greedy kmeans++ (for the L value): https://drops.dagstuhl.de/storage/00lipics/lipics-vol173-esa2020/LIPIcs.ESA.2020.18/LIPIcs.ESA.2020.18.pdf

For reviewer(s), scikit implementation: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/cluster/_kmeans.py#L174
(keep in mind if you want to test scikit results, the idea with kmeans++ is that it randomly selects initial centers and thus you can get different results across runs, but to achieve that with scikit KMeans, you have to pass it rand generator – if not, it will use one, but with a fixed seed value, so you will get the same result across multiple runs) 

Kmeans++ differs only in the initial center selection, the rest is the same. On average, it converges faster (requires less iterations) than the farthest points initialization.

I could not come up with a test case with 3 or more clusters in reasonable time (not execution, but thinking problem ;)), so I didn’t include any. I guess that’s the reason scikit implementation can be passed seed value for the generator as with it the algorithm becomes deterministic if we know all the values and the result can be calculated.
