### PR TITLE
Pin GitHub workflows to use SHA pinning for 3rd party actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Backport Bot
         id: backport
         if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( join( github.event.pull_request.labels.*.name ), 'backport') ) || contains( github.event.label.name, 'backport' ) )
-        uses: m-kuhn/backport@v1.2.7
+        uses: m-kuhn/backport@7f3cab83e4b3b26aefcffda21851c3dc3d389f45 #v1.2.7
         with:
           github_token: ${{ secrets.GH_TOKEN_BOT }}

--- a/.github/workflows/build-macos-qt6.yml
+++ b/.github/workflows/build-macos-qt6.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🐩 Install CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5 # latest
         with:
           # Pin to specific version to avoid rebuilding too often
           # Also helps to avoid spurious build failures like https://github.com/qgis/QGIS/pull/47098
@@ -54,7 +54,7 @@ jobs:
           python-version: '3.11'
 
       - name: 🍭 Setup XCode
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: latest-stable
 

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -162,7 +162,7 @@ jobs:
               silversearcher-ag
 
       - name: Retrieve changed files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c #v46
         id: changed_files
         with:
           separator: " "

--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create comment about documentation
         if: github.event.label.name == 'Needs Documentation'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GH_TOKEN_BOT }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create comment about changelog
         if: github.event.label.name == 'Changelog'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GH_TOKEN_BOT }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -115,7 +115,7 @@ jobs:
 
       # get commits from the PR
       - name: Get PR commits
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         id: get_pr_commits
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
       # create the documentation issue
       - name: Create Documentation issue
         id: doc_issue
-        uses: dacbd/create-issue-action@v2.0.0
+        uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2 # v2.0.0
         with:
           token: ${{ secrets.GH_TOKEN_BOT }}
           owner: qgis
@@ -160,7 +160,7 @@ jobs:
 
       # write comment to ping the PR author
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GH_TOKEN_BOT }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr_unstale_commit.yml
+++ b/.github/workflows/pr_unstale_commit.yml
@@ -12,7 +12,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'stale')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 #v1.0
         if: ${{ github.event.comment.user.url != 'https://github.com/apps/github-actions' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: true
           large-packages: false
@@ -274,7 +274,7 @@ jobs:
     steps:
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: true
           large-packages: false
@@ -399,7 +399,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: true
           large-packages: false

--- a/.github/workflows/sipify-bot.yml
+++ b/.github/workflows/sipify-bot.yml
@@ -20,7 +20,7 @@ jobs:
         run: pip install nose2 mock termcolor pyyaml
 
       - name: Get PR branch
-        uses: alessbell/pull-request-comment-branch@v2.1.0
+        uses: alessbell/pull-request-comment-branch@ef3408c9757d05f89cb525036383033a313758a0 # v2.1.0
         if: ${{ github.event_name == 'issue_comment' }}
         id: comment-branch
 

--- a/.github/workflows/windows-qt6.yml
+++ b/.github/workflows/windows-qt6.yml
@@ -33,18 +33,18 @@ jobs:
           choco uninstall cmake.install
 
       - name: 🐩 Install CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5
         with:
           cmakeVersion: 3.31.6
 
       - name: 🧽 Developer Command Prompt for Microsoft Visual C++
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1
 
       - name: 🎡 Setup vcpkg
         uses: ./.github/actions/setup-vcpkg
 
       - name: 🦬 Setup flex/bison
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 #v1.12
         with:
           repository: 'lexxmark/winflexbison'
           fileName: '*.zip'
@@ -52,7 +52,7 @@ jobs:
           extract: true
 
       - name: 🛍️ Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 #v1.2
         with:
           max-size: 1G
           key: build-ccache-win64-qt6-${{ github.event.pull_request.base.ref || github.ref_name }}


### PR DESCRIPTION
# Description 

Pin GitHub Workflows for better pipeline security

Unfortunately given the state of the internet, supply chain attacks are a big and increasing attack vector and compromised GitHub actions are large easy targets. 

It's recommended to pin any 3rd party workflows to use the full SHA to avoid someone/something pulling the rug on our builds and running code that we have never see or has changed between runs, or even worse sneaking something into our build itself.  

Unfortunately pinning to a git tag is not enough as they are only labels and can be replaced in the external repo behind the same label.

`tj-actions/changed-files` was already attacked in the past and other also have been recently.  Because we don't control these 3rd party actions our trust levels should be on the low end and aim to reduce the attack surface to ourselves.

**Note: I haven't done all the actions yet opening for checks and comments**

## Side comment

Pinning the SHA isn't always enough if the downstream workflow has dependent workflows which aren't also pinned so we should make sure we do a quick audit of the actions we are using to confirm we are pinning to a safe version.