### PR TITLE
Fix text detection of type when QGIS to Postgresql 

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1986,8 +1986,8 @@ QList<QgsVectorDataProvider::NativeType> QgsPostgresConn::nativeTypes()
     << QgsVectorDataProvider::NativeType( tr( "Decimal Number (double)" ), QStringLiteral( "double precision" ), QMetaType::Type::Double, -1, -1, -1, -1 )
 
     // string types
-    << QgsVectorDataProvider::NativeType( tr( "Text, fixed length (char)" ), QStringLiteral( "char" ), QMetaType::Type::QString, 1, 255, -1, -1 )
     << QgsVectorDataProvider::NativeType( tr( "Text, limited variable length (varchar)" ), QStringLiteral( "varchar" ), QMetaType::Type::QString, 1, 255, -1, -1 )
+    << QgsVectorDataProvider::NativeType( tr( "Text, fixed length (char)" ), QStringLiteral( "char" ), QMetaType::Type::QString, 1, 255, -1, -1 )
     << QgsVectorDataProvider::NativeType( tr( "Text, unlimited length (text)" ), QStringLiteral( "text" ), QMetaType::Type::QString, -1, -1, -1, -1 )
     << QgsVectorDataProvider::NativeType( tr( "Text, case-insensitive unlimited length (citext)" ), QStringLiteral( "citext" ), QMetaType::Type::QString, -1, -1, -1, -1 )
 


### PR DESCRIPTION
## Description

Currently when importing to DB using **Import Vector Layer** for **QString** types the **char** type is suggested. This does not work if length is not set up (char 0 - is not valid). This changes the preference of **QString** columns to **varchar** which works even if length of column is 0 (varchar 0 - is ok on import and is set to unlimited lenght).   

The original detection which fails on import:
![original](https://github.com/user-attachments/assets/76483cfa-c371-471f-98c8-ea79584d9fd1)

The new way which does not fail on import:
![new](https://github.com/user-attachments/assets/eed2f784-d9e5-4c2f-9e4f-1357a7930a3e)

Funded by Ocean Winds