### PR TITLE
Prefer using copc index file for processing if it exist

### DIFF
--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -306,7 +306,9 @@ QgsPointCloudLayer *QgsPdalAlgorithmBase::parameterAsPointCloudLayer( const QVar
 
   if ( fiCopcFile.exists() )
   {
-    layer = new QgsPointCloudLayer( copcFileName, layer->name() );
+    QgsPointCloudLayer *copcLayer = new QgsPointCloudLayer( copcFileName, layer->name() );
+    if ( copcLayer && copcLayer->isValid() )
+      return copcLayer;
   }
 
   return layer;

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -306,7 +306,7 @@ QgsPointCloudLayer *QgsPdalAlgorithmBase::parameterAsPointCloudLayer( const QVar
 
   if ( fiCopcFile.exists() )
   {
-    QgsPointCloudLayer *copcLayer = new QgsPointCloudLayer( copcFileName, layer->name() );
+    QgsPointCloudLayer *copcLayer = new QgsPointCloudLayer( copcFileName, layer->name(), "copc" );
     if ( copcLayer && copcLayer->isValid() )
       return copcLayer;
   }

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.h
@@ -89,7 +89,7 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
     /**
      * Returns name of index copc file for given \a filename of point cloud.
      *
-     * @param filename name of the original dataset
+     * \param filename name of the original dataset
      *
      * \since 3.44
      */

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.h
@@ -86,6 +86,22 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
 
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
+    /**
+     * Returns name of index copc file for given \a filename of point cloud.
+     *
+     * @param filename name of the original dataset
+     *
+     * \since 3.44
+     */
+    static QString copcIndexFile( const QString &filename );
+
+    /**
+     * Override that prefers copc.laz index file as datasource for faster processing (if the index file exists) otherwise uses original layer.
+     *
+     * \since 3.44
+     */
+    QgsPointCloudLayer *parameterAsPointCloudLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags ) const;
+
   private:
     QMap<QString, QVariant> mOutputValues;
     bool mEnableElevationProperties = false;

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -783,6 +783,7 @@ void TestQgsProcessingPdalAlgs::useIndexCopcFile()
 
   // generate index for use in algorithm
   QgsPointCloudLayer *lyr = new QgsPointCloudLayer( pointCloudLayerPath, "layer", "pdal" );
+  Q_UNUSED( lyr );
 
   //wait for index to be generated
   while ( !QFileInfo::exists( copcIndexFileName ) )

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -771,8 +771,9 @@ void TestQgsProcessingPdalAlgs::useIndexCopcFile()
   const QFileInfo pointCloudFileInfo( pointCloudFileName );
   const QString pointCloudLayerPath = pointCloudFileInfo.filePath();
 
+  QgsPdalAlgorithmBase *alg = const_cast<QgsPdalAlgorithmBase *>( static_cast<const QgsPdalAlgorithmBase *>( QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "pdal:exportvector" ) ) ) );
+
   auto context = std::make_unique<QgsProcessingContext>();
-  context->setProject( QgsProject::instance() );
   context->setMaximumThreads( 0 );
 
   QgsProcessingFeedback feedback;
@@ -780,9 +781,6 @@ void TestQgsProcessingPdalAlgs::useIndexCopcFile()
   // generate index for use in algorithm
   QgsPointCloudLayer *lyr = new QgsPointCloudLayer( pointCloudLayerPath, "layer", "pdal" );
   lyr->dataProvider()->generateIndex();
-
-
-  QgsPdalAlgorithmBase *alg = const_cast<QgsPdalAlgorithmBase *>( static_cast<const QgsPdalAlgorithmBase *>( QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "pdal:exportvector" ) ) ) );
 
   const QString outputFile = QDir::tempPath() + "/points.gpkg";
 
@@ -792,7 +790,7 @@ void TestQgsProcessingPdalAlgs::useIndexCopcFile()
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
   QCOMPARE( args, QStringList() << QStringLiteral( "to_vector" ) << QStringLiteral( "--input=%1" ).arg( pointCloudFileName ) << QStringLiteral( "--output=%1" ).arg( outputFile ) );
-  QVERIFY( args.at( 1 ).endsWith( "copc.laz" ) );
+  //QVERIFY( args.at( 1 ).endsWith( "copc.laz" ) );
 }
 QGSTEST_MAIN( TestQgsProcessingPdalAlgs )
 #include "testqgsprocessingpdalalgs.moc"

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -791,6 +791,7 @@ void TestQgsProcessingPdalAlgs::useIndexCopcFile()
   parameters.insert( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_vector" ) << QStringLiteral( "--input=%1" ).arg( pointCloudFileName ) << QStringLiteral( "--output=%1" ).arg( outputFile ) );
   QVERIFY( args.at( 1 ).endsWith( "copc.laz" ) );
 }
 QGSTEST_MAIN( TestQgsProcessingPdalAlgs )

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -24,6 +24,8 @@
 #include "qgspdalalgorithmbase.h"
 #include "qgspointcloudlayer.h"
 
+#include <QThread>
+
 class TestQgsProcessingPdalAlgs : public QgsTest
 {
     Q_OBJECT
@@ -781,6 +783,9 @@ void TestQgsProcessingPdalAlgs::useIndexCopcFile()
   // generate index for use in algorithm
   QgsPointCloudLayer *lyr = new QgsPointCloudLayer( pointCloudLayerPath, "layer", "pdal" );
   lyr->dataProvider()->generateIndex();
+  QThread::sleep( 3 );
+
+  QVERIFY( lyr->dataProvider()->indexingState() == QgsPointCloudDataProvider::PointCloudIndexGenerationState::Indexed );
 
   const QString outputFile = QDir::tempPath() + "/points.gpkg";
 
@@ -790,7 +795,7 @@ void TestQgsProcessingPdalAlgs::useIndexCopcFile()
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
   QCOMPARE( args, QStringList() << QStringLiteral( "to_vector" ) << QStringLiteral( "--input=%1" ).arg( pointCloudFileName ) << QStringLiteral( "--output=%1" ).arg( outputFile ) );
-  //QVERIFY( args.at( 1 ).endsWith( "copc.laz" ) );
+  QVERIFY( args.at( 1 ).endsWith( "copc.laz" ) );
 }
 QGSTEST_MAIN( TestQgsProcessingPdalAlgs )
 #include "testqgsprocessingpdalalgs.moc"


### PR DESCRIPTION
## Description

This loads **copc** index file as **PointCloudLayer** for processing instead of original **PointCloudLayer** (could be las or laz etc.). This should make processing faster. 

Fixes #53486
