### PR TITLE
Geometry checker error export: store value in string field. Fixes export to GPKG

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -255,7 +255,7 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString &file )
   attributes.append( qMakePair( QStringLiteral( "Layer" ), QStringLiteral( "String;30;" ) ) );
   attributes.append( qMakePair( QStringLiteral( "FeatureID" ), QStringLiteral( "String;20;" ) ) );
   attributes.append( qMakePair( QStringLiteral( "ErrorDesc" ), QStringLiteral( "String;80;" ) ) );
-  attributes.append( qMakePair( QStringLiteral( "Value" ), QStringLiteral( "Real" ) ) );
+  attributes.append( qMakePair( QStringLiteral( "Value" ), QStringLiteral( "String;80" ) ) );
 
   QFileInfo fi( file );
   QString ext = fi.suffix();
@@ -295,7 +295,7 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString &file )
     f.setAttribute( fieldLayer, layerName );
     f.setAttribute( fieldFeatureId, error->featureId() );
     f.setAttribute( fieldErrDesc, error->description() );
-    f.setAttribute( fieldValue, error->value() );
+    f.setAttribute( fieldValue, error->value().toString() );
     QgsGeometry geom( new QgsPoint( error->location() ) );
     f.setGeometry( geom );
     layer->dataProvider()->addFeatures( QgsFeatureList() << f );


### PR DESCRIPTION
When exporting geometry checker errors, QgsGeometryCheckError::value() is written to a field of type real. However mValue is a QVariant and a geometry error type may store a string as mValue (at least QgsGeometryDuplicateCheckError does). This is a problem when exporting the errors. Exporting to shapefiles results in an empty entry for 'value'. If exporting to GPKG however the export completely fails because of the type mismatch. To fix that I'm proposing to create a string output field and write all values as string.