### PR TITLE
fix colliding fields in processing algs

### DIFF
--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -22,6 +22,8 @@ __copyright__ = "(C) 2010, Michael Minn"
 from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (
     QgsField,
+    QgsFields,
+    QgsProcessingUtils,
     QgsGeometry,
     QgsDistanceArea,
     QgsFeature,
@@ -134,9 +136,10 @@ class HubDistanceLines(QgisAlgorithm):
 
         units = self.UNITS[self.parameterAsEnum(parameters, self.UNIT, context)]
 
-        fields = point_source.fields()
-        fields.append(QgsField("HubName", QMetaType.Type.QString))
-        fields.append(QgsField("HubDist", QMetaType.Type.Double))
+        newFields = QgsFields()
+        newFields.append(QgsField("HubName", QMetaType.Type.QString))
+        newFields.append(QgsField("HubDist", QMetaType.Type.Double))
+        fields = QgsProcessingUtils.combineFields(point_source.fields(), newFields)
 
         (sink, dest_id) = self.parameterAsSink(
             parameters,

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -22,6 +22,8 @@ __copyright__ = "(C) 2010, Michael Minn"
 from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (
     QgsField,
+    QgsFields,
+    QgsProcessingUtils,
     QgsGeometry,
     QgsFeatureSink,
     QgsDistanceArea,
@@ -131,9 +133,10 @@ class HubDistancePoints(QgisAlgorithm):
 
         units = self.UNITS[self.parameterAsEnum(parameters, self.UNIT, context)]
 
-        fields = point_source.fields()
-        fields.append(QgsField("HubName", QMetaType.Type.QString))
-        fields.append(QgsField("HubDist", QMetaType.Type.Double))
+        newFields = QgsFields()
+        newFields.append(QgsField("HubName", QMetaType.Type.QString))
+        newFields.append(QgsField("HubDist", QMetaType.Type.Double))
+        fields = QgsProcessingUtils.combineFields(point_source.fields(), newFields)
 
         (sink, dest_id) = self.parameterAsSink(
             parameters,

--- a/python/plugins/processing/algs/qgis/TopoColors.py
+++ b/python/plugins/processing/algs/qgis/TopoColors.py
@@ -27,6 +27,8 @@ from collections import defaultdict
 
 from qgis.core import (
     QgsField,
+    QgsFields,
+    QgsProcessingUtils,
     QgsFeatureSink,
     QgsGeometry,
     QgsSpatialIndex,
@@ -133,8 +135,9 @@ class TopoColor(QgisAlgorithm):
         balance_by = self.parameterAsEnum(parameters, self.BALANCE, context)
         min_distance = self.parameterAsDouble(parameters, self.MIN_DISTANCE, context)
 
-        fields = source.fields()
-        fields.append(QgsField("color_id", QMetaType.Type.Int))
+        newFields = QgsFields()
+        newFields.append(QgsField("color_id", QMetaType.Type.Int))
+        fields = QgsProcessingUtils.combineFields(source.fields(), newFields)
 
         (sink, dest_id) = self.parameterAsSink(
             parameters,

--- a/src/analysis/processing/qgsalgorithmaddxyfields.cpp
+++ b/src/analysis/processing/qgsalgorithmaddxyfields.cpp
@@ -103,10 +103,10 @@ QgsFields QgsAddXYFieldsAlgorithm::outputFields( const QgsFields &inputFields ) 
     const QString xFieldName = mPrefix + 'x';
     const QString yFieldName = mPrefix + 'y';
 
-    QgsFields outFields = inputFields;
-    outFields.append( QgsField( xFieldName, QMetaType::Type::Double, QString(), 20, 10 ) );
-    outFields.append( QgsField( yFieldName, QMetaType::Type::Double, QString(), 20, 10 ) );
-    return outFields;
+    QgsFields newFields;
+    newFields.append( QgsField( xFieldName, QMetaType::Type::Double, QString(), 20, 10 ) );
+    newFields.append( QgsField( yFieldName, QMetaType::Type::Double, QString(), 20, 10 ) );
+    return QgsProcessingUtils::combineFields( inputFields, newFields );
   }
 }
 

--- a/src/analysis/processing/qgsalgorithmangletonearest.cpp
+++ b/src/analysis/processing/qgsalgorithmangletonearest.cpp
@@ -189,6 +189,10 @@ QVariantMap QgsAngleToNearestAlgorithm::processAlgorithm( const QVariantMap &par
   }
   else
   {
+    if ( outFields.lookupField( fieldName ) >= 0 )
+    {
+      throw QgsProcessingException( QObject::tr( "A field with the same name (%1) already exists" ).arg( fieldName ) );
+    }
     outFields.append( QgsField( fieldName, QMetaType::Type::Double ) );
   }
 

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
@@ -99,8 +99,10 @@ bool QgsCalculateVectorOverlapsAlgorithm::prepareAlgorithm( const QVariantMap &p
     {
       mLayerNames << layer->name();
       mOverlayerSources.emplace_back( std::make_unique<QgsVectorLayerFeatureSource>( vl ) );
-      mOutputFields.append( QgsField( QStringLiteral( "%1_area" ).arg( vl->name() ), QMetaType::Type::Double ) );
-      mOutputFields.append( QgsField( QStringLiteral( "%1_pc" ).arg( vl->name() ), QMetaType::Type::Double ) );
+      QgsFields newFields;
+      newFields.append( QgsField( QStringLiteral( "%1_area" ).arg( vl->name() ), QMetaType::Type::Double ) );
+      newFields.append( QgsField( QStringLiteral( "%1_pc" ).arg( vl->name() ), QMetaType::Type::Double ) );
+      mOutputFields = QgsProcessingUtils::combineFields( mOutputFields, newFields );
     }
   }
 

--- a/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
@@ -118,9 +118,10 @@ QVariantMap QgsServiceAreaFromLayerAlgorithm::processAlgorithm( const QVariantMa
   feedback->pushInfo( QObject::tr( "Calculating service areas…" ) );
   std::unique_ptr<QgsGraph> graph( mBuilder->takeGraph() );
 
-  QgsFields fields = startPoints->fields();
-  fields.append( QgsField( QStringLiteral( "type" ), QMetaType::Type::QString ) );
-  fields.append( QgsField( QStringLiteral( "start" ), QMetaType::Type::QString ) );
+  QgsFields newFields;
+  newFields.append( QgsField( QStringLiteral( "type" ), QMetaType::Type::QString ) );
+  newFields.append( QgsField( QStringLiteral( "start" ), QMetaType::Type::QString ) );
+  QgsFields fields = QgsProcessingUtils::combineFields( startPoints->fields(), fields );
 
   QString pointsSinkId;
   std::unique_ptr<QgsFeatureSink> pointsSink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, pointsSinkId, fields, Qgis::WkbType::MultiPoint, mNetwork->sourceCrs() ) );

--- a/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
@@ -121,7 +121,7 @@ QVariantMap QgsServiceAreaFromLayerAlgorithm::processAlgorithm( const QVariantMa
   QgsFields newFields;
   newFields.append( QgsField( QStringLiteral( "type" ), QMetaType::Type::QString ) );
   newFields.append( QgsField( QStringLiteral( "start" ), QMetaType::Type::QString ) );
-  QgsFields fields = QgsProcessingUtils::combineFields( startPoints->fields(), fields );
+  QgsFields fields = QgsProcessingUtils::combineFields( startPoints->fields(), newFields );
 
   QString pointsSinkId;
   std::unique_ptr<QgsFeatureSink> pointsSink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, pointsSinkId, fields, Qgis::WkbType::MultiPoint, mNetwork->sourceCrs() ) );

--- a/src/analysis/processing/qgsalgorithmshortestline.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestline.cpp
@@ -107,7 +107,10 @@ QVariantMap QgsShortestLineAlgorithm::processAlgorithm( const QVariantMap &param
     mKNeighbors = mDestination->featureCount();
 
   QgsFields fields = QgsProcessingUtils::combineFields( mSource->fields(), mDestination->fields() );
-  fields.append( QgsField( QStringLiteral( "distance" ), QMetaType::Type::Double ) );
+  
+  QgsFields newFields;
+  newFields.append( QgsField( QStringLiteral( "distance" ), QMetaType::Type::Double ) );
+  fields = QgsProcessingUtils::combineFields( fields, newFields );
 
   QString dest;
   std::unique_ptr<QgsFeatureSink> sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, fields, Qgis::WkbType::MultiLineString, mSource->sourceCrs() ) );

--- a/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.cpp
@@ -77,10 +77,11 @@ QVariantMap QgsShortestPathLayerToPointAlgorithm::processAlgorithm( const QVaria
   if ( !startPoints )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "START_POINTS" ) ) );
 
-  QgsFields fields = startPoints->fields();
-  fields.append( QgsField( QStringLiteral( "start" ), QMetaType::Type::QString ) );
-  fields.append( QgsField( QStringLiteral( "end" ), QMetaType::Type::QString ) );
-  fields.append( QgsField( QStringLiteral( "cost" ), QMetaType::Type::Double ) );
+  QgsFields newFields;
+  newFields.append( QgsField( QStringLiteral( "start" ), QMetaType::Type::QString ) );
+  newFields.append( QgsField( QStringLiteral( "end" ), QMetaType::Type::QString ) );
+  newFields.append( QgsField( QStringLiteral( "cost" ), QMetaType::Type::Double ) );
+  QgsFields fields = QgsProcessingUtils::combineFields( startPoints->fields(), newFields );
 
   QString dest;
   std::unique_ptr<QgsFeatureSink> sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, fields, Qgis::WkbType::LineString, mNetwork->sourceCrs() ) );

--- a/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.cpp
@@ -82,10 +82,11 @@ QVariantMap QgsShortestPathPointToLayerAlgorithm::processAlgorithm( const QVaria
   if ( !endPoints )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "END_POINTS" ) ) );
 
-  QgsFields fields = endPoints->fields();
-  fields.append( QgsField( QStringLiteral( "start" ), QMetaType::Type::QString ) );
-  fields.append( QgsField( QStringLiteral( "end" ), QMetaType::Type::QString ) );
-  fields.append( QgsField( QStringLiteral( "cost" ), QMetaType::Type::Double ) );
+  QgsFields newFields;
+  newFields.append( QgsField( QStringLiteral( "start" ), QMetaType::Type::QString ) );
+  newFields.append( QgsField( QStringLiteral( "end" ), QMetaType::Type::QString ) );
+  newFields.append( QgsField( QStringLiteral( "cost" ), QMetaType::Type::Double ) );
+  QgsFields fields = QgsProcessingUtils::combineFields( endPoints->fields(), newFields );
 
   QString dest;
   std::unique_ptr<QgsFeatureSink> sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, fields, Qgis::WkbType::LineString, mNetwork->sourceCrs(), QgsFeatureSink::RegeneratePrimaryKey ) );

--- a/src/analysis/processing/qgsalgorithmtransect.cpp
+++ b/src/analysis/processing/qgsalgorithmtransect.cpp
@@ -104,14 +104,14 @@ QVariantMap QgsTransectAlgorithm::processAlgorithm( const QVariantMap &parameter
 
   QgsExpressionContext expressionContext = createExpressionContext( parameters, context, dynamic_cast<QgsProcessingFeatureSource *>( source.get() ) );
 
-  QgsFields fields = source->fields();
-
-  fields.append( QgsField( QStringLiteral( "TR_FID" ), QMetaType::Type::Int, QString(), 20 ) );
-  fields.append( QgsField( QStringLiteral( "TR_ID" ), QMetaType::Type::Int, QString(), 20 ) );
-  fields.append( QgsField( QStringLiteral( "TR_SEGMENT" ), QMetaType::Type::Int, QString(), 20 ) );
-  fields.append( QgsField( QStringLiteral( "TR_ANGLE" ), QMetaType::Type::Double, QString(), 5, 2 ) );
-  fields.append( QgsField( QStringLiteral( "TR_LENGTH" ), QMetaType::Type::Double, QString(), 20, 6 ) );
-  fields.append( QgsField( QStringLiteral( "TR_ORIENT" ), QMetaType::Type::Int, QString(), 1 ) );
+  QgsFields newFields;
+  newFields.append( QgsField( QStringLiteral( "TR_FID" ), QMetaType::Type::Int, QString(), 20 ) );
+  newFields.append( QgsField( QStringLiteral( "TR_ID" ), QMetaType::Type::Int, QString(), 20 ) );
+  newFields.append( QgsField( QStringLiteral( "TR_SEGMENT" ), QMetaType::Type::Int, QString(), 20 ) );
+  newFields.append( QgsField( QStringLiteral( "TR_ANGLE" ), QMetaType::Type::Double, QString(), 5, 2 ) );
+  newFields.append( QgsField( QStringLiteral( "TR_LENGTH" ), QMetaType::Type::Double, QString(), 20, 6 ) );
+  newFields.append( QgsField( QStringLiteral( "TR_ORIENT" ), QMetaType::Type::Int, QString(), 1 ) );
+  QgsFields fields = QgsProcessingUtils::combineFields( source->fields(), newFields );
 
   Qgis::WkbType outputWkb = Qgis::WkbType::LineString;
   if ( QgsWkbTypes::hasZ( source->wkbType() ) )

--- a/src/analysis/processing/qgsalgorithmuniquevalueindex.cpp
+++ b/src/analysis/processing/qgsalgorithmuniquevalueindex.cpp
@@ -80,6 +80,12 @@ QVariantMap QgsAddUniqueValueIndexAlgorithm::processAlgorithm( const QVariantMap
 
   const QString newFieldName = parameterAsString( parameters, QStringLiteral( "FIELD_NAME" ), context );
   QgsFields fields = source->fields();
+
+  if ( fields.lookupField( newFieldName ) >= 0 )
+  {
+    throw QgsProcessingException( QObject::tr( "A field with the same name (%1) already exists" ).arg( newFieldName ) );
+  }
+
   const QgsField newField = QgsField( newFieldName, QMetaType::Type::Int );
   fields.append( newField );
 


### PR DESCRIPTION
Continuation of #61716 

@agiudiceandrea and others:
Please check all, I don’t see problems with many, but the ones that could be solved another way are:

Overlap analysis – another option is to check if all layers have unique names before running the alg (for instance, you could have multiple layers named ‘merged’). Otherwise, will be fixed with combineFields.

Add X/Y fields to layer – user inputted prefix could be checked before running the alg to make sure no same named fields already exist (just throw an exception when trying to add a field which already exists). Otherwise, will be fixed with combineFields.

*Not done:
All Check Geometry (*thing*) algs require a unique field to be passed. In processing, they create their own fields and append the unique field at the end. New fields are gc_layerid, gc_layername… unlikely, but collisions are a possibility. I believe those algs are the only ones that add their own fields before existing. 

Should the fields be combined in those algs as well, with a note that the passed unique field would be added to the last place and potentially renamed if there are name collisions or leave them as they are?
