### PR TITLE
[gui][attribute form] Fix text widget not wrapping leading to unreasonably wide attribute form dialog

### DIFF
--- a/src/gui/editorwidgets/qgstextwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgstextwidgetwrapper.cpp
@@ -50,7 +50,9 @@ QWidget *QgsTextWidgetWrapper::createWidget( QWidget *parent )
       }
     } );
   }
-  return new QLabel( parent );
+  QLabel *widget = new QLabel( parent );
+  widget->setWordWrap( widget );
+  return widget;
 }
 
 void QgsTextWidgetWrapper::initWidget( QWidget *editor )


### PR DESCRIPTION
## Description

The attribute form's text widget didn't have its word wrapping turned on, which meant that using that widget with long sentences (say to deliver instructions, or show the content of a text field) would result in a dialog wide that was going way beyond screen edges even on large screens. 