### PR TITLE
Add layer ID in the information panel

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -3228,6 +3228,9 @@ QString QgsMapLayer::generalHtmlMetadata() const
   if ( dataProvider() )
     metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Provider" ) + QStringLiteral( "</td><td>%1" ).arg( dataProvider()->name() ) + QStringLiteral( "</td></tr>\n" );
 
+  // Layer ID
+  metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Layer ID" ) + QStringLiteral( "</td><td>%1" ).arg( id() ) + QStringLiteral( "</td></tr>\n" );
+
   metadata += QLatin1String( "</table>\n<br><br>" );
 
   return metadata;


### PR DESCRIPTION
I think, it was not added because it was kind of an internal information for QGIS itself.

But given that the layer ID can be used in QGIS expressions, it's the value we get when we double-click on a layer in the expression dialog.

To get the layer ID right now for a given layer, I go in the "Variables" tab.