### PR TITLE
Added one space at end of sentence

### DIFF
--- a/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
@@ -58,7 +58,7 @@ QString QgsGeometryCheckMissingVertexAlgorithm::groupId() const
 QString QgsGeometryCheckMissingVertexAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm checks for missing vertices along polygon borders.\n"
-                      "To be topologically correct, a vertex at the junction of two polygons must be present on both polygons."
+                      "To be topologically correct, a vertex at the junction of two polygons must be present on both polygons. "
                       "Missing vertices are errors." );
 }
 


### PR DESCRIPTION
Line 61: Added one space at end of sentence, as the current format renders line 61 and line 62 as one (without a space behind the period). This should fix that.

## Description
Delivering well-formed documentation


