### PR TITLE
Identify tool search radius should adjust if canvas is magnified

### DIFF
--- a/src/gui/maptools/qgsmaptool.cpp
+++ b/src/gui/maptools/qgsmaptool.cpp
@@ -237,7 +237,7 @@ double QgsMapTool::searchRadiusMM()
 
 double QgsMapTool::searchRadiusMU( const QgsRenderContext &context )
 {
-  return searchRadiusMM() * context.scaleFactor() * context.mapToPixel().mapUnitsPerPixel();
+  return context.convertToMapUnits( searchRadiusMM(), Qgis::RenderUnit::Millimeters );
 }
 
 double QgsMapTool::searchRadiusMU( QgsMapCanvas *canvas )
@@ -248,7 +248,7 @@ double QgsMapTool::searchRadiusMU( QgsMapCanvas *canvas )
   }
   const QgsMapSettings mapSettings = canvas->mapSettings();
   const QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
-  return searchRadiusMU( context );
+  return searchRadiusMU( context ) / mapSettings.magnificationFactor();
 }
 
 

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -1337,15 +1337,15 @@ void TestQgsIdentify::testSearchRadius()
   canvas.setExtent( QgsRectangle( 5, 45, 9, 47 ) );
 
   QCOMPARE( tool->searchRadiusMM(), 2 );
-  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.04724, 0.0001 );
+  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.04724, 0.001 );
 
   // magnify canvas, search radius should decrease
   canvas.setMagnificationFactor( 2 );
-  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.02362, 0.0001 );
+  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.02362, 0.001 );
 
   // de-magnify canvas, search radius should increase
   canvas.setMagnificationFactor( 0.5 );
-  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.09448, 0.0001 );
+  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.09448, 0.001 );
 }
 
 QGSTEST_MAIN( TestQgsIdentify )

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -73,6 +73,7 @@ class TestQgsIdentify : public QObject
     void testPolygonZ();
     void identifyPointCloud();
     void identifyVirtualPointCloud();
+    void testSearchRadius();
 
   private:
     void doAction();
@@ -1324,6 +1325,27 @@ void TestQgsIdentify::identifyVirtualPointCloud()
   double z = result.at( 0 ).mDerivedAttributes[QStringLiteral( "Z" )].toDouble();
   QGSCOMPARENEAR( z, 74.91, 0.001 );
 #endif
+}
+
+void TestQgsIdentify::testSearchRadius()
+{
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( "EPSG:4326" ) );
+  canvas.setFrameStyle( 0 );
+  canvas.resize( 600, 400 );
+  auto tool = std::make_unique<QgsMapToolIdentify>( &canvas );
+  canvas.setExtent( QgsRectangle( 5, 45, 9, 47 ) );
+
+  QCOMPARE( tool->searchRadiusMM(), 2 );
+  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.04724, 0.0001 );
+
+  // magnify canvas, search radius should decrease
+  canvas.setMagnificationFactor( 2 );
+  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.02362, 0.0001 );
+
+  // de-magnify canvas, search radius should increase
+  canvas.setMagnificationFactor( 0.5 );
+  QGSCOMPARENEAR( tool->searchRadiusMU( &canvas ), 0.09448, 0.0001 );
 }
 
 QGSTEST_MAIN( TestQgsIdentify )


### PR DESCRIPTION
When we have a magnified canvas, we need to adjust the map tool search radius accordingly. This ensures the same search radius in millimeters is respected regardless of magnification.

Fixes identify tool capturing features very far from clicked point when canvas is magnified.
