### PR TITLE
Correctly scale identify highlight to account for canvas magnification

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgshighlight.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgshighlight.sip.in
@@ -113,19 +113,23 @@ Set stroke width.
 
     double buffer() const;
 %Docstring
-Returns the buffer
+Returns the line/stroke buffer size (in millimeters)
+
+.. seealso:: :py:func:`setBuffer`
 
 .. versionadded:: 3.4
 %End
 
     void setBuffer( double buffer );
 %Docstring
-Set line / stroke buffer in millimeters.
+Sets the line/stroke buffer size (in millimeters).
+
+.. seealso:: :py:func:`buffer`
 %End
 
     void setMinWidth( double width );
 %Docstring
-Set minimum line / stroke width in millimeters.
+Sets the minimum line/stroke width (in millimeters).
 %End
 
     QgsMapLayer *layer() const;

--- a/python/gui/auto_generated/qgshighlight.sip.in
+++ b/python/gui/auto_generated/qgshighlight.sip.in
@@ -113,19 +113,23 @@ Set stroke width.
 
     double buffer() const;
 %Docstring
-Returns the buffer
+Returns the line/stroke buffer size (in millimeters)
+
+.. seealso:: :py:func:`setBuffer`
 
 .. versionadded:: 3.4
 %End
 
     void setBuffer( double buffer );
 %Docstring
-Set line / stroke buffer in millimeters.
+Sets the line/stroke buffer size (in millimeters).
+
+.. seealso:: :py:func:`buffer`
 %End
 
     void setMinWidth( double width );
 %Docstring
-Set minimum line / stroke width in millimeters.
+Sets the minimum line/stroke width (in millimeters).
 %End
 
     QgsMapLayer *layer() const;

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -188,14 +188,12 @@ void QgsHighlight::setSymbol( QgsSymbol *symbol, const QgsRenderContext &context
 
 double QgsHighlight::getSymbolWidth( const QgsRenderContext &context, double width, Qgis::RenderUnit unit )
 {
-  // if necessary scale mm to map units
-  double scale = 1.;
-  if ( unit == Qgis::RenderUnit::MapUnits )
-  {
-    scale = context.convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters ) / context.convertToPainterUnits( 1, Qgis::RenderUnit::MapUnits );
-  }
-  width = std::max( width + 2 * mBuffer * scale, mMinWidth * scale );
-  return width;
+  const double widthInPainterUnits = context.convertToPainterUnits( width, unit );
+  const double bufferInPainterUnits = context.convertToPainterUnits( mBuffer, Qgis::RenderUnit::Millimeters );
+  const double minWidthInPainterUnits = context.convertToPainterUnits( mMinWidth, Qgis::RenderUnit::Millimeters );
+
+  const double adjustedWidthInPainterUnits = std::max( widthInPainterUnits + 2 * bufferInPainterUnits, minWidthInPainterUnits );
+  return context.convertFromPainterUnits( adjustedWidthInPainterUnits, unit ) / mMapCanvas->magnificationFactor();
 }
 
 void QgsHighlight::setWidth( int width )

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -144,20 +144,23 @@ class GUI_EXPORT QgsHighlight : public QgsMapCanvasItem
     void setWidth( int width );
 
     /**
-     * Returns the buffer
+     * Returns the line/stroke buffer size (in millimeters)
+     *
+     * \see setBuffer()
+     *
      * \since QGIS 3.4
      */
     double buffer() const { return mBuffer; }
 
     /**
-     * Set line / stroke buffer in millimeters.
+     * Sets the line/stroke buffer size (in millimeters).
      *
+     * \see buffer()
      */
     void setBuffer( double buffer ) { mBuffer = buffer; }
 
     /**
-     * Set minimum line / stroke width in millimeters.
-     *
+     * Sets the minimum line/stroke width (in millimeters).
      */
     void setMinWidth( double width ) { mMinWidth = width; }
 
@@ -210,8 +213,8 @@ class GUI_EXPORT QgsHighlight : public QgsMapCanvasItem
     QgsGeometry mGeometry;
     QPointer<QgsMapLayer> mLayer;
     QgsFeature mFeature;
-    double mBuffer = 0;   // line / stroke buffer in pixels
-    double mMinWidth = 0; // line / stroke minimum width in pixels
+    double mBuffer = 0;   // line / stroke buffer in millimeters
+    double mMinWidth = 0; // line / stroke minimum width in millimeters
     QgsRenderContext mRenderContext;
 
     // we don't want to make PointSymbol public for now, so just grant access selectively via a friend


### PR DESCRIPTION
Avoids super-large line highlights when canvas is magnified
