### PR TITLE
Fix camera rotation in 3D globe view

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -27,6 +27,7 @@
 #include <Qt3DRender/QCamera>
 #include <Qt3DInput>
 #include <QStringLiteral>
+#include <QQuaternion>
 #include <cmath>
 
 #include "qgslogger.h"
@@ -104,30 +105,53 @@ void QgsCameraController::setVerticalAxisInversion( Qgis::VerticalAxisInversion 
 
 void QgsCameraController::rotateCamera( float diffPitch, float diffHeading )
 {
-  const float oldPitch = mCameraPose.pitchAngle();
-  const float oldHeading = mCameraPose.headingAngle();
-  float newPitch = oldPitch + diffPitch;
-  float newHeading = oldHeading + diffHeading;
+  float newPitch = mCameraPose.pitchAngle() + diffPitch;
+  float newHeading = mCameraPose.headingAngle() + diffHeading;
 
   newPitch = std::clamp( newPitch, 0.f, 180.f ); // prevent going over the head
 
-  // First undo the previously applied rotation, then apply the new rotation
-  // (We can't just apply our euler angles difference because the camera may be already rotated)
-  const QQuaternion qNew = Qgs3DUtils::rotationFromPitchHeadingAngles( newPitch, newHeading );
-  const QQuaternion qOld = Qgs3DUtils::rotationFromPitchHeadingAngles( oldPitch, oldHeading );
-  const QQuaternion q = qNew * qOld.conjugated();
+  switch ( mScene->mapSettings()->sceneMode() )
+  {
+    case Qgis::SceneMode::Globe:
+    {
+      // When on a globe, we need to calculate "where is up" (the normal of a tangent plane).
+      // Also it uses different axes than the standard plane-based view.
+      // See QgsCameraPose::updateCameraGlobe(), we basically want to make sure
+      // that after an update, the camera stays in the same spot.
+      QgsVector3D viewCenterLatLon;
+      try
+      {
+        viewCenterLatLon = mGlobeCrsToLatLon.transform( mCameraPose.centerPoint() + mOrigin );
+      }
+      catch ( const QgsCsException & )
+      {
+        QgsDebugError( QStringLiteral( "rotateCamera: ECEF -> lat,lon transform failed!" ) );
+        return;
+      }
+      QQuaternion qLatLon = QQuaternion::fromAxisAndAngle( QVector3D( 0, 0, 1 ), static_cast<float>( viewCenterLatLon.x() ) )
+                            * QQuaternion::fromAxisAndAngle( QVector3D( 0, -1, 0 ), static_cast<float>( viewCenterLatLon.y() ) );
+      QQuaternion qPitchHeading = QQuaternion::fromAxisAndAngle( QVector3D( 1, 0, 0 ), newHeading )
+                                  * QQuaternion::fromAxisAndAngle( QVector3D( 0, 1, 0 ), newPitch );
+      QVector3D newCameraToCenter = ( qLatLon * qPitchHeading * QVector3D( -1, 0, 0 ) ) * mCameraPose.distanceFromCenterPoint();
 
-  // get camera's view vector, rotate it to get new view center
-  const QVector3D position = mCamera->position();
-  QVector3D viewCenter = mCamera->viewCenter();
-  const QVector3D viewVector = viewCenter - position;
-  const QVector3D cameraToCenter = q * viewVector;
-  viewCenter = position + cameraToCenter;
+      mCameraPose.setCenterPoint( mCamera->position() + newCameraToCenter );
+      mCameraPose.setPitchAngle( newPitch );
+      mCameraPose.setHeadingAngle( newHeading );
+      updateCameraFromPose();
+      return;
+    }
 
-  mCameraPose.setCenterPoint( viewCenter );
-  mCameraPose.setPitchAngle( newPitch );
-  mCameraPose.setHeadingAngle( newHeading );
-  updateCameraFromPose();
+    case Qgis::SceneMode::Local:
+    {
+      QQuaternion q = Qgs3DUtils::rotationFromPitchHeadingAngles( newPitch, newHeading );
+      QVector3D newCameraToCenter = q * QVector3D( 0, 0, -mCameraPose.distanceFromCenterPoint() );
+      mCameraPose.setCenterPoint( mCamera->position() + newCameraToCenter );
+      mCameraPose.setPitchAngle( newPitch );
+      mCameraPose.setHeadingAngle( newHeading );
+      updateCameraFromPose();
+      return;
+    }
+  }
 }
 
 void QgsCameraController::rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint )


### PR DESCRIPTION
## Description

This PR fixes walk mode when the 3D map view is in globe mode. This is done by refactoring `QgsCameraController::rotateCamera()`, special-casing the globe mode and also simplifying the regular case in the process.

The previous code didn't work because in the ECEF coordinates, we don't have fixed axes that we could rotate around to change pitch and heading. Splitting the two cases was simpler than trying to somehow unify them, especially since the globe mode has different conventions for axes.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
