### PR TITLE
tests: adapt QVariant compare and QgsFlagKeysToValue tests to qt6

### DIFF
--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -279,7 +279,7 @@ int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs )
     }
 
     default:
-      return QString::localeAwareCompare( lhs.toString(), rhs.toString() );
+      return std::clamp( QString::localeAwareCompare( lhs.toString(), rhs.toString() ), -1, 1 );
   }
 }
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -6601,9 +6601,9 @@ template<class T> T qgsFlagKeysToValue( const QString &keys, const T &defaultVal
       const int intValue = keys.toInt( &canConvert );
       if ( canConvert )
       {
-        const QByteArray keys = metaEnum.valueToKeys( intValue );
-        const int intValueCheck = metaEnum.keysToValue( keys );
-        if ( intValue == intValueCheck )
+        const QByteArray keyArray = metaEnum.valueToKeys( intValue );
+        const int intValueCheck = metaEnum.keysToValue( keyArray );
+        if ( !keyArray.isEmpty() && intValue == intValueCheck )
         {
           if ( returnOk )
           {


### PR DESCRIPTION
This PR fixes the test_core_qgis test to work with QT6. 