### PR TITLE
Enable field rename for PostgreSQL Provider

### DIFF
--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -115,7 +115,8 @@ void QgsPostgresProviderConnection::setDefaultCapabilities()
     Capability::DeleteSpatialIndex,
     Capability::DeleteField,
     Capability::DeleteFieldCascade,
-    Capability::AddField
+    Capability::AddField,
+    Capability::RenameField
   };
   mGeometryColumnCapabilities = {
     GeometryColumnCapability::Z,
@@ -1934,4 +1935,10 @@ QgsFields QgsPostgresProviderConnection::fields( const QString &schema, const QS
     }
     throw ex;
   }
+}
+
+void QgsPostgresProviderConnection::renameField( const QString &schema, const QString &tableName, const QString &name, const QString &newName ) const
+{
+  executeSqlPrivate( QStringLiteral( "ALTER TABLE %1.%2 RENAME COLUMN %3 TO %4;" )
+                       .arg( QgsPostgresConn::quotedIdentifier( schema ), QgsPostgresConn::quotedIdentifier( tableName ), QgsPostgresConn::quotedIdentifier( name ), QgsPostgresConn::quotedIdentifier( newName ) ) );
 }

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -76,6 +76,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     QList<QgsLayerMetadataProviderResult> searchLayerMetadata( const QgsMetadataSearchContext &searchContext, const QString &searchString, const QgsRectangle &geographicExtent, QgsFeedback *feedback ) const override;
     Qgis::DatabaseProviderTableImportCapabilities tableImportCapabilities() const override;
     QString defaultPrimaryKeyColumnName() const override;
+    void renameField( const QString &schema, const QString &tableName, const QString &name, const QString &newName ) const override;
 
     static const QStringList CONFIGURATION_PARAMETERS;
     static const QString SETTINGS_BASE_KEY;

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -941,6 +941,28 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         table_names = self._table_names(connUnprivilegedUser.tables(schema))
         self.assertNotIn("layer_w_role", table_names)
 
+    def test_rename_field(self):
+        """Test rename fields"""
+
+        md = QgsProviderRegistry.instance().providerMetadata("postgres")
+        conn = md.createConnection(self.uri, {})
+
+        sql = """
+        CREATE TABLE qgis_test.rename_field (id SERIAL PRIMARY KEY);
+        ALTER TABLE qgis_test.rename_field ADD COLUMN geom geometry(POINT,4326);
+        ALTER TABLE qgis_test.rename_field ADD COLUMN column_1 TEXT;
+        INSERT INTO qgis_test.rename_field (id, geom, column_1) VALUES (221, ST_GeomFromText('point(9 45)', 4326), 'text');
+        """
+
+        conn.executeSql(sql)
+        fields = conn.fields("qgis_test", "rename_field")
+        self.assertEqual(fields.names(), ["id", "geom", "column_1"])
+
+        conn = conn.renameField("qgis_test", "rename_field", "column_1", "new_column")
+
+        fields = conn.fields("qgis_test", "rename_field")
+        self.assertEqual(fields.names(), ["id", "geom", "new_column"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -958,7 +958,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         fields = conn.fields("qgis_test", "rename_field")
         self.assertEqual(fields.names(), ["id", "geom", "column_1"])
 
-        conn = conn.renameField("qgis_test", "rename_field", "column_1", "new_column")
+        conn.renameField("qgis_test", "rename_field", "column_1", "new_column")
 
         fields = conn.fields("qgis_test", "rename_field")
         self.assertEqual(fields.names(), ["id", "geom", "new_column"])


### PR DESCRIPTION
## Description

Allow renaming field for PostgreSQL provider in Browser.

Funded by Ocean Winds
