### PR TITLE
pointtolayer alg moved to vector creation group, adjusted displayName

### DIFF
--- a/src/analysis/processing/qgsalgorithmextenttolayer.h
+++ b/src/analysis/processing/qgsalgorithmextenttolayer.h
@@ -36,8 +36,8 @@ class QgsExtentToLayerAlgorithm : public QgsProcessingAlgorithm
     QString name() const override;
     QString displayName() const override { return QObject::tr( "Create layer from extent" ); }
     QStringList tags() const override { return QObject::tr( "extent,layer,polygon,create,new" ).split( ',' ); }
-    QString group() const override { return QObject::tr( "Vector geometry" ); }
-    QString groupId() const override { return QStringLiteral( "vectorgeometry" ); }
+    QString group() const override { return QObject::tr( "Vector creation" ); }
+    QString groupId() const override { return QStringLiteral( "vectorcreation" ); }
     QString shortHelpString() const override;
     QString shortDescription() const override;
     QgsExtentToLayerAlgorithm *createInstance() const override SIP_FACTORY;

--- a/src/analysis/processing/qgsalgorithmpointtolayer.h
+++ b/src/analysis/processing/qgsalgorithmpointtolayer.h
@@ -34,10 +34,10 @@ class QgsPointToLayerAlgorithm : public QgsProcessingAlgorithm
     QgsPointToLayerAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
-    QString displayName() const override { return QObject::tr( "Create layer from point" ); }
+    QString displayName() const override { return QObject::tr( "Create single point layer" ); }
     QStringList tags() const override { return QObject::tr( "point,layer,polygon,create,new" ).split( ',' ); }
-    QString group() const override { return QObject::tr( "Vector geometry" ); }
-    QString groupId() const override { return QStringLiteral( "vectorgeometry" ); }
+    QString group() const override { return QObject::tr( "Vector creation" ); }
+    QString groupId() const override { return QStringLiteral( "vectorcreation" ); }
     QString shortHelpString() const override;
     QString shortDescription() const override;
     QgsPointToLayerAlgorithm *createInstance() const override SIP_FACTORY;

--- a/src/analysis/processing/qgsalgorithmpointtolayer.h
+++ b/src/analysis/processing/qgsalgorithmpointtolayer.h
@@ -34,7 +34,7 @@ class QgsPointToLayerAlgorithm : public QgsProcessingAlgorithm
     QgsPointToLayerAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
-    QString displayName() const override { return QObject::tr( "Create single point layer" ); }
+    QString displayName() const override { return QObject::tr( "Create layer from point" ); }
     QStringList tags() const override { return QObject::tr( "point,layer,polygon,create,new" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector creation" ); }
     QString groupId() const override { return QStringLiteral( "vectorcreation" ); }


### PR DESCRIPTION
## Description

The native algorithm `pointToLayer` is currently placed in the `Vector geometry` group, but it would fit better in the `Vector creation` group.

The Vector creation group already includes `Create points layer from table`, so I believe this one would be better categorized there as well (that’s where I would expect to find it).
I'm also proposing a slightly improved description for the displayName, in my opinion — feel free to revert it if you don’t find it appropriate.

If this PR is accepted, the documentation should be updated accordingly.