### PR TITLE
enable GdalAlgorithmsVectorTest for Qt6 builds

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -51,6 +51,5 @@ PyQgsSettingsEntry
 PyQgsServerAccessControlWFSTransactional
 ProcessingQgisAlgorithmsTestPt2
 ProcessingQgisAlgorithmsTestPt4
-ProcessingGdalAlgorithmsVectorTest
 # PyQgsProviderRegistry runs fine locally on Fedora:rawhide but not on CI
 PyQgsProviderRegistry


### PR DESCRIPTION
## Description

Try to enable ProcessingGdalAlgorithmsVectorTest on CI.