### PR TITLE
[layouts] Brand new layout item rotation handles

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -11498,10 +11498,10 @@ Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)
 Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
 Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
 Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
-Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate from top left handle. \n.. versionadded:: 4.0"
-Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate from top right handle. \n.. versionadded:: 4.0"
-Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate from bottom left handle. \n.. versionadded:: 4.0"
-Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right bottom right handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateTopLeft.__doc__ = "Rotate from top left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateTopRight.__doc__ = "Rotate from top right handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateBottomLeft.__doc__ = "Rotate from bottom left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateBottomRight.__doc__ = "Rotate right bottom right handle. \n.. versionadded:: 4.0"
 Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
 Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
 Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
@@ -11517,19 +11517,19 @@ Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
 * ``ResizeRightUp``: Resize right up (Top right handle)
 * ``ResizeLeftDown``: Resize left down (Bottom left handle)
 * ``ResizeRightDown``: Resize right down (Bottom right handle)
-* ``RotateLeftUp``: Rotate from top left handle.
+* ``RotateTopLeft``: Rotate from top left handle.
 
   .. versionadded:: 4.0
 
-* ``RotateRightUp``: Rotate from top right handle.
+* ``RotateTopRight``: Rotate from top right handle.
 
   .. versionadded:: 4.0
 
-* ``RotateLeftDown``: Rotate from bottom left handle.
+* ``RotateBottomLeft``: Rotate from bottom left handle.
 
   .. versionadded:: 4.0
 
-* ``RotateRightDown``: Rotate right bottom right handle.
+* ``RotateBottomRight``: Rotate right bottom right handle.
 
   .. versionadded:: 4.0
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -11498,10 +11498,10 @@ Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)
 Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
 Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
 Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
-Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate left up (Top left handle)"
-Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate right up (Top right handle)"
-Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate left up (Bottom left handle)"
-Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right up (Bottom right handle)"
+Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate from top left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate from top right handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate from bottom left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right bottom right handle. \n.. versionadded:: 4.0"
 Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
 Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
 Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
@@ -11517,10 +11517,22 @@ Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
 * ``ResizeRightUp``: Resize right up (Top right handle)
 * ``ResizeLeftDown``: Resize left down (Bottom left handle)
 * ``ResizeRightDown``: Resize right down (Bottom right handle)
-* ``RotateLeftUp``: Rotate left up (Top left handle)
-* ``RotateRightUp``: Rotate right up (Top right handle)
-* ``RotateLeftDown``: Rotate left up (Bottom left handle)
-* ``RotateRightDown``: Rotate right up (Bottom right handle)
+* ``RotateLeftUp``: Rotate from top left handle.
+
+  .. versionadded:: 4.0
+
+* ``RotateRightUp``: Rotate from top right handle.
+
+  .. versionadded:: 4.0
+
+* ``RotateLeftDown``: Rotate from bottom left handle.
+
+  .. versionadded:: 4.0
+
+* ``RotateRightDown``: Rotate right bottom right handle.
+
+  .. versionadded:: 4.0
+
 * ``SelectItem``: Select item
 * ``NoAction``: No action
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -11498,6 +11498,10 @@ Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)
 Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
 Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
 Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
+Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate left up (Top left handle)"
+Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate right up (Top right handle)"
+Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate left up (Bottom left handle)"
+Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right up (Bottom right handle)"
 Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
 Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
 Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
@@ -11513,6 +11517,10 @@ Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
 * ``ResizeRightUp``: Resize right up (Top right handle)
 * ``ResizeLeftDown``: Resize left down (Bottom left handle)
 * ``ResizeRightDown``: Resize right down (Bottom right handle)
+* ``RotateLeftUp``: Rotate left up (Top left handle)
+* ``RotateRightUp``: Rotate right up (Top right handle)
+* ``RotateLeftDown``: Rotate left up (Bottom left handle)
+* ``RotateRightDown``: Rotate right up (Bottom right handle)
 * ``SelectItem``: Select item
 * ``NoAction``: No action
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3346,10 +3346,10 @@ The development version
       ResizeRightUp,
       ResizeLeftDown,
       ResizeRightDown,
-      RotateLeftUp,
-      RotateRightUp,
-      RotateLeftDown,
-      RotateRightDown,
+      RotateTopLeft,
+      RotateTopRight,
+      RotateBottomLeft,
+      RotateBottomRight,
       SelectItem,
       NoAction
     };

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3346,6 +3346,10 @@ The development version
       ResizeRightUp,
       ResizeLeftDown,
       ResizeRightDown,
+      RotateLeftUp,
+      RotateRightUp,
+      RotateLeftDown,
+      RotateRightDown,
       SelectItem,
       NoAction
     };

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -11404,10 +11404,10 @@ Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)
 Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
 Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
 Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
-Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate left up (Top left handle)"
-Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate right up (Top right handle)"
-Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate left up (Bottom left handle)"
-Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right up (Bottom right handle)"
+Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate from top left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate from top right handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate from bottom left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right bottom right handle. \n.. versionadded:: 4.0"
 Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
 Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
 Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
@@ -11423,10 +11423,22 @@ Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
 * ``ResizeRightUp``: Resize right up (Top right handle)
 * ``ResizeLeftDown``: Resize left down (Bottom left handle)
 * ``ResizeRightDown``: Resize right down (Bottom right handle)
-* ``RotateLeftUp``: Rotate left up (Top left handle)
-* ``RotateRightUp``: Rotate right up (Top right handle)
-* ``RotateLeftDown``: Rotate left up (Bottom left handle)
-* ``RotateRightDown``: Rotate right up (Bottom right handle)
+* ``RotateLeftUp``: Rotate from top left handle.
+
+  .. versionadded:: 4.0
+
+* ``RotateRightUp``: Rotate from top right handle.
+
+  .. versionadded:: 4.0
+
+* ``RotateLeftDown``: Rotate from bottom left handle.
+
+  .. versionadded:: 4.0
+
+* ``RotateRightDown``: Rotate right bottom right handle.
+
+  .. versionadded:: 4.0
+
 * ``SelectItem``: Select item
 * ``NoAction``: No action
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -11404,6 +11404,10 @@ Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)
 Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
 Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
 Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
+Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate left up (Top left handle)"
+Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate right up (Top right handle)"
+Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate left up (Bottom left handle)"
+Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right up (Bottom right handle)"
 Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
 Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
 Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
@@ -11419,6 +11423,10 @@ Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
 * ``ResizeRightUp``: Resize right up (Top right handle)
 * ``ResizeLeftDown``: Resize left down (Bottom left handle)
 * ``ResizeRightDown``: Resize right down (Bottom right handle)
+* ``RotateLeftUp``: Rotate left up (Top left handle)
+* ``RotateRightUp``: Rotate right up (Top right handle)
+* ``RotateLeftDown``: Rotate left up (Bottom left handle)
+* ``RotateRightDown``: Rotate right up (Bottom right handle)
 * ``SelectItem``: Select item
 * ``NoAction``: No action
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -11404,10 +11404,10 @@ Qgis.MouseHandlesAction.ResizeLeftUp.__doc__ = "Resize left up (Top left handle)
 Qgis.MouseHandlesAction.ResizeRightUp.__doc__ = "Resize right up (Top right handle)"
 Qgis.MouseHandlesAction.ResizeLeftDown.__doc__ = "Resize left down (Bottom left handle)"
 Qgis.MouseHandlesAction.ResizeRightDown.__doc__ = "Resize right down (Bottom right handle)"
-Qgis.MouseHandlesAction.RotateLeftUp.__doc__ = "Rotate from top left handle. \n.. versionadded:: 4.0"
-Qgis.MouseHandlesAction.RotateRightUp.__doc__ = "Rotate from top right handle. \n.. versionadded:: 4.0"
-Qgis.MouseHandlesAction.RotateLeftDown.__doc__ = "Rotate from bottom left handle. \n.. versionadded:: 4.0"
-Qgis.MouseHandlesAction.RotateRightDown.__doc__ = "Rotate right bottom right handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateTopLeft.__doc__ = "Rotate from top left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateTopRight.__doc__ = "Rotate from top right handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateBottomLeft.__doc__ = "Rotate from bottom left handle. \n.. versionadded:: 4.0"
+Qgis.MouseHandlesAction.RotateBottomRight.__doc__ = "Rotate right bottom right handle. \n.. versionadded:: 4.0"
 Qgis.MouseHandlesAction.SelectItem.__doc__ = "Select item"
 Qgis.MouseHandlesAction.NoAction.__doc__ = "No action"
 Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
@@ -11423,19 +11423,19 @@ Qgis.MouseHandlesAction.__doc__ = """Action to be performed by the mouse handles
 * ``ResizeRightUp``: Resize right up (Top right handle)
 * ``ResizeLeftDown``: Resize left down (Bottom left handle)
 * ``ResizeRightDown``: Resize right down (Bottom right handle)
-* ``RotateLeftUp``: Rotate from top left handle.
+* ``RotateTopLeft``: Rotate from top left handle.
 
   .. versionadded:: 4.0
 
-* ``RotateRightUp``: Rotate from top right handle.
+* ``RotateTopRight``: Rotate from top right handle.
 
   .. versionadded:: 4.0
 
-* ``RotateLeftDown``: Rotate from bottom left handle.
+* ``RotateBottomLeft``: Rotate from bottom left handle.
 
   .. versionadded:: 4.0
 
-* ``RotateRightDown``: Rotate right bottom right handle.
+* ``RotateBottomRight``: Rotate right bottom right handle.
 
   .. versionadded:: 4.0
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -3346,10 +3346,10 @@ The development version
       ResizeRightUp,
       ResizeLeftDown,
       ResizeRightDown,
-      RotateLeftUp,
-      RotateRightUp,
-      RotateLeftDown,
-      RotateRightDown,
+      RotateTopLeft,
+      RotateTopRight,
+      RotateBottomLeft,
+      RotateBottomRight,
       SelectItem,
       NoAction
     };

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -3346,6 +3346,10 @@ The development version
       ResizeRightUp,
       ResizeLeftDown,
       ResizeRightDown,
+      RotateLeftUp,
+      RotateRightUp,
+      RotateLeftDown,
+      RotateRightDown,
       SelectItem,
       NoAction
     };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5896,6 +5896,10 @@ class CORE_EXPORT Qgis
       ResizeRightUp, //!< Resize right up (Top right handle)
       ResizeLeftDown, //!< Resize left down (Bottom left handle)
       ResizeRightDown, //!< Resize right down (Bottom right handle)
+      RotateLeftUp, //!< Rotate left up (Top left handle)
+      RotateRightUp, //!< Rotate right up (Top right handle)
+      RotateLeftDown, //!< Rotate left up (Bottom left handle)
+      RotateRightDown, //!< Rotate right up (Bottom right handle)
       SelectItem, //!< Select item
       NoAction //!< No action
     };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5896,10 +5896,10 @@ class CORE_EXPORT Qgis
       ResizeRightUp, //!< Resize right up (Top right handle)
       ResizeLeftDown, //!< Resize left down (Bottom left handle)
       ResizeRightDown, //!< Resize right down (Bottom right handle)
-      RotateLeftUp, //!< Rotate from top left handle. \since QGIS 4.0
-      RotateRightUp, //!< Rotate from top right handle. \since QGIS 4.0
-      RotateLeftDown, //!< Rotate from bottom left handle. \since QGIS 4.0
-      RotateRightDown, //!< Rotate right bottom right handle. \since QGIS 4.0
+      RotateTopLeft, //!< Rotate from top left handle. \since QGIS 4.0
+      RotateTopRight, //!< Rotate from top right handle. \since QGIS 4.0
+      RotateBottomLeft, //!< Rotate from bottom left handle. \since QGIS 4.0
+      RotateBottomRight, //!< Rotate right bottom right handle. \since QGIS 4.0
       SelectItem, //!< Select item
       NoAction //!< No action
     };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5896,10 +5896,10 @@ class CORE_EXPORT Qgis
       ResizeRightUp, //!< Resize right up (Top right handle)
       ResizeLeftDown, //!< Resize left down (Bottom left handle)
       ResizeRightDown, //!< Resize right down (Bottom right handle)
-      RotateLeftUp, //!< Rotate left up (Top left handle)
-      RotateRightUp, //!< Rotate right up (Top right handle)
-      RotateLeftDown, //!< Rotate left up (Bottom left handle)
-      RotateRightDown, //!< Rotate right up (Bottom right handle)
+      RotateLeftUp, //!< Rotate from top left handle. \since QGIS 4.0
+      RotateRightUp, //!< Rotate from top right handle. \since QGIS 4.0
+      RotateLeftDown, //!< Rotate from bottom left handle. \since QGIS 4.0
+      RotateRightDown, //!< Rotate right bottom right handle. \since QGIS 4.0
       SelectItem, //!< Select item
       NoAction //!< No action
     };

--- a/src/gui/layout/qgslayoutguiutils.cpp
+++ b/src/gui/layout/qgslayoutguiutils.cpp
@@ -196,10 +196,10 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
       case Qgis::MouseHandlesAction::MoveItem:
       case Qgis::MouseHandlesAction::NoAction:
       case Qgis::MouseHandlesAction::SelectItem:
-      case Qgis::MouseHandlesAction::RotateLeftUp:
-      case Qgis::MouseHandlesAction::RotateRightUp:
-      case Qgis::MouseHandlesAction::RotateLeftDown:
-      case Qgis::MouseHandlesAction::RotateRightDown:
+      case Qgis::MouseHandlesAction::RotateTopLeft:
+      case Qgis::MouseHandlesAction::RotateTopRight:
+      case Qgis::MouseHandlesAction::RotateBottomLeft:
+      case Qgis::MouseHandlesAction::RotateBottomRight:
         return;
 
       case Qgis::MouseHandlesAction::ResizeUp:

--- a/src/gui/layout/qgslayoutguiutils.cpp
+++ b/src/gui/layout/qgslayoutguiutils.cpp
@@ -196,6 +196,10 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
       case Qgis::MouseHandlesAction::MoveItem:
       case Qgis::MouseHandlesAction::NoAction:
       case Qgis::MouseHandlesAction::SelectItem:
+      case Qgis::MouseHandlesAction::RotateLeftUp:
+      case Qgis::MouseHandlesAction::RotateRightUp:
+      case Qgis::MouseHandlesAction::RotateLeftDown:
+      case Qgis::MouseHandlesAction::RotateRightDown:
         return;
 
       case Qgis::MouseHandlesAction::ResizeUp:

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -45,7 +45,7 @@ QgsLayoutMouseHandles::QgsLayoutMouseHandles( QgsLayout *layout, QgsLayoutView *
   , mView( view )
 {
   setRotationEnabled( true );
-  
+
   //listen for selection changes, and update handles accordingly
   connect( mLayout, &QGraphicsScene::selectionChanged, this, &QgsLayoutMouseHandles::selectionChanged );
 

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -251,6 +251,16 @@ void QgsLayoutMouseHandles::moveItem( QGraphicsItem *item, double deltaX, double
   qgis::down_cast<QgsLayoutItem *>( item )->attemptMoveBy( deltaX, deltaY );
 }
 
+void QgsLayoutMouseHandles::rotateItem( QGraphicsItem *item, double deltaDegree, double deltaCenterX, double deltaCenterY )
+{
+  QgsLayoutItem *itm = qgis::down_cast<QgsLayoutItem *>( item );
+  QgsLayoutItem::ReferencePoint previousReferencePoint = itm->referencePoint();
+  itm->setReferencePoint( QgsLayoutItem::Middle );
+  itm->attemptMoveBy( deltaCenterX, deltaCenterY );
+  itm->setItemRotation( itm->itemRotation() + deltaDegree, true );
+  itm->setReferencePoint( previousReferencePoint );
+}
+
 void QgsLayoutMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
 {
   QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item );

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -44,6 +44,8 @@ QgsLayoutMouseHandles::QgsLayoutMouseHandles( QgsLayout *layout, QgsLayoutView *
   , mLayout( layout )
   , mView( view )
 {
+  setRotationEnabled( true );
+  
   //listen for selection changes, and update handles accordingly
   connect( mLayout, &QGraphicsScene::selectionChanged, this, &QgsLayoutMouseHandles::selectionChanged );
 

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -74,6 +74,7 @@ class GUI_EXPORT QgsLayoutMouseHandles : public QgsGraphicsViewMouseHandles
     void expandItemList( const QList<QGraphicsItem *> &items, QList<QGraphicsItem *> &collected ) const override;
     void expandItemList( const QList<QgsLayoutItem *> &items, QList<QGraphicsItem *> &collected ) const;
     void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
+    void rotateItem( QGraphicsItem *item, double deltaDegree, double deltaCenterX, double deltaCenterY ) override;
     void setItemRect( QGraphicsItem *item, QRectF rect ) override;
     void showStatusMessage( const QString &message ) override;
     void hideAlignItems() override;

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -411,10 +411,10 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
     case Qgis::MouseHandlesAction::SelectItem:
       return Qt::ArrowCursor;
 
-    case Qgis::MouseHandlesAction::RotateLeftUp:
-    case Qgis::MouseHandlesAction::RotateRightUp:
-    case Qgis::MouseHandlesAction::RotateLeftDown:
-    case Qgis::MouseHandlesAction::RotateRightDown:
+    case Qgis::MouseHandlesAction::RotateTopLeft:
+    case Qgis::MouseHandlesAction::RotateTopRight:
+    case Qgis::MouseHandlesAction::RotateBottomLeft:
+    case Qgis::MouseHandlesAction::RotateBottomRight:
       return Qt::PointingHandCursor;
   }
 
@@ -515,19 +515,19 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   }
   else if ( nearLeftInner && nearUpperInner )
   {
-    return Qgis::MouseHandlesAction::RotateLeftUp;
+    return Qgis::MouseHandlesAction::RotateTopLeft;
   }
   else if ( nearRightInner && nearUpperInner )
   {
-    return Qgis::MouseHandlesAction::RotateRightUp;
+    return Qgis::MouseHandlesAction::RotateTopRight;
   }
   else if ( nearLeftInner && nearLowerInner )
   {
-    return Qgis::MouseHandlesAction::RotateLeftDown;
+    return Qgis::MouseHandlesAction::RotateBottomLeft;
   }
   else if ( nearRightInner && nearLowerInner )
   {
-    return Qgis::MouseHandlesAction::RotateRightDown;
+    return Qgis::MouseHandlesAction::RotateBottomRight;
   }
 
   //find out if cursor position is over a selected item
@@ -655,10 +655,10 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
       mCursorOffset = calcCursorEdgeOffset( mMouseMoveStartPos );
       break;
 
-    case Qgis::MouseHandlesAction::RotateLeftUp:
-    case Qgis::MouseHandlesAction::RotateRightUp:
-    case Qgis::MouseHandlesAction::RotateLeftDown:
-    case Qgis::MouseHandlesAction::RotateRightDown:
+    case Qgis::MouseHandlesAction::RotateTopLeft:
+    case Qgis::MouseHandlesAction::RotateTopRight:
+    case Qgis::MouseHandlesAction::RotateBottomLeft:
+    case Qgis::MouseHandlesAction::RotateBottomRight:
       mIsRotating = true;
       mRotationCenter = sceneTransform().map( rect().center() );
       mRotationBegin = std::atan2( mMouseMoveStartPos.y() - mRotationCenter.y(), mMouseMoveStartPos.x() - mRotationCenter.x() ) * 180 / M_PI;
@@ -1217,10 +1217,10 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
-    case Qgis::MouseHandlesAction::RotateLeftUp:
-    case Qgis::MouseHandlesAction::RotateRightUp:
-    case Qgis::MouseHandlesAction::RotateLeftDown:
-    case Qgis::MouseHandlesAction::RotateRightDown:
+    case Qgis::MouseHandlesAction::RotateTopLeft:
+    case Qgis::MouseHandlesAction::RotateTopRight:
+    case Qgis::MouseHandlesAction::RotateBottomLeft:
+    case Qgis::MouseHandlesAction::RotateBottomRight:
     case Qgis::MouseHandlesAction::MoveItem:
     case Qgis::MouseHandlesAction::SelectItem:
     case Qgis::MouseHandlesAction::NoAction:
@@ -1335,10 +1335,10 @@ QSizeF QgsGraphicsViewMouseHandles::calcCursorEdgeOffset( QPointF cursorPos )
     case Qgis::MouseHandlesAction::ResizeLeftDown:
       return QSizeF( sceneMousePos.x(), sceneMousePos.y() - rect().height() );
 
-    case Qgis::MouseHandlesAction::RotateLeftUp:
-    case Qgis::MouseHandlesAction::RotateRightUp:
-    case Qgis::MouseHandlesAction::RotateLeftDown:
-    case Qgis::MouseHandlesAction::RotateRightDown:
+    case Qgis::MouseHandlesAction::RotateTopLeft:
+    case Qgis::MouseHandlesAction::RotateTopRight:
+    case Qgis::MouseHandlesAction::RotateBottomLeft:
+    case Qgis::MouseHandlesAction::RotateBottomRight:
     case Qgis::MouseHandlesAction::MoveItem:
     case Qgis::MouseHandlesAction::SelectItem:
     case Qgis::MouseHandlesAction::NoAction:

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -15,10 +15,13 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsgraphicsviewmousehandles.h"
 #include "moc_qgsgraphicsviewmousehandles.cpp"
-#include "qgsrendercontext.h"
+
 #include "qgis.h"
+#include "qgsgraphicsviewmousehandles.h"
+#include "qgslayoututils.h"
+#include "qgsrendercontext.h"
+
 #include <QGraphicsView>
 #include <QGraphicsSceneHoverEvent>
 #include <QPainter>
@@ -86,6 +89,7 @@ QRectF QgsGraphicsViewMouseHandles::storedItemRect( QGraphicsItem *item ) const
 
 void QgsGraphicsViewMouseHandles::rotateItem( QGraphicsItem *, double, double, double )
 {
+  QgsDebugError( QStringLiteral( "Rotation is not implemented for this class" ) );
 }
 
 void QgsGraphicsViewMouseHandles::previewItemMove( QGraphicsItem *, double, double )
@@ -930,13 +934,7 @@ void QgsGraphicsViewMouseHandles::rotateMouseMove( QPointF currentPosition, bool
   mRotationDelta = mRotationCurrent - mRotationBegin;
   if ( snapToCommonAngles )
   {
-    const double commonAngles = 15;
-    double snappedRotationDelta = std::floor( std::abs( mRotationDelta ) / commonAngles ) * commonAngles;
-    if ( std::abs( std::fmod( mRotationDelta, commonAngles ) ) >= 10 )
-    {
-      snappedRotationDelta += commonAngles;
-    }
-    mRotationDelta = mRotationDelta >= 0 ? snappedRotationDelta : -snappedRotationDelta;
+    mRotationDelta = QgsLayoutUtils::snappedAngle( mRotationDelta );
   }
 
   const double itemRotationRadian = rotation() * M_PI / 180;

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -34,6 +34,17 @@ QgsGraphicsViewMouseHandles::QgsGraphicsViewMouseHandles( QGraphicsView *view )
 {
   //accept hover events, required for changing cursor to resize cursors
   setAcceptHoverEvents( true );
+  
+  //prepare rotation handle path
+  mRotationHandlePath.moveTo( 0, 14 );
+  mRotationHandlePath.lineTo( 6, 20 );
+  mRotationHandlePath.lineTo( 12, 14 );
+  mRotationHandlePath.arcTo( 8, 8, 12, 12, 180, -90 );
+  mRotationHandlePath.lineTo( 14, 12 );
+  mRotationHandlePath.lineTo( 20, 6 );
+  mRotationHandlePath.lineTo( 14, 0 );
+  mRotationHandlePath.arcTo( 4, 4, 20, 20, 90, 90 );
+  mRotationHandlePath.lineTo( 0, 14 );
 }
 
 void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHandles, bool showStaticBoundingBoxes, bool showTemporaryBoundingBoxes, const QStyleOptionGraphicsItem *, QWidget * )
@@ -60,6 +71,10 @@ void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHan
 QRectF QgsGraphicsViewMouseHandles::storedItemRect( QGraphicsItem *item ) const
 {
   return itemRect( item );
+}
+
+void QgsGraphicsViewMouseHandles::rotateItem( QGraphicsItem *, double, double, double )
+{
 }
 
 void QgsGraphicsViewMouseHandles::previewItemMove( QGraphicsItem *, double, double )
@@ -108,7 +123,7 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
   painter->setBrush( Qt::NoBrush );
   painter->drawRect( QRectF( 0, 0, rect().width(), rect().height() ) );
 
-  //draw resize handles, using a filled white box
+  //draw resize handles, using filled white boxes
   painter->setBrush( QColor( 255, 255, 255, 255 ) );
   //top left
   painter->drawRect( QRectF( 0, 0, rectHandlerSize, rectHandlerSize ) );
@@ -126,6 +141,67 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
   painter->drawRect( QRectF( ( rect().width() - rectHandlerSize ) / 2, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
   //bottom right
   painter->drawRect( QRectF( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
+  
+  //draw rotate handles
+  const double scale = rectHandlerSize / mHandleSize;
+  const bool drawBottomRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().height();
+  const bool drawRightRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().width();
+  QTransform transform;
+  
+  //top left
+  transform.reset();
+  transform.translate( rectHandlerSize, rectHandlerSize );
+  transform.scale( scale, scale );
+  painter->save();
+  painter->setTransform( transform, true );
+  painter->drawPath( mRotationHandlePath );
+  painter->restore();
+  
+  //top right
+  if ( drawRightRotationHandles )
+  {
+    transform.reset();
+    transform.translate( rect().width() - rectHandlerSize, rectHandlerSize );
+    transform.rotate( 90 );
+    transform.scale( scale, scale );
+    painter->save();
+    painter->setTransform( transform, true );
+    painter->drawPath( mRotationHandlePath );
+    painter->restore();
+  }
+  
+  if ( drawBottomRotationHandles )
+  {
+    //bottom left
+    transform.reset();
+    transform.translate( rectHandlerSize, rect().height() - rectHandlerSize );
+    transform.rotate( 270 );
+    transform.scale( scale, scale );
+    painter->save();
+    painter->setTransform( transform, true );
+    painter->drawPath( mRotationHandlePath );
+    painter->restore();
+  }
+  
+  if ( drawBottomRotationHandles && drawRightRotationHandles )
+  {
+    //bottom right
+    transform.reset();
+    transform.translate( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize );
+    transform.rotate( 180 );
+    transform.scale( scale, scale );
+    painter->save();
+    painter->setTransform( transform, true );
+    painter->drawPath( mRotationHandlePath );
+    painter->restore();
+  }
+}
+
+QRectF QgsGraphicsViewMouseHandles::boundingRect() const
+{
+  const double rectHandlerSize = rectHandlerBorderTolerance();
+  const double rectRotationHandleSize = mRotationHandleSize * rectHandlerSize / mHandleSize;
+  return QRectF( -rectRotationHandleSize, -rectRotationHandleSize, rect().width() + rectRotationHandleSize * 2, rect().height() + rectRotationHandleSize * 2 );
 }
 
 void QgsGraphicsViewMouseHandles::drawSelectedItemBounds( QPainter *painter )
@@ -181,6 +257,17 @@ void QgsGraphicsViewMouseHandles::drawSelectedItemBounds( QPainter *painter )
       relativeResizeRect( thisItemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
       itemBounds = QPolygonF( thisItemRect );
     }
+    else if ( isRotating() && !itemIsLocked( item ) )
+    {
+      const QPolygonF itemSceneBounds = item->mapToScene( itemRect( item ) );
+      const QPointF rotationCenter = sceneTransform().map( rect().center() );
+      
+      QTransform transform;
+      transform.translate( rotationCenter.x(), rotationCenter.y() );
+      transform.rotate( mRotationCurrent - mRotationBegin );
+      transform.translate( -rotationCenter.x(), -rotationCenter.y() );
+      itemBounds = mapFromScene( transform.map( itemSceneBounds ) );
+    }
     else
     {
       // not resizing or moving, so just map the item's bounds to the mouse handle item's coordinate system
@@ -195,7 +282,7 @@ void QgsGraphicsViewMouseHandles::drawSelectedItemBounds( QPainter *painter )
   }
 }
 
-double QgsGraphicsViewMouseHandles::rectHandlerBorderTolerance()
+double QgsGraphicsViewMouseHandles::rectHandlerBorderTolerance() const
 {
   if ( !mView )
     return 0;
@@ -312,6 +399,12 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
       }
     case Qgis::MouseHandlesAction::SelectItem:
       return Qt::ArrowCursor;
+    
+    case Qgis::MouseHandlesAction::RotateLeftUp:
+    case Qgis::MouseHandlesAction::RotateRightUp:
+    case Qgis::MouseHandlesAction::RotateLeftDown:
+    case Qgis::MouseHandlesAction::RotateRightDown:
+      return Qt::PointingHandCursor;
   }
 
   return Qt::ArrowCursor;
@@ -324,8 +417,14 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   bool nearLowerBorder = false;
   bool nearUpperBorder = false;
 
+  bool nearLeftInner = false;
+  bool nearRightInner = false;
+  bool nearLowerInner = false;
+  bool nearUpperInner = false;
+  
   bool withinWidth = false;
   bool withinHeight = false;
+  
   if ( itemCoordPos.x() >= 0 && itemCoordPos.x() <= rect().width() )
   {
     withinWidth = true;
@@ -336,22 +435,39 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   }
 
   double borderTolerance = rectHandlerBorderTolerance();
+  double innerTolerance = mRotationHandleSize * borderTolerance / mHandleSize;
 
   if ( itemCoordPos.x() >= 0 && itemCoordPos.x() < borderTolerance )
   {
     nearLeftBorder = true;
   }
+  else if ( itemCoordPos.x() >= borderTolerance && itemCoordPos.x() < ( borderTolerance + innerTolerance ) )
+  {
+    nearLeftInner = true;
+  }
   if ( itemCoordPos.y() >= 0 && itemCoordPos.y() < borderTolerance )
   {
     nearUpperBorder = true;
+  }
+  else if ( itemCoordPos.y() >= borderTolerance && itemCoordPos.y() < ( borderTolerance + innerTolerance ) )
+  {
+    nearUpperInner = true;
   }
   if ( itemCoordPos.x() <= rect().width() && itemCoordPos.x() > ( rect().width() - borderTolerance ) )
   {
     nearRightBorder = true;
   }
+  else if ( itemCoordPos.x() <= ( rect().width() - borderTolerance ) && itemCoordPos.x() > ( rect().width() - borderTolerance - innerTolerance ) )
+  {
+    nearRightInner = true;
+  }
   if ( itemCoordPos.y() <= rect().height() && itemCoordPos.y() > ( rect().height() - borderTolerance ) )
   {
     nearLowerBorder = true;
+  }
+  else if ( itemCoordPos.y() <= ( rect().height() - borderTolerance ) && itemCoordPos.y() > ( rect().height() - borderTolerance - innerTolerance ) )
+  {
+    nearLowerInner = true;
   }
 
   if ( nearLeftBorder && nearUpperBorder )
@@ -385,6 +501,22 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   else if ( nearLowerBorder && withinWidth )
   {
     return Qgis::MouseHandlesAction::ResizeDown;
+  }
+  else if ( nearLeftInner && nearUpperInner )
+  {
+    return Qgis::MouseHandlesAction::RotateLeftUp;
+  }
+  else if ( nearRightInner && nearUpperInner )
+  {
+    return Qgis::MouseHandlesAction::RotateRightUp;
+  }
+  else if ( nearLeftInner && nearLowerInner )
+  {
+    return Qgis::MouseHandlesAction::RotateLeftDown;
+  }
+  else if ( nearRightInner && nearLowerInner )
+  {
+    return Qgis::MouseHandlesAction::RotateRightDown;
   }
 
   //find out if cursor position is over a selected item
@@ -489,19 +621,42 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
 
   hideAlignItems();
 
-  if ( mCurrentMouseMoveAction == Qgis::MouseHandlesAction::MoveItem )
+  switch ( mCurrentMouseMoveAction )
   {
-    //moving items
-    mIsDragging = true;
-  }
-  else if ( mCurrentMouseMoveAction != Qgis::MouseHandlesAction::SelectItem && mCurrentMouseMoveAction != Qgis::MouseHandlesAction::NoAction )
-  {
-    //resizing items
-    mIsResizing = true;
-    mResizeRect = QRectF( 0, 0, mBeginHandleWidth, mBeginHandleHeight );
-    mResizeMoveX = 0;
-    mResizeMoveY = 0;
-    mCursorOffset = calcCursorEdgeOffset( mMouseMoveStartPos );
+    case Qgis::MouseHandlesAction::MoveItem:
+      //moving items
+      mIsDragging = true;
+      break;
+
+    case Qgis::MouseHandlesAction::ResizeUp:
+    case Qgis::MouseHandlesAction::ResizeDown:
+    case Qgis::MouseHandlesAction::ResizeLeft:
+    case Qgis::MouseHandlesAction::ResizeRight:
+    case Qgis::MouseHandlesAction::ResizeLeftUp:
+    case Qgis::MouseHandlesAction::ResizeRightUp:
+    case Qgis::MouseHandlesAction::ResizeLeftDown:
+    case Qgis::MouseHandlesAction::ResizeRightDown:
+      //resizing items
+      mIsResizing = true;
+      mResizeRect = QRectF( 0, 0, mBeginHandleWidth, mBeginHandleHeight );
+      mResizeMoveX = 0;
+      mResizeMoveY = 0;
+      mCursorOffset = calcCursorEdgeOffset( mMouseMoveStartPos );
+      break;
+    
+    case Qgis::MouseHandlesAction::RotateLeftUp:
+    case Qgis::MouseHandlesAction::RotateRightUp:
+    case Qgis::MouseHandlesAction::RotateLeftDown:
+    case Qgis::MouseHandlesAction::RotateRightDown:
+      mIsRotating = true;
+      mRotationCenter = QPointF( mBeginHandlePos.x() + ( sceneBoundingRect().width() / 2 ), mBeginHandlePos.y() + ( sceneBoundingRect().height() / 2 ) );
+      mRotationBegin = std::atan2( mMouseMoveStartPos.y() - mRotationCenter.y(), mMouseMoveStartPos.x() - mRotationCenter.x() ) * 180 / M_PI;
+      mRotationCurrent = 0.0;
+      break;
+    
+    case Qgis::MouseHandlesAction::SelectItem:
+    case Qgis::MouseHandlesAction::NoAction:
+      break;
   }
 }
 
@@ -537,6 +692,11 @@ void QgsGraphicsViewMouseHandles::mouseMoveEvent( QGraphicsSceneMouseEvent *even
     //resize from center if alt depressed
     resizeMouseMove( event->lastScenePos(), event->modifiers() & Qt::ShiftModifier, event->modifiers() & Qt::AltModifier );
   }
+  else if ( isRotating() )
+  {
+    //currently rotating a selection
+    rotateMouseMove( event->lastScenePos() );
+  }
 }
 
 void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
@@ -567,12 +727,13 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
   {
     mIsDragging = false;
     mIsResizing = false;
+    mIsRotating = false;
     update();
     hideAlignItems();
     return;
   }
 
-  if ( mCurrentMouseMoveAction == Qgis::MouseHandlesAction::MoveItem )
+  if ( mIsDragging )
   {
     //move selected items
     startMacroCommand( tr( "Move Items" ) );
@@ -597,8 +758,10 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
       endItemCommand( item );
     }
     endMacroCommand();
+    
+    mIsDragging = false;
   }
-  else if ( mCurrentMouseMoveAction != Qgis::MouseHandlesAction::NoAction )
+  else if ( mIsResizing )
   {
     //resize selected items
     startMacroCommand( tr( "Resize Items" ) );
@@ -635,17 +798,45 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
       endItemCommand( item );
     }
     endMacroCommand();
+    
+    mIsResizing = false;
+  }
+  else if ( mIsRotating )
+  {
+    mRotationCurrent = std::atan2( mouseMoveStopPoint.y() - mRotationCenter.y(), mouseMoveStopPoint.x() - mRotationCenter.x() ) * 180 / M_PI;
+    const QPointF itemRotationCenter = sceneTransform().map( rect().center() );
+  
+    //move selected items
+    startMacroCommand( tr( "Rotate Items" ) );
+
+    //move all selected items
+    const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+    for ( QGraphicsItem *item : selectedItems )
+    {
+      if ( itemIsLocked( item ) || ( item->flags() & QGraphicsItem::ItemIsSelectable ) == 0 || itemIsGroupMember( item ) )
+      {
+        //don't move locked items, or grouped items (group takes care of that)
+        continue;
+      }
+
+      const QPointF itemCenter = item->mapToScene( itemRect( item ) ).boundingRect().center();
+      
+      QTransform transform;
+      transform.translate( itemRotationCenter.x(), itemRotationCenter.y() );
+      transform.rotate( mRotationCurrent - mRotationBegin );
+      transform.translate( -itemRotationCenter.x(), -itemRotationCenter.y() );
+      const QPointF rotatedItemCenter = transform.map( itemCenter );
+      
+      createItemCommand( item );
+      rotateItem( item, mRotationCurrent - mRotationBegin, rotatedItemCenter.x() - itemCenter.x(), rotatedItemCenter.y() - itemCenter.y() );
+      endItemCommand( item );
+    }
+    endMacroCommand();
+    
+    mIsRotating = false;
   }
 
   hideAlignItems();
-  if ( mIsDragging )
-  {
-    mIsDragging = false;
-  }
-  if ( mIsResizing )
-  {
-    mIsResizing = false;
-  }
 
   //reset default action
   mCurrentMouseMoveAction = Qgis::MouseHandlesAction::MoveItem;
@@ -719,6 +910,28 @@ void QgsGraphicsViewMouseHandles::updateHandles()
   }
   //force redraw
   update();
+}
+
+void QgsGraphicsViewMouseHandles::rotateMouseMove( QPointF currentPosition )
+{
+  if ( !scene() )
+  {
+    return;
+  }
+  
+  mRotationCurrent = std::atan2( currentPosition.y() - mRotationCenter.y(), currentPosition.x() - mRotationCenter.x() ) * 180 / M_PI;
+  
+  const double itemRotationRadian = rotation() * M_PI / 180;
+  const double deltaX = ( rect().width() / 2 ) * cos( itemRotationRadian ) - ( rect().height() / 2 ) * sin( itemRotationRadian );
+  const double deltaY = ( rect().width() / 2 ) * sin( itemRotationRadian ) + ( rect().height() / 2 ) * cos( itemRotationRadian );
+  
+  QTransform rotateTransform;
+  rotateTransform.translate( deltaX, deltaY );
+  rotateTransform.rotate( mRotationCurrent - mRotationBegin );
+  rotateTransform.translate( -deltaX, -deltaY );
+  setTransform( rotateTransform );
+  
+  return;
 }
 
 void QgsGraphicsViewMouseHandles::dragMouseMove( QPointF currentPosition, bool lockMovement, bool preventSnap )
@@ -985,6 +1198,10 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
       break;
     }
 
+    case Qgis::MouseHandlesAction::RotateLeftUp:
+    case Qgis::MouseHandlesAction::RotateRightUp:
+    case Qgis::MouseHandlesAction::RotateLeftDown:
+    case Qgis::MouseHandlesAction::RotateRightDown:
     case Qgis::MouseHandlesAction::MoveItem:
     case Qgis::MouseHandlesAction::SelectItem:
     case Qgis::MouseHandlesAction::NoAction:
@@ -1099,6 +1316,10 @@ QSizeF QgsGraphicsViewMouseHandles::calcCursorEdgeOffset( QPointF cursorPos )
     case Qgis::MouseHandlesAction::ResizeLeftDown:
       return QSizeF( sceneMousePos.x(), sceneMousePos.y() - rect().height() );
 
+    case Qgis::MouseHandlesAction::RotateLeftUp:
+    case Qgis::MouseHandlesAction::RotateRightUp:
+    case Qgis::MouseHandlesAction::RotateLeftDown:
+    case Qgis::MouseHandlesAction::RotateRightDown:
     case Qgis::MouseHandlesAction::MoveItem:
     case Qgis::MouseHandlesAction::SelectItem:
     case Qgis::MouseHandlesAction::NoAction:

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -34,7 +34,7 @@ QgsGraphicsViewMouseHandles::QgsGraphicsViewMouseHandles( QGraphicsView *view )
 {
   //accept hover events, required for changing cursor to resize cursors
   setAcceptHoverEvents( true );
-  
+
   //prepare rotation handle path
   mRotationHandlePath.moveTo( 0, 14 );
   mRotationHandlePath.lineTo( 6, 20 );
@@ -53,7 +53,7 @@ void QgsGraphicsViewMouseHandles::setRotationEnabled( bool enable )
   {
     return;
   }
-  
+
   mRotationEnabled = enable;
   update();
 }
@@ -152,7 +152,7 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
   painter->drawRect( QRectF( ( rect().width() - rectHandlerSize ) / 2, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
   //bottom right
   painter->drawRect( QRectF( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
-  
+
   if ( isRotationEnabled() )
   {
     //draw rotate handles
@@ -160,7 +160,7 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
     const bool drawBottomRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().height();
     const bool drawRightRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().width();
     QTransform transform;
-    
+
     //top left
     transform.reset();
     transform.translate( rectHandlerSize, rectHandlerSize );
@@ -169,7 +169,7 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
     painter->setTransform( transform, true );
     painter->drawPath( mRotationHandlePath );
     painter->restore();
-    
+
     //top right
     if ( drawRightRotationHandles )
     {
@@ -182,7 +182,7 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
       painter->drawPath( mRotationHandlePath );
       painter->restore();
     }
-    
+
     if ( drawBottomRotationHandles )
     {
       //bottom left
@@ -195,7 +195,7 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
       painter->drawPath( mRotationHandlePath );
       painter->restore();
     }
-    
+
     if ( drawBottomRotationHandles && drawRightRotationHandles )
     {
       //bottom right
@@ -268,7 +268,7 @@ void QgsGraphicsViewMouseHandles::drawSelectedItemBounds( QPainter *painter )
     {
       const QPolygonF itemSceneBounds = item->mapToScene( itemRect( item ) );
       const QPointF rotationCenter = sceneTransform().map( rect().center() );
-      
+
       QTransform transform;
       transform.translate( rotationCenter.x(), rotationCenter.y() );
       transform.rotate( mRotationDelta );
@@ -406,7 +406,7 @@ Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoor
       }
     case Qgis::MouseHandlesAction::SelectItem:
       return Qt::ArrowCursor;
-    
+
     case Qgis::MouseHandlesAction::RotateLeftUp:
     case Qgis::MouseHandlesAction::RotateRightUp:
     case Qgis::MouseHandlesAction::RotateLeftDown:
@@ -428,10 +428,10 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   bool nearRightInner = false;
   bool nearLowerInner = false;
   bool nearUpperInner = false;
-  
+
   bool withinWidth = false;
   bool withinHeight = false;
-  
+
   if ( itemCoordPos.x() >= 0 && itemCoordPos.x() <= rect().width() )
   {
     withinWidth = true;
@@ -650,7 +650,7 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
       mResizeMoveY = 0;
       mCursorOffset = calcCursorEdgeOffset( mMouseMoveStartPos );
       break;
-    
+
     case Qgis::MouseHandlesAction::RotateLeftUp:
     case Qgis::MouseHandlesAction::RotateRightUp:
     case Qgis::MouseHandlesAction::RotateLeftDown:
@@ -660,7 +660,7 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
       mRotationBegin = std::atan2( mMouseMoveStartPos.y() - mRotationCenter.y(), mMouseMoveStartPos.x() - mRotationCenter.x() ) * 180 / M_PI;
       mRotationCurrent = 0.0;
       break;
-    
+
     case Qgis::MouseHandlesAction::SelectItem:
     case Qgis::MouseHandlesAction::NoAction:
       break;
@@ -766,7 +766,7 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
       endItemCommand( item );
     }
     endMacroCommand();
-    
+
     mIsDragging = false;
   }
   else if ( mIsResizing )
@@ -806,13 +806,13 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
       endItemCommand( item );
     }
     endMacroCommand();
-    
+
     mIsResizing = false;
   }
   else if ( mIsRotating )
   {
     const QPointF itemRotationCenter = sceneTransform().map( rect().center() );
-  
+
     //move selected items
     startMacroCommand( tr( "Rotate Items" ) );
 
@@ -827,19 +827,19 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
       }
 
       const QPointF itemCenter = item->mapToScene( itemRect( item ) ).boundingRect().center();
-      
+
       QTransform transform;
       transform.translate( itemRotationCenter.x(), itemRotationCenter.y() );
       transform.rotate( mRotationDelta );
       transform.translate( -itemRotationCenter.x(), -itemRotationCenter.y() );
       const QPointF rotatedItemCenter = transform.map( itemCenter );
-      
+
       createItemCommand( item );
       rotateItem( item, mRotationDelta, rotatedItemCenter.x() - itemCenter.x(), rotatedItemCenter.y() - itemCenter.y() );
       endItemCommand( item );
     }
     endMacroCommand();
-    
+
     mIsRotating = false;
   }
 
@@ -925,7 +925,7 @@ void QgsGraphicsViewMouseHandles::rotateMouseMove( QPointF currentPosition, bool
   {
     return;
   }
-  
+
   mRotationCurrent = std::atan2( currentPosition.y() - mRotationCenter.y(), currentPosition.x() - mRotationCenter.x() ) * 180 / M_PI;
   mRotationDelta = mRotationCurrent - mRotationBegin;
   if ( snapToCommonAngles )
@@ -938,17 +938,17 @@ void QgsGraphicsViewMouseHandles::rotateMouseMove( QPointF currentPosition, bool
     }
     mRotationDelta = mRotationDelta >= 0 ? snappedRotationDelta : -snappedRotationDelta;
   }
-  
+
   const double itemRotationRadian = rotation() * M_PI / 180;
   const double deltaX = ( rect().width() / 2 ) * cos( itemRotationRadian ) - ( rect().height() / 2 ) * sin( itemRotationRadian );
   const double deltaY = ( rect().width() / 2 ) * sin( itemRotationRadian ) + ( rect().height() / 2 ) * cos( itemRotationRadian );
-  
+
   QTransform rotateTransform;
   rotateTransform.translate( deltaX, deltaY );
   rotateTransform.rotate( mRotationDelta );
   rotateTransform.translate( -deltaX, -deltaY );
   setTransform( rotateTransform );
-  
+
   //show current selection rotation in status bar
   showStatusMessage( tr( "rotation: %1°" ).arg( QString::number( mRotationDelta, 'f', 2 ) ) );
 

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -197,13 +197,6 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
   }
 }
 
-QRectF QgsGraphicsViewMouseHandles::boundingRect() const
-{
-  const double rectHandlerSize = rectHandlerBorderTolerance();
-  const double rectRotationHandleSize = mRotationHandleSize * rectHandlerSize / mHandleSize;
-  return QRectF( -rectRotationHandleSize, -rectRotationHandleSize, rect().width() + rectRotationHandleSize * 2, rect().height() + rectRotationHandleSize * 2 );
-}
-
 void QgsGraphicsViewMouseHandles::drawSelectedItemBounds( QPainter *painter )
 {
   //draw dotted border around selected items to give visual feedback which items are selected
@@ -931,6 +924,9 @@ void QgsGraphicsViewMouseHandles::rotateMouseMove( QPointF currentPosition )
   rotateTransform.translate( -deltaX, -deltaY );
   setTransform( rotateTransform );
   
+  //show current selection rotation in status bar
+  showStatusMessage( tr( "rotation: %1°" ).arg( QString::number( mRotationCurrent - mRotationBegin, 'f', 2 ) ) );
+
   return;
 }
 

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -47,6 +47,17 @@ QgsGraphicsViewMouseHandles::QgsGraphicsViewMouseHandles( QGraphicsView *view )
   mRotationHandlePath.lineTo( 0, 14 );
 }
 
+void QgsGraphicsViewMouseHandles::setRotationEnabled( bool enable )
+{
+  if ( mRotationEnabled == enable )
+  {
+    return;
+  }
+  
+  mRotationEnabled = enable;
+  update();
+}
+
 void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHandles, bool showStaticBoundingBoxes, bool showTemporaryBoundingBoxes, const QStyleOptionGraphicsItem *, QWidget * )
 {
   if ( !showHandles )
@@ -142,58 +153,61 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
   //bottom right
   painter->drawRect( QRectF( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
   
-  //draw rotate handles
-  const double scale = rectHandlerSize / mHandleSize;
-  const bool drawBottomRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().height();
-  const bool drawRightRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().width();
-  QTransform transform;
-  
-  //top left
-  transform.reset();
-  transform.translate( rectHandlerSize, rectHandlerSize );
-  transform.scale( scale, scale );
-  painter->save();
-  painter->setTransform( transform, true );
-  painter->drawPath( mRotationHandlePath );
-  painter->restore();
-  
-  //top right
-  if ( drawRightRotationHandles )
+  if ( isRotationEnabled() )
   {
+    //draw rotate handles
+    const double scale = rectHandlerSize / mHandleSize;
+    const bool drawBottomRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().height();
+    const bool drawRightRotationHandles = ( rectHandlerSize * 2 ) + ( mRotationHandleSize * scale * 2 ) < rect().width();
+    QTransform transform;
+    
+    //top left
     transform.reset();
-    transform.translate( rect().width() - rectHandlerSize, rectHandlerSize );
-    transform.rotate( 90 );
+    transform.translate( rectHandlerSize, rectHandlerSize );
     transform.scale( scale, scale );
     painter->save();
     painter->setTransform( transform, true );
     painter->drawPath( mRotationHandlePath );
     painter->restore();
-  }
-  
-  if ( drawBottomRotationHandles )
-  {
-    //bottom left
-    transform.reset();
-    transform.translate( rectHandlerSize, rect().height() - rectHandlerSize );
-    transform.rotate( 270 );
-    transform.scale( scale, scale );
-    painter->save();
-    painter->setTransform( transform, true );
-    painter->drawPath( mRotationHandlePath );
-    painter->restore();
-  }
-  
-  if ( drawBottomRotationHandles && drawRightRotationHandles )
-  {
-    //bottom right
-    transform.reset();
-    transform.translate( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize );
-    transform.rotate( 180 );
-    transform.scale( scale, scale );
-    painter->save();
-    painter->setTransform( transform, true );
-    painter->drawPath( mRotationHandlePath );
-    painter->restore();
+    
+    //top right
+    if ( drawRightRotationHandles )
+    {
+      transform.reset();
+      transform.translate( rect().width() - rectHandlerSize, rectHandlerSize );
+      transform.rotate( 90 );
+      transform.scale( scale, scale );
+      painter->save();
+      painter->setTransform( transform, true );
+      painter->drawPath( mRotationHandlePath );
+      painter->restore();
+    }
+    
+    if ( drawBottomRotationHandles )
+    {
+      //bottom left
+      transform.reset();
+      transform.translate( rectHandlerSize, rect().height() - rectHandlerSize );
+      transform.rotate( 270 );
+      transform.scale( scale, scale );
+      painter->save();
+      painter->setTransform( transform, true );
+      painter->drawPath( mRotationHandlePath );
+      painter->restore();
+    }
+    
+    if ( drawBottomRotationHandles && drawRightRotationHandles )
+    {
+      //bottom right
+      transform.reset();
+      transform.translate( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize );
+      transform.rotate( 180 );
+      transform.scale( scale, scale );
+      painter->save();
+      painter->setTransform( transform, true );
+      painter->drawPath( mRotationHandlePath );
+      painter->restore();
+    }
   }
 }
 
@@ -434,7 +448,7 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   {
     nearLeftBorder = true;
   }
-  else if ( itemCoordPos.x() >= borderTolerance && itemCoordPos.x() < ( borderTolerance + innerTolerance ) )
+  else if ( isRotationEnabled() && itemCoordPos.x() >= borderTolerance && itemCoordPos.x() < ( borderTolerance + innerTolerance ) )
   {
     nearLeftInner = true;
   }
@@ -442,7 +456,7 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   {
     nearUpperBorder = true;
   }
-  else if ( itemCoordPos.y() >= borderTolerance && itemCoordPos.y() < ( borderTolerance + innerTolerance ) )
+  else if ( isRotationEnabled() && itemCoordPos.y() >= borderTolerance && itemCoordPos.y() < ( borderTolerance + innerTolerance ) )
   {
     nearUpperInner = true;
   }
@@ -450,7 +464,7 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   {
     nearRightBorder = true;
   }
-  else if ( itemCoordPos.x() <= ( rect().width() - borderTolerance ) && itemCoordPos.x() > ( rect().width() - borderTolerance - innerTolerance ) )
+  else if ( isRotationEnabled() && itemCoordPos.x() <= ( rect().width() - borderTolerance ) && itemCoordPos.x() > ( rect().width() - borderTolerance - innerTolerance ) )
   {
     nearRightInner = true;
   }
@@ -458,7 +472,7 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QP
   {
     nearLowerBorder = true;
   }
-  else if ( itemCoordPos.y() <= ( rect().height() - borderTolerance ) && itemCoordPos.y() > ( rect().height() - borderTolerance - innerTolerance ) )
+  else if ( isRotationEnabled() && itemCoordPos.y() <= ( rect().height() - borderTolerance ) && itemCoordPos.y() > ( rect().height() - borderTolerance - innerTolerance ) )
   {
     nearLowerInner = true;
   }

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -163,7 +163,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     void resizeMouseMove( QPointF currentPosition, bool lockAspect, bool fromCenter );
 
     //! Handles rotating of tiems during mouse move
-    void rotateMouseMove( QPointF currentPosition );
+    void rotateMouseMove( QPointF currentPosition, bool snapToCommonAngles );
 
     void setHandleSize( double size );
 
@@ -218,6 +218,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     QPointF mRotationCenter;
     double mRotationBegin = 0.0;
     double mRotationCurrent = 0.0;
+    double mRotationDelta = 0.0;
 
     //! Start point of the last mouse move action (in scene coordinates)
     QPointF mMouseMoveStartPos;

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -85,6 +85,12 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     //! Initializes a drag operation \since QGIS 3.34
     void startMove( QPointF sceneCoordPos );
     
+    //! Returns TRUE if rotation functionality is enabled
+    bool isRotationEnabled() const { return mRotationEnabled; }
+    
+    //! Sets whether rotation functionality is enabled
+    void setRotationEnabled( bool enable );
+
   public slots:
 
     //! Redraws handles when selected item size changes
@@ -214,10 +220,14 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
 
     QRectF mResizeRect;
 
+    bool mRotationEnabled = false;
     //! Center point around which rotation occurs
     QPointF mRotationCenter;
+    //! The starting rotation angle from center point
     double mRotationBegin = 0.0;
+    //! The current rotation angle from center point
     double mRotationCurrent = 0.0;
+    //! The rotation angle delta to be applied (can be snapped to common angle)
     double mRotationDelta = 0.0;
 
     //! Start point of the last mouse move action (in scene coordinates)

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -77,7 +77,11 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     //! Returns TRUE is user is currently resizing with the handles
     bool isResizing() const { return mIsResizing; }
 
-    //! Returns TRUE is user is currently rotating with the handles
+    /**
+     * Returns TRUE is user is currently rotating with the handles.
+     * 
+     * \since QGIS 4.0
+     */
     bool isRotating() const { return mIsRotating; }
 
     bool shouldBlockEvent( QInputEvent *event ) const;
@@ -85,10 +89,23 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     //! Initializes a drag operation \since QGIS 3.34
     void startMove( QPointF sceneCoordPos );
 
-    //! Returns TRUE if rotation functionality is enabled
+    /**
+     * Returns TRUE if rotation functionality is enabled.
+     * 
+     * Rotation is not enabled by default.
+     * 
+     * \since QGIS 4.0
+     */
     bool isRotationEnabled() const { return mRotationEnabled; }
 
-    //! Sets whether rotation functionality is enabled
+    /**
+     * Sets whether rotation functionality is enabled.
+     * 
+     * Rotation is not enabled by default. Subclasses must implement the
+     * rotateItem() method in order to support rotation.
+     * 
+     * \since QGIS 4.0
+     */
     void setRotationEnabled( bool enable );
 
   public slots:

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -84,8 +84,6 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
 
     //! Initializes a drag operation \since QGIS 3.34
     void startMove( QPointF sceneCoordPos );
-
-    QRectF boundingRect() const override;
     
   public slots:
 

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -77,11 +77,16 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     //! Returns TRUE is user is currently resizing with the handles
     bool isResizing() const { return mIsResizing; }
 
+    //! Returns TRUE is user is currently rotating with the handles
+    bool isRotating() const { return mIsRotating; }
+    
     bool shouldBlockEvent( QInputEvent *event ) const;
 
     //! Initializes a drag operation \since QGIS 3.34
     void startMove( QPointF sceneCoordPos );
 
+    QRectF boundingRect() const override;
+    
   public slots:
 
     //! Redraws handles when selected item size changes
@@ -111,6 +116,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     virtual QRectF itemRect( QGraphicsItem *item ) const = 0;
     virtual QRectF storedItemRect( QGraphicsItem *item ) const;
     virtual void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) = 0;
+    virtual void rotateItem( QGraphicsItem *item, double deltaDegree, double deltaCenterX, double deltaCenterY );
     virtual void previewItemMove( QGraphicsItem *item, double deltaX, double deltaY );
     virtual void setItemRect( QGraphicsItem *item, QRectF rect ) = 0;
 
@@ -158,6 +164,9 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     //! Handles resizing of items during mouse move
     void resizeMouseMove( QPointF currentPosition, bool lockAspect, bool fromCenter );
 
+    //! Handles rotating of tiems during mouse move
+    void rotateMouseMove( QPointF currentPosition );
+
     void setHandleSize( double size );
 
     //! Finds out which mouse move action to choose depending on the cursor position inside the widget
@@ -194,6 +203,8 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     QGraphicsView *mView = nullptr;
 
     double mHandleSize = 10;
+    double mRotationHandleSize = 20;
+    QPainterPath mRotationHandlePath;
 
     QSizeF mCursorOffset;
     double mResizeMoveX = 0;
@@ -205,6 +216,11 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
 
     QRectF mResizeRect;
 
+    //! Center point around which rotation occurs
+    QPointF mRotationCenter;
+    double mRotationBegin = 0.0;
+    double mRotationCurrent = 0.0;
+
     //! Start point of the last mouse move action (in scene coordinates)
     QPointF mMouseMoveStartPos;
 
@@ -215,6 +231,8 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     bool mIsDragging = false;
     //! True is user is currently resizing items
     bool mIsResizing = false;
+    //! True is user is currently rotating items
+    bool mIsRotating = false;
 
     //! Position of the mouse at beginning of move/resize (in scene coordinates)
     QPointF mBeginMouseEventPos;
@@ -232,7 +250,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
      * Returns the current (zoom level dependent) tolerance to decide if mouse position is close enough to the
      * item border for resizing.
     */
-    double rectHandlerBorderTolerance();
+    double rectHandlerBorderTolerance() const;
 
     //! Finds out the appropriate cursor for the current mouse position in the widget (e.g. move in the middle, resize at border)
     Qt::CursorShape cursorForPosition( QPointF itemCoordPos );

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -79,15 +79,15 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
 
     //! Returns TRUE is user is currently rotating with the handles
     bool isRotating() const { return mIsRotating; }
-    
+
     bool shouldBlockEvent( QInputEvent *event ) const;
 
     //! Initializes a drag operation \since QGIS 3.34
     void startMove( QPointF sceneCoordPos );
-    
+
     //! Returns TRUE if rotation functionality is enabled
     bool isRotationEnabled() const { return mRotationEnabled; }
-    
+
     //! Sets whether rotation functionality is enabled
     void setRotationEnabled( bool enable );
 


### PR DESCRIPTION
## Description

This PR implements rotation handles UI/UX for selected layout item(s), allowing for users to tweak item rotation to perfect their layouts straight within the layout designer sheet.

https://github.com/user-attachments/assets/185b35be-1274-4bad-922b-ab2a02b8341e

The implementation comes with a Control modifier allows the rotation to snap to 15 degree angles, and supports rotation of multiple selected items (sharing a common rotation center point).

The functionality was added to the QgsGraphicsViewMouseHandles, which means it can be re-used beyond the layout designer itself (rotated modeler parameter boxes? :wink:).


