### PR TITLE
qgisapp: Fix missing unused parameter with 3D build disabled

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13411,6 +13411,7 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name, Qgis::SceneM
   }
 #else
   Q_UNUSED( name );
+  Q_UNUSED( sceneMode );
 #endif
   return nullptr;
 }


### PR DESCRIPTION
## Description

fixes: 2078404ba7f7947c61123396feba1acd5e4c69e9
