### PR TITLE
enable QGIS algorithms tests (part 2) on Qt6

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -49,7 +49,6 @@ PyQgsSymbolLayerReadSld
 PyQgsSettings
 PyQgsSettingsEntry
 PyQgsServerAccessControlWFSTransactional
-ProcessingQgisAlgorithmsTestPt2
 ProcessingQgisAlgorithmsTestPt4
 ProcessingGdalAlgorithmsVectorTest
 # PyQgsProviderRegistry runs fine locally on Fedora:rawhide but not on CI


### PR DESCRIPTION
## Description

Try to enable ProcessingQgisAlgorithmsTestPt2 on CI.