### PR TITLE
[gui][layouts] Add set extent to layer item in the map item's toolbar menu

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -339,6 +339,7 @@
         <file>themes/default/mActionKeyboardShortcuts.svg</file>
         <file>themes/default/mActionLabel.svg</file>
         <file>themes/default/mActionLabeling.svg</file>
+        <file>themes/default/mActionLayers.svg</file>
         <file>themes/default/mActionLocalCumulativeCutStretch.svg</file>
         <file>themes/default/mActionLocalHistogramStretch.svg</file>
         <file>themes/default/mActionLockItems.svg</file>

--- a/images/themes/default/mActionLayers.svg
+++ b/images/themes/default/mActionLayers.svg
@@ -1,0 +1,1 @@
+<svg height="24" viewBox="0 0 6.35 6.35" width="24" xmlns="http://www.w3.org/2000/svg"><g fill="#eeeeec" stroke="#888a85" stroke-linecap="round" stroke-linejoin="round" stroke-width=".265"><path d="m.661 2.778h2.91v2.91h-2.909z"/><path d="m1.72 1.72h2.91v2.91h-2.91z"/><path d="m2.778.661h2.91v2.91h-2.91z"/></g></svg>

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -114,7 +114,7 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   mLayersMenu = new QMenu( this );
   QToolButton *btnLayers = new QToolButton( this );
   btnLayers->setAutoRaise( true );
-  btnLayers->setToolTip( tr( "Layers" ) );
+  btnLayers->setToolTip( tr( "Set Map Extent to Layer Extent" ) );
   btnLayers->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionLayers.svg" ) ) );
   btnLayers->setPopupMode( QToolButton::InstantPopup );
   btnLayers->setMenu( mLayersMenu );
@@ -125,7 +125,7 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   mBookmarkMenu = new QMenu( this );
   QToolButton *btnBookmarks = new QToolButton( this );
   btnBookmarks->setAutoRaise( true );
-  btnBookmarks->setToolTip( tr( "Bookmarks" ) );
+  btnBookmarks->setToolTip( tr( "Set Map Extent to Bookmark Extent" ) );
   btnBookmarks->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionShowBookmarks.svg" ) ) );
   btnBookmarks->setPopupMode( QToolButton::InstantPopup );
   btnBookmarks->setMenu( mBookmarkMenu );

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -498,9 +498,8 @@ void QgsLayoutMapWidget::aboutToShowLayersMenu()
 
     QAction *action = new QAction( icon, text, mLayersMenu );
     action->setToolTip( tooltip );
-    connect( action, &QAction::triggered, this, [=] {
-      QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
-      if ( layer )
+    connect( action, &QAction::triggered, this, [this, layerId] {
+      if ( QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId ) )
       {
         setToCustomExtent( QgsReferencedRectangle( layer->extent(), layer->crs() ) );
       }

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -480,6 +480,14 @@ void QgsLayoutMapWidget::aboutToShowLayersMenu()
     mMapLayerModel->setFilters( Qgis::LayerFilter::SpatialLayer );
   }
 
+  if ( mMapLayerModel->rowCount() == 0 )
+  {
+    QAction *action = new QAction( tr( "No spatial layers available" ) );
+    action->setEnabled( false );
+    mLayersMenu->addAction( action );
+    return;
+  }
+
   for ( int i = 0; i < mMapLayerModel->rowCount(); ++i )
   {
     const QModelIndex index = mMapLayerModel->index( i, 0 );
@@ -508,7 +516,17 @@ void QgsLayoutMapWidget::aboutToShowBookmarkMenu()
   // query the bookmarks now? or once during widget creation... Hmm. Either way, there's potentially a
   // delay if there's LOTS of bookmarks. Let's avoid the cost until bookmarks are actually required.
   if ( !mBookmarkModel )
+  {
     mBookmarkModel = new QgsBookmarkManagerProxyModel( QgsApplication::bookmarkManager(), QgsProject::instance()->bookmarkManager(), this );
+  }
+
+  if ( mBookmarkModel->rowCount() == 0 )
+  {
+    QAction *action = new QAction( tr( "No bookmarks available" ) );
+    action->setEnabled( false );
+    mBookmarkMenu->addAction( action );
+    return;
+  }
 
   QMap<QString, QMenu *> groupMenus;
   for ( int i = 0; i < mBookmarkModel->rowCount(); ++i )

--- a/src/gui/layout/qgslayoutmapwidget.h
+++ b/src/gui/layout/qgslayoutmapwidget.h
@@ -34,6 +34,7 @@ class QgsLayoutItemMapOverview;
 class QgsLayoutMapLabelingWidget;
 class QgsLayoutMapClippingWidget;
 class QgsBookmarkManagerProxyModel;
+class QgsReferencedRectangle;
 
 /**
  * \ingroup gui
@@ -144,6 +145,7 @@ class GUI_EXPORT QgsLayoutMapWidget : public QgsLayoutItemBaseWidget, private Ui
     void showLabelSettings();
     void showClipSettings();
     void switchToMoveContentTool();
+    void aboutToShowLayersMenu();
     void aboutToShowBookmarkMenu();
 
   private:
@@ -153,7 +155,9 @@ class GUI_EXPORT QgsLayoutMapWidget : public QgsLayoutItemBaseWidget, private Ui
     QgsLayoutDesignerInterface *mInterface = nullptr;
     QPointer<QgsLayoutMapLabelingWidget> mLabelWidget;
     QPointer<QgsLayoutMapClippingWidget> mClipWidget;
+    QMenu *mLayersMenu = nullptr;
     QMenu *mBookmarkMenu = nullptr;
+    QgsMapLayerProxyModel *mMapLayerModel = nullptr;
     QgsBookmarkManagerProxyModel *mBookmarkModel = nullptr;
     QString mReportTypeString;
     int mBlockThemeComboChanges = 0;
@@ -190,6 +194,8 @@ class GUI_EXPORT QgsLayoutMapWidget : public QgsLayoutItemBaseWidget, private Ui
      * The order will match the layer order from the map canvas
      */
     QList<QgsMapLayer *> orderedPresetVisibleLayers( const QString &name ) const;
+
+    void setToCustomExtent( const QgsReferencedRectangle &extent );
 };
 
 /**


### PR DESCRIPTION
## Description

This PR adds a new layout map item menu action in its toolbar to allow for quickly setting a given map item's extent to match that of a project spatial layer. Screenshot time:

![image](https://github.com/user-attachments/assets/a841dcf8-6ca3-477f-8045-915cd78a12dc)

The new button sits next to the preexisting bookmarks button which offers a similar functionality.

I've taken the time to expand the tooltip a bit to better explain what these buttons do.