### PR TITLE
Update qgsdistancearea.h - deleting outdated comment

### DIFF
--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -360,10 +360,7 @@ class CORE_EXPORT QgsDistanceArea
 
   private:
 
-    /**
-     * Calculates area of polygon on ellipsoid
-     * algorithm has been taken from GRASS: gis/area_poly1.c
-     */
+    // Calculates area of polygon on ellipsoid
     double computePolygonArea( const QVector<QgsPointXY> &points ) const;
 
     double computePolygonFlatArea( const QVector<QgsPointXY> &points ) const;


### PR DESCRIPTION
## Description

Comment is describing that computePolygonArea uses algorithm taken from GRASS. But when I studied code in CPP file all I can find is that nowdays GeographicLib is used for all ellipsoid calculations.

This commit needs review from core developer.
@wonder-sk please check this (as initial author) 