### PR TITLE
change label of the file widget in the new GeoPackage dialog (fix #60990)

### DIFF
--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -128,12 +128,12 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mCheckBoxCreateSpatialIndex->setChecked( true );
 
   const QgsSettings settings;
-  mDatabase->setStorageMode( QgsFileWidget::SaveFile );
-  mDatabase->setFilter( tr( "GeoPackage" ) + " (*.gpkg)" );
-  mDatabase->setDialogTitle( tr( "Select Existing or Create a New GeoPackage Database File…" ) );
-  mDatabase->setDefaultRoot( settings.value( QStringLiteral( "UI/lastVectorFileFilterDir" ), QDir::homePath() ).toString() );
-  mDatabase->setConfirmOverwrite( false );
-  connect( mDatabase, &QgsFileWidget::fileChanged, this, [=]( const QString &filePath ) {
+  mFileName->setStorageMode( QgsFileWidget::SaveFile );
+  mFileName->setFilter( tr( "GeoPackage" ) + " (*.gpkg)" );
+  mFileName->setDialogTitle( tr( "Select Existing or Create a New GeoPackage Database File…" ) );
+  mFileName->setDefaultRoot( settings.value( QStringLiteral( "UI/lastVectorFileFilterDir" ), QDir::homePath() ).toString() );
+  mFileName->setConfirmOverwrite( false );
+  connect( mFileName, &QgsFileWidget::fileChanged, this, [=]( const QString &filePath ) {
     QgsSettings settings;
     const QFileInfo tmplFileInfo( filePath );
     settings.setValue( QStringLiteral( "UI/lastVectorFileFilterDir" ), tmplFileInfo.absolutePath() );
@@ -152,7 +152,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   completer->setCompletionRole( static_cast<int>( QgsProviderConnectionModel::CustomRole::Uri ) );
   completer->setCompletionMode( QCompleter::PopupCompletion );
   completer->setFilterMode( Qt::MatchContains );
-  mDatabase->lineEdit()->setCompleter( completer );
+  mFileName->lineEdit()->setCompleter( completer );
 }
 
 void QgsNewGeoPackageLayerDialog::setCrs( const QgsCoordinateReferenceSystem &crs )
@@ -162,7 +162,7 @@ void QgsNewGeoPackageLayerDialog::setCrs( const QgsCoordinateReferenceSystem &cr
 
 void QgsNewGeoPackageLayerDialog::lockDatabasePath()
 {
-  mDatabase->setReadOnly( true );
+  mFileName->setReadOnly( true );
 }
 
 void QgsNewGeoPackageLayerDialog::mFieldTypeBox_currentIndexChanged( int )
@@ -208,7 +208,7 @@ void QgsNewGeoPackageLayerDialog::mLayerIdentifierEdit_textEdited( const QString
 
 void QgsNewGeoPackageLayerDialog::checkOk()
 {
-  const bool ok = !mDatabase->filePath().isEmpty() && !mTableNameEdit->text().isEmpty() && mGeometryTypeBox->currentIndex() != -1;
+  const bool ok = !mFileName->filePath().isEmpty() && !mTableNameEdit->text().isEmpty() && mGeometryTypeBox->currentIndex() != -1;
 
   mOkButton->setEnabled( ok );
 }
@@ -318,7 +318,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
     }
   }
 
-  QString fileName( mDatabase->filePath() );
+  QString fileName( mFileName->filePath() );
   if ( !fileName.endsWith( QLatin1String( ".gpkg" ), Qt::CaseInsensitive ) )
     fileName += QLatin1String( ".gpkg" );
 

--- a/src/gui/qgsnewgeopackagelayerdialog.h
+++ b/src/gui/qgsnewgeopackagelayerdialog.h
@@ -51,12 +51,12 @@ class GUI_EXPORT QgsNewGeoPackageLayerDialog : public QDialog, private Ui::QgsNe
     /**
      * Returns the database path
      */
-    QString databasePath() const { return mDatabase->filePath(); }
+    QString databasePath() const { return mFileName->filePath(); }
 
     /**
      * Sets the initial database \a path
      */
-    void setDatabasePath( const QString &path ) { mDatabase->setFilePath( path ); }
+    void setDatabasePath( const QString &path ) { mFileName->setFilePath( path ); }
 
     /**
      * Sets the database path widgets to a locked and read-only mode.

--- a/src/ui/qgsnewgeopackagelayerdialogbase.ui
+++ b/src/ui/qgsnewgeopackagelayerdialogbase.ui
@@ -399,7 +399,7 @@
          <item row="0" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout">
            <item>
-            <widget class="QgsFileWidget" name="mDatabase" native="true">
+            <widget class="QgsFileWidget" name="mFileName" native="true">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -437,12 +437,12 @@
           </widget>
          </item>
          <item row="0" column="0">
-          <widget class="QLabel" name="mDatabaseLabel">
+          <widget class="QLabel" name="mFileNameLabel">
            <property name="enabled">
             <bool>true</bool>
            </property>
            <property name="text">
-            <string>Database</string>
+            <string>File name</string>
            </property>
           </widget>
          </item>
@@ -542,6 +542,7 @@
    <class>QgsCollapsibleGroupBox</class>
    <extends>QWidget</extends>
    <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/python/test_qgsnewgeopackagelayerdialog.py
+++ b/tests/src/python/test_qgsnewgeopackagelayerdialog.py
@@ -68,7 +68,7 @@ class TestPyQgsNewGeoPackageLayerDialog(QgisTestCase):
         dialog = QgsNewGeoPackageLayerDialog()
         dialog.setProperty("hideDialogs", True)
 
-        mDatabase = dialog.findChild(QgsFileWidget, "mDatabase")
+        mFileName = dialog.findChild(QgsFileWidget, "mFileName")
         buttonBox = dialog.findChild(QDialogButtonBox, "buttonBox")
         ok_button = buttonBox.button(QDialogButtonBox.StandardButton.Ok)
         mTableNameEdit = dialog.findChild(QLineEdit, "mTableNameEdit")
@@ -91,7 +91,7 @@ class TestPyQgsNewGeoPackageLayerDialog(QgisTestCase):
         self.assertFalse(ok_button.isEnabled())
 
         dbname = os.path.join(self.basetestpath, "test.gpkg")
-        mDatabase.setFilePath(dbname)
+        mFileName.setFilePath(dbname)
         self.assertEqual(mTableNameEdit.text(), "test")
         self.assertEqual(mLayerIdentifierEdit.text(), "test")
         self.assertTrue(ok_button.isEnabled())
@@ -253,7 +253,7 @@ class TestPyQgsNewGeoPackageLayerDialog(QgisTestCase):
         self.assertEqual(description, "my_description")
 
         # Try invalid path
-        mDatabase.setFilePath("/this/is/invalid/test.gpkg")
+        mFileName.setFilePath("/this/is/invalid/test.gpkg")
         self.accepted = False
         QTest.mouseClick(ok_button, Qt.MouseButton.LeftButton)
         self.assertFalse(self.accepted)


### PR DESCRIPTION
## Description

Change file selector label from "Database" to "File name" in the New GeoPackage layer dialog to be in line with the Save as dialog and avoid confusion for beginners.

Fixes #60990.
Supersedes #61571.