### PR TITLE
do not call endArray() on global settings object if we are not reading array from it (fix #61373)

### DIFF
--- a/src/core/settings/qgssettings.cpp
+++ b/src/core/settings/qgssettings.cpp
@@ -50,7 +50,6 @@ void QgsSettings::init()
   }
 }
 
-
 QgsSettings::QgsSettings( const QString &organization, const QString &application, QObject *parent )
 {
   mUserSettings = std::make_unique<QSettings>( organization, application, parent );
@@ -87,7 +86,6 @@ QgsSettings::~QgsSettings()
 {
 }
 
-
 void QgsSettings::beginGroup( const QString &prefix, const QgsSettings::Section section )
 {
   const QString pKey = prefixedKey( prefix, section );
@@ -122,7 +120,6 @@ QStringList QgsSettings::allKeys() const
   }
   return keys;
 }
-
 
 QStringList QgsSettings::childKeys() const
 {
@@ -248,7 +245,6 @@ QString QgsSettings::prefixedKey( const QString &key, const Section section ) co
   return prefix  + "/" + sanitizeKey( key );
 }
 
-
 int QgsSettings::beginReadArray( const QString &prefix )
 {
   int size = mUserSettings->beginReadArray( sanitizeKey( prefix ) );
@@ -269,7 +265,7 @@ void QgsSettings::beginWriteArray( const QString &prefix, int size )
 void QgsSettings::endArray()
 {
   mUserSettings->endArray();
-  if ( mGlobalSettings )
+  if ( mGlobalSettings && mUsingGlobalArray )
   {
     mGlobalSettings->endArray();
   }
@@ -332,7 +328,6 @@ void QgsSettings::clear()
 {
   mUserSettings->clear();
 }
-
 
 void QgsSettings::holdFlush()
 {


### PR DESCRIPTION
## Description

Fixes Qt warning `Qt: QSettings::endArray: Expected endGroup() instead` when calling `endArray()` method. This happens because `QgsSettings::endArray()` does not check `mUsingGlobalArray` flag and calls `endArray()` on both local and global settings instances while it should be called only on one of these.

Fixes #61373.