### PR TITLE
increase precision for min and max comboboxes in the mesh styling panel  (fix #50950)

### DIFF
--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -143,6 +143,17 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer()
   const double min = settings.classificationMinimum();
   const double max = settings.classificationMaximum();
 
+  if ( std::abs( max ) < 1e-2 )
+  {
+    mScalarMinSpinBox->setDecimals( 8 );
+    mScalarMaxSpinBox->setDecimals( 8 );
+  }
+  else
+  {
+    mScalarMinSpinBox->setDecimals( 2 );
+    mScalarMaxSpinBox->setDecimals( 2 );
+  }
+
   whileBlocking( mScalarMinSpinBox )->setValue( min );
   whileBlocking( mScalarMaxSpinBox )->setValue( max );
 
@@ -219,6 +230,18 @@ void QgsMeshRendererScalarSettingsWidget::recalculateMinMaxButtonClicked()
   const QgsMeshDatasetGroupMetadata metadata = mMeshLayer->datasetGroupMetadata( mActiveDatasetGroup );
   const double min = metadata.minimum();
   const double max = metadata.maximum();
+
+  if ( std::abs( max ) < 1e-2 )
+  {
+    mScalarMinSpinBox->setDecimals( 8 );
+    mScalarMaxSpinBox->setDecimals( 8 );
+  }
+  else
+  {
+    mScalarMinSpinBox->setDecimals( 2 );
+    mScalarMaxSpinBox->setDecimals( 2 );
+  }
+
   whileBlocking( mScalarMinSpinBox )->setValue( min );
   whileBlocking( mScalarMaxSpinBox )->setValue( max );
   mScalarColorRampShaderWidget->setMinimumMaximumAndClassify( min, max );


### PR DESCRIPTION
## Description

Increase precision for min and max comboboxes in the mesh styling panel when dataset group contains very small values.

Fixes #50950.