### PR TITLE
harmonize use of PostgreSQL/PostGIS in various dialogs (fix #59886)

### DIFF
--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -215,7 +215,7 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsPr
   }
   else
   {
-    setWindowTitle( tr( "Add PostGIS Table(s)" ) );
+    setWindowTitle( tr( "Add PostgreSQL Table(s)" ) );
   }
 
   populateConnectionList();
@@ -287,7 +287,7 @@ void QgsPgSourceSelect::btnLoad_clicked()
 void QgsPgSourceSelect::btnEdit_clicked()
 {
   QgsPgNewConnection *nc = new QgsPgNewConnection( this, cmbConnections->currentText() );
-  nc->setWindowTitle( tr( "Edit PostGIS Connection" ) );
+  nc->setWindowTitle( tr( "Edit PostgreSQL Connection" ) );
   if ( nc->exec() )
   {
     populateConnectionList();

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -283,7 +283,7 @@ void QgsPostgresDataItemGuiProvider::newConnection( QgsDataItem *item )
 void QgsPostgresDataItemGuiProvider::editConnection( QgsDataItem *item )
 {
   QgsPgNewConnection nc( nullptr, item->name() );
-  nc.setWindowTitle( tr( "Edit PostGIS Connection" ) );
+  nc.setWindowTitle( tr( "Edit PostgreSQL Connection" ) );
   if ( nc.exec() )
   {
     // the parent should be updated
@@ -668,7 +668,7 @@ bool QgsPostgresDataItemGuiProvider::handleDrop( QgsPGConnectionItem *connection
       // when export is successful:
       connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, this, [=]() {
         // this is gross - TODO - find a way to get access to messageBar from data items
-        QMessageBox::information( nullptr, tr( "Import to PostGIS database" ), tr( "Import was successful." ) );
+        QMessageBox::information( nullptr, tr( "Import to PostgreSQL database" ), tr( "Import was successful." ) );
         if ( connectionItemPointer )
           connectionItemPointer->refreshSchema( toSchema );
       } );
@@ -678,7 +678,7 @@ bool QgsPostgresDataItemGuiProvider::handleDrop( QgsPGConnectionItem *connection
         if ( error != Qgis::VectorExportResult::UserCanceled )
         {
           QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
-          output->setTitle( tr( "Import to PostGIS database" ) );
+          output->setTitle( tr( "Import to PostgreSQL database" ) );
           output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
           output->showMessage();
         }
@@ -698,7 +698,7 @@ bool QgsPostgresDataItemGuiProvider::handleDrop( QgsPGConnectionItem *connection
   if ( hasError )
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
-    output->setTitle( tr( "Import to PostGIS database" ) );
+    output->setTitle( tr( "Import to PostgreSQL database" ) );
     output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
     output->showMessage();
   }
@@ -729,7 +729,7 @@ bool QgsPostgresDataItemGuiProvider::handleDropUri( QgsPGConnectionItem *connect
     }
   };
 
-  return QgsDataItemGuiProviderUtils::handleDropUriForConnection( std::move( databaseConnection ), sourceUri, toSchema, context, tr( "PostGIS Import" ), tr( "Import to PostGIS database" ), QVariantMap(), onSuccess, onFailure, this );
+  return QgsDataItemGuiProviderUtils::handleDropUriForConnection( std::move( databaseConnection ), sourceUri, toSchema, context, tr( "PostgreSQL Import" ), tr( "Import to PostgreSQL database" ), QVariantMap(), onSuccess, onFailure, this );
 }
 
 void QgsPostgresDataItemGuiProvider::handleImportVector( QgsPGConnectionItem *connectionItem, const QString &toSchema, QgsDataItemGuiContext context )
@@ -758,7 +758,7 @@ void QgsPostgresDataItemGuiProvider::handleImportVector( QgsPGConnectionItem *co
     }
   };
 
-  QgsDataItemGuiProviderUtils::handleImportVectorLayerForConnection( std::move( databaseConnection ), toSchema, context, tr( "PostGIS Import" ), tr( "Import to PostGIS database" ), QVariantMap(), onSuccess, onFailure, this );
+  QgsDataItemGuiProviderUtils::handleImportVectorLayerForConnection( std::move( databaseConnection ), toSchema, context, tr( "PostgreSQL Import" ), tr( "Import to PostgreSQL database" ), QVariantMap(), onSuccess, onFailure, this );
 }
 
 void QgsPostgresDataItemGuiProvider::exportProjectToFile( QgsPGProjectItem *projectItem, QgsDataItemGuiContext context )

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -912,7 +912,7 @@
     <string>Ctrl+Q</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::QuitRole</enum>
+    <enum>QAction::MenuRole::QuitRole</enum>
    </property>
   </action>
   <action name="mActionUndo">
@@ -1612,7 +1612,7 @@ Note : Segment snapping must be enabled in the snapping Toolbar</string>
      <normaloff>:/images/themes/default/mActionAddPostgisLayer.svg</normaloff>:/images/themes/default/mActionAddPostgisLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>Add PostGIS Layers…</string>
+    <string>Add PostgreSQL Layer…</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+D</string>
@@ -1904,7 +1904,7 @@ Note : Segment snapping must be enabled in the snapping Toolbar</string>
     <string>&amp;Options…</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
   </action>
   <action name="mActionCustomProjection">
@@ -1925,7 +1925,7 @@ Note : Segment snapping must be enabled in the snapping Toolbar</string>
     <string>Keyboard Shortcuts…</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
   </action>
   <action name="mActionLocalHistogramStretch">
@@ -1995,7 +1995,7 @@ Note : Segment snapping must be enabled in the snapping Toolbar</string>
     <string>About</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::AboutRole</enum>
+    <enum>QAction::MenuRole::AboutRole</enum>
    </property>
   </action>
   <action name="mActionSponsors">
@@ -3410,7 +3410,7 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
     <string>Database Query History</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsdbsourceselectbase.ui
+++ b/src/ui/qgsdbsourceselectbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Add PostGIS Layers</string>
+   <string>Add PostgreSQL Layers</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -27,20 +27,20 @@
    <item row="2" column="0">
     <widget class="QTreeView" name="mTablesTreeView">
      <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
      </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
      </property>
     </widget>
    </item>
    <item row="8" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::StandardButton::Help</set>
      </property>
     </widget>
    </item>
@@ -98,7 +98,7 @@
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -142,7 +142,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -173,7 +173,7 @@
          <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
        </property>
        <property name="popupMode">
-        <enum>QToolButton::MenuButtonPopup</enum>
+        <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
        </property>
        <property name="autoRaise">
         <bool>true</bool>
@@ -194,7 +194,7 @@
          <height>0</height>
         </size>
        </property>
-       <property name="showSearchIcon">
+       <property name="showSearchIcon" stdset="0">
         <bool>true</bool>
        </property>
       </widget>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Create a New PostGIS Connection</string>
+   <string>Create a New PostgreSQL Connection</string>
   </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
@@ -156,7 +156,7 @@
          <item row="0" column="0">
           <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true">
            <property name="focusPolicy">
-            <enum>Qt::StrongFocus</enum>
+            <enum>Qt::FocusPolicy::StrongFocus</enum>
            </property>
           </widget>
          </item>
@@ -173,7 +173,7 @@
       <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -229,7 +229,7 @@
       <item row="10" column="1">
        <spacer name="verticalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -259,7 +259,7 @@
          <string>If specified, only tables from the matching schema will be fetched and listed for the provider</string>
         </property>
         <property name="echoMode">
-         <enum>QLineEdit::Normal</enum>
+         <enum>QLineEdit::EchoMode::Normal</enum>
         </property>
         <property name="placeholderText">
          <string>Limit to tables from specific schema</string>
@@ -308,7 +308,7 @@
    <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description

In the Datasource Manager and Browser we use PostgreSQL while in the new connection dialog and messageboxes, as well as in the menu and tool bar we use PostGIS. Let's use "PostgreSQL" everywhere.

Fixes #59886.