### PR TITLE
Fix/minor 3d fixes

### DIFF
--- a/src/3d/framegraph/qgsframegraph.cpp
+++ b/src/3d/framegraph/qgsframegraph.cpp
@@ -470,6 +470,11 @@ void QgsFrameGraph::setSize( QSize s )
   mRenderSurfaceSelector->setExternalRenderTargetSize( mSize );
 }
 
+Qt3DRender::QRenderCapture *QgsFrameGraph::renderCapture()
+{
+  return mRenderCapture;
+}
+
 void QgsFrameGraph::setRenderCaptureEnabled( bool enabled )
 {
   if ( enabled == mRenderCaptureEnabled )

--- a/src/3d/framegraph/qgsframegraph.cpp
+++ b/src/3d/framegraph/qgsframegraph.cpp
@@ -340,6 +340,25 @@ bool QgsFrameGraph::isRenderViewEnabled( const QString &name )
   return mRenderViewMap[name] != nullptr && mRenderViewMap[name]->isEnabled();
 }
 
+void QgsFrameGraph::updateAmbientOcclusionSettings( const QgsAmbientOcclusionSettings &settings )
+{
+  QgsAmbientOcclusionRenderView &aoRenderView = ambientOcclusionRenderView();
+
+  aoRenderView.setRadius( settings.radius() );
+  aoRenderView.setIntensity( settings.intensity() );
+  aoRenderView.setThreshold( settings.threshold() );
+  aoRenderView.setEnabled( settings.isEnabled() );
+
+  mPostprocessingEntity->setAmbientOcclusionEnabled( settings.isEnabled() );
+}
+
+void QgsFrameGraph::updateEyeDomeSettings( const Qgs3DMapSettings &settings )
+{
+  mPostprocessingEntity->setEyeDomeLightingEnabled( settings.eyeDomeLightingEnabled() );
+  mPostprocessingEntity->setEyeDomeLightingStrength( settings.eyeDomeLightingStrength() );
+  mPostprocessingEntity->setEyeDomeLightingDistance( settings.eyeDomeLightingDistance() );
+}
+
 void QgsFrameGraph::updateShadowSettings( const QgsShadowSettings &shadowSettings, const QList<QgsLightSource *> &lightSources )
 {
   if ( shadowSettings.renderShadows() )
@@ -447,13 +466,6 @@ void QgsFrameGraph::setClearColor( const QColor &clearColor )
 void QgsFrameGraph::setFrustumCullingEnabled( bool enabled )
 {
   forwardRenderView().setFrustumCullingEnabled( enabled );
-}
-
-void QgsFrameGraph::setupEyeDomeLighting( bool enabled, double strength, int distance )
-{
-  mPostprocessingEntity->setEyeDomeLightingEnabled( enabled );
-  mPostprocessingEntity->setEyeDomeLightingStrength( strength );
-  mPostprocessingEntity->setEyeDomeLightingDistance( distance );
 }
 
 void QgsFrameGraph::setSize( QSize s )

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -50,6 +50,7 @@ class QgsDepthRenderView;
 class QgsShadowSettings;
 class QgsDebugTextureEntity;
 class QgsAmbientOcclusionRenderView;
+class QgsAmbientOcclusionSettings;
 
 #define SIP_NO_FILE
 
@@ -95,8 +96,6 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     //! Sets the clear color of the scene (background color)
     void setClearColor( const QColor &clearColor );
 
-    //! Sets eye dome lighting shading related settings
-    void setupEyeDomeLighting( bool enabled, double strength, int distance );
     //! Sets the size of the buffers used for rendering
     void setSize( QSize s );
 
@@ -209,6 +208,18 @@ class QgsFrameGraph : public Qt3DCore::QEntity
      * \since QGIS 3.44
      */
     void updateDebugDepthMapSettings( const Qgs3DMapSettings &settings );
+
+    /**
+     * Updates settings for ambient occlusion
+     * \since QGIS 3.44
+     */
+    void updateAmbientOcclusionSettings( const QgsAmbientOcclusionSettings &settings );
+
+    /**
+     * Updates settings for eye dome lighting
+     * \since QGIS 3.44
+     */
+    void updateEyeDomeSettings( const Qgs3DMapSettings &settings );
 
     static const QString FORWARD_RENDERVIEW;
     static const QString SHADOW_RENDERVIEW;

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -84,7 +84,7 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     Qt3DCore::QEntity *rubberBandsRootEntity() { return mRubberBandsRootEntity; }
 
     //! Returns the render capture object used to take an image of the scene
-    Qt3DRender::QRenderCapture *renderCapture() { return mRenderCapture; }
+    Qt3DRender::QRenderCapture *renderCapture();
 
     //! Returns the render capture object used to take an image of the depth buffer of the scene
     Qt3DRender::QRenderCapture *depthRenderCapture();
@@ -105,12 +105,6 @@ class QgsFrameGraph : public Qt3DCore::QEntity
      * \since QGIS 3.18
      */
     void setRenderCaptureEnabled( bool enabled );
-
-    /**
-     * Returns whether it will be possible to render to an image
-     * \since QGIS 3.18
-     */
-    bool renderCaptureEnabled() const { return mRenderCaptureEnabled; }
 
     /**
      * Sets whether debug overlay is enabled

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -67,9 +67,11 @@ Qgs3DMapCanvas::Qgs3DMapCanvas()
   mEngine = new QgsWindow3DEngine( this );
 
   connect( mEngine, &QgsAbstract3DEngine::imageCaptured, this, [=]( const QImage &image ) {
-    image.save( mCaptureFileName, mCaptureFileFormat.toLocal8Bit().data() );
-    mEngine->setRenderCaptureEnabled( false );
-    emit savedAsImage( mCaptureFileName );
+    if ( image.save( mCaptureFileName, mCaptureFileFormat.toLocal8Bit().data() ) )
+    {
+      mEngine->setRenderCaptureEnabled( false );
+      emit savedAsImage( mCaptureFileName );
+    }
   } );
 
   setCursor( Qt::OpenHandCursor );

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -69,7 +69,6 @@ Qgs3DMapCanvas::Qgs3DMapCanvas()
   connect( mEngine, &QgsAbstract3DEngine::imageCaptured, this, [=]( const QImage &image ) {
     if ( image.save( mCaptureFileName, mCaptureFileFormat.toLocal8Bit().data() ) )
     {
-      mEngine->setRenderCaptureEnabled( false );
       emit savedAsImage( mCaptureFileName );
     }
   } );
@@ -213,7 +212,6 @@ void Qgs3DMapCanvas::saveAsImage( const QString &fileName, const QString &fileFo
 
   mCaptureFileName = fileName;
   mCaptureFileFormat = fileFormat;
-  mEngine->setRenderCaptureEnabled( true );
   // Setup a frame action that is used to wait until next frame
   Qt3DLogic::QFrameAction *screenCaptureFrameAction = new Qt3DLogic::QFrameAction;
   mScene->addComponent( screenCaptureFrameAction );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -85,7 +85,6 @@
 
 #include "qgswindow3dengine.h"
 #include "qgspointcloudlayer.h"
-#include "qgsshadowrenderview.h"
 #include "qgsforwardrenderview.h"
 #include "qgsambientocclusionrenderview.h"
 #include "qgspostprocessingentity.h"
@@ -1007,22 +1006,12 @@ void Qgs3DMapScene::onSkyboxSettingsChanged()
 
 void Qgs3DMapScene::onShadowSettingsChanged()
 {
-  QgsFrameGraph *frameGraph = mEngine->frameGraph();
-  frameGraph->updateShadowSettings( mMap.shadowSettings(), mMap.lightSources() );
+  mEngine->frameGraph()->updateShadowSettings( mMap.shadowSettings(), mMap.lightSources() );
 }
 
 void Qgs3DMapScene::onAmbientOcclusionSettingsChanged()
 {
-  QgsAmbientOcclusionSettings ambientOcclusionSettings = mMap.ambientOcclusionSettings();
-
-  QgsAmbientOcclusionRenderView &aoRenderView = mEngine->frameGraph()->ambientOcclusionRenderView();
-
-  aoRenderView.setRadius( ambientOcclusionSettings.radius() );
-  aoRenderView.setIntensity( ambientOcclusionSettings.intensity() );
-  aoRenderView.setThreshold( ambientOcclusionSettings.threshold() );
-  aoRenderView.setEnabled( ambientOcclusionSettings.isEnabled() );
-
-  mEngine->frameGraph()->postprocessingEntity()->setAmbientOcclusionEnabled( ambientOcclusionSettings.isEnabled() );
+  mEngine->frameGraph()->updateAmbientOcclusionSettings( mMap.ambientOcclusionSettings() );
 }
 
 void Qgs3DMapScene::onDebugShadowMapSettingsChanged()
@@ -1043,10 +1032,7 @@ void Qgs3DMapScene::onDebugOverlayEnabledChanged()
 
 void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()
 {
-  bool edlEnabled = mMap.eyeDomeLightingEnabled();
-  double edlStrength = mMap.eyeDomeLightingStrength();
-  double edlDistance = mMap.eyeDomeLightingDistance();
-  mEngine->frameGraph()->setupEyeDomeLighting( edlEnabled, edlStrength, edlDistance );
+  mEngine->frameGraph()->updateEyeDomeSettings( mMap );
 }
 
 void Qgs3DMapScene::onCameraMovementSpeedChanged()

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -55,7 +55,6 @@ class QgsChunkedEntity;
 class QgsSkyboxEntity;
 class QgsSkyboxSettings;
 class Qgs3DMapExportSettings;
-class QgsPostprocessingEntity;
 class QgsChunkNode;
 class QgsDoubleRange;
 class Qgs3DMapSceneEntity;

--- a/src/3d/qgsabstract3dengine.cpp
+++ b/src/3d/qgsabstract3dengine.cpp
@@ -30,11 +30,13 @@ QgsAbstract3DEngine::QgsAbstract3DEngine( QObject *parent )
 void QgsAbstract3DEngine::requestCaptureImage()
 {
   Qt3DRender::QRenderCaptureReply *captureReply;
+  mFrameGraph->setRenderCaptureEnabled( true );
   captureReply = mFrameGraph->renderCapture()->requestCapture();
 
   connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [=] {
     emit imageCaptured( captureReply->image() );
     captureReply->deleteLater();
+    mFrameGraph->setRenderCaptureEnabled( false );
   } );
 }
 
@@ -47,16 +49,6 @@ void QgsAbstract3DEngine::requestDepthBufferCapture()
     emit depthBufferCaptured( captureReply->image() );
     captureReply->deleteLater();
   } );
-}
-
-void QgsAbstract3DEngine::setRenderCaptureEnabled( bool enabled )
-{
-  mFrameGraph->setRenderCaptureEnabled( enabled );
-}
-
-bool QgsAbstract3DEngine::renderCaptureEnabled() const
-{
-  return mFrameGraph->renderCaptureEnabled();
 }
 
 void QgsAbstract3DEngine::dumpFrameGraphToConsole() const

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -111,21 +111,6 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
     QgsFrameGraph *frameGraph() { return mFrameGraph; }
 
     /**
-     * Sets whether it will be possible to render to an image
-     *
-     * \note for QgsWindow3DEngine render capture will be disabled by default
-     *  and for QgsOffscreen3DEngine it is enabled by default
-     * \since QGIS 3.18
-     */
-    void setRenderCaptureEnabled( bool enabled );
-
-    /**
-     * Returns whether it will be possible to render to an image
-     * \since QGIS 3.18
-     */
-    bool renderCaptureEnabled() const;
-
-    /**
      * Dump the current frame graph and scene graph to the console
      */
     void dumpFrameGraphToConsole() const;

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -104,7 +104,6 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   mOffscreenSurface->create();
 
   mFrameGraph = new QgsFrameGraph( mOffscreenSurface, mSize, mCamera, mRoot );
-  mFrameGraph->setRenderCaptureEnabled( true );
   mFrameGraph->shadowRenderView().setEnabled( false );
   // Set this frame graph to be in use.
   // the render settings also sets itself as the parent of mSurfaceSelector

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
@@ -39,7 +39,7 @@
         (Qt3DRender::QRenderStateSet{121/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
           (Qt3DRender::QLayerFilter{124/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
             (Qt3DRender::QRenderTargetSelector{128/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{126[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [D] [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
       (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
         (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
           (Qt3DRender::QClearBuffers{149/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
@@ -39,7 +39,7 @@
         (Qt3DRender::QRenderStateSet{121/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
           (Qt3DRender::QLayerFilter{124/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
             (Qt3DRender::QRenderTargetSelector{128/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{126[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [D] [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
       (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
         (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
           (Qt3DRender::QClearBuffers{149/<no_name>})


### PR DESCRIPTION
3 minor 3D fixes:
* check if image was really saved before emitting signal
* simplify use to setRenderCaptureEnabled (now done by QgsAbstract3DEngine::requestCaptureImage)
* make update setting calls uniform in qgs3dmapcanvas ==> migrate code in framegraph

cc @ptitjano @mkrus 

Funded by CEA/DAM @renardf