### PR TITLE
qgsvectorlayerchunkloader: Fix rayIntersection

### DIFF
--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -16,6 +16,7 @@
 #include "qgsvectorlayerchunkloader_p.h"
 #include "moc_qgsvectorlayerchunkloader_p.cpp"
 #include "qgs3dutils.h"
+#include "qgsgeotransform.h"
 #include "qgsline3dsymbol.h"
 #include "qgspoint3dsymbol.h"
 #include "qgspolygon3dsymbol.h"
@@ -317,8 +318,12 @@ QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection
         QVector3D nodeIntPoint;
         int triangleIndex = -1;
 
-        // TODO: use also geo transform matrix here???
-        if ( QgsRayCastingUtils::rayMeshIntersection( rend, ray, transformMatrix, nodeIntPoint, triangleIndex ) )
+        // the node geometry has been translated by chunkOrigin
+        // This translation is stored in the QTransform component
+        // this needs to be taken into account to get the whole transformation
+        const QMatrix4x4 nodeTransformMatrix = node->entity()->findChild<QgsGeoTransform *>()->matrix();
+        const QMatrix4x4 fullTransformMatrix = transformMatrix * nodeTransformMatrix;
+        if ( QgsRayCastingUtils::rayMeshIntersection( rend, ray, fullTransformMatrix, nodeIntPoint, triangleIndex ) )
         {
 #ifdef QGISDEBUG
           hits++;

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -2577,6 +2577,5 @@ void TestQgs3DRendering::test3DSceneExporterBig()
   mapSettings.setLayers( {} );
 }
 
-
 QGSTEST_MAIN( TestQgs3DRendering )
 #include "testqgs3drendering.moc"

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -82,6 +82,9 @@ class TestQgs3DUtils : public QgsTest
     void testScreenPointToMapCoordinates();
     void testLineSegmentToClippingPlanes();
     void testLineSegmentToCameraPose();
+
+  private:
+    QgsRasterLayer *mLayerRgb;
 };
 
 //runs before all tests
@@ -90,6 +93,9 @@ void TestQgs3DUtils::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
   Qgs3D::initialize();
+
+  mLayerRgb = new QgsRasterLayer( testDataPath( "/3d/rgb.tif" ), "rgb", "gdal" );
+  QVERIFY( mLayerRgb->isValid() );
 }
 
 //runs after all tests
@@ -521,11 +527,10 @@ void TestQgs3DUtils::testDecomposeTransformMatrix()
 
 void TestQgs3DUtils::testScreenPointToMapCoordinates()
 {
-  QgsRasterLayer *layer = new QgsRasterLayer( testDataPath( "/3d/rgb.tif" ), "rgb", "gdal" );
   Qgs3DMapSettings map;
-  map.setCrs( layer->crs() );
-  map.setExtent( layer->extent() );
-  map.setLayers( QList<QgsMapLayer *>() << layer );
+  map.setCrs( mLayerRgb->crs() );
+  map.setExtent( mLayerRgb->extent() );
+  map.setLayers( QList<QgsMapLayer *>() << mLayerRgb );
   QgsOffscreen3DEngine engine;
   const Qgs3DMapScene *scene = new Qgs3DMapScene( map, &engine );
   const QgsPoint mapPoint = Qgs3DUtils::screenPointToMapCoordinates( QPoint( 50, 50 ), QSize( 100, 100 ), scene->cameraController(), &map );

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -15,6 +15,7 @@
 
 #include "qgstest.h"
 
+#include "qgs3d.h"
 #include "qgs3dutils.h"
 
 #include "qgsbox3d.h"
@@ -88,6 +89,7 @@ void TestQgs3DUtils::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  Qgs3D::initialize();
 }
 
 //runs after all tests

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -24,8 +24,12 @@
 #include "qgs3dexportobject.h"
 #include "qgs3dmapscene.h"
 #include "qgscameracontroller.h"
+#include "qgsflatterrainsettings.h"
 #include "qgsoffscreen3dengine.h"
+#include "qgspolygon3dsymbol.h"
 #include "qgsrasterlayer.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayer3drenderer.h"
 
 #include <QSize>
 #include <QtMath>
@@ -82,9 +86,11 @@ class TestQgs3DUtils : public QgsTest
     void testScreenPointToMapCoordinates();
     void testLineSegmentToClippingPlanes();
     void testLineSegmentToCameraPose();
+    void test3DSceneRay3D();
 
   private:
     QgsRasterLayer *mLayerRgb;
+    QgsVectorLayer *mLayerBuildings;
 };
 
 //runs before all tests
@@ -96,6 +102,9 @@ void TestQgs3DUtils::initTestCase()
 
   mLayerRgb = new QgsRasterLayer( testDataPath( "/3d/rgb.tif" ), "rgb", "gdal" );
   QVERIFY( mLayerRgb->isValid() );
+
+  mLayerBuildings = new QgsVectorLayer( testDataPath( "/3d/buildings.shp" ), "buildings", "ogr" );
+  QVERIFY( mLayerBuildings->isValid() );
 }
 
 //runs after all tests
@@ -601,6 +610,70 @@ void TestQgs3DUtils::testLineSegmentToCameraPose()
   QCOMPARE( camPose.pitchAngle(), 90 );
   QCOMPARE( camPose.headingAngle(), 45 );
   QGSCOMPARENEAR( camPose.distanceFromCenterPoint(), 52.5, 0.2 );
+}
+
+void TestQgs3DUtils::test3DSceneRay3D()
+{
+  // configure map Settings
+  Qgs3DMapSettings mapSettings;
+  mapSettings.setCrs( mLayerRgb->crs() );
+  mapSettings.setExtent( mLayerRgb->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mLayerBuildings << mLayerRgb );
+
+  QgsFlatTerrainSettings *flatTerrainSettings = new QgsFlatTerrainSettings;
+  mapSettings.setTerrainSettings( flatTerrainSettings );
+
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setAmbient( Qt::lightGray );
+  QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
+  symbol3d->setMaterialSettings( materialSettings.clone() );
+  symbol3d->setExtrusionHeight( 10.f );
+  QgsVectorLayer3DRenderer *renderer3d = new QgsVectorLayer3DRenderer( symbol3d );
+  mLayerBuildings->setRenderer3D( renderer3d );
+
+  // create the 3d scene
+  const QSize winSize( 640, 480 ); // default window size
+  QgsOffscreen3DEngine engine;
+  engine.setSize( winSize );
+  Qgs3DMapScene *scene = new Qgs3DMapScene( mapSettings, &engine );
+  engine.setRootEntity( scene );
+
+  scene->cameraController()->setLookingAtPoint( QVector3D( 0, -280, 0 ), 50, 40.0, -10.0 );
+
+  // This is needed to ensure that the nodes of mLayerBuildings are loaded
+  Qgs3DUtils::captureSceneImage( engine, scene );
+
+  // click on a building
+  // building and terrain are hit
+  // the distance to the building should be smaller than the distance to the terrain
+  Qt3DRender::QCamera *camera = scene->cameraController()->camera();
+  const QPoint clickedPoint1( 115, 374 );
+  const QgsRay3D ray1 = Qgs3DUtils::rayFromScreenPoint( clickedPoint1, winSize, camera );
+  const QHash<QgsMapLayer *, QVector<QgsRayCastingUtils::RayHit>> allHits1 = Qgs3DUtils::castRay( scene, ray1, QgsRayCastingUtils::RayCastContext( true, winSize, camera->farPlane() ) );
+  QCOMPARE( allHits1.size(), 2 );
+  QVERIFY( allHits1.contains( mLayerBuildings ) );
+  QVERIFY( allHits1.contains( nullptr ) );
+  QCOMPARE( allHits1[mLayerBuildings].size(), 1 );
+  QCOMPARE( allHits1[nullptr].size(), 1 );
+  const float buildingDistance1 = allHits1[mLayerBuildings][0].distance;
+  const float terrainDistance1 = allHits1[nullptr][0].distance;
+  QGSCOMPARENEAR( buildingDistance1, 33.59, 1.0 );
+  QGSCOMPARENEAR( terrainDistance1, 45.46, 1.0 );
+
+
+  // clicking on the terrain
+  // the building layer should not be hit
+  const QPoint clickedPoint2( 419, 326 );
+  const QgsRay3D ray2 = Qgs3DUtils::rayFromScreenPoint( clickedPoint2, winSize, camera );
+  const QHash<QgsMapLayer *, QVector<QgsRayCastingUtils::RayHit>> allHits2 = Qgs3DUtils::castRay( scene, ray2, QgsRayCastingUtils::RayCastContext( true, winSize, camera->farPlane() ) );
+  QCOMPARE( allHits2.size(), 1 );
+  QVERIFY( !allHits2.contains( mLayerBuildings ) );
+  QVERIFY( allHits2.contains( nullptr ) );
+  QCOMPARE( allHits2[nullptr].size(), 1 );
+  const float terrainDistance2 = allHits2[nullptr][0].distance;
+  QGSCOMPARENEAR( terrainDistance2, 45.59, 1.0 );
+
+  delete scene;
 }
 
 


### PR DESCRIPTION
## Description

The coordinates of vector data chunks are now independant from the
scene origin. However, the `rayIntersection` does not take this change
into account. This means that the ray used to test the intersection is
expressed in the scene origin coordinates while the vector data
geometry are relative to the chunk origin. Therefore, the intersection
cannot be checked properly and always returns false.

This issue is fixed by retrieving the chunk origin based on the node
entity translation. Then, this translation is added to the transform
matrix  used to convert the geometry coordinates into the scene
coordinate system.

With this change, the different objects (the ray and the triangles)
are now expressed in the scene coordinate system and the intersection
can be properly checked. 

Fixes: 3cde17724e2703183e6c08662380d912e6665b21