### PR TITLE
clear author name and creation date project metadata when anonymize_saved_projects setting is set to true (fix #42413)

### DIFF
--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3260,6 +3260,11 @@ bool QgsProject::writeProjectFile( const QString &filename )
     qgisNode.setAttribute( QStringLiteral( "saveUserFull" ), newSaveUserFull );
     mSaveUser = newSaveUser;
     mSaveUserFull = newSaveUserFull;
+    mMetadata.setAuthor( QgsApplication::userFullName() );
+    if ( !mMetadata.creationDateTime().isValid() )
+    {
+      mMetadata.setCreationDateTime( QDateTime( QDateTime::currentDateTime() ) );
+    }
     mSaveDateTime = QDateTime::currentDateTime();
     qgisNode.setAttribute( QStringLiteral( "saveDateTime" ), mSaveDateTime.toString( Qt::ISODate ) );
   }
@@ -3267,6 +3272,8 @@ bool QgsProject::writeProjectFile( const QString &filename )
   {
     mSaveUser.clear();
     mSaveUserFull.clear();
+    mMetadata.setAuthor( "" );
+    mMetadata.setCreationDateTime( QDateTime() );
     mSaveDateTime = QDateTime();
   }
   doc->appendChild( qgisNode );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3272,7 +3272,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
   {
     mSaveUser.clear();
     mSaveUserFull.clear();
-    mMetadata.setAuthor( "" );
+    mMetadata.setAuthor( QString() );
     mMetadata.setCreationDateTime( QDateTime() );
     mSaveDateTime = QDateTime();
   }

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -603,6 +603,8 @@ void TestQgsProject::projectSaveUser()
 
   QVERIFY( p.saveUser().isEmpty() );
   QVERIFY( p.saveUserFullName().isEmpty() );
+  QVERIFY( p.metadata().author().isEmpty() );
+  QVERIFY( !p.metadata().creationDateTime().isValid() );
   QVERIFY( !p.lastSaveDateTime().isValid() );
 
   s.setValue( QStringLiteral( "projects/anonymize_saved_projects" ), false, QgsSettings::Core );
@@ -610,6 +612,8 @@ void TestQgsProject::projectSaveUser()
   p.write();
   QCOMPARE( p.saveUser(), QgsApplication::userLoginName() );
   QCOMPARE( p.saveUserFullName(), QgsApplication::userFullName() );
+  QCOMPARE( p.metadata().author(), QgsApplication::userFullName() );
+  QCOMPARE( p.metadata().creationDateTime().date(), QDateTime::currentDateTime().date() );
   QCOMPARE( p.lastSaveDateTime().date(), QDateTime::currentDateTime().date() );
 
   QgsProject p2;


### PR DESCRIPTION
## Description

When `anonymize_saved_projects` advanced setting is set to `true` we clear save datetime and save user values, but author and project creation date in the project metadata are kept and are saved in the `.qgs` file.

Fixes #42413.