### PR TITLE
do not show in the layer context menu actions which works with a single layer if more than one layer is selected (fix #30130)

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -670,7 +670,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           {
             QMenu *menuExportRaster = new QMenu( tr( "E&xport" ), menu );
             menuExportRaster->setObjectName( QStringLiteral( "exportMenu" ) );
-            if (  mView->selectedLayerNodes().count() == 1 )
+            if ( mView->selectedLayerNodes().count() == 1 )
             {
               QAction *actionSaveAs = new QAction( tr( "Save &As…" ), menuExportRaster );
               connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [=] { QgisApp::instance()->saveAsFile(); } );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -224,7 +224,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( actions->actionRenameGroupOrLayer( menu ) );
       }
 
-      if ( rlayer )
+      if ( rlayer && mView->selectedLayerNodes().count() == 1 )
       {
         QAction *zoomToNative = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomActual.svg" ) ), tr( "Zoom to Nat&ive Resolution (100%)" ), QgisApp::instance(), &QgisApp::legendLayerZoomNative );
         zoomToNative->setEnabled( rlayer->isValid() );
@@ -668,15 +668,16 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           case Qgis::LayerType::PointCloud:
           case Qgis::LayerType::TiledScene:
           {
-            bool enableSaveAs = ( pcLayer && pcLayer->isValid() && pcLayer->dataProvider()->hasValidIndex() ) || ( rlayer && rlayer->isValid() );
             QMenu *menuExportRaster = new QMenu( tr( "E&xport" ), menu );
             menuExportRaster->setObjectName( QStringLiteral( "exportMenu" ) );
-            QAction *actionSaveAs = new QAction( tr( "Save &As…" ), menuExportRaster );
+            if (  mView->selectedLayerNodes().count() == 1 )
+            {
+              QAction *actionSaveAs = new QAction( tr( "Save &As…" ), menuExportRaster );
+              connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [=] { QgisApp::instance()->saveAsFile(); } );
+              menuExportRaster->addAction( actionSaveAs );
+            }
             QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportRaster );
             QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportRaster );
-            connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [=] { QgisApp::instance()->saveAsFile(); } );
-            menuExportRaster->addAction( actionSaveAs );
-            actionSaveAs->setEnabled( enableSaveAs );
             connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
             menuExportRaster->addAction( actionSaveAsDefinitionLayer );
             connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [=] { QgisApp::instance()->saveStyleFile(); } );


### PR DESCRIPTION
## Description

If more than one layer is selected in the layer tree, context menu still contains actions which work with a single layer, for example "Save Features" or "Properties".

For all layer types, if more than one layer is selected, do not add do not add to the context menu actions:

- Rename
- Add/edit layer notes
- Change datasource
- Properties

If more than one vector layer is selected, do not add to the context menu actions:

- Update SQL layer
- Edit virtual layer
- Open attribute table
- Filter
 - Make permanent
- Save features
- Save selected features

If more than one raster layer is selected, do not add to the context menu actions:

- Zoom to native resolution
- Stretch using current extent
- Open raster attribute table
- Create raster attribute table
- Load raster attribute table from VAT.DBF


Fixes #30130.