### PR TITLE
fix drop event in multiple layer line edit

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -7097,7 +7097,8 @@ void QgsProcessingMultipleLayerLineEdit::dropEvent( QDropEvent *event )
   const QStringList uris = QgsProcessingMultipleInputPanelWidget::compatibleUrisFromMimeData( mParam, event->mimeData(), {} );
   if ( !uris.isEmpty() )
   {
-    event->acceptProposedAction();
+    event->setDropAction( Qt::CopyAction );
+    event->accept();
     QVariantList uriList;
     uriList.reserve( uris.size() );
     for ( const QString &uri : uris )


### PR DESCRIPTION
fix: #61521 

https://github.com/user-attachments/assets/3bc68fa5-0ff2-4742-8e17-267b9c5881c1

Introduced in #57910 
@nyalldawson is there a reason why drop event was set to overwrite previous selection (L7144, setValue() is used to set a selection)? I was expecting new drops to be added to an existing selection. I guess both is valid, but this way the user would have to select multiple connections and drag them all into the box at the same time.

See:
https://github.com/user-attachments/assets/bf02cd95-dd1a-45b8-a1e2-4a052f421e52


