### PR TITLE
Install missing header

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -961,6 +961,7 @@ set(QGIS_GUI_HDRS
   qgsmaplayerconfigwidget.h
   qgsmaplayerconfigwidgetfactory.h
   qgsmaplayersavestyledialog.h
+  qgsmaplayerserverpropertieswidget.h
   qgsmaplayerloadstyledialog.h
   qgsmaplayerrefreshsettingswidget.h
   qgsmaplayerstylecategoriesmodel.h


### PR DESCRIPTION
## Description
The header is included by other public headers, so it needs to be installed to be usable for downstream apps