### PR TITLE
Adjust representation of help text for custom (python) expression functions

### DIFF
--- a/python/PyQt6/core/additions/qgsfunction.py
+++ b/python/PyQt6/core/additions/qgsfunction.py
@@ -138,7 +138,7 @@ def register_function(
     """
 
     # Format the help text
-    helptemplate = string.Template("<h3>$name function</h3><br>$doc")
+    helptemplate = string.Template("<h3>function $name</h3>\n$doc")
     name = kwargs.get("name", function.__name__)
     helptext = kwargs.get("helpText") or function.__doc__ or ""
     helptext = helptext.strip()

--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -138,7 +138,7 @@ def register_function(
     """
 
     # Format the help text
-    helptemplate = string.Template("<h3>$name function</h3><br>$doc")
+    helptemplate = string.Template("<h3>function $name</h3>\n$doc")
     name = kwargs.get("name", function.__name__)
     helptext = kwargs.get("helpText") or function.__doc__ or ""
     helptext = helptext.strip()

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -120,13 +120,13 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         """Test help about python function."""
         QgsExpression.registerFunction(self.help_with_variable)
         html = (
-            "<h3>help_with_variable function</h3><br>" "The help comes from a variable."
+            "<h3>function help_with_variable</h3>\n" "The help comes from a variable."
         )
         self.assertEqual(self.help_with_variable.helpText(), html)
 
         QgsExpression.registerFunction(self.help_with_docstring)
         html = (
-            "<h3>help_with_docstring function</h3><br>"
+            "<h3>function help_with_docstring</h3>\n"
             "The help comes from the python docstring."
         )
         self.assertEqual(self.help_with_docstring.helpText(), html)


### PR DESCRIPTION
## Description

This PR changes the order of the function name and the text 'function' itself in the help text title for custom (python) expression functions (`QgsPyExpressionFunction`). Additionally, the following HTML line break is replaced with a newline character, to remove the extra space between the title and description.

This is done to achieve consistency in the representation of the help text for custom expression functions and native QGIS expression functions.

Before:
![my_sum_before](https://github.com/user-attachments/assets/2bef8d31-2708-4f47-9073-0a2e264756a5)

After:
![my_sum_after](https://github.com/user-attachments/assets/ff02b6e9-6071-49e0-80ca-3e8891b64f50)

For reference:
![for_reference_sum](https://github.com/user-attachments/assets/cdbe1536-d3cc-43af-a122-91132c9ed714)
