### PR TITLE
Revert hue value calculation results in QgsColorWidget

### DIFF
--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -41,7 +41,7 @@
 
 #include <cmath>
 
-#define HUE_MAX 359
+#define HUE_MAX 360
 
 
 // TODO QGIS 4 remove typedef, QColor was qreal (double) and is now float

--- a/tests/src/gui/testqgscompoundcolorwidget.cpp
+++ b/tests/src/gui/testqgscompoundcolorwidget.cpp
@@ -286,7 +286,7 @@ void TestQgsCompoundColorWidget::testSliderWidgets()
   w.mSaturationSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mSaturationSlider->mRampWidget->width() ) / 2.f, 0.f ) );
   w.mValueSlider->mRampWidget->setColorFromPoint( QPointF( static_cast<float>( w.mValueSlider->mRampWidget->width() ) / 2.f, 0.f ) );
 
-  QCOMPARE( w.mHueSlider->mSpinBox->value(), 179.5 );
+  QCOMPARE( w.mHueSlider->mSpinBox->value(), 180 );
   compareFloat( w.mHueSlider->mRampWidget->color().hueF(), 0.5f );
   QCOMPARE( w.mSaturationSlider->mSpinBox->value(), 50 );
   compareFloat( w.mSaturationSlider->mRampWidget->color().saturationF(), 0.5f );


### PR DESCRIPTION
Due to #58375, the extreme value of each color by hue value is now 59.83 increments, which is 359 divided by 6. To get the normal 60 increments, it seems appropriate to set the HUE_MAX value from 359 to 360.

Before applying #58375 (QGIS 3.38 or earlier):
![fig1](https://github.com/user-attachments/assets/43250d05-83ad-44e1-9dfc-044eb3886b9c)

After applying #58375 (QGIS 3.40 or later):
![fig2](https://github.com/user-attachments/assets/bb60d50c-138b-48f9-bce5-e0a0ef5524d8)

After changing HUE_MAX from 359 to 360:
![fig3](https://github.com/user-attachments/assets/daab3bd1-dbe6-47fd-8b81-28a30f85f203)