### PR TITLE
Fix QgsZipUtils' unzip function throwing warnings when attempting to write into a directory

### DIFF
--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -85,6 +85,11 @@ bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QString
         if ( zip_fread( file, buf.get(), len ) != -1 )
         {
           const QString fileName( stat.name );
+          if ( fileName.endsWith( "/" ) )
+          {
+            continue;
+          }
+
           const QFileInfo newFile( QDir( dir ), fileName );
 
           if ( !QString( QDir::cleanPath( newFile.absolutePath() ) + QStringLiteral( "/" ) ).startsWith( QDir( dir ).absolutePath() + QStringLiteral( "/" ) ) )

--- a/tests/src/core/testqgsziputils.cpp
+++ b/tests/src/core/testqgsziputils.cpp
@@ -63,7 +63,7 @@ void TestQgsZipUtils::unzipWithSubdirs()
 {
   QStringList testFileNames;
   testFileNames << "/folder/folder2/landsat_b2.tif" << "/folder/points.geojson" << "/points.qml";
-  genericTest( QString( "testzip" ), 11, true, testFileNames );
+  genericTest( QString( "testzip" ), 9, true, testFileNames );
 }
 
 /**
@@ -154,7 +154,13 @@ void TestQgsZipUtils::genericTest( QString zipName, int expectedEntries, bool in
   QDirIterator it( dir, QDirIterator::Subdirectories );
   QStringList filesFromResultDir;
   while ( it.hasNext() )
-    filesFromResultDir << it.next();
+  {
+    it.next();
+    if ( !it.fileInfo().isDir() )
+    {
+      filesFromResultDir << it.filePath();
+    }
+  }
 
   // Test if ziplib matches number of files in the root folder
   QCOMPARE( files.count(), filesFromResultDir.count() );

--- a/tests/src/python/test_qgsziputils.py
+++ b/tests/src/python/test_qgsziputils.py
@@ -83,7 +83,7 @@ class TestQgsZip(unittest.TestCase):
         rc, files = QgsZipUtils.unzip(zip, outDir.path())
 
         self.assertTrue(rc)
-        self.assertEqual(len(files), 11)
+        self.assertEqual(len(files), 9)
 
     def test_unzip_file_not_exist(self):
         outDir = QTemporaryDir()


### PR DESCRIPTION
## Description

The QgsZipUtils::unzip function was not skipping directory items, leading to harmless (but scary) warnings in the message logs panel, let's fix that.