### PR TITLE
fix(QgsAuxiliaryStorage): remove tmp file only if it exists

### DIFF
--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -635,7 +635,8 @@ QgsAuxiliaryStorage::QgsAuxiliaryStorage( const QString &filename, bool copy )
 
 QgsAuxiliaryStorage::~QgsAuxiliaryStorage()
 {
-  QFile::remove( mTmpFileName );
+  if ( QFile::exists( mTmpFileName ) )
+    QFile::remove( mTmpFileName );
 }
 
 bool QgsAuxiliaryStorage::isValid() const


### PR DESCRIPTION
Just a really easy fix to remove useless Warning message when no temp file has been created.