### PR TITLE
do not limit Style Manager to the specific style database when opening it from the layer properties dialog (fix #58653)

### DIFF
--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -541,8 +541,16 @@ void QgsStyleItemsListWidget::openStyleManager()
        || !QgsGui::windowManager()->openStandardDialog( QgsWindowManagerInterface::DialogStyleManager ) )
   {
     // fallback to modal dialog
-    QgsStyleManagerDialog dlg( this );
-    dlg.exec();
+    std::unique_ptr<  QgsStyleManagerDialog > dlg;
+    if ( mStyle && mStyle != QgsStyle::defaultStyle() )
+    {
+      dlg = std::make_unique< QgsStyleManagerDialog >( mStyle, this );
+    }
+    else
+    {
+      dlg = std::make_unique< QgsStyleManagerDialog >( this );
+    }
+    dlg->exec();
 
     updateModelFilters(); // probably not needed -- the model should automatically update if any changes were made
   }

--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -541,7 +541,7 @@ void QgsStyleItemsListWidget::openStyleManager()
        || !QgsGui::windowManager()->openStandardDialog( QgsWindowManagerInterface::DialogStyleManager ) )
   {
     // fallback to modal dialog
-    QgsStyleManagerDialog dlg( mStyle, this );
+    QgsStyleManagerDialog dlg( this );
     dlg.exec();
 
     updateModelFilters(); // probably not needed -- the model should automatically update if any changes were made


### PR DESCRIPTION
## Description

When Style Manager is opened from the Symbology tab of the layer properties dialog, it misses style database selector in the top left corner. This is inconsistent with the other ways to access Style Manager, e.g. by opening it from the QGIS main dialog toolbar/menu or from Layer Styling panel.

Fixes #58653.