### PR TITLE
testing: Ignore swig deprecation warnings

### DIFF
--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -335,6 +335,8 @@ class QgisTestCase(unittest.TestCase):
                     "glx: failed to create drisw screen",
                     "failed to load driver: zink",
                     "QML debugging is enabled. Only use this in a safe environment.",
+                    "<frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute",
+                    "<frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute",
                 )
                 and not "LC_ALL: cannot change locale" in e
             ]


### PR DESCRIPTION
## Description

With recent versions of Python + unittest + swig (like the ones from fedora 42), `PyQgsProcessExecutablePt1` and
`PyQgsProcessExecutablePt2` unit test fail because of some deprecation warning message coming from Swig.

This issue will be fixed in Swig 4.4. In the meantime, ignore them.

See: https://github.com/swig/swig/issues/2881
