### PR TITLE
change CRS of the main annotation layer when project CRS is changed (fix #48046)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11508,6 +11508,12 @@ void QgisApp::projectCrsChanged()
       askUserForDatumTransform( it.value()->crs(), QgsProject::instance()->crs(), it.value() );
     }
   }
+
+  // update CRS of the main annotation layer if it is empty
+  if ( QgsProject::instance()->mainAnnotationLayer() && QgsProject::instance()->mainAnnotationLayer()->isEmpty() && QgsProject::instance()->mainAnnotationLayer()->crs() != QgsProject::instance()->crs() )
+  {
+    QgsProject::instance()->mainAnnotationLayer()->setCrs( QgsProject::instance()->crs() );
+  }
 }
 
 void QgisApp::projectTemporalRangeChanged()


### PR DESCRIPTION
## Description

When project CRS is changed and there are no annotations in the main annotation layer — change CRS of the main annotation layer to match project CRS to ensure that annotations are added in the current project CRS.

Fixes  #48046.