### PR TITLE
Don't build a giant lambda for function help initialization

### DIFF
--- a/scripts/process_function_template.py
+++ b/scripts/process_function_template.py
@@ -12,14 +12,9 @@ sys.path.append(
 cpp = open(sys.argv[1], "w", encoding="utf-8")
 cpp.write(
     '#include "qgsexpression.h"\n'
-    '#include "qgsexpression_p.h"\n'
-    "#include <mutex>\n"
     "\n"
-    "void QgsExpression::initFunctionHelp()\n"
+    "void QgsExpression::buildFunctionHelp()\n"
     "{\n"
-    "  static std::once_flag initialized;\n"
-    "  std::call_once( initialized, []\n"
-    "  {"
 )
 
 
@@ -88,14 +83,14 @@ for f in sorted(glob.glob("resources/function_help/json/*")):
                 )
 
     cpp.write(
-        '\n\n    QgsExpression::functionHelpTexts().insert( QStringLiteral( {0} ),\n      Help( QStringLiteral( {0} ), tr( "{1}" ), tr( "{2}" ),\n        QList<HelpVariant>()'.format(
+        '\n\n  QgsExpression::functionHelpTexts().insert( QStringLiteral( {0} ),\n    Help( QStringLiteral( {0} ), tr( "{1}" ), tr( "{2}" ),\n      QList<HelpVariant>()'.format(
             name, json_params["type"], json_params["description"]
         )
     )
 
     for v in json_params["variants"]:
         cpp.write(
-            '\n          << HelpVariant( tr( "{}" ), tr( "{}" ),\n            QList<HelpArg>()'.format(
+            '\n        << HelpVariant( tr( "{}" ), tr( "{}" ),\n          QList<HelpArg>()'.format(
                 v["variant"], v["variant_description"]
             )
         )
@@ -103,7 +98,7 @@ for f in sorted(glob.glob("resources/function_help/json/*")):
         if "arguments" in v:
             for a in v["arguments"]:
                 cpp.write(
-                    '\n                << HelpArg( QStringLiteral( "{}" ), tr( "{}" ), {}, {}, {}, {} )'.format(
+                    '\n              << HelpArg( QStringLiteral( "{}" ), tr( "{}" ), {}, {}, {}, {} )'.format(
                         a["arg"],
                         a.get("description", ""),
                         "true" if a.get("descOnly", False) else "false",
@@ -118,40 +113,40 @@ for f in sorted(glob.glob("resources/function_help/json/*")):
                 )
 
         cpp.write(
-            ",\n            /* variableLenArguments */ {}".format(
+            ",\n          /* variableLenArguments */ {}".format(
                 "true" if v.get("variableLenArguments", False) else "false"
             )
         )
-        cpp.write(",\n            QList<HelpExample>()")
+        cpp.write(",\n          QList<HelpExample>()")
 
         if "examples" in v:
             for e in v["examples"]:
                 cpp.write(
-                    '\n              << HelpExample( tr( "{}" ), tr( "{}" ), tr( "{}" ) )'.format(
+                    '\n            << HelpExample( tr( "{}" ), tr( "{}" ), tr( "{}" ) )'.format(
                         e["expression"], e["returns"], e.get("note", "")
                     )
                 )
 
         if "notes" in v:
-            cpp.write(',\n            tr( "{}" )'.format(v["notes"]))
+            cpp.write(',\n          tr( "{}" )'.format(v["notes"]))
         else:
-            cpp.write(",\n            QString()")
+            cpp.write(",\n          QString()")
 
-        cpp.write(",\n            QStringList()")
+        cpp.write(",\n          QStringList()")
         if "tags" in v:
-            cpp.write('\n              << tr( "{}" )'.format(",".join(v["tags"])))
+            cpp.write('\n            << tr( "{}" )'.format(",".join(v["tags"])))
 
-        cpp.write("\n         )")
+        cpp.write("\n       )")
 
-    cpp.write("\n        )")
-    cpp.write("\n      );")
+    cpp.write("\n      )")
+    cpp.write("\n    );")
 
 for f in sorted(glob.glob("resources/function_help/text/*")):
     n = os.path.basename(f)
 
     with open(f) as content:
         cpp.write(
-            '\n\n    QgsExpression::functionHelpTexts().insert( "{0}",\n    Help( tr( "{0}" ), tr( "group" ), tr( "{1}" ), QList<HelpVariant>() ) );\n'.format(
+            '\n\n  QgsExpression::functionHelpTexts().insert( "{0}",\n  Help( tr( "{0}" ), tr( "group" ), tr( "{1}" ), QList<HelpVariant>() ) );\n'.format(
                 n,
                 content.read()
                 .replace("\\", "&#92;")
@@ -161,5 +156,6 @@ for f in sorted(glob.glob("resources/function_help/text/*")):
             )
         )
 
-cpp.write("\n  } );\n}\n")
+cpp.write("\n" "}\n" "\n")
+
 cpp.close()

--- a/src/core/callouts/qgscallout.cpp
+++ b/src/core/callouts/qgscallout.cpp
@@ -194,10 +194,7 @@ void QgsCallout::setEnabled( bool enabled )
 QgsPropertiesDefinition QgsCallout::propertyDefinitions()
 {
   static std::once_flag initialized;
-  std::call_once( initialized, [ = ]( )
-  {
-    initPropertyDefinitions();
-  } );
+  std::call_once( initialized, initPropertyDefinitions );
   return sPropertyDefinitions;
 }
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -725,9 +725,12 @@ QStringList QgsExpression::tags( const QString &name )
 
 void QgsExpression::initVariableHelp()
 {
-  if ( !sVariableHelpTexts()->isEmpty() )
-    return;
+  static std::once_flag initialized;
+  std::call_once( initialized, buildVariableHelp );
+}
 
+void QgsExpression::buildVariableHelp()
+{
   //global variables
   sVariableHelpTexts()->insert( QStringLiteral( "qgis_version" ), QCoreApplication::translate( "variable_help", "Current QGIS version string." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "qgis_version_no" ), QCoreApplication::translate( "variable_help", "Current QGIS version number." ) );
@@ -955,9 +958,9 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "plot_axis_value" ), QCoreApplication::translate( "plot_axis_value", "The current value for the plot axis." ) );
 }
 
-
 bool QgsExpression::addVariableHelpText( const QString name, const QString &description )
 {
+  QgsExpression::initVariableHelp();
   if ( sVariableHelpTexts()->contains( name ) )
   {
     return false;

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -343,6 +343,12 @@ void QgsExpression::detach()
   }
 }
 
+void QgsExpression::initFunctionHelp()
+{
+  static std::once_flag initialized;
+  std::call_once( initialized, buildFunctionHelp );
+}
+
 void QgsExpression::setGeomCalculator( const QgsDistanceArea *calc )
 {
   detach();

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -821,6 +821,8 @@ class CORE_EXPORT QgsExpression
     //! \note not available in Python bindings
     static void initFunctionHelp() SIP_SKIP;
     //! \note not available in Python bindings
+    static void buildFunctionHelp() SIP_SKIP;
+    //! \note not available in Python bindings
     static void initVariableHelp() SIP_SKIP;
 
     friend class QgsExpressionNodeFunction;

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -824,6 +824,8 @@ class CORE_EXPORT QgsExpression
     static void buildFunctionHelp() SIP_SKIP;
     //! \note not available in Python bindings
     static void initVariableHelp() SIP_SKIP;
+    //! \note not available in Python bindings
+    static void buildVariableHelp() SIP_SKIP;
 
     friend class QgsExpressionNodeFunction;
     static QRecursiveMutex sFunctionsMutex;

--- a/src/core/network/qgsnetworkdiskcache.cpp
+++ b/src/core/network/qgsnetworkdiskcache.cpp
@@ -123,75 +123,76 @@ void QgsNetworkDiskCache::clear()
   return sDiskCache.clear();
 }
 
-qint64 QgsNetworkDiskCache::smartCacheSize( const QString &cacheDir )
+void determineSmartCacheSize( const QString &cacheDir, qint64 &cacheSize )
 {
-  static qint64 cacheSize = 0;
-  static std::once_flag initialized;
-  std::call_once( initialized, [ = ]
+  std::function<qint64( const QString & )> dirSize;
+  dirSize = [&dirSize]( const QString & dirPath ) -> qint64
   {
-    std::function<qint64( const QString & )> dirSize;
-    dirSize = [&dirSize]( const QString & dirPath ) -> qint64
+    qint64 size = 0;
+    QDir dir( dirPath );
+
+    const QStringList filePaths = dir.entryList( QDir::Files | QDir::System | QDir::Hidden );
+    for ( const QString &filePath : filePaths )
     {
-      qint64 size = 0;
-      QDir dir( dirPath );
-
-      const QStringList filePaths = dir.entryList( QDir::Files | QDir::System | QDir::Hidden );
-      for ( const QString &filePath : filePaths )
-      {
-        QFileInfo fi( dir, filePath );
-        size += fi.size();
-      }
-
-      const QStringList childDirPaths = dir.entryList( QDir::Dirs | QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::NoSymLinks );
-      for ( const QString &childDirPath : childDirPaths )
-      {
-        size += dirSize( dirPath + QDir::separator() + childDirPath );
-      }
-
-      return size;
-    };
-
-    qint64 bytesFree;
-    QStorageInfo storageInfo( cacheDir );
-    bytesFree = storageInfo.bytesFree() + dirSize( cacheDir );
-
-    // NOLINTBEGIN(bugprone-narrowing-conversions)
-    // Logic taken from Firefox's smart cache size handling
-    qint64 available10MB = bytesFree / 1024 / ( 1024LL * 10 );
-    qint64 cacheSize10MB = 0;
-    if ( available10MB > 2500 )
-    {
-      // Cap the cache size to 1GB
-      cacheSize10MB = 100;
+      QFileInfo fi( dir, filePath );
+      size += fi.size();
     }
-    else
+
+    const QStringList childDirPaths = dir.entryList( QDir::Dirs | QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::NoSymLinks );
+    for ( const QString &childDirPath : childDirPaths )
     {
-      if ( available10MB > 700 )
-      {
-        // Add 2.5% of the free space above 7GB
-        cacheSize10MB += ( available10MB - 700 ) * 0.025;
-        available10MB = 700;
-      }
-      if ( available10MB > 50 )
-      {
-        // Add 7.5% of free space between 500MB to 7GB
-        cacheSize10MB += ( available10MB - 50 ) * 0.075;
-        available10MB = 50;
-      }
+      size += dirSize( dirPath + QDir::separator() + childDirPath );
+    }
+
+    return size;
+  };
+
+  qint64 bytesFree;
+  QStorageInfo storageInfo( cacheDir );
+  bytesFree = storageInfo.bytesFree() + dirSize( cacheDir );
+
+  // NOLINTBEGIN(bugprone-narrowing-conversions)
+  // Logic taken from Firefox's smart cache size handling
+  qint64 available10MB = bytesFree / 1024 / ( 1024LL * 10 );
+  qint64 cacheSize10MB = 0;
+  if ( available10MB > 2500 )
+  {
+    // Cap the cache size to 1GB
+    cacheSize10MB = 100;
+  }
+  else
+  {
+    if ( available10MB > 700 )
+    {
+      // Add 2.5% of the free space above 7GB
+      cacheSize10MB += ( available10MB - 700 ) * 0.025;
+      available10MB = 700;
+    }
+    if ( available10MB > 50 )
+    {
+      // Add 7.5% of free space between 500MB to 7GB
+      cacheSize10MB += ( available10MB - 50 ) * 0.075;
+      available10MB = 50;
+    }
 
 #if defined( Q_OS_ANDROID )
-      // On Android, smaller/older devices may have very little storage
+    // On Android, smaller/older devices may have very little storage
 
-      // Add 16% of free space up to 500 MB
-      cacheSize10MB += std::max( 2LL, static_cast<qint64>( available10MB * 0.16 ) );
-#else
-      // Add 30% of free space up to 500 MB
-      cacheSize10MB += std::max( 5LL, static_cast<qint64>( available10MB * 0.30 ) );
+    // Add 16% of free space up to 500 MB
+    cacheSize10MB += std::max( 2LL, static_cast<qint64>( available10MB * 0.16 ) );
+#else \
+  // Add 30% of free space up to 500 MB
+    cacheSize10MB += std::max( 5LL, static_cast<qint64>( available10MB * 0.30 ) );
 #endif
-    }
-    cacheSize = cacheSize10MB * 10 * 1024 * 1024;
-    // NOLINTEND(bugprone-narrowing-conversions)
-  } );
+  }
+  cacheSize = cacheSize10MB * 10 * 1024 * 1024;
+  // NOLINTEND(bugprone-narrowing-conversions)
+}
 
-  return cacheSize;
+qint64 QgsNetworkDiskCache::smartCacheSize( const QString &cacheDir )
+{
+  static qint64 sCacheSize = 0;
+  static std::once_flag initialized;
+  std::call_once( initialized, determineSmartCacheSize, cacheDir, sCacheSize );
+  return sCacheSize;
 }

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2961,7 +2961,7 @@ void buildSupportedRasterFileFilterAndExtensions( QString &fileFiltersString, QS
 
   QgsDebugMsgLevel( "Raster filter list built: " + fileFiltersString, 2 );
   QgsDebugMsgLevel( "Raster extension list built: " + extensions.join( ' ' ), 2 );
-}                               // buildSupportedRasterFileFilter_()
+}
 
 bool QgsGdalProvider::isValidRasterFileName( QString const &fileNameQString, QString &retErrMsg )
 {
@@ -4429,12 +4429,7 @@ QList<QgsProviderSublayerDetails> QgsGdalProviderMetadata::querySublayers( const
 
     // get supported extensions
     static std::once_flag initialized;
-    std::call_once( initialized, [ = ]
-    {
-      buildSupportedRasterFileFilterAndExtensions( sFilterString, sExtensions, sWildcards );
-      QgsDebugMsgLevel( QStringLiteral( "extensions: " ) + sExtensions.join( ' ' ), 2 );
-      QgsDebugMsgLevel( QStringLiteral( "wildcards: " ) + sWildcards.join( ' ' ), 2 );
-    } );
+    std::call_once( initialized, buildSupportedRasterFileFilterAndExtensions, sFilterString, sExtensions, sWildcards );
 
     const QString suffix = uriParts.value( QStringLiteral( "vsiSuffix" ) ).toString().isEmpty()
                            ? pathInfo.suffix().toLower()

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -226,6 +226,73 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
 
 }
 
+void registerMetaTypes()
+{
+  qRegisterMetaType<QgsGeometry::Error>( "QgsGeometry::Error" );
+  qRegisterMetaType<QgsDatabaseQueryLogEntry>( "QgsDatabaseQueryLogEntry" );
+  qRegisterMetaType<QgsProcessingFeatureSourceDefinition>( "QgsProcessingFeatureSourceDefinition" );
+  qRegisterMetaType<QgsProcessingOutputLayerDefinition>( "QgsProcessingOutputLayerDefinition" );
+  qRegisterMetaType<Qgis::LayoutUnit>( "Qgis::LayoutUnit" );
+  qRegisterMetaType<QgsUnsetAttributeValue>( "QgsUnsetAttributeValue" );
+  qRegisterMetaType<QgsFeatureId>( "QgsFeatureId" );
+  qRegisterMetaType<QgsFields>( "QgsFields" );
+  qRegisterMetaType<QgsFeatureIds>( "QgsFeatureIds" );
+  qRegisterMetaType<QgsProperty>( "QgsProperty" );
+  qRegisterMetaType<QgsFeatureStoreList>( "QgsFeatureStoreList" );
+  qRegisterMetaType<Qgis::MessageLevel>( "Qgis::MessageLevel" );
+  qRegisterMetaType<Qgis::BrowserItemState>( "Qgis::BrowserItemState" );
+  qRegisterMetaType<Qgis::GpsFixStatus>( "Qgis::GpsFixStatus" );
+  qRegisterMetaType<QgsReferencedRectangle>( "QgsReferencedRectangle" );
+  qRegisterMetaType<QgsReferencedPointXY>( "QgsReferencedPointXY" );
+  qRegisterMetaType<QgsReferencedGeometry>( "QgsReferencedGeometry" );
+  qRegisterMetaType<QgsLayoutRenderContext::Flags>( "QgsLayoutRenderContext::Flags" );
+  qRegisterMetaType<QgsStyle::StyleEntity>( "QgsStyle::StyleEntity" );
+  qRegisterMetaType<QgsCoordinateReferenceSystem>( "QgsCoordinateReferenceSystem" );
+  qRegisterMetaType<QgsAuthManager::MessageLevel>( "QgsAuthManager::MessageLevel" );
+  qRegisterMetaType<QgsNetworkRequestParameters>( "QgsNetworkRequestParameters" );
+  qRegisterMetaType<QgsNetworkReplyContent>( "QgsNetworkReplyContent" );
+  qRegisterMetaType<QgsFeature>( "QgsFeature" );
+  qRegisterMetaType<QgsGeometry>( "QgsGeometry" );
+  qRegisterMetaType<QgsInterval>( "QgsInterval" );
+  qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
+  qRegisterMetaType<QgsPointXY>( "QgsPointXY" );
+  qRegisterMetaType<QgsPoint>( "QgsPoint" );
+  qRegisterMetaType<QgsDatumTransform::GridDetails>( "QgsDatumTransform::GridDetails" );
+  qRegisterMetaType<QgsDatumTransform::TransformDetails>( "QgsDatumTransform::TransformDetails" );
+  qRegisterMetaType<QgsNewsFeedParser::Entry>( "QgsNewsFeedParser::Entry" );
+  qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
+  qRegisterMetaType<QgsLocatorResult>( "QgsLocatorResult" );
+  qRegisterMetaType<QgsGradientColorRamp>( "QgsGradientColorRamp" );
+  qRegisterMetaType<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  // Qt6 documentation says these are not needed anymore (https://www.qt.io/blog/whats-new-in-qmetatype-qvariant) #spellok
+  // TODO: when tests can run against Qt6 builds, check for any regressions
+  qRegisterMetaTypeStreamOperators<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
+#endif
+  qRegisterMetaType<QgsRemappingSinkDefinition>( "QgsRemappingSinkDefinition" );
+  qRegisterMetaType<QgsProcessingModelChildDependency>( "QgsProcessingModelChildDependency" );
+  qRegisterMetaType<QgsTextFormat>( "QgsTextFormat" );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  QMetaType::registerComparators<QgsProcessingModelChildDependency>();
+  QMetaType::registerEqualsComparator<QgsProcessingFeatureSourceDefinition>();
+  QMetaType::registerEqualsComparator<QgsProperty>();
+  QMetaType::registerEqualsComparator<QgsDateTimeRange>();
+  QMetaType::registerEqualsComparator<QgsDateRange>();
+  QMetaType::registerEqualsComparator<QgsUnsetAttributeValue>();
+#endif
+  qRegisterMetaType<QPainter::CompositionMode>( "QPainter::CompositionMode" );
+  qRegisterMetaType<QgsDateTimeRange>( "QgsDateTimeRange" );
+  qRegisterMetaType<QgsDoubleRange>( "QgsDoubleRange" );
+  qRegisterMetaType<QgsIntRange>( "QgsIntRange" );
+  qRegisterMetaType<QList<QgsMapLayer *>>( "QList<QgsMapLayer*>" );
+  qRegisterMetaType<QMap<QNetworkRequest::Attribute, QVariant>>( "QMap<QNetworkRequest::Attribute,QVariant>" );
+  qRegisterMetaType<QMap<QNetworkRequest::KnownHeaders, QVariant>>( "QMap<QNetworkRequest::KnownHeaders,QVariant>" );
+  qRegisterMetaType<QList<QNetworkReply::RawHeaderPair>>( "QList<QNetworkReply::RawHeaderPair>" );
+  qRegisterMetaType< QAuthenticator * >( "QAuthenticator*" );
+  qRegisterMetaType< QgsGpsInformation >( "QgsGpsInformation" );
+  qRegisterMetaType< QgsSensorThingsExpansionDefinition >( "QgsSensorThingsExpansionDefinition" );
+};
+
 void QgsApplication::init( QString profileFolder )
 {
   // Initialize application members in desktop app (at this point, profile folder is known)
@@ -257,72 +324,7 @@ void QgsApplication::init( QString profileFolder )
   *sProfilePath() = profileFolder;
 
   static std::once_flag sMetaTypesRegistered;
-  std::call_once( sMetaTypesRegistered, []
-  {
-    qRegisterMetaType<QgsGeometry::Error>( "QgsGeometry::Error" );
-    qRegisterMetaType<QgsDatabaseQueryLogEntry>( "QgsDatabaseQueryLogEntry" );
-    qRegisterMetaType<QgsProcessingFeatureSourceDefinition>( "QgsProcessingFeatureSourceDefinition" );
-    qRegisterMetaType<QgsProcessingOutputLayerDefinition>( "QgsProcessingOutputLayerDefinition" );
-    qRegisterMetaType<Qgis::LayoutUnit>( "Qgis::LayoutUnit" );
-    qRegisterMetaType<QgsUnsetAttributeValue>( "QgsUnsetAttributeValue" );
-    qRegisterMetaType<QgsFeatureId>( "QgsFeatureId" );
-    qRegisterMetaType<QgsFields>( "QgsFields" );
-    qRegisterMetaType<QgsFeatureIds>( "QgsFeatureIds" );
-    qRegisterMetaType<QgsProperty>( "QgsProperty" );
-    qRegisterMetaType<QgsFeatureStoreList>( "QgsFeatureStoreList" );
-    qRegisterMetaType<Qgis::MessageLevel>( "Qgis::MessageLevel" );
-    qRegisterMetaType<Qgis::BrowserItemState>( "Qgis::BrowserItemState" );
-    qRegisterMetaType<Qgis::GpsFixStatus>( "Qgis::GpsFixStatus" );
-    qRegisterMetaType<QgsReferencedRectangle>( "QgsReferencedRectangle" );
-    qRegisterMetaType<QgsReferencedPointXY>( "QgsReferencedPointXY" );
-    qRegisterMetaType<QgsReferencedGeometry>( "QgsReferencedGeometry" );
-    qRegisterMetaType<QgsLayoutRenderContext::Flags>( "QgsLayoutRenderContext::Flags" );
-    qRegisterMetaType<QgsStyle::StyleEntity>( "QgsStyle::StyleEntity" );
-    qRegisterMetaType<QgsCoordinateReferenceSystem>( "QgsCoordinateReferenceSystem" );
-    qRegisterMetaType<QgsAuthManager::MessageLevel>( "QgsAuthManager::MessageLevel" );
-    qRegisterMetaType<QgsNetworkRequestParameters>( "QgsNetworkRequestParameters" );
-    qRegisterMetaType<QgsNetworkReplyContent>( "QgsNetworkReplyContent" );
-    qRegisterMetaType<QgsFeature>( "QgsFeature" );
-    qRegisterMetaType<QgsGeometry>( "QgsGeometry" );
-    qRegisterMetaType<QgsInterval>( "QgsInterval" );
-    qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
-    qRegisterMetaType<QgsPointXY>( "QgsPointXY" );
-    qRegisterMetaType<QgsPoint>( "QgsPoint" );
-    qRegisterMetaType<QgsDatumTransform::GridDetails>( "QgsDatumTransform::GridDetails" );
-    qRegisterMetaType<QgsDatumTransform::TransformDetails>( "QgsDatumTransform::TransformDetails" );
-    qRegisterMetaType<QgsNewsFeedParser::Entry>( "QgsNewsFeedParser::Entry" );
-    qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
-    qRegisterMetaType<QgsLocatorResult>( "QgsLocatorResult" );
-    qRegisterMetaType<QgsGradientColorRamp>( "QgsGradientColorRamp" );
-    qRegisterMetaType<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    // Qt6 documentation says these are not needed anymore (https://www.qt.io/blog/whats-new-in-qmetatype-qvariant) #spellok
-    // TODO: when tests can run against Qt6 builds, check for any regressions
-    qRegisterMetaTypeStreamOperators<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
-#endif
-    qRegisterMetaType<QgsRemappingSinkDefinition>( "QgsRemappingSinkDefinition" );
-    qRegisterMetaType<QgsProcessingModelChildDependency>( "QgsProcessingModelChildDependency" );
-    qRegisterMetaType<QgsTextFormat>( "QgsTextFormat" );
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QMetaType::registerComparators<QgsProcessingModelChildDependency>();
-    QMetaType::registerEqualsComparator<QgsProcessingFeatureSourceDefinition>();
-    QMetaType::registerEqualsComparator<QgsProperty>();
-    QMetaType::registerEqualsComparator<QgsDateTimeRange>();
-    QMetaType::registerEqualsComparator<QgsDateRange>();
-    QMetaType::registerEqualsComparator<QgsUnsetAttributeValue>();
-#endif
-    qRegisterMetaType<QPainter::CompositionMode>( "QPainter::CompositionMode" );
-    qRegisterMetaType<QgsDateTimeRange>( "QgsDateTimeRange" );
-    qRegisterMetaType<QgsDoubleRange>( "QgsDoubleRange" );
-    qRegisterMetaType<QgsIntRange>( "QgsIntRange" );
-    qRegisterMetaType<QList<QgsMapLayer *>>( "QList<QgsMapLayer*>" );
-    qRegisterMetaType<QMap<QNetworkRequest::Attribute, QVariant>>( "QMap<QNetworkRequest::Attribute,QVariant>" );
-    qRegisterMetaType<QMap<QNetworkRequest::KnownHeaders, QVariant>>( "QMap<QNetworkRequest::KnownHeaders,QVariant>" );
-    qRegisterMetaType<QList<QNetworkReply::RawHeaderPair>>( "QList<QNetworkReply::RawHeaderPair>" );
-    qRegisterMetaType< QAuthenticator * >( "QAuthenticator*" );
-    qRegisterMetaType< QgsGpsInformation >( "QgsGpsInformation" );
-    qRegisterMetaType< QgsSensorThingsExpansionDefinition >( "QgsSensorThingsExpansionDefinition" );
-  } );
+  std::call_once( sMetaTypesRegistered, registerMetaTypes );
 
   ( void ) resolvePkgPath();
 

--- a/src/core/qgsmaplayerelevationproperties.cpp
+++ b/src/core/qgsmaplayerelevationproperties.cpp
@@ -124,10 +124,7 @@ void QgsMapLayerElevationProperties::setDataDefinedProperties( const QgsProperty
 QgsPropertiesDefinition QgsMapLayerElevationProperties::propertyDefinitions()
 {
   static std::once_flag initialized;
-  std::call_once( initialized, [ = ]( )
-  {
-    initPropertyDefinitions();
-  } );
+  std::call_once( initialized, initPropertyDefinitions );
   return sPropertyDefinitions;
 }
 

--- a/src/core/raster/qgsrasterpipe.cpp
+++ b/src/core/raster/qgsrasterpipe.cpp
@@ -454,9 +454,6 @@ void QgsRasterPipe::initPropertyDefinitions()
 QgsPropertiesDefinition QgsRasterPipe::propertyDefinitions()
 {
   static std::once_flag initialized;
-  std::call_once( initialized, [ = ]( )
-  {
-    initPropertyDefinitions();
-  } );
+  std::call_once( initialized, initPropertyDefinitions );
   return sPropertyDefinitions;
 }


### PR DESCRIPTION
This is likely the cause of QgsExpression::initFunctionHelp crashes on Windows Qt 6 builds

Thanks to @NathanW2, who diagnosed the crash as a stack overflow, caused when local variables exceed 8k...

Refs https://github.com/qgis/QGIS/issues/61956
Refs https://github.com/qgis/QGIS/issues/62009
Refs https://github.com/qgis/QGIS/issues/59003
Refs https://github.com/qgis/QGIS/issues/61910
Refs https://github.com/qgis/QGIS/issues/61644
Refs https://github.com/qgis/QGIS/issues/60434
Refs https://github.com/qgis/QGIS/issues/61452
Refs https://github.com/qgis/QGIS/issues/60922
Refs https://github.com/qgis/QGIS/issues/60429