### PR TITLE
Fix various new connection dialog spacing and size

### DIFF
--- a/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingsdataitemguiprovider.cpp
@@ -15,6 +15,8 @@
 
 #include "qgssensorthingsdataitemguiprovider.h"
 #include "moc_qgssensorthingsdataitemguiprovider.cpp"
+
+#include "qgsapplication.h"
 #include "qgssensorthingsdataitems.h"
 #include "qgssensorthingsconnection.h"
 #include "qgssensorthingsconnectiondialog.h"
@@ -103,7 +105,7 @@ void QgsSensorThingsDataItemGuiProvider::duplicateConnection( QgsDataItem *item 
 
 void QgsSensorThingsDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsSensorThingsConnectionDialog dlg;
+  QgsSensorThingsConnectionDialog dlg( QgsApplication::instance()->activeWindow() );
   if ( !dlg.exec() )
     return;
 

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -149,21 +149,21 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
       mWmsOptionsGroupBox->setTitle( tr( "WCS Options" ) );
 
       cbxIgnoreGetFeatureInfoURI->setVisible( false );
-      mGroupBox->layout()->removeWidget( cbxIgnoreGetFeatureInfoURI );
+      mWmsOptionsGroupBox->layout()->removeWidget( cbxIgnoreGetFeatureInfoURI );
 
       sbFeatureCount->setVisible( false );
-      mGroupBox->layout()->removeWidget( sbFeatureCount );
+      mWmsOptionsGroupBox->layout()->removeWidget( sbFeatureCount );
       lblFeatureCount->setVisible( false );
-      mGroupBox->layout()->removeWidget( lblFeatureCount );
+      mWmsOptionsGroupBox->layout()->removeWidget( lblFeatureCount );
 
       cmbDpiMode->setVisible( false );
-      mGroupBox->layout()->removeWidget( cmbDpiMode );
+      mWmsOptionsGroupBox->layout()->removeWidget( cmbDpiMode );
       lblDpiMode->setVisible( false );
-      mGroupBox->layout()->removeWidget( lblDpiMode );
+      mWmsOptionsGroupBox->layout()->removeWidget( lblDpiMode );
       cmbTilePixelRatio->setVisible( false );
-      mGroupBox->layout()->removeWidget( cmbTilePixelRatio );
+      mWmsOptionsGroupBox->layout()->removeWidget( cmbTilePixelRatio );
       lblTilePixelRatio->setVisible( false );
-      mGroupBox->layout()->removeWidget( lblTilePixelRatio );
+      mWmsOptionsGroupBox->layout()->removeWidget( lblTilePixelRatio );
     }
   }
 
@@ -367,7 +367,6 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
 void QgsNewHttpConnection::showEvent( QShowEvent *event )
 {
   QDialog::showEvent( event );
-  adjustSize();
 }
 
 QUrl QgsNewHttpConnection::urlTrimmed() const

--- a/src/gui/stac/qgsstacdataitemguiprovider.cpp
+++ b/src/gui/stac/qgsstacdataitemguiprovider.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsstacdataitemguiprovider.h"
 #include "moc_qgsstacdataitemguiprovider.cpp"
+
+#include "qgsapplication.h"
 #include "qgsstaccontroller.h"
 #include "qgsstacdataitems.h"
 #include "qgsstacconnection.h"
@@ -128,7 +130,7 @@ void QgsStacDataItemGuiProvider::refreshConnection( QgsDataItem *item )
 
 void QgsStacDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsStacConnectionDialog dlg;
+  QgsStacConnectionDialog dlg( QgsApplication::instance()->activeWindow() );
   if ( !dlg.exec() )
     return;
 

--- a/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
+++ b/src/gui/tiledscene/qgstiledscenedataitemguiprovider.cpp
@@ -15,6 +15,8 @@
 
 #include "qgstiledscenedataitemguiprovider.h"
 #include "moc_qgstiledscenedataitemguiprovider.cpp"
+
+#include "qgsapplication.h"
 #include "qgsquantizedmeshdataprovider.h"
 #include "qgstiledscenedataitems.h"
 #include "qgstiledsceneconnection.h"
@@ -107,7 +109,7 @@ void QgsTiledSceneDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
 
 void QgsTiledSceneDataItemGuiProvider::newConnection( QgsDataItem *item, QString provider )
 {
-  QgsTiledSceneConnectionDialog dlg;
+  QgsTiledSceneConnectionDialog dlg( QgsApplication::instance()->activeWindow() );
   if ( !dlg.exec() )
     return;
 

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -16,6 +16,7 @@
 #include "qgsvectortiledataitemguiprovider.h"
 #include "moc_qgsvectortiledataitemguiprovider.cpp"
 
+#include "qgsapplication.h"
 #include "qgsvectortiledataitems.h"
 #include "qgsvectortileconnectiondialog.h"
 #include "qgsarcgisvectortileconnectiondialog.h"
@@ -127,7 +128,7 @@ void QgsVectorTileDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
 
 void QgsVectorTileDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsVectorTileConnectionDialog dlg;
+  QgsVectorTileConnectionDialog dlg( QgsApplication::instance()->activeWindow() );
   if ( !dlg.exec() )
     return;
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsarcgisrestdataitemguiprovider.h"
 #include "moc_qgsarcgisrestdataitemguiprovider.cpp"
+
+#include "qgsapplication.h"
 #include "qgsarcgisrestdataitems.h"
 #include "qgsmanageconnectionsdialog.h"
 #include "qgsnewarcgisrestconnection.h"
@@ -147,7 +149,7 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
 
 void QgsArcGisRestDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsNewArcGisRestConnectionDialog nc( nullptr, QString() );
+  QgsNewArcGisRestConnectionDialog nc( QgsApplication::instance()->activeWindow(), QString() );
   nc.setWindowTitle( tr( "Create a New ArcGIS REST Server Connection" ) );
 
   if ( nc.exec() )

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -14,9 +14,11 @@
  * (at your option) any later version.
  *
  ***************************************************************************/
+
 #include "qgshanadataitems.h"
 #include "qgshanadataitemguiprovider.h"
 #include "moc_qgshanadataitemguiprovider.cpp"
+#cinlude "qgsapplication.h"
 #include "qgshananewconnection.h"
 #include "qgshanaproviderconnection.h"
 #include "qgshanasourceselect.h"
@@ -203,7 +205,7 @@ QWidget *QgsHanaDataItemGuiProvider::createParamWidget( QgsDataItem *root, QgsDa
 
 void QgsHanaDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsHanaNewConnection nc( nullptr );
+  QgsHanaNewConnection nc( QgsApplication::instance()->activeWindow() );
   if ( nc.exec() )
   {
     item->refresh();

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -18,7 +18,7 @@
 #include "qgshanadataitems.h"
 #include "qgshanadataitemguiprovider.h"
 #include "moc_qgshanadataitemguiprovider.cpp"
-#cinlude "qgsapplication.h"
+#include "qgsapplication.h"
 #include "qgshananewconnection.h"
 #include "qgshanaproviderconnection.h"
 #include "qgshanasourceselect.h"

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -17,6 +17,7 @@
 #include "qgsmssqlconnection.h"
 #include "qgsmssqldataitemguiprovider.h"
 #include "moc_qgsmssqldataitemguiprovider.cpp"
+#include "qgsapplication.h"
 #include "qgsmssqldataitems.h"
 #include "qgsmssqlnewconnection.h"
 #include "qgsmssqlsourceselect.h"
@@ -188,7 +189,7 @@ bool QgsMssqlDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiC
 
 void QgsMssqlDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsMssqlNewConnection nc( nullptr );
+  QgsMssqlNewConnection nc( QgsApplication::instance()->activeWindow() );
   if ( nc.exec() )
   {
     item->refreshConnections();

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -12,8 +12,11 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #include "qgsoracledataitems.h"
 #include "moc_qgsoracledataitems.cpp"
+
+#include "qgsapplication.h"
 #include "qgsoraclenewconnection.h"
 #include "qgsoraclecolumntypetask.h"
 #include "qgsoracleprovider.h"
@@ -576,7 +579,7 @@ void QgsOracleRootItem::connectionsChanged()
 
 void QgsOracleRootItem::newConnection()
 {
-  QgsOracleNewConnection nc( nullptr );
+  QgsOracleNewConnection nc( QgsApplication::instance()->activeWindow() );
   if ( nc.exec() )
   {
     refreshConnections();

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -16,6 +16,7 @@
 #include "qgspostgresdataitemguiprovider.h"
 #include "moc_qgspostgresdataitemguiprovider.cpp"
 
+#include "qgsapplication.h"
 #include "qgsmanageconnectionsdialog.h"
 #include "qgspostgresdataitems.h"
 #include "qgspgnewconnection.h"
@@ -273,7 +274,7 @@ QString QgsPostgresDataItemGuiProvider::typeNameFromLayer( const QgsPostgresLaye
 
 void QgsPostgresDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsPgNewConnection nc( nullptr );
+  QgsPgNewConnection nc( QgsApplication::instance()->activeWindow() );
   if ( nc.exec() )
   {
     item->refresh();

--- a/src/providers/wcs/qgswcsdataitemguiprovider.cpp
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.cpp
@@ -16,6 +16,7 @@
 #include "qgswcsdataitemguiprovider.h"
 #include "moc_qgswcsdataitemguiprovider.cpp"
 
+#include "qgsapplication.h"
 #include "qgsmanageconnectionsdialog.h"
 #include "qgswcsdataitems.h"
 #include "qgsnewhttpconnection.h"
@@ -76,7 +77,7 @@ void QgsWcsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
 void QgsWcsDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsNewHttpConnection nc( nullptr, QgsNewHttpConnection::ConnectionWcs, QStringLiteral( "WCS" ), QString(), QgsNewHttpConnection::FlagShowHttpSettings );
+  QgsNewHttpConnection nc( QgsApplication::instance()->activeWindow(), QgsNewHttpConnection::ConnectionWcs, QStringLiteral( "WCS" ), QString(), QgsNewHttpConnection::FlagShowHttpSettings );
 
   if ( nc.exec() )
   {

--- a/src/providers/wfs/qgswfsdataitemguiprovider.cpp
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.cpp
@@ -16,6 +16,7 @@
 #include "qgswfsdataitemguiprovider.h"
 #include "moc_qgswfsdataitemguiprovider.cpp"
 
+#include "qgsapplication.h"
 #include "qgsmanageconnectionsdialog.h"
 #include "qgswfsnewconnection.h"
 #include "qgswfsconnection.h"
@@ -76,7 +77,7 @@ void QgsWfsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
 void QgsWfsDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsWFSNewConnection nc( nullptr );
+  QgsWFSNewConnection nc( QgsApplication::instance()->activeWindow() );
   nc.setWindowTitle( tr( "Create a New WFS Connection" ) );
 
   if ( nc.exec() )

--- a/src/providers/wms/qgswmsdataitemguiproviders.cpp
+++ b/src/providers/wms/qgswmsdataitemguiproviders.cpp
@@ -18,6 +18,7 @@
 
 #include "qgswmsdataitems.h"
 
+#include "qgsapplication.h"
 #include "qgsnewhttpconnection.h"
 #include "qgswmsconnection.h"
 #include "qgsxyzconnectiondialog.h"
@@ -139,7 +140,7 @@ void QgsWmsDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
 
 void QgsWmsDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsNewHttpConnection nc( nullptr, QgsNewHttpConnection::ConnectionWms, QStringLiteral( "WMS" ), QString(), QgsNewHttpConnection::FlagShowHttpSettings );
+  QgsNewHttpConnection nc( QgsApplication::instance()->activeWindow(), QgsNewHttpConnection::ConnectionWms, QStringLiteral( "WMS" ), QString(), QgsNewHttpConnection::FlagShowHttpSettings );
 
   if ( nc.exec() )
   {
@@ -249,7 +250,7 @@ void QgsXyzDataItemGuiProvider::duplicateConnection( QgsDataItem *item )
 
 void QgsXyzDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsXyzConnectionDialog dlg;
+  QgsXyzConnectionDialog dlg( QgsApplication::instance()->activeWindow() );
   if ( !dlg.exec() )
     return;
 

--- a/src/ui/qgsnewarcgisrestconnectionbase.ui
+++ b/src/ui/qgsnewarcgisrestconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>649</width>
-    <height>607</height>
+    <width>646</width>
+    <height>792</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
    <item row="3" column="0">
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -33,8 +33,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>631</width>
-        <height>557</height>
+        <width>628</width>
+        <height>741</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -52,6 +52,12 @@
        </property>
        <item>
         <widget class="QGroupBox" name="mGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Connection Details</string>
          </property>
@@ -127,6 +133,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>ArcGIS Portal Details</string>
          </property>
@@ -201,7 +213,7 @@
              </sizepolicy>
             </property>
             <property name="focusPolicy">
-             <enum>Qt::FocusPolicy::StrongFocus</enum>
+             <enum>Qt::StrongFocus</enum>
             </property>
            </widget>
           </item>
@@ -209,12 +221,19 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsHttpHeaderWidget" name="mHttpHeaders" native="true"/>
+        <widget class="QgsHttpHeaderWidget" name="mHttpHeaders" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -231,7 +250,7 @@
    <item row="6" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>849</width>
-    <height>664</height>
+    <width>880</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
    <item>
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -32,9 +32,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-87</y>
-        <width>817</width>
-        <height>701</height>
+        <y>0</y>
+        <width>920</width>
+        <height>862</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
@@ -153,7 +153,7 @@
           <item row="9" column="0" colspan="2">
            <spacer name="verticalSpacer">
             <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
+             <enum>Qt::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -170,6 +170,12 @@
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <widget class="QGroupBox" name="mWmsOptionsGroupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="title">
             <string>WMS/WMTS Options</string>
            </property>
@@ -208,6 +214,12 @@
             </item>
             <item row="0" column="0">
              <widget class="QLabel" name="lblDpiMode">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>WMS DPI-&amp;Mode</string>
               </property>
@@ -225,6 +237,12 @@
             </item>
             <item row="2" column="0">
              <widget class="QLabel" name="lblFeatureCount">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Maximum number of GetFeatureInfo results</string>
               </property>
@@ -246,6 +264,12 @@
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="lblTilePixelRatio">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>WMTS server-side tile pixel ratio</string>
               </property>
@@ -268,11 +292,30 @@
               </property>
              </widget>
             </item>
+            <item row="14" column="0" colspan="2">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </widget>
          </item>
          <item>
           <widget class="QGroupBox" name="mWfsOptionsGroupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="title">
             <string>WFS Options</string>
            </property>
@@ -299,6 +342,12 @@
             </item>
             <item row="3" column="0">
              <widget class="QLabel" name="lblFeaturePaging">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Feature paging</string>
               </property>
@@ -306,6 +355,12 @@
             </item>
             <item row="2" column="0">
              <widget class="QLabel" name="lblMaxNumFeatures">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Max. number of features</string>
               </property>
@@ -330,6 +385,12 @@
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="lblVersion_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Preferred HTTP method</string>
               </property>
@@ -357,6 +418,12 @@
             </item>
             <item row="4" column="0">
              <widget class="QLabel" name="lblPageSize">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Page size</string>
               </property>
@@ -364,6 +431,12 @@
             </item>
             <item row="5" column="0">
              <widget class="QLabel" name="lblFeatureMode">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Feature mode&lt;br/&gt;(Simple vs Complex)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -371,26 +444,32 @@
             </item>
             <item row="0" column="0">
              <widget class="QLabel" name="lblVersion">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Version</string>
               </property>
              </widget>
             </item>
+            <item row="9" column="0" colspan="3">
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Orientation::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </item>
@@ -401,7 +480,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>878</width>
-    <height>637</height>
+    <width>880</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -75,7 +75,7 @@
       <item row="5" column="1" colspan="2">
        <widget class="QLineEdit" name="txtWorkspace">
         <property name="echoMode">
-         <enum>QLineEdit::EchoMode::Normal</enum>
+         <enum>QLineEdit::Normal</enum>
         </property>
        </widget>
       </item>
@@ -99,7 +99,7 @@
       <item row="4" column="1" colspan="2">
        <widget class="QLineEdit" name="txtOptions">
         <property name="echoMode">
-         <enum>QLineEdit::EchoMode::Normal</enum>
+         <enum>QLineEdit::Normal</enum>
         </property>
        </widget>
       </item>
@@ -137,7 +137,7 @@
          <item row="0" column="0">
           <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true">
            <property name="focusPolicy">
-            <enum>Qt::FocusPolicy::StrongFocus</enum>
+            <enum>Qt::StrongFocus</enum>
            </property>
           </widget>
          </item>
@@ -171,7 +171,7 @@
       <item row="11" column="1">
        <spacer name="verticalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Orientation::Vertical</enum>
+         <enum>Qt::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -192,6 +192,12 @@
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="7" column="0">
        <widget class="QLabel" name="TextLabel3_5">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Schema</string>
         </property>
@@ -203,7 +209,7 @@
          <string>If specified, only tables from the matching schema will be fetched and listed for the provider</string>
         </property>
         <property name="echoMode">
-         <enum>QLineEdit::EchoMode::Normal</enum>
+         <enum>QLineEdit::Normal</enum>
         </property>
         <property name="placeholderText">
          <string>Limit to tables from specific schema</string>
@@ -282,7 +288,7 @@
       <item row="8" column="0" colspan="2">
        <spacer name="verticalSpacer">
         <property name="orientation">
-         <enum>Qt::Orientation::Vertical</enum>
+         <enum>Qt::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -298,7 +304,7 @@
    <item row="3" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>821</width>
-    <height>610</height>
+    <width>880</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -32,7 +32,7 @@
    <item row="1" column="0" colspan="2">
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -42,8 +42,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>803</width>
-        <height>563</height>
+        <width>936</width>
+        <height>630</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
@@ -186,7 +186,7 @@
              <item row="0" column="0">
               <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true">
                <property name="focusPolicy">
-            <enum>Qt::FocusPolicy::StrongFocus</enum>
+                <enum>Qt::StrongFocus</enum>
                </property>
               </widget>
              </item>
@@ -203,7 +203,7 @@
           <item>
            <spacer name="verticalSpacer">
             <property name="orientation">
-         <enum>Qt::Orientation::Vertical</enum>
+             <enum>Qt::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -218,6 +218,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Database Details</string>
          </property>
@@ -259,7 +265,7 @@
           <item row="10" column="1">
            <spacer name="verticalSpacer_2">
             <property name="orientation">
-         <enum>Qt::Orientation::Vertical</enum>
+             <enum>Qt::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -278,6 +284,12 @@
           </item>
           <item row="9" column="0">
            <widget class="QLabel" name="TextLabel3_5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Schema</string>
             </property>
@@ -289,7 +301,7 @@
              <string>If specified, only tables from the matching schema will be fetched and listed for the provider</string>
             </property>
             <property name="echoMode">
-         <enum>QLineEdit::EchoMode::Normal</enum>
+             <enum>QLineEdit::Normal</enum>
             </property>
             <property name="placeholderText">
              <string>Limit to tables from specific schema</string>
@@ -342,7 +354,7 @@
    <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description

This PR fixes the layout regression following the merging of https://github.com/qgis/QGIS/pull/61948 .

Here are screenshots of the regression:

![image](https://github.com/user-attachments/assets/c4d3fd36-66ff-4d74-8de2-041115613b68)

![image](https://github.com/user-attachments/assets/0696e9ef-fedd-4a6a-823c-59f5d2cbdb49)

![image](https://github.com/user-attachments/assets/25a3c45e-079b-4dab-92e8-c9edb2c9e708)

etc.

While fixing this, I noticed some of the widget styling within the dialogs were "wrong" (e.g. the groupbox titles font not being bold). The PR fixes that by parenting the browser panel's new connection dialogs to the main window.

The result:

![image](https://github.com/user-attachments/assets/f6d5972e-7dba-4868-a12b-335510002d2b)

