### PR TITLE
[locator] Fix sorting not taking into account result score

### DIFF
--- a/src/core/locator/qgslocatormodel.cpp
+++ b/src/core/locator/qgslocatormodel.cpp
@@ -170,7 +170,7 @@ QVariant QgsLocatorModel::data( const QModelIndex &index, int role ) const
       return static_cast<int>( entry.type );
 
     case static_cast< int >( CustomRole::ResultScore ):
-      if ( entry.filter )
+      if ( !entry.filter )
         return 0;
       else
         return ( entry.result.score );


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/62013 . The if ( filter ) return 0 logic meant that all results were given a score of 0 (instead of the actual result score).