### PR TITLE
[vector] Fix vector file writer's handling of (read-only) .gpkg.zip files

### DIFF
--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -673,21 +673,13 @@ bool QgsOgrProviderMetadata::saveLayerMetadata( const QString &uri, const QgsLay
       {
         adjustedPath.chop( 3 );
       }
-      else if ( adjustedPath.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) )
-      {
-        adjustedPath.chop( 4 );
-      }
-      else if ( adjustedPath.endsWith( QLatin1String( ".tar" ), Qt::CaseInsensitive ) )
+      else if ( adjustedPath.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) || adjustedPath.endsWith( QLatin1String( ".tar" ), Qt::CaseInsensitive ) || adjustedPath.endsWith( QLatin1String( ".tgz" ), Qt::CaseInsensitive ) )
       {
         adjustedPath.chop( 4 );
       }
       else if ( adjustedPath.endsWith( QLatin1String( ".tar.gz" ), Qt::CaseInsensitive ) )
       {
         adjustedPath.chop( 7 );
-      }
-      else if ( adjustedPath.endsWith( QLatin1String( ".tgz" ), Qt::CaseInsensitive ) )
-      {
-        adjustedPath.chop( 4 );
       }
       const QFileInfo fi( adjustedPath );
       const QString qmdFileName = fi.dir().filePath( fi.completeBaseName() + QStringLiteral( ".qmd" ) );

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -669,18 +669,16 @@ bool QgsOgrProviderMetadata::saveLayerMetadata( const QString &uri, const QgsLay
       // which could be added for those formats before we resort to the sidecar approach!)
 
       QString adjustedPath = path;
-      if ( adjustedPath.endsWith( QLatin1String( ".gz" ), Qt::CaseInsensitive ) )
+      const QStringList excludedExtensions = { QLatin1String( ".gz" ), QLatin1String( ".zip" ), QLatin1String( ".tar" ), QLatin1String( ".tgz" ), QLatin1String( ".tar.gz" ) };
+      for ( const QString &excludedExtension : excludedExtensions )
       {
-        adjustedPath.chop( 3 );
+        if ( adjustedPath.endsWith( excludedExtension, Qt::CaseInsensitive ) )
+        {
+          adjustedPath.chop( excludedExtension.size() );
+          break;
+        }
       }
-      else if ( adjustedPath.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) || adjustedPath.endsWith( QLatin1String( ".tar" ), Qt::CaseInsensitive ) || adjustedPath.endsWith( QLatin1String( ".tgz" ), Qt::CaseInsensitive ) )
-      {
-        adjustedPath.chop( 4 );
-      }
-      else if ( adjustedPath.endsWith( QLatin1String( ".tar.gz" ), Qt::CaseInsensitive ) )
-      {
-        adjustedPath.chop( 7 );
-      }
+
       const QFileInfo fi( adjustedPath );
       const QString qmdFileName = fi.dir().filePath( fi.completeBaseName() + QStringLiteral( ".qmd" ) );
       QFile qmdFile( qmdFileName );

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -547,8 +547,7 @@ bool QgsOgrProviderMetadata::saveLayerMetadata( const QString &uri, const QgsLay
     QTextStream textStream( &metadataXml );
     document.save( textStream, 2 );
 
-    QFileInfo fi( path );
-    if ( fi.suffix().compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0 )
+    if ( path.endsWith( QLatin1String( ".gpkg" ), Qt::CaseInsensitive ) )
     {
       const QString layerName = parts.value( QStringLiteral( "layerName" ) ).toString();
       QgsOgrLayerUniquePtr userLayer;
@@ -668,6 +667,29 @@ bool QgsOgrProviderMetadata::saveLayerMetadata( const QString &uri, const QgsLay
       // file based, but not a geopackage -- store as .qmd sidecar file instead
       // (possibly there's other formats outside of GPKG which also has some native means of storing metadata,
       // which could be added for those formats before we resort to the sidecar approach!)
+
+      QString adjustedPath = path;
+      if ( adjustedPath.endsWith( QLatin1String( ".gz" ), Qt::CaseInsensitive ) )
+      {
+        adjustedPath.chop( 3 );
+      }
+      else if ( adjustedPath.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) )
+      {
+        adjustedPath.chop( 4 );
+      }
+      else if ( adjustedPath.endsWith( QLatin1String( ".tar" ), Qt::CaseInsensitive ) )
+      {
+        adjustedPath.chop( 4 );
+      }
+      else if ( adjustedPath.endsWith( QLatin1String( ".tar.gz" ), Qt::CaseInsensitive ) )
+      {
+        adjustedPath.chop( 7 );
+      }
+      else if ( adjustedPath.endsWith( QLatin1String( ".tgz" ), Qt::CaseInsensitive ) )
+      {
+        adjustedPath.chop( 4 );
+      }
+      const QFileInfo fi( adjustedPath );
       const QString qmdFileName = fi.dir().filePath( fi.completeBaseName() + QStringLiteral( ".qmd" ) );
       QFile qmdFile( qmdFileName );
       if ( qmdFile.open( QFile::WriteOnly | QFile::Truncate ) )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -289,7 +289,8 @@ void QgsVectorFileWriter::init( QString vectorFileName,
       const auto constAllExts = allExts;
       for ( const QString &ext : constAllExts )
       {
-        if ( vectorFileName.endsWith( '.' + ext.mid( 2 ), Qt::CaseInsensitive ) )
+        // Remove the wildcard (*) at the beginning of the extension
+        if ( vectorFileName.endsWith( ext.mid( 1 ), Qt::CaseInsensitive ) )
         {
           found = true;
           break;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -284,12 +284,12 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   {
     if ( metadataFound )
     {
-      QStringList allExts = metadata.ext.split( ' ', Qt::SkipEmptyParts );
+      QStringList allExts = metadata.glob.split( ' ', Qt::SkipEmptyParts );
       bool found = false;
       const auto constAllExts = allExts;
       for ( const QString &ext : constAllExts )
       {
-        if ( vectorFileName.endsWith( '.' + ext, Qt::CaseInsensitive ) )
+        if ( vectorFileName.endsWith( '.' + ext.mid( 2 ), Qt::CaseInsensitive ) )
         {
           found = true;
           break;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -298,6 +298,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
       if ( !found )
       {
+        allExts = metadata.ext.split( ' ', Qt::SkipEmptyParts );
         vectorFileName += '.' + allExts[0];
       }
     }


### PR DESCRIPTION
## Description

This PR deals with https://github.com/qgis/QGIS/issues/61773 in two parts:
- insures the QgsVectorFileWriter::init() validates file extension against *all* extensions for a given driver (i.e. in this case .gpkg.zip)
- fix the ogr metadata creation logic to produce a qmd filename that matches the QgsMapLayer::metadataUri() logic
