### PR TITLE
Add "concave hull by feature" algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/custom/concave_hull_points.gml
+++ b/python/plugins/processing/tests/testdata/custom/concave_hull_points.gml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ concave_hull_points.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-2.29257714762302 0.0</gml:lowerCorner><gml:upperCorner>3 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                            
+  <ogr:featureMember>
+    <ogr:concave_hull_points gml:id="concave_hull_points.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1.0 0.164303586321935</gml:lowerCorner><gml:upperCorner>3 3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_points.geom.0"><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.0.0"><gml:pos>1 1</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.0.1"><gml:pos>1.32243536280234 2.19599666388657</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.0.2"><gml:pos>3 3</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.0.3"><gml:pos>2.57648040033361 0.164303586321935</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.0.4"><gml:pos>2.05104253544621 1.30625521267723</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:d>1</ogr:d>
+    </ogr:concave_hull_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_points gml:id="concave_hull_points.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>0.12443703085905 4.0</gml:lowerCorner><gml:upperCorner>2.0930775646372 5.85304420350292</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_points.geom.1"><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.1.0"><gml:pos>2 5</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.1.1"><gml:pos>1 4</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.1.2"><gml:pos>0.12443703085905 4.11559633027523</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.1.3"><gml:pos>2.0930775646372 5.85304420350292</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.1.4"><gml:pos>1.36447039199333 4.67606338615513</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:d>2</ogr:d>
+    </ogr:concave_hull_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_points gml:id="concave_hull_points.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 8</gml:lowerCorner><gml:upperCorner>-1 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_points.geom.2"><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.2.0"><gml:pos>-1 8</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:d>3</ogr:d>
+    </ogr:concave_hull_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_points gml:id="concave_hull_points.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-2.29257714762302 0.0</gml:lowerCorner><gml:upperCorner>-0.534111759799833 7.0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_points.geom.3"><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.3.0"><gml:pos>-1 7</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.3.1"><gml:pos>-1 0</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.3.2"><gml:pos>-0.534111759799833 1.34128440366972</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.3.3"><gml:pos>-2.29257714762302 2.63736447039199</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point gml:id="concave_hull_points.geom.3.4"><gml:pos>-1.36080066722268 3.97547956630525</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:d>4</ogr:d>
+    </ogr:concave_hull_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_points gml:id="concave_hull_points.4">
+      <ogr:fid>points.9</ogr:fid>
+      <ogr:d>5</ogr:d>
+    </ogr:concave_hull_points>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/concave_hull_points.xsd
+++ b/python/plugins/processing/tests/testdata/custom/concave_hull_points.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="concave_hull_points" type="ogr:concave_hull_points_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="concave_hull_points_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:MultiPointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="d" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_by_feature.gml
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_by_feature.gml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ concave_hull_by_feature.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-2.29257714762302 0.0</gml:lowerCorner><gml:upperCorner>3 7</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                            
+  <ogr:featureMember>
+    <ogr:concave_hull_by_feature gml:id="concave_hull_points.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1.0 0.164303586321935</gml:lowerCorner><gml:upperCorner>3 3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_by_feature.geom.0"><gml:exterior><gml:LinearRing><gml:posList>2.05104253544621 1.30625521267723 3 3 1.32243536280234 2.19599666388657 1 1 2.57648040033361 0.164303586321935 2.05104253544621 1.30625521267723</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:d>1</ogr:d>
+      <ogr:area>2.298928</ogr:area>
+      <ogr:perimeter>8.081767</ogr:perimeter>
+    </ogr:concave_hull_by_feature>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_by_feature gml:id="concave_hull_points.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>0.12443703085905 4.0</gml:lowerCorner><gml:upperCorner>2.0930775646372 5.85304420350292</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_by_feature.geom.1"><gml:exterior><gml:LinearRing><gml:posList>0.12443703085905 4.11559633027523 1 4 2 5 2.0930775646372 5.85304420350292 1.36447039199333 4.67606338615513 0.12443703085905 4.11559633027523</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:d>2</ogr:d>
+      <ogr:area>0.728822</ogr:area>
+      <ogr:perimeter>5.900544</ogr:perimeter>
+    </ogr:concave_hull_by_feature>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_by_feature gml:id="concave_hull_points.2">
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:d>3</ogr:d>
+      <ogr:area xsi:nil="true"/>
+      <ogr:perimeter xsi:nil="true"/>
+    </ogr:concave_hull_by_feature>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_by_feature gml:id="concave_hull_points.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-2.29257714762302 0.0</gml:lowerCorner><gml:upperCorner>-0.534111759799833 7.0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_by_feature.geom.3"><gml:exterior><gml:LinearRing><gml:posList>-0.534111759799833 1.34128440366972 -1.36080066722268 3.97547956630525 -1 7 -2.29257714762302 2.63736447039199 -1 0 -0.534111759799833 1.34128440366972</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:d>4</ogr:d>
+      <ogr:area>4.429250</ogr:area>
+      <ogr:perimeter>14.713901</ogr:perimeter>
+    </ogr:concave_hull_by_feature>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_by_feature gml:id="concave_hull_points.4">
+      <ogr:fid>points.9</ogr:fid>
+      <ogr:d>5</ogr:d>
+      <ogr:area xsi:nil="true"/>
+      <ogr:perimeter xsi:nil="true"/>
+    </ogr:concave_hull_by_feature>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_by_feature.xsd
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_by_feature.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="concave_hull_by_feature" type="ogr:concave_hull_by_feature_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="concave_hull_by_feature_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:SurfacePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to Polygon --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="d" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="perimeter" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
@@ -361,3 +361,15 @@ tests:
         hash: 38169bd8e8ff1400109936c8de70e429ab319926a053ab5142791010
         type: rasterhash
 
+  - algorithm: native:concavehullbyfeature
+    name: Concave hull by feature
+    params:
+      ALPHA: 0.3
+      HOLES: true
+      INPUT:
+        name: custom/concave_hull_points.gml|layername=concave_hull_points
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/concave_hull_by_feature.gml
+        type: vector

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -96,6 +96,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmclimb.cpp
   processing/qgsalgorithmclip.cpp
   processing/qgsalgorithmconcavehull.cpp
+  processing/qgsalgorithmconcavehullbyfeature.cpp
   processing/qgsalgorithmconditionalbranch.cpp
   processing/qgsalgorithmconstantraster.cpp
   processing/qgsalgorithmconverttocurves.cpp

--- a/src/analysis/processing/qgsalgorithmconcavehull.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehull.cpp
@@ -30,7 +30,7 @@ QString QgsConcaveHullAlgorithm::name() const
 
 QString QgsConcaveHullAlgorithm::displayName() const
 {
-  return QObject::tr( "Concave hull" );
+  return QObject::tr( "Concave hull (by layer)" );
 }
 
 QStringList QgsConcaveHullAlgorithm::tags() const
@@ -50,12 +50,13 @@ QString QgsConcaveHullAlgorithm::groupId() const
 
 QString QgsConcaveHullAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm computes the concave hull of the features from an input layer." );
+  return QObject::tr( "This algorithm computes the concave hull covering all features from an input layer." ) + QStringLiteral( "\n\n" )
+         + QObject::tr( "See the 'Concave hull (by feature)' algorithm for a concave hull calculation which covers individual features from a layer." );
 }
 
 QString QgsConcaveHullAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Computes the concave hull of the features from an input layer." );
+  return QObject::tr( "Computes the concave hull of all features from an input layer." );
 }
 
 QgsConcaveHullAlgorithm *QgsConcaveHullAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmconcavehull.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehull.cpp
@@ -50,13 +50,13 @@ QString QgsConcaveHullAlgorithm::groupId() const
 
 QString QgsConcaveHullAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm computes the concave hull covering all features from an input layer." ) + QStringLiteral( "\n\n" )
+  return QObject::tr( "This algorithm computes the concave hull covering all features from an input point layer." ) + QStringLiteral( "\n\n" )
          + QObject::tr( "See the 'Concave hull (by feature)' algorithm for a concave hull calculation which covers individual features from a layer." );
 }
 
 QString QgsConcaveHullAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Computes the concave hull of all features from an input layer." );
+  return QObject::tr( "Computes the concave hull of all features from an input point layer." );
 }
 
 QgsConcaveHullAlgorithm *QgsConcaveHullAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
@@ -32,7 +32,7 @@ QString QgsConcaveHullByFeatureAlgorithm::displayName() const
 
 QStringList QgsConcaveHullByFeatureAlgorithm::tags() const
 {
-  return QObject::tr( "concave,hull,bounds,bounding" ).split( ',' );
+  return QObject::tr( "concave,hull,bounds,bounding,convex" ).split( ',' );
 }
 
 QString QgsConcaveHullByFeatureAlgorithm::group() const

--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
@@ -1,0 +1,146 @@
+/***************************************************************************
+                         qgsalgorithmconcavehullbyfeature.cpp
+                         ---------------------
+    begin                : May 2025
+    copyright            : (C) 2025 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmconcavehullbyfeature.h"
+#include "qgsgeometrycollection.h"
+
+///@cond PRIVATE
+
+QString QgsConcaveHullByFeatureAlgorithm::name() const
+{
+  return QStringLiteral( "concavehullbyfeature" );
+}
+
+QString QgsConcaveHullByFeatureAlgorithm::displayName() const
+{
+  return QObject::tr( "Concave hull (by feature)" );
+}
+
+QStringList QgsConcaveHullByFeatureAlgorithm::tags() const
+{
+  return QObject::tr( "concave,hull,bounds,bounding" ).split( ',' );
+}
+
+QString QgsConcaveHullByFeatureAlgorithm::group() const
+{
+  return QObject::tr( "Vector geometry" );
+}
+
+QString QgsConcaveHullByFeatureAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorgeometry" );
+}
+
+QString QgsConcaveHullByFeatureAlgorithm::outputName() const
+{
+  return QObject::tr( "Concave hulls" );
+}
+
+QString QgsConcaveHullByFeatureAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm calculates the concave hull for each feature in an input layer." ) + QStringLiteral( "\n\n" )
+         + QObject::tr( "A concave hull is a polygon which contains all the points of the input geometries, but is a better approximation than the convex hull to the area occupied by the input." ) + QStringLiteral( "\n\n" )
+         + QObject::tr( "It is frequently used to convert a multi-point into a polygonal area which contains all the points from the input geometry." ) + QStringLiteral( "\n\n" )
+         + QObject::tr( "See the 'Concave hull (by layer)' algorithm for a concave hull calculation which covers the whole layer or grouped subsets of features." );
+}
+
+QString QgsConcaveHullByFeatureAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Calculates the concave hull for each feature in an input layer." );
+}
+
+QgsConcaveHullByFeatureAlgorithm *QgsConcaveHullByFeatureAlgorithm::createInstance() const
+{
+  return new QgsConcaveHullByFeatureAlgorithm();
+}
+
+void QgsConcaveHullByFeatureAlgorithm::initParameters( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "ALPHA" ), QObject::tr( "Threshold (0-1, where 1 is equivalent with Convex Hull)" ), Qgis::ProcessingNumberParameterType::Double, 0.3, false, 0, 1 ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "HOLES" ), QObject::tr( "Allow holes" ), true ) );
+}
+
+QList<int> QgsConcaveHullByFeatureAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint );
+}
+
+QgsFields QgsConcaveHullByFeatureAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  QgsFields newFields;
+  newFields.append( QgsField( QStringLiteral( "area" ), QMetaType::Type::Double, QString(), 20, 6 ) );
+  newFields.append( QgsField( QStringLiteral( "perimeter" ), QMetaType::Type::Double, QString(), 20, 6 ) );
+  return QgsProcessingUtils::combineFields( inputFields, newFields );
+}
+
+bool QgsConcaveHullByFeatureAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+#if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 11
+  throw QgsProcessingException( QObject::tr( "This algorithm requires a QGIS build based on GEOS 3.11 or later" ) );
+#endif
+  mPercentage = parameterAsDouble( parameters, QStringLiteral( "ALPHA" ), context );
+  mAllowHoles = parameterAsBool( parameters, QStringLiteral( "HOLES" ), context );
+  return true;
+}
+
+QgsFeatureList QgsConcaveHullByFeatureAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
+{
+  QgsFeature f = feature;
+  if ( f.hasGeometry() )
+  {
+    QgsGeometry outputGeometry;
+    const QgsAbstractGeometry *inputGeometry = f.geometry().constGet();
+    const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( inputGeometry );
+    if ( !collection || collection->numGeometries() == 1 )
+    {
+      feedback->reportError( QObject::tr( "Cannot calculate convex hull for a single point feature (%1) (try 'Concave hull (by layer)' algorithm instead)." ).arg( f.id() ) );
+      f.clearGeometry();
+    }
+    else
+    {
+      outputGeometry = f.geometry().concaveHull( mPercentage, mAllowHoles );
+      if ( outputGeometry.isNull() )
+        feedback->reportError( outputGeometry.lastError() );
+      f.setGeometry( outputGeometry );
+    }
+    if ( outputGeometry.type() == Qgis::GeometryType::Polygon )
+    {
+      QgsAttributes attrs = f.attributes();
+      attrs << outputGeometry.constGet()->area()
+            << outputGeometry.constGet()->perimeter();
+      f.setAttributes( attrs );
+    }
+    else
+    {
+      if ( outputGeometry.type() == Qgis::GeometryType::Line )
+      {
+        feedback->pushWarning( QObject::tr( "Concave hull for feature %1 resulted in a linestring, ignoring" ).arg( f.id() ) );
+      }
+      else if ( outputGeometry.type() == Qgis::GeometryType::Point )
+      {
+        feedback->pushWarning( QObject::tr( "Concave hull for feature %1 resulted in a point, ignoring" ).arg( f.id() ) );
+      }
+      QgsAttributes attrs = f.attributes();
+      attrs << QVariant()
+            << QVariant();
+      f.setAttributes( attrs );
+    }
+  }
+  return QgsFeatureList() << f;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.h
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+                         qgsalgorithmconcavehullbyfeature.h
+                         ---------------------
+    begin                : May 2025
+    copyright            : (C) 2025 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMCONCAVEHULLBYFEATURE_H
+#define QGSALGORITHMCONCAVEHULLBYFEATURE_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
+
+///@cond PRIVATE
+
+
+/**
+ * Native feature based concave hull algorithm.
+ */
+class QgsConcaveHullByFeatureAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+  public:
+    QgsConcaveHullByFeatureAlgorithm() = default;
+    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/algorithms/mAlgorithmConvexHull.svg" ) ); }
+    QString svgIconPath() const override { return QgsApplication::iconPath( QStringLiteral( "/algorithms/mAlgorithmConvexHull.svg" ) ); }
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsConcaveHullByFeatureAlgorithm *createInstance() const override SIP_FACTORY;
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    QList<int> inputLayerTypes() const override;
+
+  protected:
+    QString outputName() const override;
+    Qgis::WkbType outputWkbType( Qgis::WkbType ) const override { return Qgis::WkbType::Polygon; }
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+    double mPercentage = 0;
+    bool mAllowHoles = false;
+};
+
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMCONCAVEHULLBYFEATURE_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -77,6 +77,7 @@
 #include "qgsalgorithmclimb.h"
 #include "qgsalgorithmclip.h"
 #include "qgsalgorithmconcavehull.h"
+#include "qgsalgorithmconcavehullbyfeature.h"
 #include "qgsalgorithmconditionalbranch.h"
 #include "qgsalgorithmconstantraster.h"
 #include "qgsalgorithmconverttocurves.h"
@@ -389,6 +390,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsCollectAlgorithm() );
   addAlgorithm( new QgsCombineStylesAlgorithm() );
   addAlgorithm( new QgsConcaveHullAlgorithm() );
+  addAlgorithm( new QgsConcaveHullByFeatureAlgorithm() );
   addAlgorithm( new QgsConditionalBranchAlgorithm() );
   addAlgorithm( new QgsConstantRasterAlgorithm() );
   addAlgorithm( new QgsConvertToCurvesAlgorithm() );


### PR DESCRIPTION
The existing concave hull algorithm is quite restrictive as it forces operation on an entire layer, which makes it useless eg to create concave hulls from service area outputs.

Rename the existing one to "concave hull (by layer)", and make sure all the documentation explains this so its more predictable for users.
