### PR TITLE
[vector tiles] Fix handling of source containing a relative path to the root of the server hosting the style json

### DIFF
--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -132,7 +132,14 @@ QMap<QString, QString> QgsVectorTileUtils::parseStyleSourceUrl( const QString &s
         {
           // take a random one from the list
           // we might want to save the alternatives for a fallback later
-          sources.insert( sourceName, tiles[rand() % tiles.count()].toString() );
+          QString tilesString = tiles[rand() % tiles.count()].toString();
+          QUrl tilesUrl( tilesString );
+          if ( tilesUrl.isRelative() )
+          {
+            QUrl temporaryStyleUrl( styleUrl );
+            tilesString = QStringLiteral( "%1://%2%3" ).arg( temporaryStyleUrl.scheme(), temporaryStyleUrl.host(), tilesString );
+          }
+          sources.insert( sourceName, tilesString );
         }
       }
       return sources;

--- a/tests/src/core/testqgsvectortileutils.cpp
+++ b/tests/src/core/testqgsvectortileutils.cpp
@@ -92,9 +92,11 @@ void TestQgsVectorTileUtils::test_urlsFromStyle()
   QCOMPARE( sourceUrl, "https://vectortilesX.geo.admin.ch/tiles/ch.swisstopo.relief.vt/v1.0.0/{z}/{x}/{y}.pbf" );
 
   sources = QgsVectorTileUtils::parseStyleSourceUrl( "file://" + dataDir + "/vector_tile/styles/style2.json" );
-  QCOMPARE( sources.count(), 1 );
+  QCOMPARE( sources.count(), 2 );
   QVERIFY( sources.contains( "plan_ign" ) );
   QCOMPARE( sources.value( "plan_ign" ), "https://data.geopf.fr/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf" );
+  QVERIFY( sources.contains( "plan_ign_relative" ) );
+  QCOMPARE( sources.value( "plan_ign_relative" ), "file:///tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf" );
 }
 
 QGSTEST_MAIN( TestQgsVectorTileUtils )

--- a/tests/testdata/vector_tile/styles/style2.json
+++ b/tests/testdata/vector_tile/styles/style2.json
@@ -9,6 +9,12 @@
             "tiles": [
                 "https://data.geopf.fr/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
             ]
+        },
+        "plan_ign_relative": {
+            "type": "vector",
+            "tiles": [
+                "/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
+            ]
         }
     },
 	"transition": {


### PR DESCRIPTION
## Description

While testing openstreetmap vector tile styles (https://vector.openstreetmap.org/demo/shortbread/#1/0/0), I stumbled on a compatibility issue whereas the style json reports the vector tile source as a path _without_ the URL scheme/host , i.e.:

```
  "sources": {
    "versatiles-shortbread": {
      "attribution": "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
      "tiles": [
        "/shortbread_v1/{z}/{x}/{y}.mvt"
      ],
      "type": "vector",
      "scheme": "xyz",
      "bounds": [
        -180,
        -85.0511287798066,
        180,
        85.0511287798066
      ],
      "minzoom": 0,
      "maxzoom": 14
    }
  },
```

This PR tweaks the code to add the missing details when fetching the source URL from the style. 
