### PR TITLE
[keyboard shorcuts] When importing/loading keyboard shortcuts, insure preexisting shortcuts for different actions are taken into consideration

### DIFF
--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -280,8 +280,7 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
   QString actionSettingKey;
 
   QDomElement child = root.firstChildElement();
-  bool reassignAll = false;
-  bool skipAll = false;
+  ActionOnExisting actionOnExisting = ActionOnExisting::Ask;
   while ( !child.isNull() )
   {
     actionShortcut = child.attribute( QStringLiteral( "shortcut" ) );
@@ -313,18 +312,24 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
           text = shortcut->whatsThis();
         }
 
-        if ( !reassignAll && !skipAll )
+        if ( actionOnExisting == ActionOnExisting::Ask )
         {
           const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No | QMessageBox::NoToAll );
           if ( res == QMessageBox::No || res == QMessageBox::NoToAll )
           {
-            skipAll = res == QMessageBox::NoToAll;
+            if ( res == QMessageBox::NoToAll )
+            {
+              actionOnExisting = ActionOnExisting::SkipAll;
+            }
             child = child.nextSiblingElement();
             continue;
           }
-          reassignAll = res == QMessageBox::YesToAll;
+          if ( res == QMessageBox::YesToAll )
+          {
+            actionOnExisting = ActionOnExisting::ReassignAll;
+          }
         }
-        else if ( skipAll )
+        else if ( actionOnExisting == ActionOnExisting::SkipAll )
         {
           child = child.nextSiblingElement();
           continue;
@@ -364,18 +369,24 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
             text = shortcut->whatsThis();
           }
 
-          if ( !reassignAll && !skipAll )
+          if ( actionOnExisting == ActionOnExisting::Ask )
           {
             const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No | QMessageBox::NoToAll );
             if ( res == QMessageBox::No || res == QMessageBox::NoToAll )
             {
-              skipAll = res == QMessageBox::NoToAll;
+              if ( res == QMessageBox::NoToAll )
+              {
+                actionOnExisting = ActionOnExisting::SkipAll;
+              }
               child = child.nextSiblingElement();
               continue;
             }
-            reassignAll = res == QMessageBox::YesToAll;
+            if ( res == QMessageBox::YesToAll )
+            {
+              actionOnExisting = ActionOnExisting::ReassignAll;
+            }
           }
-          else if ( skipAll )
+          else if ( actionOnExisting == ActionOnExisting::SkipAll )
           {
             child = child.nextSiblingElement();
             continue;

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -281,6 +281,7 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
 
   QDomElement child = root.firstChildElement();
   bool reassignAll = false;
+  bool skipAll = false;
   while ( !child.isNull() )
   {
     actionShortcut = child.attribute( QStringLiteral( "shortcut" ) );
@@ -312,15 +313,21 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
           text = shortcut->whatsThis();
         }
 
-        if ( !reassignAll )
+        if ( !reassignAll && !skipAll )
         {
-          const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No );
-          if ( res == QMessageBox::No )
+          const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No | QMessageBox::NoToAll );
+          if ( res == QMessageBox::No || res == QMessageBox::NoToAll )
           {
+            skipAll = res == QMessageBox::NoToAll;
             child = child.nextSiblingElement();
             continue;
           }
           reassignAll = res == QMessageBox::YesToAll;
+        }
+        else if ( skipAll )
+        {
+          child = child.nextSiblingElement();
+          continue;
         }
         mManager->setObjectKeySequence( previousAction ? qobject_cast<QObject *>( previousAction ) : qobject_cast<QObject *>( previousShortcut ), QString() );
       }
@@ -357,15 +364,21 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
             text = shortcut->whatsThis();
           }
 
-          if ( !reassignAll )
+          if ( !reassignAll && !skipAll )
           {
-            const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No );
-            if ( res == QMessageBox::No )
+            const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No | QMessageBox::NoToAll );
+            if ( res == QMessageBox::No || res == QMessageBox::NoToAll )
             {
+              skipAll = res == QMessageBox::NoToAll;
               child = child.nextSiblingElement();
               continue;
             }
             reassignAll = res == QMessageBox::YesToAll;
+          }
+          else if ( skipAll )
+          {
+            child = child.nextSiblingElement();
+            continue;
           }
           mManager->setObjectKeySequence( previousObj, QString() );
         }

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -280,12 +280,50 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
   QString actionSettingKey;
 
   QDomElement child = root.firstChildElement();
+  bool reassignAll = false;
   while ( !child.isNull() )
   {
     actionShortcut = child.attribute( QStringLiteral( "shortcut" ) );
+    QKeySequence actionShortcutSequence( actionShortcut );
+    QString previousText;
+
     if ( version < QgsProjectVersion( QStringLiteral( "1.1" ) ) )
     {
       actionName = child.attribute( QStringLiteral( "name" ) );
+      QShortcut *previousShortcut = mManager->shortcutForSequence( actionShortcutSequence );
+      QAction *previousAction = mManager->actionForSequence( actionShortcutSequence );
+      if ( previousShortcut && previousShortcut->objectName() != actionName )
+      {
+        previousText = previousShortcut->whatsThis();
+      }
+      else if ( previousAction && previousAction->objectName() != actionName )
+      {
+        previousText = previousAction->text().remove( '&' );
+      }
+      if ( !previousText.isEmpty() )
+      {
+        QString text;
+        if ( QAction *action = mManager->actionByName( actionName ) )
+        {
+          text = action->text().remove( '&' );
+        }
+        else if ( QShortcut *shortcut = mManager->shortcutByName( actionName ) )
+        {
+          text = shortcut->whatsThis();
+        }
+
+        if ( !reassignAll )
+        {
+          const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No );
+          if ( res == QMessageBox::No )
+          {
+            child = child.nextSiblingElement();
+            continue;
+          }
+          reassignAll = res == QMessageBox::YesToAll;
+        }
+        mManager->setObjectKeySequence( previousAction ? qobject_cast<QObject *>( previousAction ) : qobject_cast<QObject *>( previousShortcut ), QString() );
+      }
       mManager->setKeySequence( actionName, actionShortcut );
     }
     else
@@ -293,7 +331,46 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
       actionSettingKey = child.attribute( QStringLiteral( "setting" ) );
       QObject *obj = mManager->objectForSettingKey( actionSettingKey );
       if ( obj )
+      {
+        QObject *previousObj = mManager->objectForSequence( actionShortcutSequence );
+        if ( previousObj && previousObj != obj )
+        {
+          if ( QAction *previousAction = qobject_cast<QAction *>( previousObj ) )
+          {
+            previousText = previousAction->text().remove( '&' );
+          }
+          else if ( QShortcut *previousShortcut = qobject_cast<QShortcut *>( previousObj ) )
+          {
+            previousText = previousShortcut->whatsThis();
+          }
+        }
+
+        if ( !previousText.isEmpty() )
+        {
+          QString text;
+          if ( QAction *action = qobject_cast<QAction *>( obj ) )
+          {
+            text = action->text().remove( '&' );
+          }
+          else if ( QShortcut *shortcut = qobject_cast<QShortcut *>( obj ) )
+          {
+            text = shortcut->whatsThis();
+          }
+
+          if ( !reassignAll )
+          {
+            const int res = QMessageBox::question( this, tr( "Load Shortcut" ), tr( "Shortcut %1 is already assigned to action %2. Reassign to %3?" ).arg( actionShortcut, previousText, text ), QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No );
+            if ( res == QMessageBox::No )
+            {
+              child = child.nextSiblingElement();
+              continue;
+            }
+            reassignAll = res == QMessageBox::YesToAll;
+          }
+          mManager->setObjectKeySequence( previousObj, QString() );
+        }
         mManager->setObjectKeySequence( obj, actionShortcut );
+      }
     }
 
     child = child.nextSiblingElement();

--- a/src/gui/qgsconfigureshortcutsdialog.h
+++ b/src/gui/qgsconfigureshortcutsdialog.h
@@ -63,6 +63,13 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
     void showHelp();
 
   private:
+    enum class ActionOnExisting
+    {
+      Ask,
+      ReassignAll,
+      SkipAll,
+    };
+
     //! Populates the dialog with all actions from the manager
     void populateActions();
 


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/ffde53d6-5f5b-4d09-8cf2-c7b4b56d7371)

This PR fixes https://github.com/qgis/QGIS/issues/61717 . If a user tries to import a keyboard shortcut that's already bound to a _different_ action, they will be asked what to do.