### PR TITLE
disable "Editable" and "Reuse last value" checkboxes for JsonView editor widget (fix #47755)

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgseditorwidgetfactory.py
+++ b/python/PyQt6/gui/auto_additions/qgseditorwidgetfactory.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/editorwidgets/core/qgseditorwidgetfactory.h
 try:
-    QgsEditorWidgetFactory.__virtual_methods__ = ['createSearchWidget', 'fieldScore']
+    QgsEditorWidgetFactory.__virtual_methods__ = ['createSearchWidget', 'isReadOnly', 'fieldScore']
     QgsEditorWidgetFactory.__abstract_methods__ = ['create', 'configWidget']
     QgsEditorWidgetFactory.__group__ = ['editorwidgets', 'core']
 except (NameError, AttributeError):

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetfactory.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetfactory.sip.in
@@ -61,6 +61,13 @@ Returns The human readable identifier name of this widget type
 :return: a name
 %End
 
+    virtual bool isReadOnly() const;
+%Docstring
+Returns true if this widget is a read-only widget.
+
+.. versionadded:: 3.44
+%End
+
     virtual QgsEditorConfigWidget *configWidget( QgsVectorLayer *vl, int fieldIdx, QWidget *parent ) const = 0 /Factory/;
 %Docstring
 Override this in your implementation. Create a new configuration widget

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetregistry.sip.in
@@ -121,6 +121,15 @@ Gets the human readable name for a widget type
 :return: A human readable name
 %End
 
+    bool isReadOnly( const QString &widgetId );
+%Docstring
+Gets the widget's read-only flag
+
+:param widgetId: The widget type to get the read-only flag for
+
+.. versionadded:: 3.44
+%End
+
     QMap<QString, QgsEditorWidgetFactory *> factories();
 %Docstring
 Gets access to all registered factories

--- a/python/gui/auto_additions/qgseditorwidgetfactory.py
+++ b/python/gui/auto_additions/qgseditorwidgetfactory.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/editorwidgets/core/qgseditorwidgetfactory.h
 try:
-    QgsEditorWidgetFactory.__virtual_methods__ = ['createSearchWidget', 'fieldScore']
+    QgsEditorWidgetFactory.__virtual_methods__ = ['createSearchWidget', 'isReadOnly', 'fieldScore']
     QgsEditorWidgetFactory.__abstract_methods__ = ['create', 'configWidget']
     QgsEditorWidgetFactory.__group__ = ['editorwidgets', 'core']
 except (NameError, AttributeError):

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetfactory.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetfactory.sip.in
@@ -61,6 +61,13 @@ Returns The human readable identifier name of this widget type
 :return: a name
 %End
 
+    virtual bool isReadOnly() const;
+%Docstring
+Returns true if this widget is a read-only widget.
+
+.. versionadded:: 3.44
+%End
+
     virtual QgsEditorConfigWidget *configWidget( QgsVectorLayer *vl, int fieldIdx, QWidget *parent ) const = 0 /Factory/;
 %Docstring
 Override this in your implementation. Create a new configuration widget

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetregistry.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetregistry.sip.in
@@ -121,6 +121,15 @@ Gets the human readable name for a widget type
 :return: A human readable name
 %End
 
+    bool isReadOnly( const QString &widgetId );
+%Docstring
+Gets the widget's read-only flag
+
+:param widgetId: The widget type to get the read-only flag for
+
+.. versionadded:: 3.44
+%End
+
     QMap<QString, QgsEditorWidgetFactory *> factories();
 %Docstring
 Gets access to all registered factories

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -237,8 +237,20 @@ void QgsAttributeTypeDialog::setEditorWidgetType( const QString &type, bool forc
     }
   }
 
-  // update general widget properties, like "Editable"
-  updateGeneralProperties( type );
+  // "Editable" and "Reuse last entered value" checkboxes should be disabled for read-only widgets like JsonEdit
+  // see https://github.com/qgis/QGIS/issues/47755
+  if ( QgsGui::editorWidgetRegistry()->isReadOnly( type ) )
+  {
+    isFieldEditableCheckBox->setEnabled( false );
+    mEditableExpressionButton->setEnabled( false );
+    reuseLastValuesCheckBox->setEnabled( false );
+  }
+  else
+  {
+    isFieldEditableCheckBox->setEnabled( true );
+    mEditableExpressionButton->setEnabled( true );
+    reuseLastValuesCheckBox->setEnabled( true );
+  }
 
   //update default expression preview
   defaultExpressionChanged();
@@ -374,18 +386,6 @@ void QgsAttributeTypeDialog::setDefaultValueExpression( const QString &expressio
 int QgsAttributeTypeDialog::fieldIdx() const
 {
   return mFieldIdx;
-}
-
-void QgsAttributeTypeDialog::updateGeneralProperties( const QString &type )
-{
-  // "Editable" and "Reuse last entered value" checkboxes should be disabled for JsonEdit
-  // as this widget is readonly (see https://github.com/qgis/QGIS/issues/47755)
-  if ( type.compare( QStringLiteral( "JsonEdit" ), Qt::CaseSensitivity::CaseInsensitive ) == 0 )
-  {
-    isFieldEditableCheckBox->setEnabled( false );
-    mEditableExpressionButton->setEnabled( false );
-    reuseLastValuesCheckBox->setEnabled( false );
-  }
 }
 
 QgsExpressionContext QgsAttributeTypeDialog::createExpressionContext() const

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -65,6 +65,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   if ( vl->fields().fieldOrigin( fieldIdx ) == Qgis::FieldOrigin::Join || vl->fields().fieldOrigin( fieldIdx ) == Qgis::FieldOrigin::Expression || vl->fields().field( fieldIdx ).isReadOnly() )
   {
     isFieldEditableCheckBox->setEnabled( false );
+    mEditableExpressionButton->setEnabled( false );
   }
 
   mExpressionWidget->registerExpressionContextGenerator( this );
@@ -236,6 +237,9 @@ void QgsAttributeTypeDialog::setEditorWidgetType( const QString &type, bool forc
     }
   }
 
+  // update general widget properties, like "Editable"
+  updateGeneralProperties( type );
+
   //update default expression preview
   defaultExpressionChanged();
 }
@@ -372,6 +376,17 @@ int QgsAttributeTypeDialog::fieldIdx() const
   return mFieldIdx;
 }
 
+void QgsAttributeTypeDialog::updateGeneralProperties( const QString &type )
+{
+  // "Editable" and "Reuse last entered value" checkboxes should be disabled for JsonEdit
+  // as this widget is readonly (see https://github.com/qgis/QGIS/issues/47755)
+  if ( type.compare( QStringLiteral( "JsonEdit" ), Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+  {
+    isFieldEditableCheckBox->setEnabled( false );
+    mEditableExpressionButton->setEnabled( false );
+    reuseLastValuesCheckBox->setEnabled( false );
+  }
+}
 
 QgsExpressionContext QgsAttributeTypeDialog::createExpressionContext() const
 {

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -305,6 +305,8 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
 
     void updateMergePolicyLabel();
 
+    void updateGeneralProperties( const QString &type );
+
   private:
     QgsVectorLayer *mLayer = nullptr;
     int mFieldIdx;

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -305,8 +305,6 @@ class GUI_EXPORT QgsAttributeTypeDialog : public QWidget, private Ui::QgsAttribu
 
     void updateMergePolicyLabel();
 
-    void updateGeneralProperties( const QString &type );
-
   private:
     QgsVectorLayer *mLayer = nullptr;
     int mFieldIdx;

--- a/src/gui/editorwidgets/core/qgseditorwidgetfactory.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetfactory.h
@@ -75,6 +75,12 @@ class GUI_EXPORT QgsEditorWidgetFactory
     QString name() const;
 
     /**
+     * Returns true if this widget is a read-only widget.
+     * \since QGIS 3.44
+     */
+    virtual bool isReadOnly() const { return false; }
+
+    /**
      * Override this in your implementation.
      * Create a new configuration widget for this widget type.
      *

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -169,6 +169,16 @@ QString QgsEditorWidgetRegistry::name( const QString &widgetId )
   return QString();
 }
 
+bool QgsEditorWidgetRegistry::isReadOnly( const QString &widgetId )
+{
+  if ( mWidgetFactories.contains( widgetId ) )
+  {
+    return mWidgetFactories[widgetId]->isReadOnly();
+  }
+
+  return false;
+}
+
 QMap<QString, QgsEditorWidgetFactory *> QgsEditorWidgetRegistry::factories()
 {
   return mWidgetFactories;

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
@@ -134,6 +134,15 @@ class GUI_EXPORT QgsEditorWidgetRegistry : public QObject
     QString name( const QString &widgetId );
 
     /**
+     * Gets the widget's read-only flag
+     *
+     * \param widgetId The widget type to get the read-only flag for
+     *
+     * \since QGIS 3.44
+     */
+    bool isReadOnly( const QString &widgetId );
+
+    /**
      * Gets access to all registered factories
      *
      * \returns All ids and factories

--- a/src/gui/editorwidgets/qgshiddenwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgshiddenwidgetfactory.cpp
@@ -32,3 +32,8 @@ QgsEditorConfigWidget *QgsHiddenWidgetFactory::configWidget( QgsVectorLayer *vl,
 {
   return new QgsDummyConfigDlg( vl, fieldIdx, parent, QObject::tr( "A hidden field will be invisible - the user is not able to see its contents." ) );
 }
+
+bool QgsHiddenWidgetFactory::isReadOnly() const
+{
+  return true;
+}

--- a/src/gui/editorwidgets/qgshiddenwidgetfactory.h
+++ b/src/gui/editorwidgets/qgshiddenwidgetfactory.h
@@ -40,6 +40,7 @@ class GUI_EXPORT QgsHiddenWidgetFactory : public QgsEditorWidgetFactory
   public:
     QgsEditorWidgetWrapper *create( QgsVectorLayer *vl, int fieldIdx, QWidget *editor, QWidget *parent ) const override;
     QgsEditorConfigWidget *configWidget( QgsVectorLayer *vl, int fieldIdx, QWidget *parent ) const override;
+    bool isReadOnly() const override;
 };
 
 #endif // QGSHIDDENWIDGETFACTORY_H

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
@@ -23,7 +23,6 @@ QgsHiddenWidgetWrapper::QgsHiddenWidgetWrapper( QgsVectorLayer *layer, int field
 {
 }
 
-
 QVariant QgsHiddenWidgetWrapper::value() const
 {
   return mValue;

--- a/src/gui/editorwidgets/qgsjsoneditwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsjsoneditwidgetfactory.cpp
@@ -55,3 +55,8 @@ unsigned int QgsJsonEditWidgetFactory::fieldScore( const QgsVectorLayer *vl, int
       break;
   }
 }
+
+bool QgsJsonEditWidgetFactory::isReadOnly() const
+{
+  return true;
+}

--- a/src/gui/editorwidgets/qgsjsoneditwidgetfactory.h
+++ b/src/gui/editorwidgets/qgsjsoneditwidgetfactory.h
@@ -43,6 +43,8 @@ class GUI_EXPORT QgsJsonEditWidgetFactory : public QgsEditorWidgetFactory
     QgsEditorConfigWidget *configWidget( QgsVectorLayer *vl, int fieldIdx, QWidget *parent ) const override;
 
     unsigned int fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const override;
+
+    bool isReadOnly() const override;
 };
 
 #endif // QGSJSONEDITWIDGETFACTORY_H

--- a/src/gui/editorwidgets/qgsuuidwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetfactory.cpp
@@ -39,3 +39,8 @@ unsigned int QgsUuidWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fie
   const QMetaType::Type type = vl->fields().field( fieldIdx ).type();
   return type == QMetaType::Type::QString ? 5 : 0;
 }
+
+bool QgsUuidWidgetFactory::isReadOnly() const
+{
+  return true;
+}

--- a/src/gui/editorwidgets/qgsuuidwidgetfactory.h
+++ b/src/gui/editorwidgets/qgsuuidwidgetfactory.h
@@ -42,6 +42,7 @@ class GUI_EXPORT QgsUuidWidgetFactory : public QgsEditorWidgetFactory
     QgsEditorWidgetWrapper *create( QgsVectorLayer *vl, int fieldIdx, QWidget *editor, QWidget *parent ) const override;
     QgsEditorConfigWidget *configWidget( QgsVectorLayer *vl, int fieldIdx, QWidget *parent ) const override;
     unsigned int fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const override;
+    bool isReadOnly() const override;
 };
 
 #endif // QGSUUIDWIDGETFACTORY_H


### PR DESCRIPTION
## Description

JsonView editor widget is a read-only widget, however the "Editable" and "Reuse last entered value" checkboxes are enabled for it confusing users and making a false impression that this widgets allows editing.

Also fixes enabled data-defined override button for "Editable" property when target field is a read-only field.

Fixes #47755.