### PR TITLE
When applying a named style to a font, check for untranslated style if the translated one is missing

### DIFF
--- a/src/core/qgsfontutils.cpp
+++ b/src/core/qgsfontutils.cpp
@@ -158,11 +158,18 @@ bool QgsFontUtils::updateFontViaStyle( QFont &f, const QString &fontstyle, bool 
   }
 
   QFontDatabase fontDB;
+  QString actualFontStyle = fontstyle;
 
   if ( !fallback )
   {
     // does the font even have the requested style?
-    const bool hasstyle = fontFamilyHasStyle( f.family(), fontstyle );
+    bool hasstyle = fontFamilyHasStyle( f.family(), actualFontStyle );
+    if ( !hasstyle )
+    {
+      actualFontStyle = untranslateNamedStyle( fontstyle );
+      hasstyle = fontFamilyHasStyle( f.family(), actualFontStyle );
+    }
+
     if ( !hasstyle )
     {
       return false;
@@ -170,7 +177,7 @@ bool QgsFontUtils::updateFontViaStyle( QFont &f, const QString &fontstyle, bool 
   }
 
   // is the font's style already the same as requested?
-  if ( fontstyle == fontDB.styleString( f ) )
+  if ( actualFontStyle == fontDB.styleString( f ) )
   {
     return false;
   }
@@ -182,8 +189,8 @@ bool QgsFontUtils::updateFontViaStyle( QFont &f, const QString &fontstyle, bool 
   bool foundmatch = false;
 
   // if fontDB.font() fails, it returns the default app font; but, that may be the target style
-  styledfont = fontDB.font( f.family(), fontstyle, defaultSize );
-  if ( appfont != styledfont || fontstyle != fontDB.styleString( f ) )
+  styledfont = fontDB.font( f.family(), actualFontStyle, defaultSize );
+  if ( appfont != styledfont || actualFontStyle != fontDB.styleString( f ) )
   {
     foundmatch = true;
   }


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/61660 whereas font named styles within QML would not be properly restored with a non-English application locale.

Basically, the bold/italic/etc. named style is *not* always translated into the application locale, but until now we assumed as much. If a user would load a QML file with a font's namedStyle="Bold", we would only check against the translated style (e.g. "Gras") and if the styles provided by the QFontDatabase were not translated, we'd just miss them. This PR adds an untranslated check to cover that scenario.