### PR TITLE
[gui] Fix confusing save vector layer dialog's include z dimension checkbox when geometry combobox is set to automatic

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -1198,17 +1198,23 @@ void QgsVectorLayerSaveAsDialog::mSymbologyExportComboBox_currentIndexChanged( c
 
 void QgsVectorLayerSaveAsDialog::mGeometryTypeComboBox_currentIndexChanged( int )
 {
-  Qgis::WkbType currentIndexData = static_cast<Qgis::WkbType>( mGeometryTypeComboBox->currentData().toInt() );
-
-  if ( mGeometryTypeComboBox->currentIndex() != -1 && currentIndexData != Qgis::WkbType::NoGeometry )
+  const int currentIndexData = mGeometryTypeComboBox->currentData().toInt();
+  if ( currentIndexData != -1 && static_cast<Qgis::WkbType>( currentIndexData ) != Qgis::WkbType::NoGeometry )
   {
     mForceMultiCheckBox->setEnabled( true );
     mIncludeZCheckBox->setEnabled( true );
   }
   else
   {
-    mForceMultiCheckBox->setEnabled( false );
-    mForceMultiCheckBox->setChecked( false );
+    if ( static_cast<Qgis::WkbType>( currentIndexData ) == Qgis::WkbType::NoGeometry )
+    {
+      mForceMultiCheckBox->setEnabled( false );
+      mForceMultiCheckBox->setChecked( false );
+    }
+    else
+    {
+      mForceMultiCheckBox->setEnabled( true );
+    }
     mIncludeZCheckBox->setEnabled( false );
     mIncludeZCheckBox->setChecked( false );
   }

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -264,16 +264,16 @@
            </layout>
           </item>
           <item>
-           <widget class="QCheckBox" name="mForceMultiCheckBox">
+           <widget class="QCheckBox" name="mIncludeZCheckBox">
             <property name="text">
-             <string>Force multi-type</string>
+             <string>Include z-dimension</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="mIncludeZCheckBox">
+           <widget class="QCheckBox" name="mForceMultiCheckBox">
             <property name="text">
-             <string>Include z-dimension</string>
+             <string>Force multi-type</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/61554 . As per the QgsVectorFileWriter logic here ( ), the include z dimension checkbox is only taken into account when the geometry type is overwritten (i.e. not "automatic"). Leaving the checkbox enabled leads to users being misinformed as to when the checkbox actually does something.

I suspect this is merely fixing a typo as a currentIndex() of -1 is not a thing with comboboxes that have items (such as the geometry combobox here).