### PR TITLE
add kmeans from seed layer algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -26,28 +26,14 @@
 
 ///@cond PRIVATE
 
-
-/**
- * Native k-means clustering algorithm.
- */
-class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsProcessingAlgorithm
+class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithmBase : public QgsProcessingAlgorithm
 {
   public:
-    QgsKMeansClusteringAlgorithm() = default;
-    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
-    QString name() const override;
-    QString displayName() const override;
     QStringList tags() const override;
     QString group() const override;
     QString groupId() const override;
-    QString shortHelpString() const override;
-    QString shortDescription() const override;
-    QgsKMeansClusteringAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
-    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-
-  private:
     struct Feature
     {
         Feature( QgsPointXY point )
@@ -58,13 +44,30 @@ class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsProcessingAlgorit
         int cluster = -1;
     };
 
-    static void initClustersFarthestPoints( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
-    static void initClustersPlusPlus( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     static void calculateKMeans( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     static void findNearest( std::vector<Feature> &points, const std::vector<QgsPointXY> &centers, int k, bool &changed );
     static void updateMeans( const std::vector<Feature> &points, std::vector<QgsPointXY> &centers, std::vector<uint> &weights, int k );
+};
 
+class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsKMeansClusteringAlgorithmBase
+{
+  public:
+    QgsKMeansClusteringAlgorithm() = default;
+    
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsKMeansClusteringAlgorithm *createInstance() const override SIP_FACTORY;
+
+  private:
+    static void initClustersFarthestPoints( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
+    static void initClustersPlusPlus( std::vector<Feature> &points, std::vector<QgsPointXY> &centers, int k, QgsProcessingFeedback *feedback );
     friend class TestQgsProcessingAlgsPt1;
+
+  protected:
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -67,7 +67,7 @@ class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsKMeansClusteringA
     friend class TestQgsProcessingAlgsPt1;
 
   protected:
-    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 };
 
 class ANALYSIS_EXPORT QgsKMeansClusteringFromSeedLayerAlgorithm : public QgsKMeansClusteringAlgorithmBase
@@ -83,7 +83,7 @@ class ANALYSIS_EXPORT QgsKMeansClusteringFromSeedLayerAlgorithm : public QgsKMea
     QgsKMeansClusteringFromSeedLayerAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
-    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -53,7 +53,7 @@ class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsKMeansClusteringA
 {
   public:
     QgsKMeansClusteringAlgorithm() = default;
-    
+
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;
@@ -74,7 +74,7 @@ class ANALYSIS_EXPORT QgsKMeansClusteringFromSeedLayerAlgorithm : public QgsKMea
 {
   public:
     QgsKMeansClusteringFromSeedLayerAlgorithm() = default;
-    
+
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -70,6 +70,22 @@ class ANALYSIS_EXPORT QgsKMeansClusteringAlgorithm : public QgsKMeansClusteringA
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
 };
 
+class ANALYSIS_EXPORT QgsKMeansClusteringFromSeedLayerAlgorithm : public QgsKMeansClusteringAlgorithmBase
+{
+  public:
+    QgsKMeansClusteringFromSeedLayerAlgorithm() = default;
+    
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsKMeansClusteringFromSeedLayerAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+};
+
 ///@endcond PRIVATE
 
 #endif // QGSALGORITHMKMEANSCLUSTERING_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -481,6 +481,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsJoinWithLinesAlgorithm() );
   addAlgorithm( new QgsKeepNBiggestPartsAlgorithm() );
   addAlgorithm( new QgsKMeansClusteringAlgorithm() );
+  addAlgorithm( new QgsKMeansClusteringFromSeedLayerAlgorithm() );
   addAlgorithm( new QgsLayerToBookmarksAlgorithm() );
   addAlgorithm( new QgsLayoutMapExtentToLayerAlgorithm() );
   addAlgorithm( new QgsLayoutAtlasToImageAlgorithm() );


### PR DESCRIPTION
closes: #44012 

Kmeans from seed layer uses point layer geometry (SEED) for the initial centers.

Base Kmeans algorithm is created.
Since the functions used in this new alg are part of the base algorithm, new tests are not required.