### PR TITLE
[processing] Fix parameterAsExtentGeometry not returning a geometry when the CRS extracted from the string matches the function's CRS parameter

### DIFF
--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -1285,6 +1285,10 @@ QgsGeometry QgsProcessingParameters::parameterAsExtentGeometry( const QgsProcess
           }
           return g;
         }
+        else
+        {
+          return g;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/61365 -- while the error was relatively harmless, it did mean a perfectly fine rectangle + [projection] string would not be returned as geometry and instead would go through the additional CPU cycles of attempting to parse it as a map layer.