### PR TITLE
[ui] Fix user profile selector dialog colors on Qt6 with dark theme OSes

### DIFF
--- a/src/ui/qgsuserprofileselectiondialog.ui
+++ b/src/ui/qgsuserprofileselectiondialog.ui
@@ -10,70 +10,6 @@
     <height>417</height>
    </rect>
   </property>
-  <property name="palette">
-   <palette>
-    <active>
-     <colorrole role="Base">
-      <brush brushstyle="SolidPattern">
-       <color alpha="255">
-        <red>255</red>
-        <green>255</green>
-        <blue>255</blue>
-       </color>
-      </brush>
-     </colorrole>
-     <colorrole role="Window">
-      <brush brushstyle="SolidPattern">
-       <color alpha="255">
-        <red>255</red>
-        <green>255</green>
-        <blue>255</blue>
-       </color>
-      </brush>
-     </colorrole>
-    </active>
-    <inactive>
-     <colorrole role="Base">
-      <brush brushstyle="SolidPattern">
-       <color alpha="255">
-        <red>255</red>
-        <green>255</green>
-        <blue>255</blue>
-       </color>
-      </brush>
-     </colorrole>
-     <colorrole role="Window">
-      <brush brushstyle="SolidPattern">
-       <color alpha="255">
-        <red>255</red>
-        <green>255</green>
-        <blue>255</blue>
-       </color>
-      </brush>
-     </colorrole>
-    </inactive>
-    <disabled>
-     <colorrole role="Base">
-      <brush brushstyle="SolidPattern">
-       <color alpha="255">
-        <red>255</red>
-        <green>255</green>
-        <blue>255</blue>
-       </color>
-      </brush>
-     </colorrole>
-     <colorrole role="Window">
-      <brush brushstyle="SolidPattern">
-       <color alpha="255">
-        <red>255</red>
-        <green>255</green>
-        <blue>255</blue>
-       </color>
-      </brush>
-     </colorrole>
-    </disabled>
-   </palette>
-  </property>
   <property name="windowTitle">
    <string>User Profile Selector</string>
   </property>
@@ -121,9 +57,6 @@
    </item>
    <item>
     <widget class="QListWidget" name="mProfileListWidget">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="uniformItemSizes">
       <bool>true</bool>
      </property>
@@ -149,6 +82,18 @@
    </item>
    <item>
     <widget class="QToolButton" name="mAddProfileButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>40</width>
+       <height>32</height>
+      </size>
+     </property>
      <property name="text">
       <string>Add new profile</string>
      </property>
@@ -158,8 +103,8 @@
      </property>
      <property name="iconSize">
       <size>
-       <width>24</width>
-       <height>24</height>
+       <width>16</width>
+       <height>16</height>
       </size>
      </property>
      <property name="toolButtonStyle">


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/61557 , namely insures the user profile selector dialog colors when built against Qt6 and the OS has a dark theme are readable.

The fix is to drop the arbitrary palette color definition and leave it to the OS to style the dialog. Future proof, and avoids looking us into a Windows 10-era white background dialog :)