### PR TITLE
[ui] Fix custom font size not applied properly with Qt6 builds

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1543,6 +1543,31 @@ int main( int argc, char *argv[] )
   // this should be done in QgsApplication::init() but it doesn't know the settings dir.
   QgsApplication::setMaxThreads( settings.value( QStringLiteral( "qgis/max_threads" ), -1 ).toInt() );
 
+  QFont defaultFont = QApplication::font();
+  bool defaultFontCustomized = false;
+  const double fontSize = settings.value( QStringLiteral( "/app/fontPointSize" ), defaultFont.pointSizeF() ).toDouble();
+  if ( fontSize != defaultFont.pointSizeF() )
+  {
+    defaultFont.setPointSizeF( fontSize );
+    defaultFontCustomized = true;
+  }
+
+  QString fontFamily = settings.value( QStringLiteral( "/app/fontFamily" ), defaultFont.family() ).toString();
+  if ( fontFamily != defaultFont.family() )
+  {
+    const QFont tempFont( fontFamily );
+    if ( tempFont.family() == fontFamily )
+    {
+      // font exists on system, proceed
+      defaultFont.setFamily( fontFamily );
+      defaultFontCustomized = true;
+    }
+  }
+  if ( defaultFontCustomized )
+  {
+    QApplication::setFont( defaultFont );
+  }
+
   QgisApp *qgis = new QgisApp( mypSplash, qgisAppOptions, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
   qgis->setObjectName( QStringLiteral( "QgisApp" ) );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1890,8 +1890,6 @@ void QgsOptions::saveOptions()
   {
     mStyleSheetBuilder->setUserFontSize( newFontSize );
     mStyleSheetBuilder->setUserFontFamily( newUserFontFamily );
-    // trigger a style sheet build to propagate saved settings
-    mStyleSheetBuilder->updateStyleSheet();
   }
 
   mDefaultDatumTransformTableWidget->transformContext().writeSettings();

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -28,7 +28,6 @@
 #include "qgssettings.h"
 #include "qgsguiutils.h"
 
-bool QgisAppStyleSheet::sIsFirstRun = true;
 
 QgisAppStyleSheet::QgisAppStyleSheet( QObject *parent )
   : QObject( parent )
@@ -56,51 +55,6 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
 {
   const QgsSettings settings;
   QString ss;
-
-  // QgisApp-wide font
-  {
-    bool overriddenFontSize = false;
-    double currentFontSize = fontSize();
-    const QFont appFont = QApplication::font();
-    if ( opts.contains( QStringLiteral( "fontPointSize" ) ) )
-    {
-      const double fontSizeFromOpts = opts.value( QStringLiteral( "fontPointSize" ) ).toDouble();
-      currentFontSize = fontSizeFromOpts;
-    }
-    QgsDebugMsgLevel( QStringLiteral( "fontPointSize: %1" ).arg( currentFontSize ), 2 );
-    if ( currentFontSize != appFont.pointSizeF() )
-    {
-      overriddenFontSize = true;
-    }
-
-    bool overriddenFontFamily = false;
-    QString currentFontFamily = fontFamily();
-    if ( opts.contains( QStringLiteral( "fontFamily" ) ) )
-    {
-      currentFontFamily = opts.value( QStringLiteral( "fontFamily" ) ).toString();
-    }
-    QgsDebugMsgLevel( QStringLiteral( "fontFamily: %1" ).arg( currentFontFamily ), 2 );
-    if ( !currentFontFamily.isEmpty() && currentFontFamily != appFont.family() )
-    {
-      overriddenFontFamily = true;
-    }
-
-    if ( overriddenFontFamily || overriddenFontSize )
-    {
-      // this seems only safe to do at startup, at least on Windows.
-      // see https://github.com/qgis/QGIS/issues/54402, https://github.com/qgis/QGIS/issues/54295
-      // Let's play it safe and require a restart to change the font.
-      if ( sIsFirstRun )
-      {
-        QFont font = QApplication::font();
-        if ( overriddenFontFamily )
-          font.setFamily( currentFontFamily );
-        if ( overriddenFontSize )
-          font.setPointSizeF( currentFontSize );
-        QApplication::setFont( font );
-      }
-    }
-  }
 
   if ( mMacStyle )
   {
@@ -176,8 +130,6 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
   }
 
   QgsDebugMsgLevel( QStringLiteral( "Stylesheet built: %1" ).arg( ss ), 2 );
-
-  sIsFirstRun = false;
 
   emit appStyleSheetChanged( ss );
 }

--- a/src/app/qgisappstylesheet.h
+++ b/src/app/qgisappstylesheet.h
@@ -114,8 +114,6 @@ class APP_EXPORT QgisAppStyleSheet : public QObject
     // platforms, specific
     bool mWinOS = false;
     bool mAndroidOS = false;
-
-    static bool sIsFirstRun;
 };
 
 #endif //QGISAPPSTYLESHEET_H


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/62007 whereas the custom font size is not applied to _multiple_ widgets (including the menu bar) on app launch.

The long story short here is that Qt6 isn't happy we re-define the font family/size while we are constructing QgisApp, but handles it fine when we set it _prior_ to that point. 