### PR TITLE
Use protected, not private virtual methods for map tool classes

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgsmaptoolcapturelayergeometry.py
+++ b/python/PyQt6/gui/auto_additions/qgsmaptoolcapturelayergeometry.py
@@ -1,6 +1,7 @@
 # The following has been generated automatically from src/gui/maptools/qgsmaptoolcapturelayergeometry.h
 try:
     QgsMapToolCaptureLayerGeometry.__virtual_methods__ = ['layerGeometryCaptured', 'layerPointCaptured', 'layerLineCaptured', 'layerPolygonCaptured']
+    QgsMapToolCaptureLayerGeometry.__overridden_methods__ = ['geometryCaptured']
     QgsMapToolCaptureLayerGeometry.__group__ = ['maptools']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_additions/qgsmaptooldigitizefeature.py
+++ b/python/PyQt6/gui/auto_additions/qgsmaptooldigitizefeature.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/gui/maptools/qgsmaptooldigitizefeature.h
 try:
     QgsMapToolDigitizeFeature.__attribute_docs__ = {'digitizingCompleted': 'Emitted whenever the digitizing has been successfully completed\n\n:param feature: the new digitized feature\n', 'digitizingFinished': 'Emitted whenever the digitizing has been ended without digitizing any\nfeature\n', 'digitizingCanceled': 'Emitted when the digitizing process was interrupted by the user.\n\n.. versionadded:: 3.28\n'}
-    QgsMapToolDigitizeFeature.__virtual_methods__ = ['featureDigitized']
+    QgsMapToolDigitizeFeature.__virtual_methods__ = ['layerGeometryCaptured', 'featureDigitized']
     QgsMapToolDigitizeFeature.__overridden_methods__ = ['capabilities', 'supportsTechnique', 'cadCanvasReleaseEvent', 'activate', 'deactivate', 'reactivate', 'keyPressEvent']
     QgsMapToolDigitizeFeature.__signal_arguments__ = {'digitizingCompleted': ['feature: QgsFeature']}
     QgsMapToolDigitizeFeature.__group__ = ['maptools']

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
@@ -321,6 +321,48 @@ Set the points on which to work
 Close an open polygon
 %End
 
+    virtual void geometryCaptured( const QgsGeometry &geometry );
+%Docstring
+Called when the geometry is captured.
+
+A more specific handler is also called afterwards
+(:py:func:`~QgsMapToolCapture.pointCaptured`,
+:py:func:`~QgsMapToolCapture.lineCaptured` or
+:py:func:`~QgsMapToolCapture.polygonCaptured`).
+
+.. versionadded:: 3.26
+%End
+
+    virtual void pointCaptured( const QgsPoint &point );
+%Docstring
+Called when a point is captured.
+
+The generic :py:func:`~QgsMapToolCapture.geometryCaptured` method will
+be called immediately before this point-specific method.
+
+.. versionadded:: 3.26
+%End
+
+    virtual void lineCaptured( const QgsCurve *line );
+%Docstring
+Called when a line is captured
+
+The generic :py:func:`~QgsMapToolCapture.geometryCaptured` method will
+be called immediately before this line-specific method.
+
+.. versionadded:: 3.26
+%End
+
+    virtual void polygonCaptured( const QgsCurvePolygon *polygon );
+%Docstring
+Called when a polygon is captured.
+
+The generic :py:func:`~QgsMapToolCapture.geometryCaptured` method will
+be called immediately before this polygon-specific method.
+
+.. versionadded:: 3.26
+%End
+
   protected slots:
 
     void stopCapturing();
@@ -328,32 +370,6 @@ Close an open polygon
 Stop capturing
 %End
 
-  private:
-    virtual void geometryCaptured( const QgsGeometry &geometry );
-%Docstring
-Called when the geometry is captured A more specific handler is also
-called afterwards (pointCaptured, lineCaptured or polygonCaptured)
-
-.. versionadded:: 3.26
-%End
-    virtual void pointCaptured( const QgsPoint &point );
-%Docstring
-Called when a point is captured geometryCaptured is called just before
-
-.. versionadded:: 3.26
-%End
-    virtual void lineCaptured( const QgsCurve *line );
-%Docstring
-Called when a line is captured geometryCaptured is called just before
-
-.. versionadded:: 3.26
-%End
-    virtual void polygonCaptured( const QgsCurvePolygon *polygon );
-%Docstring
-Called when a polygon is captured geometryCaptured is called just before
-
-.. versionadded:: 3.26
-%End
 };
 
 QFlags<QgsMapToolCapture::Capability> operator|(QgsMapToolCapture::Capability f1, QFlags<QgsMapToolCapture::Capability> f2);

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapturelayergeometry.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapturelayergeometry.sip.in
@@ -30,31 +30,45 @@ the user.
 Constructor
 %End
 
-  private:
     virtual void layerGeometryCaptured( const QgsGeometry &geometry );
 %Docstring
-Called when the geometry is captured A more specific handler is also
-called afterwards (layerPointCaptured, layerLineCaptured or
-layerPolygonCaptured)
+Called when the geometry is captured.
+
+A more specific handler is also called afterwards
+(:py:func:`~QgsMapToolCaptureLayerGeometry.layerPointCaptured`,
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerLineCaptured` or
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerPolygonCaptured`).
 %End
+
     virtual void layerPointCaptured( const QgsPoint &point );
 %Docstring
-Called when a point is captured The generic
-:py:func:`~QgsMapToolCaptureLayerGeometry.geometryCaptured` signal will
-be emitted immediately before this point-specific signal.
+Called when a point is captured.
+
+The generic
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerGeometryCaptured` method
+will be called immediately before this point-specific method.
 %End
+
     virtual void layerLineCaptured( const QgsCurve *line );
 %Docstring
-Called when a line is captured The generic
-:py:func:`~QgsMapToolCaptureLayerGeometry.geometryCaptured` signal will
-be emitted immediately before this line-specific signal.
+Called when a line is captured.
+
+The generic
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerGeometryCaptured` method
+will be called immediately before this line-specific method.
 %End
+
     virtual void layerPolygonCaptured( const QgsCurvePolygon *polygon );
 %Docstring
-Called when a polygon is captured The generic
-:py:func:`~QgsMapToolCaptureLayerGeometry.geometryCaptured` signal will
-be emitted immediately before this polygon-specific signal.
+Called when a polygon is captured.
+
+The generic
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerGeometryCaptured` method
+will be called immediately before this polygon-specific method.
 %End
+
+    virtual void geometryCaptured( const QgsGeometry &geometry );
+
 };
 
 /************************************************************************

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
@@ -93,13 +93,21 @@ Check if CaptureMode matches layer type. Default is ``True``.
 Check if CaptureMode matches layer type. Default is ``True``.
 %End
 
-  private:
+    virtual void layerGeometryCaptured( const QgsGeometry &geometry ) ${SIP_FINAL};
+
+%Docstring
+Called when the feature has been digitized.
+
+:param geometry: the digitized geometry
+%End
+
     virtual void featureDigitized( const QgsFeature &feature );
 %Docstring
 Called when the feature has been digitized
 
 .. versionadded:: 3.26
 %End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_additions/qgsmaptoolcapturelayergeometry.py
+++ b/python/gui/auto_additions/qgsmaptoolcapturelayergeometry.py
@@ -1,6 +1,7 @@
 # The following has been generated automatically from src/gui/maptools/qgsmaptoolcapturelayergeometry.h
 try:
     QgsMapToolCaptureLayerGeometry.__virtual_methods__ = ['layerGeometryCaptured', 'layerPointCaptured', 'layerLineCaptured', 'layerPolygonCaptured']
+    QgsMapToolCaptureLayerGeometry.__overridden_methods__ = ['geometryCaptured']
     QgsMapToolCaptureLayerGeometry.__group__ = ['maptools']
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_additions/qgsmaptooldigitizefeature.py
+++ b/python/gui/auto_additions/qgsmaptooldigitizefeature.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/gui/maptools/qgsmaptooldigitizefeature.h
 try:
     QgsMapToolDigitizeFeature.__attribute_docs__ = {'digitizingCompleted': 'Emitted whenever the digitizing has been successfully completed\n\n:param feature: the new digitized feature\n', 'digitizingFinished': 'Emitted whenever the digitizing has been ended without digitizing any\nfeature\n', 'digitizingCanceled': 'Emitted when the digitizing process was interrupted by the user.\n\n.. versionadded:: 3.28\n'}
-    QgsMapToolDigitizeFeature.__virtual_methods__ = ['featureDigitized']
+    QgsMapToolDigitizeFeature.__virtual_methods__ = ['layerGeometryCaptured', 'featureDigitized']
     QgsMapToolDigitizeFeature.__overridden_methods__ = ['capabilities', 'supportsTechnique', 'cadCanvasReleaseEvent', 'activate', 'deactivate', 'reactivate', 'keyPressEvent']
     QgsMapToolDigitizeFeature.__signal_arguments__ = {'digitizingCompleted': ['feature: QgsFeature']}
     QgsMapToolDigitizeFeature.__group__ = ['maptools']

--- a/python/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
@@ -321,6 +321,48 @@ Set the points on which to work
 Close an open polygon
 %End
 
+    virtual void geometryCaptured( const QgsGeometry &geometry );
+%Docstring
+Called when the geometry is captured.
+
+A more specific handler is also called afterwards
+(:py:func:`~QgsMapToolCapture.pointCaptured`,
+:py:func:`~QgsMapToolCapture.lineCaptured` or
+:py:func:`~QgsMapToolCapture.polygonCaptured`).
+
+.. versionadded:: 3.26
+%End
+
+    virtual void pointCaptured( const QgsPoint &point );
+%Docstring
+Called when a point is captured.
+
+The generic :py:func:`~QgsMapToolCapture.geometryCaptured` method will
+be called immediately before this point-specific method.
+
+.. versionadded:: 3.26
+%End
+
+    virtual void lineCaptured( const QgsCurve *line );
+%Docstring
+Called when a line is captured
+
+The generic :py:func:`~QgsMapToolCapture.geometryCaptured` method will
+be called immediately before this line-specific method.
+
+.. versionadded:: 3.26
+%End
+
+    virtual void polygonCaptured( const QgsCurvePolygon *polygon );
+%Docstring
+Called when a polygon is captured.
+
+The generic :py:func:`~QgsMapToolCapture.geometryCaptured` method will
+be called immediately before this polygon-specific method.
+
+.. versionadded:: 3.26
+%End
+
   protected slots:
 
     void stopCapturing();
@@ -328,32 +370,6 @@ Close an open polygon
 Stop capturing
 %End
 
-  private:
-    virtual void geometryCaptured( const QgsGeometry &geometry );
-%Docstring
-Called when the geometry is captured A more specific handler is also
-called afterwards (pointCaptured, lineCaptured or polygonCaptured)
-
-.. versionadded:: 3.26
-%End
-    virtual void pointCaptured( const QgsPoint &point );
-%Docstring
-Called when a point is captured geometryCaptured is called just before
-
-.. versionadded:: 3.26
-%End
-    virtual void lineCaptured( const QgsCurve *line );
-%Docstring
-Called when a line is captured geometryCaptured is called just before
-
-.. versionadded:: 3.26
-%End
-    virtual void polygonCaptured( const QgsCurvePolygon *polygon );
-%Docstring
-Called when a polygon is captured geometryCaptured is called just before
-
-.. versionadded:: 3.26
-%End
 };
 
 QFlags<QgsMapToolCapture::Capability> operator|(QgsMapToolCapture::Capability f1, QFlags<QgsMapToolCapture::Capability> f2);

--- a/python/gui/auto_generated/maptools/qgsmaptoolcapturelayergeometry.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptoolcapturelayergeometry.sip.in
@@ -30,31 +30,45 @@ the user.
 Constructor
 %End
 
-  private:
     virtual void layerGeometryCaptured( const QgsGeometry &geometry );
 %Docstring
-Called when the geometry is captured A more specific handler is also
-called afterwards (layerPointCaptured, layerLineCaptured or
-layerPolygonCaptured)
+Called when the geometry is captured.
+
+A more specific handler is also called afterwards
+(:py:func:`~QgsMapToolCaptureLayerGeometry.layerPointCaptured`,
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerLineCaptured` or
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerPolygonCaptured`).
 %End
+
     virtual void layerPointCaptured( const QgsPoint &point );
 %Docstring
-Called when a point is captured The generic
-:py:func:`~QgsMapToolCaptureLayerGeometry.geometryCaptured` signal will
-be emitted immediately before this point-specific signal.
+Called when a point is captured.
+
+The generic
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerGeometryCaptured` method
+will be called immediately before this point-specific method.
 %End
+
     virtual void layerLineCaptured( const QgsCurve *line );
 %Docstring
-Called when a line is captured The generic
-:py:func:`~QgsMapToolCaptureLayerGeometry.geometryCaptured` signal will
-be emitted immediately before this line-specific signal.
+Called when a line is captured.
+
+The generic
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerGeometryCaptured` method
+will be called immediately before this line-specific method.
 %End
+
     virtual void layerPolygonCaptured( const QgsCurvePolygon *polygon );
 %Docstring
-Called when a polygon is captured The generic
-:py:func:`~QgsMapToolCaptureLayerGeometry.geometryCaptured` signal will
-be emitted immediately before this polygon-specific signal.
+Called when a polygon is captured.
+
+The generic
+:py:func:`~QgsMapToolCaptureLayerGeometry.layerGeometryCaptured` method
+will be called immediately before this polygon-specific method.
 %End
+
+    virtual void geometryCaptured( const QgsGeometry &geometry );
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptooldigitizefeature.sip.in
@@ -93,13 +93,21 @@ Check if CaptureMode matches layer type. Default is ``True``.
 Check if CaptureMode matches layer type. Default is ``True``.
 %End
 
-  private:
+    virtual void layerGeometryCaptured( const QgsGeometry &geometry ) ${SIP_FINAL};
+
+%Docstring
+Called when the feature has been digitized.
+
+:param geometry: the digitized geometry
+%End
+
     virtual void featureDigitized( const QgsFeature &feature );
 %Docstring
 Called when the feature has been digitized
 
 .. versionadded:: 3.26
 %End
+
 };
 
 /************************************************************************

--- a/src/gui/maptools/qgsmaptoolcapture.h
+++ b/src/gui/maptools/qgsmaptoolcapture.h
@@ -330,6 +330,42 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      */
     void closePolygon();
 
+    /**
+     * Called when the geometry is captured.
+     *
+     * A more specific handler is also called afterwards (pointCaptured(), lineCaptured() or polygonCaptured()).
+     *
+     * \since QGIS 3.26
+     */
+    virtual void geometryCaptured( const QgsGeometry &geometry ) { Q_UNUSED( geometry ) }
+
+    /**
+     * Called when a point is captured.
+     *
+     * The generic geometryCaptured() method will be called immediately before this point-specific method.
+     *
+     * \since QGIS 3.26
+     */
+    virtual void pointCaptured( const QgsPoint &point ) { Q_UNUSED( point ) }
+
+    /**
+     * Called when a line is captured
+     *
+     * The generic geometryCaptured() method will be called immediately before this line-specific method.
+     *
+     * \since QGIS 3.26
+     */
+    virtual void lineCaptured( const QgsCurve *line ) { Q_UNUSED( line ) }
+
+    /**
+     * Called when a polygon is captured.
+     *
+     * The generic geometryCaptured() method will be called immediately before this polygon-specific method.
+     *
+     * \since QGIS 3.26
+     */
+    virtual void polygonCaptured( const QgsCurvePolygon *polygon ) { Q_UNUSED( polygon ) }
+
   protected slots:
 
     /**
@@ -338,34 +374,6 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     void stopCapturing();
 
   private:
-    /**
-     * Called when the geometry is captured
-     * A more specific handler is also called afterwards (pointCaptured, lineCaptured or polygonCaptured)
-     * \since QGIS 3.26
-     */
-    virtual void geometryCaptured( const QgsGeometry &geometry ) SIP_FORCE { Q_UNUSED( geometry ) }
-
-    /**
-     * Called when a point is captured
-     * geometryCaptured is called just before
-     * \since QGIS 3.26
-     */
-    virtual void pointCaptured( const QgsPoint &point ) SIP_FORCE { Q_UNUSED( point ) }
-
-    /**
-     * Called when a line is captured
-     * geometryCaptured is called just before
-     * \since QGIS 3.26
-     */
-    virtual void lineCaptured( const QgsCurve *line ) SIP_FORCE { Q_UNUSED( line ) }
-
-    /**
-     * Called when a polygon is captured
-     * geometryCaptured is called just before
-     * \since QGIS 3.26
-     */
-    virtual void polygonCaptured( const QgsCurvePolygon *polygon ) SIP_FORCE { Q_UNUSED( polygon ) }
-
     //! whether tracing has been requested by the user
     bool tracingEnabled();
     //! first point that will be used as a start of the trace

--- a/src/gui/maptools/qgsmaptoolcapturelayergeometry.h
+++ b/src/gui/maptools/qgsmaptoolcapturelayergeometry.h
@@ -37,32 +37,35 @@ class GUI_EXPORT QgsMapToolCaptureLayerGeometry : public QgsMapToolCapture
       : QgsMapToolCapture( canvas, cadDockWidget, mode )
     {}
 
-  private:
+    /**
+     * Called when the geometry is captured.
+     *
+     * A more specific handler is also called afterwards (layerPointCaptured(), layerLineCaptured() or layerPolygonCaptured()).
+     */
+    virtual void layerGeometryCaptured( const QgsGeometry &geometry ) { Q_UNUSED( geometry ) }
+
+    /**
+     * Called when a point is captured.
+     *
+     * The generic layerGeometryCaptured() method will be called immediately before this point-specific method.
+     */
+    virtual void layerPointCaptured( const QgsPoint &point ) { Q_UNUSED( point ) }
+
+    /**
+     * Called when a line is captured.
+     *
+     * The generic layerGeometryCaptured() method will be called immediately before this line-specific method.
+     */
+    virtual void layerLineCaptured( const QgsCurve *line ) { Q_UNUSED( line ) }
+
+    /**
+     * Called when a polygon is captured.
+     *
+     * The generic layerGeometryCaptured() method will be called immediately before this polygon-specific method.
+     */
+    virtual void layerPolygonCaptured( const QgsCurvePolygon *polygon ) { Q_UNUSED( polygon ) }
+
     void geometryCaptured( const QgsGeometry &geometry ) override;
-
-    /**
-     * Called when the geometry is captured
-     * A more specific handler is also called afterwards (layerPointCaptured, layerLineCaptured or layerPolygonCaptured)
-     */
-    virtual void layerGeometryCaptured( const QgsGeometry &geometry ) SIP_FORCE { Q_UNUSED( geometry ) }
-
-    /**
-     * Called when a point is captured
-     * The generic geometryCaptured() signal will be emitted immediately before this point-specific signal.
-     */
-    virtual void layerPointCaptured( const QgsPoint &point ) SIP_FORCE { Q_UNUSED( point ) }
-
-    /**
-     * Called when a line is captured
-     * The generic geometryCaptured() signal will be emitted immediately before this line-specific signal.
-     */
-    virtual void layerLineCaptured( const QgsCurve *line ) SIP_FORCE { Q_UNUSED( line ) }
-
-    /**
-     * Called when a polygon is captured
-     * The generic geometryCaptured() signal will be emitted immediately before this polygon-specific signal.
-     */
-    virtual void layerPolygonCaptured( const QgsCurvePolygon *polygon ) SIP_FORCE { Q_UNUSED( polygon ) }
 };
 
 #endif // QGSMAPTOOLCAPTURELAYERGEOMETRY_H

--- a/src/gui/maptools/qgsmaptooldigitizefeature.h
+++ b/src/gui/maptools/qgsmaptooldigitizefeature.h
@@ -92,7 +92,6 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
     void setCheckGeometryType( bool checkGeometryType );
     // TODO QGIS 4: remove if GRASS plugin is dropped
 
-  private:
     /**
      * Called when the feature has been digitized.
      * \param geometry the digitized geometry
@@ -103,8 +102,9 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
      * Called when the feature has been digitized
      * \since QGIS 3.26
      */
-    virtual void featureDigitized( const QgsFeature &feature ) SIP_FORCE { Q_UNUSED( feature ) }
+    virtual void featureDigitized( const QgsFeature &feature ) { Q_UNUSED( feature ) }
 
+  private:
     /**
      * individual layer per digitizing session
     */


### PR DESCRIPTION
These are NOT called by sip when implementing the class in Python, making these classes unusable in PyQGIS. Just make the virtual methods protected instead.
